### PR TITLE
feat: upgrade localstack version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - '27017:27017'
 
   localstack:
-    image: localstack/localstack:0.8.0
+    image: localstack/localstack:latest
     container_name: formsg-localstack
     depends_on:
       - formsg


### PR DESCRIPTION
The [issue](https://github.com/localstack/localstack/issues/2407) which was holding back our Localstack version has now been resolved, so we can upgrade to the latest version.

**However, the edge port 4566 still doesn't work.** I keep running into the error `Unable to find forwarding rule for host` when doing `docker-compose`, and from the Localstack repo it seems that many other folks are running into issues with the edge port as well. Hence we are sticking to 4572 for now.