### PR TITLE
fix: prevent discriminated models from being created before their base model

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -493,42 +493,24 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   return FormModel
 }
 
-const compileEmailFormModel = (db: Mongoose) => {
-  return db.model<IEmailFormSchema, IEmailFormModel>(
-    ResponseMode.Email,
-    EmailFormSchema,
-  )
-}
-
-export const getEmailFormModel = (db: Mongoose) => {
-  try {
-    return db.model(ResponseMode.Email) as IEmailFormModel
-  } catch {
-    return compileEmailFormModel(db)
-  }
-}
-
-const compileEncryptedFormModel = (db: Mongoose) => {
-  return db.model<IEncryptedFormSchema, IEncryptedFormModel>(
-    ResponseMode.Encrypt,
-    EncryptedFormSchema,
-  )
-}
-
-export const getEncryptedFormModel = (db: Mongoose) => {
-  try {
-    return db.model(ResponseMode.Encrypt) as IEncryptedFormModel
-  } catch {
-    return compileEncryptedFormModel(db)
-  }
-}
-
 const getFormModel = (db: Mongoose) => {
   try {
     return db.model(FORM_SCHEMA_ID) as IFormModel
   } catch {
     return compileFormModel(db)
   }
+}
+
+export const getEmailFormModel = (db: Mongoose) => {
+  // Load or build base model first
+  getFormModel(db)
+  return db.model(ResponseMode.Email) as IEmailFormModel
+}
+
+export const getEncryptedFormModel = (db: Mongoose) => {
+  // Load or build base model first
+  getFormModel(db)
+  return db.model(ResponseMode.Encrypt) as IEncryptedFormModel
 }
 
 export default getFormModel

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -152,34 +152,6 @@ encryptSubmissionSchema.methods.getWebhookView = function (
   }
 }
 
-export const getEmailSubmissionModel = (db: Mongoose) => {
-  try {
-    return db.model(SubmissionType.Email) as IEmailSubmissionModel
-  } catch {
-    return db.model<IEmailSubmissionSchema, IEmailSubmissionModel>(
-      SubmissionType.Email,
-      emailSubmissionSchema,
-    )
-  }
-}
-
-export const getEncryptSubmissionModel = (db: Mongoose) => {
-  try {
-    return db.model(SubmissionType.Encrypt) as IEncryptSubmissionModel
-  } catch {
-    return db.model<IEncryptedSubmissionSchema, IEncryptSubmissionModel>(
-      SubmissionType.Encrypt,
-      encryptSubmissionSchema,
-    )
-  }
-}
-
-/**
- * Form Submission Schema
- * @param  {Object} db - Active DB Connection
- * @return {Object} Mongoose Model
- */
-
 const compileSubmissionModel = (db: Mongoose) => {
   const Submission = db.model('Submission', SubmissionSchema)
   Submission.discriminator(SubmissionType.Email, emailSubmissionSchema)
@@ -193,6 +165,16 @@ const getSubmissionModel = (db: Mongoose) => {
   } catch {
     return compileSubmissionModel(db)
   }
+}
+
+export const getEmailSubmissionModel = (db: Mongoose) => {
+  getSubmissionModel(db)
+  return db.model(SubmissionType.Email) as IEmailSubmissionModel
+}
+
+export const getEncryptSubmissionModel = (db: Mongoose) => {
+  getSubmissionModel(db)
+  return db.model(SubmissionType.Encrypt) as IEncryptSubmissionModel
 }
 
 export default getSubmissionModel

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -91,7 +91,7 @@ export interface IForm {
   webhook?: Webhook
   msgSrvcName?: string
 
-  responseMode?: ResponseMode
+  responseMode: ResponseMode
 
   // Schema properties
   _id: Document['_id']

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -656,18 +656,16 @@ describe('Email Submissions Controller', () => {
     it('errors with 400 if submission fail', (done) => {
       const badSubmission = jasmine.createSpyObj('Submission', ['save'])
       badSubmission.save.and.callFake((callback) => callback(new Error('boom')))
-
       const badSubmissionModel = jasmine.createSpy()
       badSubmissionModel.and.returnValue(badSubmission)
-      const mongoose = jasmine.createSpyObj('mongoose', ['model'])
-      mongoose.model
-        .withArgs('emailSubmission')
-        .and.returnValue(badSubmissionModel)
-
+      const getEmailSubmissionModel = jasmine.createSpy(
+        'getEmailSubmissionModel',
+      )
+      getEmailSubmissionModel.and.returnValue(badSubmissionModel)
       const badController = spec(
         'dist/backend/app/controllers/email-submissions.server.controller',
         {
-          mongoose,
+          '../models/submission.server.model': { getEmailSubmissionModel },
         },
       )
 


### PR DESCRIPTION
## Problem

Using `EncryptSubmission` Model without having compiled `Submission` Model causes `EncryptSubmission` Model to be without core keys like `form`

This problem extends to `Form` model as well.

Closes #243

## Solution

**Bug Fixes**:

- Fix possible race conditions by only returning discriminated models after compiling/retrieving their base instead of compiling from scratch.

Note: The usual way of exporting discriminated models should be employed once we have fully migrated over to Typescript.

```ts
export const EmailFormModel = FormModel.discriminator(ResponseMode.Email, EmailFormSchema)
export const EncryptFormModel = FormModel.discriminator(ResponseMode.Encrypt, EncryptedFormSchema)
```