### PR TITLE
feat: add core ApplicationError for express app

### DIFF
--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -1,0 +1,28 @@
+/**
+ * A custom base error class that encapsulates the name, message, status code,
+ * and logging meta string (if any) for the error.
+ */
+export class ApplicationError extends Error {
+  /**
+   * Http status code for the error to be returned in the response.
+   */
+  status: number
+  /**
+   * Meta string to be logged by the application logger, if any.
+   */
+  meta?: string
+
+  constructor(message?: string, status?: number, meta?: string) {
+    super()
+
+    Error.captureStackTrace(this, this.constructor)
+
+    this.name = this.constructor.name
+
+    this.message = message || 'Something went wrong. Please try again.'
+
+    this.status = status || 500
+
+    this.meta = meta
+  }
+}


### PR DESCRIPTION
## Problem

This PR adds a core `ApplicationError` class for easy wrapping and consistent handling of errors in the express application:

```ts
constructor(message?: string, status?: number, meta?: string)
```

It has 2 extra parameters `status` and `meta` as compared to the `Error` class it extends from. See the documentation in the class for more details.

## Example Usage

```ts
import HttpStatus from 'http-status-codes'

import { ApplicationError } from '../core/core.errors'

export class InvalidOtpError extends ApplicationError {
  constructor(message: string, meta?: string) {
    super(message, HttpStatus.UNPROCESSABLE_ENTITY, meta)
  }
}

export class MalformedOtpError extends ApplicationError {
  constructor(
    message: string = 'Malformed OTP. Please try again later. If the problem persists, contact us.',
    meta?: string,
  ) {
    super(message, HttpStatus.INTERNAL_SERVER_ERROR, meta)
  }
}
```

### Instantiation

```ts
//// File_A.ts
const someFunctionInFileA = () => {
  throw new InvalidOtpError(
      'You have hit the max number of attempts. Please request for a new OTP.',
      `Some string for logging`,
    )
}
```

### Error handling
```ts
//// File_B.ts
const someExpressControllerFunction = () => {
  try {
    await someFunctionInFileA()
  } catch (err) {
    // Meta can be used for internal logging
    logger.warn(err.meta ?? err)
    if (err instanceof ApplicationError) {
      // Error values used to return statuses and error message.
      return res.status(err.status).send(err.message)
    } else {
      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send(err.message)
    }
  }
}
```
