### PR TITLE
feat: add `lastAccessed` key to track user login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18387,6 +18387,12 @@
       "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.4.tgz",
       "integrity": "sha512-vTgEjKjS89C5yHL5qWPpT6BzKuOVqABp+A3Szpbx34pIy3sngxlGaFpgHhfj6fKze1w0QKeOSDbU7SKu7wDvRQ=="
     },
+    "mockdate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.2.tgz",
+      "integrity": "sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==",
+      "dev": true
+    },
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
     "lint-staged": "^10.4.0",
     "maildev": "^1.1.0",
     "mini-css-extract-plugin": "^0.5.0",
+    "mockdate": "^3.0.2",
     "mongodb-memory-server-core": "^6.7.5",
     "ngrok": "^3.2.7",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -54,7 +54,10 @@ const compileUserModel = (db: Mongoose) => {
         },
       },
       lastAccessed: Date,
-      updatedAt: Date,
+      updatedAt: {
+        type: Date,
+        default: () => Date.now(),
+      },
       betaFlags: {},
     },
     {
@@ -119,7 +122,7 @@ const compileUserModel = (db: Mongoose) => {
  * @param db The mongoose instance to retrieve the User model from
  * @returns The User model
  */
-const getUserModel = (db: Mongoose) => {
+const getUserModel = (db: Mongoose): IUserModel => {
   try {
     return db.model(USER_SCHEMA_ID) as IUserModel
   } catch {

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -149,6 +149,7 @@ export const updateUserContact = async (
   }
 
   admin.contact = contact
+  admin.updatedAt = new Date()
   return admin.save()
 }
 

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -183,6 +183,7 @@ export const retrieveUser = (
     UserModel.upsertUser({
       email,
       agency: agencyId,
+      lastAccessed: new Date(),
     }),
     (error) => {
       logger.error({

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,13 +10,15 @@ export interface IUser {
   email: string
   agency: IAgencySchema['_id']
   contact?: string
-  created?: Date
   betaFlags?: Record<string, never>
   _id?: Document['_id']
+  lastAccessed?: Date
+  updatedAt?: Date
 }
 
 export interface IUserSchema extends IUser, Document {
   _id: Document['_id']
+  created?: Date
 }
 
 export interface IUserModel extends Model<IUserSchema> {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -30,7 +30,7 @@ export interface IUserModel extends Model<IUserSchema> {
    * @returns the user document after upsert with populated agency details
    */
   upsertUser: (
-    upsertParams: Pick<IUser, 'email' | 'agency'>,
+    upsertParams: Pick<IUser, 'email' | 'agency' | 'lastAccessed'>,
   ) => Promise<IPopulatedUser>
 }
 

--- a/tests/unit/backend/@types/vendor/@shelf/jest-mongodb/setup.d.ts
+++ b/tests/unit/backend/@types/vendor/@shelf/jest-mongodb/setup.d.ts
@@ -1,0 +1,1 @@
+declare module '@shelf/jest-mongodb/setup'

--- a/tests/unit/backend/@types/vendor/@shelf/jest-mongodb/teardown.d.ts
+++ b/tests/unit/backend/@types/vendor/@shelf/jest-mongodb/teardown.d.ts
@@ -1,0 +1,1 @@
+declare module '@shelf/jest-mongodb/teardown'

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -1,22 +1,21 @@
-// @ts-ignore
 import mongoSetup from '@shelf/jest-mongodb/setup'
-// @ts-ignore
 import mongoTeardown from '@shelf/jest-mongodb/teardown'
 import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
 
 import getAgencyModel from 'src/app/models/agency.server.model'
 import getUserModel from 'src/app/models/user.server.model'
+import { IAgencySchema, IUserSchema } from 'src/types'
 
 /**
  * Connect to the in-memory database using MONGO_URL exposed by
  * \@shelf/jest-mongodb.
  */
-const connect = async () => {
+const connect = async (): Promise<typeof mongoose> => {
   // Do it here so each test can have it's own mongoose instance.
   await mongoSetup()
   // process.env.MONGO_URL is now set by jest-mongodb.
-  const conn = await mongoose.connect(process.env.MONGO_URL!, {
+  const conn = await mongoose.connect(process.env.MONGO_URL ?? '', {
     useNewUrlParser: true,
     useUnifiedTopology: true,
     useCreateIndex: true,
@@ -28,7 +27,7 @@ const connect = async () => {
 /**
  * Disconnect all mongoose connections.
  */
-const closeDatabase = async () => {
+const closeDatabase = async (): Promise<void> => {
   await mongoose.disconnect()
   await mongoTeardown()
 }
@@ -36,7 +35,7 @@ const closeDatabase = async () => {
 /**
  * Remove all the data for all db collections.
  */
-const clearDatabase = async () => {
+const clearDatabase = async (): Promise<void> => {
   const collections = mongoose.connection.collections
 
   for (const key in collections) {
@@ -45,7 +44,7 @@ const clearDatabase = async () => {
   }
 }
 
-const clearCollection = async (collection: string) => {
+const clearCollection = async (collection: string): Promise<void> => {
   await mongoose.connection.collections[collection].deleteMany({})
 }
 
@@ -53,7 +52,7 @@ const insertDefaultAgency = async ({
   mailDomain = 'test.gov.sg',
 }: {
   mailDomain?: string
-} = {}) => {
+} = {}): Promise<IAgencySchema> => {
   const Agency = getAgencyModel(mongoose)
   const agency = await Agency.create({
     shortName: 'govtest',
@@ -75,7 +74,7 @@ const insertUser = async ({
   userId?: ObjectID
   mailName?: string
   mailDomain?: string
-}) => {
+}): Promise<IUserSchema> => {
   const User = getUserModel(mongoose)
 
   return User.create({
@@ -99,7 +98,10 @@ const insertFormCollectionReqs = async ({
   userId?: ObjectID
   mailName?: string
   mailDomain?: string
-} = {}) => {
+} = {}): Promise<{
+  agency: IAgencySchema
+  user: IUserSchema
+}> => {
   const User = getUserModel(mongoose)
 
   const agency = await insertDefaultAgency({ mailDomain })

--- a/tests/unit/backend/models/user.server.model.spec.ts
+++ b/tests/unit/backend/models/user.server.model.spec.ts
@@ -153,7 +153,8 @@ describe('User Model', () => {
       it('should create new User document when user does not yet exist in the collection', async () => {
         // Arrange
         const validEmail = `test@${AGENCY_DOMAIN}`
-        await expect(User.countDocuments()).resolves.toEqual(0)
+        const initialUserCount = await User.countDocuments()
+        expect(initialUserCount).toEqual(0)
 
         // Act
         const user = await User.upsertUser({
@@ -167,7 +168,9 @@ describe('User Model', () => {
           email: validEmail,
           updatedAt: MOCKED_DATE,
         }
-        await expect(User.countDocuments()).resolves.toEqual(1)
+        // Should now have 1 user since user should be created.
+        const afterUserCount = await User.countDocuments()
+        expect(afterUserCount).toEqual(1)
         expect(user.toObject()).toEqual(
           expect.objectContaining(expectedPartialUser),
         )
@@ -181,7 +184,8 @@ describe('User Model', () => {
           email: validEmail,
         })
         // Should have the initial user.
-        await expect(User.countDocuments()).resolves.toEqual(1)
+        const initialUserCount = await User.countDocuments()
+        expect(initialUserCount).toEqual(1)
 
         // Act
         // Upsert with updated lastAccessed.
@@ -197,7 +201,9 @@ describe('User Model', () => {
           agency: agency.toObject(),
           lastAccessed: MOCKED_DATE,
         }
-        await expect(User.countDocuments()).resolves.toEqual(1)
+        // Should continue having 1 user since it is an upsert.
+        const afterUserCount = await User.countDocuments()
+        expect(afterUserCount).toEqual(1)
         expect(upsertedUser.toObject()).toEqual(expectedUser)
       })
     })

--- a/tests/unit/backend/modules/user/user.service.spec.ts
+++ b/tests/unit/backend/modules/user/user.service.spec.ts
@@ -1,4 +1,5 @@
 import { ObjectID } from 'bson'
+import MockDate from 'mockdate'
 import mongoose from 'mongoose'
 import { ImportMock } from 'ts-mock-imports'
 
@@ -13,6 +14,9 @@ import dbHandler from '../../helpers/jest-db'
 
 const AdminVerification = getAdminVerificationModel(mongoose)
 const UserModel = getUserModel(mongoose)
+
+const MOCKED_DATE = new Date(Date.now())
+MockDate.set(MOCKED_DATE)
 
 describe('user.service', () => {
   // Obtained from Twilio's
@@ -220,7 +224,7 @@ describe('user.service', () => {
       const actual = await UserService.getPopulatedUserById(USER_ID)
 
       // Assert
-      expect(actual!.toObject()).toEqual(expected)
+      expect(actual?.toObject()).toEqual(expected)
     })
 
     it('should return null when user cannot be found', async () => {
@@ -264,6 +268,7 @@ describe('user.service', () => {
       const expectedUser: Partial<IPopulatedUser> = {
         agency: defaultAgency,
         email: newUserEmail,
+        lastAccessed: MOCKED_DATE,
       }
       expect(actualResult.isOk()).toBe(true)
       // Should now have 2 user documents
@@ -289,6 +294,7 @@ describe('user.service', () => {
       const expectedUser: Partial<IPopulatedUser> = {
         ...defaultUser,
         agency: defaultAgency,
+        lastAccessed: MOCKED_DATE,
       }
       expect(actualResult.isOk()).toBe(true)
       // Should still only have 1 user document.


### PR DESCRIPTION
## Problem

This PR adds a new `lastAccessed` key in the `User` collection which gets updated every time the user's document is retrieved when the user logs into the application.

This PR also adds a new `updatedAt` key which is only updated when contact is updated for now. The `timestamp` plugin is not used as updating the `lastAccessed` key will also inadvertently update the `updatedAt` key, which is not the behaviour we want.

Closes #345

## Solution

**Features**:

- add `lastAccessed` and `updatedAt` keys to User model which gets updated when user logins and when new user is created/user updates their contact respectively.
