### PR TITLE
fix: update dependabot config to use v2 syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    commit_message:
+    commit-message:
       prefix: "fix"
-      prefix_development: "chore"
+      prefix-development: "chore"
       include: "scope"


### PR DESCRIPTION
This PR fixes dependabot errors due to using v1 syntax instead of the newer v2 syntax. :(

The config has now been tested with https://dependabot.com/docs/config-file/validator/ and is valid.