### PR TITLE
feat: Bulk download of storage mode attachments in a zip file

### DIFF
--- a/src/public/modules/forms/admin/components/response-components/response-attachment.client.component.js
+++ b/src/public/modules/forms/admin/components/response-components/response-attachment.client.component.js
@@ -8,7 +8,11 @@ angular.module('forms').component('responseAttachmentComponent', {
     encryptionKey: '<',
   },
   controllerAs: 'vm',
-  controller: ['Submissions', '$timeout', responseAttachmentComponentController],
+  controller: [
+    'Submissions',
+    '$timeout',
+    responseAttachmentComponentController,
+  ],
 })
 
 function responseAttachmentComponentController(Submissions, $timeout) {
@@ -16,7 +20,10 @@ function responseAttachmentComponentController(Submissions, $timeout) {
 
   vm.downloadAndDecryptAttachment = function () {
     vm.hasDownloadError = false
-    Submissions.downloadAndDecryptAttachment(vm.field.downloadUrl, vm.encryptionKey.secretKey)
+    Submissions.downloadAndDecryptAttachment(
+      vm.field.downloadUrl,
+      vm.encryptionKey.secretKey,
+    )
       .then((bytesArray) => {
         // Construct a downloadable link and click on it to download the file
         let blob = new Blob([bytesArray])

--- a/src/public/modules/forms/admin/components/response-components/response-attachment.client.component.js
+++ b/src/public/modules/forms/admin/components/response-components/response-attachment.client.component.js
@@ -1,5 +1,4 @@
 const { triggerFileDownload } = require('../../../helpers/util')
-const { decode: decodeBase64 } = require('@stablelib/base64')
 
 angular.module('forms').component('responseAttachmentComponent', {
   templateUrl:
@@ -9,23 +8,15 @@ angular.module('forms').component('responseAttachmentComponent', {
     encryptionKey: '<',
   },
   controllerAs: 'vm',
-  controller: ['FormSgSdk', '$timeout', responseAttachmentComponentController],
+  controller: ['Submissions', '$timeout', responseAttachmentComponentController],
 })
 
-function responseAttachmentComponentController(FormSgSdk, $timeout) {
+function responseAttachmentComponentController(Submissions, $timeout) {
   const vm = this
 
   vm.downloadAndDecryptAttachment = function () {
     vm.hasDownloadError = false
-    fetch(vm.field.downloadUrl)
-      .then((response) => response.json())
-      .then((data) => {
-        data.encryptedFile.binary = decodeBase64(data.encryptedFile.binary)
-        return FormSgSdk.crypto.decryptFile(
-          vm.encryptionKey.secretKey,
-          data.encryptedFile,
-        )
-      })
+    Submissions.downloadAndDecryptAttachment(vm.field.downloadUrl, vm.encryptionKey.secretKey)
       .then((bytesArray) => {
         // Construct a downloadable link and click on it to download the file
         let blob = new Blob([bytesArray])

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -237,7 +237,7 @@ function ViewResponsesController(
 
     Promise.all(downloadPromises).then((promises) => {
       zip.generateAsync({type: 'blob'}).then((blob) => {
-        triggerFileDownload(blob, 'Response ' + vm.tableParams.data[vm.currentResponse.index].refNo + '.zip')
+        triggerFileDownload(blob, 'RefNo ' + vm.tableParams.data[vm.currentResponse.index].refNo + '.zip')
       })
     }).catch((error) => {
       console.error(error)

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -204,7 +204,7 @@ function ViewResponsesController(
           }
           // Populate S3 presigned URL for attachments
           if (attachmentMetadata[field._id]) {
-            vm.attachmentDownloadUrls.set(field.questionNumber, {url: attachmentMetadata[field._id], filename: field.answer})
+            vm.attachmentDownloadUrls.set(questionCount - 1, {url: attachmentMetadata[field._id], filename: field.answer})
             field.downloadUrl = attachmentMetadata[field._id]
           }
         })

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -204,7 +204,10 @@ function ViewResponsesController(
           }
           // Populate S3 presigned URL for attachments
           if (attachmentMetadata[field._id]) {
-            vm.attachmentDownloadUrls.set(questionCount - 1, {url: attachmentMetadata[field._id], filename: field.answer})
+            vm.attachmentDownloadUrls.set(questionCount - 1, {
+              url: attachmentMetadata[field._id],
+              filename: field.answer,
+            })
             field.downloadUrl = attachmentMetadata[field._id]
           }
         })
@@ -220,29 +223,41 @@ function ViewResponsesController(
     })
   }
 
-  vm.downloadAllAttachments = function() {
-    var zip = new JSZip();
+  vm.downloadAllAttachments = function () {
+    var zip = new JSZip()
     let downloadPromises = []
 
     for (const [questionNum, metadata] of vm.attachmentDownloadUrls) {
       downloadPromises.push(
         Submissions.downloadAndDecryptAttachment(
           metadata.url,
-          vm.encryptionKey.secretKey
+          vm.encryptionKey.secretKey,
         ).then((bytesArray) => {
-          zip.file('Question ' + questionNum + ' - ' + metadata.filename, bytesArray)
-        })
+          zip.file(
+            'Question ' + questionNum + ' - ' + metadata.filename,
+            bytesArray,
+          )
+        }),
       )
     }
 
-    Promise.all(downloadPromises).then((promises) => {
-      zip.generateAsync({type: 'blob'}).then((blob) => {
-        triggerFileDownload(blob, 'RefNo ' + vm.tableParams.data[vm.currentResponse.index].refNo + '.zip')
+    Promise.all(downloadPromises)
+      .then(() => {
+        zip.generateAsync({ type: 'blob' }).then((blob) => {
+          triggerFileDownload(
+            blob,
+            'RefNo ' +
+              vm.tableParams.data[vm.currentResponse.index].refNo +
+              '.zip',
+          )
+        })
       })
-    }).catch((error) => {
-      console.error(error)
-      Toastr.error('An error occurred while downloading the attachments in a ZIP file. Try downloading them separately.')
-    })
+      .catch((error) => {
+        console.error(error)
+        Toastr.error(
+          'An error occurred while downloading the attachments in a ZIP file. Try downloading them separately.',
+        )
+      })
   }
 
   vm.nextRespondent = function () {

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -3,7 +3,6 @@
 const processDecryptedContent = require('../../helpers/process-decrypted-content')
 const { triggerFileDownload } = require('../../helpers/util')
 const JSZip = require('jszip')
-const { decode: decodeBase64 } = require('@stablelib/base64')
 
 const SHOW_PROGRESS_DELAY_MS = 3000
 

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -455,8 +455,15 @@
   padding: 30px 25px;
 }
 
-#responses-tab #detailed-responses #respondent-timestamp div.row:first-child {
+#responses-tab
+  #detailed-responses
+  #respondent-timestamp
+  div.row:not(:last-child) {
   padding-bottom: 10px;
+}
+
+#responses-tab #detailed-responses #respondent-timestamp a {
+  cursor: pointer;
 }
 
 #responses-tab #detailed-responses #question-answer-grp {

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -168,6 +168,15 @@
             {{ vm.decryptedResponse.submissionTime }}
           </div>
         </div>
+        <div class="row" ng-if="vm.attachmentDownloadUrls.size > 0">
+          <div class="col-xs-12 col-sm-4"><b>Attachments</b></div>
+          <div class="col-xs-12 col-sm-8">
+            <a ng-click="vm.downloadAllAttachments()"
+              >Download {{ vm.attachmentDownloadUrls.size }} Attachment(s) in
+              ZIP</a
+            >
+          </div>
+        </div>
       </div>
 
       <div id="question-answer-grp">


### PR DESCRIPTION
## Problem

Users have complained that managing high volume forms with lots of attachments is hard.

## Solution

This adds a feature which allows users to download all attachments from a particular respondent with one click. The download attachment link will only show up when there is at least one attachment in the submission.

## Screenshots

![image](https://user-images.githubusercontent.com/691628/90326699-4498ff80-df40-11ea-9aff-b5bc2233baeb.png)
