### PR TITLE
feat: refresh storage mode responses when navigating to data / responses tab

### DIFF
--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -72,6 +72,12 @@ function AdminFormController(
   FormApi,
 ) {
 
+  // Track active main tab
+  $scope.activeMainTab = 'Build'
+  $scope.setActiveMainTab = (value) => {
+    $scope.activeMainTab = value
+  }
+
   // Banner message on form builder routes
   $scope.bannerContent = $window.siteBannerContent || $window.adminBannerContent
 

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -272,6 +272,8 @@ function ViewResponsesController(
   
   // When this route is initialized, call the responses count function
   // Trigger refresh when user navigates to responses subtab
+  // It is necessary to watch $parent for vm.activeResultsTab as
+  // a different object with the same name (vm) already exists in $scope 
   $scope.$parent.$watch('vm.activeResultsTab', (newValue) => {
     if (newValue === 'responses') {
       vm.setSubmissionsCount()

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -255,21 +255,27 @@ function ViewResponsesController(
     }
   }
 
+  vm.setSubmissionsCount = function() {
+    Submissions.count({
+      formId: vm.myform._id,
+    })
+    .then((responsesCount) => {
+      vm.responsesCount = responsesCount
+      $timeout(() => {
+        vm.loading = false
+      }, 200)
+    })
+    .catch((error) => {
+      console.error(error)
+    })
+  }
+  
   // When this route is initialized, call the responses count function
+  // Trigger refresh when user navigates to responses subtab
   $scope.$parent.$watch('vm.activeResultsTab', (newValue) => {
-    if (newValue === 'responses' && vm.loading) {
-      Submissions.count({
-        formId: vm.myform._id,
-      })
-        .then((responsesCount) => {
-          vm.responsesCount = responsesCount
-          $timeout(() => {
-            vm.loading = false
-          }, 200)
-        })
-        .catch((error) => {
-          console.error(error)
-        })
+    if (newValue === 'responses') {
+      vm.setSubmissionsCount()
+      vm.refreshResponses()
     }
   })
 
@@ -330,6 +336,24 @@ function ViewResponsesController(
     }
   }
 
+
+  // Trigger refresh when user navigates to Data tab
+
+  $scope.$watch(
+    'activeMainTab',
+    (newValue) => {
+      if (newValue === 'results') vm.refreshResponses()
+    },
+  )
+
+  // Trigger refresh of response count for unlocked responses when user navigates to Data tab 
+
+  $scope.$watch('activeMainTab', (newValue) => {
+    if (newValue === 'results') {
+      vm.setSubmissionsCount()
+    }
+  })
+  
   // Triggers the download progress modal after SHOW_PROGRESS_DELAY_MS has
   // passed and is still downloading after export button click.
   let timeoutPromise

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -322,6 +322,14 @@ function ViewResponsesController(
     }
   }
 
+  // Refresh responses if responses have already been unlocked, and 
+  // user navigates to Data tab or Responses subtab
+  vm.refreshResponses = function() {
+    if (vm.encryptionKey) {
+      vm.loadResponses()
+    }
+  }
+
   // Triggers the download progress modal after SHOW_PROGRESS_DELAY_MS has
   // passed and is still downloading after export button click.
   let timeoutPromise

--- a/src/public/modules/forms/admin/views/admin-form.client.view.html
+++ b/src/public/modules/forms/admin/views/admin-form.client.view.html
@@ -291,7 +291,11 @@
   <uib-tabset type="pills">
     <div id="admin-tab-bar">
       <div id="admin-tabs-container" drag-scroll="true">
-        <uib-tab ng-repeat="viewTab in viewTabs" heading="{{viewTab.title}}">
+        <uib-tab
+          ng-repeat="viewTab in viewTabs"
+          heading="{{viewTab.title}}"
+          select="setActiveMainTab(viewTab.route)"
+        >
           <div ui-view="{{viewTab.route}}"></div>
         </uib-tab>
       </div>


### PR DESCRIPTION
## Problem

Closes #182

## Tests

- [ ] Create a storage mode form. Activate the form. Go to the Data tab in the admin panel. The responses view should say "This form doesn't have any responses yet.".
- [ ] Submit a response. Click the feedback sub-tab and then back to responses. The response count should now be 1.
- [ ] Submit another responses. Click the Share tab and then back to Data. The response count 
should now be 2.
- [ ] Unlock responses. Submit another response. Click the feedback sub-tab and then back to responses. The response count should now be 3. Check that the responses are correctly reflected in the list of responses.
- [ ] Submit another responses. Click the Share tab and then back to Data. The response count should now be 4. Check that the responses are correctly reflected in the list of responses.
- [ ] Open a response in the list. Submit another response. Exit the response view. The response count should now be 5. Check that the responses are correctly reflected in the list of responses.
