### PR TITLE
fix: enable forceDelivery on twilio message sending

### DIFF
--- a/src/app/services/sms.service.ts
+++ b/src/app/services/sms.service.ts
@@ -146,7 +146,12 @@ const send = async (
   const { client, msgSrvcSid } = twilioConfig
 
   return client.messages
-    .create({ to: recipient, body: message, from: msgSrvcSid })
+    .create({
+      to: recipient,
+      body: message,
+      from: msgSrvcSid,
+      forceDelivery: true,
+    })
     .then(({ status, sid, errorCode, errorMessage }) => {
       // Sent but with error code.
       // Throw error to be caught in catch block.


### PR DESCRIPTION
This PR enables the `forceDelivery` option on Twilio to attempt to send messages without validating against `libphonenumber` (which has delays when new mobile numbers are issued).

Closes #177