### PR TITLE
chore(deps-dev): bump typescript to 4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23990,6 +23990,12 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        },
+        "typescript": {
+          "version": "3.9.7",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+          "dev": true
         }
       }
     },
@@ -24947,9 +24953,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "ts-mock-imports": "^1.3.0",
     "ts-node": "^8.10.2",
     "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^3.9.7",
+    "typescript": "^4.0.2",
     "url-loader": "^1.1.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",


### PR DESCRIPTION
**Rationale**

1. Minimal [breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#breaking-changes) in TS4, and the breaking changes shouldn't affect us anyway.
2. A lot of useful new features, e.g. `??=` assignment operator.
3. 4.0.2 - 3.9.7 = 0.0.5 which doesn't seem like that big of a change.
<img width="246" alt="Screenshot 2020-08-24 at 1 30 15 PM" src="https://user-images.githubusercontent.com/29480346/91007206-f48bfe00-e60d-11ea-9ee2-520170dc8ad3.png">
