### PR TITLE
feat: add Emergency Contact feature backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3386,9 +3386,9 @@
       }
     },
     "@hapi/address": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
-      "integrity": "sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -4781,6 +4781,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/hapi__joi": {
+      "version": "17.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.4.tgz",
+      "integrity": "sha512-gqY3TeTyZvnyNhM02HgyCIoGIWsTFMnuzMfnD8evTsr1KIfueGJaz+QC77j+dFvhZ5cJArUNjDRHUjPxNohzGA=="
     },
     "@types/has-ansi": {
       "version": "3.0.0",
@@ -8009,12 +8014,14 @@
       "dev": true
     },
     "celebrate": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-12.1.1.tgz",
-      "integrity": "sha512-d6A0KRX3sbGCbB/id6D4FAqGHwRfFb1B2e77pberUFF1awsF3P9RsLeeRYwbsrgA6Zj7J01SA07NgUyR6BeJVQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-12.2.0.tgz",
+      "integrity": "sha512-dkcQaUL4zrPOua/NwTM74jf/NY3wv9Fyb1mkC2ru75KRHowSIDe/tJtIG9yRyPyFCfkr1odif8zNQq23eTwEYg==",
       "requires": {
         "@hapi/joi": "17.x.x",
-        "escape-html": "1.0.3"
+        "@types/hapi__joi": "17.x.x",
+        "escape-html": "1.0.3",
+        "lodash": "4.17.x"
       }
     },
     "chai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4620,6 +4620,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bcrypt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-3.0.0.tgz",
+      "integrity": "sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@babel/preset-env": "^7.11.0",
     "@opengovsg/mockpass": "^2.1.1",
     "@shelf/jest-mongodb": "^1.2.2",
+    "@types/bcrypt": "^3.0.0",
     "@types/compression": "^1.7.0",
     "@types/convict": "^5.2.1",
     "@types/cookie-parser": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "boxicons": "1.8.0",
     "bson-ext": "^2.0.3",
     "busboy": "^0.3.1",
-    "celebrate": "^12.1.0",
+    "celebrate": "^12.2.0",
     "compression": "~1.7.2",
     "connect": "^3.6.6",
     "connect-mongo": "^3.2.0",

--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -25,6 +25,7 @@ const logger = require('../../config/logger').createLoggerWithLabel(
 )
 const { sendNodeMail } = require('../services/mail.service')
 const { EMAIL_HEADERS, EMAIL_TYPES } = require('../utils/constants')
+const { generateOtp } = require('../utils/otp')
 
 const MAX_OTP_ATTEMPTS = 10
 
@@ -150,7 +151,7 @@ exports.createOtp = function (req, res, next) {
   // 3. Save OTP to DB
 
   let email = res.locals.email
-  let otp = config.otpGenerator()
+  let otp = generateOtp()
   bcrypt.hash(otp, 10, function (bcryptErr, hashedOtp) {
     if (bcryptErr) {
       return res

--- a/src/app/factories/sms.factory.js
+++ b/src/app/factories/sms.factory.js
@@ -30,6 +30,18 @@ const smsFactory = ({ isEnabled, props }) => {
         )
       }
     },
+    async sendAdminContactOtp(recipient, otp, userId) {
+      if (isEnabled) {
+        return smsService.sendAdminContactOtp(
+          recipient,
+          otp,
+          userId,
+          twilioConfig,
+        )
+      } else {
+        throw new Error(`Send Admin Contact OTP has not been enabled`)
+      }
+    },
   }
 }
 

--- a/src/app/models/admin_verification.server.model.ts
+++ b/src/app/models/admin_verification.server.model.ts
@@ -57,6 +57,17 @@ AdminVerificationSchema.statics.upsertOtp = async function (
   )
 }
 
+AdminVerificationSchema.statics.incrementAttemptsByAdminId = async function (
+  this: IAdminVerificationModel,
+  adminId: string,
+) {
+  return this.findOneAndUpdate(
+    { admin: adminId },
+    { $inc: { numOtpAttempts: 1 } },
+    { new: true },
+  )
+}
+
 const compileAdminVerificationModel = (db: Mongoose) =>
   db.model<IAdminVerificationSchema, IAdminVerificationModel>(
     ADMIN_VERIFICATION_SCHEMA_ID,

--- a/src/app/models/admin_verification.server.model.ts
+++ b/src/app/models/admin_verification.server.model.ts
@@ -4,7 +4,9 @@ import {
   IAdminVerificationModel,
   IAdminVerificationSchema,
   UpsertOtpParams,
-} from 'src/types/admin_verification'
+} from '../../types/admin_verification'
+
+import { USER_SCHEMA_ID } from './user.server.model'
 
 export const ADMIN_VERIFICATION_SCHEMA_ID = 'AdminVerification'
 
@@ -12,7 +14,7 @@ const AdminVerificationSchema = new Schema<IAdminVerificationSchema>(
   {
     admin: {
       type: Schema.Types.ObjectId,
-      ref: 'User',
+      ref: USER_SCHEMA_ID,
       required: 'AdminVerificationSchema must have an Admin',
     },
     hashedContact: {

--- a/src/app/models/admin_verification.server.model.ts
+++ b/src/app/models/admin_verification.server.model.ts
@@ -37,9 +37,7 @@ const AdminVerificationSchema = new Schema<IAdminVerificationSchema>(
     },
   },
   {
-    timestamps: {
-      updatedAt: false,
-    },
+    timestamps: true,
   },
 )
 AdminVerificationSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 })

--- a/src/app/models/admin_verification.server.model.ts
+++ b/src/app/models/admin_verification.server.model.ts
@@ -1,4 +1,3 @@
-import { parsePhoneNumberFromString } from 'libphonenumber-js/mobile'
 import { Mongoose, Schema } from 'mongoose'
 
 import {
@@ -16,18 +15,9 @@ const AdminVerificationSchema = new Schema<IAdminVerificationSchema>(
       ref: 'User',
       required: 'AdminVerificationSchema must have an Admin',
     },
-    contact: {
+    hashedContact: {
       type: String,
       required: true,
-      validate: {
-        // Check if phone number is valid.
-        validator: function (value: string) {
-          const phoneNumber = parsePhoneNumberFromString(value)
-          if (!phoneNumber) return false
-          return phoneNumber.isValid()
-        },
-        message: (props) => `${props.value} is not a valid mobile number`,
-      },
     },
     hashedOtp: {
       type: String,

--- a/src/app/models/admin_verification.server.model.ts
+++ b/src/app/models/admin_verification.server.model.ts
@@ -1,0 +1,72 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js/mobile'
+import { Model, Mongoose, Schema } from 'mongoose'
+
+import { IAdminVerificationSchema } from 'src/types/admin_verification'
+
+export const ADMIN_VERIFICATION_SCHEMA_ID = 'AdminVerification'
+
+const AdminVerificationSchema = new Schema<IAdminVerificationSchema>(
+  {
+    admin: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: 'AdminVerificationSchema must have an Admin',
+    },
+    contact: {
+      type: String,
+      validate: {
+        // Check if phone number is valid.
+        validator: function (value: string) {
+          const phoneNumber = parsePhoneNumberFromString(value)
+          if (!phoneNumber) return false
+          return phoneNumber.isValid()
+        },
+        message: (props) => `${props.value} is not a valid mobile number`,
+      },
+    },
+    hashedOtp: {
+      type: String,
+    },
+    expireAt: {
+      type: Date,
+    },
+    numOtpAttempts: {
+      type: Number,
+      default: 0,
+    },
+    numOtpSent: {
+      type: Number,
+      default: 0,
+    },
+  },
+  {
+    timestamps: {
+      updatedAt: false,
+    },
+  },
+)
+AdminVerificationSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 })
+
+const compileAdminVerificationModel = (db: Mongoose) =>
+  db.model<IAdminVerificationSchema>(
+    ADMIN_VERIFICATION_SCHEMA_ID,
+    AdminVerificationSchema,
+  )
+
+/**
+ * Retrieves the AdminVerification model on the given Mongoose instance. If the
+ * model is not registered yet, the model will be registered and returned.
+ * @param db The mongoose instance to retrieve the AdminVerification model from
+ * @returns The agency model
+ */
+const getAdminVerificationModel = (db: Mongoose) => {
+  try {
+    return db.model(ADMIN_VERIFICATION_SCHEMA_ID) as Model<
+      IAdminVerificationSchema
+    >
+  } catch {
+    return compileAdminVerificationModel(db)
+  }
+}
+
+export default getAdminVerificationModel

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -10,12 +10,12 @@ import {
   BasicFieldType,
   Colors,
   FormLogoState,
+  FormOtpData,
   IEmailFormSchema,
   IEncryptedFormSchema,
   IFormSchema,
   IPopulatedForm,
   LogicType,
-  OtpData,
   Permission,
   ResponseMode,
   Status,
@@ -85,7 +85,7 @@ const formSchemaOptions: SchemaOptions = {
 }
 
 export interface IFormModel extends Model<IFormSchema> {
-  getOtpData(formId: string): Promise<OtpData | null>
+  getOtpData(formId: string): Promise<FormOtpData | null>
   getFullFormById(formId: string): Promise<IPopulatedForm | null>
 }
 
@@ -432,7 +432,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         path: 'admin',
         select: 'email',
       })
-      const otpData: OtpData = {
+      const otpData: FormOtpData = {
         form: data._id,
         formAdmin: {
           email: data.admin.email,

--- a/src/app/models/sms_count.server.model.ts
+++ b/src/app/models/sms_count.server.model.ts
@@ -1,7 +1,8 @@
-import { Model, Mongoose, Schema } from 'mongoose'
+import { Mongoose, Schema } from 'mongoose'
 
 import {
   ISmsCount,
+  ISmsCountModel,
   ISmsCountSchema,
   LogSmsParams,
   LogType,
@@ -12,10 +13,6 @@ import { FORM_SCHEMA_ID } from './form.server.model'
 import { USER_SCHEMA_ID } from './user.server.model'
 
 const SMS_COUNT_SCHEMA_NAME = 'SmsCount'
-
-interface ISmsCountModel extends Model<ISmsCountSchema> {
-  logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>
-}
 
 const SmsCountSchema = new Schema<ISmsCountSchema>(
   {

--- a/src/app/models/sms_count.server.model.ts
+++ b/src/app/models/sms_count.server.model.ts
@@ -1,6 +1,7 @@
 import { Mongoose, Schema } from 'mongoose'
 
 import {
+  IAdminContactSmsCountSchema,
   ISmsCount,
   ISmsCountModel,
   ISmsCountSchema,
@@ -28,6 +29,14 @@ const VerificationSmsCountSchema = new Schema<IVerificationSmsCountSchema>({
       ref: USER_SCHEMA_ID,
       required: true,
     },
+  },
+})
+
+const AdminContactSmsCountSchema = new Schema<IAdminContactSmsCountSchema>({
+  admin: {
+    type: Schema.Types.ObjectId,
+    ref: USER_SCHEMA_ID,
+    required: true,
   },
 })
 
@@ -81,6 +90,7 @@ const compileSmsCountModel = (db: Mongoose) => {
 
   // Adding Discriminators
   SmsCountModel.discriminator(SmsType.verification, VerificationSmsCountSchema)
+  SmsCountModel.discriminator(SmsType.adminContact, AdminContactSmsCountSchema)
 
   return SmsCountModel
 }

--- a/src/app/models/sms_count.server.model.ts
+++ b/src/app/models/sms_count.server.model.ts
@@ -4,6 +4,7 @@ import {
   ISmsCount,
   ISmsCountModel,
   ISmsCountSchema,
+  IVerificationSmsCountSchema,
   LogSmsParams,
   LogType,
   SmsType,
@@ -14,65 +15,74 @@ import { USER_SCHEMA_ID } from './user.server.model'
 
 const SMS_COUNT_SCHEMA_NAME = 'SmsCount'
 
-const SmsCountSchema = new Schema<ISmsCountSchema>(
-  {
-    form: {
+const VerificationSmsCountSchema = new Schema<IVerificationSmsCountSchema>({
+  form: {
+    type: Schema.Types.ObjectId,
+    ref: FORM_SCHEMA_ID,
+    required: true,
+  },
+  formAdmin: {
+    email: { type: String, required: true },
+    userId: {
       type: Schema.Types.ObjectId,
-      ref: FORM_SCHEMA_ID,
+      ref: USER_SCHEMA_ID,
       required: true,
     },
-    formAdmin: {
-      email: { type: String, required: true },
-      userId: {
-        type: Schema.Types.ObjectId,
-        ref: USER_SCHEMA_ID,
+  },
+})
+
+const compileSmsCountModel = (db: Mongoose) => {
+  const SmsCountSchema = new Schema<ISmsCountSchema>(
+    {
+      msgSrvcSid: {
+        type: String,
+        required: true,
+      },
+      logType: {
+        type: String,
+        enum: Object.values(LogType),
+        required: true,
+      },
+      smsType: {
+        type: String,
+        enum: Object.values(SmsType),
         required: true,
       },
     },
-    msgSrvcSid: {
-      type: String,
-      required: true,
+    {
+      timestamps: {
+        createdAt: true,
+        updatedAt: false,
+      },
+      discriminatorKey: 'smsType',
     },
-    logType: {
-      type: String,
-      enum: Object.values(LogType),
-      required: true,
-    },
-    smsType: {
-      type: String,
-      enum: Object.values(SmsType),
-      required: true,
-    },
-  },
-  {
-    timestamps: {
-      createdAt: true,
-      updatedAt: false,
-    },
-  },
-)
+  )
 
-SmsCountSchema.statics.logSms = async function (
-  this: ISmsCountModel,
-  { otpData, msgSrvcSid, smsType, logType }: LogSmsParams,
-) {
-  const schemaData: Omit<ISmsCount, '_id'> = {
-    ...otpData,
-    msgSrvcSid,
-    smsType,
-    logType,
+  SmsCountSchema.statics.logSms = async function (
+    this: ISmsCountModel,
+    { otpData, msgSrvcSid, smsType, logType }: LogSmsParams,
+  ) {
+    const schemaData: Omit<ISmsCount, '_id'> = {
+      ...otpData,
+      msgSrvcSid,
+      smsType,
+      logType,
+    }
+
+    const smsCount: ISmsCountSchema = new this(schemaData)
+
+    return smsCount.save()
   }
 
-  const smsCount: ISmsCountSchema = new this(schemaData)
-
-  return smsCount.save()
-}
-
-const compileSmsCountModel = (db: Mongoose) => {
-  return db.model<ISmsCountSchema, ISmsCountModel>(
+  const SmsCountModel = db.model<ISmsCountSchema, ISmsCountModel>(
     SMS_COUNT_SCHEMA_NAME,
     SmsCountSchema,
   )
+
+  // Adding Discriminators
+  SmsCountModel.discriminator(SmsType.verification, VerificationSmsCountSchema)
+
+  return SmsCountModel
 }
 
 /**

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -1,0 +1,28 @@
+/**
+ * A custom base error class that encapsulates the name, message, status code,
+ * and logging meta string (if any) for the error.
+ */
+export class ApplicationError extends Error {
+  /**
+   * Http status code for the error to be returned in the response.
+   */
+  status: number
+  /**
+   * Meta string to be logged by the application logger, if any.
+   */
+  meta?: string
+
+  constructor(message?: string, status?: number, meta?: string) {
+    super()
+
+    Error.captureStackTrace(this, this.constructor)
+
+    this.name = this.constructor.name
+
+    this.message = message || 'Something went wrong. Please try again.'
+
+    this.status = status || 500
+
+    this.meta = meta
+  }
+}

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -1,0 +1,54 @@
+import to from 'await-to-js'
+import { RequestHandler } from 'express'
+import HttpStatus from 'http-status-codes'
+
+import {
+  createContactOtp,
+  sendContactOtp,
+  updateUserContact,
+  verifyContactOtp,
+} from './user.service'
+
+export const handleContactSendOtp: RequestHandler<
+  {},
+  {},
+  { contact: string; userId: string }
+> = async (req, res) => {
+  const { contact, userId } = req.body
+
+  try {
+    const generatedOtp = await createContactOtp(userId, contact)
+    await sendContactOtp(generatedOtp, contact)
+  } catch (err) {
+    // Send different error messages according to error.
+    return res.sendStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+
+  return res.sendStatus(HttpStatus.OK)
+}
+
+export const handleContactVerifyOtp: RequestHandler<
+  {},
+  {},
+  {
+    userId: string
+    otp: string
+    contact: string
+  }
+> = async (req, res) => {
+  const { userId, otp, contact } = req.body
+
+  const [verifyErr] = await to(verifyContactOtp(otp, contact, userId))
+  if (verifyErr) {
+    // Handle vfn error
+    return
+  }
+
+  // No error, update user with given contact.
+  const [updateErr] = await to(updateUserContact(contact, userId))
+  if (updateErr) {
+    // Handle update error
+  }
+
+  return res.sendStatus(HttpStatus.OK)
+}

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -19,12 +19,12 @@ export const handleContactSendOtp: RequestHandler<
   try {
     const generatedOtp = await createContactOtp(userId, contact)
     await sendContactOtp(generatedOtp, contact)
+
+    return res.sendStatus(HttpStatus.OK)
   } catch (err) {
     // Send different error messages according to error.
-    return res.sendStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    return res.status(HttpStatus.BAD_REQUEST).send(err.message)
   }
-
-  return res.sendStatus(HttpStatus.OK)
 }
 
 export const handleContactVerifyOtp: RequestHandler<

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -2,9 +2,10 @@ import to from 'await-to-js'
 import { RequestHandler } from 'express'
 import HttpStatus from 'http-status-codes'
 
+import SmsFactory from '../../factories/sms.factory'
+
 import {
   createContactOtp,
-  sendContactOtp,
   updateUserContact,
   verifyContactOtp,
 } from './user.service'
@@ -18,7 +19,7 @@ export const handleContactSendOtp: RequestHandler<
 
   try {
     const generatedOtp = await createContactOtp(userId, contact)
-    await sendContactOtp(generatedOtp, contact)
+    await SmsFactory.sendAdminContactOtp(contact, generatedOtp, userId)
 
     return res.sendStatus(HttpStatus.OK)
   } catch (err) {

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -57,7 +57,9 @@ export const handleContactVerifyOtp: RequestHandler<
   // No error, update user with given contact.
   const [updateErr] = await to(updateUserContact(contact, userId))
   if (updateErr) {
-    // Handle update error
+    // Handle update error.
+    logger.warn(updateErr)
+    return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send(updateErr.message)
   }
 
   return res.sendStatus(HttpStatus.OK)

--- a/src/app/modules/user/user.errors.ts
+++ b/src/app/modules/user/user.errors.ts
@@ -1,0 +1,18 @@
+import HttpStatus from 'http-status-codes'
+
+import { ApplicationError } from '../core/core.errors'
+
+export class InvalidOtpError extends ApplicationError {
+  constructor(message: string, meta?: string) {
+    super(message, HttpStatus.UNPROCESSABLE_ENTITY, meta)
+  }
+}
+
+export class MalformedOtpError extends ApplicationError {
+  constructor(
+    message: string = 'Malformed OTP. Please try again later. If the problem persists, contact us.',
+    meta?: string,
+  ) {
+    super(message, HttpStatus.INTERNAL_SERVER_ERROR, meta)
+  }
+}

--- a/src/app/modules/user/user.routes.ts
+++ b/src/app/modules/user/user.routes.ts
@@ -1,0 +1,21 @@
+import { celebrate } from 'celebrate'
+import { Router } from 'express'
+
+import * as UserController from './user.controller'
+import * as UserRules from './user.rules'
+
+const UserRouter = Router()
+
+UserRouter.post(
+  '/contact/sendotp',
+  celebrate(UserRules.forContactSendOtp),
+  UserController.handleContactSendOtp,
+)
+
+UserRouter.post(
+  '/contact/verifyotp',
+  celebrate(UserRules.forContactVerifyOtp),
+  UserController.handleContactVerifyOtp,
+)
+
+export default UserRouter

--- a/src/app/modules/user/user.rules.ts
+++ b/src/app/modules/user/user.rules.ts
@@ -1,0 +1,16 @@
+import { Joi, Segments } from 'celebrate'
+
+export const forContactSendOtp = {
+  [Segments.BODY]: Joi.object().keys({
+    contact: Joi.string().required(),
+    userId: Joi.string().required(),
+  }),
+}
+
+export const forContactVerifyOtp = {
+  [Segments.BODY]: Joi.object().keys({
+    userId: Joi.string().required(),
+    otp: Joi.string().length(6).required(),
+    contact: Joi.string().required(),
+  }),
+}

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -1,0 +1,49 @@
+/**
+ * Creates a contact OTP and saves it into the AdminVerification collection.
+ * @param userId the user ID the contact is to be linked to
+ * @param contact the contact number to send the generated OTP to
+ * @returns the generated OTP if saving into DB is successful
+ * @throws error if any error occur whilst creating the OTP or insertion of OTP into the database.
+ */
+export const createContactOtp = async (
+  userId: string,
+  contact: string,
+): Promise<string> => {
+  return '123456'
+}
+
+/**
+ * Sends the given OTP to the given contact
+ * @param otp the OTP to send
+ * @param contact the contact number to send the OTP to
+ * @throws error if sending of OTP fails
+ */
+export const sendContactOtp = async (otp: string, contact: string) => {}
+
+/**
+ * Compares the otpToVerify and contact number with their hashed counterparts in
+ * the database to be retrieved with the userId.
+ *
+ * If the both hashes matches, the saved document in the database is removed and
+ * returned. Else, the document is kept in the database and a HashMismatchError is thrown.
+ * @param otpToVerify the OTP to verify with the hashed counterpart
+ * @param contactToVerify the contact number to verify with the hashed counterpart
+ * @param userId the id of the user used to retrieve the verification document from the database
+ * @returns
+ * @throws HashMismatchError if hashes do not match, or any other errors that may occur.
+ */
+export const verifyContactOtp = async (
+  otpToVerify: string,
+  contactToVerify: string,
+  userId: string,
+) => {}
+
+/**
+ * Updates the user document with the userId with the given contact.
+ * @param contact the contact to update
+ * @param userId the user id of the user document to update
+ */
+export const updateUserContact = async (contact: string, userId: string) => {
+  // Retrieve user from database.
+  // Update user's contact details.
+}

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -125,4 +125,11 @@ export const verifyContactOtp = async (
 export const updateUserContact = async (contact: string, userId: string) => {
   // Retrieve user from database.
   // Update user's contact details.
+  const admin = await User.findById(userId)
+  if (!admin) {
+    throw new Error('User id is invalid')
+  }
+
+  admin.contact = contact
+  return admin.save()
 }

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -30,11 +30,12 @@ export const createContactOtp = async (
 
   const otp = generateOtp()
   const hashedOtp = await bcrypt.hash(otp, DEFAULT_SALT_ROUNDS)
+  const hashedContact = await bcrypt.hash(contact, DEFAULT_SALT_ROUNDS)
 
   await AdminVerification.upsertOtp({
     admin: userId,
-    contact,
     expireAt: new Date(Date.now() + config.otpLifeSpan),
+    hashedContact,
     hashedOtp,
   })
 

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -42,14 +42,6 @@ export const createContactOtp = async (
 }
 
 /**
- * Sends the given OTP to the given contact
- * @param otp the OTP to send
- * @param contact the contact number to send the OTP to
- * @throws error if sending of OTP fails
- */
-export const sendContactOtp = async (otp: string, contact: string) => {}
-
-/**
  * Compares the otpToVerify and contact number with their hashed counterparts in
  * the database to be retrieved with the userId.
  *

--- a/src/app/services/sms.service.ts
+++ b/src/app/services/sms.service.ts
@@ -7,7 +7,7 @@ import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { isPhoneNumber } from '../../shared/util/phone-num-validation'
 import { VfnErrors } from '../../shared/util/verification'
-import { LogSmsParams, LogType, OtpData, SmsType } from '../../types'
+import { FormOtpData, LogSmsParams, LogType, SmsType } from '../../types'
 import getFormModel from '../models/form.server.model'
 import getSmsCountModel from '../models/sms_count.server.model'
 
@@ -134,7 +134,7 @@ const getOtpDataFromForm = async (formId: string) => {
  */
 const send = async (
   twilioConfig: TwilioConfig,
-  otpData: OtpData,
+  otpData: FormOtpData,
   recipient: string,
   message: string,
   smsType: SmsType,

--- a/src/app/services/sms.service.ts
+++ b/src/app/services/sms.service.ts
@@ -7,7 +7,13 @@ import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { isPhoneNumber } from '../../shared/util/phone-num-validation'
 import { VfnErrors } from '../../shared/util/verification'
-import { FormOtpData, LogSmsParams, LogType, SmsType } from '../../types'
+import {
+  AdminContactOtpData,
+  FormOtpData,
+  LogSmsParams,
+  LogType,
+  SmsType,
+} from '../../types'
 import getFormModel from '../models/form.server.model'
 import getSmsCountModel from '../models/sms_count.server.model'
 
@@ -134,7 +140,7 @@ const getOtpDataFromForm = async (formId: string) => {
  */
 const send = async (
   twilioConfig: TwilioConfig,
-  otpData: FormOtpData,
+  otpData: FormOtpData | AdminContactOtpData,
   recipient: string,
   message: string,
   smsType: SmsType,
@@ -224,6 +230,23 @@ const sendVerificationOtp = async (
   return send(twilioData, otpData, recipient, message, SmsType.verification)
 }
 
+const sendAdminContactOtp = async (
+  recipient: string,
+  otp: string,
+  userId: string,
+  defaultConfig: TwilioConfig,
+) => {
+  logger.info(`sendAdminContactOtp: userId="${userId}"`)
+
+  const message = `Use the OTP ${otp} to verify your emergency contact number.`
+
+  const otpData: AdminContactOtpData = {
+    admin: userId,
+  }
+
+  return send(defaultConfig, otpData, recipient, message, SmsType.adminContact)
+}
+
 class TwilioError extends Error {
   code: number
   status: string
@@ -242,4 +265,5 @@ class TwilioError extends Error {
 
 module.exports = {
   sendVerificationOtp,
+  sendAdminContactOtp,
 }

--- a/src/app/services/verification.service.js
+++ b/src/app/services/verification.service.js
@@ -1,11 +1,11 @@
 const mongoose = require('mongoose')
 const bcrypt = require('bcrypt')
 const _ = require('lodash')
-const { otpGenerator } = require('../../config/config')
 const mailService = require('./mail.service')
 const smsFactory = require('./../factories/sms.factory')
 const vfnUtil = require('../../shared/util/verification')
 const formsgSdk = require('../../config/formsg-sdk')
+const { generateOtp } = require('../utils/otp')
 
 const getFormModel = require('../models/form.server.model').default
 const getVerificationModel = require('../models/verification.server.model')
@@ -111,7 +111,7 @@ const getNewOtp = async (transaction, fieldId, answer) => {
     )
   } else {
     const hashCreatedAt = new Date()
-    const otp = otpGenerator()
+    const otp = generateOtp()
     const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS)
     const signedData = formsgSdk.verification.generateSignature({
       transactionId,

--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -1,0 +1,19 @@
+import crypto from 'crypto'
+
+/**
+ * Randomly generates and returns a 6 digit OTP.
+ * @return 6 digit OTP string
+ */
+export const generateOtp = () => {
+  const length = 6
+  const chars = '0123456789'
+  // Generates cryptographically strong pseudo-random data.
+  // The size argument is a number indicating the number of bytes to generate.
+  const rnd = crypto.randomBytes(length)
+  const d = chars.length / 256
+  const digits = new Array(length)
+  for (let i = 0; i < length; i++) {
+    digits[i] = chars[Math.floor(rnd[i] * d)]
+  }
+  return digits.join('')
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,5 @@
 import { PackageMode } from '@opengovsg/formsg-sdk/dist/types'
 import aws from 'aws-sdk'
-import crypto from 'crypto'
 import { SessionOptions } from 'express-session'
 import { ConnectionOptions } from 'mongoose'
 import nodemailer from 'nodemailer'
@@ -80,7 +79,6 @@ type Config = {
 
   // Functions
   configureAws: () => Promise<void>
-  otpGenerator: () => string
 }
 
 // Enums
@@ -394,24 +392,6 @@ const configureAws = async () => {
   }
 }
 
-/**
- * Generates OTP for passwordless login
- * @return 6 digit OTP string
- */
-const otpGenerator = () => {
-  let length = 6
-  let chars = '0123456789'
-  // Generates cryptographically strong pseudo-random data.
-  // The size argument is a number indicating the number of bytes to generate.
-  const rnd = crypto.randomBytes(length)
-  const d = chars.length / 256
-  const value = new Array(length)
-  for (let i = 0; i < length; i++) {
-    value[i] = chars[Math.floor(rnd[i] * d)]
-  }
-  return value.join('')
-}
-
 const config: Config = {
   app: appConfig,
   db: dbConfig,
@@ -433,7 +413,6 @@ const config: Config = {
   siteBannerContent,
   adminBannerContent,
   configureAws,
-  otpGenerator,
 }
 
 export = config

--- a/src/loaders/express/index.ts
+++ b/src/loaders/express/index.ts
@@ -7,6 +7,7 @@ import { Connection } from 'mongoose'
 import path from 'path'
 import url from 'url'
 
+import UserRouter from '../../app/modules/user/user.routes'
 import apiRoutes from '../../app/routes'
 import config from '../../config/config'
 
@@ -120,6 +121,7 @@ const loadExpressApp = async (connection: Connection) => {
   apiRoutes.forEach(function (routeFunction) {
     routeFunction(app)
   })
+  app.use('/user', UserRouter)
 
   app.use(sentryMiddlewares())
 

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -22,10 +22,5 @@ export type UpsertOtpParams = Pick<
 >
 export interface IAdminVerificationModel
   extends Model<IAdminVerificationSchema> {
-  upsertOtp: ({
-    admin,
-    hashedContact,
-    hashedOtp,
-    expireAt,
-  }: UpsertOtpParams) => Promise<IAdminVerificationSchema>
+  upsertOtp: (params: UpsertOtpParams) => Promise<IAdminVerificationSchema>
 }

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -1,4 +1,4 @@
-import { Document } from 'mongoose'
+import { Document, Model } from 'mongoose'
 
 import { IUserSchema } from './user'
 
@@ -7,11 +7,25 @@ export interface IAdminVerification {
   contact: string
   hashedOtp: string
   expireAt: Date
-  numOtpAttempts: number
-  numOtpSent: number
+  numOtpAttempts?: number
+  numOtpSent?: number
   _id?: Document['_id']
 }
 
 export interface IAdminVerificationSchema extends IAdminVerification, Document {
   _id: Document['_id']
+}
+
+export type UpsertOtpParams = Pick<
+  IAdminVerificationSchema,
+  'hashedOtp' | 'contact' | 'admin' | 'expireAt'
+>
+export interface IAdminVerificationModel
+  extends Model<IAdminVerificationSchema> {
+  upsertOtp: ({
+    admin,
+    contact,
+    hashedOtp,
+    expireAt,
+  }: UpsertOtpParams) => Promise<IAdminVerificationSchema>
 }

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -4,7 +4,7 @@ import { IUserSchema } from './user'
 
 export interface IAdminVerification {
   admin: IUserSchema['_id']
-  contact: string
+  hashedContact: string
   hashedOtp: string
   expireAt: Date
   numOtpAttempts?: number
@@ -18,13 +18,13 @@ export interface IAdminVerificationSchema extends IAdminVerification, Document {
 
 export type UpsertOtpParams = Pick<
   IAdminVerificationSchema,
-  'hashedOtp' | 'contact' | 'admin' | 'expireAt'
+  'hashedOtp' | 'hashedContact' | 'admin' | 'expireAt'
 >
 export interface IAdminVerificationModel
   extends Model<IAdminVerificationSchema> {
   upsertOtp: ({
     admin,
-    contact,
+    hashedContact,
     hashedOtp,
     expireAt,
   }: UpsertOtpParams) => Promise<IAdminVerificationSchema>

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -1,0 +1,17 @@
+import { Document } from 'mongoose'
+
+import { IUserSchema } from './user'
+
+export interface IAdminVerification {
+  admin: IUserSchema['_id']
+  contact: string
+  hashedOtp: string
+  expireAt: Date
+  numOtpAttempts: number
+  numOtpSent: number
+  _id?: Document['_id']
+}
+
+export interface IAdminVerificationSchema extends IAdminVerification, Document {
+  _id: Document['_id']
+}

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -23,4 +23,7 @@ export type UpsertOtpParams = Pick<
 export interface IAdminVerificationModel
   extends Model<IAdminVerificationSchema> {
   upsertOtp: (params: UpsertOtpParams) => Promise<IAdminVerificationSchema>
+  incrementAttemptsByAdminId: (
+    adminId: string,
+  ) => Promise<IAdminVerificationSchema>
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -32,7 +32,7 @@ export enum ResponseMode {
 }
 
 // Typings
-export type OtpData = {
+export type FormOtpData = {
   form: IFormSchema['_id']
   formAdmin: {
     email: IUserSchema['email']

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -1,10 +1,11 @@
 import { Document, Model } from 'mongoose'
 
 import { FormOtpData, IFormSchema } from './form'
-import { IUserSchema } from './user'
+import { AdminContactOtpData, IUserSchema } from './user'
 
 export enum SmsType {
   verification = 'VERIFICATION',
+  adminContact = 'ADMIN_CONTACT',
 }
 
 export enum LogType {
@@ -13,7 +14,7 @@ export enum LogType {
 }
 
 export type LogSmsParams = {
-  otpData: FormOtpData
+  otpData: FormOtpData | AdminContactOtpData
   msgSrvcSid: string
   smsType: SmsType
   logType: LogType
@@ -39,6 +40,12 @@ export interface IVerificationSmsCount extends ISmsCount {
 }
 
 export interface IVerificationSmsCountSchema extends ISmsCountSchema {}
+
+export interface IAdminContactSmsCount extends ISmsCount {
+  admin: IUserSchema['_id']
+}
+
+export interface IAdminContactSmsCountSchema extends ISmsCountSchema {}
 
 export interface ISmsCountModel extends Model<ISmsCountSchema> {
   logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -1,6 +1,6 @@
 import { Document, Model } from 'mongoose'
 
-import { IFormSchema, OtpData } from './form'
+import { FormOtpData, IFormSchema } from './form'
 import { IUserSchema } from './user'
 
 export enum SmsType {
@@ -13,7 +13,7 @@ export enum LogType {
 }
 
 export type LogSmsParams = {
-  otpData: OtpData
+  otpData: FormOtpData
   msgSrvcSid: string
   smsType: SmsType
   logType: LogType

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -1,4 +1,4 @@
-import { Document } from 'mongoose'
+import { Document, Model } from 'mongoose'
 
 import { IFormSchema, OtpData } from './form'
 import { IUserSchema } from './user'
@@ -34,3 +34,7 @@ export interface ISmsCount {
 }
 
 export interface ISmsCountSchema extends ISmsCount, Document {}
+
+export interface ISmsCountModel extends Model<ISmsCountSchema> {
+  logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>
+}

--- a/src/types/sms_count.ts
+++ b/src/types/sms_count.ts
@@ -20,11 +20,6 @@ export type LogSmsParams = {
 }
 
 export interface ISmsCount {
-  form: IFormSchema['_id']
-  formAdmin: {
-    email: string
-    userId: IUserSchema['_id']
-  }
   // The Twilio SID used to send the SMS. Not to be confused with msgSrvcName.
   msgSrvcSid: string
   logType: LogType
@@ -34,6 +29,16 @@ export interface ISmsCount {
 }
 
 export interface ISmsCountSchema extends ISmsCount, Document {}
+
+export interface IVerificationSmsCount extends ISmsCount {
+  form: IFormSchema['_id']
+  formAdmin: {
+    email: string
+    userId: IUserSchema['_id']
+  }
+}
+
+export interface IVerificationSmsCountSchema extends ISmsCountSchema {}
 
 export interface ISmsCountModel extends Model<ISmsCountSchema> {
   logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,6 +2,10 @@ import { Document } from 'mongoose'
 
 import { IAgencySchema } from './agency'
 
+export type AdminContactOtpData = {
+  admin: IUserSchema['_id']
+}
+
 export interface IUser {
   email: string
   agency: IAgencySchema['_id']

--- a/tests/unit/backend/controllers/authentication.server.controller.spec.js
+++ b/tests/unit/backend/controllers/authentication.server.controller.spec.js
@@ -17,8 +17,8 @@ describe('Authentication Controller', () => {
     'dist/backend/app/controllers/authentication.server.controller',
     {
       mongoose: Object.assign(mongoose, { '@noCallThru': true }),
-      '../../config/config': {
-        otpGenerator: () => TEST_OTP,
+      '../utils/otp': {
+        generateOtp: () => TEST_OTP,
       },
       '../services/mail.service': {
         sendNodeMail: mockSendNodeMail,

--- a/tests/unit/backend/controllers/verification.server.controller.spec.js
+++ b/tests/unit/backend/controllers/verification.server.controller.spec.js
@@ -28,8 +28,8 @@ describe('Verification Controller', () => {
   const service = spec('dist/backend/app/services/verification.service', {
     mongoose: Object.assign(mongoose, { '@noCallThru': true }),
     bcrypt,
-    '../../config/config': {
-      otpGenerator: () => testOtp,
+    '../utils/otp': {
+      generateOtp: () => testOtp,
       logger: console,
     },
     './mail.service': {

--- a/tests/unit/backend/models/sms_count.server.model.spec.ts
+++ b/tests/unit/backend/models/sms_count.server.model.spec.ts
@@ -3,7 +3,7 @@ import { cloneDeep, merge, omit } from 'lodash'
 import mongoose from 'mongoose'
 
 import getSmsCountModel from 'src/app/models/sms_count.server.model'
-import { ISmsCount, LogType, SmsType } from 'src/types'
+import { IVerificationSmsCount, LogType, SmsType } from 'src/types'
 
 import dbHandler from '../helpers/jest-db'
 
@@ -24,10 +24,10 @@ describe('SmsCount', () => {
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  describe('Schema', () => {
+  describe('VerificationCount Schema', () => {
     it('should create and save successfully', async () => {
       // Arrange
-      const smsCountParams = createSmsCountParams()
+      const smsCountParams = createVerificationSmsCountParams()
 
       // Act
       const validSmsCount = new SmsCount(smsCountParams)
@@ -49,9 +49,12 @@ describe('SmsCount', () => {
 
     it('should save successfully, but not save fields that is not defined in the schema', async () => {
       // Arrange
-      const smsCountParamsWithExtra = merge(createSmsCountParams(), {
-        extra: 'somethingExtra',
-      })
+      const smsCountParamsWithExtra = merge(
+        createVerificationSmsCountParams(),
+        {
+          extra: 'somethingExtra',
+        },
+      )
 
       // Act
       const validSmsCount = new SmsCount(smsCountParamsWithExtra)
@@ -75,7 +78,7 @@ describe('SmsCount', () => {
 
     it('should reject if form key is missing', async () => {
       // Arrange
-      const malformedParams = omit(createSmsCountParams(), 'form')
+      const malformedParams = omit(createVerificationSmsCountParams(), 'form')
       const malformedSmsCount = new SmsCount(malformedParams)
 
       // Act + Assert
@@ -86,7 +89,10 @@ describe('SmsCount', () => {
 
     it('should reject if formAdmin.email is missing', async () => {
       // Arrange
-      const malformedParams = omit(createSmsCountParams(), 'formAdmin.email')
+      const malformedParams = omit(
+        createVerificationSmsCountParams(),
+        'formAdmin.email',
+      )
       const malformedSmsCount = new SmsCount(malformedParams)
 
       // Act + Assert
@@ -97,7 +103,10 @@ describe('SmsCount', () => {
 
     it('should reject if formAdmin.userId is missing', async () => {
       // Arrange
-      const malformedParams = omit(createSmsCountParams(), 'formAdmin.userId')
+      const malformedParams = omit(
+        createVerificationSmsCountParams(),
+        'formAdmin.userId',
+      )
       const malformedSmsCount = new SmsCount(malformedParams)
 
       // Act + Assert
@@ -108,7 +117,10 @@ describe('SmsCount', () => {
 
     it('should reject if logType is missing', async () => {
       // Arrange
-      const malformedParams = omit(createSmsCountParams(), 'logType')
+      const malformedParams = omit(
+        createVerificationSmsCountParams(),
+        'logType',
+      )
       const malformedSmsCount = new SmsCount(malformedParams)
 
       // Act + Assert
@@ -119,7 +131,7 @@ describe('SmsCount', () => {
 
     it('should reject if logType is invalid', async () => {
       // Arrange
-      const malformedParams = createSmsCountParams()
+      const malformedParams = createVerificationSmsCountParams()
       // @ts-ignore
       malformedParams.logType = 'INVALID_LOG_TYPE'
       const malformedSmsCount = new SmsCount(malformedParams)
@@ -132,7 +144,10 @@ describe('SmsCount', () => {
 
     it('should reject if smsType is missing', async () => {
       // Arrange
-      const malformedParams = omit(createSmsCountParams(), 'smsType')
+      const malformedParams = omit(
+        createVerificationSmsCountParams(),
+        'smsType',
+      )
       const malformedSmsCount = new SmsCount(malformedParams)
 
       // Act + Assert
@@ -143,7 +158,7 @@ describe('SmsCount', () => {
 
     it('should reject if smsType is invalid', async () => {
       // Arrange
-      const malformedParams = createSmsCountParams()
+      const malformedParams = createVerificationSmsCountParams()
       // @ts-ignore
       malformedParams.smsType = 'INVALID_SMS_TYPE'
       const malformedSmsCount = new SmsCount(malformedParams)
@@ -234,14 +249,16 @@ describe('SmsCount', () => {
   })
 })
 
-const createSmsCountParams = ({
+const createVerificationSmsCountParams = ({
   logType = LogType.success,
   smsType = SmsType.verification,
 }: {
   logType?: LogType
   smsType?: SmsType
 } = {}) => {
-  const smsCountParams: Partial<ISmsCount> = cloneDeep(MOCK_SMSCOUNT_PARAMS)
+  const smsCountParams: Partial<IVerificationSmsCount> = cloneDeep(
+    MOCK_SMSCOUNT_PARAMS,
+  )
   smsCountParams.logType = logType
   smsCountParams.smsType = smsType
   smsCountParams.msgSrvcSid = MOCK_MSG_SRVC_SID


### PR DESCRIPTION
**_This PR is ready for review, with the exceptions of TODOs listed below_**

**Todos**:
- [ ] Add unit tests for new `user` module
- [ ] Add unit tests for new `adminverifications` collection
- [ ] Hook up backend and frontend (this will be done in a separate PR as this PR is already quite big)

## Problem

This PR includes the backend changes for the proposed emergency contact feature.

The module/usecases folder structure is also employed as a guinea pig for our intended folder structure going forward. See Features for more information.

Related to #13

## Solution

**Features**:

- Add new `user` module to encapsulate User-related layers. The files in `modules/user` include:
  - `user.routes`: Contains the express router for the `/user` route.
  - `user.controller`: Contains the controller functions to handle each user route.
  - `user.service`: Contains the main business logic that controllers call.
  - `user.rules`: Contains route param validation rules, using Joi validation. 
  - `user.errors`: Contains custom errors that the `user` module may use.

> Other file naming convention that may be employed (but not used in this example) are: 
> - `<usecase>.types.ts`
> - `<usecase>.utils.ts`
> - `<usecase>.middleware.ts` <- probably avoid this as much as we can, as we are trying to minimize middlewares in our codebase moving forward.

- Add new `core` module to hold `core.error`, which contains a custom error class `ApplicationError` that other modules can extend from. `ApplicationError` is a helpful abstraction in which Express can unwrap to send the correct response status code and message.

- Add `smsType` as discriminator to `SmsCount` model to support emergency sms logging
  - No backfill script is necessary as all previous `SmsCount` documents already have `smsType='VERIFICATION'`
  - The new smsType `ADMIN_CONTACT` is used for logging emergency contact number sms sends.

**Refactors**:
- Extract method `config#otpGenerator` and relocate to `utils/otp#generateOtp` for a more semantically correct location and name.

**New dependencies**:
Update for typing.
```diff
- "celebrate": "^12.1.0",
+ "celebrate": "^12.2.0",
```

**New dev dependencies**:
Various packages for adding types.
```diff
+ "@types/bcrypt": "^3.0.0",
```