### PR TITLE
feat: show error upon FileReader failure

### DIFF
--- a/src/public/modules/forms/base/componentViews/field-attachment.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-attachment.client.view.html
@@ -45,10 +45,10 @@
         ngf-select="vm.uploadFile($file, $invalidFiles, vm.field._id)"
         ng-model="vm.field.fieldValue"
       />
-      <span ng-if="vm.buttonResizing[vm.field._id]">
+      <span ng-if="vm.isLoading">
         <i class="bx bx-loader bx-spin bx-md icon-spacing"></i>Loading...
       </span>
-      <span ng-if="!vm.buttonResizing[vm.field._id]">
+      <span ng-if="!vm.isLoading">
         <i class="fa fa-cloud-upload attachment-upload"></i>Upload File
       </span>
     </label>

--- a/src/public/modules/forms/base/componentViews/field-attachment.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-attachment.client.view.html
@@ -34,6 +34,7 @@
         id="{{ vm.field._id || 'defaultID' }}"
         type="file"
         class="attachment-upload-input"
+        ng-class="vm.isLoading ? btn-pressed : ''"
         name="{{ vm.field._id || 'defaultID' }}"
         ng-required="vm.field.required"
         ngf-before-model-change="vm.beforeResizingImages(vm.field._id)"

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -105,7 +105,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
       $timeout(() => {
         showAttachmentError(
           'Upload failed. If you are using online storage such as Google Drive, ' +
-          'download your file from storage then attach the downloaded version'
+          'download your file before attaching the downloaded version.'
         )
       })
     }

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -23,15 +23,13 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
   }
 
   vm.fileAttached = false
-
-  // Used to store fieldIds that are currently resizing
-  vm.buttonResizing = {}
+  vm.isLoading = false
   vm.beforeResizingImages = function (fieldId) {
-    vm.buttonResizing[fieldId] = true
+    vm.isLoading = true
     $('#' + fieldId).addClass('btn-pressed')
   }
   vm.uploadFile = function (file, errFiles, fieldId) {
-    delete vm.buttonResizing[fieldId]
+    vm.isLoading = false
     $('#' + fieldId).removeClass('btn-pressed')
     let err
     if (errFiles.length > 0) {
@@ -93,7 +91,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
 
   vm.attachmentIsDisabled = (field) => {
     return (
-      (vm.isadminpreview && !vm.buttonResizing[field._id]) || field.disabled
+      (vm.isadminpreview && !vm.isLoading) || field.disabled
     )
   }
 

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -29,7 +29,6 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
     $('#' + fieldId).addClass('btn-pressed')
   }
   vm.uploadFile = function (file, errFiles, fieldId) {
-    vm.isLoading = false
     $('#' + fieldId).removeClass('btn-pressed')
     let err
     if (errFiles.length > 0) {
@@ -133,6 +132,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
         } else {
           vm.fileSize = String((file.size / 1000).toFixed(2)) + ' KB'
         }
+        vm.isLoading = false
       })
     }
     reader.readAsArrayBuffer(file)
@@ -146,5 +146,6 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
     vm.fileError = message
     vm.field.fieldValue = ''
     vm.fileAttached = false
+    vm.isLoading = false
   }
 }

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -98,6 +98,9 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
   const saveFileToField = (file) => {
     const reader = new FileReader()
 
+    // Context: Android file picker gives an option to upload files directly
+    // from Google Drive, but those cause errors with FileReader and
+    // XMLHttpRequest.
     reader.onerror = () => {
       $timeout(() => {
         showAttachmentError(

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -68,16 +68,6 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
             const stringOfInvalidExtensions = invalidFiles.join(', ')
             showAttachmentError(`The following file extensions in your zip are not valid: ${stringOfInvalidExtensions}`)
           } else {
-            vm.fileAttached = true
-            vm.fileError = false
-            vm.fileName = file.name
-            vm.field.fieldValue = file.name
-            vm.fileSize = file.size / 1000
-            if (file.size / 1000 > 1000) {
-              vm.fileSize = String((file.size / 1000000).toFixed(2)) + ' MB'
-            } else {
-              vm.fileSize = String((file.size / 1000).toFixed(2)) + ' KB'
-            }
             saveFileToField(file)
           }
         })
@@ -112,16 +102,29 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
     const reader = new FileReader()
 
     reader.onload = function (e) {
-      const blob = new Blob([new Uint8Array(e.target.result)], {
-        type: file.type,
+      $timeout(() => {
+        const blob = new Blob([new Uint8Array(e.target.result)], {
+          type: file.type,
+        })
+
+        // Not using File constructor because IE11 does not support File
+        blob.name = file.name
+        blob.lastModifiedDate = file.lastModifiedDate
+
+        // Assign it to the field.
+        vm.field.file = blob
+
+        vm.fileAttached = true
+        vm.fileError = false
+        vm.fileName = file.name
+        vm.field.fieldValue = file.name
+        vm.fileSize = file.size / 1000
+        if (file.size / 1000 > 1000) {
+          vm.fileSize = String((file.size / 1000000).toFixed(2)) + ' MB'
+        } else {
+          vm.fileSize = String((file.size / 1000).toFixed(2)) + ' KB'
+        }
       })
-
-      // Not using File constructor because IE11 does not support File
-      blob.name = file.name
-      blob.lastModifiedDate = file.lastModifiedDate
-
-      // Assign it to the field.
-      vm.field.file = blob
     }
     reader.readAsArrayBuffer(file)
   }
@@ -133,5 +136,6 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
   const showAttachmentError = (message) => {
     vm.fileError = message
     vm.field.fieldValue = ''
+    vm.fileAttached = false
   }
 }

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -101,6 +101,15 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
   const saveFileToField = (file) => {
     const reader = new FileReader()
 
+    reader.onerror = () => {
+      $timeout(() => {
+        showAttachmentError(
+          'Upload failed. If you are using online storage such as Google Drive, ' +
+          'download your file from storage then attach the downloaded version'
+        )
+      })
+    }
+
     reader.onload = function (e) {
       $timeout(() => {
         const blob = new Blob([new Uint8Array(e.target.result)], {

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -26,10 +26,8 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
   vm.isLoading = false
   vm.beforeResizingImages = function (fieldId) {
     vm.isLoading = true
-    $('#' + fieldId).addClass('btn-pressed')
   }
   vm.uploadFile = function (file, errFiles, fieldId) {
-    $('#' + fieldId).removeClass('btn-pressed')
     let err
     if (errFiles.length > 0) {
       err = errFiles[0].$error

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -105,7 +105,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
       $timeout(() => {
         showAttachmentError(
           'Upload failed. If you are using online storage such as Google Drive, ' +
-          'download your file before attaching the downloaded version.'
+          'download your file before attaching the downloaded version'
         )
       })
     }

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -122,11 +122,11 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
 
         // Assign it to the field.
         vm.field.file = blob
+        vm.field.fieldValue = file.name
 
         vm.fileAttached = true
         vm.fileError = false
         vm.fileName = file.name
-        vm.field.fieldValue = file.name
         vm.fileSize = file.size / 1000
         if (file.size / 1000 > 1000) {
           vm.fileSize = String((file.size / 1000000).toFixed(2)) + ' MB'

--- a/src/public/modules/forms/base/components/field-attachment.client.component.js
+++ b/src/public/modules/forms/base/components/field-attachment.client.component.js
@@ -37,17 +37,13 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
     if (errFiles.length > 0) {
       err = errFiles[0].$error
       if (err === 'maxSize') {
-        vm.fileError =
-          String((errFiles[0].size / 1000000).toFixed(2)) +
-          ' MB / ' +
-          vm.field.attachmentSize +
-          ' MB: File size exceeded'
+        const currentSize = (errFiles[0].size / 1000000).toFixed(2)
+        showAttachmentError(`${currentSize} MB / ${vm.field.attachmentSize} MB: File size exceeded`)
       } else if (err === 'resize') {
-        vm.fileError = `An error has occurred while resizing your image`
+        showAttachmentError(`An error has occurred while resizing your image`)
       } else {
-        vm.fileError = err
+        showAttachmentError(err)
       }
-      vm.field.fieldValue = ''
       return
     }
 
@@ -55,9 +51,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
 
     let fileExt = FileHandler.getFileExtension(file.name)
     if (FileHandler.isInvalidFileExtension(fileExt)) {
-      vm.fileError =
-        "Your file's extension ending in *" + fileExt + ' is not allowed'
-      vm.field.fieldValue = ''
+      showAttachmentError(`Your file's extension ending in *${fileExt} is not allowed`)
       return
     }
 
@@ -74,10 +68,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
         $timeout(() => {
           if (invalidFiles.length > 0) {
             const stringOfInvalidExtensions = invalidFiles.join(', ')
-            vm.fileError =
-              'The following file extensions in your zip are not valid: ' +
-              stringOfInvalidExtensions
-            vm.field.fieldValue = ''
+            showAttachmentError(`The following file extensions in your zip are not valid: ${stringOfInvalidExtensions}`)
           } else {
             vm.fileAttached = true
             vm.fileError = false
@@ -95,8 +86,7 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
       })
       .catch(() => {
         $timeout(() => {
-          vm.fileError = 'An error has occurred while parsing your zip file'
-          vm.field.fieldValue = ''
+          showAttachmentError('An error has occurred while parsing your zip file')
         })
       })
   }
@@ -136,5 +126,14 @@ function attachmentFieldComponentController(FileHandler, $timeout) {
       vm.field.file = blob
     }
     reader.readAsArrayBuffer(file)
+  }
+
+  /**
+   * Shows an error message and erases file.
+   * @param {string} message Error message to show. Should not include period as period is hardcoded in view.
+   */
+  const showAttachmentError = (message) => {
+    vm.fileError = message
+    vm.field.fieldValue = ''
   }
 }


### PR DESCRIPTION
## Problem

We have a high frequency of "Required but no attachment content" validation errors from attachment fields, meaning the user and the frontend think that the attachment was uploaded successfully, but the backend discovers that the attachment content is actually missing. These errors occur almost exclusively on Android phones.

Closes #23 

## Solution

The error occurs when the user attempts to upload a file directly from Google Drive. The UI behaves as if the file has been uploaded correctly, but in fact `FileReader` has failed silently because we have not set an error handler on it.

The ideal solution would be to fix file uploads from Google Drive, but this is unlikely to be straightforward and likely to introduce a lot of special cases in the code since Google Drive files clearly behave differently from files in the local file system.

Hence this solution does two things:
1. Adds an error handler which prompts the user to download their file first if they are using Google Drive.
2. Only shows that the file was uploaded successfully if the file was saved as a blob successfully. This makes sense because the upload is really only successful after we have set `vm.field.file`. It also prevents situations where the UI first behaves as if the attachment was successful, then suddenly flips to an error when `FileReader.onerror` is called.

I also took the opportunity to introduce a few small refactors to simplify the attachment component.

## Screenshots
<img width="448" alt="Screenshot 2020-08-11 at 10 48 47 PM" src="https://user-images.githubusercontent.com/29480346/89912180-d47b3880-dc24-11ea-9cce-1a07f7641612.png">

## Tests
- [ ] Upload an attachment from Google Drive on an Android phone. The error should show as per the screenshot.
- [ ] On both desktop and mobile, upload a valid attachment. The UI should behave correctly. Make sure that this works for .zip files.
- [ ] On both desktop and mobile, upload an attachment which exceeds the maximum allowed size. You should see the correct error message, and you should subsequently be able to upload a valid attachment and submit the form.
- [ ] On both desktop and mobile, upload an attachment of an invalid file type (e.g. .js). You should see the correct error message, and you should subsequently be able to upload a valid attachment and submit the form.