### PR TITLE
feat(frontend): remove element from DOM instead of hiding if feature is disabled

### DIFF
--- a/src/public/modules/core/directives/feature-toggle.client.directive.js
+++ b/src/public/modules/core/directives/feature-toggle.client.directive.js
@@ -7,7 +7,9 @@ function featureToggle(Features) {
     restrict: 'A',
     link: function (scope, element, attrs) {
       Features.getfeatureStates().then(function (response) {
-        element.css('display', response[attrs.featureName] ? '' : 'none')
+        if (!response[attrs.featureName]) {
+          element.remove()
+        }
         scope.feature = response
       })
     },


### PR DESCRIPTION
In the current implementation, savvy users will still be able to go into element inspector and unhide the hidden element.

This PR fixes that by completely removing the disabled element from the DOM.

## Screenshots
### Before:
![recording (15)](https://user-images.githubusercontent.com/22133008/90604440-6986be80-e22f-11ea-903d-d1c7c7f24992.gif)


### After:
Does not even exist on the DOM
![Screenshot 2020-08-19 at 3 26 37 PM](https://user-images.githubusercontent.com/22133008/90605036-60e2b800-e230-11ea-9248-80af92f0c2be.png)
