### PR TITLE
feat: support &`;'" in form title

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -145,7 +145,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         minlength: [4, 'Form name must be at least 4 characters'],
         maxlength: [200, 'Form name can have a maximum of 200 characters'],
         match: [
-          /^[a-zA-Z0-9_\-./() ]*$/,
+          /^[a-zA-Z0-9_\-./() &`;'"]*$/,
           'Form name cannot contain special characters',
         ],
       },

--- a/src/public/modules/forms/admin/componentViews/form-title-input.client.view.html
+++ b/src/public/modules/forms/admin/componentViews/form-title-input.client.view.html
@@ -13,7 +13,7 @@
       ng-minlength="4"
       ng-required="true"
       ng-maxlength="200"
-      ng-pattern="/^[a-zA-Z0-9_\-.\/() ]*$/"
+      ng-pattern="/^[a-zA-Z0-9_\-.\/() &`;'&quot;]*$/"
       autocomplete="off"
       ng-keyup="$event.keyCode === 13 && vm.formController.title.$valid && vm.saveForm()"
       ng-class="vm.formController.title.$invalid && vm.formController.title.$dirty ? 'input-error' : ''"


### PR DESCRIPTION
Users have been requesting for us to support more special characters in the form title.

Closes #132

![image](https://user-images.githubusercontent.com/29480346/90471671-69b08c80-e151-11ea-80b9-2b5c2dffd31a.png)
