### PR TITLE
Release 4.30.2 - fix AWS endpoint and /emailnotifications log group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FormSG",
-  "version": "4.30.1",
+  "version": "4.30.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
-  "version": "4.30.1",
+  "version": "4.30.2",
   "homepage": "https://form.gov.sg",
   "authors": [
     "FormSG <formsg@data.gov.sg>"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -332,7 +332,7 @@ const awsConfig: AwsConfig = (function () {
   // Else, the environment variables to instantiate S3 are used.
   const awsEndpoint = isDev
     ? defaults.aws.endpoint
-    : `https://s3.${region}.amazonaws.com/`
+    : `https://s3.${region}.amazonaws.com`
 
   const logoBucketUrl = `${awsEndpoint}/${logoS3Bucket}`
   const imageBucketUrl = `${awsEndpoint}/${imageS3Bucket}`

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -332,11 +332,12 @@ const awsConfig: AwsConfig = (function () {
   // Else, the environment variables to instantiate S3 are used.
   const awsEndpoint = isDev
     ? defaults.aws.endpoint
-    : `https://s3.${region}.amazonaws.com`
+    : `https://s3.${region}.amazonaws.com` // NOTE NO TRAILING / AT THE END OF THIS URL!
 
   const logoBucketUrl = `${awsEndpoint}/${logoS3Bucket}`
   const imageBucketUrl = `${awsEndpoint}/${imageS3Bucket}`
-  const attachmentBucketUrl = `${awsEndpoint}/${attachmentS3Bucket}`
+  // NOTE THE TRAILING / AT THE END OF THIS URL! This is only for attachments!
+  const attachmentBucketUrl = `${awsEndpoint}/${attachmentS3Bucket}/`
 
   const s3 = new aws.S3({
     region,

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -6,11 +6,13 @@ import { v4 as uuidv4 } from 'uuid'
 import { format, LoggerOptions, loggers, transports } from 'winston'
 import WinstonCloudWatch from 'winston-cloudwatch'
 
-import { aws, customCloudWatchGroup } from './config'
+import defaults from './defaults'
 
-// Cannot use config's isDev due to logger being instantiated first, and
+// Cannot use config due to logger being instantiated first, and
 // having circular dependencies.
 const isDev = process.env.NODE_ENV === 'development'
+const customCloudWatchGroup = process.env.CUSTOM_CLOUDWATCH_LOG_GROUP
+const awsRegion = process.env.AWS_REGION || defaults.aws.region
 
 // Config to make winston logging like console logging, allowing multiple
 // arguments.
@@ -121,7 +123,7 @@ export const createCloudWatchLogger = (label: string) => {
         // not share sequence tokens. Hence generate a unique ID for each instance
         // of the logger.
         logStreamName: uuidv4(),
-        awsRegion: aws.region,
+        awsRegion,
         jsonMessage: true,
       }),
     ]


### PR DESCRIPTION
## Problem

1. In the current release, logs from our `/emailnotifications` endpoint are going to the main log group instead of the custom log group `formsg-email-notifications-production`. This means that our bounce alarms are on the wrong log group, and email logs are being stored for a year instead of a week as intended.

2. An extra trailing `/` was introduced to the AWS endpoint during the TypeScript migration, breaking all image, logo and attachment uploads and downloads.

## Solution

1. The problem was that during the TypeScript migration for `src/config/logger`, the AWS and CloudWatch environment variables were modified to be imported from `config` instead of taken directly from `process.env`. This caused them to be undefined because `config` depends on `logger`, resulting in a circular dependency. The solution is to get the env vars directly from `process.env` instead of importing them from `config`.

2. Removing the trailing `/`.