### PR TITLE
fix: fix myInfoError typo

### DIFF
--- a/src/public/modules/forms/base/views/submit-form.client.view.html
+++ b/src/public/modules/forms/base/views/submit-form.client.view.html
@@ -21,7 +21,7 @@
     <submit-form-directive
       form="vm.myform"
       logo-url="vm.logoUrl"
-      myinfo-error="vm.myInfoError"
+      my-info-error="vm.myInfoError"
     ></submit-form-directive>
   </div>
 </section>


### PR DESCRIPTION
## Problem

In the case of a MyInfo error, the form fields are being shown instead of the error message.

## Solution

The issue is that the submit form controller is passing `vm.myInfoError` to the submit form directive via an attribute called `myinfo-error`, whereas the submit form directive is reading it as `myInfoError` (note uppercase I) instead of `myinfoError` (note lowercase i). The solution is to change the attribute to `my-info-error` (note extra hyphen) so it can be read correctly as `myInfoError`(note uppercase I).

## Screenshots
The following screenshots are after setting `myInfoError` to `true` in `SubmitFormController`.

### Before
![image](https://user-images.githubusercontent.com/29480346/89861064-7b38e800-dbd7-11ea-91c0-c9bedfd8eb48.png)

### After
![image](https://user-images.githubusercontent.com/29480346/89861070-7ffd9c00-dbd7-11ea-9246-509c0ce169e6.png)
