### PR TITLE
feat: add trace to logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4505,10 +4505,18 @@
         "@types/serve-static": "*"
       }
     },
+    "@types/express-request-id": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/express-request-id/-/express-request-id-1.4.1.tgz",
+      "integrity": "sha512-39g9HGiBJBjsSJZ80vYgkR4yvu7XVL2R/R/KezU/060gnW5e9btRP7d0R8QORzJ3/Uo7Sis36AM58KSQQOfgcw==",
+      "requires": {
+        "@types/express-serve-static-core": "*"
+      }
+    },
     "@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11634,6 +11634,21 @@
       "resolved": "https://registry.npmjs.org/express-partials/-/express-partials-0.3.0.tgz",
       "integrity": "sha1-iLnEAWSv2aVSeGKbKUjmrOe/9F8="
     },
+    "express-request-id": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/express-request-id/-/express-request-id-1.4.1.tgz",
+      "integrity": "sha512-qpxK6XhDYtdx9FvxwCHkUeZVWtkGbWR87hBAzGECfwYF/QQCPXEwwB2/9NGkOR1tT7/aLs9mma3CT0vjSzuZVw==",
+      "requires": {
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "express-session": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "ejs": "^3.1.5",
     "express": "^4.16.4",
     "express-device": "~0.4.2",
+    "express-request-id": "^1.4.1",
     "express-session": "^1.15.6",
     "express-winston": "^4.0.5",
     "fetch-readablestream": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "@sentry/browser": "^5.22.3",
     "@sentry/integrations": "^5.24.2",
     "@stablelib/base64": "^1.0.0",
+    "@types/express-request-id": "^1.4.1",
+    "@types/express-serve-static-core": "^4.17.13",
     "JSONStream": "^1.3.5",
     "angular": "~1.8.0",
     "angular-animate": "^1.8.0",

--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -20,7 +20,7 @@ const Form = getFormModel(mongoose)
 const _ = require('lodash')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 
 // Examples search-specific constants
 const PAGE_SIZE = 16 // maximum number of results to return
@@ -577,6 +577,7 @@ exports.getExampleFormsUsingAggregateCollection = function (req, res) {
           meta: {
             action: 'getExampleFormsUsingAggregateCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -609,6 +610,7 @@ exports.getExampleFormsUsingSubmissionsCollection = function (req, res) {
           meta: {
             action: 'getExampleFormsUsingSubmissionsCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -699,6 +701,7 @@ exports.getSingleExampleFormUsingSubmissionCollection = function (req, res) {
           meta: {
             action: 'getSingleExampleFormUsingSubmissionCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -727,6 +730,7 @@ exports.getSingleExampleFormUsingAggregateCollection = function (req, res) {
           meta: {
             action: 'getSingleExampleFormUsingAggregateCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -808,6 +812,7 @@ exports.getLoginStats = function (req, res) {
           meta: {
             action: 'getLoginStats',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },

--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -832,6 +832,7 @@ exports.getLoginStats = function (req, res) {
           }`,
           meta: {
             action: 'getLoginStats',
+            trace: getTrace(req),
           },
         })
 

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -11,7 +11,7 @@ const { StatusCodes } = require('http-status-codes')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const errorHandler = require('./errors.server.controller')
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const { FormLogoState } = require('../../types')
 
 const {
@@ -69,6 +69,7 @@ function makeModule(connection) {
         meta: {
           action: 'respondOnMongoError',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           url: req.url,
           headers: req.headers,
         },
@@ -290,6 +291,7 @@ function makeModule(connection) {
             meta: {
               action: 'makeModule.update',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               formId: form._id,
             },
           })
@@ -307,6 +309,7 @@ function makeModule(connection) {
               meta: {
                 action: 'makeModule.update',
                 ip: getRequestIp(req),
+                trace: getTrace(req),
                 formId: form._id,
               },
               error,
@@ -521,6 +524,7 @@ function makeModule(connection) {
             meta: {
               action: 'makeModule.countFeedback',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               url: req.url,
               headers: req.headers,
             },
@@ -550,6 +554,7 @@ function makeModule(connection) {
             meta: {
               action: 'makeModule.streamFeedback',
               ip: getRequestIp(req),
+              trace: getTrace(req),
             },
             error: err,
           })
@@ -564,6 +569,7 @@ function makeModule(connection) {
             meta: {
               action: 'makeModule.streamFeedback',
               ip: getRequestIp(req),
+              trace: getTrace(req),
             },
             error: err,
           })
@@ -578,6 +584,7 @@ function makeModule(connection) {
             meta: {
               action: 'makeModule.streamFeedback',
               ip: getRequestIp(req),
+              trace: getTrace(req),
             },
             error: err,
           })
@@ -689,6 +696,7 @@ function makeModule(connection) {
               meta: {
                 action: 'makeModule.streamFeedback',
                 ip: getRequestIp(req),
+                trace: getTrace(req),
               },
               error: err,
             })
@@ -736,6 +744,7 @@ function makeModule(connection) {
               meta: {
                 action: 'makeModule.streamFeedback',
                 ip: getRequestIp(req),
+                trace: getTrace(req),
               },
               error: err,
             })
@@ -764,6 +773,7 @@ function makeModule(connection) {
           meta: {
             action: 'makeModule.transferOwner',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },

--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -5,7 +5,7 @@
  */
 const { StatusCodes } = require('http-status-codes')
 const PERMISSIONS = require('../utils/permission-levels').default
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 
 /**
@@ -50,6 +50,7 @@ const logUnauthorizedAccess = (req, action, requiredPermission) => {
     meta: {
       action: action,
       ip: getRequestIp(req),
+      trace: getTrace(req),
       url: req.url,
       headers: req.headers,
     },

--- a/src/app/controllers/core.server.controller.js
+++ b/src/app/controllers/core.server.controller.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
 const { StatusCodes } = require('http-status-codes')
 
 const config = require('../../config/config')
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 
 const getFormStatisticsTotalModel = require('../models/form_statistics_total.server.model')
@@ -53,6 +53,7 @@ exports.formCountUsingAggregateCollection = (req, res) => {
           meta: {
             action: 'formCountUsingAggregateCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -97,6 +98,7 @@ exports.formCountUsingSubmissionsCollection = (req, res) => {
           meta: {
             action: 'formCountUsingSubmissionsCollection',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             url: req.url,
             headers: req.headers,
           },
@@ -124,6 +126,7 @@ exports.userCount = (req, res) => {
         meta: {
           action: 'userCount',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           url: req.url,
           headers: req.headers,
         },
@@ -149,6 +152,7 @@ exports.submissionCount = (req, res) => {
         meta: {
           action: 'submissionCount',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           url: req.url,
           headers: req.headers,
         },

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose')
 const { getEmailSubmissionModel } = require('../models/submission.server.model')
 const emailSubmission = getEmailSubmissionModel(mongoose)
 const { StatusCodes } = require('http-status-codes')
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const { ConflictError } = require('../modules/submission/submission.errors')
 const { MB } = require('../constants/filesize')
 const {
@@ -57,6 +57,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       meta: {
         action: 'receiveEmailSubmissionUsingBusBoy',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         formId: _.get(req, 'form._id'),
       },
       error: err,
@@ -108,6 +109,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
           meta: {
             action: 'receiveEmailSubmissionUsingBusBoy',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             formId: req.form._id,
           },
           error: err,
@@ -125,6 +127,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
         meta: {
           action: 'receiveEmailSubmissionUsingBusBoy',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           formId: req.form._id,
         },
       })
@@ -155,6 +158,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
         action: 'receiveEmailSubmissionUsingBusBoy',
         formId: req.form._id,
         ip: getRequestIp(req),
+        trace: getTrace(req),
         uin: hashedUinFin,
         submission: hashedSubmission,
       },
@@ -168,6 +172,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
           meta: {
             action: 'receiveEmailSubmissionUsingBusBoy',
             ip: getRequestIp(req),
+            trace: getTrace(req),
             formId: req.form._id,
           },
         })
@@ -192,6 +197,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
         meta: {
           action: 'receiveEmailSubmissionUsingBusBoy',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           formId: req.form._id,
           uin: hashedUinFin,
           submission: hashedSubmission,
@@ -210,6 +216,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       meta: {
         action: 'receiveEmailSubmissionUsingBusBoy',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         formId: req.form._id,
       },
       error: err,
@@ -246,6 +253,7 @@ exports.validateEmailSubmission = function (req, res, next) {
         meta: {
           action: 'validateEmailSubmission',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           formId: req.form._id,
         },
         error: err,
@@ -502,6 +510,7 @@ function onSubmissionEmailFailure(err, req, res, submission) {
     meta: {
       action: 'onSubmissionEmailFailure',
       ip: getRequestIp(req),
+      trace: getTrace(req),
       url: req.url,
       headers: req.headers,
     },
@@ -601,6 +610,7 @@ exports.saveMetadataToDb = function (req, res, next) {
           submissionId: submission.id,
           formId: form._id,
           ip: getRequestIp(req),
+          trace: getTrace(req),
           responseHash: submission.responseHash,
         },
       })
@@ -643,6 +653,7 @@ exports.sendAdminEmail = async function (req, res, next) {
         submissionId: submission.id,
         formId: form._id,
         ip: getRequestIp(req),
+        trace: getTrace(req),
         submissionHash: submission.responseHash,
       },
     })
@@ -665,6 +676,7 @@ exports.sendAdminEmail = async function (req, res, next) {
         submissionId: submission.id,
         formId: form._id,
         ip: getRequestIp(req),
+        trace: getTrace(req),
         submissionHash: submission.responseHash,
       },
       error: err,

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -188,6 +188,7 @@ exports.saveResponseToDb = function (req, res, next) {
             message: 'Attachment upload error',
             meta: {
               action: 'saveResponseToDb',
+              trace: getTrace(req),
             },
             error: err,
           })

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -15,7 +15,7 @@ const encryptSubmission = getEncryptSubmissionModel(mongoose)
 
 const { checkIsEncryptedEncoding } = require('../utils/encryption')
 const { ConflictError } = require('../modules/submission/submission.errors')
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const {
@@ -46,6 +46,7 @@ exports.validateEncryptSubmission = function (req, res, next) {
       meta: {
         action: 'validateEncryptSubmission',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         formId: form._id,
       },
       error,
@@ -65,6 +66,7 @@ exports.validateEncryptSubmission = function (req, res, next) {
         meta: {
           action: 'validateEncryptSubmission',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           formId: form._id,
         },
         error: err,
@@ -113,6 +115,7 @@ function onEncryptSubmissionFailure(err, req, res, submission) {
     meta: {
       action: 'onEncryptSubmissionFailure',
       ip: getRequestIp(req),
+      trace: getTrace(req),
       url: req.url,
       headers: req.headers,
     },
@@ -246,6 +249,7 @@ exports.getMetadata = function (req, res) {
               meta: {
                 action: 'getMetadata',
                 ip: getRequestIp(req),
+                trace: getTrace(req),
                 url: req.url,
                 headers: req.headers,
               },
@@ -320,6 +324,7 @@ exports.getMetadata = function (req, res) {
             meta: {
               action: 'getMetadata',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               url: req.url,
               headers: req.headers,
             },
@@ -379,6 +384,7 @@ exports.getEncryptedResponse = function (req, res) {
         meta: {
           action: 'getEncryptedResponse',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           url: req.url,
           headers: req.headers,
         },
@@ -455,6 +461,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         meta: {
           action: 'streamEncryptedResponse',
           ip: getRequestIp(req),
+          trace: getTrace(req),
         },
         error: err,
       })
@@ -471,6 +478,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         meta: {
           action: 'streamEncryptedResponse',
           ip: getRequestIp(req),
+          trace: getTrace(req),
         },
         error: err,
       })
@@ -485,6 +493,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         meta: {
           action: 'streamEncryptedResponse',
           ip: getRequestIp(req),
+          trace: getTrace(req),
         },
         error: err,
       })

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -7,7 +7,7 @@ const mongoose = require('mongoose')
 const _ = require('lodash')
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormModel = require('../models/form.server.model').default
 
@@ -121,6 +121,7 @@ exports.formById = async function (req, res, next) {
       meta: {
         action: 'formById',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         url: req.url,
         headers: req.headers,
       },

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -11,7 +11,7 @@ const moment = require('moment')
 const { StatusCodes } = require('http-status-codes')
 
 const { sessionSecret } = require('../../config/config')
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getMyInfoHashModel = require('../models/myinfo_hash.server.model').default
 const MyInfoHash = getMyInfoHashModel(mongoose)
@@ -58,6 +58,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
       meta: {
         action: 'addMyInfo',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         formId,
         esrvcId,
       },
@@ -110,6 +111,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
               meta: {
                 action: 'addMyInfo',
                 ip: getRequestIp(req),
+                trace: getTrace(req),
                 formId,
               },
               error: err,
@@ -125,6 +127,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
         meta: {
           action: 'addMyInfo',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           formId,
         },
         error,
@@ -192,6 +195,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
             meta: {
               action: 'verifyMyInfoVals',
               ip: getRequestIp(req),
+              trace: getTrace(req),
             },
             error: err,
           })
@@ -207,6 +211,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
             meta: {
               action: 'verifyMyInfoVals',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               formId: formObjId,
             },
           })
@@ -255,6 +260,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
                 meta: {
                   action: 'verifyMyInfoVals',
                   ip: getRequestIp(req),
+                  trace: getTrace(req),
                   failedFields: hashFailedAttrs,
                 },
               })

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -58,6 +58,7 @@ exports.redirect = async function (req, res) {
       message: 'Error fetching metatags',
       meta: {
         action: 'redirect',
+        trace: getTrace(req),
       },
       error: err,
     })

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -3,7 +3,7 @@
 const mongoose = require('mongoose')
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormFeedbackModel = require('../models/form_feedback.server.model')
   .default
@@ -97,6 +97,7 @@ exports.submitFeedback = function (req, res) {
           meta: {
             action: 'submitFeedback',
             ip: getRequestIp(req),
+            trace: getTrace(req),
           },
           error: err,
         })

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -261,6 +261,7 @@ exports.validateESrvcId = (req, res) => {
           message: 'Could not find title',
           meta: {
             action: 'validateESrvcId',
+            trace: getTrace(req),
             redirectUrl: redirectURL,
             data,
           },
@@ -292,6 +293,7 @@ exports.validateESrvcId = (req, res) => {
         message: 'Could not contact singpass to validate eservice id',
         meta: {
           action: 'validateESrvcId',
+          trace: getTrace(req),
           redirectUrl: redirectURL,
           statusCode,
         },

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -9,7 +9,7 @@ const crypto = require('crypto')
 const { StatusCodes } = require('http-status-codes')
 const axios = require('axios')
 
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const { mapDataToKey } = require('../../shared/util/verified-content')
 const getFormModel = require('../models/form.server.model').default
@@ -148,6 +148,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
             meta: {
               action: 'handleOOBAuthenticationWith',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               url: req.url,
               headers: req.headers,
             },
@@ -353,6 +354,7 @@ exports.addSpcpSessionInfo = (authClients) => {
             meta: {
               action: 'addSpcpSessionInfo',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               url: req.url,
               headers: req.headers,
             },
@@ -415,6 +417,7 @@ exports.encryptedVerifiedFields = (signingSecretKey) => {
           action: 'encryptedVerifiedFields',
           formId: req.form._id,
           ip: getRequestIp(req),
+          trace: getTrace(req),
         },
         error,
       })
@@ -483,6 +486,7 @@ exports.isSpcpAuthenticated = (authClients) => {
             meta: {
               action: 'isSpcpAuthenticated',
               ip: getRequestIp(req),
+              trace: getTrace(req),
               url: req.url,
               headers: req.headers,
             },

--- a/src/app/controllers/submissions.server.controller.js
+++ b/src/app/controllers/submissions.server.controller.js
@@ -9,7 +9,7 @@ const Submission = getSubmissionModel(mongoose)
 
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp } = require('../utils/request')
+const { getRequestIp, getTrace } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const MailService = require('../services/mail.service').default
@@ -38,6 +38,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
             action: 'captchaCheck',
             formId: req.form._id,
             ip: getRequestIp(req),
+            trace: getTrace(req),
           },
         })
         return res.status(StatusCodes.BAD_REQUEST).send({
@@ -60,6 +61,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
                   action: 'captchaCheck',
                   formId: req.form._id,
                   ip: getRequestIp(req),
+                  trace: getTrace(req),
                 },
               })
               return res.status(StatusCodes.BAD_REQUEST).send({
@@ -76,6 +78,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
                 action: 'captchaCheck',
                 formId: req.form._id,
                 ip: getRequestIp(req),
+                trace: getTrace(req),
               },
               error: err,
             })
@@ -180,6 +183,7 @@ const sendEmailAutoReplies = async function (req) {
       meta: {
         action: 'sendEmailAutoReplies',
         ip: getRequestIp(req),
+        trace: getTrace(req),
         formId: req.form._id,
         submissionId: submission.id,
       },
@@ -223,6 +227,7 @@ exports.count = function (req, res) {
         meta: {
           action: 'count',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           url: req.url,
           headers: req.headers,
         },

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { LINKS } from '../../../shared/constants'
 import MailService from '../../services/mail.service'
-import { getRequestIp } from '../../utils/request'
+import { getRequestIp, getTrace } from '../../utils/request'
 import * as UserService from '../user/user.service'
 
 import * as AuthService from './auth.service'
@@ -37,6 +37,7 @@ export const handleCheckUser: RequestHandler<
         meta: {
           action: 'handleCheckUser',
           ip: getRequestIp(req),
+          trace: getTrace(req),
           email,
         },
         error,
@@ -64,6 +65,7 @@ export const handleLoginSendOtp: RequestHandler<
     action: 'handleLoginSendOtp',
     email,
     ip: requestIp,
+    trace: getTrace(req),
   }
 
   return (
@@ -123,6 +125,7 @@ export const handleLoginVerifyOtp: RequestHandler<
     action: 'handleLoginVerifyOtp',
     email,
     ip: getRequestIp(req),
+    trace: getTrace(req),
   }
   const coreErrorMessage = `Failed to process OTP. Please try again later and if the problem persists, submit our Support Form (${LINKS.supportFormLink}).`
 

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -1,5 +1,14 @@
 import { Request } from 'express'
 
-export const getRequestIp = (req: Request) => {
+interface IRequestWithId extends Request {
+  // Need to extend Request interface as id is not present in native express
+  id?: string
+}
+
+export const getRequestIp = (req: IRequestWithId) => {
   return req.get('cf-connecting-ip') ?? req.ip
+}
+
+export const getTrace = (req: IRequestWithId) => {
+  return req.get('cf-ray') ?? req.id // trace using cloudflare cf-ray header, with x-request-id header as backup
 }

--- a/src/loaders/express/index.ts
+++ b/src/loaders/express/index.ts
@@ -1,6 +1,7 @@
 import compression from 'compression'
 import express, { Express } from 'express'
 import device from 'express-device'
+import addRequestId from 'express-request-id'
 import http from 'http'
 import { Connection } from 'mongoose'
 import nocache from 'nocache'
@@ -104,6 +105,9 @@ const loadExpressApp = async (connection: Connection) => {
   )
 
   app.use(nocache()) // Add headers to prevent browser caching front-end code
+
+  // Generate UUID for request and add it to X-Request-Id header
+  app.use(addRequestId())
 
   // Setting the app static folder
   app.use('/public', express.static(path.resolve('./dist/frontend')))

--- a/src/loaders/express/logging.ts
+++ b/src/loaders/express/logging.ts
@@ -2,6 +2,7 @@ import expressWinston from 'express-winston'
 import get from 'lodash/get'
 import winston from 'winston'
 
+import { getTrace } from '../../app/utils/request'
 import config from '../../config/config'
 import { customFormat } from '../../config/logger'
 
@@ -12,6 +13,7 @@ type LogMeta = {
   userId: string
   contentLength?: string
   transactionId?: string
+  trace?: string
 }
 
 const loggingMiddleware = () => {
@@ -44,6 +46,7 @@ const loggingMiddleware = () => {
         // Define our own token for client ip
         // req.headers['cf-connecting-ip'] : Cloudflare
         // req.ip : Contains the remote IP address of the request.
+        // trace: use cloudflare cf-ray header, with x-request-id header as backup
         // If trust proxy setting is true, the value of this property is
         // derived from the left-most entry in the X-Forwarded-For header.
         // This header can be set by the client or by the proxy.
@@ -52,6 +55,7 @@ const loggingMiddleware = () => {
         // req.connection.remoteAddress.
         clientIp: req.get('cf-connecting-ip') || req.ip,
         userId: get(req, 'session.user._id', ''),
+        trace: getTrace(req),
       }
 
       const contentLength = res.get('content-length')


### PR DESCRIPTION
## Problem

Implements tracing for (https://github.com/datagovsg/formsg-private/issues/25)

## Solution

Add trace to logs using cloudflare cf-ray header. If cf-ray does not exist, trace using x-request-id header

## Tests

**On staging**
- [ ] At the login page, key in an invalid email address abc@abc.com. Check that the value of cf-ray header is logged under trace in the server logs error message.
- [ ] Access a public form. Check that the value of cf-ray header is logged under trace in the server logs for the get request.

**On localhost**
- [ ] At the login page, key in an invalid email address abc@abc.com. Check that the value of x-request-id header is logged under trace in the server logs error message.
- [ ] In L162-L164 of `logger.ts`, replace
```
isDev
  ? format.combine(format.colorize(), errorPrinter(), customFormat)
  : format.json({ replacer: jsonErrorReplacer }),
```
with 
``` 
format.json({ replacer: jsonErrorReplacer }),
```
Access a public form. Check that the value of x-request-id header is logged under trace in the server logs for the get request. 

## New dependencies

- express-request-id^1.4.1
