### PR TITLE
feat: mailto option after form activation

### DIFF
--- a/src/public/main.js
+++ b/src/public/main.js
@@ -273,6 +273,7 @@ require('./modules/forms/services/rating.client.service.js')
 require('./modules/forms/services/betas.client.factory.js')
 require('./modules/forms/services/verification.client.factory.js')
 require('./modules/forms/services/captcha.client.service.js')
+require('./modules/forms/services/mailto.client.factory.js')
 
 /**
  * Users module

--- a/src/public/modules/core/css/core.css
+++ b/src/public/modules/core/css/core.css
@@ -584,7 +584,7 @@ body #toast-container > .toast-error > .toast-message > a {
 }
 
 body #toast-container > .toast-success > .toast-message > a {
-  color: #038363;
+  color: #2560eb;
   text-decoration: underline;
 }
 

--- a/src/public/modules/core/css/core.css
+++ b/src/public/modules/core/css/core.css
@@ -583,6 +583,11 @@ body #toast-container > .toast-error > .toast-message > a {
   text-decoration: underline;
 }
 
+body #toast-container > .toast-success > .toast-message > a {
+  color: #038363;
+  text-decoration: underline;
+}
+
 /* Custom css for icons */
 
 i.glyphicon-question-sign {

--- a/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
@@ -1,3 +1,5 @@
+const dedent = require('dedent-js')
+
 angular
   .module('forms')
   .controller('ActivateFormController', [
@@ -5,6 +7,7 @@ angular
     '$timeout',
     'SpcpValidateEsrvcId',
     'externalScope',
+    'MailTo',
     ActivateFormController,
   ])
 
@@ -13,8 +16,9 @@ function ActivateFormController(
   $timeout,
   SpcpValidateEsrvcId,
   externalScope,
+  MailTo,
 ) {
-  let { updateFormStatusAndSave, checks } = externalScope
+  let { updateFormStatusAndSave, checks, formParams } = externalScope
 
   const vm = this
 
@@ -110,10 +114,20 @@ function ActivateFormController(
     if (encryptionKey !== null) {
       vm.remainingChecks--
       vm.savingStatus = 1
-      updateFormStatusAndSave('Congrats! Your form has gone live.').then(() => {
-        vm.savingStatus = 2
-        vm.closeActivateFormModal()
-      })
+      const toastMessage = dedent`
+        Congrats! Your form has gone live.<br/>
+        <a href=${MailTo.generateMailToUri(formParams.title, encryptionKey.secretKey, formParams._id)}>
+          Email secret key to colleagues for safekeeping.
+        </a>
+        `
+      updateFormStatusAndSave(
+        toastMessage,
+        { timeOut: 10000, extendedTimeOut: 10000, skipLinky: true },
+      )
+        .then(() => {
+          vm.savingStatus = 2
+          vm.closeActivateFormModal()
+        })
     }
   }
 }

--- a/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
@@ -116,18 +116,22 @@ function ActivateFormController(
       vm.savingStatus = 1
       const toastMessage = dedent`
         Congrats! Your form has gone live.<br/>
-        <a href=${MailTo.generateMailToUri(formParams.title, encryptionKey.secretKey, formParams._id)}>
+        <a href=${MailTo.generateMailToUri(
+          formParams.title,
+          encryptionKey.secretKey,
+          formParams._id,
+        )}>
           Email secret key to colleagues for safekeeping.
         </a>
         `
-      updateFormStatusAndSave(
-        toastMessage,
-        { timeOut: 10000, extendedTimeOut: 10000, skipLinky: true },
-      )
-        .then(() => {
-          vm.savingStatus = 2
-          vm.closeActivateFormModal()
-        })
+      updateFormStatusAndSave(toastMessage, {
+        timeOut: 10000,
+        extendedTimeOut: 10000,
+        skipLinky: true,
+      }).then(() => {
+        vm.savingStatus = 2
+        vm.closeActivateFormModal()
+      })
     }
   }
 }

--- a/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
@@ -114,24 +114,28 @@ function ActivateFormController(
     if (encryptionKey !== null) {
       vm.remainingChecks--
       vm.savingStatus = 1
-      const toastMessage = dedent`
-        Congrats! Your form has gone live.<br/>
-        <a href=${MailTo.generateMailToUri(
-          formParams.title,
-          encryptionKey.secretKey,
-          formParams._id,
-        )}>
-          Email secret key to colleagues for safekeeping.
-        </a>
-        `
-      updateFormStatusAndSave(toastMessage, {
-        timeOut: 10000,
-        extendedTimeOut: 10000,
-        skipLinky: true,
-      }).then(() => {
-        vm.savingStatus = 2
-        vm.closeActivateFormModal()
-      })
+      MailTo.generateMailToUri(
+        formParams.title,
+        encryptionKey.secretKey,
+        formParams._id,
+      )
+        .then((mailToUri) => {
+          const toastMessage = dedent`
+            Congrats! Your form has gone live.<br/>
+            <a href=${mailToUri}>
+              Email secret key to colleagues for safekeeping.
+            </a>
+            `
+          return updateFormStatusAndSave(toastMessage, {
+            timeOut: 10000,
+            extendedTimeOut: 10000,
+            skipLinky: true,
+          })
+        })
+        .then(() => {
+          vm.savingStatus = 2
+          vm.closeActivateFormModal()
+        })
     }
   }
 }

--- a/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
@@ -219,13 +219,17 @@ function CreateFormModalController(
       vm.formData.responseMode === responseModeEnum.ENCRYPT
     ) {
       vm.formStatus = 2
-      $timeout(() => {
-        const { publicKey, secretKey } = FormSgSdk.crypto.generate()
-        vm.publicKey = publicKey
-        vm.secretKey = secretKey
-        vm.mailToUri = MailTo.generateMailToUri(vm.formData.title, secretKey)
-        vm.formStatus = 3
-      })
+      const { publicKey, secretKey } = FormSgSdk.crypto.generate()
+      vm.publicKey = publicKey
+      vm.secretKey = secretKey
+      MailTo.generateMailToUri(vm.formData.title, secretKey).then(
+        (mailToUri) => {
+          $timeout(() => {
+            vm.mailToUri = mailToUri
+            vm.formStatus = 3
+          })
+        },
+      )
     } else if (
       (vm.formStatus === 1 &&
         vm.formData.responseMode === responseModeEnum.EMAIL) ||

--- a/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
@@ -2,7 +2,6 @@
 const { triggerFileDownload } = require('../../helpers/util')
 const { templates } = require('../constants/covid19')
 const Form = require('../../viewmodels/Form.class')
-const dedent = require('dedent-js')
 
 /**
  * Determine the form title when duplicating a form
@@ -34,7 +33,6 @@ angular
     '$state',
     '$timeout',
     '$uibModal',
-    '$window',
     'Toastr',
     'responseModeEnum',
     'createFormModalOptions',
@@ -44,6 +42,7 @@ angular
     'GTag',
     'FormSgSdk',
     'externalScope',
+    'MailTo',
     CreateFormModalController,
   ])
 
@@ -52,7 +51,6 @@ function CreateFormModalController(
   $state,
   $timeout,
   $uibModal,
-  $window,
   Toastr,
   responseModeEnum,
   createFormModalOptions,
@@ -62,6 +60,7 @@ function CreateFormModalController(
   GTag,
   FormSgSdk,
   externalScope,
+  MailTo,
 ) {
   const vm = this
 
@@ -224,7 +223,7 @@ function CreateFormModalController(
         const { publicKey, secretKey } = FormSgSdk.crypto.generate()
         vm.publicKey = publicKey
         vm.secretKey = secretKey
-        vm.mailToUri = generateMailToUri(vm.formData.title, secretKey)
+        vm.mailToUri = MailTo.generateMailToUri(vm.formData.title, secretKey)
         vm.formStatus = 3
       })
     } else if (
@@ -299,28 +298,6 @@ function CreateFormModalController(
     } else {
       Toastr.error('An error occurred creating the form, please try again')
     }
-  }
-
-  const generateMailToUri = (title, secretKey) => {
-    return (
-      'mailto:?subject=' +
-      $window.encodeURIComponent(`Shared Secret Key for ${title}`) +
-      '&body=' +
-      $window.encodeURIComponent(
-        dedent`
-          Dear collaborator,
-
-          I am sharing my form's secret key with you for safekeeping and backup. This is an important key that is needed to access all form responses.
-
-          Form title: ${title}
-          Secret key: ${secretKey}
-
-          All you need to do is keep this email as a record, and please do not share this key with anyone else.
-
-          Thank you for helping to safekeep my form!
-        `,
-      )
-    )
   }
 
   vm.handleMailToClick = () => {

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -242,7 +242,7 @@ function settingsFormDirective(
         }
 
         // Toggle form status between PUBLIC and PRIVATE
-        const updateFormStatusAndSave = (toastText) => {
+        const updateFormStatusAndSave = (toastText, toastOptions = {}) => {
           $scope.tempForm.status =
             $scope.tempForm.status === 'PRIVATE' ? 'PUBLIC' : 'PRIVATE'
           $scope.btnLiveState = 2 // pressed; loading
@@ -252,7 +252,7 @@ function settingsFormDirective(
               $timeout(() => {
                 $scope.btnLiveState = 1 // unpressed
               }, 1000)
-              Toastr.success(toastText || 'Form updated')
+              Toastr.success(toastText || 'Form updated', toastOptions)
             }, 1000)
           })
         }

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -271,8 +271,8 @@ function settingsFormDirective(
                 checks,
                 formParams: {
                   _id: $scope.myform._id,
-                  title: $scope.myform.title
-                }
+                  title: $scope.myform.title,
+                },
               }),
             },
           })

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -269,6 +269,10 @@ function settingsFormDirective(
               externalScope: () => ({
                 updateFormStatusAndSave,
                 checks,
+                formParams: {
+                  _id: $scope.myform._id,
+                  title: $scope.myform.title
+                }
               }),
             },
           })

--- a/src/public/modules/forms/services/mailto.client.factory.js
+++ b/src/public/modules/forms/services/mailto.client.factory.js
@@ -1,8 +1,8 @@
 const dedent = require('dedent-js')
 
-angular.module('forms').factory('MailTo', ['$window', MailTo])
+angular.module('forms').factory('MailTo', ['$window', '$translate', MailTo])
 
-function MailTo($window) {
+function MailTo($window, $translate) {
   /**
    * Generates a mailto URI which opens the client's default email application
    * with an email to share their secret key. This requires the form title and
@@ -10,35 +10,39 @@ function MailTo($window) {
    * @param {string} title
    * @param {string} secretKey
    * @param {string} [formId]
+   * @return {Promise<string>}
    */
   const generateMailToUri = (title, secretKey, formId) => {
-    // Construct body piece by piece to avoid confusion with order of operations
-    let body = dedent`
-      Dear collaborator,
+    return $translate(['LINKS.APP.ROOT']).then((translations) => {
+      const appUrl = translations['LINKS.APP.ROOT']
+      // Construct body piece by piece to avoid confusion with order of operations
+      let body = dedent`
+        Dear collaborator,
 
-      I am sharing my form's secret key with you for safekeeping and backup. This is an important key that is needed to access all form responses.
+        I am sharing my form's secret key with you for safekeeping and backup. This is an important key that is needed to access all form responses.
 
-      Form title: ${title}`
-    if (formId) {
+        Form title: ${title}`
+      if (formId) {
+        // Note the newline at the start
+        body += dedent`
+
+        Form URL: ${appUrl}/${formId}`
+      }
       // Note the newline at the start
       body += dedent`
 
-      Form URL: https://form.gov.sg/${formId}`
-    }
-    // Note the newline at the start
-    body += dedent`
+        Secret key: ${secretKey}
 
-      Secret key: ${secretKey}
+        All you need to do is keep this email as a record, and please do not share this key with anyone else.
 
-      All you need to do is keep this email as a record, and please do not share this key with anyone else.
-
-      Thank you for helping to safekeep my form!`
-    return (
-      'mailto:?subject=' +
-      $window.encodeURIComponent(`Shared Secret Key for ${title}`) +
-      '&body=' +
-      $window.encodeURIComponent(body)
-    )
+        Thank you for helping to safekeep my form!`
+      return (
+        'mailto:?subject=' +
+        $window.encodeURIComponent(`Shared Secret Key for ${title}`) +
+        '&body=' +
+        $window.encodeURIComponent(body)
+      )
+    })
   }
   return { generateMailToUri }
 }

--- a/src/public/modules/forms/services/mailto.client.factory.js
+++ b/src/public/modules/forms/services/mailto.client.factory.js
@@ -1,0 +1,41 @@
+const dedent = require('dedent-js')
+
+angular.module('forms').factory('MailTo', ['$window', MailTo])
+
+function MailTo($window) {
+  /**
+   * Generates a mailto URI which opens the client's default email application
+   * with an email to share their secret key. This requires the form title and
+   * secret key at minimum, and optionally the form ID.
+   * @param {string} title
+   * @param {string} secretKey
+   * @param {string} [formId]
+   */
+  const generateMailToUri = (title, secretKey, formId) => {
+    // Construct body piece by piece to avoid confusion with order of operations
+    let body = dedent`
+      Dear collaborator,
+
+      I am sharing my form's secret key with you for safekeeping and backup. This is an important key that is needed to access all form responses.
+
+      Form title: ${title}`
+    if (formId) {
+      body += `Form URL: https://form.gov.sg/${formId}`
+    }
+    // Note the newline at the start
+    body += dedent`
+
+      Secret key: ${secretKey}
+
+      All you need to do is keep this email as a record, and please do not share this key with anyone else.
+
+      Thank you for helping to safekeep my form!`
+    return (
+      'mailto:?subject=' +
+      $window.encodeURIComponent(`Shared Secret Key for ${title}`) +
+      '&body=' +
+      $window.encodeURIComponent(body)
+    )
+  }
+  return { generateMailToUri }
+}

--- a/src/public/modules/forms/services/mailto.client.factory.js
+++ b/src/public/modules/forms/services/mailto.client.factory.js
@@ -20,7 +20,10 @@ function MailTo($window) {
 
       Form title: ${title}`
     if (formId) {
-      body += `Form URL: https://form.gov.sg/${formId}`
+      // Note the newline at the start
+      body += dedent`
+
+      Form URL: https://form.gov.sg/${formId}`
     }
     // Note the newline at the start
     body += dedent`

--- a/src/public/modules/forms/services/toastr.client.factory.js
+++ b/src/public/modules/forms/services/toastr.client.factory.js
@@ -36,9 +36,11 @@ function Toastr($filter) {
 
   let toastrNotification = {
     success: function (message, options = {}, title = '') {
-      const linkyfiedMessage = $filter('linky')(message, '_blank')
+      if (!options.skipLinky) {
+        message = $filter('linky')(message, '_blank')
+      }
       toastr.success(
-        linkyfiedMessage + successIconHtml,
+        message + successIconHtml,
         title,
         Object.assign({}, defaultSuccessOptions, options),
       )


### PR DESCRIPTION
Related to #9 


## Screenshots
![image](https://user-images.githubusercontent.com/29480346/91268142-5a5fbd80-e7a7-11ea-8c34-5c088063aeee.png)

![image](https://user-images.githubusercontent.com/29480346/91268445-f093e380-e7a7-11ea-9e3b-11750b3bcddf.png)

## Tests
- [ ] Activating storage mode form shows the Toastr as per the screenshot. Toastr lasts for 10 seconds. Clicking on the link opens an email with the form title, URL and secret key, also as per the screenshot.
