### PR TITLE
refactor: add _id to all model interfaces

### DIFF
--- a/src/app/models/sms_count.server.model.ts
+++ b/src/app/models/sms_count.server.model.ts
@@ -58,7 +58,7 @@ SmsCountSchema.statics.logSms = async function (
   this: ISmsCountModel,
   { otpData, msgSrvcSid, smsType, logType }: LogSmsParams,
 ) {
-  const schemaData: ISmsCount = {
+  const schemaData: Omit<ISmsCount, '_id'> = {
     ...otpData,
     msgSrvcSid,
     smsType,

--- a/src/types/agency.ts
+++ b/src/types/agency.ts
@@ -7,7 +7,7 @@ export interface IAgency {
   logo: string
   created: Date
   lastModified?: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IAgencySchema extends IAgency, Document {}

--- a/src/types/agency.ts
+++ b/src/types/agency.ts
@@ -7,6 +7,7 @@ export interface IAgency {
   logo: string
   created: Date
   lastModified?: Date
+  _id: any
 }
 
 export interface IAgencySchema extends IAgency, Document {}

--- a/src/types/field/baseField.ts
+++ b/src/types/field/baseField.ts
@@ -22,7 +22,7 @@ export interface IField {
   disabled: boolean
   fieldType: BasicFieldType
   myInfo?: IMyInfo
-  _id: any
+  _id: Document['_id']
 }
 
 // Manual override since mongoose types don't have generics yet.

--- a/src/types/field/baseField.ts
+++ b/src/types/field/baseField.ts
@@ -22,6 +22,7 @@ export interface IField {
   disabled: boolean
   fieldType: BasicFieldType
   myInfo?: IMyInfo
+  _id: any
 }
 
 // Manual override since mongoose types don't have generics yet.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -93,7 +93,7 @@ export interface IForm {
 
   responseMode: ResponseMode
 
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IFormSchema extends IForm, Document {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -92,6 +92,8 @@ export interface IForm {
   msgSrvcName?: string
 
   responseMode: ResponseMode
+
+  _id: any
 }
 
 export interface IFormSchema extends IForm, Document {

--- a/src/types/form_feedback.ts
+++ b/src/types/form_feedback.ts
@@ -8,6 +8,7 @@ export interface IFormFeedback {
   comment: string
   created: Date
   lastModified?: Date
+  _id: any
 }
 
 export interface IFormFeedbackSchema extends Document {}

--- a/src/types/form_feedback.ts
+++ b/src/types/form_feedback.ts
@@ -8,7 +8,7 @@ export interface IFormFeedback {
   comment: string
   created: Date
   lastModified?: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IFormFeedbackSchema extends Document {}

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -36,7 +36,7 @@ export interface IConditionSchema extends ICondition, Document {
 export interface ILogic {
   conditions: IConditionSchema[]
   logicType: LogicType
-  _id: any
+  _id: Document['_id']
 }
 
 export interface ILogicSchema extends ILogic, Document {}

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -36,6 +36,7 @@ export interface IConditionSchema extends ICondition, Document {
 export interface ILogic {
   conditions: IConditionSchema[]
   logicType: LogicType
+  _id: any
 }
 
 export interface ILogicSchema extends ILogic, Document {}

--- a/src/types/form_statistics_total.ts
+++ b/src/types/form_statistics_total.ts
@@ -3,6 +3,7 @@ import { Document } from 'mongoose'
 export interface IFormStatisticsTotal {
   totalCount: number
   lastSubmission: Date
+  _id: any
 }
 
 export interface IFormStatisticsTotalSchema

--- a/src/types/form_statistics_total.ts
+++ b/src/types/form_statistics_total.ts
@@ -3,7 +3,7 @@ import { Document } from 'mongoose'
 export interface IFormStatisticsTotal {
   totalCount: number
   lastSubmission: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IFormStatisticsTotalSchema

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -11,6 +11,7 @@ export interface ILogin {
   authType: AuthType
   esrvcId: string
   created: Date
+  _id: any
 }
 
 export interface ILoginSchema extends ILogin, Document {}

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -11,7 +11,7 @@ export interface ILogin {
   authType: AuthType
   esrvcId: string
   created: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface ILoginSchema extends ILogin, Document {}

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -13,7 +13,7 @@ interface IMyInfoHash {
   fields: IHashes
   expireAt: Date
   created: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IMyInfoHashSchema extends IMyInfoHash, Document {}

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -13,6 +13,7 @@ interface IMyInfoHash {
   fields: IHashes
   expireAt: Date
   created: Date
+  _id: any
 }
 
 export interface IMyInfoHashSchema extends IMyInfoHash, Document {}

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -30,6 +30,7 @@ export interface ISmsCount {
   logType: LogType
   smsType: SmsType
   createdAt?: Date
+  _id: any
 }
 
 export interface ISmsCountSchema extends ISmsCount, Document {}

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -30,7 +30,7 @@ export interface ISmsCount {
   logType: LogType
   smsType: SmsType
   createdAt?: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface ISmsCountSchema extends ISmsCount, Document {}

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -15,6 +15,7 @@ export interface ISubmission {
   submissionType: SubmissionType
   created: Date
   lastModified: Date
+  _id: any
 }
 
 export interface ISubmissionSchema extends ISubmission, Document {

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -15,7 +15,7 @@ export interface ISubmission {
   submissionType: SubmissionType
   created: Date
   lastModified: Date
-  _id: any
+  _id: Document['_id']
 }
 
 export interface ISubmissionSchema extends ISubmission, Document {

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -6,6 +6,7 @@ export interface IToken {
   expireAt: Date
   numOtpAttempts: number
   numOtpSent: number
+  _id: any
 }
 
 export interface ITokenSchema extends IToken, Document {}

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -6,7 +6,7 @@ export interface IToken {
   expireAt: Date
   numOtpAttempts: number
   numOtpSent: number
-  _id: any
+  _id: Document['_id']
 }
 
 export interface ITokenSchema extends IToken, Document {}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -9,6 +9,7 @@ export interface IUser {
   betaFlag?: {
     allowSms?: boolean
   }
+  _id: any
 }
 
 export interface IUserSchema extends IUser, Document {}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -9,7 +9,7 @@ export interface IUser {
   betaFlag?: {
     allowSms?: boolean
   }
-  _id: any
+  _id: Document['_id']
 }
 
 export interface IUserSchema extends IUser, Document {}


### PR DESCRIPTION
## Problem

We have two interfaces for each model, one for plain objects and one for Mongoose documents. For example, we have `IForm` for plain Form objects, and `IFormSchema` for documents retrieved from the database. However, none of our interfaces for plain objects include an `_id` key, despite the fact that all objects retrieved from the database have an `_id` key which we frequently access. This makes it difficult for us to write typed code for objects retrieved from the database, as every time we need to access the `_id` key, we have to create a union type.

## Solution

Add an `_id` key to all relevant interfaces. The following interfaces were excluded because we set `_id: false` in the schema:
- Form logo
- Custom form logo
- MyInfo schema (part of baseField)
- Columns in table fields

The disadvantage of this approach is that when declaring new documents to add to the database, we have to omit `_id` from the type, as can be seen in `sms_count.server.model.ts`. However, I think this is a tiny minority of cases compared to the number of cases where we need the `_id` key to be present.