### PR TITLE
refactor: turn on strict mode in Typescript configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4160,13 +4160,13 @@
       }
     },
     "@shelf/jest-mongodb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-1.2.2.tgz",
-      "integrity": "sha512-FgNmvYmfXuOFyffziRheSwCBXrFwBZ0zTcNny04YyBD5VO1ukr7jnR+rKkKSMZ8E9LOVFU8Go8Ex24E2J917kw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-1.2.3.tgz",
+      "integrity": "sha512-RGECov7b9anpHqrEoegYeZFWN3WEOw/3hPu3fQUi4gnNIGH0jyMVCQd4DgB37n2aoEWFfe7Kq59aQUrgIQRITA==",
       "dev": true,
       "requires": {
         "debug": "4.1.1",
-        "mongodb-memory-server": "6.6.3",
+        "mongodb-memory-server": "6.6.7",
         "uuid": "8.3.0"
       },
       "dependencies": {
@@ -4799,6 +4799,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.3.tgz",
+      "integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q==",
       "dev": true
     },
     "@types/serve-static": {
@@ -18512,12 +18518,12 @@
       }
     },
     "mongodb-memory-server": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.6.3.tgz",
-      "integrity": "sha512-zx91SQQUBafVfBX8IJjfZa0lIMzdDYs/UB1vnr33e5bSPBwSai+mVV6gW3osF4paLFxOkcvOwx758G9F9HytgA==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.6.7.tgz",
+      "integrity": "sha512-azRGr5csTAl0MCLR/amPCJrmV5TFwRcVtal56dHrPy1o2T8wZRc3AaJyukob8a/JP38JYa/pQnw1AQH7lFA2Cg==",
       "dev": true,
       "requires": {
-        "mongodb-memory-server-core": "6.6.3"
+        "mongodb-memory-server-core": "6.6.7"
       },
       "dependencies": {
         "agent-base": {
@@ -18527,17 +18533,6 @@
           "dev": true,
           "requires": {
             "debug": "4"
-          }
-        },
-        "bl": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
           }
         },
         "camelcase": {
@@ -18613,6 +18608,14 @@
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
         "md5-file": {
@@ -18628,9 +18631,9 @@
           "dev": true
         },
         "mongodb-memory-server-core": {
-          "version": "6.6.3",
-          "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.6.3.tgz",
-          "integrity": "sha512-MTs2qCb+5JG4qPCenqo+L0cxQiO09EqTZNk4I5+dz8nRUiVPFLL64tO/oJ1WDuSJ6vcyk8dC+QsNAD1wjZxx8g==",
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.6.7.tgz",
+          "integrity": "sha512-21g2FpQdgqN3sFsj5lbGje1BhrSRGNHgz6gMAl8bvmdpRpoZErclkImVtjBXNHCNmCc1Dxr+EBvH11KaVE+9iQ==",
           "dev": true,
           "requires": {
             "@types/cross-spawn": "^6.0.2",
@@ -18641,12 +18644,12 @@
             "@types/lockfile": "^1.0.1",
             "@types/md5-file": "^4.0.2",
             "@types/mkdirp": "^1.0.1",
+            "@types/semver": "^7.3.3",
             "@types/tmp": "^0.2.0",
             "@types/uuid": "^8.0.0",
             "camelcase": "^6.0.0",
             "cross-spawn": "^7.0.3",
             "debug": "^4.1.1",
-            "dedent": "^0.7.0",
             "find-cache-dir": "^3.3.1",
             "find-package-json": "^1.2.0",
             "get-port": "^5.1.1",
@@ -18655,6 +18658,7 @@
             "md5-file": "^5.0.0",
             "mkdirp": "^1.0.4",
             "mongodb": "^3.5.9",
+            "semver": "^7.3.2",
             "tar-stream": "^2.1.3",
             "tmp": "^0.2.1",
             "uuid": "^8.2.0",
@@ -18706,21 +18710,10 @@
             "find-up": "^4.0.0"
           }
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "shebang-command": {
@@ -18737,19 +18730,6 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
-        },
-        "tar-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-          "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-          "dev": true,
-          "requires": {
-            "bl": "^4.0.1",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          }
         },
         "tmp": {
           "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,6 +4545,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
+    "@types/json-stringify-safe": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+      "integrity": "sha512-UUA1sH0RSRROdInuDOA1yoRzbi5xVFD1RHCoOvNRPTNwR8zBkJ/84PZ6NhKVDtKp0FTeIccJCdQz1X2aJPr4uw==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4611,6 +4611,12 @@
         "@types/node": "*"
       }
     },
+    "@types/mongodb-uri": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@types/mongodb-uri/-/mongodb-uri-0.9.0.tgz",
+      "integrity": "sha512-N52kUCiYyH4H2xOMHV7lIDjv4ZLRcRgEiN0xut/BNKHD/dLox10Q6WVl1vjnfA+rvdL9rFZGUxs9EQunQosAlA==",
+      "dev": true
+    },
     "@types/mongoose": {
       "version": "5.7.36",
       "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.7.36.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16600,12 +16600,12 @@
       }
     },
     "jest-util": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.2.0.tgz",
-      "integrity": "sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+      "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.2.0",
+        "@jest/types": "^26.3.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -16614,16 +16614,25 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.2.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
-          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
+            "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
           }
         },
         "ansi-styles": {
@@ -16668,9 +16677,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -25173,11 +25182,12 @@
       }
     },
     "ts-jest": {
-      "version": "26.1.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.4.tgz",
-      "integrity": "sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.3.0.tgz",
+      "integrity": "sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==",
       "dev": true,
       "requires": {
+        "@types/jest": "26.x",
         "bs-logger": "0.x",
         "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@babel/core": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@opengovsg/mockpass": "^2.4.6",
-    "@shelf/jest-mongodb": "^1.2.2",
+    "@shelf/jest-mongodb": "^1.2.3",
     "@types/bcrypt": "^3.0.0",
     "@types/compression": "^1.7.0",
     "@types/convict": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "@types/ip": "^1.1.0",
     "@types/jest": "^26.0.9",
     "@types/json-stringify-safe": "^5.0.0",
+    "@types/mongodb-uri": "^0.9.0",
     "@types/mongoose": "^5.7.36",
     "@types/node": "^14.0.13",
     "@types/nodemailer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "@types/helmet": "0.0.48",
     "@types/ip": "^1.1.0",
     "@types/jest": "^26.0.9",
+    "@types/json-stringify-safe": "^5.0.0",
     "@types/mongoose": "^5.7.36",
     "@types/node": "^14.0.13",
     "@types/nodemailer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "supertest": "^3.3.0",
     "terser-webpack-plugin": "^1.2.3",
     "testcafe": "^1.8.6",
-    "ts-jest": "^26.1.4",
+    "ts-jest": "^26.3.0",
     "ts-loader": "^7.0.5",
     "ts-mock-imports": "^1.3.0",
     "ts-node": "^8.10.2",

--- a/src/app/models/field/attachmentField.ts
+++ b/src/app/models/field/attachmentField.ts
@@ -30,7 +30,7 @@ const createAttachmentFieldSchema = () => {
   ) {
     const { webhook, responseMode } = this.parent()
 
-    if (responseMode === ResponseMode.Encrypt && webhook.url) {
+    if (responseMode === ResponseMode.Encrypt && webhook?.url) {
       return next(
         Error('Attachments are not allowed when a form has a webhook url'),
       )

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -18,7 +18,7 @@ const createDateFieldSchema = () => {
       },
       selectedDateValidation: {
         type: String,
-        enum: Object.values(DateSelectedValidation).concat([null]),
+        enum: [...Object.values(DateSelectedValidation), null],
         default: null,
       },
     },

--- a/src/app/models/field/longTextField.ts
+++ b/src/app/models/field/longTextField.ts
@@ -22,7 +22,7 @@ const createLongTextFieldSchema = () => {
       },
       selectedValidation: {
         type: String,
-        enum: Object.values(LongTextSelectedValidation).concat([null]),
+        enum: [...Object.values(LongTextSelectedValidation), null],
         default: null,
       },
     },

--- a/src/app/models/field/numberField.ts
+++ b/src/app/models/field/numberField.ts
@@ -22,7 +22,7 @@ const createNumberFieldSchema = () => {
       },
       selectedValidation: {
         type: String,
-        enum: Object.values(NumberSelectedValidation).concat([null]),
+        enum: [...Object.values(NumberSelectedValidation), null],
         default: null,
       },
     },

--- a/src/app/models/field/shortTextField.ts
+++ b/src/app/models/field/shortTextField.ts
@@ -25,7 +25,7 @@ const createShortTextFieldSchema = () => {
       },
       selectedValidation: {
         type: String,
-        enum: Object.values(ShortTextSelectedValidation).concat([null]),
+        enum: [...Object.values(ShortTextSelectedValidation), null],
         default: null,
       },
     },

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -416,18 +416,16 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         path: 'admin',
         select: 'email',
       })
-      if (!data) {
-        return null
-      }
-      const otpData: FormOtpData = {
-        form: data._id,
-        formAdmin: {
-          email: data.admin.email,
-          userId: data.admin._id,
-        },
-        msgSrvcName: data.msgSrvcName,
-      }
-      return otpData
+      return data
+        ? ({
+            form: data._id,
+            formAdmin: {
+              email: data.admin.email,
+              userId: data.admin._id,
+            },
+            msgSrvcName: data.msgSrvcName,
+          } as FormOtpData)
+        : null
     } catch {
       return null
     }

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -392,7 +392,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     }
 
     // Compact is used to remove undefined from array
-    return compact(uniq(this.form_fields.map((field) => field.myInfo?.attr)))
+    return compact(uniq(this.form_fields?.map((field) => field.myInfo?.attr)))
   }
 
   // Return a duplicate form object with the given properties
@@ -416,6 +416,9 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         path: 'admin',
         select: 'email',
       })
+      if (!data) {
+        return null
+      }
       const otpData: FormOtpData = {
         form: data._id,
         formAdmin: {
@@ -434,8 +437,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   FormSchema.statics.getFullFormById = async function (
     this: IFormModel,
     formId: string,
-  ): Promise<IPopulatedForm> {
-    const data: IPopulatedForm = await this.findById(formId).populate({
+  ): Promise<IPopulatedForm | null> {
+    const data: IPopulatedForm | null = await this.findById(formId).populate({
       path: 'admin',
       populate: {
         path: 'agency',

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -136,7 +136,7 @@ const encryptSubmissionSchema = new Schema<IEncryptedSubmissionSchema>({
  * which will be posted to the webhook URL.
  */
 encryptSubmissionSchema.methods.getWebhookView = function (
-  this: ISubmissionSchema,
+  this: IEncryptedSubmissionSchema,
 ): WebhookView {
   const webhookData: WebhookData = {
     formId: String(this.form),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -69,7 +69,11 @@ const compileUserModel = (db: Mongoose) => {
    *
    * See: https://masteringjs.io/tutorials/mongoose/e11000-duplicate-key.
    */
-  UserSchema.post<IUserSchema>('save', function (err, doc, next) {
+  UserSchema.post<IUserSchema>('save', function (
+    err: any,
+    _doc: IUserSchema,
+    next: any,
+  ) {
     if (err.name === 'MongoError' && err.code === 11000) {
       next(new Error('Account already exists with this email'))
     } else {

--- a/src/app/models/verification.server.model.ts
+++ b/src/app/models/verification.server.model.ts
@@ -28,7 +28,7 @@ const VerificationFieldSchema = new Schema<IVerificationFieldSchema>({
   hashRetries: { type: Number, default: 0 },
 })
 
-const compileVerificationModel = (db: Mongoose) => {
+const compileVerificationModel = (db: Mongoose): IVerificationModel => {
   const VerificationSchema = new Schema<IVerificationSchema>({
     formId: {
       type: Schema.Types.ObjectId,

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -46,11 +46,11 @@ export const handleLoginSendOtp: RequestHandler = async (
   // Create OTP.
   const [otpErr, otp] = await to(AuthService.createLoginOtp(email))
 
-  if (otpErr) {
+  if (otpErr || !otp) {
     logger.error({
       message: 'Error generating OTP',
       meta: logMeta,
-      error: otpErr,
+      error: otpErr ?? undefined,
     })
     return res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)
@@ -138,7 +138,7 @@ export const handleLoginVerifyOtp: RequestHandler = async (
 
   // OTP is valid, proceed to login user.
   try {
-    const user = await UserService.retrieveUser(email, agency)
+    const user = await UserService.retrieveUser(email, agency!)
     // Create user object to return to frontend.
     const userObj = { ...user.toObject(), agency }
 
@@ -181,7 +181,7 @@ export const handleSignout: RequestHandler = async (req, res) => {
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
 
-  req.session.destroy((error) => {
+  req.session!.destroy((error) => {
     if (error) {
       logger.error({
         message: 'Failed to destroy session',

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -138,6 +138,7 @@ export const handleLoginVerifyOtp: RequestHandler = async (
 
   // OTP is valid, proceed to login user.
   try {
+    // TODO (#317): remove usage of non-null assertion
     const user = await UserService.retrieveUser(email, agency!)
     // Create user object to return to frontend.
     const userObj = { ...user.toObject(), agency }

--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -4,11 +4,14 @@ import { mocked } from 'ts-jest/utils'
 
 import { handleSns } from 'src/app/modules/bounce/bounce.controller'
 import * as BounceService from 'src/app/modules/bounce/bounce.service'
+import { ISnsNotification } from 'src/types'
 
 jest.mock('src/app/modules/bounce/bounce.service')
 const MockBounceService = mocked(BounceService, true)
 
-const MOCK_REQ = expressHandler.mockRequest({ body: { someKey: 'someValue' } })
+const MOCK_REQ = expressHandler.mockRequest({
+  body: ({ someKey: 'someValue' } as unknown) as ISnsNotification,
+})
 const MOCK_RES = expressHandler.mockResponse()
 
 describe('handleSns', () => {

--- a/src/app/modules/bounce/__tests__/bounce.model.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.model.spec.ts
@@ -146,12 +146,12 @@ describe('Bounce Model', () => {
           ).Message,
         )
         const actual = Bounce.fromSnsNotification(notification)
-        expect(omit(extractBounceObject(actual), 'expireAt')).toEqual({
+        expect(omit(extractBounceObject(actual!), 'expireAt')).toEqual({
           formId,
           bounces: [{ email: MOCK_EMAIL, hasBounced: false }],
           hasAlarmed: false,
         })
-        expect(actual.expireAt).toBeInstanceOf(Date)
+        expect(actual!.expireAt).toBeInstanceOf(Date)
       })
 
       it('should create documents correctly when bounce notification is valid', () => {
@@ -166,12 +166,12 @@ describe('Bounce Model', () => {
           ).Message,
         )
         const actual = Bounce.fromSnsNotification(notification)
-        expect(omit(extractBounceObject(actual), 'expireAt')).toEqual({
+        expect(omit(extractBounceObject(actual!), 'expireAt')).toEqual({
           formId,
           bounces: [{ email: MOCK_EMAIL, hasBounced: true }],
           hasAlarmed: false,
         })
-        expect(actual.expireAt).toBeInstanceOf(Date)
+        expect(actual!.expireAt).toBeInstanceOf(Date)
       })
     })
   })

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -41,21 +41,19 @@ import {
 const Bounce = getBounceModel(mongoose)
 
 describe('isValidSnsRequest', () => {
-  let keys, body: ISnsNotification
-
-  beforeAll(() => {
-    keys = crypto.generateKeyPairSync('rsa', {
-      modulusLength: 2048,
-      publicKeyEncoding: {
-        type: 'pkcs1',
-        format: 'pem',
-      },
-      privateKeyEncoding: {
-        type: 'pkcs8',
-        format: 'pem',
-      },
-    })
+  const keys = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: 'pkcs1',
+      format: 'pem',
+    },
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem',
+    },
   })
+
+  let body: ISnsNotification
 
   beforeEach(() => {
     body = cloneDeep(MOCK_SNS_BODY)
@@ -65,12 +63,12 @@ describe('isValidSnsRequest', () => {
   })
 
   it('should gracefully reject when input is empty', () => {
-    return expect(isValidSnsRequest(undefined)).resolves.toBe(false)
+    return expect(isValidSnsRequest(undefined!)).resolves.toBe(false)
   })
 
   it('should reject requests when their structure is invalid', () => {
-    delete body.Type
-    return expect(isValidSnsRequest(body)).resolves.toBe(false)
+    const invalidBody = omit(cloneDeep(body), 'Type') as ISnsNotification
+    return expect(isValidSnsRequest(invalidBody)).resolves.toBe(false)
   })
 
   it('should reject requests when their certificate URL is invalid', () => {
@@ -140,7 +138,7 @@ describe('updateBounces', () => {
     )
     await updateBounces(notification)
     const actualBounceDoc = await Bounce.findOne({ formId })
-    const actualBounce = extractBounceObject(actualBounceDoc)
+    const actualBounce = extractBounceObject(actualBounceDoc!)
     const expectedBounces = recipientList.map((email) => ({
       email,
       hasBounced: false,
@@ -175,7 +173,7 @@ describe('updateBounces', () => {
     )
     await updateBounces(notification)
     const actualBounceDoc = await Bounce.findOne({ formId })
-    const actualBounce = extractBounceObject(actualBounceDoc)
+    const actualBounce = extractBounceObject(actualBounceDoc!)
     const expectedBounces = recipientList.map((email) => ({
       email,
       hasBounced: bounces[email],
@@ -208,7 +206,7 @@ describe('updateBounces', () => {
     )
     await updateBounces(notification)
     const actualBounceDoc = await Bounce.findOne({ formId })
-    const actualBounce = extractBounceObject(actualBounceDoc)
+    const actualBounce = extractBounceObject(actualBounceDoc!)
     const expectedBounces = recipientList.map((email) => ({
       email,
       hasBounced: true,

--- a/src/app/modules/bounce/bounce.model.ts
+++ b/src/app/modules/bounce/bounce.model.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash'
 import { Model, Mongoose, Schema } from 'mongoose'
 import validator from 'validator'
 
@@ -62,21 +61,25 @@ const BounceSchema = new Schema<IBounceSchema>({
 })
 BounceSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 })
 
-// Create a new Bounce document from an SNS notification.
-// More info on format of SNS notifications:
-// https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
+/**
+ * Create a new Bounce document from an SNS notification.
+ * More info on format of SNS notifications:
+ * https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html.
+ * @param snsInfo the SNS notification to create a document from
+ * @returns the created Bounce document
+ */
 BounceSchema.statics.fromSnsNotification = function (
   this: IBounceModel,
   snsInfo: IEmailNotification,
 ): IBounceSchema | null {
   const emailType = extractHeader(snsInfo, EMAIL_HEADERS.emailType)
   const formId = extractHeader(snsInfo, EMAIL_HEADERS.formId)
-  // We only care about admin emails
+  // Only care about admin emails
   if (emailType !== EmailType.AdminResponse || !formId) {
     return null
   }
   const isBounce = isBounceNotification(snsInfo)
-  const bounces: ISingleBounce[] = get(snsInfo, 'mail.commonHeaders.to').map(
+  const bounces: ISingleBounce[] = snsInfo.mail.commonHeaders.to.map(
     (email) => {
       if (isBounce && hasEmailBounced(snsInfo as IBounceNotification, email)) {
         return { email, hasBounced: true }
@@ -88,14 +91,18 @@ BounceSchema.statics.fromSnsNotification = function (
   return new this({ formId, bounces })
 }
 
-// Updates an old bounce document with info from a new bounce document as well
-// as an SNS notification. This function does 3 things:
-// 1) If the old bounce document indicates that an email bounced, set hasBounced
-// to true for that email.
-// 2) If the new delivery notification indicates that an email was delivered
-// successfully, set hasBounced to false for that email, even if the old bounce
-// document indicates that that email previously bounced.
-// 3) Update the old recipient list according to the newest bounce notification.
+/**
+ * Updates an old bounce document with info from a new bounce document as well
+ * as an SNS notification. This function does 3 things:
+ * 1) If the old bounce document indicates that an email bounced, set
+ *    `hasBounced` to `true` for that email.
+ * 2) If the new delivery notification indicates that an email was delivered
+ *    successfully, set `hasBounced` to `false` for that email, even if the old
+ *    bounce document indicates that that email previously bounced.
+ * 3) Update the old recipient list according to the newest bounce notification.
+ * @param latestBounces the newer bounce document to merge into the current document
+ * @param snsInfo the notification information to merge
+ */
 BounceSchema.methods.merge = function (
   this: IBounceSchema,
   latestBounces: IBounceSchema,

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -108,7 +108,7 @@ export const isValidSnsRequest = async (
 // Writes a log message if all recipients have bounced
 const logCriticalBounce = (
   bounceDoc: IBounceSchema,
-  submissionId: string,
+  submissionId: string | undefined,
   bounceInfo: IBounceNotification['bounce'] | undefined,
 ): void => {
   if (bounceDoc.isCriticalBounce()) {
@@ -118,7 +118,7 @@ const logCriticalBounce = (
         action: 'updateBounces',
         hasAlarmed: bounceDoc.hasAlarmed,
         formId: String(bounceDoc.formId),
-        submissionId,
+        submissionId: submissionId,
         recipients: bounceDoc.bounces.map((emailInfo) => emailInfo.email),
         // We know for sure that critical bounces can only happen because of bounce
         // notifications, so we don't expect this to be undefined
@@ -169,7 +169,9 @@ export const updateBounces = async (body: ISnsNotification): Promise<void> => {
   if (!latestBounces) return
   const formId = latestBounces.formId
   const submissionId = extractHeader(notification, EMAIL_HEADERS.submissionId)
-  const bounceInfo = isBounceNotification(notification) && notification.bounce
+  const bounceInfo = isBounceNotification(notification)
+    ? notification.bounce
+    : undefined
   const oldBounces = await Bounce.findOne({ formId })
   if (oldBounces) {
     oldBounces.merge(latestBounces, notification)

--- a/src/app/modules/bounce/bounce.util.ts
+++ b/src/app/modules/bounce/bounce.util.ts
@@ -8,6 +8,7 @@ import {
  * and email type (admin response, email confirmation OTP etc).
  * @param body Body of SNS notification
  * @param header Key of header to extract
+ * @returns the header from the body, if any.
  */
 export const extractHeader = (
   body: IEmailNotification,
@@ -22,6 +23,7 @@ export const extractHeader = (
  * Whether a bounce notification says a given email has bounced.
  * @param bounceInfo Bounce notification from SNS
  * @param email Email address to check
+ * @returns true if the email as bounced, false otherwise
  */
 export const hasEmailBounced = (
   bounceInfo: IBounceNotification,

--- a/src/app/modules/bounce/bounce.util.ts
+++ b/src/app/modules/bounce/bounce.util.ts
@@ -13,7 +13,7 @@ import {
 export const extractHeader = (
   body: IEmailNotification,
   header: string,
-): string => {
+): string | undefined => {
   return body.mail.headers.find(
     (mailHeader) => mailHeader.name.toLowerCase() === header.toLowerCase(),
   )?.value

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -27,6 +27,7 @@ const getFilteredResponses = (
   const modeFilter = getModeFilter(form.responseMode)
 
   // _id must be transformed to string as form response is jsonified.
+  // TODO (#317): remove usage of non-null assertion
   const fieldIds = modeFilter(form.form_fields!).map((field) => ({
     _id: String(field._id),
   }))

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -27,7 +27,7 @@ const getFilteredResponses = (
   const modeFilter = getModeFilter(form.responseMode)
 
   // _id must be transformed to string as form response is jsonified.
-  const fieldIds = modeFilter(form.form_fields).map((field) => ({
+  const fieldIds = modeFilter(form.form_fields!).map((field) => ({
     _id: String(field._id),
   }))
   const uniqueResponses = _.uniqBy(modeFilter(responses), '_id')
@@ -69,7 +69,7 @@ export const getProcessedResponses = (
   }
 
   // Create a map keyed by field._id for easier access
-  const fieldMap = form.form_fields.reduce<{
+  const fieldMap = form.form_fields!.reduce<{
     [fieldId: string]: IFieldSchema
   }>((acc, field) => {
     acc[field._id] = field

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -128,7 +128,7 @@ export const handleFetchUser: RequestHandler = async (req, res) => {
         action: 'handleFetchUser',
         userId: sessionUserId,
       },
-      error: dbErr,
+      error: dbErr ?? undefined,
     })
     return res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -98,7 +98,7 @@ export const verifyContactOtp = async (
   )
 
   if (contactHashErr || otpHashError) {
-    throw new MalformedOtpError(null, `bcrypt error for ${userId}`)
+    throw new MalformedOtpError(undefined, `bcrypt error for ${userId}`)
   }
 
   if (!isOtpMatch) {
@@ -149,7 +149,7 @@ export const updateUserContact = async (
 
 export const getPopulatedUserById = async (
   userId: IUserSchema['_id'],
-): Promise<IPopulatedUser> => {
+): Promise<IPopulatedUser | null> => {
   return UserModel.findById(userId).populate({
     path: 'agency',
     model: AGENCY_SCHEMA_ID,

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -8,10 +8,10 @@ import * as verification from './verification.controller'
 
 interface IVerifiedFieldsFactory {
   createTransaction: RequestHandler
-  getTransactionMetadata: RequestHandler
-  resetFieldInTransaction: RequestHandler
-  getNewOtp: RequestHandler
-  verifyOtp: RequestHandler
+  getTransactionMetadata: RequestHandler<{ transactionId: string }>
+  resetFieldInTransaction: RequestHandler<{ transactionId: string }>
+  getNewOtp: RequestHandler<{ transactionId: string }>
+  verifyOtp: RequestHandler<{ transactionId: string }>
 }
 
 const verifiedFieldsFactory = ({

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -122,6 +122,7 @@ export const getNewOtp = async (
   fieldId: string,
   answer: string,
 ): Promise<void> => {
+  // TODO (#317): remove usage of non-null assertion
   if (isTransactionExpired(transaction.expireAt!)) {
     throwError(VfnErrors.TransactionNotFound)
   }
@@ -130,6 +131,7 @@ export const getNewOtp = async (
     return throwError('Field not found in transaction', VfnErrors.FieldNotFound)
   }
   const { _id: transactionId, formId } = transaction
+  // TODO (#317): remove usage of non-null assertion
   const waitForSeconds = waitToResendOtpSeconds(field.hashCreatedAt!)
   if (waitForSeconds > 0) {
     return throwError(
@@ -177,6 +179,7 @@ export const verifyOtp = async (
   fieldId: string,
   inputOtp: string,
 ): Promise<string> => {
+  // TODO (#317): remove usage of non-null assertion
   if (isTransactionExpired(transaction.expireAt!)) {
     throwError(VfnErrors.TransactionNotFound)
   }

--- a/src/app/modules/webhook/webhook.controller.ts
+++ b/src/app/modules/webhook/webhook.controller.ts
@@ -22,7 +22,7 @@ export const post = (
   // There should only be a webhook service, which is called within the submission controller
   // This will also remove the need for retrieval of form/submission from req.
   const { form, submission } = req
-  const webhookUrl = form.webhook.url
+  const webhookUrl = form.webhook?.url
   const submissionWebhookView = submission.getWebhookView()
   if (webhookUrl) {
     // Note that we push data to webhook endpoints on a best effort basis

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -273,7 +273,7 @@ const getFormattedResponse = (
  */
 export const pushData = async (
   webhookUrl: WebhookParams['webhookUrl'],
-  submissionWebhookView: WebhookView,
+  submissionWebhookView: WebhookView | null,
 ): Promise<any> => {
   const now = Date.now()
   // Log and return, this should not happen.
@@ -282,7 +282,6 @@ export const pushData = async (
       new WebhookValidationError('submissionWebhookView was null'),
       {
         webhookUrl,
-        submissionWebhookView,
         now,
       },
     )

--- a/src/app/services/mail.service.ts
+++ b/src/app/services/mail.service.ts
@@ -90,20 +90,20 @@ export class MailService {
    * The application name to be shown in some sent emails' fields such as mail
    * subject or mail body.
    */
-  #appName: Required<MailServiceParams['appName']>
+  #appName: Required<MailServiceParams>['appName']
   /**
    * The application URL to be shown in some sent emails' fields such as mail
    * subject or mail body.
    */
-  #appUrl: Required<MailServiceParams['appUrl']>
+  #appUrl: Required<MailServiceParams>['appUrl']
   /**
    * The transporter to be used to send mail.
    */
-  #transporter: Required<MailServiceParams['transporter']>
+  #transporter: Required<MailServiceParams>['transporter']
   /**
    * The email string to denote the "from" field of the email.
    */
-  #senderMail: Required<MailServiceParams['senderMail']>
+  #senderMail: Required<MailServiceParams>['senderMail']
   /**
    * The full string that can be shown in the mail's "from" field created from
    * the given `appName` and `senderMail` arguments.

--- a/src/app/services/sms.service.ts
+++ b/src/app/services/sms.service.ts
@@ -82,7 +82,7 @@ type TwilioConfig = {
  * @returns A TwilioConfig containing the client and the sid linked to the msgSrvcName if defined, or the defaultConfig if not.
  */
 const getTwilio = async (
-  msgSrvcName: string,
+  msgSrvcName: string | undefined,
   defaultConfig: TwilioConfig,
 ): Promise<TwilioConfig> => {
   if (msgSrvcName) {

--- a/src/app/utils/attachment.ts
+++ b/src/app/utils/attachment.ts
@@ -69,7 +69,7 @@ export const addAttachmentToResponses = (
   const attachmentMap: Record<
     IAttachmentInfo['fieldId'],
     IAttachmentInfo
-  > = attachments.reduce((acc, attachment) => {
+  > = attachments.reduce<Record<string, IAttachmentInfo>>((acc, attachment) => {
     acc[attachment.fieldId] = attachment
     return acc
   }, {})

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -196,10 +196,10 @@ const configureAws = async () => {
       })
     }
     await getCredentials()
-    if (!aws.config.credentials.accessKeyId) {
+    if (!aws.config.credentials?.accessKeyId) {
       throw new Error(`AWS Access Key Id is missing`)
     }
-    if (!aws.config.credentials.secretAccessKey) {
+    if (!aws.config.credentials?.secretAccessKey) {
       throw new Error(`AWS Secret Access Key is missing`)
     }
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -99,7 +99,7 @@ if (isDev) {
 }
 
 const dbConfig: DbConfig = {
-  uri: dbUri,
+  uri: dbUri!,
   options: {
     user: '',
     pass: '',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -99,6 +99,7 @@ if (isDev) {
 }
 
 const dbConfig: DbConfig = {
+  // TODO (#317): remove usage of non-null assertion
   uri: dbUri!,
   options: {
     user: '',

--- a/src/config/feature-manager/util/FeatureManager.class.ts
+++ b/src/config/feature-manager/util/FeatureManager.class.ts
@@ -78,15 +78,19 @@ export default class FeatureManager {
   }
 
   /**
-   * Return whether requested feature is enabled
-   * @param name
+   * Return true if requested feature is enabled. Else, throw error.
+   * @param name the feature name to check enabledness
+   * @returns true iff feature is enabled
+   * @throws {Error} if feature is not enabled
    */
   isEnabled(name: FeatureNames): boolean {
-    if (this.states[name] !== undefined) {
-      return this.states[name]
-    } else {
-      throw new Error(`A feature called ${name} does not exist`)
+    const isInState = this.states[name]
+    if (isInState) {
+      return isInState
     }
+
+    // Not enabled or not in state.
+    throw new Error(`A feature called ${name} does not exist`)
   }
 
   /**
@@ -94,11 +98,13 @@ export default class FeatureManager {
    * @param name
    */
   props<K extends FeatureNames>(name: K) {
-    if (this.states[name] !== undefined) {
-      return this.properties[name]
-    } else {
-      throw new Error(`A feature called ${name} does not exist`)
+    const isInState = this.states[name]
+    if (isInState) {
+      return this.properties[name]!
     }
+
+    // Not enabled or not in state.
+    throw new Error(`A feature called ${name} does not exist`)
   }
 
   /**

--- a/src/config/feature-manager/util/FeatureManager.class.ts
+++ b/src/config/feature-manager/util/FeatureManager.class.ts
@@ -112,6 +112,7 @@ export default class FeatureManager {
   get(name: FeatureNames): RegisteredFeature<FeatureNames> {
     return {
       isEnabled: this.isEnabled(name),
+      // TODO (#317): remove usage of non-null assertion
       props: this.props(name)!,
     }
   }

--- a/src/config/feature-manager/util/FeatureManager.class.ts
+++ b/src/config/feature-manager/util/FeatureManager.class.ts
@@ -80,29 +80,26 @@ export default class FeatureManager {
   /**
    * Return true if requested feature is enabled. Else, throw error.
    * @param name the feature name to check enabledness
-   * @returns true iff feature is enabled
-   * @throws {Error} if feature is not enabled
+   * @returns true if the feature is enabled, false if disabled
+   * @throws {Error} if name given is not a registered feature
    */
   isEnabled(name: FeatureNames): boolean {
-    const isInState = this.states[name]
-    if (isInState) {
-      return isInState
+    if (this.states[name] !== undefined) {
+      return !!this.states[name]
     }
 
-    // Not enabled or not in state.
+    // Only throw error if state is undefined.
     throw new Error(`A feature called ${name} does not exist`)
   }
 
   /**
    * Return props registered for requested feature
-   * @param name
+   * @param name the feature to return properties for
    */
   props<K extends FeatureNames>(name: K) {
-    const isInState = this.states[name]
-    if (isInState) {
-      return this.properties[name]!
+    if (this.states[name] !== undefined) {
+      return this.properties[name]
     }
-
     // Not enabled or not in state.
     throw new Error(`A feature called ${name} does not exist`)
   }
@@ -110,12 +107,12 @@ export default class FeatureManager {
   /**
    * Return properties registered for requested feature
    * and whether requested feature is enabled
-   * @param name
+   * @param name the name of the feature to return
    */
   get(name: FeatureNames): RegisteredFeature<FeatureNames> {
     return {
       isEnabled: this.isEnabled(name),
-      props: this.props(name),
+      props: this.props(name)!,
     }
   }
 }

--- a/src/config/formsg-sdk.ts
+++ b/src/config/formsg-sdk.ts
@@ -11,14 +11,14 @@ const formsgSdk = formsgSdkPackage({
   webhookSecretKey: get(
     featureManager.props(FeatureNames.WebhookVerifiedContent),
     'signingSecretKey',
-    null,
+    undefined,
   ),
   mode: formsgSdkMode,
   verificationOptions: {
     secretKey: get(
       featureManager.props(FeatureNames.VerifiedFields),
       'verificationSecretKey',
-      null,
+      undefined,
     ),
     transactionExpiry: vfnConstants.TRANSACTION_EXPIRE_AFTER_SECONDS,
   },

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -122,21 +122,22 @@ export const customFormat = format.printf((info) => {
  * Function courtesy of
  * https://github.com/winstonjs/winston/issues/1243#issuecomment-463548194.
  */
-const jsonErrorReplacer = (_key: never, value: any) => {
+function jsonErrorReplacer(this: any, key: string, value: any) {
   if (value instanceof Error) {
     return Object.getOwnPropertyNames(value).reduce((all, valKey) => {
       if (valKey === 'stack') {
+        const errStack = value.stack ?? ''
         return {
           ...all,
-          at: value[valKey]
+          at: errStack
             .split('\n')
-            .filter((va) => va.trim().slice(0, 5) != 'Error')
-            .map((va, i) => `stack ${i} ${va.trim().slice(3).trim()}`),
+            .filter((va) => va.trim().slice(0, 5) !== 'Error')
+            .map((va, i) => `stack ${i} ${va.trim()}`),
         }
       } else {
         return {
           ...all,
-          [valKey]: value[valKey],
+          [valKey]: value[valKey as keyof Error],
         }
       }
     }, {})
@@ -180,7 +181,7 @@ const getModuleLabel = (callingModule: NodeModule) => {
   // Remove the file extension from the filename and split with path separator.
   const parts = callingModule.filename.replace(/\.[^/.]+$/, '').split(path.sep)
   // Join the last two parts of the file path together.
-  return path.join(parts[parts.length - 2], parts.pop())
+  return path.join(parts[parts.length - 2], parts.pop() ?? '')
 }
 
 /**

--- a/src/loaders/express/index.ts
+++ b/src/loaders/express/index.ts
@@ -23,25 +23,31 @@ import sentryMiddlewares from './sentry'
 import sessionMiddlewares from './session'
 
 const loadExpressApp = async (connection: Connection) => {
-  // Initialize express app
+  // Initialize express app.
   let app = express()
   app.locals = appLocals
 
-  const environmentConfigs = {
-    production(app: Express) {
-      // Trust the load balancer that is in front of the server
-      app.set('trust proxy', true)
-      return app
-    },
+  const getConfigFunctionFor = (environment: string) => {
+    switch (environment) {
+      case 'production': {
+        return function (app: Express) {
+          // Trust the load balancer that is in front of the server
+          app.set('trust proxy', true)
+          return app
+        }
+      }
+      default:
+        return null
+    }
   }
 
-  const configureEnvironmentFor = environmentConfigs[config.nodeEnv]
-  if (typeof configureEnvironmentFor === 'function') {
+  const configureEnvironmentFor = getConfigFunctionFor(config.nodeEnv)
+  if (configureEnvironmentFor) {
     app = configureEnvironmentFor(app)
   }
 
   app.use(function (req, res, next) {
-    const urlPath = url.parse(req.url).path.split('/')
+    const urlPath = url.parse(req.url).path?.split('/') ?? []
     if (
       urlPath.indexOf('static') > -1 &&
       urlPath.indexOf('view') === urlPath.indexOf('static') - 1

--- a/src/loaders/mongoose.ts
+++ b/src/loaders/mongoose.ts
@@ -7,7 +7,7 @@ import { createLoggerWithLabel } from '../config/logger'
 const logger = createLoggerWithLabel(module)
 
 export default async (): Promise<Connection> => {
-  const usingMockedDb = config.db.uri === undefined
+  const usingMockedDb = !config.db.uri
   // Mock out the database if we're developing locally
   if (usingMockedDb) {
     logger.warn({
@@ -43,7 +43,7 @@ export default async (): Promise<Connection> => {
 
   // Actually connect to the database
   function connect() {
-    return mongoose.connect(config.db.uri, config.db.options)
+    return mongoose.connect(config.db.uri!, config.db.options)
   }
 
   // Only required for initial connection errors, reconnect on error.

--- a/src/loaders/mongoose.ts
+++ b/src/loaders/mongoose.ts
@@ -43,6 +43,7 @@ export default async (): Promise<Connection> => {
 
   // Actually connect to the database
   function connect() {
+    // TODO (#317): remove usage of non-null assertion
     return mongoose.connect(config.db.uri!, config.db.options)
   }
 

--- a/src/shared/util/file-validation.ts
+++ b/src/shared/util/file-validation.ts
@@ -109,9 +109,11 @@ export const getInvalidFileExtensionsInZip = (
 
   // We wrap this checker into a closure because the data format
   // needs to be different for frontend vs backend.
-  const checkZipForInvalidFiles = async function (file: File | Buffer) {
+  const checkZipForInvalidFiles = async (
+    file: Blob | Buffer,
+  ): Promise<string[]> => {
     const zip = await JSZip.loadAsync(file)
-    const invalidFileExtensions = []
+    const invalidFileExtensions: (string | string[] | Promise<string[]>)[] = []
     zip.forEach((relativePath, fileEntry) => {
       if (fileEntry.dir) return
       const fileExt = getFileExtension(fileEntry.name)
@@ -124,6 +126,7 @@ export const getInvalidFileExtensionsInZip = (
         )
       }
     })
+
     const results = await Promise.all(invalidFileExtensions)
     return uniq(flattenDeep(results))
   }

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -134,6 +134,7 @@ export const getLogicUnitPreventingSubmit = (
   }
   const preventSubmitConditions = getPreventSubmitConditions(form)
   return preventSubmitConditions.find((logicUnit) =>
+    // TODO (#317): remove usage of non-null assertion
     isLogicUnitSatisfied(submission, logicUnit.conditions, visibleFieldIds!),
   )
 }

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -6,10 +6,11 @@ import {
   ILogicSchema,
   IPreventSubmitLogicSchema,
   IShowFieldsLogicSchema,
+  LogicConditionState,
   LogicType,
 } from '../../types'
 
-type GroupedLogic = Record<IClientFieldSchema['_id'], IConditionSchema[][]>
+type GroupedLogic = Record<string, IConditionSchema[][]>
 type FieldIdSet = Set<IClientFieldSchema['_id']>
 // This module handles logic on both the client side (IFieldSchema[])
 // and server side (FieldResponse[])
@@ -31,11 +32,13 @@ const isPreventSubmitLogic = (
 }
 
 /**
- * Parse logic into a map of fields that are shown/hidden depending on the values of other fields
- * Discards invalid logic, where the id in show or conditions do not exist in form_field
+ * Parse logic into a map of fields that are shown/hidden depending on the
+ * values of other fields.
+ * Discards invalid logic, where the id in show or conditions do not exist in
+ * the form_field.
  *
- * Example:
-  Show Email (_id: 1001) and Number (_id: 1002) if Dropdown (_id: 1003) is "Option 1" and Yes_No (_id: 1004) is "Yes"
+ * @example
+ * Show Email (_id: 1001) and Number (_id: 1002) if Dropdown (_id: 1003) is "Option 1" and Yes_No (_id: 1004) is "Yes"
   Then,
   form_logics: [
     {
@@ -54,30 +57,24 @@ const isPreventSubmitLogic = (
     "1002": [ [{field: "1003", ifValueType: "single-select", state: "is equals to", value: "Option 1"},
         {field: "1004", ifValueType: "single-select", state: "is equals to", value: "Yes"}] ]
   }
-
-  If "1001" is deleted, "1002" will still be rendered since we just won't add "1001" into logicUnitsGroupedByField
+ * @caption If "1001" is deleted, "1002" will still be rendered since we just won't add "1001" into logicUnitsGroupedByField
  *
- * @param {Object} form
- * @param {Mongoose.ObjectId} form._id : id of form
- * @param {Array} form.form_logics : An array of objects containing the conditions and ids of fields to be displayed. See FormLogicSchema
- * @param {Array} form.form_fields : An array of form fields containing the ids of the fields
- * @returns {Object} Object containing fields to be displayed and their corresponding conditions, keyed by id of the displayable field
+ * @param form the form object to group its logic by field for
+ * @returns an object containing fields to be displayed and their corresponding conditions, keyed by id of the displayable field
  */
 export const groupLogicUnitsByField = (form: IForm): GroupedLogic => {
   const formId = form._id
-  const formLogics = form.form_logics.filter(isShowFieldsLogic)
+  const formLogics = form.form_logics?.filter(isShowFieldsLogic) ?? []
   const formFieldIds = new Set(
-    form.form_fields.map((field) => String(field._id)),
+    form.form_fields?.map((field) => String(field._id)),
   )
 
-  /**
-   * @type {Object.<string, Array<Array<ConditionSchema>>>} An index of logic units keyed by the field id to be shown. See FormLogicSchema
-   */
+  /** An index of logic units keyed by the field id to be shown. */
   const logicUnitsGroupedByField: GroupedLogic = {}
 
   let hasInvalidLogic = false
   formLogics.forEach(function (logicUnit) {
-    // Only add fields with valid logic conditions to the returned map
+    // Only add fields with valid logic conditions to the returned map.
     if (allConditionsExist(logicUnit.conditions, formFieldIds)) {
       logicUnit.show.forEach(function (fieldId) {
         fieldId = String(fieldId)
@@ -98,42 +95,43 @@ export const groupLogicUnitsByField = (form: IForm): GroupedLogic => {
 }
 
 /**
- * Parse logic to get a list of conditions where, if any condition in this list is
- * fulfilled, form submission is prevented.
- * @param {Object} form Form object
- * @returns {Array} Array of conditions to prevent submission
+ * Parse logic to get a list of conditions where, if any condition in this list
+ * is fulfilled, form submission is prevented.
+ * @param form the form document to check
+ * @returns array of conditions that prevent submission, can be empty
  */
 const getPreventSubmitConditions = (
   form: IForm,
 ): IPreventSubmitLogicSchema[] => {
   const formFieldIds = new Set(
-    form.form_fields.map((field) => String(field._id)),
+    form.form_fields?.map((field) => String(field._id)),
   )
-  return form.form_logics.filter((formLogic) => {
-    return (
-      isPreventSubmitLogic(formLogic) &&
-      allConditionsExist(formLogic.conditions, formFieldIds)
-    )
-  })
+  const preventFormLogics =
+    form.form_logics?.filter(
+      (formLogic) =>
+        isPreventSubmitLogic(formLogic) &&
+        allConditionsExist(formLogic.conditions, formFieldIds),
+    ) ?? []
+
+  return preventFormLogics
 }
 
 /**
  * Determines whether the submission should be prevented by form logic. If so,
  * return the condition preventing the submission. If not, return undefined.
- * @param {Array} submission - form_fields (on client), or req.body.responses (on server)
- * @param {Object} form Form object
- * @param {Set} [visibleFieldIds] Optional set of currently visible fields. If this is not
- * provided, the function recomputes it.
- * @returns {Object} Condition if submission is to prevented, otherwise undefined
+ * @param submission the submission responses to retrieve logic units for. Can be `form_fields` (on client), or `req.body.responses` (on server)
+ * @param form the form document for the submission
+ * @param optionalVisibleFieldIds the optional set of currently visible fields. If this is not provided, it will be recomputed using the given form parameter.
+ * @returns a condition if submission is to prevented, otherwise `undefined`
  */
 export const getLogicUnitPreventingSubmit = (
   submission: LogicFieldArray,
   form: IForm,
-  visibleFieldIds?: FieldIdSet,
-): IPreventSubmitLogicSchema => {
-  if (!visibleFieldIds) {
-    visibleFieldIds = getVisibleFieldIds(submission, form)
-  }
+  optionalVisibleFieldIds?: FieldIdSet,
+): IPreventSubmitLogicSchema | undefined => {
+  const visibleFieldIds =
+    optionalVisibleFieldIds ?? getVisibleFieldIds(submission, form)
+
   const preventSubmitConditions = getPreventSubmitConditions(form)
   return preventSubmitConditions.find((logicUnit) =>
     isLogicUnitSatisfied(submission, logicUnit.conditions, visibleFieldIds),
@@ -141,11 +139,11 @@ export const getLogicUnitPreventingSubmit = (
 }
 
 /**
- * Checks if the field ids in logic's conditions all exist in the fieldIds
+ * Checks if the field ids in logic's conditions all exist in the fieldIds.
  *
- * @param {Array} conditions
- * @param {Set} formFieldIds
- * @returns {Boolean}
+ * @param conditions the list of conditions to check
+ * @param formFieldIds the set of form field ids to check
+ * @returns true if every condition's related form field id exists in the set of formFieldIds, false otherwise.
  */
 const allConditionsExist = (
   conditions: IConditionSchema[],
@@ -158,13 +156,12 @@ const allConditionsExist = (
 
 /**
  * Gets the IDs of visible fields in a form according to its responses.
- * This function loops through all the form fields until the set of visible fields no longer
- * changes. The first loop adds all the fields with no conditions attached, the second adds
- * fields which are made visible due to fields added in the previous loop, and so on.
- * @param {Array} submission - form_fields (on client), or req.body.responses (on server)
- * @param {Object} form - Form object
- * @var {Array} logicUnits - Array of logic units
- * @returns {Set} Set of IDs of visible fields
+ * This function loops through all the form fields until the set of visible
+ * fields no longer changes. The first loop adds all the fields with no
+ * conditions attached, the second adds fields which are made visible due to fields added in the previous loop, and so on.
+ * @param submission the submission responses to retrieve logic units for. Can be `form_fields` (on client), or `req.body.responses` (on server)
+ * @param form the form document for the submission
+ * @returns a set of IDs of visible fields in the submission
  */
 export const getVisibleFieldIds = (
   submission: LogicFieldArray,
@@ -176,10 +173,12 @@ export const getVisibleFieldIds = (
   let changesMade = true
   while (changesMade) {
     changesMade = false
-    form.form_fields.forEach((field) => {
+    form.form_fields?.forEach((field) => {
       const logicUnits = logicUnitsGroupedByField[String(field._id)]
-      // If a field's visibility does not have any conditions, it is always visible.
-      // Otherwise, a field's visibility can be toggled by a combination of conditions.
+      // If a field's visibility does not have any conditions, it is always
+      // visible.
+      // Otherwise, a field's visibility can be toggled by a combination of
+      // conditions.
       // Eg. the following are logicUnits - just one of them has to be satisfied
       // 1) Show X if Y=yes and Z=yes
       // Or
@@ -220,7 +219,7 @@ const isLogicUnitSatisfied = (
   })
 }
 
-const getCurrentValue = (field: LogicField): string => {
+const getCurrentValue = (field: LogicField): string | null => {
   if ('fieldValue' in field) {
     // client
     return field.fieldValue
@@ -230,6 +229,7 @@ const getCurrentValue = (field: LogicField): string => {
   }
   return null
 }
+
 /**
  * Checks if the field's value matches the condition
  * @param {Object} field
@@ -244,17 +244,19 @@ const isConditionFulfilled = (
     return false
   }
   let currentValue = getCurrentValue(field)
-  if (
-    currentValue === null ||
-    currentValue === undefined ||
-    currentValue.length === 0
-  ) {
+
+  if (!currentValue || currentValue.length === 0) {
     return false
-  } else if (
-    condition.state === 'is equals to' ||
-    condition.state === 'is either'
+  }
+
+  if (
+    condition.state === LogicConditionState.Equal ||
+    condition.state === LogicConditionState.Either
   ) {
-    const conditionValues = [].concat(condition.value).map(String) // condition.value can be a string (is equals to), or an array (is either)
+    // condition.value can be a string (is equals to), or an array (is either)
+    const conditionValues = ([] as unknown[])
+      .concat(condition.value)
+      .map(String)
     currentValue = String(currentValue)
     /*
     Handling 'Others' for radiobutton
@@ -302,7 +304,7 @@ const isConditionFulfilled = (
 const findConditionField = (
   submission: LogicFieldArray,
   fieldId: IConditionSchema['field'],
-): LogicField => {
+): LogicField | undefined => {
   return submission.find(
     (submittedField) => String(submittedField._id) === String(fieldId),
   )

--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -39,12 +39,16 @@ export const isMobilePhoneNumber = (mobileNumber: string): boolean => {
     )
   }
 
+  // Not Singapore number, check type and early return if undefined.
+  const parsedType = parsedNumber.getType()
+  if (!parsedType) return false
+
   // All other countries uses number type to check for validity.
   return (
     isPhoneNumber(mobileNumber) &&
     // Have to include both MOBILE, FIXED_LINE_OR_MOBILE as some countries lump
     // the types together.
-    ['FIXED_LINE_OR_MOBILE', 'MOBILE'].includes(parsedNumber.getType())
+    ['FIXED_LINE_OR_MOBILE', 'MOBILE'].includes(parsedType)
   )
 }
 

--- a/src/shared/util/stringify-safe.ts
+++ b/src/shared/util/stringify-safe.ts
@@ -1,18 +1,21 @@
 import stringify from 'json-stringify-safe'
 
 /**
- * JSON.stringify docs:
+ * `JSON.stringify` docs:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
  *
- * JSON.stringify throws an exception in two cases: if circular references are found,
- * and if a value is of type 'bigint'. This function wraps JSON.stringify in checks
- * to make sure circular references are dealt with (by the json-stringify-safe
- * library) and BigInts are converted to Numbers, so JSON.stringify does not throw
- * any errors. It is useful for stringifying objects which are passed to us by
- * external systems, e.g. HTTP responses.
+ * `JSON.stringify` throws an exception in two cases: if circular references are
+ * found, and if a value is of type `bigint`.
  *
- * Currently does not support the replacer or spaces arguments to JSON.stringify.
- * @param obj Object to be stringified
+ * This function wraps JSON.stringify
+ * in checks to make sure circular references are dealt with (by the
+ * `json-stringify-safe` library) and `BigInts` are converted to `Numbers`, so
+ * `JSON.stringify` does not throw any errors. It is useful for stringifying
+ * objects which are passed to us by external systems, e.g. HTTP responses.
+ *
+ * Currently does not support the replacer or spaces arguments to
+ * JSON.stringify.
+ * @param obj the object to be stringified
  */
 export const stringifySafe = (obj: any): string => {
   const bigIntReplacer = (_key: any, value: any): any => {

--- a/src/shared/util/verified-content.ts
+++ b/src/shared/util/verified-content.ts
@@ -35,7 +35,7 @@ const CpVerifiedKeys: ICpVerifiedKeys = {
 
 // Array determines the order to process and display the verified fields in both
 // the detailed responses page and the csv file.
-export const CURRENT_VERIFIED_FIELDS: VerifiedKeys[] = []
+export const CURRENT_VERIFIED_FIELDS: VerifiedKeys[] = ([] as VerifiedKeys[])
   .concat(values(SpVerifiedKeys))
   .concat(values(CpVerifiedKeys))
 
@@ -68,10 +68,7 @@ const getVerifiedKeyMap = (type?: 'SP' | 'CP'): VerifiedKeyMap => {
  * @param newKeys The oldKey-newKey mapping
  * @returns A new object with the renamed keys
  */
-const renameKeys = (
-  obj: Record<VerifiedKeys, unknown>,
-  newKeys: VerifiedKeyMap,
-): Record<string, unknown> => {
+const renameKeys = (obj: Record<string, any>, newKeys: Record<string, any>) => {
   const keyValues = Object.keys(obj).map((key) => {
     const newKey = newKeys[key] || key
     return { [newKey]: obj[key] }
@@ -99,10 +96,7 @@ export const mapDataToKey = ({
   data,
 }: IMappableData): Record<string, unknown> => {
   const fieldMap = getVerifiedKeyMap(type)
-  const subsetKeys = pick(data, Object.keys(fieldMap)) as Record<
-    VerifiedKeys,
-    unknown
-  >
+  const subsetKeys = pick(data, Object.keys(fieldMap))
 
   return renameKeys(subsetKeys, fieldMap)
 }

--- a/src/types/admin_verification.ts
+++ b/src/types/admin_verification.ts
@@ -9,13 +9,19 @@ export interface IAdminVerification {
   expireAt: Date
   numOtpAttempts?: number
   numOtpSent?: number
-  _id?: Document['_id']
 }
 
 export interface IAdminVerificationSchema extends IAdminVerification, Document {
-  _id: Document['_id']
   createdAt?: Date
   updatedAt?: Date
+}
+
+// Fully created document with defaults populated.
+export interface IAdminVerificationDoc extends IAdminVerificationSchema {
+  createdAt: Date
+  updatedAt: Date
+  numOtpAttempts: number
+  numOtpSent: number
 }
 
 export type UpsertOtpParams = Pick<
@@ -27,5 +33,5 @@ export interface IAdminVerificationModel
   upsertOtp: (params: UpsertOtpParams) => Promise<IAdminVerificationSchema>
   incrementAttemptsByAdminId: (
     adminId: IUserSchema['_id'],
-  ) => Promise<IAdminVerificationSchema>
+  ) => Promise<IAdminVerificationDoc>
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -109,7 +109,7 @@ export interface IFormSchema extends IForm, Document {
 }
 
 export interface IPopulatedForm extends IFormSchema {
-  admin: IPopulatedUser | null
+  admin: IPopulatedUser
 }
 
 export interface IEncryptedForm extends IForm {

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -31,10 +31,10 @@ export interface ISubmission {
 export interface WebhookData {
   formId: string
   submissionId: string
-  encryptedContent: string
-  verifiedContent: string
-  version: number
-  created: Date
+  encryptedContent: IEncryptedSubmissionSchema['encryptedContent']
+  verifiedContent: IEncryptedSubmissionSchema['verifiedContent']
+  version: IEncryptedSubmissionSchema['version']
+  created: IEncryptedSubmissionSchema['created']
 }
 
 export interface WebhookView {

--- a/src/types/vendor/aws-info.d.ts
+++ b/src/types/vendor/aws-info.d.ts
@@ -1,0 +1,12 @@
+declare module 'aws-info' {
+  type Data = {
+    regions: Record<string, unknown>
+    services: Record<string, unknown>
+  }
+
+  export const data: Data
+
+  export function endpoint(serviceName: string, regionName: string): string
+
+  export function regionName(regionNameShort: string): string
+}

--- a/src/types/vendor/bson-ext.d.ts
+++ b/src/types/vendor/bson-ext.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/ban-types */
 // Internal type definitions for bson-ext 2.0.3
 // !!! Typings are not verified !!!
 // Definitions retrieved from https://www.npmjs.com/package/@types/bson and

--- a/src/types/vendor/bson-ext.d.ts
+++ b/src/types/vendor/bson-ext.d.ts
@@ -1,0 +1,506 @@
+// Internal type definitions for bson-ext 2.0.3
+// !!! Typings are not verified !!!
+// Definitions retrieved from https://www.npmjs.com/package/@types/bson and
+// typed to follow bson-ext's exports.
+/// <reference types="node"/>
+
+declare module 'bson-ext' {
+  interface CommonSerializeOptions {
+    /** {default:false}, the serializer will check if keys are valid. */
+    checkKeys?: boolean
+    /** {default:false}, serialize the javascript functions. */
+    serializeFunctions?: boolean
+    /** {default:true}, ignore undefined fields. */
+    ignoreUndefined?: boolean
+  }
+
+  export interface SerializeOptions extends CommonSerializeOptions {
+    /** {default:1024*1024*17}, minimum size of the internal temporary serialization buffer. */
+    minInternalBufferSize?: number
+  }
+
+  export interface SerializeWithBufferAndIndexOptions
+    extends CommonSerializeOptions {
+    /** {default:0}, the index in the buffer where we wish to start serializing into. */
+    index?: number
+  }
+
+  export interface DeserializeOptions {
+    /** {default:false}, evaluate functions in the BSON document scoped to the object deserialized. */
+    evalFunctions?: boolean
+    /** {default:false}, cache evaluated functions for reuse. */
+    cacheFunctions?: boolean
+    /** {default:false}, use a crc32 code for caching, otherwise use the string of the function. */
+    cacheFunctionsCrc32?: boolean
+    /** {default:true}, when deserializing a Long will fit it into a Number if it's smaller than 53 bits. */
+    promoteLongs?: boolean
+    /** {default:false}, deserialize Binary data directly into node.js Buffer object. */
+    promoteBuffers?: boolean
+    /** {default:false}, when deserializing will promote BSON values to their Node.js closest equivalent types. */
+    promoteValues?: boolean
+    /** {default:null}, allow to specify if there what fields we wish to return as unserialized raw buffer. */
+    fieldsAsRaw?: { readonly [fieldName: string]: boolean }
+    /** {default:false}, return BSON regular expressions as BSONRegExp instances. */
+    bsonRegExp?: boolean
+    /** {default:false}, allows the buffer to be larger than the parsed BSON object. */
+    allowObjectSmallerThanBufferSize?: boolean
+  }
+
+  export interface CalculateObjectSizeOptions {
+    /** {default:false}, serialize the javascript functions */
+    serializeFunctions?: boolean
+    /** {default:true}, ignore undefined fields. */
+    ignoreUndefined?: boolean
+  }
+
+  /**
+   * Base class for Long and Timestamp.
+   * In original js-node@1.0.x code 'Timestamp' is a 100% copy-paste of 'Long'
+   * with 'Long' replaced by 'Timestamp' (changed to inheritance in js-node@2.0.0)
+   */
+  class LongLike<T> {
+    /**
+     * @param low The low (signed) 32 bits.
+     * @param high The high (signed) 32 bits.
+     */
+    constructor(low: number, high: number)
+
+    /** Returns the sum of `this` and the `other`. */
+    add(other: T): T
+    /** Returns the bitwise-AND of `this` and the `other`. */
+    and(other: T): T
+    /**
+     * Compares `this` with the given `other`.
+     * @returns 0 if they are the same, 1 if the this is greater, and -1 if the given one is greater.
+     */
+    compare(other: T): number
+    /** Returns `this` divided by the given `other`. */
+    div(other: T): T
+    /** Return whether `this` equals the `other` */
+    equals(other: T): boolean
+    /** Return the high 32-bits value. */
+    getHighBits(): number
+    /** Return the low 32-bits value. */
+    getLowBits(): number
+    /** Return the low unsigned 32-bits value. */
+    getLowBitsUnsigned(): number
+    /** Returns the number of bits needed to represent the absolute value of `this`. */
+    getNumBitsAbs(): number
+    /** Return whether `this` is greater than the `other`. */
+    greaterThan(other: T): boolean
+    /** Return whether `this` is greater than or equal to the `other`. */
+    greaterThanOrEqual(other: T): boolean
+    /** Return whether `this` value is negative. */
+    isNegative(): boolean
+    /** Return whether `this` value is odd. */
+    isOdd(): boolean
+    /** Return whether `this` value is zero. */
+    isZero(): boolean
+    /** Return whether `this` is less than the `other`. */
+    lessThan(other: T): boolean
+    /** Return whether `this` is less than or equal to the `other`. */
+    lessThanOrEqual(other: T): boolean
+    /** Returns `this` modulo the given `other`. */
+    modulo(other: T): T
+    /** Returns the product of `this` and the given `other`. */
+    multiply(other: T): T
+    /** The negation of this value. */
+    negate(): T
+    /** The bitwise-NOT of this value. */
+    not(): T
+    /** Return whether `this` does not equal to the `other`. */
+    notEquals(other: T): boolean
+    /** Returns the bitwise-OR of `this` and the given `other`. */
+    or(other: T): T
+    /**
+     * Returns `this` with bits shifted to the left by the given amount.
+     * @param numBits The number of bits by which to shift.
+     */
+    shiftLeft(numBits: number): T
+    /**
+     * Returns `this` with bits shifted to the right by the given amount.
+     * @param numBits The number of bits by which to shift.
+     */
+    shiftRight(numBits: number): T
+    /**
+     * Returns `this` with bits shifted to the right by the given amount, with the new top bits matching the current sign bit.
+     * @param numBits The number of bits by which to shift.
+     */
+    shiftRightUnsigned(numBits: number): T
+    /** Returns the difference of `this` and the given `other`. */
+    subtract(other: T): T
+    /** Return the int value (low 32 bits). */
+    toInt(): number
+    /** Return the JSON value. */
+    toJSON(): string
+    /** Returns closest floating-point representation to `this` value */
+    toNumber(): number
+    /**
+     * Return as a string
+     * @param radix the radix in which the text should be written. {default:10}
+     */
+    toString(radix?: number): string
+    /** Returns the bitwise-XOR of `this` and the given `other`. */
+    xor(other: T): T
+  }
+
+  /** A class representation of the BSON Binary type. */
+  export class Binary {
+    static readonly SUBTYPE_DEFAULT: number
+    static readonly SUBTYPE_FUNCTION: number
+    static readonly SUBTYPE_BYTE_ARRAY: number
+    static readonly SUBTYPE_UUID_OLD: number
+    static readonly SUBTYPE_UUID: number
+    static readonly SUBTYPE_MD5: number
+    static readonly SUBTYPE_USER_DEFINED: number
+
+    /**
+     * @param buffer A buffer object containing the binary data
+     * @param subType Binary data subtype
+     */
+    constructor(buffer: Buffer, subType?: number)
+
+    /** The underlying Buffer which stores the binary data. */
+    readonly buffer: Buffer
+    /** Binary data subtype */
+    readonly sub_type?: number
+
+    /** The length of the binary. */
+    length(): number
+    /** Updates this binary with byte_value */
+    put(byte_value: number | string): void
+    /** Reads length bytes starting at position. */
+    read(position: number, length: number): Buffer
+    /** Returns the value of this binary as a string. */
+    value(): string
+    /** Writes a buffer or string to the binary */
+    write(buffer: Buffer | string, offset: number): void
+  }
+
+  /** A class representation of the BSON Code type. */
+  export class Code {
+    /**
+     * @param code A string or function.
+     * @param scope An optional scope for the function.
+     */
+    constructor(code: string | Function, scope?: any)
+
+    readonly code: string | Function
+    readonly scope?: any
+  }
+
+  /**
+   * A class representation of the BSON DBRef type.
+   */
+  export class DBRef {
+    /**
+     * @param namespace The collection name.
+     * @param oid The reference ObjectId.
+     * @param db Optional db name, if omitted the reference is local to the current db
+     */
+    constructor(namespace: string, oid: ObjectId, db?: string)
+    namespace: string
+    oid: ObjectId
+    db?: string
+  }
+
+  /** A class representation of the BSON Double type. */
+  export class Double {
+    /**
+     * @param value The number we want to represent as a double.
+     */
+    constructor(value: number)
+
+    /**
+     * https://github.com/mongodb/js-bson/blob/master/lib/double.js#L17
+     */
+    value: number
+
+    valueOf(): number
+  }
+
+  /** A class representation of the BSON Int32 type. */
+  export class Int32 {
+    /**
+     * @param value The number we want to represent as an int32.
+     */
+    constructor(value: number)
+
+    valueOf(): number
+  }
+
+  /** A class representation of the BSON Decimal128 type. */
+  export class Decimal128 {
+    /** Create a Decimal128 instance from a string representation. */
+    static fromString(s: string): Decimal128
+
+    /**
+     * @param bytes A buffer containing the raw Decimal128 bytes.
+     */
+    constructor(bytes: Buffer)
+
+    /** A buffer containing the raw Decimal128 bytes. */
+    readonly bytes: Buffer
+
+    toJSON(): string
+    toString(): string
+  }
+
+  /**
+   * A class representation of the BSON Long type, a 64-bit two's-complement
+   * integer value, which faithfully simulates the behavior of a Java "Long". This
+   * implementation is derived from LongLib in GWT.
+   */
+  export class Long extends LongLike<Long> {
+    static readonly MAX_VALUE: Long
+    static readonly MIN_VALUE: Long
+    static readonly NEG_ONE: Long
+    static readonly ONE: Long
+    static readonly ZERO: Long
+
+    /** Returns a Long representing the given (32-bit) integer value. */
+    static fromInt(i: number): Long
+    /** Returns a Long representing the given value, provided that it is a finite number. Otherwise, zero is returned. */
+    static fromNumber(n: number): Long
+    /**
+     * Returns a Long representing the 64-bit integer that comes by concatenating the given high and low bits. Each is assumed to use 32 bits.
+     * @param lowBits The low 32-bits.
+     * @param highBits The high 32-bits.
+     */
+    static fromBits(lowBits: number, highBits: number): Long
+    /**
+     * Returns a Long representation of the given string
+     * @param opt_radix The radix in which the text is written. {default:10}
+     */
+    static fromString(s: string, opt_radix?: number): Long
+  }
+
+  /** A class representation of the BSON MaxKey type. */
+  export class MaxKey {
+    constructor()
+  }
+
+  /** A class representation of the BSON MinKey type. */
+  export class MinKey {
+    constructor()
+  }
+
+  /** A class representation of the BSON ObjectId type. */
+  export class ObjectId {
+    /**
+     * Create a new ObjectId instance
+     * @param {(string|number|ObjectId)} id Can be a 24 byte hex string, 12 byte binary string or a Number.
+     */
+    constructor(id?: string | number | ObjectId)
+    /** The generation time of this ObjectId instance */
+    generationTime: number
+    /** If true cache the hex string representation of ObjectId */
+    static cacheHexString?: boolean
+    /**
+     * Creates an ObjectId from a hex string representation of an ObjectId.
+     * @param {string} hexString create a ObjectId from a passed in 24 byte hexstring.
+     * @return {ObjectId} return the created ObjectId
+     */
+    static createFromHexString(hexString: string): ObjectId
+    /**
+     * Creates an ObjectId from a second based number, with the rest of the ObjectId zeroed out. Used for comparisons or sorting the ObjectId.
+     * @param {number} time an integer number representing a number of seconds.
+     * @return {ObjectId} return the created ObjectId
+     */
+    static createFromTime(time: number): ObjectId
+    /**
+     * Checks if a value is a valid bson ObjectId
+     *
+     * @return {boolean} return true if the value is a valid bson ObjectId, return false otherwise.
+     */
+    static isValid(id: string | number | ObjectId): boolean
+    /**
+     * Compares the equality of this ObjectId with `otherID`.
+     * @param {ObjectId|string} otherID ObjectId instance to compare against.
+     * @return {boolean} the result of comparing two ObjectId's
+     */
+    equals(otherID: ObjectId | string): boolean
+    /**
+     * Generate a 12 byte id string used in ObjectId's
+     * @param {number} time optional parameter allowing to pass in a second based timestamp.
+     * @return {string} return the 12 byte id binary string.
+     */
+    static generate(time?: number): Buffer
+    /**
+     * Returns the generation date (accurate up to the second) that this ID was generated.
+     * @return {Date} the generation date
+     */
+    getTimestamp(): Date
+    /**
+     * Return the ObjectId id as a 24 byte hex string representation
+     * @return {string} return the 24 byte hex string representation.
+     */
+    toHexString(): string
+  }
+
+  /** A class representation of the BSON RegExp type. */
+  export class BSONRegExp {
+    constructor(pattern: string, options: string)
+
+    readonly pattern: string
+    readonly options: string
+  }
+
+  /**
+   * A class representation of the BSON Symbol type.
+   * @deprecated
+   */
+  export class Symbol {
+    constructor(value: string)
+
+    /** Access the wrapped string value. */
+    valueOf(): string
+  }
+
+  /** A class representation of the BSON Timestamp type. */
+  export class Timestamp extends LongLike<Timestamp> {
+    static readonly MAX_VALUE: Timestamp
+    static readonly MIN_VALUE: Timestamp
+    static readonly NEG_ONE: Timestamp
+    static readonly ONE: Timestamp
+    static readonly ZERO: Timestamp
+
+    /** Returns a Timestamp represented by the given (32-bit) integer value */
+    static fromInt(value: number): Timestamp
+    /** Returns a Timestamp representing the given number value, provided that it is a finite number. */
+    static fromNumber(value: number): Timestamp
+    /**
+     * Returns a Timestamp for the given high and low bits. Each is assumed to use 32 bits.
+     * @param lowBits The low 32-bits.
+     * @param highBits The high 32-bits.
+     */
+    static fromBits(lowBits: number, highBits: number): Timestamp
+    /**
+     * Returns a Timestamp from the given string.
+     * @param opt_radix The radix in which the text is written. {default:10}
+     */
+    static fromString(str: string, opt_radix?: number): Timestamp
+  }
+
+  /**
+   * A class representation of the BSON Map type.
+   * @deprecated
+   */
+  export class Map {
+    constructor()
+  }
+
+  export default class BSON {
+    constructor(types: any[]) {}
+
+    // BSON MAX VALUES
+    static readonly BSON_INT32_MAX = 0x7fffffff
+    static readonly BSON_INT32_MIN = -0x80000000
+
+    static readonly BSON_INT64_MAX = Math.pow(2, 63) - 1
+    static readonly BSON_INT64_MIN = -Math.pow(2, 63)
+
+    // JS MAX PRECISE VALUES
+    static readonly JS_INT_MAX = 0x20000000000000 // Any integer up to 2^53 can be precisely represented by a double.
+    static readonly JS_INT_MIN = -0x20000000000000 // Any integer down to -2^53 can be precisely represented by a double.
+
+    static Binary = Binary
+    static Code = Code
+    static DBRef = DBRef
+    static Decimal128 = Decimal128
+    static Double = Double
+    static Int32 = Int32
+    static Long = Long
+    /** @deprecated */
+    static Map = Map
+    static MaxKey = MaxKey
+    static MinKey = MinKey
+    static ObjectId = ObjectId
+    // special case for deprecated names
+    /** @deprecated */
+    static ObjectID = ObjectId
+    static BSONRegExp = BSONRegExp
+    /** @deprecated */
+    static Symbol = Symbol
+    static Timestamp = Timestamp
+
+    // Just add constants to the Native BSON parser
+    static readonly BSON_BINARY_SUBTYPE_DEFAULT = 0
+    static readonly BSON_BINARY_SUBTYPE_FUNCTION = 1
+    static readonly BSON_BINARY_SUBTYPE_BYTE_ARRAY = 2
+    static readonly BSON_BINARY_SUBTYPE_UUID = 3
+    static readonly BSON_BINARY_SUBTYPE_MD5 = 4
+    static readonly BSON_BINARY_SUBTYPE_USER_DEFINED = 128
+
+    /**
+     * Calculate the bson size for a passed in Javascript object.
+     *
+     * @param {Object} object the Javascript object to calculate the BSON byte size for.
+     * @param {CalculateObjectSizeOptions} Options
+     * @return {Number} returns the number of bytes the BSON object will take up.
+     */
+    calculateObjectSize(
+      object: any,
+      options?: CalculateObjectSizeOptions,
+    ): number
+
+    /**
+     * Serialize a Javascript object.
+     *
+     * @param object The Javascript object to serialize.
+     * @param options Serialize options.
+     * @return The Buffer object containing the serialized object.
+     */
+    serialize(object: any, options?: SerializeOptions): Buffer
+
+    /**
+     * Serialize a Javascript object using a predefined Buffer and index into the buffer, useful when pre-allocating the space for serialization.
+     *
+     * @param object The Javascript object to serialize.
+     * @param buffer The Buffer you pre-allocated to store the serialized BSON object.
+     * @param options Serialize options.
+     * @returns The index pointing to the last written byte in the buffer
+     */
+    serializeWithBufferAndIndex(
+      object: any,
+      buffer: Buffer,
+      options?: SerializeWithBufferAndIndexOptions,
+    ): number
+
+    /**
+     * Deserialize data as BSON.
+     *
+     * @param buffer The buffer containing the serialized set of BSON documents.
+     * @param options Deserialize options.
+     * @returns The deserialized Javascript Object.
+     */
+    deserialize(buffer: Buffer, options?: DeserializeOptions): any
+
+    /**
+     * Deserialize stream data as BSON documents.
+     *
+     * @param data The buffer containing the serialized set of BSON documents.
+     * @param startIndex The start index in the data Buffer where the deserialization is to start.
+     * @param numberOfDocuments Number of documents to deserialize
+     * @param documents An array where to store the deserialized documents
+     * @param docStartIndex The index in the documents array from where to start inserting documents
+     * @param options Additional options used for the deserialization
+     * @returns The next index in the buffer after deserialization of the `numberOfDocuments`
+     */
+    deserializeStream(
+      data: Buffer,
+      startIndex: number,
+      numberOfDocuments: number,
+      documents: Array<any>,
+      docStartIndex: number,
+      options?: DeserializeOptions,
+    ): number
+  }
+
+  /**
+   * ObjectID (with capital "D") is deprecated. Use ObjectId (lowercase "d")
+   * instead.
+   * @deprecated
+   */
+  export { ObjectId as ObjectID }
+}

--- a/src/types/vendor/convict-format-with-validator.d.ts
+++ b/src/types/vendor/convict-format-with-validator.d.ts
@@ -2,27 +2,21 @@ declare module 'convict-format-with-validator' {
   function coerce(v): string
   function validate(x): void
 
-  const url = {
+  export const url = {
     name: 'url' as const,
     coerce,
     validate,
   }
 
-  const ipaddress = {
+  export const ipaddress = {
     name: 'ipaddress' as const,
     coerce,
     validate,
   }
 
-  const email = {
+  export const email = {
     name: 'email' as const,
     coerce,
     validate,
-  }
-
-  export default {
-    url,
-    ipaddress,
-    email,
   }
 }

--- a/src/types/vendor/convict-format-with-validator.d.ts
+++ b/src/types/vendor/convict-format-with-validator.d.ts
@@ -1,0 +1,28 @@
+declare module 'convict-format-with-validator' {
+  function coerce(v): string
+  function validate(x): void
+
+  const url = {
+    name: 'url' as const,
+    coerce,
+    validate,
+  }
+
+  const ipaddress = {
+    name: 'ipaddress' as const,
+    coerce,
+    validate,
+  }
+
+  const email = {
+    name: 'email' as const,
+    coerce,
+    validate,
+  }
+
+  export default {
+    url,
+    ipaddress,
+    email,
+  }
+}

--- a/src/types/vendor/express-device.d.ts
+++ b/src/types/vendor/express-device.d.ts
@@ -1,0 +1,23 @@
+declare module 'express-device' {
+  import { RequestHandler } from 'express'
+
+  type UserAgentDevice = 'desktop' | 'tv' | 'tablet' | 'phone' | 'bot' | 'car'
+
+  type CaptureOptions = {
+    emptyUserAgentDeviceType?: UserAgentDevice
+    unknownUserAgentDeviceType?: UserAgentDevice
+    botUserAgentDeviceType?: UserAgentDevice
+    carUserAgentDeviceType?: UserAgentDevice
+    parseUserAgent?: boolean
+  }
+
+  function capture(options: CaptureOptions): RequestHandler
+
+  // This typing is incomplete, to be typed when other functionality is needed.
+  // See https://github.com/rguerreiro/express-device/blob/master/lib/device.js
+  // for the module exports.
+
+  export default {
+    capture,
+  }
+}

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -3,11 +3,15 @@ import { Document } from 'mongoose'
 import { IFormSchema } from './form'
 
 export interface IVerificationField {
+  // _id is basically a generated transactionId, so it has to be a string,
+  // instead of being converted to a string from ObjectId.
+  // This must be a string, or transaction fetching will fail.
+  _id: string
   fieldType: string
-  signedData: string | null
-  hashedOtp: string | null
-  hashCreatedAt: Date | null
-  hashRetries: number
+  signedData?: string | null
+  hashedOtp?: string | null
+  hashCreatedAt?: Date | null
+  hashRetries?: number
 }
 
 export interface IVerificationFieldSchema extends IVerificationField, Document {
@@ -19,7 +23,7 @@ export interface IVerificationFieldSchema extends IVerificationField, Document {
 
 export interface IVerification {
   formId: IFormSchema['_id']
-  expireAt: Date
+  expireAt?: Date
   fields: IVerificationFieldSchema[]
 }
 

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -1,4 +1,6 @@
+// @ts-ignore
 import mongoSetup from '@shelf/jest-mongodb/setup'
+// @ts-ignore
 import mongoTeardown from '@shelf/jest-mongodb/teardown'
 import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
@@ -14,7 +16,7 @@ const connect = async () => {
   // Do it here so each test can have it's own mongoose instance.
   await mongoSetup()
   // process.env.MONGO_URL is now set by jest-mongodb.
-  const conn = await mongoose.connect(process.env.MONGO_URL, {
+  const conn = await mongoose.connect(process.env.MONGO_URL!, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
     useCreateIndex: true,

--- a/tests/unit/backend/helpers/jest-express.ts
+++ b/tests/unit/backend/helpers/jest-express.ts
@@ -1,9 +1,6 @@
 import { Request, Response } from 'express'
 
-const mockRequest = <
-  P extends Record<string, string>,
-  B extends Record<string, string>
->({
+const mockRequest = <P extends Record<string, string>, B>({
   params,
   body,
   session,

--- a/tests/unit/backend/helpers/jest-express.ts
+++ b/tests/unit/backend/helpers/jest-express.ts
@@ -1,23 +1,22 @@
 import { Request, Response } from 'express'
 
-const mockRequest = ({
-  body,
+const mockRequest = <
+  P extends Record<string, string>,
+  B extends Record<string, string>
+>({
   params,
+  body,
   session,
 }: {
-  body?: Record<string, string>
-  params?: Record<string, string>
+  params?: P
+  body: B
   session?: any
-} = {}) => {
+}) => {
   return {
-    body: body ?? {},
-    params: params ?? {},
-    session: session ?? {},
-    get(name: string) {
-      if (name === 'cf-connecting-ip') return 'MOCK_IP'
-      return null
-    },
-  } as Request
+    body,
+    params,
+    session,
+  } as Request<P, any, B>
 }
 
 const mockResponse = (extraArgs: Partial<Record<keyof Response, any>> = {}) => {

--- a/tests/unit/backend/helpers/jest-express.ts
+++ b/tests/unit/backend/helpers/jest-express.ts
@@ -6,13 +6,17 @@ const mockRequest = <P extends Record<string, string>, B>({
   session,
 }: {
   params?: P
-  body: B
+  body?: B
   session?: any
-}) => {
+} = {}) => {
   return {
-    body,
-    params,
-    session,
+    body: body ?? {},
+    params: params ?? {},
+    session: session ?? {},
+    get(name: string) {
+      if (name === 'cf-connecting-ip') return 'MOCK_IP'
+      return undefined
+    },
   } as Request<P, any, B>
 }
 

--- a/tests/unit/backend/models/admin_verification.server.model.spec.ts
+++ b/tests/unit/backend/models/admin_verification.server.model.spec.ts
@@ -87,6 +87,7 @@ describe('AdminVerification Model', () => {
       }
 
       // Act
+      // @ts-ignore
       const actualPromise = AdminVerification.create(missingContactParams)
 
       // Assert
@@ -103,6 +104,7 @@ describe('AdminVerification Model', () => {
       }
 
       // Act
+      // @ts-ignore
       const actualPromise = AdminVerification.create(missingOtpParams)
 
       // Assert
@@ -119,6 +121,7 @@ describe('AdminVerification Model', () => {
       }
 
       // Act
+      // @ts-ignore
       const actualPromise = AdminVerification.create(missingExpireParams)
 
       // Assert

--- a/tests/unit/backend/models/form.server.model.spec.ts
+++ b/tests/unit/backend/models/form.server.model.spec.ts
@@ -10,6 +10,7 @@ import {
   IAgencySchema,
   IEncryptedForm,
   IUserSchema,
+  Permission,
   ResponseMode,
 } from 'src/types'
 
@@ -167,7 +168,9 @@ describe('Form Model', () => {
         // Remove indeterministic id from actual permission list
         const actualPermissionList = saved
           .toObject()
-          .permissionList.map((permission) => omit(permission, '_id'))
+          .permissionList!.map((permission: Permission[]) =>
+            omit(permission, '_id'),
+          )
         expect(actualPermissionList).toEqual(permissionList)
       })
 
@@ -351,7 +354,7 @@ describe('Form Model', () => {
         expect(actualSavedObject).toEqual(expectedObject)
 
         // Remove indeterministic id from actual permission list
-        const actualPermissionList = (saved.toObject() as IEncryptedForm).permissionList.map(
+        const actualPermissionList = (saved.toObject() as IEncryptedForm).permissionList!.map(
           (permission) => omit(permission, '_id'),
         )
         expect(actualPermissionList).toEqual(permissionList)
@@ -555,7 +558,9 @@ describe('Form Model', () => {
         // Remove indeterministic id from actual permission list
         const actualPermissionList = saved
           .toObject()
-          .permissionList.map((permission) => omit(permission, '_id'))
+          .permissionList!.map((permission: Permission[]) =>
+            omit(permission, '_id'),
+          )
         expect(actualPermissionList).toEqual(permissionList)
       })
 
@@ -690,7 +695,7 @@ describe('Form Model', () => {
         const form = (await Form.create(emailFormParams)).toObject()
 
         // Act
-        const actualForm = (await Form.getFullFormById(form._id)).toObject()
+        const actualForm = (await Form.getFullFormById(form._id))!.toObject()
 
         // Assert
         // Form should be returned
@@ -721,7 +726,7 @@ describe('Form Model', () => {
         const form = (await Form.create(encryptFormParams)).toObject()
 
         // Act
-        const actualForm = (await Form.getFullFormById(form._id)).toObject()
+        const actualForm = (await Form.getFullFormById(form._id))!.toObject()
 
         // Assert
         // Form should be returned

--- a/tests/unit/backend/models/form_fields.schema.spec.ts
+++ b/tests/unit/backend/models/form_fields.schema.spec.ts
@@ -2,7 +2,7 @@ import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
 
 import getFormModel from 'src/app/models/form.server.model'
-import { BasicField, ResponseMode } from 'src/types'
+import { BasicField, IFieldSchema, ResponseMode } from 'src/types'
 
 import dbHandler from '../helpers/jest-db'
 
@@ -121,9 +121,10 @@ const createAndReturnFormField = async (
 
   const formParam = {
     ...baseParams,
-    form_fields: [formFieldParams],
+    responseMode: formType,
+    form_fields: [formFieldParams] as IFieldSchema[],
   }
   const form = await Form.create(formParam)
 
-  return form.form_fields[0]
+  return form.form_fields![0]
 }

--- a/tests/unit/backend/models/sms_count.server.model.spec.ts
+++ b/tests/unit/backend/models/sms_count.server.model.spec.ts
@@ -194,7 +194,7 @@ describe('SmsCount', () => {
           form: MOCK_FORM_ID,
         }).lean()
 
-        expect(actualLog._id).toBeDefined()
+        expect(actualLog!._id).toBeDefined()
         // Retrieve object and compare to params, remove indeterministic keys
         const actualSavedObject = omit(actualLog, ['_id', 'createdAt', '__v'])
         expect(actualSavedObject).toEqual(expectedLog)
@@ -220,7 +220,7 @@ describe('SmsCount', () => {
           form: MOCK_FORM_ID,
         }).lean()
 
-        expect(actualLog._id).toBeDefined()
+        expect(actualLog!._id).toBeDefined()
         // Retrieve object and compare to params, remove indeterministic keys
         const actualSavedObject = omit(actualLog, ['_id', 'createdAt', '__v'])
         expect(actualSavedObject).toEqual(expectedLog)

--- a/tests/unit/backend/modules/submission/submission.utils.spec.ts
+++ b/tests/unit/backend/modules/submission/submission.utils.spec.ts
@@ -47,7 +47,7 @@ describe('submission.utils', () => {
 
     it('should throw error if called with invalid responseMode', async () => {
       // Act + Assert
-      expect(() => getModeFilter(undefined)).toThrowError(
+      expect(() => getModeFilter(undefined!)).toThrowError(
         'getResponsesForEachField: Invalid response mode parameter',
       )
     })

--- a/tests/unit/backend/modules/user/user.service.spec.ts
+++ b/tests/unit/backend/modules/user/user.service.spec.ts
@@ -221,7 +221,7 @@ describe('user.service', () => {
       const actual = await UserService.getPopulatedUserById(USER_ID)
 
       // Assert
-      expect(actual.toObject()).toEqual(expected)
+      expect(actual!.toObject()).toEqual(expected)
     })
 
     it('should return null when user cannot be found', async () => {

--- a/tests/unit/backend/modules/verification/verification.controller.spec.ts
+++ b/tests/unit/backend/modules/verification/verification.controller.spec.ts
@@ -33,12 +33,10 @@ const invalidOtpError = 'INVALID_OTP'
 
 describe('Verification controller', () => {
   describe('createTransaction', () => {
-    let mockReq
-    afterEach(() => jest.clearAllMocks())
-
-    beforeAll(() => {
-      mockReq = expressHandler.mockRequest({ body: { formId: MOCK_FORM_ID } })
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: { formId: MOCK_FORM_ID },
     })
+    afterEach(() => jest.clearAllMocks())
 
     it('should correctly return transaction when parameters are valid', async () => {
       const returnValue = {
@@ -48,7 +46,7 @@ describe('Verification controller', () => {
       MockVfnService.createTransaction.mockReturnValueOnce(
         Promise.resolve(returnValue),
       )
-      await createTransaction(mockReq, MOCK_RES, noop)
+      await createTransaction(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
@@ -57,8 +55,8 @@ describe('Verification controller', () => {
     })
 
     it('should correctly return 200 when transaction is not found', async () => {
-      MockVfnService.createTransaction.mockReturnValueOnce(null)
-      await createTransaction(mockReq, MOCK_RES, noop)
+      MockVfnService.createTransaction.mockResolvedValueOnce(null)
+      await createTransaction(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
@@ -67,15 +65,11 @@ describe('Verification controller', () => {
   })
 
   describe('getTransactionMetadata', () => {
-    let mockReq
-    afterEach(() => jest.clearAllMocks())
-
-    beforeAll(() => {
-      mockReq = expressHandler.mockRequest({
-        body: {},
-        params: { transactionId: MOCK_TRANSACTION_ID },
-      })
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: {},
+      params: { transactionId: MOCK_TRANSACTION_ID },
     })
+    afterEach(() => jest.clearAllMocks())
 
     it('should correctly return metadata when parameters are valid', async () => {
       // Coerce type
@@ -85,7 +79,7 @@ describe('Verification controller', () => {
       MockVfnService.getTransactionMetadata.mockReturnValueOnce(
         Promise.resolve(transaction),
       )
-      await getTransactionMetadata(mockReq, MOCK_RES, noop)
+      await getTransactionMetadata(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
@@ -99,7 +93,7 @@ describe('Verification controller', () => {
         error.name = notFoundError
         throw error
       })
-      await getTransactionMetadata(mockReq, MOCK_RES, noop)
+      await getTransactionMetadata(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
@@ -109,22 +103,18 @@ describe('Verification controller', () => {
   })
 
   describe('resetFieldInTransaction', () => {
-    let mockReq
-    afterEach(() => jest.clearAllMocks())
-
-    beforeAll(() => {
-      mockReq = expressHandler.mockRequest({
-        body: { fieldId: MOCK_FIELD_ID },
-        params: { transactionId: MOCK_TRANSACTION_ID },
-      })
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: { fieldId: MOCK_FIELD_ID },
+      params: { transactionId: MOCK_TRANSACTION_ID },
     })
+    afterEach(() => jest.clearAllMocks())
 
     it('should correctly call service when params are valid', async () => {
       const transaction = new Verification({ formId: new ObjectId() })
       MockVfnService.getTransaction.mockReturnValueOnce(
         Promise.resolve(transaction),
       )
-      await resetFieldInTransaction(mockReq, MOCK_RES, noop)
+      await resetFieldInTransaction(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
@@ -141,7 +131,7 @@ describe('Verification controller', () => {
         error.name = notFoundError
         throw error
       })
-      await resetFieldInTransaction(mockReq, MOCK_RES, noop)
+      await resetFieldInTransaction(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
@@ -151,27 +141,25 @@ describe('Verification controller', () => {
   })
 
   describe('getNewOtp', () => {
-    let mockReq, transaction
-    afterEach(() => jest.clearAllMocks())
-
-    beforeAll(() => {
-      mockReq = expressHandler.mockRequest({
-        body: { fieldId: MOCK_FIELD_ID, answer: MOCK_ANSWER },
-        params: { transactionId: MOCK_TRANSACTION_ID },
-      })
-      transaction = new Verification({ formId: new ObjectId() })
-      MockVfnService.getTransaction.mockReturnValue(
-        Promise.resolve(transaction),
-      )
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: { fieldId: MOCK_FIELD_ID, answer: MOCK_ANSWER },
+      params: { transactionId: MOCK_TRANSACTION_ID },
     })
 
+    const MOCK_TRANSACTION = new Verification({ formId: new ObjectId() })
+    MockVfnService.getTransaction.mockReturnValue(
+      Promise.resolve(MOCK_TRANSACTION),
+    )
+
+    afterEach(() => jest.clearAllMocks())
+
     it('should call service correctly when params are valid', async () => {
-      await getNewOtp(mockReq, MOCK_RES, noop)
+      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
@@ -184,12 +172,12 @@ describe('Verification controller', () => {
         error.name = notFoundError
         throw error
       })
-      await getNewOtp(mockReq, MOCK_RES, noop)
+      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
@@ -203,12 +191,12 @@ describe('Verification controller', () => {
         error.name = waitOtpError
         throw error
       })
-      await getNewOtp(mockReq, MOCK_RES, noop)
+      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
@@ -222,12 +210,12 @@ describe('Verification controller', () => {
         error.name = sendOtpError
         throw error
       })
-      await getNewOtp(mockReq, MOCK_RES, noop)
+      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
@@ -237,29 +225,28 @@ describe('Verification controller', () => {
   })
 
   describe('verifyOtp', () => {
-    let mockReq, transaction
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: { fieldId: MOCK_FIELD_ID, otp: MOCK_OTP },
+      params: { transactionId: MOCK_TRANSACTION_ID },
+    })
+    const MOCK_TRANSACTION = new Verification({ formId: new ObjectId() })
 
     afterEach(() => jest.clearAllMocks())
 
     beforeAll(() => {
-      mockReq = expressHandler.mockRequest({
-        body: { fieldId: MOCK_FIELD_ID, otp: MOCK_OTP },
-        params: { transactionId: MOCK_TRANSACTION_ID },
-      })
-      transaction = new Verification({ formId: new ObjectId() })
       MockVfnService.getTransaction.mockReturnValue(
-        Promise.resolve(transaction),
+        Promise.resolve(MOCK_TRANSACTION),
       )
     })
 
     it('should call service correctly when params are valid', async () => {
       MockVfnService.verifyOtp.mockReturnValue(Promise.resolve(MOCK_DATA))
-      await verifyOtp(mockReq, MOCK_RES, noop)
+      await verifyOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.verifyOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_OTP,
       )
@@ -273,12 +260,12 @@ describe('Verification controller', () => {
         error.name = invalidOtpError
         throw error
       })
-      await verifyOtp(mockReq, MOCK_RES, noop)
+      await verifyOtp(MOCK_REQ, MOCK_RES, noop)
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
       expect(MockVfnService.verifyOtp).toHaveBeenCalledWith(
-        transaction,
+        MOCK_TRANSACTION,
         MOCK_FIELD_ID,
         MOCK_OTP,
       )

--- a/tests/unit/backend/modules/verification/verification.service.spec.ts
+++ b/tests/unit/backend/modules/verification/verification.service.spec.ts
@@ -90,8 +90,8 @@ describe('Verification service', () => {
       })
       expect(foundTransaction).toBeTruthy()
       expect(returnedTransaction).toEqual({
-        transactionId: foundTransaction._id,
-        expireAt: foundTransaction.expireAt,
+        transactionId: foundTransaction!._id,
+        expireAt: foundTransaction!.expireAt,
       })
     })
   })
@@ -138,7 +138,7 @@ describe('Verification service', () => {
       const hashRetries = 1
       const transaction = new Verification({
         formId,
-        fields: testForm.form_fields.map(({ _id, fieldType }) => ({
+        fields: testForm.form_fields!.map(({ _id, fieldType }) => ({
           _id,
           fieldType,
           hashCreatedAt,
@@ -148,19 +148,19 @@ describe('Verification service', () => {
         })),
       })
       await transaction.save()
-      await resetFieldInTransaction(transaction, testForm.form_fields[0]._id)
+      await resetFieldInTransaction(transaction, testForm.form_fields![0]._id)
       const actual = await Verification.findOne({ formId })
-      expect(actual.fields[0].toObject()).toEqual({
-        _id: String(testForm.form_fields[0]._id),
-        fieldType: testForm.form_fields[0].fieldType,
+      expect(actual!.fields[0].toObject()).toEqual({
+        _id: String(testForm.form_fields![0]._id),
+        fieldType: testForm.form_fields![0].fieldType,
         hashCreatedAt: null,
         hashedOtp: null,
         signedData: null,
         hashRetries: 0,
       })
-      expect(actual.fields[1].toObject()).toEqual({
-        _id: String(testForm.form_fields[1]._id),
-        fieldType: testForm.form_fields[1].fieldType,
+      expect(actual!.fields[1].toObject()).toEqual({
+        _id: String(testForm.form_fields![1]._id),
+        fieldType: testForm.form_fields![1].fieldType,
         hashCreatedAt,
         hashedOtp,
         signedData,
@@ -221,7 +221,7 @@ describe('Verification service', () => {
       })
       MockGenerateOtp.mockReturnValue(mockOtp)
       MockBcrypt.hash.mockReturnValue(Promise.resolve(hashedOtp))
-      MockFormsgSdk.verification.generateSignature.mockReturnValue(signedData)
+      MockFormsgSdk.verification.generateSignature!.mockReturnValue(signedData)
     })
 
     afterEach(async () => await dbHandler.clearDatabase())
@@ -260,7 +260,7 @@ describe('Verification service', () => {
       expect(MockGenerateOtp).toHaveBeenCalled()
       expect(MockBcrypt.hash.mock.calls[0][0]).toBe(mockOtp)
       expect(
-        MockFormsgSdk.verification.generateSignature.mock.calls[0][0],
+        MockFormsgSdk.verification.generateSignature!.mock.calls[0][0],
       ).toEqual({
         transactionId: transaction._id,
         formId: transaction.formId,
@@ -274,10 +274,10 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashCreatedAt).toBeInstanceOf(Date)
-      expect(foundTransaction.fields[0].hashedOtp).toBe(hashedOtp)
-      expect(foundTransaction.fields[0].signedData).toBe(signedData)
-      expect(foundTransaction.fields[0].hashRetries).toBe(0)
+      expect(foundTransaction!.fields[0].hashCreatedAt).toBeInstanceOf(Date)
+      expect(foundTransaction!.fields[0].hashedOtp).toBe(hashedOtp)
+      expect(foundTransaction!.fields[0].signedData).toBe(signedData)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(0)
     })
 
     it('should send OTP when params are valid for mobile field', async () => {
@@ -291,7 +291,7 @@ describe('Verification service', () => {
       expect(MockGenerateOtp).toHaveBeenCalled()
       expect(MockBcrypt.hash.mock.calls[0][0]).toBe(mockOtp)
       expect(
-        MockFormsgSdk.verification.generateSignature.mock.calls[0][0],
+        MockFormsgSdk.verification.generateSignature!.mock.calls[0][0],
       ).toEqual({
         transactionId: transaction._id,
         formId: transaction.formId,
@@ -306,10 +306,10 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[1].hashCreatedAt).toBeInstanceOf(Date)
-      expect(foundTransaction.fields[1].hashedOtp).toBe(hashedOtp)
-      expect(foundTransaction.fields[1].signedData).toBe(signedData)
-      expect(foundTransaction.fields[1].hashRetries).toBe(0)
+      expect(foundTransaction!.fields[1].hashCreatedAt).toBeInstanceOf(Date)
+      expect(foundTransaction!.fields[1].hashedOtp).toBe(hashedOtp)
+      expect(foundTransaction!.fields[1].signedData).toBe(signedData)
+      expect(foundTransaction!.fields[1].hashRetries).toBe(0)
     })
 
     it('should catch and re-throw errors thrown when sending email', async () => {
@@ -390,7 +390,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries)
     })
 
     it('should throw error when field ID is invalid', async () => {
@@ -402,7 +402,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries)
     })
 
     it('should throw error when hashed OTP is invalid', async () => {
@@ -415,7 +415,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries)
     })
 
     it('should throw error when hashCreatedAt is invalid', async () => {
@@ -428,7 +428,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries)
     })
 
     it('should throw error when hash is expired', async () => {
@@ -442,7 +442,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries)
     })
 
     it('should throw error when retries are maxed out', async () => {
@@ -456,7 +456,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(tooManyRetries)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(tooManyRetries)
     })
 
     it('should reject when OTP is invalid', async () => {
@@ -469,7 +469,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries + 1)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries + 1)
     })
 
     it('should resolve when OTP is invalid', async () => {
@@ -482,7 +482,7 @@ describe('Verification service', () => {
       const foundTransaction = await Verification.findOne({
         _id: transaction._id,
       })
-      expect(foundTransaction.fields[0].hashRetries).toBe(hashRetries + 1)
+      expect(foundTransaction!.fields[0].hashRetries).toBe(hashRetries + 1)
     })
   })
 })

--- a/tests/unit/backend/modules/webhook/webhook.service.spec.ts
+++ b/tests/unit/backend/modules/webhook/webhook.service.spec.ts
@@ -76,7 +76,7 @@ describe('WebhooksService', () => {
 
   let testEncryptSubmission: IEncryptedSubmissionSchema
   let testConfig: AxiosRequestConfig
-  let testSubmissionWebhookView: WebhookView
+  let testSubmissionWebhookView: WebhookView | null
   let testSignature: string
 
   beforeEach(async () => {
@@ -147,7 +147,7 @@ describe('WebhooksService', () => {
       let submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission.webhookResponses[0]).toEqual(
+      expect(submission!.webhookResponses[0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,
@@ -172,7 +172,7 @@ describe('WebhooksService', () => {
       let submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission.webhookResponses[0]).toEqual(
+      expect(submission!.webhookResponses[0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,
@@ -188,7 +188,7 @@ describe('WebhooksService', () => {
         toJSON: () => {}
         config: object
         response: AxiosResponse
-        constructor(msg, response) {
+        constructor(msg: string, response: AxiosResponse) {
           super(msg)
           this.isAxiosError = false
           this.response = response
@@ -220,7 +220,7 @@ describe('WebhooksService', () => {
       let submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission.webhookResponses[0]).toEqual(
+      expect(submission!.webhookResponses[0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,

--- a/tests/unit/backend/services/mail.service.spec.ts
+++ b/tests/unit/backend/services/mail.service.spec.ts
@@ -850,7 +850,7 @@ describe('mail.service', () => {
         html: expectedMailBody,
         // Attachments should be concatted with mock pdf response
         attachments: [
-          ...MOCK_AUTOREPLY_PARAMS.attachments,
+          ...MOCK_AUTOREPLY_PARAMS.attachments!,
           {
             content: MOCK_PDF,
             filename: 'response.pdf',

--- a/tests/unit/backend/utils/attachment.spec.ts
+++ b/tests/unit/backend/utils/attachment.spec.ts
@@ -11,6 +11,7 @@ import {
 } from 'src/app/utils/attachment'
 import {
   BasicField,
+  FieldResponse,
   IAttachmentResponse,
   ISingleAnswerResponse,
 } from 'src/types'
@@ -182,7 +183,7 @@ describe('addAttachmentToResponses', () => {
   })
 
   it('should do nothing when responses are empty', () => {
-    const responses = []
+    const responses: FieldResponse[] = []
     addAttachmentToResponses(responses, [validSingleFile])
     expect(responses).toEqual([])
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    // "strict": true,                        /* Enable all strict type-checking options. */
+    "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */


### PR DESCRIPTION
## Problem

Turn on strict mode that allows the Typescript compiler to alert us on undefined or nullable errors.

Various changes are made in the codebase to accommodate this change.

Also add better JSDocs on the functions I've come across

Closes #163

**Features**
- add vendor typings for `convict-format-with-validator` in `types/vendors`
- add vendor typing for `express-device` package in `types/vendors`
- add vendor typing for `bson-ext` package in `types/vendors`

**Improvements**
- Correct all errors that arise from the change to strict mode

**Dev Dependencies**
- bump `ts-jest` from 26.1.4 to 26.3.0: This removes the Typescript unsupported warning
- bump `@shelf/jest-mongodb` from 1.2.2 to 1.2.3: I thought this would allow us to not have to manually setup and teardown on `dbHandler.connect`, but that does not seem to be the case. No harm updating though so it stays.