### PR TITLE
fix: pass missing $state param into EditContactNumberModalController

### DIFF
--- a/src/public/modules/core/controllers/edit-contact-number-modal.client.controller.js
+++ b/src/public/modules/core/controllers/edit-contact-number-modal.client.controller.js
@@ -1,6 +1,7 @@
 angular
   .module('core')
   .controller('EditContactNumberModalController', [
+    '$state',
     '$interval',
     '$http',
     '$timeout',
@@ -13,6 +14,7 @@ angular
   ])
 
 function EditContactNumberModalController(
+  $state,
   $interval,
   $http,
   $timeout,


### PR DESCRIPTION
Hotfix for missing param in `EditContactNumberModalController`. 

edit: why did it work on staging though :hmm:
edit2: it worked because Auth always passed during test, meaning $state will not get invoked.