### PR TITLE
fix: fix invocations of logger that does not adhere to expected shape

### DIFF
--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -78,7 +78,7 @@ export const handleContactVerifyOtp: RequestHandler<
     await verifyContactOtp(otp, contact, userId)
   } catch (err) {
     logger.warn({
-      message: `Error occurred whilst verifying contact OTP for ${userId}`,
+      message: 'Error occurred whilst verifying contact OTP',
       meta: {
         action: 'handleContactVerifyOtp',
         userId,
@@ -99,7 +99,7 @@ export const handleContactVerifyOtp: RequestHandler<
   } catch (updateErr) {
     // Handle update error.
     logger.warn({
-      message: `Error occurred whilst updating contact of user ${userId}`,
+      message: 'Error occurred whilst updating user contact',
       meta: {
         action: 'handleContactVerifyOtp',
         userId,

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -77,7 +77,14 @@ export const handleContactVerifyOtp: RequestHandler<
   try {
     await verifyContactOtp(otp, contact, userId)
   } catch (err) {
-    logger.warn(err.meta ?? err)
+    logger.warn({
+      message: `Error occurred whilst verifying contact OTP for ${userId}`,
+      meta: {
+        action: 'handleContactVerifyOtp',
+        userId,
+      },
+      error: err,
+    })
     if (err instanceof ApplicationError) {
       return res.status(err.status).send(err.message)
     } else {
@@ -91,7 +98,14 @@ export const handleContactVerifyOtp: RequestHandler<
     return res.status(StatusCodes.OK).send(updatedUser)
   } catch (updateErr) {
     // Handle update error.
-    logger.warn(updateErr)
+    logger.warn({
+      message: `Error occurred whilst updating contact of user ${userId}`,
+      meta: {
+        action: 'handleContactVerifyOtp',
+        userId,
+      },
+      error: updateErr,
+    })
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(updateErr.message)
   }
 }
@@ -110,6 +124,7 @@ export const handleFetchUser: RequestHandler = async (req, res) => {
       message: `Unable to retrieve user ${sessionUserId}`,
       meta: {
         action: 'handleFetchUser',
+        userId: sessionUserId,
       },
       error: dbErr,
     })

--- a/src/loaders/express/error-handler.ts
+++ b/src/loaders/express/error-handler.ts
@@ -45,7 +45,14 @@ const errorHandlerMiddlewares = () => {
         })
         return res.status(StatusCodes.BAD_REQUEST).send(errorMessage)
       }
-      logger.error(err)
+
+      logger.error({
+        message: 'Unknown error',
+        meta: {
+          action: 'genericErrorHandlerMiddleware',
+        },
+        error: err,
+      })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .send({ message: genericErrorMessage })

--- a/src/loaders/mongoose.ts
+++ b/src/loaders/mongoose.ts
@@ -48,7 +48,13 @@ export default async (): Promise<Connection> => {
 
   // Only required for initial connection errors, reconnect on error.
   connect().catch((err) => {
-    logger.error(err)
+    logger.error({
+      message: '@MongoDB: Error caught while connecting',
+      meta: {
+        action: 'init',
+      },
+      error: err,
+    })
     return connect()
   })
 


### PR DESCRIPTION
This PR cleans up remnants of logger invocations that does not adhere to the expected format.

Typescript did not complain due to the `any` type of the parameters being passed in :(