### PR TITLE
fix: run npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10436,9 +10436,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",


### PR DESCRIPTION
Resolves security issues with the `minimist` dependency in the `selectize` package.

![image](https://user-images.githubusercontent.com/5690550/90735601-17619e00-e300-11ea-9360-c5c228505b17.png)
