### PR TITLE
fix: fix off by one for storage mode bulk attachment downloads

### DIFF
--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -204,7 +204,7 @@ function ViewResponsesController(
           }
           // Populate S3 presigned URL for attachments
           if (attachmentMetadata[field._id]) {
-            vm.attachmentDownloadUrls.set(questionCount - 1, {
+            vm.attachmentDownloadUrls.set(questionCount, {
               url: attachmentMetadata[field._id],
               filename: field.answer,
             })


### PR DESCRIPTION
## Problem

Question number for storage mode bulk download is off by one.

![image](https://user-images.githubusercontent.com/29480346/91789726-cd52b380-ec41-11ea-82c1-a1e3d4c023fe.png)

## Solution

This is because there was a mistaken `- 1` when setting the question number, so this was removed.