### PR TITLE
feat: add try-catch block to custom logger for js files

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -189,23 +189,40 @@ const getModuleLabel = (callingModule: NodeModule) => {
 /**
  * Overrides the given winston logger with a new signature, so as to enforce a
  * log format.
+ * TODO(#42): Remove try catch blocks when application is 100% TypeScript.
  * @param logger the logger to override
  */
 const createCustomLogger = (logger: Logger) => {
   return {
-    info: ({ message, meta }: Omit<CustomLoggerParams, 'error'>) =>
-      logger.info(message, { meta }),
-    warn: ({ message, meta, error }: CustomLoggerParams) => {
-      if (error) {
-        return logger.warn(message, { meta }, error)
+    info: (params: Omit<CustomLoggerParams, 'error'>) => {
+      try {
+        const { message, meta } = params
+        return logger.info(message, { meta })
+      } catch {
+        return logger.info(params)
       }
-      return logger.warn(message, { meta })
     },
-    error: ({ message, meta, error }: CustomLoggerParams) => {
-      if (error) {
-        return logger.error(message, { meta }, error)
+    warn: (params: CustomLoggerParams) => {
+      try {
+        const { message, meta, error } = params
+        if (error) {
+          return logger.warn(message, { meta }, error)
+        }
+        return logger.warn(message, { meta })
+      } catch {
+        return logger.warn(params)
       }
-      return logger.error(message, { meta })
+    },
+    error: (params: CustomLoggerParams) => {
+      try {
+        const { message, meta, error } = params
+        if (error) {
+          return logger.error(message, { meta }, error)
+        }
+        return logger.error(message, { meta })
+      } catch {
+        return logger.error(params)
+      }
     },
   }
 }

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,4 +1,5 @@
 import hasAnsi from 'has-ansi'
+import { isEmpty } from 'lodash'
 import omit from 'lodash/omit'
 import logform from 'logform'
 import path from 'path'
@@ -197,7 +198,11 @@ const createCustomLogger = (logger: Logger) => {
     info: (params: Omit<CustomLoggerParams, 'error'>) => {
       try {
         const { message, meta } = params
-        return logger.info(message, { meta })
+        // Not the expected shape, throw to catch block.
+        if (!message || isEmpty(meta)) {
+          throw new Error('Wrong shape')
+        }
+        return logger.info(params)
       } catch {
         return logger.info(params)
       }
@@ -205,6 +210,10 @@ const createCustomLogger = (logger: Logger) => {
     warn: (params: CustomLoggerParams) => {
       try {
         const { message, meta, error } = params
+        // Not the expected shape, throw to catch block.
+        if (!message || isEmpty(meta)) {
+          throw new Error('Wrong shape')
+        }
         if (error) {
           return logger.warn(message, { meta }, error)
         }
@@ -216,6 +225,10 @@ const createCustomLogger = (logger: Logger) => {
     error: (params: CustomLoggerParams) => {
       try {
         const { message, meta, error } = params
+        // Not the expected shape, throw to catch block.
+        if (!message || isEmpty(meta)) {
+          throw new Error('Wrong shape')
+        }
         if (error) {
           return logger.error(message, { meta }, error)
         }

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -202,7 +202,7 @@ const createCustomLogger = (logger: Logger) => {
         if (!message || isEmpty(meta)) {
           throw new Error('Wrong shape')
         }
-        return logger.info(params)
+        return logger.info(message, { meta })
       } catch {
         return logger.info(params)
       }


### PR DESCRIPTION
JavaScript files will not throw any error when the wrong argument signature is passed into logger invocations. Add try catch block as a defensive measure at least until the application is 100% typescript, to prevent possible errors from being thrown due to the wrong type