### PR TITLE
refactor: make bounceType required

### DIFF
--- a/src/types/bounce.ts
+++ b/src/types/bounce.ts
@@ -8,9 +8,7 @@ export type ISingleBounce =
   | {
       email: string
       hasBounced: true
-      // TODO (private #44): this key should be required,
-      // but is currently optional for backwards compatibility reasons.
-      bounceType?: BounceType
+      bounceType: BounceType
     }
   | {
       email: string


### PR DESCRIPTION
`bounceType` was made optional in #318  for backwards compatibility reasons, since old Bounce collection documents would not have that key. Since documents in the Bounce collection expire after 24h, it is now safe to make the key required.