### PR TITLE
refactor: remove unused isFutureOnly key

### DIFF
--- a/src/types/field/dateField.ts
+++ b/src/types/field/dateField.ts
@@ -13,7 +13,6 @@ export type DateValidationOptions = {
 }
 
 export interface IDateField extends IField {
-  isFutureOnly: boolean
   dateValidation: DateValidationOptions
 }
 


### PR DESCRIPTION
We have deprecated the `isFutureOnly` key, but there was one last reference to it in the types for `dateField`.