### PR TITLE
feat: Share form secret keys across browser tabs using BroadcastChannel

### DIFF
--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -47,6 +47,18 @@ function ViewResponsesController(
 
   vm.datePicker = { date: { startDate: null, endDate: null } }
 
+  // BroadcastChannel will only broadcast the message to scripts from the same origin 
+  // (i.e. https://form.gov.sg in practice) so all data should be controlled by scripts 
+  // originating from FormSG. This does not store any data in browser-based storage 
+  // (e.g. cookies or localStorage) so secrets would not be retained past the user closing 
+  // all FormSG tabs containing the form.
+
+  // We do not use polyfills for BroadcastChannel as they usually involve localStorage, 
+  // which is not safe for secret key handling.
+    
+  // BroadcastChannel is not available on Safari and IE 11, so this feature is not available
+  // on those two browsers. Current behavior where users have to upload the secret key on
+  // each tab will continue for users on those two browsers.
   if (typeof BroadcastChannel === 'function') {
     vm.privateKeyChannel = new BroadcastChannel('formsg_private_key_sharing')
     vm.privateKeyChannel.onmessage = function (e) {


### PR DESCRIPTION
## Problem

Users have to repeatedly enter their form secret key if they open multiple tabs with the same form. This hinders future bulk downloading of attachments (Issue #16) because there are multiple clicks involved in unlocking a response from a tab.

## Solution

We utilize `BroadcastChannel` to request and broadcast the form secret key to other tabs.

## Tests

- Open two tabs and navigate to the View Responses page of a storage mode form. Upload a secret key to one form to unlock. The other tab should be unlocked automatically.
- Unlock responses on one form. Open a second tab and go to view responses. The tab should already be unlocked.

## Security

`BroadcastChannel` will only broadcast the message to scripts from the same origin (i.e. `https://form.gov.sg` in practice) so all data should be controlled by scripts originating from FormSG. This does not store any data in browser-based storage (e.g. cookies or localStorage) so secrets would not be retained past the user closing all FormSG tabs containing the form.

We do not use polyfills for `BroadcastChannel` as they usually involve `localStorage`, which is not safe for secret key handling.

## Browser Compatibility

`BroadcastChannel` is not available on Safari and IE 11, so this feature is not available on those two browsers. Current behavior where users have to upload the secret key on each tab will continue for users on those two browsers.
