### PR TITLE
feat: Filter Storage Mode Responses by Submission Id

### DIFF
--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -25,6 +25,8 @@ const {
   getProcessedResponses,
 } = require('../modules/submission/submission.service')
 
+const HttpStatus = require('http-status-codes')
+
 /**
  * Extracts relevant fields, injects questions, verifies visibility of field and validates answers
  * to produce req.body.parsedResponses
@@ -223,15 +225,47 @@ exports.saveResponseToDb = function (req, res, next) {
  */
 exports.getMetadata = function (req, res) {
   let pageSize = 10
-  let { page } = req.query || {}
+  let { page, submissionId } = req.query || {}
   let numToSkip = parseInt(page - 1 || 0) * pageSize
+
+  let matchClause = {
+    form: req.form._id,
+    submissionType: 'encryptSubmission',
+  }
+
+  if (submissionId) {
+    if (mongoose.Types.ObjectId.isValid(submissionId)) {
+      matchClause._id = mongoose.Types.ObjectId(submissionId)
+      // Reading from primary to avoid any contention issues with bulk queries on secondary servers
+      Submission.findOne(matchClause, { created: 1 })
+        .read('primary')
+        .exec((err, result) => {
+          if (err) {
+            logger.error(getRequestIp(req), req.url, req.headers, err)
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
+              message: errorHandler.getMongoErrorMessage(err),
+            })
+          }
+          if (!result) {
+            return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+          }
+          let entry = {
+            number: 1,
+            refNo: result._id,
+            submissionTime: moment(result.created)
+              .tz('Asia/Singapore')
+              .format('Do MMM YYYY, h:mm:ss a'),
+          }
+          return res.status(HttpStatus.OK).send({ metadata: [entry], count: 1 })
+        })
+    } else {
+      return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+    }
+  }
 
   Submission.aggregate([
     {
-      $match: {
-        form: req.form._id,
-        submissionType: 'encryptSubmission',
-      },
+      $match: matchClause,
     },
     {
       $sort: { created: -1 },

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -40,7 +40,12 @@ function ViewResponsesController(
   vm.isEncryptResponseMode = vm.myform.responseMode === responseModeEnum.ENCRYPT
   vm.encryptionKey = null // will be set to an instance of EncryptionKey when form is unlocked successfully
   vm.csvDownloading = false // whether CSV export is in progress
+
   vm.attachmentDownloadUrls = new Map()
+  vm.filterBySubmissionRefId = '' // whether to filter submissions by a specific ID
+  vm.filterBySubmissionRefIdTextbox = ''
+  vm.filterBySubmissionRefIdMatcher = /^[0-9A-Fa-f]{24}$/
+  vm.filterBySubmissionShowFilterBox = false
 
   // Three views:
   // 1 - Unlock view for verifying form password
@@ -318,12 +323,29 @@ function ViewResponsesController(
     }
   })
 
+  vm.filterBySubmissionChanged = function () {
+    // We only reload the table if the text box has changed. This prevents excessive
+    // requests being sent by users clicking on the "Filter" button repeatedly.
+    if (
+      vm.filterBySubmissionRefIdTextbox !== '' &&
+      vm.filterBySubmissionRefId !== vm.filterBySubmissionRefIdTextbox
+    ) {
+      vm.filterBySubmissionRefId = vm.filterBySubmissionRefIdTextbox
+      vm.tableParams.reload()
+    }
+  }
+
+  vm.filterBySubmissionReset = function () {
+    vm.filterBySubmissionShowFilterBox = false
+    vm.filterBySubmissionRefId = ''
+    vm.filterBySubmissionRefIdTextbox = ''
+    vm.tableParams.reload()
+  }
+
   // Called by child directive unlockResponsesForm after key is verified to get responses
-  vm.loadResponses = function (formPassword) {
-    vm.formPassword = formPassword
+  vm.loadResponses = function () {
     vm.currentView = 2
     vm.loading = true
-
     vm.tableParams = new NgTableParams(
       {
         page: 1, // show first page
@@ -334,6 +356,7 @@ function ViewResponsesController(
           let { page } = params.url()
           return Submissions.getMetadata({
             formId: vm.myform._id,
+            filterBySubmissionRefId: vm.filterBySubmissionRefId,
             page,
           })
             .then((data) => {

--- a/src/public/modules/forms/admin/css/export-button.css
+++ b/src/public/modules/forms/admin/css/export-button.css
@@ -7,7 +7,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-width: 164px;
   margin-left: auto;
 }
 

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -101,7 +101,7 @@
 }
 
 #responses-tab .response-stats {
-  width: 100%;
+  white-space: nowrap;
 }
 
 #responses-tab .datepicker-export-container {
@@ -718,6 +718,18 @@
 
 #filter-by-submission-reset-link {
   padding-top: 13px;
+  padding-left: 13px;
   white-space: nowrap;
   cursor: pointer;
+}
+
+#filter-by-submission-filter-link {
+  padding-top: 13px;
+  padding-left: 5px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+#filter-by-submission-filter-textbox-container {
+  display: flex;
 }

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -715,3 +715,9 @@
   padding-left: 16px !important;
   border: solid 1px #ccc;
 }
+
+#filter-by-submission-reset-link {
+  padding-top: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+}

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -102,6 +102,7 @@
 
 #responses-tab .response-stats {
   white-space: nowrap;
+  min-width: 240px;
 }
 
 #responses-tab .datepicker-export-container {
@@ -732,4 +733,5 @@
 
 #filter-by-submission-filter-textbox-container {
   display: flex;
+  min-width: 240px;
 }

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -90,14 +90,14 @@
             class="input-custom input-medium"
             ng-model="vm.filterBySubmissionRefIdTextbox"
             ng-change="vm.filterBySubmissionChanged()"
-            ng-model-options="{ debounce: 500 }"
+            ng-model-options="{ debounce: 150 }"
             placeholder="Search by reference no."
           />
           <span
             id="filter-by-submission-reset-link"
             ng-show="vm.filterBySubmissionRefId !== ''"
           >
-            <a ng-click="vm.filterBySubmissionReset()">Reset</a>
+            <a ng-click="vm.filterBySubmissionReset()">View&nbsp;All</a>
           </span>
         </div>
         <div class="datepicker-export-container col-md-3">

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -31,7 +31,9 @@
 
   <!-- Storage Mode -->
   <div ng-if="!vm.loading && vm.isEncryptResponseMode">
-    <div ng-if="vm.responsesCount === 0">
+    <div
+      ng-if="vm.currentView === 1 && vm.responsesCount === 0 && vm.filterBySubmissionRefId === ''"
+    >
       <div class="flex-column">
         <img
           id="no-responses"
@@ -62,17 +64,24 @@
       >
       </verify-secret-key-directive>
     </div>
-    <div ng-if="vm.responsesCount > 0 && vm.currentView === 2">
+    <div ng-if="vm.currentView === 2">
       <div class="flex-row">
-        <div class="response-stats">
+        <div class="col-md-3 response-stats">
           <span class="stats-text">
             <span
               ><span class="stats">{{vm.responsesCount}}</span> response(s) to
               date</span
             >
+            <button
+              ng-show="!vm.filterBySubmissionShowFilterBox"
+              class="btn-custom"
+              ng-click="vm.filterBySubmissionShowFilterBox = true"
+            >
+              <i class="bx bx-search"></i>
+            </button>
           </span>
         </div>
-        <div class="datepicker-export-container">
+        <div class="datepicker-export-container col-md-6">
           <date-range-picker-directive
             class="datepicker-container"
             ng-model="vm.datePicker.date"
@@ -84,8 +93,28 @@
           ></export-button-component>
         </div>
       </div>
+      <div class="flex-row" ng-show="vm.filterBySubmissionShowFilterBox">
+        <div class="col-md-5">
+          <div class="col-md-9">
+            <input
+              class="input-custom input-medium"
+              ng-model="vm.filterBySubmissionRefIdTextbox"
+              ng-change="vm.filterBySubmissionChanged()"
+              ng-model-options="{ debounce: 500 }"
+              placeholder="Filter by Submission Ref No."
+            />
+          </div>
+          <div
+            class="col-md-3"
+            id="filter-by-submission-reset-link"
+            ng-show="vm.filterBySubmissionRefId !== ''"
+          >
+            <a ng-click="vm.filterBySubmissionReset()">Reset</a>
+          </div>
+        </div>
+      </div>
       <div class="row">
-        <div class="col-md-12">
+        <div ng-if="vm.responsesCount > 0" class="col-md-12">
           <table class="table" ng-table="vm.tableParams" show-filter="false">
             <tr ng-repeat="row in $data" ng-click="vm.rowOnClick($index)">
               <td
@@ -107,6 +136,21 @@
               </td>
             </tr>
           </table>
+        </div>
+        <div
+          ng-if="vm.responsesCount === 0 && vm.filterBySubmissionRefId !== ''"
+        >
+          <div class="flex-column">
+            <img
+              ng-src="/public/modules/core/img/error-illustration.svg"
+              id="no-responses"
+            />
+            <div class="title">No results found</div>
+            <div class="subtitle">
+              Did you enter the right reference number? We can't seem to find
+              the response.
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -72,16 +72,35 @@
               ><span class="stats">{{vm.responsesCount}}</span> response(s) to
               date</span
             >
-            <button
+            <a
+              id="filter-by-submission-filter-link"
               ng-show="!vm.filterBySubmissionShowFilterBox"
-              class="btn-custom"
               ng-click="vm.filterBySubmissionShowFilterBox = true"
             >
               <i class="bx bx-search"></i>
-            </button>
+            </a>
           </span>
         </div>
-        <div class="datepicker-export-container col-md-6">
+        <div
+          class="col-md-6"
+          ng-show="vm.filterBySubmissionShowFilterBox"
+          id="filter-by-submission-filter-textbox-container"
+        >
+          <input
+            class="input-custom input-medium"
+            ng-model="vm.filterBySubmissionRefIdTextbox"
+            ng-change="vm.filterBySubmissionChanged()"
+            ng-model-options="{ debounce: 500 }"
+            placeholder="Search by reference no."
+          />
+          <span
+            id="filter-by-submission-reset-link"
+            ng-show="vm.filterBySubmissionRefId !== ''"
+          >
+            <a ng-click="vm.filterBySubmissionReset()">Reset</a>
+          </span>
+        </div>
+        <div class="datepicker-export-container col-md-3">
           <date-range-picker-directive
             class="datepicker-container"
             ng-model="vm.datePicker.date"
@@ -94,24 +113,7 @@
         </div>
       </div>
       <div class="flex-row" ng-show="vm.filterBySubmissionShowFilterBox">
-        <div class="col-md-5">
-          <div class="col-md-9">
-            <input
-              class="input-custom input-medium"
-              ng-model="vm.filterBySubmissionRefIdTextbox"
-              ng-change="vm.filterBySubmissionChanged()"
-              ng-model-options="{ debounce: 500 }"
-              placeholder="Filter by Submission Ref No."
-            />
-          </div>
-          <div
-            class="col-md-3"
-            id="filter-by-submission-reset-link"
-            ng-show="vm.filterBySubmissionRefId !== ''"
-          >
-            <a ng-click="vm.filterBySubmissionReset()">Reset</a>
-          </div>
-        </div>
+        <div class="col-md-5"></div>
       </div>
       <div class="row">
         <div ng-if="vm.responsesCount > 0" class="col-md-12">

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -146,9 +146,13 @@ function SubmissionsFactory(
     },
     getMetadata: function (params) {
       const deferred = $q.defer()
-      const resUrl = `${fixParamsToUrl(params, submitAdminUrl)}/metadata?page=${
+      let resUrl = `${fixParamsToUrl(params, submitAdminUrl)}/metadata?page=${
         params.page
       }`
+
+      if (params.filterBySubmissionRefId) {
+        resUrl += `&submissionId=${params.filterBySubmissionRefId}`
+      }
 
       $http.get(resUrl).then(
         function (response) {


### PR DESCRIPTION
## Problem

Users have trouble finding specific responses and trying to download attachments for these responses.

## Solution

This introduces a new textbox which filters submissions by reference ID so users can jump to a certain response immediately.

## Screenshots

![image](https://user-images.githubusercontent.com/691628/89267274-da9d6380-d5eb-11ea-9fff-9767c04108fd.png)

![image](https://user-images.githubusercontent.com/691628/89267306-e6892580-d5eb-11ea-85b7-00411a28183f.png)

![image](https://user-images.githubusercontent.com/691628/89267343-f6a10500-d5eb-11ea-8064-815bfe659067.png)

## Notes

This is a resubmission of #71 as the earlier PR was reverted due to performance issues.