### PR TITLE
chore: remove form_field.isFutureOnly key

### DIFF
--- a/scripts/date-logic/date-logic.js
+++ b/scripts/date-logic/date-logic.js
@@ -54,5 +54,30 @@
     { '$count': 'numFormFields' }
   ]
   db.getCollection('forms').aggregate(afterScriptFormFieldsWithIsFutureOnlyTrue)
+ 
 
+// REMOVE ISFUTUREONLY KEY 
+
+  // Number of forms with isFutureOnly key - expect 0 after running update
+
+  db.forms.count({ 'form_fields': { '$elemMatch': { 'isFutureOnly': {$exists: true}  } } })
+
+  // Number of form fields with isFutureOnly key - expect 0 after running update
+
+  const formFieldsWithIsFutureOnlyExist = [
+    { '$match': { 'form_fields': { '$elemMatch': { 'isFutureOnly': {$exists: true} } } } },
+    { '$project': { 'form_fields': 1 } },
+    { '$unwind': '$form_fields' },
+    { '$match': { 'form_fields.isFutureOnly': {$exists: true} } },
+    { '$count': 'numFormFields' }
+  ]
   
+  db.getCollection('forms').aggregate(formFieldsWithIsFutureOnlyExist)
+
+  // Update - Remove isFutureOnly key
+
+  db.forms.update(
+    {"form_fields.isFutureOnly": {$exists: true}}, 
+    {"$unset": {"form_fields.$[elem].isFutureOnly": ""}}, 
+    {"arrayFilters": [{"elem.isFutureOnly": {$exists: true}}], "multi" : true }
+  )

--- a/scripts/date-logic/date-logic.js
+++ b/scripts/date-logic/date-logic.js
@@ -55,29 +55,3 @@
   ]
   db.getCollection('forms').aggregate(afterScriptFormFieldsWithIsFutureOnlyTrue)
  
-
-// REMOVE ISFUTUREONLY KEY 
-
-  // Number of forms with isFutureOnly key - expect 0 after running update
-
-  db.forms.count({ 'form_fields': { '$elemMatch': { 'isFutureOnly': {$exists: true}  } } })
-
-  // Number of form fields with isFutureOnly key - expect 0 after running update
-
-  const formFieldsWithIsFutureOnlyExist = [
-    { '$match': { 'form_fields': { '$elemMatch': { 'isFutureOnly': {$exists: true} } } } },
-    { '$project': { 'form_fields': 1 } },
-    { '$unwind': '$form_fields' },
-    { '$match': { 'form_fields.isFutureOnly': {$exists: true} } },
-    { '$count': 'numFormFields' }
-  ]
-  
-  db.getCollection('forms').aggregate(formFieldsWithIsFutureOnlyExist)
-
-  // Update - Remove isFutureOnly key
-
-  db.forms.update(
-    {"form_fields.isFutureOnly": {$exists: true}}, 
-    {"$unset": {"form_fields.$[elem].isFutureOnly": ""}}, 
-    {"arrayFilters": [{"elem.isFutureOnly": {$exists: true}}], "multi" : true }
-  )

--- a/scripts/date-logic/remove-isfutureonly-key.js
+++ b/scripts/date-logic/remove-isfutureonly-key.js
@@ -3,7 +3,7 @@
 // Number of forms with isFutureOnly key - expect 0 after running update
 
 db.forms.count({
-  form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } },
+  form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } }
 })
 
 // Number of form fields with isFutureOnly key - expect 0 after running update
@@ -11,13 +11,13 @@ db.forms.count({
 const formFieldsWithIsFutureOnlyExist = [
   {
     $match: {
-      form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } },
+      form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } }
     },
   },
   { $project: { form_fields: 1 } },
   { $unwind: '$form_fields' },
   { $match: { 'form_fields.isFutureOnly': { $exists: true } } },
-  { $count: 'numFormFields' },
+  { $count: 'numFormFields' }
 ]
 
 db.getCollection('forms').aggregate(formFieldsWithIsFutureOnlyExist)
@@ -27,5 +27,5 @@ db.getCollection('forms').aggregate(formFieldsWithIsFutureOnlyExist)
 db.forms.update(
   { 'form_fields.isFutureOnly': { $exists: true } },
   { $unset: { 'form_fields.$[elem].isFutureOnly': '' } },
-  { arrayFilters: [{ 'elem.isFutureOnly': { $exists: true } }], multi: true },
+  { arrayFilters: [{ 'elem.isFutureOnly': { $exists: true } }], multi: true }
 )

--- a/scripts/date-logic/remove-isfutureonly-key.js
+++ b/scripts/date-logic/remove-isfutureonly-key.js
@@ -1,0 +1,31 @@
+/* eslint-disable */
+
+// Number of forms with isFutureOnly key - expect 0 after running update
+
+db.forms.count({
+  form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } },
+})
+
+// Number of form fields with isFutureOnly key - expect 0 after running update
+
+const formFieldsWithIsFutureOnlyExist = [
+  {
+    $match: {
+      form_fields: { $elemMatch: { isFutureOnly: { $exists: true } } },
+    },
+  },
+  { $project: { form_fields: 1 } },
+  { $unwind: '$form_fields' },
+  { $match: { 'form_fields.isFutureOnly': { $exists: true } } },
+  { $count: 'numFormFields' },
+]
+
+db.getCollection('forms').aggregate(formFieldsWithIsFutureOnlyExist)
+
+// Update - Remove isFutureOnly key
+
+db.forms.update(
+  { 'form_fields.isFutureOnly': { $exists: true } },
+  { $unset: { 'form_fields.$[elem].isFutureOnly': '' } },
+  { arrayFilters: [{ 'elem.isFutureOnly': { $exists: true } }], multi: true },
+)

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -159,26 +159,7 @@ function makeModule(connection) {
       (f) => f.globalId === field.globalId,
     )
 
-    // To keep date schema in sync (isFutureOnly and dateValidation)
     const actionNameString = String(action.name)
-    if (field.fieldType === 'date') {
-      // TODO: Remove after 31 Jul 2020 (#2437)
-      if (field.isNewClient === true) {
-        // If form is edited by admin using new client
-        field.isFutureOnly =
-          get(field.dateValidation, 'selectedDateValidation') ===
-          'Disallow past dates'
-      } else {
-        // If form is edited by admin using old client
-        field.dateValidation = {
-          selectedDateValidation: field.isFutureOnly
-            ? 'Disallow past dates'
-            : null,
-          customMinDate: null,
-          customMaxDate: null,
-        }
-      }
-    }
 
     switch (actionNameString) {
       case EditFieldActions.Create:

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -8,7 +8,6 @@ const moment = require('moment-timezone')
 const _ = require('lodash')
 const JSONStream = require('JSONStream')
 const { StatusCodes } = require('http-status-codes')
-const get = require('lodash/get')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const errorHandler = require('./errors.server.controller')

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -7,13 +7,6 @@ import { MyInfoSchema } from './baseField'
 const createDateFieldSchema = () => {
   return new Schema<IDateFieldSchema>({
     myInfo: MyInfoSchema,
-
-    // TODO((#2437): Remove isFutureOnly key after 31 Aug 2020
-    isFutureOnly: {
-      type: Boolean,
-      default: false,
-    },
-
     dateValidation: {
       customMinDate: {
         type: Date,

--- a/src/public/modules/forms/services/form-api.client.factory.js
+++ b/src/public/modules/forms/services/form-api.client.factory.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { get, set } = require('lodash')
+const { get } = require('lodash')
 const Form = require('../viewmodels/Form.class')
 
 // Forms service used for communicating with the forms REST endpoints
@@ -42,10 +42,6 @@ function FormApi($resource, FormErrorService, FormFields) {
   const getInterceptor = (redirectOnError, errorTargetState) => {
     const interceptor = {
       request: (config) => {
-        if (get(config, 'data.form.editFormField.field')) {
-          set(config, 'data.form.editFormField.field.isNewClient', true)
-          // TODO: Remove isNewClient() after 31 Aug 2020 (#2437)
-        }
         if (get(config, 'data.form')) {
           FormFields.removeMyInfoFromForm(config.data.form)
         }


### PR DESCRIPTION
## Problem

Closes #40 


## Tests

Create 5 date fields in admin view with the following options. Test that the validations work in the preview panel datepicker on the right (i.e. the popup calendar).

- [ ] Disallow past dates
- [ ] Disallow future dates
- [ ] Custom date range with Min Date only
- [ ] Custom date range with Max Date only
- [ ] Custom date range with both Min and Max Date

Validation for date range validation option in admin view

- [ ] Check that it is not possible for admin to save a form with a custom date range where both Min and Max date are left blank
- [ ] Check that it is not possible for admin to save a form with a custom date range where Max date is before Min date

Able to submit forms correctly

- [ ] Publish the form. Test that all 5 date field validations still work in the public form datepicker (i.e. the popup calendar)
- [ ] Test that all 5 date field validations still work in the public form using manual input to the date field and manual input of date outside the validation range is rejected

Test for editing and reordering, instead of creating

- [ ] Using the existing form fields, shuffle the form validations of the five fields by editing the validation options
- [ ] Reorder the form fields
- [ ] Repeat the above tests to make sure the date validations remain correct

## Scripts

- DB script in remove-isfutureonly-key.js, to be run one week after release