### PR TITLE
refactor: use res.json or sendStatus for objects or empty body

### DIFF
--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -583,7 +583,7 @@ exports.getExampleFormsUsingAggregateCollection = function (req, res) {
           },
           error,
         })
-      return res.status(status).send(result)
+      return res.status(status).json(result)
     },
   )
 }
@@ -617,7 +617,7 @@ exports.getExampleFormsUsingSubmissionsCollection = function (req, res) {
           error,
         })
       }
-      return res.status(status).send(result)
+      return res.status(status).json(result)
     },
   )
 }
@@ -708,7 +708,7 @@ exports.getSingleExampleFormUsingSubmissionCollection = function (req, res) {
           error,
         })
       }
-      return res.status(status).send(result)
+      return res.status(status).json(result)
     },
   )
 }
@@ -737,7 +737,7 @@ exports.getSingleExampleFormUsingAggregateCollection = function (req, res) {
           error: err,
         })
       }
-      return res.status(status).send(result)
+      return res.status(status).json(result)
     },
   )
 }
@@ -836,7 +836,7 @@ exports.getLoginStats = function (req, res) {
           },
         })
 
-        return res.send({
+        return res.json({
           loginStats,
         })
       }

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -91,7 +91,7 @@ function makeModule(connection) {
         statusCode = StatusCodes.INTERNAL_SERVER_ERROR
       }
 
-      return res.status(statusCode).send({
+      return res.status(statusCode).json({
         message: errorHandler.getMongoErrorMessage(err),
       })
     }
@@ -220,7 +220,7 @@ function makeModule(connection) {
      */
     isFormActive: function (req, res, next) {
       if (req.form.status === 'ARCHIVED') {
-        return res.status(StatusCodes.NOT_FOUND).send({
+        return res.status(StatusCodes.NOT_FOUND).json({
           message: 'Form has been archived',
         })
       } else {
@@ -235,7 +235,7 @@ function makeModule(connection) {
      */
     isFormEncryptMode: function (req, res, next) {
       if (req.form.responseMode !== 'encrypt') {
-        return res.status(StatusCodes.UNPROCESSABLE_ENTITY).send({
+        return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
           message: 'Form is not encrypt mode',
         })
       }
@@ -248,7 +248,7 @@ function makeModule(connection) {
      */
     create: function (req, res) {
       if (!req.body.form) {
-        return res.status(StatusCodes.BAD_REQUEST).send({
+        return res.status(StatusCodes.BAD_REQUEST).json({
           message: 'Invalid Input',
         })
       }
@@ -297,7 +297,7 @@ function makeModule(connection) {
           })
           return res
             .status(StatusCodes.BAD_REQUEST)
-            .send({ message: 'Invalid update to form' })
+            .json({ message: 'Invalid update to form' })
         } else {
           const { error, formFields } = getEditedFormFields(
             _.cloneDeep(form.form_fields),
@@ -314,7 +314,7 @@ function makeModule(connection) {
               },
               error,
             })
-            return res.status(StatusCodes.BAD_REQUEST).send({ message: error })
+            return res.status(StatusCodes.BAD_REQUEST).json({ message: error })
           }
           form.form_fields = formFields
           delete updatedForm.editFormField
@@ -377,7 +377,7 @@ function makeModule(connection) {
         } else if (!form) {
           return res
             .status(StatusCodes.NOT_FOUND)
-            .send({ message: 'Form not found for duplication' })
+            .json({ message: 'Form not found for duplication' })
         } else {
           let responseMode = req.body.responseMode || 'email'
           // Custom properties on the new form
@@ -453,7 +453,7 @@ function makeModule(connection) {
           if (err) {
             return respondOnMongoError(req, res, err)
           } else if (!forms) {
-            return res.status(StatusCodes.NOT_FOUND).send({
+            return res.status(StatusCodes.NOT_FOUND).json({
               message: 'No user-created and collaborated-on forms found',
             })
           }
@@ -477,7 +477,7 @@ function makeModule(connection) {
         } else if (!feedback) {
           return res
             .status(StatusCodes.NOT_FOUND)
-            .send({ message: 'No feedback found' })
+            .json({ message: 'No feedback found' })
         } else {
           let sum = 0
           let count = 0
@@ -530,7 +530,7 @@ function makeModule(connection) {
             },
             error: err,
           })
-          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
             message: errorHandler.getMongoErrorMessage(err),
           })
         } else {
@@ -558,7 +558,7 @@ function makeModule(connection) {
             },
             error: err,
           })
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
             message: 'Error retrieving from database.',
           })
         })
@@ -573,7 +573,7 @@ function makeModule(connection) {
             },
             error: err,
           })
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
             message: 'Error converting feedback to JSON',
           })
         })
@@ -588,7 +588,7 @@ function makeModule(connection) {
             },
             error: err,
           })
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
             message: 'Error writing feedback to HTTP stream',
           })
         })
@@ -700,9 +700,9 @@ function makeModule(connection) {
               },
               error: err,
             })
-            return res.status(StatusCodes.BAD_REQUEST).send(err)
+            return res.status(StatusCodes.BAD_REQUEST).json(err)
           } else {
-            return res.status(StatusCodes.OK).send(presignedPostObject)
+            return res.status(StatusCodes.OK).json(presignedPostObject)
           }
         },
       )
@@ -748,9 +748,9 @@ function makeModule(connection) {
               },
               error: err,
             })
-            return res.status(StatusCodes.BAD_REQUEST).send(err)
+            return res.status(StatusCodes.BAD_REQUEST).json(err)
           } else {
-            return res.status(StatusCodes.OK).send(presignedPostObject)
+            return res.status(StatusCodes.OK).json(presignedPostObject)
           }
         },
       )
@@ -779,7 +779,7 @@ function makeModule(connection) {
           },
           err,
         })
-        return res.status(StatusCodes.CONFLICT).send({ message: err.message })
+        return res.status(StatusCodes.CONFLICT).json({ message: err.message })
       }
       req.form.save(function (err, savedForm) {
         if (err) return respondOnMongoError(req, res, err)

--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -20,7 +20,7 @@ exports.authenticateUser = function (req, res, next) {
   } else {
     return res
       .status(StatusCodes.UNAUTHORIZED)
-      .send({ message: 'User is unauthorized.' })
+      .json({ message: 'User is unauthorized.' })
   }
 }
 
@@ -80,7 +80,7 @@ exports.verifyPermission = (requiredPermission) =>
     // Forbidden if requiredPersmission is admin but user is not
     if (!isFormAdmin && requiredPermission === PERMISSIONS.DELETE) {
       logUnauthorizedAccess(req, 'verifyPermission', requiredPermission)
-      return res.status(StatusCodes.FORBIDDEN).send({
+      return res.status(StatusCodes.FORBIDDEN).json({
         message: makeUnauthorizedMessage(
           req.session.user.email,
           req.form.title,
@@ -114,7 +114,7 @@ exports.verifyPermission = (requiredPermission) =>
 
     if (!hasSufficientPermission) {
       logUnauthorizedAccess(req, 'verifyPermission', requiredPermission)
-      return res.status(StatusCodes.FORBIDDEN).send({
+      return res.status(StatusCodes.FORBIDDEN).json({
         message: makeUnauthorizedMessage(
           req.session.user.email,
           req.form.title,

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -62,7 +62,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       },
       error: err,
     })
-    return res.status(StatusCodes.BAD_REQUEST).send({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'Required headers are missing',
     })
   }
@@ -133,7 +133,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       })
       return res
         .status(StatusCodes.REQUEST_TOO_LONG)
-        .send({ message: 'Your submission is too large.' })
+        .json({ message: 'Your submission is too large.' })
     }
 
     // Log hash of submission for incident investigation purposes
@@ -176,13 +176,13 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
             formId: req.form._id,
           },
         })
-        return res.status(StatusCodes.BAD_REQUEST).send({
+        return res.status(StatusCodes.BAD_REQUEST).json({
           message: 'Some files were invalid. Try uploading another file.',
         })
       }
 
       if (areAttachmentsMoreThan7MB(attachments)) {
-        return res.status(StatusCodes.UNPROCESSABLE_ENTITY).send({
+        return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
           message: 'Please keep the size of your attachments under 7MB.',
         })
       }
@@ -206,7 +206,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .send({ message: 'Unable to process submission.' })
+        .json({ message: 'Unable to process submission.' })
     }
   })
 
@@ -223,7 +223,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
     })
     return res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .send({ message: 'Unable to process submission.' })
+      .json({ message: 'Unable to process submission.' })
   })
 
   req.pipe(busboy)
@@ -259,12 +259,12 @@ exports.validateEmailSubmission = function (req, res, next) {
         error: err,
       })
       if (err instanceof ConflictError) {
-        return res.status(err.status).send({
+        return res.status(err.status).json({
           message:
             'The form has been updated. Please refresh and submit again.',
         })
       } else {
-        return res.status(StatusCodes.BAD_REQUEST).send({
+        return res.status(StatusCodes.BAD_REQUEST).json({
           message:
             'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
         })
@@ -516,7 +516,7 @@ function onSubmissionEmailFailure(err, req, res, submission) {
     },
     error: err,
   })
-  return res.status(StatusCodes.BAD_REQUEST).send({
+  return res.status(StatusCodes.BAD_REQUEST).json({
     message:
       'Could not send submission. For assistance, please contact the person who asked you to fill in this form.',
     submissionId: submission._id,

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -53,7 +53,7 @@ exports.validateEncryptSubmission = function (req, res, next) {
     })
     return res
       .status(StatusCodes.BAD_REQUEST)
-      .send({ message: 'Invalid data was found. Please submit again.' })
+      .json({ message: 'Invalid data was found. Please submit again.' })
   }
 
   if (req.body.responses) {
@@ -72,12 +72,12 @@ exports.validateEncryptSubmission = function (req, res, next) {
         error: err,
       })
       if (err instanceof ConflictError) {
-        return res.status(err.status).send({
+        return res.status(err.status).json({
           message:
             'The form has been updated. Please refresh and submit again.',
         })
       } else {
-        return res.status(StatusCodes.BAD_REQUEST).send({
+        return res.status(StatusCodes.BAD_REQUEST).json({
           message:
             'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
         })
@@ -121,7 +121,7 @@ function onEncryptSubmissionFailure(err, req, res, submission) {
     },
     error: err,
   })
-  return res.status(StatusCodes.BAD_REQUEST).send({
+  return res.status(StatusCodes.BAD_REQUEST).json({
     message:
       'Could not send submission. For assistance, please contact the person who asked you to fill in this form.',
     submissionId: submission._id,
@@ -256,12 +256,12 @@ exports.getMetadata = function (req, res) {
               },
               error: err,
             })
-            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
               message: errorHandler.getMongoErrorMessage(err),
             })
           }
           if (!result) {
-            return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+            return res.status(HttpStatus.OK).json({ metadata: [], count: 0 })
           }
           let entry = {
             number: 1,
@@ -270,10 +270,10 @@ exports.getMetadata = function (req, res) {
               .tz('Asia/Singapore')
               .format('Do MMM YYYY, h:mm:ss a'),
           }
-          return res.status(HttpStatus.OK).send({ metadata: [entry], count: 1 })
+          return res.status(HttpStatus.OK).json({ metadata: [entry], count: 1 })
         })
     } else {
-      return res.status(HttpStatus.OK).send({ metadata: [], count: 0 })
+      return res.status(HttpStatus.OK).json({ metadata: [], count: 0 })
     }
   } else {
     Submission.aggregate([
@@ -331,7 +331,7 @@ exports.getMetadata = function (req, res) {
             },
             error: err,
           })
-          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
             message: errorHandler.getMongoErrorMessage(err),
           })
         } else {
@@ -350,7 +350,7 @@ exports.getMetadata = function (req, res) {
             number--
             return entry
           })
-          return res.status(StatusCodes.OK).send({ metadata, count })
+          return res.status(StatusCodes.OK).json({ metadata, count })
         }
       })
   }
@@ -391,7 +391,7 @@ exports.getEncryptedResponse = function (req, res) {
         },
         error: err,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
         message: errorHandler.getMongoErrorMessage(err),
       })
     } else {
@@ -427,7 +427,7 @@ exports.streamEncryptedResponses = async function (req, res) {
     isMalformedDate(req.query.startDate) ||
     isMalformedDate(req.query.endDate)
   ) {
-    return res.status(StatusCodes.BAD_REQUEST).send({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'Malformed date parameter',
     })
   }
@@ -466,7 +466,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         },
         error: err,
       })
-      res.status(500).send({
+      res.status(500).json({
         message: 'Error retrieving from database.',
       })
     })
@@ -483,7 +483,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         },
         error: err,
       })
-      res.status(500).send({
+      res.status(500).json({
         message: 'Error converting submissions to JSON',
       })
     })
@@ -498,7 +498,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         },
         error: err,
       })
-      res.status(500).send({
+      res.status(500).json({
         message: 'Error writing submissions to HTTP stream',
       })
     })

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -75,7 +75,7 @@ exports.read = (requestType) =>
       form = _.pick(form, formPublicFields)
     }
 
-    return res.send({
+    return res.json({
       form,
       spcpSession,
       myInfoError,
@@ -95,20 +95,20 @@ exports.formById = async function (req, res, next) {
   let id = req.params && req.params.formId
 
   if (!mongoose.Types.ObjectId.isValid(id)) {
-    return res.status(StatusCodes.BAD_REQUEST).send({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'Form URL is invalid.',
     })
   }
   try {
     const form = await Form.getFullFormById(id)
     if (!form) {
-      return res.status(StatusCodes.NOT_FOUND).send({
+      return res.status(StatusCodes.NOT_FOUND).json({
         message: "Oops! We can't find the form you're looking for.",
       })
     } else {
       // Remove sensitive information from User object
       if (!form.admin) {
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
           message: 'Server error.',
         })
       }

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -199,7 +199,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
             },
             error: err,
           })
-          return res.status(StatusCodes.SERVICE_UNAVAILABLE).send({
+          return res.status(StatusCodes.SERVICE_UNAVAILABLE).json({
             message: 'MyInfo verification unavailable, please try again later.',
             spcpSubmissionFailure: true,
           })
@@ -215,7 +215,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
               formId: formObjId,
             },
           })
-          return res.status(StatusCodes.GONE).send({
+          return res.status(StatusCodes.GONE).json({
             message:
               'MyInfo verification expired, please refresh and try again.',
             spcpSubmissionFailure: true,
@@ -264,7 +264,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
                   failedFields: hashFailedAttrs,
                 },
               })
-              return res.status(StatusCodes.UNAUTHORIZED).send({
+              return res.status(StatusCodes.UNAUTHORIZED).json({
                 message: 'MyInfo verification failed.',
                 spcpSubmissionFailure: true,
               })

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -24,7 +24,7 @@ exports.isFormPublic = function (req, res, next) {
     case 'ARCHIVED':
       return res.sendStatus(StatusCodes.GONE)
     default:
-      return res.status(StatusCodes.NOT_FOUND).send({
+      return res.status(StatusCodes.NOT_FOUND).json({
         message: req.form.inactiveMessage,
         isPageFound: true, // Flag to prevent default 404 subtext ("please check link") from showing
         formTitle: req.form.title,

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -112,7 +112,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
     const payloads = String(relayState).split(',')
 
     if (payloads.length !== 2) {
-      return res.status(StatusCodes.BAD_REQUEST).send()
+      return res.sendStatus(StatusCodes.BAD_REQUEST)
     }
 
     const destination = payloads[0]
@@ -126,7 +126,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
         authType,
       )
     ) {
-      res.status(StatusCodes.UNAUTHORIZED).send()
+      res.sendStatus(StatusCodes.UNAUTHORIZED)
       return
     }
 
@@ -134,11 +134,11 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
     samlArt = String(samlArt).replace(/ /g, '+')
 
     if (!destinationIsValid(destination))
-      return res.status(StatusCodes.BAD_REQUEST).send()
+      return res.sendStatus(StatusCodes.BAD_REQUEST)
 
     getForm(destination, (err, form) => {
       if (err || !form || form.authType !== authType) {
-        res.status(StatusCodes.NOT_FOUND).send()
+        res.sendStatus(StatusCodes.NOT_FOUND)
         return
       }
       authClient.getAttributes(samlArt, destination, (err, data) => {
@@ -225,7 +225,7 @@ exports.createSpcpRedirectURL = (authClients) => {
 }
 
 exports.returnSpcpRedirectURL = function (req, res) {
-  return res.status(StatusCodes.OK).send({ redirectURL: req.redirectURL })
+  return res.status(StatusCodes.OK).json({ redirectURL: req.redirectURL })
 }
 
 const getSubstringBetween = (text, markerStart, markerEnd) => {
@@ -266,12 +266,12 @@ exports.validateESrvcId = (req, res) => {
             data,
           },
         })
-        return res.status(StatusCodes.BAD_GATEWAY).send({
+        return res.status(StatusCodes.BAD_GATEWAY).json({
           message: 'Singpass returned incomprehensible content',
         })
       }
       if (title.indexOf('Error') === -1) {
-        return res.status(StatusCodes.OK).send({
+        return res.status(StatusCodes.OK).json({
           isValid: true,
         })
       }
@@ -282,7 +282,7 @@ exports.validateESrvcId = (req, res) => {
         'System Code:&nbsp<b>',
         '</b>',
       )
-      return res.status(StatusCodes.OK).send({
+      return res.status(StatusCodes.OK).json({
         isValid: false,
         errorCode,
       })
@@ -299,7 +299,7 @@ exports.validateESrvcId = (req, res) => {
         },
         error: err,
       })
-      return res.status(StatusCodes.SERVICE_UNAVAILABLE).send({
+      return res.status(StatusCodes.SERVICE_UNAVAILABLE).json({
         message: 'Failed to contact Singpass',
       })
     })
@@ -425,7 +425,7 @@ exports.encryptedVerifiedFields = (signingSecretKey) => {
       })
       return res
         .status(StatusCodes.BAD_REQUEST)
-        .send({ message: 'Invalid data was found. Please submit again.' })
+        .json({ message: 'Invalid data was found. Please submit again.' })
     }
   }
 }
@@ -494,7 +494,7 @@ exports.isSpcpAuthenticated = (authClients) => {
             },
             error: err,
           })
-          res.status(StatusCodes.UNAUTHORIZED).send({
+          res.status(StatusCodes.UNAUTHORIZED).json({
             message: 'User is not SPCP authenticated',
             spcpSubmissionFailure: true,
           })

--- a/src/app/controllers/submissions.server.controller.js
+++ b/src/app/controllers/submissions.server.controller.js
@@ -28,7 +28,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
       return next()
     } else {
       if (!captchaPrivateKey) {
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
           message: 'Captcha not set-up',
         })
       } else if (!req.query.captchaResponse) {
@@ -41,7 +41,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
             trace: getTrace(req),
           },
         })
-        return res.status(StatusCodes.BAD_REQUEST).send({
+        return res.status(StatusCodes.BAD_REQUEST).json({
           message: 'Captcha was missing. Please refresh and submit again.',
         })
       } else {
@@ -64,7 +64,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
                   trace: getTrace(req),
                 },
               })
-              return res.status(StatusCodes.BAD_REQUEST).send({
+              return res.status(StatusCodes.BAD_REQUEST).json({
                 message: 'Captcha was incorrect. Please submit again.',
               })
             }
@@ -82,7 +82,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
               },
               error: err,
             })
-            return res.status(StatusCodes.BAD_REQUEST).send({
+            return res.status(StatusCodes.BAD_REQUEST).json({
               message:
                 'Could not verify captcha. Please submit again in a few minutes.',
             })
@@ -208,7 +208,7 @@ exports.count = function (req, res) {
     isMalformedDate(req.query.startDate) ||
     isMalformedDate(req.query.endDate)
   ) {
-    return res.status(StatusCodes.BAD_REQUEST).send({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'Malformed date parameter',
     })
   }
@@ -234,7 +234,7 @@ exports.count = function (req, res) {
         error: err,
       })
 
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
         message: errorHandler.getMongoErrorMessage(err),
       })
     } else {
@@ -246,7 +246,7 @@ exports.count = function (req, res) {
 exports.sendAutoReply = function (req, res) {
   const { form, submission } = req
   // Return the reply early to the submitter
-  res.send({
+  res.json({
     message: 'Form submission successful.',
     submissionId: submission.id,
   })

--- a/src/app/factories/google-analytics.factory.js
+++ b/src/app/factories/google-analytics.factory.js
@@ -10,7 +10,7 @@ const googleAnalyticsFactory = ({ isEnabled }) => {
   } else {
     return {
       datalayer: (req, res) => {
-        res.type('text/javascript').status(StatusCodes.OK).send()
+        res.type('text/javascript').sendStatus(StatusCodes.OK)
       },
     }
   }

--- a/src/app/factories/spcp-myinfo.factory.js
+++ b/src/app/factories/spcp-myinfo.factory.js
@@ -138,17 +138,17 @@ const spcpFactory = ({ isEnabled, props }) => {
         }),
       verifyMyInfoVals: (req, res, next) => next(),
       returnSpcpRedirectURL: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       singPassLogin: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       corpPassLogin: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       addSpcpSessionInfo: (req, res, next) => next(),
       isSpcpAuthenticated: (req, res, next) => next(),
       createSpcpRedirectURL: (req, res, next) => next(),
       addMyInfo: (req, res, next) => next(),
       validateESrvcId: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
     }
   }
 }

--- a/src/app/factories/spcp-myinfo.factory.js
+++ b/src/app/factories/spcp-myinfo.factory.js
@@ -133,7 +133,7 @@ const spcpFactory = ({ isEnabled, props }) => {
       encryptedVerifiedFields: (req, res, next) => next(),
       passThroughSpcp: (req, res, next) => next(),
       getLoginStats: (req, res) =>
-        res.send({
+        res.json({
           loginStats: [],
         }),
       verifyMyInfoVals: (req, res, next) => next(),

--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -183,7 +183,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.send).toBeCalledWith(mockUser.toObject())
+      expect(mockRes.json).toBeCalledWith(mockUser.toObject())
     })
 
     it('should return with ApplicationError status and message when retrieving agency returns an ApplicationError', async () => {

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -171,7 +171,7 @@ export const handleLoginVerifyOtp: RequestHandler<
           meta: logMeta,
         })
 
-        return res.status(StatusCodes.OK).send(userObj)
+        return res.status(StatusCodes.OK).json(userObj)
       })
       // Step 3b: Error occured in one of the steps.
       .mapErr((error) => {

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -97,7 +97,7 @@ export const handleContactVerifyOtp: RequestHandler<
   // No error, update user with given contact.
   try {
     const updatedUser = await updateUserContact(contact, userId)
-    return res.status(StatusCodes.OK).send(updatedUser)
+    return res.status(StatusCodes.OK).json(updatedUser)
   } catch (updateErr) {
     // Handle update error.
     logger.warn({
@@ -135,7 +135,7 @@ export const handleFetchUser: RequestHandler = async (req, res) => {
       .send('Unable to retrieve user')
   }
 
-  return res.send(retrievedUser)
+  return res.json(retrievedUser)
 }
 
 // TODO(#212): Save userId instead of entire user collection in session.

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -30,15 +30,15 @@ const verifiedFieldsFactory = ({
     const errMsg = 'Verified fields feature is not enabled'
     return {
       createTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       getTransactionMetadata: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       resetFieldInTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       getNewOtp: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       verifyOtp: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(errMsg),
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
     }
   }
 }

--- a/src/app/routes/frontend.server.routes.js
+++ b/src/app/routes/frontend.server.routes.js
@@ -22,6 +22,6 @@ module.exports = function (app) {
   )
 
   app.route('/frontend/features').get((req, res) => {
-    res.send(featureManager.states)
+    res.json(featureManager.states)
   })
 }

--- a/src/loaders/express/error-handler.ts
+++ b/src/loaders/express/error-handler.ts
@@ -54,7 +54,7 @@ const errorHandlerMiddlewares = (): (
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .send({ message: genericErrorMessage })
+        .json({ message: genericErrorMessage })
     }
   }
 
@@ -63,7 +63,7 @@ const errorHandlerMiddlewares = (): (
     _req,
     res,
   ) {
-    res.status(StatusCodes.NOT_FOUND).send()
+    res.sendStatus(StatusCodes.NOT_FOUND)
   }
 
   return [genericErrorHandlerMiddleware, catchNonExistentRoutesMiddleware]

--- a/tests/unit/backend/controllers/forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/forms.server.controller.spec.js
@@ -57,7 +57,7 @@ describe('Form Controller', () => {
         'betaFlags',
       ])
       Controller.read(Controller.REQUEST_TYPE.ADMIN)(req, res)
-      expect(res.send).toHaveBeenCalledWith({
+      expect(res.json).toHaveBeenCalledWith({
         form: expectedForm,
         spcpSession: res.locals.spcpSession,
         myInfoError: res.locals.myInfoError,
@@ -95,7 +95,7 @@ describe('Form Controller', () => {
       ])
 
       Controller.read(Controller.REQUEST_TYPE.PUBLIC)(req, res)
-      expect(res.send).toHaveBeenCalledWith({
+      expect(res.json).toHaveBeenCalledWith({
         form: expectedForm,
         spcpSession: res.locals.spcpSession,
         myInfoError: res.locals.myInfoError,

--- a/tests/unit/backend/controllers/myinfo.server.controller.spec.js
+++ b/tests/unit/backend/controllers/myinfo.server.controller.spec.js
@@ -686,6 +686,7 @@ describe('MyInfo Controller', () => {
                 ),
               ).toBeTruthy()
               expect(res.send).not.toHaveBeenCalled()
+              expect(res.json).not.toHaveBeenCalled()
               done()
             })
             Controller.verifyMyInfoVals(req, res, next)

--- a/tests/unit/backend/controllers/spcp.server.controller.spec.js
+++ b/tests/unit/backend/controllers/spcp.server.controller.spec.js
@@ -67,6 +67,7 @@ describe('SPCP Controller', () => {
       'redirect',
       'cookie',
       'locals',
+      'sendStatus',
     ])
     res.status.and.returnValue(res)
     res.send.and.returnValue(res)
@@ -155,9 +156,11 @@ describe('SPCP Controller', () => {
   }
 
   const expectResponse = (code, content) => {
-    expect(res.status).toHaveBeenCalledWith(code)
     if (content) {
-      expect(res.send).toHaveBeenCalledWith(content)
+      expect(res.status).toHaveBeenCalledWith(code)
+      expect(res.json).toHaveBeenCalledWith(content)
+    } else {
+      expect(res.sendStatus).toHaveBeenCalledWith(code)
     }
   }
 
@@ -177,22 +180,26 @@ describe('SPCP Controller', () => {
     it('should return 400 if target not provided', () => {
       req.query.target = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
-      expectResponse(StatusCodes.BAD_REQUEST)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
     })
 
     it('should return 400 if authType not provided', () => {
       req.query.authType = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
-      expectResponse(StatusCodes.BAD_REQUEST)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
     })
     it('should return 400 if esrvcId not provided', () => {
       req.query.esrvcId = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
-      expectResponse(StatusCodes.BAD_REQUEST)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
     })
     it('should return 400 if authType is NIL', () => {
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
-      expectResponse(StatusCodes.BAD_REQUEST)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
     })
     it('should return 200 and redirectUrl if authType is SP', () => {
       req.query.authType = 'SP'
@@ -363,7 +370,7 @@ describe('SPCP Controller', () => {
     let expectedRelayState
 
     const expectBadRequestOnLogin = (statusCode, done) => {
-      res.status.and.callFake((status) => {
+      res.sendStatus.and.callFake((status) => {
         expect(status).toEqual(statusCode)
         done()
         return res

--- a/tests/unit/backend/modules/user/user.controller.spec.ts
+++ b/tests/unit/backend/modules/user/user.controller.spec.ts
@@ -200,7 +200,7 @@ describe('user.controller', () => {
         MOCK_REQ.body.userId,
       )
       expect(mockRes.status).toBeCalledWith(StatusCodes.OK)
-      expect(mockRes.send).toBeCalledWith(MOCK_UPDATED_USER)
+      expect(mockRes.json).toBeCalledWith(MOCK_UPDATED_USER)
     })
 
     it('should return 401 when user id is not in session', async () => {
@@ -348,7 +348,7 @@ describe('user.controller', () => {
       await UserController.handleFetchUser(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
-      expect(mockRes.send).toBeCalledWith(mockPopulatedUser)
+      expect(mockRes.json).toBeCalledWith(mockPopulatedUser)
     })
 
     it('should return 401 when user id is not in session', async () => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Usage of `res.send` creates the risk of HTML injection attacks if not used with care. Using `res.json` is better practice.

## Solution
<!-- How did you solve the problem? -->

**This PR addresses the cases where changing from `res.status` to `res.json` or `res.sendStatus` should be risk-free.**

When `res.send` is called with an object, it behaves the same way as if `res.json` is called, since Express just [calls `res.json` internally](https://github.com/expressjs/express/blob/508936853a6e311099c9985d4c11a4b1b8f6af07/lib/response.js#L158). Moreover, when `res.send` is called with no argument, it is (almost) equivalent to calling `res.sendStatus`, since the client should not be doing anything with the empty response body. This PR addresses these two cases throughout the codebase by changing `res.send` to `res.json` or `res.sendStatus` as necessary.