### PR TITLE
build: Release 4.30.1 - Fix field creation on old clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FormSG",
-  "version": "4.30.0",
+  "version": "4.30.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
-  "version": "4.30.0",
+  "version": "4.30.1",
   "homepage": "https://form.gov.sg",
   "authors": [
     "FormSG <formsg@data.gov.sg>"

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,6 @@
 // Enum of actions that can be used to edit a form field
 export enum EditFieldActions {
-  Create = 'Create',
+  Create = 'CREATE',
   Duplicate = 'DUPLICATE',
   Reorder = 'REORDER',
   Update = 'UPDATE',


### PR DESCRIPTION
While migrating `src/shared/constants.js` to TypeScript, one of the enum fields was accidentally changed from uppercase to sentence case. This caused a problem where old clients were not able to create form fields. This release fixes the issue.