### PR TITLE
fix: shift userEmail retrieval to GA service

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -4,7 +4,7 @@ function GTag($rootScope, $window) {
   // Google Analytics tracking ID provided on signup.
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
-  const userEmail = JSON.parse($window.localStorage.getItem("user")).email
+  const userEmail = JSON.parse($window.localStorage.getItem('user')).email
 
   /**
    * Internal wrapper function to initialise GA with some globals
@@ -344,7 +344,7 @@ function GTag($rootScope, $window) {
    * Logs the start of a storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} params.formTitle The title of the form 
+   * @param {String} params.formTitle The title of the form
    * @param {String} userEmail The email of the user downloading
    * @param {number} expectedNumSubmissions The expected number of submissions to download
    * @param {number} numWorkers The number of decryption workers
@@ -369,7 +369,7 @@ function GTag($rootScope, $window) {
    * Logs a successful storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} params.formTitle The title of the form 
+   * @param {String} params.formTitle The title of the form
    * @param {String} userEmail The email of the user downloading
    * @param {number} downloadedNumSubmissions The number of submissions downloaded
    * @param {number} numWorkers The number of decryption workers
@@ -397,7 +397,7 @@ function GTag($rootScope, $window) {
    * Logs a failed storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} params.formTitle The title of the form 
+   * @param {String} params.formTitle The title of the form
    * @param {String} userEmail The email of the user downloading
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
@@ -481,7 +481,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Secret key mailto clicked',
-      event_label: formTitle
+      event_label: formTitle,
     })
   }
 

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -8,9 +8,14 @@ function GTag($rootScope, $window) {
   let gtagService = {}
 
   const getUserEmail = () => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
-    return userEmail
+    let user = $window.localStorage.getItem('user')
+    try {
+      let userDetails = JSON.parse(user)
+      let userEmail = get(userDetails, 'email', null)
+      return userEmail
+    } catch (error) {
+      return null
+    }
   }
 
   /**

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -4,6 +4,7 @@ function GTag($rootScope, $window) {
   // Google Analytics tracking ID provided on signup.
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
+  const userEmail = JSON.parse($window.localStorage.getItem("user")).email
 
   /**
    * Internal wrapper function to initialise GA with some globals
@@ -344,7 +345,7 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form 
-   * @param {String} params.userEmail The email of the user downloading
+   * @param {String} userEmail The email of the user downloading
    * @param {number} expectedNumSubmissions The expected number of submissions to download
    * @param {number} numWorkers The number of decryption workers
    * @return {Void}
@@ -357,7 +358,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download start',
-      event_label: `${params.formTitle} (${params.formId}), ${params.userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
       form_id: params.formId,
       num_workers: numWorkers,
       num_submissions: expectedNumSubmissions,
@@ -369,7 +370,7 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form 
-   * @param {String} params.userEmail The email of the user downloading
+   * @param {String} userEmail The email of the user downloading
    * @param {number} downloadedNumSubmissions The number of submissions downloaded
    * @param {number} numWorkers The number of decryption workers
    * @param {number} duration The duration taken by the download
@@ -384,7 +385,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download success',
-      event_label: `${params.formTitle} (${params.formId}), ${params.userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -397,7 +398,7 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form 
-   * @param {String} params.userEmail The email of the user downloading
+   * @param {String} userEmail The email of the user downloading
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
    * @param  {number} duration The duration taken by the download
@@ -414,7 +415,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download failure',
-      event_label: `${params.formTitle} (${params.formId}), ${params.userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -427,7 +428,7 @@ function GTag($rootScope, $window) {
    * Logs a failed attempt to even start storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} params.userEmail The email of the user downloading
+   * @param {String} userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {string} errorMessage The error message for the failure
    * @return {Void}
@@ -436,7 +437,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Network failure',
-      event_label: `${params.formTitle} (${params.formId}), ${params.userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
       form_id: params.formId,
       message: errorMessage,
     })
@@ -446,7 +447,7 @@ function GTag($rootScope, $window) {
    * Logs partial (or full) decryption failure when downloading responses.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} params.userEmail The email of the user downloading
+   * @param {String} userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
@@ -464,7 +465,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Partial decrypt error',
-      event_label: `${params.formTitle} (${params.formId}), ${params.userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -1,10 +1,11 @@
+const get = require('lodash/get')
+
 angular.module('core').factory('GTag', ['$rootScope', '$window', GTag])
 
 function GTag($rootScope, $window) {
   // Google Analytics tracking ID provided on signup.
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
-  const userEmail = JSON.parse($window.localStorage.getItem('user')).email
 
   /**
    * Internal wrapper function to initialise GA with some globals
@@ -51,7 +52,11 @@ function GTag($rootScope, $window) {
    * start with a slash (/) character.
    * @return {Void}
    */
-  const _gtagPageview = ({ pageTitle, pagePath, pageLocation }) => {
+  const _gtagPageview = ({
+    pageTitle,
+    pagePath,
+    pageLocation
+  }) => {
     if (GATrackingID) {
       $window.gtag('config', GATrackingID, {
         page_title: pageTitle,
@@ -355,6 +360,8 @@ function GTag($rootScope, $window) {
     expectedNumSubmissions,
     numWorkers,
   ) => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download start',
@@ -364,6 +371,7 @@ function GTag($rootScope, $window) {
       num_submissions: expectedNumSubmissions,
     })
   }
+
 
   /**
    * Logs a successful storage mode responses download.
@@ -382,6 +390,8 @@ function GTag($rootScope, $window) {
     numWorkers,
     duration,
   ) => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download success',
@@ -412,6 +422,8 @@ function GTag($rootScope, $window) {
     duration,
     errorMessage,
   ) => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download failure',
@@ -434,6 +446,8 @@ function GTag($rootScope, $window) {
    * @return {Void}
    */
   gtagService.downloadNetworkFailure = (params, errorMessage) => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Network failure',
@@ -462,6 +476,8 @@ function GTag($rootScope, $window) {
     errorCount,
     duration,
   ) => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Partial decrypt error',

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -7,7 +7,7 @@ function GTag($rootScope, $window) {
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
 
-  const userEmail = () => {
+  const getUserEmail = () => {
     const userDetails = JSON.parse($window.localStorage.getItem('user'))
     const userEmail = get(userDetails, 'email', null)
     return userEmail
@@ -368,13 +368,12 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download start',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
       form_id: params.formId,
       num_workers: numWorkers,
       num_submissions: expectedNumSubmissions,
     })
   }
-
 
   /**
    * Logs a successful storage mode responses download.
@@ -395,7 +394,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download success',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -424,7 +423,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download failure',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -445,7 +444,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Network failure',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
       form_id: params.formId,
       message: errorMessage,
     })
@@ -472,7 +471,7 @@ function GTag($rootScope, $window) {
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Partial decrypt error',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -7,6 +7,12 @@ function GTag($rootScope, $window) {
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
 
+  const userEmail = () => {
+    const userDetails = JSON.parse($window.localStorage.getItem('user'))
+    const userEmail = get(userDetails, 'email', null)
+    return userEmail
+  }
+
   /**
    * Internal wrapper function to initialise GA with some globals
    *
@@ -350,7 +356,6 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
-   * @param {String} userEmail The email of the user downloading
    * @param {number} expectedNumSubmissions The expected number of submissions to download
    * @param {number} numWorkers The number of decryption workers
    * @return {Void}
@@ -360,12 +365,10 @@ function GTag($rootScope, $window) {
     expectedNumSubmissions,
     numWorkers,
   ) => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download start',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
       form_id: params.formId,
       num_workers: numWorkers,
       num_submissions: expectedNumSubmissions,
@@ -378,7 +381,6 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
-   * @param {String} userEmail The email of the user downloading
    * @param {number} downloadedNumSubmissions The number of submissions downloaded
    * @param {number} numWorkers The number of decryption workers
    * @param {number} duration The duration taken by the download
@@ -390,12 +392,10 @@ function GTag($rootScope, $window) {
     numWorkers,
     duration,
   ) => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download success',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -408,7 +408,6 @@ function GTag($rootScope, $window) {
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
    * @param {String} params.formTitle The title of the form
-   * @param {String} userEmail The email of the user downloading
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
    * @param  {number} duration The duration taken by the download
@@ -422,12 +421,10 @@ function GTag($rootScope, $window) {
     duration,
     errorMessage,
   ) => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Download failure',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,
@@ -440,18 +437,15 @@ function GTag($rootScope, $window) {
    * Logs a failed attempt to even start storage mode responses download.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {string} errorMessage The error message for the failure
    * @return {Void}
    */
   gtagService.downloadNetworkFailure = (params, errorMessage) => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Network failure',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
       form_id: params.formId,
       message: errorMessage,
     })
@@ -461,7 +455,6 @@ function GTag($rootScope, $window) {
    * Logs partial (or full) decryption failure when downloading responses.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form
-   * @param {String} userEmail The email of the user downloading
    * @param {String} params.formTitle The title of the form
    * @param {number} numWorkers The number of decryption workers
    * @param {number} expectedNumSubmissions The expected number of submissions
@@ -476,12 +469,10 @@ function GTag($rootScope, $window) {
     errorCount,
     duration,
   ) => {
-    const userDetails = JSON.parse($window.localStorage.getItem('user'))
-    const userEmail = get(userDetails, 'email', null)
     _gtagEvents('storage', {
       event_category: 'Storage Mode Form',
       event_action: 'Partial decrypt error',
-      event_label: `${params.formTitle} (${params.formId}), ${userEmail}`,
+      event_label: `${params.formTitle} (${params.formId}), ${userEmail()}`,
       form_id: params.formId,
       duration: duration,
       num_workers: numWorkers,

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -1,21 +1,13 @@
-const get = require('lodash/get')
+angular.module('core').factory('GTag', ['Auth', '$rootScope', '$window', GTag])
 
-angular.module('core').factory('GTag', ['$rootScope', '$window', GTag])
-
-function GTag($rootScope, $window) {
+function GTag(Auth, $rootScope, $window) {
   // Google Analytics tracking ID provided on signup.
   const GATrackingID = $window.GATrackingID
   let gtagService = {}
 
   const getUserEmail = () => {
-    let user = $window.localStorage.getItem('user')
-    try {
-      let userDetails = JSON.parse(user)
-      let userEmail = get(userDetails, 'email', null)
-      return userEmail
-    } catch (error) {
-      return null
-    }
+    const user = Auth.getUser()
+    return user && user.email
   }
 
   /**

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -16,7 +16,6 @@ angular
     '$timeout',
     'moment',
     'FormSgSdk',
-    '$window',
     ViewResponsesController,
   ])
 
@@ -30,7 +29,6 @@ function ViewResponsesController(
   $timeout,
   moment,
   FormSgSdk,
-  $window,
 ) {
   const vm = this
 
@@ -63,11 +61,9 @@ function ViewResponsesController(
 
   // Trigger for export CSV
   vm.exportCsv = function () {
-    const userDetails = JSON.parse($window.localStorage.getItem("user"))
     let params = {
       formId: vm.myform._id,
       formTitle: vm.myform.title,
-      userEmail: userDetails.email,
     }
     if (vm.datePicker.date.startDate && vm.datePicker.date.endDate) {
       params.startDate = moment(new Date(vm.datePicker.date.startDate)).format(


### PR DESCRIPTION
## Problem

Builds on PR #154 to avoid userEmail unintentionally being sent as a query parameter

## Solution

- Shift retrieval of userEmail to GA service