### PR TITLE
fix: activation modal width change when activation succeeds

### DIFF
--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -253,7 +253,6 @@
 #secret-key .instructions-caption {
   margin-top: 15px;
   margin-bottom: 15px;
-  padding-left: 16px;
   text-align: center;
 }
 
@@ -327,9 +326,9 @@
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
@@ -366,9 +365,8 @@
 }
 
 #secret-key #enter-secret-key input {
-  width: 513px;
   height: 54px;
-  margin: 0 10px;
+  margin-right: 10px;
 }
 
 #secret-key .input-acknowledgement {
@@ -418,7 +416,6 @@
 
 #secret-key .instructions {
   text-align: left;
-  padding-left: 16px;
 }
 
 #secret-key .warning-acknowledgement {
@@ -435,9 +432,6 @@
 @media (min-width: 576px) {
   #secret-key .instructions-container {
     width: calc(100% - 115px);
-  }
-  #secret-key .input-acknowledgement {
-    margin: 10px 10px 0;
   }
 }
 


### PR DESCRIPTION
## Problem

Removes the weird width change when storage mode forms successfully activates
## Before & After Screenshots

**BEFORE**:
![](https://user-images.githubusercontent.com/29480346/89253746-0eaa7000-d650-11ea-92dd-af1e72760659.gif)

**AFTER**:
![recording (12)](https://user-images.githubusercontent.com/22133008/89259645-584d8780-d65d-11ea-8d22-76ae5e609d6f.gif)

Also updated the CSS to not have weird left paddings
![Screenshot 2020-08-04 at 2 15 58 PM](https://user-images.githubusercontent.com/22133008/89259664-5f749580-d65d-11ea-9412-ff6db80d497b.png)
