### PR TITLE
fix: allow inline styles from angular-sanitize in CSP

### DIFF
--- a/src/loaders/express/helmet.ts
+++ b/src/loaders/express/helmet.ts
@@ -73,6 +73,8 @@ const helmetMiddlewares = () => {
       'https://www.recaptcha.net/recaptcha/',
       'https://www.gstatic.com/recaptcha/',
       'https://www.gstatic.cn/',
+      // For inline styles in angular-sanitize.js
+      "'sha256-b3IrgBVvuKx/Q3tmAi79fnf6AFClibrz/0S5x1ghdGU='",
     ],
     formAction: ["'self'"],
     upgradeInsecureRequests: !config.isDev,


### PR DESCRIPTION
## Problem

Since the last release a week ago, Sentry has had 1.2m events due to CSP errors. While the errors do not seem to affect any functionality, they are likely to cause us to burst our Sentry limits again.

In particular, there are problems caused by the `angular-sanitize` package, which show up in both the `form.gov.sg` landing page and all public forms:
![image](https://user-images.githubusercontent.com/29480346/93033604-84e7bc80-f669-11ea-967d-f753642b4d38.png)

As well as problems due to the `jquery` package, which show up in the `form.gov.sg` landing page:
![image](https://user-images.githubusercontent.com/29480346/93033611-8fa25180-f669-11ea-8121-2d95e8d50a6a.png)

## Solution

Allow inline styles from `angular-sanitize.js` by adding the relevant hash to the allowed `style-src` list. This fixes the issue on public forms:
<img width="1551" alt="Screenshot 2020-09-14 at 9 08 48 AM" src="https://user-images.githubusercontent.com/29480346/93033692-e90a8080-f669-11ea-9d22-bba1560ae92b.png">

However, the issue with `jquery` is less straightforward because it sets attributes rather than inline style tags, so we [cannot use a hash](https://stackoverflow.com/questions/52724956/why-doesnt-chrome-respect-my-content-security-policy-hashes). Since we don't want to introduce security vulnerabilities by adding `unsafe-inline`, it seems we have to put up with our Sentry being somewhat polluted by CSP errors until we move to React. Hopefully fixing the issue for `angular-sanitize` will significantly reduce the errors, since that is the issue which appears on public forms.