### PR TITLE
fix(dev): fix Localstack yet again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - LOGO_S3_BUCKET=local-logo-bucket
       - FORMSG_SDK_MODE=development
       - BOUNCE_LIFE_SPAN=1800000
+      - AWS_ACCESS_KEY_ID=fakeKey
+      - AWS_SECRET_ACCESS_KEY=fakeSecret
       - GA_TRACKING_ID
       - SENTRY_CONFIG_URL
       - TWILIO_ACCOUNT_SID

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -124,6 +124,8 @@ The following env variables are set in Travis:
 | Variable                      | Description                                                                                                                         |
 | :---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `AWS_REGION`                  | AWS region.                                                                                                                         |
+| `AWS_ACCESS_KEY_ID`           | AWS IAM access key ID used to access S3.                                                                                            |
+| `AWS_SECRET_ACCESS_KEY`       | AWS IAM access secret used to access S3.                                                                                            |
 | `IMAGE_S3_BUCKET`             | Name of S3 bucket for image field uploads.                                                                                          |
 | `LOGO_S3_BUCKET`              | Name of S3 bucket for form logo uploads.                                                                                            |
 | `LOGO_S3_BUCKET`              | Name of S3 bucket for form logo uploads.                                                                                            |
@@ -258,9 +260,9 @@ If this feature is enabled, storage mode forms will also support authentication 
 
 ### Tests
 
-| Variable               | Description                                                                                                                                     |
-| :--------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MONGO_BINARY_VERSION` | Version of the Mongo binary used. Defaults to `'latest'` according to [MongoMemoryServer](https://github.com/nodkz/mongodb-memory-server) docs. |
-| `PWD`                  | Path of working directory.                                                                                                                      |
-| `MOCK_WEBHOOK_CONFIG_FILE`                  | Path of configuration file for mock webhook server                                                                                                                      |
-| `MOCK_WEBHOOK_PORT`                  | Port of mock webhook server                                                                                                                      |
+| Variable                   | Description                                                                                                                                     |
+| :------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MONGO_BINARY_VERSION`     | Version of the Mongo binary used. Defaults to `'latest'` according to [MongoMemoryServer](https://github.com/nodkz/mongodb-memory-server) docs. |
+| `PWD`                      | Path of working directory.                                                                                                                      |
+| `MOCK_WEBHOOK_CONFIG_FILE` | Path of configuration file for mock webhook server                                                                                              |
+| `MOCK_WEBHOOK_PORT`        | Port of mock webhook server                                                                                                                     |

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -4,7 +4,7 @@ until $(curl --output /dev/null --silent --head --fail http://localhost:4572); d
   printf 'Waiting for Localstack to be ready...'
   sleep 5
 done
-awslocal s3 mb s3://$IMAGE_S3_BUCKET
-awslocal s3 mb s3://$LOGO_S3_BUCKET
-awslocal s3 mb s3://$ATTACHMENT_S3_BUCKET
+awslocal --endpoint-url=http://localhost:4572 s3 mb s3://$IMAGE_S3_BUCKET
+awslocal --endpoint-url=http://localhost:4572 s3 mb s3://$LOGO_S3_BUCKET
+awslocal --endpoint-url=http://localhost:4572 s3 mb s3://$ATTACHMENT_S3_BUCKET
 set +x

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,6 +6,7 @@ import nodemailer from 'nodemailer'
 import directTransport from 'nodemailer-direct-transport'
 import Mail from 'nodemailer/lib/mailer'
 import SMTPPool from 'nodemailer/lib/smtp-pool'
+import { promisify } from 'util'
 
 import defaults from './defaults'
 import { createLoggerWithLabel } from './logger'
@@ -379,19 +380,8 @@ const cookieSettings: SessionOptions['cookie'] = {
 // Functions
 const configureAws = async () => {
   if (!isDev) {
-    const getCredentials = () => {
-      return new Promise((resolve, reject) => {
-        aws.config.getCredentials((err) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve()
-          }
-        })
-      })
-    }
-
-    await getCredentials()
+    // Convert to async function, then call and await
+    await promisify(aws.config.getCredentials)()
     if (!aws.config.credentials.accessKeyId) {
       throw new Error(`AWS Access Key Id is missing`)
     }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -382,12 +382,13 @@ const configureAws = async () => {
   if (!isDev) {
     // Convert to async function, then call and await
     await promisify(aws.config.getCredentials)()
-    if (!aws.config.credentials.accessKeyId) {
-      throw new Error(`AWS Access Key Id is missing`)
-    }
-    if (!aws.config.credentials.secretAccessKey) {
-      throw new Error(`AWS Secret Access Key is missing`)
-    }
+  }
+  // In dev environment, credentials should be set from env vars
+  if (!aws.config.credentials.accessKeyId) {
+    throw new Error(`AWS Access Key Id is missing`)
+  }
+  if (!aws.config.credentials.secretAccessKey) {
+    throw new Error(`AWS Secret Access Key is missing`)
   }
 }
 


### PR DESCRIPTION
## Problem

All Localstack services (image upload, logo upload, storage mode attachments) were not working.

Closes #202 

## Solution

### Initialising Localstack using `awslocal`
In their latest version, [the `awslocal` CLI](https://github.com/localstack/awscli-local) switched to using the edge port 4566 for all services by default. However, this edge port is not available to us, since we are using an older version of Localstack. Hence it is now necessary to specify the endpoint URL in `init-localstack.sh` when creating the S3 buckets.

### Specifying mock AWS credentials
All actions involving S3 require the global `AWS` object to have its credentials configured. Since we removed the mock AWS credentials, those credentials could no longer be set, resulting in all S3 operations failing. The solution was to restore the mock credentials to `docker-compose`.

### What about upgrading Localstack?
Sadly, the [issue](https://github.com/localstack/localstack/issues/2407) opened by our esteemed @karrui on the Localstack repo doesn't seem to have been resolved, since I tried upgrading Localstack but ran into the same problem. We seem to be stuck with v0.8.0 for now.