### PR TITLE
chore: add --watch flag back to build-frontend-dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run build-backend && npm run build-frontend",
     "build-backend": "tsc -p tsconfig.build.json",
     "build-frontend": "webpack --config webpack.prod.js",
-    "build-frontend-dev": "webpack --config webpack.dev.js",
+    "build-frontend-dev": "webpack --config webpack.dev.js --watch",
     "start": "node dist/backend/server.js",
     "dev": "docker-compose up --build",
     "docker-dev": "npm run build-frontend-dev & ts-node-dev --respawn --transpileOnly --inspect=0.0.0.0 -- src/server.ts",


### PR DESCRIPTION
## Problem

Certain refactorings seem to have removed the webpack watch flag from the `build-frontend-dev` script.

This PR adds it back.
