### PR TITLE
refactor: remove unused Nodemailer env vars

### DIFF
--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -2,10 +2,10 @@
 
 This document details what is needed to create an environment to run FormSG in AWS.
 
-### Build and run your nodejs app
+## Build and run your NodeJS app
 
-```
-$ npm install
+```bash
+npm install
 $ npm run build
 $ npm start
 ```
@@ -25,7 +25,7 @@ As a prerequisite for EB deployment, make sure you have already created your AWS
 
 ### Dockerrun.aws.json
 
-```
+```json
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
@@ -52,7 +52,7 @@ FormSG supports storing of users' Twilio API credentials using AWS Secret Manage
 
 Firstly, name the secret with a unique secret name and store the secret value in the following format:
 
-```
+```json
 {
   "accountSid": "",
   "apiKey": "",
@@ -145,8 +145,6 @@ The following env variables are set in Travis:
 | `SES_PASS`            | SMTP password.                                                                                                                                                                                 |
 | `SES_MAX_MESSAGES`    | Nodemailer configuration. Connection removed and new one created when this limit is reached. This helps to keep the connection up-to-date for long-running email messaging. Defaults to `100`. |
 | `SES_POOL`            | Connection pool to send email in parallel to the SMTP server. Defaults to `38`.                                                                                                                |
-| `SES_RATE`            | Maximum email to send per second, or per `rateDelta` if supplied.                                                                                                                              |
-| `SES_RATEDELTA`       | Defines the time measuring period in milliseconds for rate limiting. Defaults to `1000`.                                                                                                       |
 | `MAIL_FROM`           | Sender email address. Defaults to `'donotreply@mail.form.gov.sg'`.                                                                                                                             |  |
 | `MAIL_SOCKET_TIMEOUT` | Milliseconds of inactivity to allow before killing a connection. This helps to keep the connection up-to-date for long-running email messaging. Defaults to `600000`.                          |
 | `MAIL_LOGGER`         | If set to true then logs to console. If value is not set or is false then nothing is logged.                                                                                                   |
@@ -258,9 +256,9 @@ If this feature is enabled, storage mode forms will also support authentication 
 
 ### Tests
 
-| Variable               | Description                                                                                                                                     |
-| :--------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MONGO_BINARY_VERSION` | Version of the Mongo binary used. Defaults to `'latest'` according to [MongoMemoryServer](https://github.com/nodkz/mongodb-memory-server) docs. |
-| `PWD`                  | Path of working directory.                                                                                                                      |
-| `MOCK_WEBHOOK_CONFIG_FILE`                  | Path of configuration file for mock webhook server                                                                                                                      |
-| `MOCK_WEBHOOK_PORT`                  | Port of mock webhook server                                                                                                                      |
+| Variable                   | Description                                                                                                                                     |
+| :------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MONGO_BINARY_VERSION`     | Version of the Mongo binary used. Defaults to `'latest'` according to [MongoMemoryServer](https://github.com/nodkz/mongodb-memory-server) docs. |
+| `PWD`                      | Path of working directory.                                                                                                                      |
+| `MOCK_WEBHOOK_CONFIG_FILE` | Path of configuration file for mock webhook server                                                                                              |
+| `MOCK_WEBHOOK_PORT`        | Port of mock webhook server                                                                                                                     |

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -259,15 +259,6 @@ const mailConfig: MailConfig = (function () {
       // If set to true, then logs SMTP traffic, otherwise logs only transaction
       // events.
       debug: String(process.env.MAIL_DEBUG).toLowerCase() === 'true',
-      // Per second, or per rateDelta if supplied.
-      rateLimit: process.env.SES_RATE
-        ? Number(process.env.SES_RATE)
-        : undefined,
-      // Defines the time measuring period in milliseconds (defaults to 1000)
-      // for rate limiting.
-      rateDelta: process.env.SES_RATEDELTA
-        ? Number(process.env.SES_RATEDELTA)
-        : undefined,
     }
 
     transporter = nodemailer.createTransport(options)


### PR DESCRIPTION
## Problem

The following environment variables are deprecated by Nodemailer and verified to be no longer in use in production

* SES_RATE
* SES_RATELIMIT

## Solution

Removed aforementioned environment variables from the codebase.

Additionally, addressed Markdown linting issues in the deployment setup
file.

**Improvements**:

- Improved code cleanliness
- Improved documentation

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**Removed environment variables**:

* SES_RATE
* SES_RATELIMIT

