### PR TITLE
fix: correct squished styling when user emails are too long

### DIFF
--- a/src/public/modules/core/css/avatar-dropdown.css
+++ b/src/public/modules/core/css/avatar-dropdown.css
@@ -115,15 +115,6 @@
 }
 
 .navbar__dropdown__user__avatar {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   color: #fff;
   text-transform: uppercase;
   height: 40px;
@@ -134,6 +125,9 @@
   border-radius: 50%;
   outline: none;
   margin-right: 16px;
+  display: inline-table;
+  text-align: center;
+  line-height: 36px;
 }
 
 .navbar__dropdown__user__details {
@@ -143,6 +137,7 @@
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  word-break: break-all;
 }
 
 .navbar__dropdown__user__details--email {


### PR DESCRIPTION
Styling for avatar dropdown is not great if the email is long -- the avatar circle gets squished, whilst the email text expands outside of its parent.

![Screenshot 2020-09-29 at 2 12 39 PM](https://user-images.githubusercontent.com/22133008/94519898-ef9a1a00-025d-11eb-932f-9859d54d44cc.png)


This PR fixes that by correcting the CSS styling.
![Screenshot 2020-09-29 at 2 15 43 PM](https://user-images.githubusercontent.com/22133008/94520118-4acc0c80-025e-11eb-921d-784a7ef1c892.png)
