### PR TITLE
feat(FormSchema): New indexes for form dashboard

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -487,6 +487,16 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     title: 'text',
   })
 
+  FormSchema.index({
+    'permissionList.email': 1,
+    lastModified: -1,
+  })
+
+  FormSchema.index({
+    admin: 1,
+    lastModified: -1,
+  })
+
   const FormModel = db.model<IFormSchema, IFormModel>(
     FORM_SCHEMA_ID,
     FormSchema,


### PR DESCRIPTION
## Problem

Slow queries in production for the dashboard page were the result of collection scans from a lack of relevant indexes on the form schema. The query logic requires that a form be loaded if the user is either an admin or collaborator.

## Solution

Create two indexes for each query - admin or collaborator as advised by the Mongo Performance Advisor.

