### PR TITLE
chore: update travis.yml and pin localstack in docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - npm run lint-ci
   - npm run build
   - npm run test-ci
-  # - npm run test-e2e-ci
+  - npm run test-e2e-ci
 
 before_deploy:
   # Workaround to run before_deploy only once

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ cache:
   - npm
   - pip
 
-# Setup browsers needed for end-to-end tests
-before_install:
-  - sudo apt-get clean && sudo apt-get update
-  - sudo apt-get install -y dpkg google-chrome-stable fluxbox chromium-browser
+addons:
+  chrome: stable
 
 notifications:
   email:
@@ -26,9 +24,8 @@ notifications:
     on_failure: always
 
 before_script:
-  - fluxbox >/dev/null 2>&1 &
   - pyenv global 3.7.1
-  - pip3 install --user localstack[full]
+  - pip3 install 'localstack==0.11.5' --force-reinstall
 
 script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ language: node_js
 node_js: '12'
 cache:
   - npm
-  - pip
 
 addons:
   chrome: stable
@@ -23,10 +22,6 @@ notifications:
     on_success: always
     on_failure: always
 
-before_script:
-  - pyenv global 3.7.1
-  - pip3 install 'localstack==0.11.5' --force-reinstall
-
 script:
   - set -e
   - npm run lint-ci
@@ -38,7 +33,6 @@ before_deploy:
   # Workaround to run before_deploy only once
   - >
     if ! [ "$TAG" ]; then
-      pip install --user awscli
       # Put AWS in path
       export PATH=$PATH:$HOME/.local/bin
       # Login to AWS ECR, credentials defined in $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - '27017:27017'
 
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.11.5
     container_name: formsg-localstack
     depends_on:
       - formsg


### PR DESCRIPTION
Travis will now install a pinned version of `localstack` and use Travis's [chrome addon](https://docs.travis-ci.com/user/chrome) instead of downloading from `apt`. This PR also cleans up the redundant script installations such as `fluxbox` (which from tracing past commits seems to have been used to start browsers for e2e tests which are now not required).

This PR also pins the `localstack` version in docker-compose to `0.11.5`, which prevents any commits in `localstack:master` (which is then pushed to `latest` in Dockerhub) from causing any build failures (if any) suddenly.

