### PR TITLE
fix: set nodeEnv to assigned variable if in dev environment

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -34,7 +34,7 @@ const basicVars = merge(optionalVars, compulsoryVars)
 const isDev =
   basicVars.core.nodeEnv === Environment.Dev ||
   basicVars.core.nodeEnv === Environment.Test
-const nodeEnv = isDev ? Environment.Dev : Environment.Prod
+const nodeEnv = isDev ? basicVars.core.nodeEnv : Environment.Prod
 
 // Load and validate configuration values which are compulsory only in production
 // If environment variables are not present, an error will be thrown


### PR DESCRIPTION
## Problem

Lots of console log spam in tests due to the silencing check in `logger.ts` not working. This PR fixes the conditional by assigning `config.nodeEnv` in dev environment properly.

