### PR TITLE
chore: add lint-staged entry to run tests on committed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix",
+    "*.ts": "jest --findRelatedTests",
     "*.css": "stylelint --fix",
     "*.html": [
       "htmlhint",


### PR DESCRIPTION
## Problem

This PR uses `jest` to run tests on committed files, catching failing tests before they get committed.

Note that commits may take longer if the committed files happen to have tests, since tests have to be run against the committed files.

Closes #191
