### PR TITLE
refactor: use validator's isEmail for validating email domains

### DIFF
--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,6 +1,5 @@
 import { Schema } from 'mongoose'
-
-import { validateEmailDomains } from 'src/shared/util/email-domain-validation'
+import { validateEmailDomains } from 'shared/util/email-domain-validation'
 
 import { IEmailFieldSchema, ResponseMode } from '../../../types'
 

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 import { Schema } from 'mongoose'
+import validator from 'validator'
 
 import { IEmailFieldSchema, ResponseMode } from '../../../types'
 
@@ -49,19 +50,21 @@ const createEmailFieldSchema = () => {
         {
           type: String,
           trim: true,
-          match: [/.+\..+/, 'There are one or more invalid email domains.'],
         },
       ],
-      // If there allowedEmailDomains is empty, then all email domains should be allowed.
+      // If allowedEmailDomains is empty, then all email domains should be allowed.
       default: [],
       validate: {
         validator: (emailDomains: string[]) => {
           return (
             isEmpty(emailDomains) ||
-            new Set(emailDomains).size === emailDomains.length
+            (new Set(emailDomains).size === emailDomains.length &&
+              emailDomains.every((emailDomain) =>
+                validator.isEmail('bob' + emailDomain),
+              ))
           )
         },
-        message: 'There are one or more duplicate email domains.',
+        message: 'There are one or more duplicate or invalid email domains.',
       },
     },
   })

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -3,10 +3,8 @@ import { Schema } from 'mongoose'
 import { validateEmailDomains } from '../../../shared/util/email-domain-validation'
 import { IEmailFieldSchema, ResponseMode } from '../../../types'
 
-const createEmailFieldSchema = () => {
-  const EmailFieldSchema: Schema<IEmailFieldSchema> = new Schema<
-    IEmailFieldSchema
-  >({
+const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
+  const EmailFieldSchema = new Schema<IEmailFieldSchema>({
     autoReplyOptions: {
       hasAutoReply: {
         type: Boolean,

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,11 +1,13 @@
-import { isEmpty } from 'lodash'
 import { Schema } from 'mongoose'
-import validator from 'validator'
+
+import { validateEmailDomains } from 'src/shared/util/email-domain-validation'
 
 import { IEmailFieldSchema, ResponseMode } from '../../../types'
 
 const createEmailFieldSchema = () => {
-  const EmailFieldSchema = new Schema<IEmailFieldSchema>({
+  const EmailFieldSchema: Schema<IEmailFieldSchema> = new Schema<
+    IEmailFieldSchema
+  >({
     autoReplyOptions: {
       hasAutoReply: {
         type: Boolean,
@@ -55,14 +57,8 @@ const createEmailFieldSchema = () => {
       // If allowedEmailDomains is empty, then all email domains should be allowed.
       default: [],
       validate: {
-        validator: (emailDomains: string[]) => {
-          return (
-            isEmpty(emailDomains) ||
-            (new Set(emailDomains).size === emailDomains.length &&
-              emailDomains.every((emailDomain) =>
-                validator.isEmail('bob' + emailDomain),
-              ))
-          )
+        validator: (emailDomains: string[]): boolean => {
+          return validateEmailDomains(emailDomains)
         },
         message: 'There are one or more duplicate or invalid email domains.',
       },

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'mongoose'
-import { validateEmailDomains } from 'shared/util/email-domain-validation'
 
+import { validateEmailDomains } from '../../../shared/util/email-domain-validation'
 import { IEmailFieldSchema, ResponseMode } from '../../../types'
 
 const createEmailFieldSchema = () => {

--- a/src/public/modules/forms/admin/directives/validate-email-domain-from-text.directive.js
+++ b/src/public/modules/forms/admin/directives/validate-email-domain-from-text.directive.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { validateEmailDomains } = require('shared/util/email-domain-validation')
+
 angular
   .module('forms')
   .directive('validateEmailDomainFromText', validateEmailDomainFromText)
@@ -20,11 +22,7 @@ function validateEmailDomainFromText() {
           .split('\n')
           .map((s) => s.trim())
           .filter((s) => s)
-        if (emailDomains.length === 0) return true
-        const validDedupedDomainsSet = new Set(
-          emailDomains.filter((s) => s.match(/@.+\..+/)),
-        )
-        return validDedupedDomainsSet.size === emailDomains.length
+        return validateEmailDomains(emailDomains)
       }
     },
   }

--- a/src/public/modules/forms/admin/directives/validate-email-domain-from-text.directive.js
+++ b/src/public/modules/forms/admin/directives/validate-email-domain-from-text.directive.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const { validateEmailDomains } = require('shared/util/email-domain-validation')
+const {
+  validateEmailDomains,
+} = require('../../../../../shared/util/email-domain-validation')
 
 angular
   .module('forms')

--- a/src/shared/util/email-domain-validation.ts
+++ b/src/shared/util/email-domain-validation.ts
@@ -1,0 +1,12 @@
+import { isEmpty } from 'lodash'
+import validator from 'validator'
+
+export const validateEmailDomains = (emailDomains: string[]): boolean => {
+  return (
+    isEmpty(emailDomains) ||
+    (new Set(emailDomains).size === emailDomains.length &&
+      emailDomains.every((emailDomain) =>
+        validator.isEmail('bob' + emailDomain),
+      ))
+  )
+}

--- a/src/shared/util/email-domain-validation.ts
+++ b/src/shared/util/email-domain-validation.ts
@@ -2,6 +2,8 @@ import { isEmpty } from 'lodash'
 import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
+  // We need to prepend "bob" to the email domain so that it can form an email address and can be
+  // validated by validator.isEmail.
   return (
     isEmpty(emailDomains) ||
     (new Set(emailDomains).size === emailDomains.length &&


### PR DESCRIPTION
## Problem

Currently, email domain validation is done via regex. We would like to use `validator.isEmail` to validate email domains. In order to use `isEmail`, we will prepend email domains with a string i.e. "bob".

Closes #54 

## Interesting things to note

I put in a lot of thought before finally deciding on "bob". I wanted something short and not nonsensical like abc.

I received these linting errors:

```bash
/Users/jiayee/FormSG/src/app/models/field/emailField.ts
  7:32  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types

/Users/jiayee/FormSG/src/public/modules/forms/admin/directives/validate-email-domain-from-text.directive.js
  3:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'
```

As such, I had to do the following extra stuff:

1. `const EmailFieldSchema: Schema<IEmailFieldSchema> = ...` instead of leaving it alone (originally `const EmailFieldSchema = ...`
1. `const { validateEmailDomains } = require('shared/util/email-domain-validation')` instead of `import { ... } from '...'`.

I also found out that `src/app/models/agency.server.model.ts` validates email domains by `match: [/.+\..+/, 'Please fill a valid email domain.'],`.