### PR TITLE
feat: soft-launch rate-limiting of API endpoints

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -105,3 +105,7 @@ FORMSG_SDK_MODE=
 
 # IS_SP_MAINTENANCE=
 # IS_CP_MAINTENANCE=
+
+## Per-minute, per-IP request limits applied to specific endpoints
+# SUBMISSIONS_RATE_LIMIT=
+# SEND_AUTH_OTP_RATE_LIMIT=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=fakeSecret
       - SESSION_SECRET=thisisasecret
       - AWS_ENDPOINT=http://localhost:4566
+      - SUBMISSIONS_RATE_LIMIT=200
+      - SEND_AUTH_OTP_RATE_LIMIT=60
       - GA_TRACKING_ID
       - SENTRY_CONFIG_URL
       - TWILIO_ACCOUNT_SID

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -212,6 +212,14 @@ SITE_BANNER_CONTENT=hello:This is an invalid banner type, and the full text will
 | `CHROMIUM_BIN`        | Filepath to chromium binary. Required for email autoreply PDF generation with Puppeteer.                                                                                                                             |
 | `BOUNCE_LIFE_SPAN`    | Time in milliseconds that bounces are tracked for each form. Defaults to 86400000ms or 24 hours. Only relevant if you have set up AWS to send bounce and delivery notifications to the /emailnotifications endpoint. |
 
+#### Rate limits at specific endpoints
+
+The app applies per-minute, per-IP rate limits at specific API endpoints as a security measure. The limits can be specified with the following environment variables.
+| Variable | Description |
+| :-------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SUBMISSIONS_RATE_LIMIT` | Per-minute, per-IP request limit for each submissions endpoint. The limit is applied separately for the email mode and encrypt mode endpoints. |
+| `SEND_AUTH_OTP_RATE_LIMIT` | Per-minute, per-IP request limit for the endpoint which requests for new login OTPs for the admin console. |
+
 ### Additional Features
 
 The app supports a number of additional features like Captcha protection, Sentry reporting and Google Analytics. Each of these features requires specific environment variables which are detailed below. To deploy a bare bones application without these additional features, one can safely exclude the respective environment variables without any extra configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4505,6 +4505,15 @@
         "@types/serve-static": "*"
       }
     },
+    "@types/express-rate-limit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-5.1.0.tgz",
+      "integrity": "sha512-vmg7S3hUnfFmp06V01DrTB41mbQYXMV/F4aF5KKnfCIeSlnizatXaqO9UgR6LvNEEd3eMpuUTLxR6nv3d4hZ6g==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/express-request-id": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@types/express-request-id/-/express-request-id-1.4.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11613,6 +11613,11 @@
       "resolved": "https://registry.npmjs.org/express-partials/-/express-partials-0.3.0.tgz",
       "integrity": "sha1-iLnEAWSv2aVSeGKbKUjmrOe/9F8="
     },
+    "express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-TINcxve5510pXj4n9/1AMupkj3iWxl3JuZaWhCdYDlZeoCPqweGZrxbrlqTCFb1CT5wli7s8e2SH/Qz2c9GorA=="
+    },
     "express-request-id": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/express-request-id/-/express-request-id-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/ejs": "^3.0.4",
     "@types/express": "^4.17.8",
+    "@types/express-rate-limit": "^5.1.0",
     "@types/express-session": "^1.17.0",
     "@types/has-ansi": "^3.0.0",
     "@types/helmet": "0.0.48",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "ejs": "^3.1.5",
     "express": "^4.16.4",
     "express-device": "~0.4.2",
+    "express-rate-limit": "^5.1.3",
     "express-request-id": "^1.4.1",
     "express-session": "^1.15.6",
     "express-winston": "^4.0.5",

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -4,8 +4,6 @@ const mongoose = require('mongoose')
 const { StatusCodes } = require('http-status-codes')
 
 const { getRequestIp, getTrace } = require('../utils/request')
-const RateLimit = require('express-rate-limit')
-const { merge } = require('lodash')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormFeedbackModel = require('../models/form_feedback.server.model')
   .default
@@ -114,35 +112,6 @@ exports.submitFeedback = function (req, res) {
       }
     },
   )
-}
-
-/**
- * Returns a middleware which logs a message if the rate of requests
- * to an API endpoint exceeds a given rate.
- * TODO (private #49): update this documentation.
- * @param {RateLimit.Options} options Custom options to be passed to RateLimit
- * @return {RateLimit.RateLimit} Rate-limiting middleware
- */
-exports.limitRate = function (options = {}) {
-  const defaultOptions = {
-    windowMs: 15 * 60 * 1000,
-    max: 600,
-    handler: (req, _res, next) => {
-      logger.warn({
-        message: 'Rate limit exceeded',
-        meta: {
-          action: 'limitRate',
-          url: req.url,
-          ip: getRequestIp(req),
-          method: req.method,
-          rateLimitInfo: req.rateLimit,
-        },
-      })
-      // TODO (private #49): terminate the request with 429
-      return next()
-    },
-  }
-  return RateLimit(merge(defaultOptions, options))
 }
 
 /**

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -126,7 +126,7 @@ exports.submitFeedback = function (req, res) {
 exports.limitRate = function (options = {}) {
   const defaultOptions = {
     windowMs: 15 * 60 * 1000,
-    max: 3,
+    max: 600,
     handler: (req, _res, next) => {
       logger.warn({
         message: 'Rate limit exceeded',

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -133,6 +133,7 @@ exports.limitRate = function (options = {}) {
         meta: {
           action: 'limitRate',
           url: req.url,
+          ip: getRequestIp(req),
           method: req.method,
           rateLimitInfo: req.rateLimit,
         },

--- a/src/app/modules/auth/auth.routes.ts
+++ b/src/app/modules/auth/auth.routes.ts
@@ -1,16 +1,12 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { Router } from 'express'
 
+import { rateLimitConfig } from '../../../config/config'
 import { limitRate } from '../../utils/limit-rate'
 
 import * as AuthController from './auth.controller'
 
 export const AuthRouter = Router()
-
-/**
- * @constant {number} SEND_OTP_RATE_LIMIT Per-minute, per-IP limit on /sendotp endpoint
- */
-const SEND_OTP_RATE_LIMIT = 60
 
 /**
  * Check if email domain is a valid agency
@@ -47,7 +43,7 @@ AuthRouter.post(
  */
 AuthRouter.post(
   '/sendotp',
-  limitRate({ max: SEND_OTP_RATE_LIMIT }),
+  limitRate({ max: rateLimitConfig.sendAuthOtp }),
   celebrate({
     [Segments.BODY]: Joi.object().keys({
       email: Joi.string()

--- a/src/app/modules/auth/auth.routes.ts
+++ b/src/app/modules/auth/auth.routes.ts
@@ -1,9 +1,16 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { Router } from 'express'
 
+import { limitRate } from '../../utils/limit-rate'
+
 import * as AuthController from './auth.controller'
 
 export const AuthRouter = Router()
+
+/**
+ * @constant {number} SEND_OTP_RATE_LIMIT Per-minute, per-IP limit on /sendotp endpoint
+ */
+const SEND_OTP_RATE_LIMIT = 60
 
 /**
  * Check if email domain is a valid agency
@@ -40,6 +47,7 @@ AuthRouter.post(
  */
 AuthRouter.post(
   '/sendotp',
+  limitRate({ max: SEND_OTP_RATE_LIMIT }),
   celebrate({
     [Segments.BODY]: Joi.object().keys({
       email: Joi.string()

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -31,12 +31,10 @@ module.exports = function (app) {
    */
   app
     .route('/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?')
-    .get(publicForms.limitRate(), publicForms.redirect)
+    .get(publicForms.redirect)
 
   // TODO: Remove this embed endpoint
-  app
-    .route('/:Id([a-fA-F0-9]{24})/embed')
-    .get(publicForms.limitRate(), publicForms.redirect)
+  app.route('/:Id([a-fA-F0-9]{24})/embed').get(publicForms.redirect)
 
   /**
    * Redirect a form to the main index, with the specified path
@@ -58,12 +56,12 @@ module.exports = function (app) {
     .route(
       '/forms/:agency/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
     )
-    .get(publicForms.limitRate(), publicForms.redirect)
+    .get(publicForms.redirect)
 
   // TODO: Remove this embed endpoint
   app
     .route('/forms/:agency/:Id([a-fA-F0-9]{24})/embed')
-    .get(publicForms.limitRate(), publicForms.redirect)
+    .get(publicForms.redirect)
 
   /**
    * @typedef Feedback
@@ -84,12 +82,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/feedback')
-    .post(
-      publicForms.limitRate(),
-      forms.formById,
-      publicForms.isFormPublic,
-      publicForms.submitFeedback,
-    )
+    .post(forms.formById, publicForms.isFormPublic, publicForms.submitFeedback)
 
   /**
    * @typedef PublicForm
@@ -113,7 +106,6 @@ module.exports = function (app) {
   app
     .route('/:formId([a-fA-F0-9]{24})/publicform')
     .get(
-      publicForms.limitRate(),
       forms.formById,
       publicForms.isFormPublic,
       spcpFactory.addSpcpSessionInfo,
@@ -146,7 +138,6 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/email/:formId([a-fA-F0-9]{24})').post(
-    publicForms.limitRate(),
     CaptchaFactory.validateCaptcha,
     forms.formById,
     publicForms.isFormPublic,
@@ -208,7 +199,6 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/encrypt/:formId([a-fA-F0-9]{24})').post(
-    publicForms.limitRate(),
     CaptchaFactory.validateCaptcha,
     celebrate({
       body: Joi.object({

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -12,6 +12,12 @@ const { celebrate, Joi } = require('celebrate')
 const spcpFactory = require('../factories/spcp-myinfo.factory')
 const webhookVerifiedContentFactory = require('../factories/webhook-verified-content.factory')
 const { CaptchaFactory } = require('../factories/captcha.factory')
+const { limitRate } = require('../utils/limit-rate')
+
+/**
+ * @constant {number} SUBMISSIONS_RATE_LIMIT Per-minute, per-IP limit on submissions endpoint
+ */
+const SUBMISSIONS_RATE_LIMIT = 200
 
 module.exports = function (app) {
   /**
@@ -138,6 +144,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/email/:formId([a-fA-F0-9]{24})').post(
+    limitRate({ max: SUBMISSIONS_RATE_LIMIT }),
     CaptchaFactory.validateCaptcha,
     forms.formById,
     publicForms.isFormPublic,
@@ -199,6 +206,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/encrypt/:formId([a-fA-F0-9]{24})').post(
+    limitRate({ max: SUBMISSIONS_RATE_LIMIT }),
     CaptchaFactory.validateCaptcha,
     celebrate({
       body: Joi.object({

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -13,11 +13,7 @@ const spcpFactory = require('../factories/spcp-myinfo.factory')
 const webhookVerifiedContentFactory = require('../factories/webhook-verified-content.factory')
 const { CaptchaFactory } = require('../factories/captcha.factory')
 const { limitRate } = require('../utils/limit-rate')
-
-/**
- * @constant {number} SUBMISSIONS_RATE_LIMIT Per-minute, per-IP limit on submissions endpoint
- */
-const SUBMISSIONS_RATE_LIMIT = 200
+const { rateLimitConfig } = require('../../config/config')
 
 module.exports = function (app) {
   /**
@@ -144,7 +140,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/email/:formId([a-fA-F0-9]{24})').post(
-    limitRate({ max: SUBMISSIONS_RATE_LIMIT }),
+    limitRate({ max: rateLimitConfig.submissions }),
     CaptchaFactory.validateCaptcha,
     forms.formById,
     publicForms.isFormPublic,
@@ -206,7 +202,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/encrypt/:formId([a-fA-F0-9]{24})').post(
-    limitRate({ max: SUBMISSIONS_RATE_LIMIT }),
+    limitRate({ max: rateLimitConfig.submissions }),
     CaptchaFactory.validateCaptcha,
     celebrate({
       body: Joi.object({

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -31,10 +31,12 @@ module.exports = function (app) {
    */
   app
     .route('/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?')
-    .get(publicForms.redirect)
+    .get(publicForms.limitRate(), publicForms.redirect)
 
   // TODO: Remove this embed endpoint
-  app.route('/:Id([a-fA-F0-9]{24})/embed').get(publicForms.redirect)
+  app
+    .route('/:Id([a-fA-F0-9]{24})/embed')
+    .get(publicForms.limitRate(), publicForms.redirect)
 
   /**
    * Redirect a form to the main index, with the specified path
@@ -56,12 +58,12 @@ module.exports = function (app) {
     .route(
       '/forms/:agency/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
     )
-    .get(publicForms.redirect)
+    .get(publicForms.limitRate(), publicForms.redirect)
 
   // TODO: Remove this embed endpoint
   app
     .route('/forms/:agency/:Id([a-fA-F0-9]{24})/embed')
-    .get(publicForms.redirect)
+    .get(publicForms.limitRate(), publicForms.redirect)
 
   /**
    * @typedef Feedback
@@ -82,7 +84,12 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/feedback')
-    .post(forms.formById, publicForms.isFormPublic, publicForms.submitFeedback)
+    .post(
+      publicForms.limitRate(),
+      forms.formById,
+      publicForms.isFormPublic,
+      publicForms.submitFeedback,
+    )
 
   /**
    * @typedef PublicForm
@@ -106,6 +113,7 @@ module.exports = function (app) {
   app
     .route('/:formId([a-fA-F0-9]{24})/publicform')
     .get(
+      publicForms.limitRate(),
       forms.formById,
       publicForms.isFormPublic,
       spcpFactory.addSpcpSessionInfo,
@@ -138,6 +146,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/email/:formId([a-fA-F0-9]{24})').post(
+    publicForms.limitRate(),
     CaptchaFactory.validateCaptcha,
     forms.formById,
     publicForms.isFormPublic,
@@ -199,6 +208,7 @@ module.exports = function (app) {
    * @returns {SubmissionResponse.model} 400 - submission has bad data and could not be processed
    */
   app.route('/v2/submissions/encrypt/:formId([a-fA-F0-9]{24})').post(
+    publicForms.limitRate(),
     CaptchaFactory.validateCaptcha,
     celebrate({
       body: Joi.object({

--- a/src/app/utils/__tests__/limit-rate.spec.ts
+++ b/src/app/utils/__tests__/limit-rate.spec.ts
@@ -1,0 +1,43 @@
+import RateLimit from 'express-rate-limit'
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+import { mocked } from 'ts-jest/utils'
+
+jest.mock('express-rate-limit')
+const MockRateLimit = mocked(RateLimit, true)
+
+// eslint-disable-next-line import/first
+import { limitRate } from 'src/app/utils/limit-rate'
+
+const MOCK_MAX = 5
+const MOCK_WINDOW = 10
+
+describe('limitRate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should create a rate-limiting middleware with defaults', () => {
+    limitRate()
+    expect(MockRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ windowMs: 60000, max: 1200 }),
+    )
+  })
+
+  it('should create a rate-limiting middleware with custom options', () => {
+    limitRate({ max: MOCK_MAX, windowMs: MOCK_WINDOW })
+    expect(MockRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ windowMs: MOCK_WINDOW, max: MOCK_MAX }),
+    )
+  })
+
+  it('should call next() in the handler', () => {
+    limitRate()
+    const handler = MockRateLimit.mock.calls[0][0]!.handler!
+    const mockNext = jest.fn()
+    handler(
+      expressHandler.mockRequest(),
+      expressHandler.mockResponse(),
+      mockNext,
+    )
+    expect(mockNext).toHaveBeenCalled()
+  })
+})

--- a/src/app/utils/limit-rate.ts
+++ b/src/app/utils/limit-rate.ts
@@ -1,0 +1,40 @@
+import RateLimit, {
+  Options as RateLimitOptions,
+  RateLimit as RateLimitFn,
+} from 'express-rate-limit'
+import { merge } from 'lodash'
+
+import { createLoggerWithLabel } from '../../config/logger'
+
+import { getRequestIp } from './request'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Returns a middleware which logs a message if the rate of requests
+ * to an API endpoint exceeds a given rate.
+ * TODO (private #49): update this documentation.
+ * @param options Custom options to be passed to RateLimit
+ * @return Rate-limiting middleware
+ */
+export const limitRate = (options: RateLimitOptions = {}): RateLimitFn => {
+  const defaultOptions: RateLimitOptions = {
+    windowMs: 60 * 1000, // Apply rate per-minute
+    max: 1200,
+    handler: (req, _res, next) => {
+      logger.warn({
+        message: 'Rate limit exceeded',
+        meta: {
+          action: 'limitRate',
+          url: req.url,
+          ip: getRequestIp(req),
+          method: req.method,
+          rateLimitInfo: req.rateLimit,
+        },
+      })
+      // TODO (private #49): terminate the request with HTTP 429
+      return next()
+    },
+  }
+  return RateLimit(merge(defaultOptions, options))
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -226,6 +226,7 @@ const config: Config = {
   isLoginBanner: basicVars.banner.isLoginBanner,
   siteBannerContent: basicVars.banner.siteBannerContent,
   adminBannerContent: basicVars.banner.adminBannerContent,
+  rateLimitConfig: basicVars.rateLimit,
   configureAws,
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -266,6 +266,21 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       env: 'NODE_ENV',
     },
   },
+  rateLimit: {
+    submissions: {
+      doc: 'Per-minute, per-IP request limit for submissions endpoints',
+      format: 'int',
+      default: 200,
+      env: 'SUBMISSIONS_RATE_LIMIT',
+    },
+    sendAuthOtp: {
+      doc:
+        'Per-minute, per-IP request limit for OTPs to log in to the admin console',
+      format: 'int',
+      default: 60,
+      env: 'SEND_AUTH_OTP_RATE_LIMIT',
+    },
+  },
 }
 
 export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,6 +46,11 @@ export type MailConfig = {
   transporter: Mail
 }
 
+export type RateLimitConfig = {
+  submissions: number
+  sendAuthOtp: number
+}
+
 export type Config = {
   app: AppConfig
   db: DbConfig
@@ -68,6 +73,7 @@ export type Config = {
   isLoginBanner: string
   siteBannerContent: string
   adminBannerContent: string
+  rateLimitConfig: RateLimitConfig
 
   // Functions
   configureAws: () => Promise<void>
@@ -121,6 +127,10 @@ export interface IOptionalVarsSchema {
     maxMessages: number
     maxConnections: number
     socketTimeout: number
+  }
+  rateLimit: {
+    submissions: number
+    sendAuthOtp: number
   }
 }
 


### PR DESCRIPTION
## Problem

We want to limit the rate of requests to public endpoints as a security measure against DDoS attacks. However, we need to ensure that the limits do not affect regular application usage. Hence it is necessary to ensure that the limits do not get exceeded on a regular basis, before actually denying requests which exceed the limit.

After some discussion, we decided to apply the limits to three endpoints: `/auth/sendotp` as well as both submissions endpoints, `v2/submissions/email` and `v2/submissions/encrypt`.

## Solution

Use `express-rate-limit` with a custom handler which logs a message if the rate limit is exceeded, then carries on handling the request as normal. Note that the package uses per-IP limits by default.

The log message looks like this:
<img width="814" alt="Screenshot 2020-10-06 at 10 35 24 AM" src="https://user-images.githubusercontent.com/29480346/95152466-b282da00-07bf-11eb-991a-84bc625fbed5.png">

### Determining the limit
It is important to apply a limit which does not affect regular application usage. To determine the limit, I counted the per-minute requests per IP address over the past week to each of the endpoints.

Between both `v2/submissions` endpoints, the maximum was 46 requests to `/v2/submissions/email`:
![Screenshot 2020-10-05 at 5 27 49 PM](https://user-images.githubusercontent.com/29480346/95151562-88c8b380-07bd-11eb-85a5-0b935b9c9aa4.png)

Multiplying this by 4 to get the maximum seemed reasonable, since programmatic attacks are likely to exceed regular usage numbers by far more. Moreover, the limit is applied per-instance rather than across instances (see next section). Hence I chose a per-minute limit of 200.

As for the `/auth/sendotp` endpoint, the maximum was 4 requests in a minute. To be safe, I set the per-minute maximum at 60.

### Per-instance vs instance-wide limits
`express-rate-limit` uses an in-memory store by default. This means that the rate limits are applied per-instance. Applying them instance-wide would require setting up a store in our database using [MongoDB plugin](https://www.npmjs.com/package/rate-limit-mongo). However, the plugin does not seem to support reusing existing connections, which means we would have to create a new connection to the database. I decided against this to avoid concurrency issues with multiple instances accessing the same documents, so the limits are applied per-instance.

## Tests
- [ ] Production environment is updated with the environment variables `SUBMISSIONS_RATE_LIMIT=200` and `SEND_AUTH_OTP_RATE_LIMIT=60`.
- [ ] In production, an alarm has been set for any occurrence of the "Rate limit exceeded" log message.
- In the staging environment, set `SUBMISSIONS_RATE_LIMIT=2` and `SEND_AUTH_OTP_RATE_LIMIT=2`.
    - [ ] On the admin console login page, try to resend your OTP 3 times within a minute. Ensure that you receive all 3 OTPs, and that a "Rate limit exceeded" message gets logged with metadata about the rate limit (IP address, endpoint, current number of requests).
    - [ ] Try submitting 3 different forms within 1 minute. Ensure that all 3 forms can be submitted, and that a "Rate limit exceeded" message gets logged with metadata about the rate limit (IP address, endpoint, current number of requests).
    - [ ] In the staging environment, set `SUBMISSIONS_RATE_LIMIT=200` and `SEND_AUTH_OTP_RATE_LIMIT=60`.