### PR TITLE
chore: add lint rule to prevent floating promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,8 @@
         "sourceType": "module",
         "ecmaFeatures": {
           "modules": true
-        }
+        },
+        "project": "./tsconfig.json"
       },
       "plugins": ["@typescript-eslint", "import", "simple-import-sort"],
       "extends": ["plugin:@typescript-eslint/recommended"],
@@ -50,7 +51,8 @@
         "import/order": "off",
         "import/first": "error",
         "import/newline-after-import": "error",
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        "@typescript-eslint/no-floating-promises": 2,
       }
     },
     { "files": ["*.spec.ts"], "extends": ["plugin:jest/recommended"] }

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -493,7 +493,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     }
 
     // Validate that admin exists before form is created.
-    User.findById(this.admin, function (error, admin) {
+    void User.findById(this.admin, function (error, admin) {
       if (error) {
         return next(Error(`Error validating admin for form.`))
       }

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -484,7 +484,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   }
 
   // Hooks
-  FormSchema.pre<IFormSchema>('validate', function (next) {
+  FormSchema.pre<IFormSchema>('validate', async function (next) {
     // Reject save if form document is too large
     if (bson.calculateObjectSize(this) > 10 * MB) {
       const err = new Error('Form size exceeded.')
@@ -493,7 +493,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     }
 
     // Validate that admin exists before form is created.
-    void User.findById(this.admin, function (error, admin) {
+    await User.findById(this.admin, function (error, admin) {
       if (error) {
         return next(Error(`Error validating admin for form.`))
       }

--- a/src/app/modules/webhook/webhook.controller.ts
+++ b/src/app/modules/webhook/webhook.controller.ts
@@ -27,7 +27,7 @@ export const post = (
   if (webhookUrl) {
     // Note that we push data to webhook endpoints on a best effort basis
     // As such, we should not await on these post requests
-    pushData(webhookUrl, submissionWebhookView)
+    void pushData(webhookUrl, submissionWebhookView)
   }
   return next()
 }

--- a/src/loaders/mongoose.ts
+++ b/src/loaders/mongoose.ts
@@ -97,7 +97,7 @@ export default async (): Promise<Connection> => {
       emailDomain: 'data.gov.sg',
       logo: '/public/modules/core/img/govtech.jpg',
     })
-    agency.save()
+    await agency.save()
   }
 
   return mongoose.connection

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,4 +21,4 @@ const initServer = async () => {
   })
 }
 
-initServer()
+void initServer()


### PR DESCRIPTION
## Problem

A couple of scares that happened with promises failing to be invoked or awaited, etc (floating promises), most recently with https://github.com/opengovsg/FormSG/pull/362 (correct me if I'm wrong).

This PR adds an ESLint rule that returns an error if any promises are floating. Also fixes the errors that this lint rule highlighted.

