### PR TITLE
fix: correct left margin in acknowledgment error when activating storage mode form

### DIFF
--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -418,13 +418,6 @@
   text-align: left;
 }
 
-#secret-key .warning-acknowledgement {
-  display: flex;
-  padding: 8px 10px;
-  margin: 0 10px 0;
-  width: 100%;
-}
-
 #secret-key .instructions-container {
   margin: 0 auto 30px;
 }

--- a/src/public/modules/forms/admin/directiveViews/verify-secret-key-activation.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/verify-secret-key-activation.client.view.html
@@ -79,7 +79,7 @@
     </div>
     <div
       ng-if="isAcknowledgementWrong() && acknowledgementForm.acknowledgementInput.$dirty"
-      class="alert-custom alert-error warning-acknowledgement"
+      class="alert-custom alert-error"
     >
       <i class="bx bx-exclamation bx-md icon-spacing"></i>
       <span class="alert-msg"


### PR DESCRIPTION
## Problem

This PR fixes a small misalignment in the error message box when typing in the storage mode acknowledgment input.

## Solution

## Before & After Screenshots

**BEFORE**:
![Screenshot 2020-09-01 at 10 24 52 AM](https://user-images.githubusercontent.com/22133008/91787938-95497180-ec3d-11ea-88fb-d9aacd2583fb.png)

**AFTER**:
![Screenshot 2020-09-01 at 10 24 42 AM](https://user-images.githubusercontent.com/22133008/91787929-924e8100-ec3d-11ea-963d-2d1b803d64ba.png)

