### PR TITLE
feat: remove unused mongoTimestamp plugin

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import { PackageMode } from '@opengovsg/formsg-sdk/dist/types'
 import aws from 'aws-sdk'
 import crypto from 'crypto'
 import { SessionOptions } from 'express-session'
-import { ConnectionOptions, Schema } from 'mongoose'
+import { ConnectionOptions } from 'mongoose'
 import nodemailer from 'nodemailer'
 import directTransport from 'nodemailer-direct-transport'
 import Mail from 'nodemailer/lib/mailer'
@@ -81,7 +81,6 @@ type Config = {
   // Functions
   configureAws: () => Promise<void>
   otpGenerator: () => string
-  mongoTimestamp: (schema: Schema, options: any) => void
 }
 
 // Enums
@@ -409,43 +408,6 @@ const otpGenerator = () => {
   return value.join('')
 }
 
-// TODO(#2505): Remove this once no models rely on this and use mongoose's own
-// timestamps.
-/**
- * Generates created and last modified fields for several mongo models.
- * Taken from mongoose-utilities's timestamp function.
- * Should really be inside a utils.js file.
- * @param  schema  Mongoose schema
- * @param  options Dictionary of created and modified
- */
-const mongoTimestamp = (schema: Schema, options: any) => {
-  options || (options = {})
-
-  // Options
-  let fields = {}
-  let createdPath = options.createdPath || 'created'
-  let modifiedPath = options.modifiedPath || 'modified'
-
-  // Add paths to schema if not present
-  if (!schema.paths[createdPath]) {
-    fields[modifiedPath] = { type: Date }
-  }
-  if (!schema.paths[createdPath]) {
-    fields[createdPath] = {
-      type: Date,
-      default: Date.now,
-    }
-  }
-
-  schema.add(fields)
-
-  // Update the modified timestamp on save
-  schema.pre('save', function (next) {
-    this[modifiedPath] = new Date()
-    return next()
-  })
-}
-
 const config: Config = {
   app: appConfig,
   db: dbConfig,
@@ -468,7 +430,6 @@ const config: Config = {
   adminBannerContent,
   configureAws,
   otpGenerator,
-  mongoTimestamp,
 }
 
 export = config


### PR DESCRIPTION
## Problem

This PR removes the now unused mongoTimestamp plugin, since we have mongoose's own timestamp plugin.

