### PR TITLE
feat: log more info about critical bounces

### DIFF
--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -98,19 +98,19 @@ export const isValidSnsRequest = async (
 }
 
 // Writes a log message if all recipients have bounced
-const logCriticalBounce = (bounceInfo: IBounceSchema, formId: string): void => {
+const logCriticalBounce = (bounceDoc: IBounceSchema, formId: string): void => {
   if (
-    !bounceInfo.hasAlarmed &&
-    bounceInfo.bounces.every((emailInfo) => emailInfo.hasBounced)
+    !bounceDoc.hasAlarmed &&
+    bounceDoc.bounces.every((emailInfo) => emailInfo.hasBounced)
   ) {
     logger.warn({
       type: 'CRITICAL BOUNCE',
       formId,
-      recipients: bounceInfo.bounces.map((emailInfo) => emailInfo.email),
+      recipients: bounceDoc.bounces.map((emailInfo) => emailInfo.email),
     })
     // We don't want a flood of logs and alarms, so we use this to limit the rate of
     // critical bounce logs for each form ID
-    bounceInfo.hasAlarmed = true
+    bounceDoc.hasAlarmed = true
   }
 }
 


### PR DESCRIPTION
As requested by @syan-syan, we should log more information about critical bounces so the information is easier to access.

## Tests
- [ ] Create a critical bounce by submitting a form where all email recipients are invalid. In CloudWatch, filter for `message.type = 'CRITICAL BOUNCE'`. Under `message.bounceInfo` in the log message, you should see the bounce type, subtype and some information regarding each bounced recipient, including a `diagnosticCode`.