### PR TITLE
feat: increase breaker window time and add volume threshold

### DIFF
--- a/src/app/services/myinfo.service.js
+++ b/src/app/services/myinfo.service.js
@@ -12,8 +12,10 @@ class MyInfoService {
     this.myInfoClientBreaker = new CircuitBreaker(
       (params) => MyInfoGovClient.getPersonBasic(params),
       {
-        errorThresholdPercentage: 80,
-        timeout: 5000,
+        errorThresholdPercentage: 80, // % of errors before breaker trips
+        timeout: 5000, // max time before individual request fails, ms
+        rollingCountTimeout: 30000, // width of statistical window, ms
+        volumeThreshold: 5, // min number of requests within statistical window before breaker trips
       },
     )
   }


### PR DESCRIPTION
## Problem

MyInfo circuit breaker is too sensitive, potentially resulting in many users getting locked out of MyInfo unnecessarily.

Closes #118 

## Solution

Decrease the sensitivity by:
1. Increasing the statistical window from 10s (default) to 30s. This means that, over 30s, at least 80% of requests to MyInfo must take at least 5s in order for the breaker to open.
2. Increasing the volume threshold from 0 (default) to 5. This means that within the 30s statistical window, there must be at least 5 requests which take at least 5s in order for the breaker to open.