### PR TITLE
fix: phone validation now only accepts 8 digit #s starting with 8 or 9

### DIFF
--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -14,8 +14,12 @@ export const isPhoneNumber = (phoneNumber: string): boolean => {
 
   // Using length validation only for SG numbers due to some valid SG numbers
   // being marked as invalid due to its newness.
+  // Regex checks if the national number starts with 8 or 9, and is of length 8.
   if (parsedNumber.countryCallingCode === '65') {
-    return parsedNumber.isPossible() && parsedNumber.nationalNumber.length === 8
+    return (
+      parsedNumber.isPossible() &&
+      !!parsedNumber.nationalNumber.match(/^[89][0-9]{7}$/g)
+    )
   }
   return parsedNumber.isValid()
 }

--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -12,14 +12,10 @@ export const isPhoneNumber = (phoneNumber: string): boolean => {
     return false
   }
 
-  // Using length validation only for SG numbers due to some valid SG numbers
+  // Using isPossible() only for SG numbers due to some valid SG numbers
   // being marked as invalid due to its newness.
-  // Regex checks if the national number starts with 8 or 9, and is of length 8.
   if (parsedNumber.countryCallingCode === '65') {
-    return (
-      parsedNumber.isPossible() &&
-      !!parsedNumber.nationalNumber.match(/^[89][0-9]{7}$/g)
-    )
+    return parsedNumber.isPossible()
   }
   return parsedNumber.isValid()
 }
@@ -34,14 +30,21 @@ export const isMobilePhoneNumber = (mobileNumber: string): boolean => {
 
   if (!parsedNumber) return false
 
+  if (parsedNumber.countryCallingCode === '65') {
+    return (
+      isPhoneNumber(mobileNumber) &&
+      // Regex checks if the national number starts with 8 or 9, and is of
+      // length 8.
+      !!parsedNumber.nationalNumber.match(/^[89][0-9]{7}$/g)
+    )
+  }
+
+  // All other countries uses number type to check for validity.
   return (
     isPhoneNumber(mobileNumber) &&
-    // Have to include both MOBILE, FIXED_LINE_OR_MOBILE and unknown (as
-    // `undefined`) as some countries lump the types together, or the number is
-    // too new (in SG's case).
-    ['FIXED_LINE_OR_MOBILE', 'MOBILE', undefined].includes(
-      parsedNumber.getType(),
-    )
+    // Have to include both MOBILE, FIXED_LINE_OR_MOBILE as some countries lump
+    // the types together.
+    ['FIXED_LINE_OR_MOBILE', 'MOBILE'].includes(parsedNumber.getType())
   )
 }
 


### PR DESCRIPTION
## Problem

This PR adds an even strong mobile validation (only for Singapore numbers). SG phone number validation now only accepts 8 digit numbers starting with `8` or `9` using a regex match: 
```ts
nationalNumber.match(/^[89][0-9]{7}$/g)
```

Closes #100

## Solution

**Bug Fixes**:

- Increases mobile validation strength by also validating the start of the number in addition to the number length.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2020-08-06 at 6 18 53 PM](https://user-images.githubusercontent.com/22133008/89521002-50364900-d811-11ea-8e84-f75e0d7da7aa.png)
![Screenshot 2020-08-06 at 6 18 48 PM](https://user-images.githubusercontent.com/22133008/89521010-51677600-d811-11ea-86c5-4ada91c54cf7.png)
![Screenshot 2020-08-06 at 6 18 42 PM](https://user-images.githubusercontent.com/22133008/89521012-52000c80-d811-11ea-8b1e-5f828691a567.png)


**AFTER**:
![Screenshot 2020-08-06 at 6 14 46 PM](https://user-images.githubusercontent.com/22133008/89520917-2e3cc680-d811-11ea-9146-034d794839ef.png)
![Screenshot 2020-08-06 at 6 14 38 PM](https://user-images.githubusercontent.com/22133008/89520920-2f6df380-d811-11ea-8fe3-ee9c88ce22cb.png)
![Screenshot 2020-08-06 at 6 14 29 PM](https://user-images.githubusercontent.com/22133008/89520923-30068a00-d811-11ea-936e-400a1a572d62.png)
![Screenshot 2020-08-06 at 6 27 41 PM](https://user-images.githubusercontent.com/22133008/89521693-8cb67480-d812-11ea-97df-429c16c44836.png)

