### PR TITLE
feat: Add Bulk Attachment Download Features for Submissions in a Date Range

### DIFF
--- a/src/public/main.js
+++ b/src/public/main.js
@@ -507,6 +507,10 @@ app.run([
       require('./modules/forms/admin/views/decrypt-progress.client.modal.html'),
     )
     $templateCache.put(
+      'modules/forms/admin/views/download-all-attachments.client.modal.html',
+      require('./modules/forms/admin/views/download-all-attachments.client.modal.html'),
+    )
+    $templateCache.put(
       'modules/forms/admin/views/create-form-template.client.modal.html',
       require('./modules/forms/admin/views/create-form-template.client.modal.html'),
     )

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -261,17 +261,32 @@ function ViewResponsesController(
     }
     Submissions.count(params).then((responsesCount) => {
       vm.downloadAttachmentResponsesCount = responsesCount
-      vm.confirmDownloadModal = $uibModal.open({
-        backdrop: 'static',
-        templateUrl:
-          'modules/forms/admin/views/download-all-attachments.client.modal.html',
-        scope: $scope,
-      })
+      $uibModal
+        .open({
+          backdrop: 'static',
+          resolve: { responsesCount },
+          controller: [
+            '$scope',
+            '$uibModalInstance',
+            'responsesCount',
+            function ($scope, $uibModalInstance, responsesCount) {
+              $scope.ok = function () {
+                $uibModalInstance.close()
+              }
+              $scope.cancel = function () {
+                $uibModalInstance.dismiss()
+              }
+              $scope.responsesCount = responsesCount
+            },
+          ],
+          templateUrl:
+            'modules/forms/admin/views/download-all-attachments.client.modal.html',
+        })
+        .result.then(() => vm.downloadMultipleSubmissionAttachments())
     })
   }
 
   vm.downloadMultipleSubmissionAttachments = function () {
-    vm.confirmDownloadModal.close()
     vm.csvDownloading = true
     let params = {
       formId: vm.myform._id,

--- a/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
+++ b/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
@@ -1,0 +1,40 @@
+<div class="modal-body">
+  <div class="modal-header">
+    <button
+      type="button"
+      class="close"
+      ng-click="vm.confirmDownloadModal.close()"
+      aria-label="Close"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title" id="downloadModalLabel">
+      Download Attachments from Multiple Submissions
+    </h4>
+  </div>
+  <div class="modal-body">
+    <p>
+      You are going to download attachments from
+      <strong>{{ vm.downloadAttachmentResponsesCount }}</strong>
+      submissions. This may take a long time, during which you should not close
+      this browser tab.
+    </p>
+    <p>Do you wish to continue?</p>
+  </div>
+  <div class="modal-footer">
+    <button
+      type="button"
+      class="btn btn-primary"
+      ng-click="vm.downloadMultipleSubmissionAttachments()"
+    >
+      Yes, download attachments
+    </button>
+    <button
+      type="button"
+      class="btn btn-default"
+      ng-click="vm.confirmDownloadModal.close()"
+    >
+      Close
+    </button>
+  </div>
+</div>

--- a/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
+++ b/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
@@ -1,40 +1,18 @@
 <div class="modal-body">
-  <div class="modal-header">
-    <button
-      type="button"
-      class="close"
-      ng-click="vm.confirmDownloadModal.close()"
-      aria-label="Close"
-    >
-      <span aria-hidden="true">&times;</span>
-    </button>
-    <h4 class="modal-title" id="downloadModalLabel">
-      Download Attachments from Multiple Submissions
-    </h4>
-  </div>
   <div class="modal-body">
+    <h3 id="download-attachment-modal-header">
+      Download attachments for {{ responsesCount }} responses
+    </h3>
     <p>
-      You are going to download attachments from
-      <strong>{{ vm.downloadAttachmentResponsesCount }}</strong>
-      submissions. This may take a long time, during which you should not close
-      this browser tab.
+      Downloading many attachments may take a long time. The attachments from
+      each response will be downloaded as a separate ZIP file. Start now, or
+      adjust your date range before proceeding.
     </p>
-    <p>Do you wish to continue?</p>
   </div>
   <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-primary"
-      ng-click="vm.downloadMultipleSubmissionAttachments()"
-    >
-      Yes, download attachments
+    <button type="button" class="btn-custom btn-medium" ng-click="ok()">
+      Download
     </button>
-    <button
-      type="button"
-      class="btn btn-default"
-      ng-click="vm.confirmDownloadModal.close()"
-    >
-      Close
-    </button>
+    <a class="modal-cancel-btn" ng-click="cancel()"> Cancel </a>
   </div>
 </div>

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -105,11 +105,43 @@
             class="datepicker-container"
             ng-model="vm.datePicker.date"
           ></date-range-picker-directive>
-          <export-button-component
-            on-click="vm.exportCsv(vm.myform)"
-            is-disabled="vm.csvDownloading"
-            is-loading="vm.csvDownloading"
-          ></export-button-component>
+          <div class="btn-group" uib-dropdown dropdown-append-to-body>
+            <button
+              class="btn-custom btn-small"
+              aria-haspopup="true"
+              aria-expanded="false"
+              uib-dropdown-toggle
+              id="btn-export-dropdown"
+            >
+              <span class="hidden-xs" ng-hide="vm.csvDownloading">Export</span>
+              <span class="hidden-xs" ng-show="vm.csvDownloading"
+                >Downloading</span
+              >
+              <span class="caret"></span>
+            </button>
+            <ul
+              class="dropdown-menu"
+              uib-dropdown-menu
+              role="menu"
+              aria-labelledby="btn-export-dropdown"
+            >
+              <li>
+                <a
+                  id="btn-export-dropdown-responses"
+                  ng-click="vm.exportCsv(vm.myform)"
+                  style="cursor: pointer"
+                  >Responses</a
+                >
+              </li>
+              <li>
+                <a
+                  ng-click="vm.confirmSubmissionCountsBeforeDownload()"
+                  style="cursor: pointer"
+                  >Attachments</a
+                >
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
       <div class="flex-row" ng-show="vm.filterBySubmissionShowFilterBox">
@@ -209,7 +241,8 @@
         <div class="row" ng-if="vm.attachmentDownloadUrls.size > 0">
           <div class="col-xs-12 col-sm-4"><b>Attachments</b></div>
           <div class="col-xs-12 col-sm-8">
-            <a ng-click="vm.downloadAllAttachments()"
+            <a
+              ng-click="vm.downloadAllAttachments(vm.attachmentDownloadUrls, vm.tableParams.data[vm.currentResponse.index].refNo)"
               >Download {{ vm.attachmentDownloadUrls.size }} Attachment(s) in
               ZIP</a
             >

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -150,6 +150,10 @@ function SubmissionsFactory(
         params.page
       }`
 
+      if (params.startDate && params.endDate) {
+        resUrl += `&startDate=${params.startDate}&endDate=${params.endDate}`
+      }
+
       if (params.filterBySubmissionRefId) {
         resUrl += `&submissionId=${params.filterBySubmissionRefId}`
       }

--- a/tests/end-to-end/helpers/encrypt-mode.js
+++ b/tests/end-to-end/helpers/encrypt-mode.js
@@ -125,6 +125,7 @@ async function checkDownloadCsv(t, formData, authData, formId) {
   let { formFields, formOptions } = formData
   formFields = formFields.concat(getAuthFields(formOptions.authType, authData))
   await t.click(dataTab.exportBtn)
+  await t.click(dataTab.exportBtnDropdownResponses)
   await t.wait(2000)
   const csvContent = await fs.promises.readFile(
     `${getDownloadsFolder()}/${formOptions.title}-${formId}.csv`,

--- a/tests/end-to-end/helpers/selectors.js
+++ b/tests/end-to-end/helpers/selectors.js
@@ -104,7 +104,8 @@ const dataTab = {
   getNthFieldTitle: (n) => Selector('.response-title-container').nth(n),
   getNthFieldAnswer: (n) => Selector('.response-answer').nth(n),
   getNthFieldDownloadLink: (n) => Selector('.response-answer').nth(n).find('a'),
-  exportBtn: Selector('#btn-export'),
+  exportBtn: Selector('#btn-export-dropdown'),
+  exportBtnDropdownResponses: Selector('#btn-export-dropdown-responses'),
   getNthFieldTableCell: (n, row, col) =>
     Selector('.response-answer')
       .nth(n)


### PR DESCRIPTION
## Problem

This allows users to specify a date range (with the same export CSV date picker) and download all attachments from submissions within that date range.

## Solution

This leverages existing code within view-responses to retrieve, process, and download multiple submissions as individual ZIP files.
