### PR TITLE
feat: upgrade Sentry SDK

### DIFF
--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -180,7 +180,7 @@ If this feature is enabled, client-side error events will be piped to [sentry.io
 
 | Variable            | Description                                                                                           |
 | :------------------ | ----------------------------------------------------------------------------------------------------- |
-| `SENTRY_CONFIG_URL` | Sentry.io URL for configuring the Raven SDK.                                                          |
+| `SENTRY_CONFIG_URL` | Sentry.io URL for configuring the Sentry SDK.                                                         |
 | `CSP_REPORT_URI`    | Reporting URL for Content Security Policy violdations. Can be configured to use a Sentry.io endpoint. |
 
 #### Examples page Using Pre-Computed Results

--- a/package-lock.json
+++ b/package-lock.json
@@ -4470,6 +4470,74 @@
         "xpath": "0.0.27"
       }
     },
+    "@sentry/browser": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.22.3.tgz",
+      "integrity": "sha512-2TzE/CoBa5ZkvxJizDdi1Iz1ldmXSJpFQ1mL07PIXBjCt0Wxf+WOuFSj5IP4L40XHfJE5gU8wEvSH0VDR8nXtA==",
+      "requires": {
+        "@sentry/core": "5.22.3",
+        "@sentry/types": "5.22.3",
+        "@sentry/utils": "5.22.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.22.3.tgz",
+      "integrity": "sha512-eGL5uUarw3o4i9QUb9JoFHnhriPpWCaqeaIBB06HUpdcvhrjoowcKZj1+WPec5lFg5XusE35vez7z/FPzmJUDw==",
+      "requires": {
+        "@sentry/hub": "5.22.3",
+        "@sentry/minimal": "5.22.3",
+        "@sentry/types": "5.22.3",
+        "@sentry/utils": "5.22.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.22.3.tgz",
+      "integrity": "sha512-INo47m6N5HFEs/7GMP9cqxOIt7rmRxdERunA3H2L37owjcr77MwHVeeJ9yawRS6FMtbWXplgWTyTIWIYOuqVbw==",
+      "requires": {
+        "@sentry/types": "5.22.3",
+        "@sentry/utils": "5.22.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.22.3.tgz",
+      "integrity": "sha512-Fx6h8DTDvUpEOymx8Wi49LBdVcNYHwaI6NqApm1qVU9qn/I50Q29KWoZTCGBjBwmkJud+DOAHWYWoU2qRrIvcQ==",
+      "requires": {
+        "@sentry/types": "5.22.3",
+        "@sentry/utils": "5.22.3",
+        "localforage": "1.8.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.22.3.tgz",
+      "integrity": "sha512-HoINpYnVYCpNjn2XIPIlqH5o4BAITpTljXjtAftOx6Hzj+Opjg8tR8PWliyKDvkXPpc4kXK9D6TpEDw8MO0wZA==",
+      "requires": {
+        "@sentry/hub": "5.22.3",
+        "@sentry/types": "5.22.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.22.3.tgz",
+      "integrity": "sha512-cv+VWK0YFgCVDvD1/HrrBWOWYG3MLuCUJRBTkV/Opdy7nkdNjhCAJQrEyMM9zX0sac8FKWKOHT0sykNh8KgmYw=="
+    },
+    "@sentry/utils": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.22.3.tgz",
+      "integrity": "sha512-AHNryXMBvIkIE+GQxTlmhBXD0Ksh+5w1SwM5qi6AttH+1qjWLvV6WB4+4pvVvEoS8t5F+WaVUZPQLmCCWp6zKw==",
+      "requires": {
+        "@sentry/types": "5.22.3",
+        "tslib": "^1.9.3"
+      }
+    },
     "@shelf/jest-mongodb": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-1.2.2.tgz",
@@ -17428,6 +17496,24 @@
         "json5": "^1.0.1"
       }
     },
+    "localforage": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.8.1.tgz",
+      "integrity": "sha512-azSSJJfc7h4bVpi0PGi+SmLQKJl2/8NErI+LhJsrORNikMZnhaQ7rv9fHj+ofwgSHrKRlsDCL/639a6nECIKuQ==",
+      "requires": {
+        "lie": "3.1.1"
+      },
+      "dependencies": {
+        "lie": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+          "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+          "requires": {
+            "immediate": "~3.0.5"
+          }
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -25211,8 +25297,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21272,11 +21272,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
-    "raven-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
-      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ=="
-    },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "@opengovsg/myinfo-gov-client": "^1.0.4",
     "@opengovsg/ng-file-upload": "^12.2.14",
     "@opengovsg/spcp-auth-client": "^1.3.0",
+    "@sentry/browser": "^5.22.3",
+    "@sentry/integrations": "^5.22.3",
     "@stablelib/base64": "^1.0.0",
     "JSONStream": "^1.3.5",
     "angular": "~1.8.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "promise-retry": "^2.0.1",
     "proxyquire": "^2.1.0",
     "puppeteer-core": "^5.2.1",
-    "raven-js": "^3.27.0",
     "rimraf": "^3.0.2",
     "selectize": "0.12.4",
     "slick-carousel": "1.8.1",

--- a/src/config/feature-manager/sentry.config.ts
+++ b/src/config/feature-manager/sentry.config.ts
@@ -4,7 +4,7 @@ const sentryFeature: RegisterableFeature<FeatureNames.Sentry> = {
   name: FeatureNames.Sentry,
   schema: {
     sentryConfigUrl: {
-      doc: 'Sentry.io URL for configuring the Raven SDK',
+      doc: 'Sentry.io URL for configuring the Sentry SDK',
       format: 'url',
       default: null,
       env: 'SENTRY_CONFIG_URL',

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const textEncoding = require('text-encoding')
+const Sentry = require('@sentry/browser')
+const { Angular: AngularIntegration } = require('@sentry/integrations')
 
 if (!window['TextDecoder']) {
   window['TextDecoder'] = textEncoding.TextDecoder
@@ -41,12 +43,13 @@ window.$ = window.jQuery
 const angular = require('angular')
 
 // Sentry.io SDK
-const Raven = require('raven-js')
+// Docs: https://docs.sentry.io/platforms/javascript/guides/angular/angular1/
 if (window.sentryConfigUrl) {
-  Raven.config(window.sentryConfigUrl)
-    .addPlugin(require('raven-js/plugins/angular'), angular)
-    .install()
-  moduleDependencies.push('ngRaven')
+  Sentry.init({
+    dsn: window.sentryConfigUrl,
+    integrations: [new AngularIntegration()],
+  })
+  moduleDependencies.push('ngSentry')
 }
 
 require('angular-translate')

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -12,7 +12,7 @@ if (!window['TextEncoder']) {
   window['TextEncoder'] = textEncoding.TextEncoder
 }
 
-// Define module dependencies (without ngRaven)
+// Define module dependencies (without ngSentry)
 const moduleDependencies = [
   'ui.select',
   'ngAnimate',


### PR DESCRIPTION
The Raven SDK is outdated. From the [Sentry repo](https://github.com/getsentry/sentry-javascript):

> raven-js: Our old stable JavaScript SDK, we still support and release bug fixes for the SDK but all new features will be implemented in @sentry/browser which is the successor.

This PR upgrades our Sentry SDK to the latest version, and adds the [AngularJS plugin](https://docs.sentry.io/platforms/javascript/guides/angular/angular1/).