### PR TITLE
feat: Filter Storage Mode Responses by Submission Id

### DIFF
--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -202,15 +202,25 @@ exports.saveResponseToDb = function (req, res, next) {
  */
 exports.getMetadata = function (req, res) {
   let pageSize = 10
-  let { page } = req.query || {}
+  let { page, filterBySubmissionRefId } = req.query || {}
   let numToSkip = parseInt(page - 1 || 0) * pageSize
+
+  let matchClause = {
+    form: req.form._id,
+    submissionType: 'encryptSubmission',
+  }
+
+  if (filterBySubmissionRefId) {
+    if (mongoose.Types.ObjectId.isValid(filterBySubmissionRefId)) {
+      matchClause._id = mongoose.Types.ObjectId(filterBySubmissionRefId)
+    } else {
+      return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+    }
+  }
 
   Submission.aggregate([
     {
-      $match: {
-        form: req.form._id,
-        submissionType: 'encryptSubmission',
-      },
+      $match: matchClause,
     },
     {
       $sort: { created: -1 },

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -202,7 +202,7 @@ exports.saveResponseToDb = function (req, res, next) {
  */
 exports.getMetadata = function (req, res) {
   let pageSize = 10
-  let { page, filterBySubmissionRefId } = req.query || {}
+  let { page, submissionId } = req.query || {}
   let numToSkip = parseInt(page - 1 || 0) * pageSize
 
   let matchClause = {
@@ -210,9 +210,28 @@ exports.getMetadata = function (req, res) {
     submissionType: 'encryptSubmission',
   }
 
-  if (filterBySubmissionRefId) {
-    if (mongoose.Types.ObjectId.isValid(filterBySubmissionRefId)) {
-      matchClause._id = mongoose.Types.ObjectId(filterBySubmissionRefId)
+  if (submissionId) {
+    if (mongoose.Types.ObjectId.isValid(submissionId)) {
+      matchClause._id = mongoose.Types.ObjectId(submissionId)
+      Submission.findOne(matchClause, { created: 1 }).exec((err, result) => {
+        if (err) {
+          logger.error(getRequestIp(req), req.url, req.headers, err)
+          return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
+            message: errorHandler.getMongoErrorMessage(err),
+          })
+        }
+        if (!result) {
+          return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+        }
+        let entry = {
+          number: 1,
+          refNo: result._id,
+          submissionTime: moment(result.created)
+            .tz('Asia/Singapore')
+            .format('Do MMM YYYY, h:mm:ss a'),
+        }
+        return res.status(HttpStatus.OK).send({ metadata: [entry], count: 1 })
+      })
     } else {
       return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
     }

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -38,6 +38,8 @@ function ViewResponsesController(
   vm.isEncryptResponseMode = vm.myform.responseMode === responseModeEnum.ENCRYPT
   vm.encryptionKey = null // will be set to an instance of EncryptionKey when form is unlocked successfully
   vm.csvDownloading = false // whether CSV export is in progress
+  vm.filterBySubmissionRefId = '' // whether to filter submissions by a specific ID
+  vm.filterBySubmissionRefIdTextbox = ''
 
   // Three views:
   // 1 - Unlock view for verifying form password
@@ -236,12 +238,15 @@ function ViewResponsesController(
     }
   })
 
+  vm.filterBySubmissionChanged = function () {
+    vm.filterBySubmissionRefId = vm.filterBySubmissionRefIdTextbox
+    vm.tableParams.reload()
+  }
+
   // Called by child directive unlockResponsesForm after key is verified to get responses
-  vm.loadResponses = function (formPassword) {
-    vm.formPassword = formPassword
+  vm.loadResponses = function () {
     vm.currentView = 2
     vm.loading = true
-
     vm.tableParams = new NgTableParams(
       {
         page: 1, // show first page
@@ -252,6 +257,7 @@ function ViewResponsesController(
           let { page } = params.url()
           return Submissions.getMetadata({
             formId: vm.myform._id,
+            filterBySubmissionRefId: vm.filterBySubmissionRefId,
             page,
           })
             .then((data) => {

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -31,7 +31,9 @@
 
   <!-- Storage Mode -->
   <div ng-if="!vm.loading && vm.isEncryptResponseMode">
-    <div ng-if="vm.responsesCount === 0">
+    <div
+      ng-if="vm.currentView === 1 && vm.responsesCount === 0 && vm.filterBySubmissionRefId === ''"
+    >
       <div class="flex-column">
         <img
           id="no-responses"
@@ -64,9 +66,9 @@
       >
       </verify-secret-key-directive>
     </div>
-    <div ng-if="vm.responsesCount > 0 && vm.currentView === 2">
+    <div ng-if="vm.currentView === 2">
       <div class="flex-row">
-        <div class="response-stats">
+        <div class="col-md-12 response-stats">
           <span class="stats-text">
             <span
               ><span class="stats">{{vm.responsesCount}}</span> response(s) to
@@ -74,7 +76,18 @@
             >
           </span>
         </div>
-        <div class="datepicker-export-container">
+      </div>
+      <div class="flex-row">
+        <div class="col-md-6">
+          <input
+            class="input-custom input-medium"
+            ng-model="vm.filterBySubmissionRefIdTextbox"
+            ng-change="vm.filterBySubmissionChanged()"
+            ng-model-options="{ debounce: 200 }"
+            placeholder="Filter by Submission Ref No."
+          />
+        </div>
+        <div class="datepicker-export-container col-md-6">
           <date-range-picker-directive
             class="datepicker-container"
             ng-model="vm.datePicker.date"
@@ -87,7 +100,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-12">
+        <div ng-if="vm.responsesCount > 0" class="col-md-12">
           <table class="table" ng-table="vm.tableParams" show-filter="false">
             <tr ng-repeat="row in $data" ng-click="vm.rowOnClick($index)">
               <td
@@ -109,6 +122,21 @@
               </td>
             </tr>
           </table>
+        </div>
+        <div
+          ng-if="vm.responsesCount === 0 && vm.filterBySubmissionRefId !== ''"
+        >
+          <div class="flex-column">
+            <img
+              ng-src="/public/modules/core/img/error-illustration.svg"
+              id="no-responses"
+            />
+            <div class="title">No results found</div>
+            <div class="subtitle">
+              Did you enter the right reference number? We can't seem to find
+              the response.
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -143,9 +143,13 @@ function SubmissionsFactory(
     },
     getMetadata: function (params) {
       const deferred = $q.defer()
-      const resUrl = `${fixParamsToUrl(params, submitAdminUrl)}/metadata?page=${
+      let resUrl = `${fixParamsToUrl(params, submitAdminUrl)}/metadata?page=${
         params.page
       }`
+
+      if (params.filterBySubmissionRefId) {
+        resUrl += `&filterBySubmissionRefId=${params.filterBySubmissionRefId}`
+      }
 
       $http.get(resUrl).then(
         function (response) {

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -148,7 +148,7 @@ function SubmissionsFactory(
       }`
 
       if (params.filterBySubmissionRefId) {
-        resUrl += `&filterBySubmissionRefId=${params.filterBySubmissionRefId}`
+        resUrl += `&submissionId=${params.filterBySubmissionRefId}`
       }
 
       $http.get(resUrl).then(


### PR DESCRIPTION
## Problem

Users have trouble finding specific responses and trying to download attachments for these responses.

## Solution

This introduces a new textbox which filters submissions by reference ID so users can jump to a certain response immediately.

## Screenshots

![image](https://user-images.githubusercontent.com/691628/89267274-da9d6380-d5eb-11ea-9fff-9767c04108fd.png)

![image](https://user-images.githubusercontent.com/691628/89267306-e6892580-d5eb-11ea-85b7-00411a28183f.png)

![image](https://user-images.githubusercontent.com/691628/89267343-f6a10500-d5eb-11ea-8064-815bfe659067.png)
