### PR TITLE
fix: specify betaFlags key correctly

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -11,7 +11,7 @@ export interface IUser {
   agency: IAgencySchema['_id']
   contact?: string
   created?: Date
-  betaFlag?: Record<string, never>
+  betaFlags?: Record<string, never>
   _id?: Document['_id']
 }
 


### PR DESCRIPTION
The types for `User` use a key called `betaFlag` which should actually be called `betaFlags` according to `user.server.model.ts`.