### PR TITLE
build: remove Localstack from end-to-end tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-ci": "npm run test-backend && npm run test-frontend && coveralls < coverage/lcov.info",
     "test": "npm run build-backend && npm run test-backend && npm run test-frontend",
     "test-e2e-build": "npm run build-backend && npm run build-frontend-dev",
-    "test-run": "concurrently --success last --kill-others \"mockpass\" \"maildev\" \"node dist/backend/server.js\" \"localstack start --host\" \"node ./tests/mock-webhook-server.js\"",
+    "test-run": "concurrently --success last --kill-others \"mockpass\" \"maildev\" \"node dist/backend/server.js\" \"node ./tests/mock-webhook-server.js\"",
     "testcafe-full-env": "testcafe --skip-js-errors -c 3 chrome:headless ./tests/end-to-end --test-meta full-env=true --app \"npm run test-run\" --app-init-delay 10000",
     "testcafe-basic-env": "testcafe --skip-js-errors -c 3 chrome:headless ./tests/end-to-end --test-meta basic-env=true --app \"npm run test-run\" --app-init-delay 10000",
     "download-binary": "node tests/end-to-end/helpers/get-mongo-binary.js",

--- a/tests/end-to-end/encrypt-submission.e2e.js
+++ b/tests/end-to-end/encrypt-submission.e2e.js
@@ -16,17 +16,16 @@ const {
   createWebhookConfig,
   removeWebhookConfig,
 } = require('./helpers/encrypt-mode')
-const { allFields } = require('./helpers/all-fields')
+const { allFieldsEncrypt } = require('./helpers/all-fields')
 const { verifiableEmailField } = require('./helpers/verifiable-email-field')
 const {
-  hiddenFieldsData,
-  hiddenFieldsLogicData,
+  hiddenFieldsDataEncrypt,
+  hiddenFieldsLogicDataEncrypt,
 } = require('./helpers/all-hidden-form')
 
 const chainDisabled = require('./helpers/disabled-form-chained')
 
 const { cloneDeep } = require('lodash')
-const aws = require('aws-sdk')
 
 let User
 let Form
@@ -49,15 +48,6 @@ fixture('Storage mode submissions')
     govTech = await Agency.findOne({ shortName: 'govtech' }).exec()
     // Check whether captcha is enabled in environment
     captchaEnabled = await getFeatureState('captcha')
-
-    // Create s3 bucket for attachments
-    const s3 = new aws.S3({
-      endpoint: process.env.AWS_ENDPOINT,
-      s3ForcePathStyle: true,
-    })
-    await s3
-      .createBucket({ Bucket: process.env.ATTACHMENT_S3_BUCKET })
-      .promise()
   })
   .after(async () => {
     // Delete models defined by mongoose and close connection
@@ -77,7 +67,7 @@ fixture('Storage mode submissions')
 // Form with all field types available in storage mode
 test.meta('basic-env', 'true').before(async (t) => {
   const formData = await getDefaultFormOptions()
-  formData.formFields = cloneDeep(allFields)
+  formData.formFields = cloneDeep(allFieldsEncrypt)
   t.ctx.formData = formData
 })('Create and submit form with all field types', async (t) => {
   t.ctx.form = await createForm(t, t.ctx.formData, Form, captchaEnabled)
@@ -87,8 +77,8 @@ test.meta('basic-env', 'true').before(async (t) => {
 // Form where all basic field types are hidden by logic
 test.meta('basic-env', 'true').before(async (t) => {
   const formData = await getDefaultFormOptions()
-  formData.formFields = cloneDeep(hiddenFieldsData)
-  formData.logicData = cloneDeep(hiddenFieldsLogicData)
+  formData.formFields = cloneDeep(hiddenFieldsDataEncrypt)
+  formData.logicData = cloneDeep(hiddenFieldsLogicDataEncrypt)
   t.ctx.formData = formData
 })('Create and submit form with all field types hidden', async (t) => {
   t.ctx.form = await createForm(t, t.ctx.formData, Form, captchaEnabled)
@@ -98,7 +88,7 @@ test.meta('basic-env', 'true').before(async (t) => {
 // Form where all fields are optional and no field is answered
 test.meta('basic-env', 'true').before(async (t) => {
   const formData = await getDefaultFormOptions()
-  formData.formFields = allFields.map((field) => {
+  formData.formFields = allFieldsEncrypt.map((field) => {
     return getBlankVersion(getOptionalVersion(field))
   })
   t.ctx.formData = formData

--- a/tests/end-to-end/helpers/all-fields.js
+++ b/tests/end-to-end/helpers/all-fields.js
@@ -117,4 +117,9 @@ const allFieldInfo = [
   },
 ]
 const allFields = allFieldInfo.map(makeField)
-module.exports = { allFields }
+module.exports = {
+  allFields,
+  allFieldsEncrypt: allFields.filter(
+    (field) => field.fieldType !== 'attachment',
+  ),
+}

--- a/tests/end-to-end/helpers/all-hidden-form.js
+++ b/tests/end-to-end/helpers/all-hidden-form.js
@@ -1,7 +1,7 @@
 // Exports data for a form containing all basic field types, where all the fields are
 // hidden due to logic depending on the value of the first field.
 
-const { allFields } = require('./all-fields')
+const { allFields, allFieldsEncrypt } = require('./all-fields')
 const {
   getBlankVersion,
   getHiddenVersion,
@@ -16,6 +16,9 @@ const shownFields = [
   },
 ].map(makeField)
 const hiddenFields = allFields.map((field) =>
+  getHiddenVersion(getBlankVersion(field)),
+)
+const hiddenFieldsEncrypt = allFieldsEncrypt.map((field) =>
   getHiddenVersion(getBlankVersion(field)),
 )
 
@@ -36,9 +39,29 @@ const hiddenFieldsLogicData = [
     logicType: 'showFields',
   },
 ]
+const hiddenFieldsLogicDataEncrypt = [
+  {
+    showFieldIndices: listIntsInclusive(
+      shownFields.length,
+      shownFields.length + hiddenFieldsEncrypt.length - 1,
+    ),
+    conditions: [
+      {
+        fieldIndex: 0,
+        state: 'is equals to',
+        value: 'Yes',
+        ifValueType: 'single-select',
+      },
+    ],
+    logicType: 'showFields',
+  },
+]
 const hiddenFieldsData = [...shownFields, ...hiddenFields]
+const hiddenFieldsDataEncrypt = [...shownFields, ...hiddenFieldsEncrypt]
 
 module.exports = {
   hiddenFieldsData,
   hiddenFieldsLogicData,
+  hiddenFieldsDataEncrypt,
+  hiddenFieldsLogicDataEncrypt,
 }


### PR DESCRIPTION
## Problem

Localstack keeps making breaking changes which cause our CI pipeline to fail. This is particularly harmful in cases where we need to make an urgent hotfix e.g. #333.

## Solution

Remove Localstack as a dependency from our end-to-end tests. We should remember to test storage mode attachments manually before every release.