### PR TITLE
feat: mailto link for secret key

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -468,5 +468,16 @@ function GTag($rootScope, $window) {
     })
   }
 
+  /**
+   * Logs clicking on mailto link to share form secret key with collaborators.
+   */
+  gtagService.clickSecretKeyMailto = (formTitle) => {
+    _gtagEvents('storage', {
+      event_category: 'Storage Mode Form',
+      event_action: 'Secret key mailto clicked',
+      event_label: formTitle
+    })
+  }
+
   return gtagService
 }

--- a/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
@@ -321,6 +321,10 @@ function CreateFormModalController(
       )
   }
 
+  vm.handleMailToClick = () => {
+    GTag.clickSecretKeyMailto(vm.formData.title)
+  }
+
   // Whether user has copied secret key
   vm.isCopied = false
   vm.copied = () => {

--- a/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
@@ -2,6 +2,7 @@
 const { triggerFileDownload } = require('../../helpers/util')
 const { templates } = require('../constants/covid19')
 const Form = require('../../viewmodels/Form.class')
+const dedent = require('dedent-js')
 
 /**
  * Determine the form title when duplicating a form
@@ -33,6 +34,7 @@ angular
     '$state',
     '$timeout',
     '$uibModal',
+    '$window',
     'Toastr',
     'responseModeEnum',
     'createFormModalOptions',
@@ -50,6 +52,7 @@ function CreateFormModalController(
   $state,
   $timeout,
   $uibModal,
+  $window,
   Toastr,
   responseModeEnum,
   createFormModalOptions,
@@ -221,6 +224,7 @@ function CreateFormModalController(
         const { publicKey, secretKey } = FormSgSdk.crypto.generate()
         vm.publicKey = publicKey
         vm.secretKey = secretKey
+        vm.mailToUri = generateMailToUri(vm.formData.title, secretKey)
         vm.formStatus = 3
       })
     } else if (
@@ -295,6 +299,26 @@ function CreateFormModalController(
     } else {
       Toastr.error('An error occurred creating the form, please try again')
     }
+  }
+
+  const generateMailToUri = (title, secretKey) => {
+    return 'mailto:?subject=' +
+      $window.encodeURIComponent(`Shared Secret Key for ${title}`) +
+      '&body=' +
+      $window.encodeURIComponent(
+        dedent`
+          Dear collaborator,
+
+          I am sharing my form's secret key with you for safekeeping and backup. This is an important key that is needed to access all form responses.
+
+          Form title: ${title}
+          Secret key: ${secretKey}
+
+          All you need to do is keep this email as a record, and please do not share this key with anyone else.
+
+          Thank you for helping to safekeep my form!
+        `
+      )
   }
 
   // Whether user has copied secret key

--- a/src/public/modules/forms/admin/css/pop-up-modal.css
+++ b/src/public/modules/forms/admin/css/pop-up-modal.css
@@ -196,3 +196,7 @@
   content: '-';
   margin-right: 0.5em;
 }
+
+#create-form-modal .secret-key-safekeeping a {
+  color: #2f60ce;
+}

--- a/src/public/modules/forms/admin/css/pop-up-modal.css
+++ b/src/public/modules/forms/admin/css/pop-up-modal.css
@@ -174,3 +174,25 @@
   display: block;
   margin: 0 auto;
 }
+
+#create-form-modal .secret-key-safekeeping.alert-custom {
+  display: flex;
+  padding: 14px 16px;
+  line-height: 1.39;
+}
+
+#create-form-modal .secret-key-safekeeping i {
+  padding-top: 4px;
+  padding-right: 16px;
+}
+
+#create-form-modal .secret-key-safekeeping ul {
+  list-style-type: none;
+  padding-left: 0;
+  padding-top: 0.5em;
+}
+
+#create-form-modal .secret-key-safekeeping li::before {
+  content: '-';
+  margin-right: 0.5em;
+}

--- a/src/public/modules/forms/admin/css/pop-up-modal.css
+++ b/src/public/modules/forms/admin/css/pop-up-modal.css
@@ -193,7 +193,8 @@
 }
 
 #create-form-modal .secret-key-safekeeping li::before {
-  content: '-';
+  /* Add a space here because otherwise there's a weird spacing before the first word */
+  content: '- ';
   margin-right: 0.5em;
 }
 

--- a/src/public/modules/forms/admin/views/create-form.client.modal.html
+++ b/src/public/modules/forms/admin/views/create-form.client.modal.html
@@ -121,7 +121,10 @@
                 >(guide)</a
               >
               <ul>
-                <li>Email your secret key to collaborators for safekeeping</li>
+                <li>
+                  <a ng-href="{{ vm.mailToUri }}" target="_blank">Email</a> your
+                  secret key to collaborators for safekeeping
+                </li>
                 <li>Organise multiple keys in a spreadsheet</li>
               </ul>
             </span>

--- a/src/public/modules/forms/admin/views/create-form.client.modal.html
+++ b/src/public/modules/forms/admin/views/create-form.client.modal.html
@@ -110,13 +110,22 @@
           </span>
         </div>
         <br />
-        <div>
-          <a
-            translate-attr="{ href: 'LINKS.GUIDE.SECRET_KEY_SAFEKEEPING' }"
-            target="_blank"
-            >Secret key safekeeping</a
-          >: Email your secret key to colleagues for safekeeping, or organize
-          multiple keys in a spreadsheet.
+        <div class="alert-custom alert-info secret-key-safekeeping">
+          <i class="bx bx-error-circle"></i>
+          <div class="alert-msg">
+            <span class="alert-content">
+              <b>Ways to safekeep</b>
+              <a
+                translate-attr="{ href: 'LINKS.GUIDE.SECRET_KEY_SAFEKEEPING' }"
+                target="_blank"
+                >(guide)</a
+              >
+              <ul>
+                <li>Email your secret key to collaborators for safekeeping</li>
+                <li>Organise multiple keys in a spreadsheet</li>
+              </ul>
+            </span>
+          </div>
         </div>
       </div>
       <div class="same-width-container">

--- a/src/public/modules/forms/admin/views/create-form.client.modal.html
+++ b/src/public/modules/forms/admin/views/create-form.client.modal.html
@@ -122,8 +122,13 @@
               >
               <ul>
                 <li>
-                  <a ng-href="{{ vm.mailToUri }}" target="_blank">Email</a> your
-                  secret key to collaborators for safekeeping
+                  <a
+                    ng-href="{{ vm.mailToUri }}"
+                    target="_blank"
+                    ng-click="vm.handleMailToClick()"
+                    >Email</a
+                  >
+                  your secret key to collaborators for safekeeping
                 </li>
                 <li>Organise multiple keys in a spreadsheet</li>
               </ul>


### PR DESCRIPTION
## Problem

People lose their secret keys, thus losing all responses.

Addresses #9, but not fully as design is not finalised.

## Solution

Update the warning in the secret key modal to include guidelines for safekeeping secret keys, and add a convenient mailto URL to encourage users to share their secret keys.

## Screenshots

### Before
<img width="781" alt="Screenshot 2020-08-18 at 12 10 52 PM" src="https://user-images.githubusercontent.com/29480346/90469606-dfb1f500-e14b-11ea-9f21-874bc838515d.png">

### After
![image](https://user-images.githubusercontent.com/29480346/90724744-9ac7c300-e2f1-11ea-880a-486c1dfe6df2.png)

![image](https://user-images.githubusercontent.com/29480346/90384871-d295f700-e0b4-11ea-9b31-377bd81e1001.png)

## Tests
- [ ] Clicking on "Email" link in secret key modal opens email with correct subject, form title and secret key