### PR TITLE
feat: log user email when bulk downloading storage mode responses

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -344,6 +344,8 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
+   * @param {String} params.userId The id of the user downloading
+   * @param {String} params.userEmail The email of the user downloading
    * @param {number} expectedNumSubmissions The expected number of submissions to download
    * @param {number} numWorkers The number of decryption workers
    * @return {Void}
@@ -357,6 +359,8 @@ function GTag($rootScope, $window) {
       event_category: 'Storage Mode Form',
       event_action: 'Download start',
       event_label: params.formTitle,
+      user_id: params.userId,
+      user_email: params.userEmail,
       form_id: params.formId,
       num_workers: numWorkers,
       num_submissions: expectedNumSubmissions,
@@ -368,12 +372,15 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
+   * @param {String} params.userId The id of the user downloading
+   * @param {String} params.userEmail The email of the user downloading
    * @param {number} downloadedNumSubmissions The number of submissions downloaded
    * @param {number} numWorkers The number of decryption workers
    * @param {number} duration The duration taken by the download
    * @return {Void}
    */
   gtagService.downloadResponseSuccess = (
+    // (#42)
     params,
     downloadedNumSubmissions,
     numWorkers,
@@ -383,6 +390,8 @@ function GTag($rootScope, $window) {
       event_category: 'Storage Mode Form',
       event_action: 'Download success',
       event_label: params.formTitle,
+      user_id: params.userId,
+      user_email: params.userEmail,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -395,6 +404,8 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
+   * @param {String} params.userId The id of the user downloading
+   * @param {String} params.userEmail The email of the user downloading
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
    * @param  {number} duration The duration taken by the download
@@ -412,6 +423,8 @@ function GTag($rootScope, $window) {
       event_category: 'Storage Mode Form',
       event_action: 'Download failure',
       event_label: params.formTitle,
+      user_id: params.userId,
+      user_email: params.userEmail,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -424,6 +437,8 @@ function GTag($rootScope, $window) {
    * Logs a failed attempt to even start storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
+   * @param {String} params.userId The id of the user downloading
+   * @param {String} params.userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {string} errorMessage The error message for the failure
    * @return {Void}
@@ -433,6 +448,8 @@ function GTag($rootScope, $window) {
       event_category: 'Storage Mode Form',
       event_action: 'Network failure',
       event_label: params.formTitle,
+      user_id: params.userId,
+      user_email: params.userEmail,
       form_id: params.formId,
       message: errorMessage,
     })

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -16,6 +16,8 @@ function GTag($rootScope, $window) {
         custom_map: {
           dimension1: 'form_id',
           dimension2: 'message',
+          dimension3: 'user_id',
+          dimension4: 'user_email',
           metric1: 'duration',
           metric2: 'num_workers',
           metric3: 'num_submissions',
@@ -380,7 +382,6 @@ function GTag($rootScope, $window) {
    * @return {Void}
    */
   gtagService.downloadResponseSuccess = (
-    // (#42)
     params,
     downloadedNumSubmissions,
     numWorkers,
@@ -459,6 +460,8 @@ function GTag($rootScope, $window) {
    * Logs partial (or full) decryption failure when downloading responses.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
+   * @param {String} params.userId The id of the user downloading
+   * @param {String} params.userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
@@ -477,6 +480,8 @@ function GTag($rootScope, $window) {
       event_category: 'Storage Mode Form',
       event_action: 'Partial decrypt error',
       event_label: params.formTitle,
+      user_id: params.userId,
+      user_email: params.userEmail,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -16,6 +16,7 @@ angular
     '$timeout',
     'moment',
     'FormSgSdk',
+    '$window',
     ViewResponsesController,
   ])
 
@@ -29,6 +30,7 @@ function ViewResponsesController(
   $timeout,
   moment,
   FormSgSdk,
+  $window,
 ) {
   const vm = this
 
@@ -61,11 +63,13 @@ function ViewResponsesController(
 
   // Trigger for export CSV
   vm.exportCsv = function () {
+    const userDetails = JSON.parse($window.localStorage.getItem("user"))
     let params = {
       formId: vm.myform._id,
       formTitle: vm.myform.title,
+      userId: userDetails._id,
+      userEmail: userDetails.email,
     }
-
     if (vm.datePicker.date.startDate && vm.datePicker.date.endDate) {
       params.startDate = moment(new Date(vm.datePicker.date.startDate)).format(
         'YYYY-MM-DD',

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -127,7 +127,7 @@ function SubmissionsFactory(
     count: function (params) {
       const deferred = $q.defer()
       let resUrl = fixParamsToUrl(params, submitAdminUrl) + '/count'
-      resUrl += `/?user=${params.userId}&email=${params.userEmail}` // Log user id and email
+      resUrl += `?user=${params.userId}&email=${params.userEmail}` // Log user id and email
       if (params.startDate && params.endDate) {
         resUrl += `&startDate=${params.startDate}&endDate=${params.endDate}`
       }

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -127,8 +127,9 @@ function SubmissionsFactory(
     count: function (params) {
       const deferred = $q.defer()
       let resUrl = fixParamsToUrl(params, submitAdminUrl) + '/count'
+      resUrl += `/?user=${params.userId}&email=${params.userEmail}` // Log user id and email
       if (params.startDate && params.endDate) {
-        resUrl += `?startDate=${params.startDate}&endDate=${params.endDate}`
+        resUrl += `&startDate=${params.startDate}&endDate=${params.endDate}`
       }
 
       $http.get(resUrl).then(

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -127,9 +127,8 @@ function SubmissionsFactory(
     count: function (params) {
       const deferred = $q.defer()
       let resUrl = fixParamsToUrl(params, submitAdminUrl) + '/count'
-      resUrl += `?user=${params.userId}&email=${params.userEmail}` // Log user id and email
       if (params.startDate && params.endDate) {
-        resUrl += `&startDate=${params.startDate}&endDate=${params.endDate}`
+        resUrl += `?startDate=${params.startDate}&endDate=${params.endDate}`
       }
 
       $http.get(resUrl).then(


### PR DESCRIPTION
## Problem

Closes #170

## Solution

- Include user id and email in GET request for easier tracking when user downloads storage mode responses

## Before & After Screenshots

**BEFORE**:
![Screenshot from 2020-08-19 14-01-26](https://user-images.githubusercontent.com/63710093/90597877-7fdb4d00-e224-11ea-8124-7fabe338e94a.png)

**AFTER**:
![Screenshot from 2020-08-19 13-57-59-2](https://user-images.githubusercontent.com/63710093/90597987-c6c94280-e224-11ea-8324-134a6baa59c2.png)

## Tests

- [ ] Create a storage mode form. Submit a response. Download responses. Check that the admin user id and email is present in the logs.
