### PR TITLE
fix: Hotfix v4.32.1 -- split mail by semicolon in addition to comma when validating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FormSG",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "homepage": "https://form.gov.sg",
   "authors": [
     "FormSG <formsg@data.gov.sg>"

--- a/src/app/utils/mail.ts
+++ b/src/app/utils/mail.ts
@@ -115,7 +115,9 @@ export const isToFieldValid = (addresses: string | string[]) => {
   const mails = flattenDeep(
     flattenDeep([addresses]).map((addrString) =>
       String(addrString)
-        .split(',')
+        // Split by both commas and semicolons, as some legacy emails are
+        // delimited by semicolons.
+        .split(/,|;/)
         .map((addr) => addr.trim()),
     ),
   )


### PR DESCRIPTION
Hotfix for valid mail being rejected as invalid due to being split by semicolons `;` instead of commas `,`.

This is due to legacy forms having their emails split by semicolons in the past.