### PR TITLE
fix: only show exclamation in navbar if sms feature is enabled

### DIFF
--- a/src/public/modules/core/componentViews/avatar-dropdown.html
+++ b/src/public/modules/core/componentViews/avatar-dropdown.html
@@ -11,7 +11,9 @@
   ng-mouseleave="vm.isDropdownHover=false"
 >
   <button class="navbar__avatar__avatar">{{vm.avatarText}}</button>
-  <div ng-show="!vm.user.contact" class="navbar__avatar__avatar--alert">!</div>
+  <div ng-show="vm.showExclamation" class="navbar__avatar__avatar--alert">
+    !
+  </div>
   <div ng-show="vm.isDropdownOpen" class="navbar__dropdown">
     <ul>
       <!-- User details block -->

--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -51,6 +51,10 @@ function avatarDropdownController(
       if (trueUser.contact) return
 
       const features = await Features.getFeatureStates()
+
+      // Only show exclamation mark in avatar if sms feature is enabled.
+      vm.showExclamation = features.sms && !vm.user.contact
+
       // Do not proceed if sms feature is not available.
       if (!features.sms) return
 


### PR DESCRIPTION
In staging alt, even if the sms feature is not turned on, the exclamation will show, since the conditional is whether the user has a contact number or not. However, that results in an exclamation mark that cannot be removed:

![Screenshot 2020-09-29 at 2 04 08 PM](https://user-images.githubusercontent.com/22133008/94520884-a77bf700-025f-11eb-90cf-7988c0a53819.png)

This PR updates the conditional to only show the exclamation mark if the sms feature is available AND when the user has no contact number: 
```diff
- showExclamation = !vm.user.contact
+ showExclamation = features.sms && !vm.user.contact
```