### PR TITLE
fix: invalid key reference in retrieving form submissions

### DIFF
--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -428,7 +428,7 @@ let sortByCreated = [
 let searchSubmissionsForForm = (key, formId) => [
   {
     $match: {
-      key: mongoose.Types.ObjectId(formId),
+      [key]: mongoose.Types.ObjectId(formId),
     },
   },
 ]


### PR DESCRIPTION
## Problem

`searchSubmissionsForForm` aggregate pipeline step was incorrectly matching against a key of `key` instead of the key parameter passed into the function:

```ts
let searchSubmissionsForForm = (key, formId) => [
  {
    $match: {
      // key "key" is matched instead of the key parameter.
      key: mongoose.Types.ObjectId(formId),
    },
  },
]
```

This PR fixes that by correctly using the given key parameter as a match key:

```ts
let searchSubmissionsForForm = (key, formId) => [
  {
    $match: {
      [key]: mongoose.Types.ObjectId(formId),
    },
  },
]
```
