### PR TITLE
refactor: use res.json if backwards compatible with client

### DIFF
--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -820,11 +820,11 @@ exports.getLoginStats = function (req, res) {
         })
         return res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .send('Error in retrieving billing records')
+          .json({ message: 'Error in retrieving billing records' })
       } else if (!loginStats) {
         return res
           .status(StatusCodes.NOT_FOUND)
-          .send('No billing records found')
+          .json({ message: 'No billing records found' })
       } else {
         logger.info({
           message: `Billing search for ${esrvcId} by ${

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -612,9 +612,11 @@ function makeModule(connection) {
       ) {
         return res
           .status(StatusCodes.BAD_REQUEST)
-          .send('Form feedback data not passed in')
+          .json({ message: 'Form feedback data not passed in' })
       } else {
-        return res.status(StatusCodes.OK).send('Successfully received feedback')
+        return res
+          .status(StatusCodes.OK)
+          .json({ message: 'Successfully received feedback' })
       }
     },
     /**

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -82,7 +82,7 @@ exports.submitFeedback = function (req, res) {
   ) {
     return res
       .status(StatusCodes.BAD_REQUEST)
-      .send('Form feedback data not passed in')
+      .json({ message: 'Form feedback data not passed in' })
   }
 
   FormFeedback.create(
@@ -104,11 +104,11 @@ exports.submitFeedback = function (req, res) {
         })
         return res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .send('Form feedback could not be created')
+          .json({ message: 'Form feedback could not be created' })
       } else {
         return res
           .status(StatusCodes.OK)
-          .send('Successfully submitted feedback')
+          .json({ message: 'Successfully submitted feedback' })
       }
     },
   )

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -219,7 +219,9 @@ exports.createSpcpRedirectURL = (authClients) => {
       req.redirectURL = authClient.createRedirectURL(target, esrvcId)
       return next()
     } else {
-      return res.status(StatusCodes.BAD_REQUEST).send('Redirect URL malformed')
+      return res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Redirect URL malformed' })
     }
   }
 }

--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -294,7 +294,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.send).toBeCalledWith('Sign out successful')
+      expect(mockRes.json).toBeCalledWith({ message: 'Sign out successful' })
       expect(mockClearCookie).toBeCalledTimes(1)
       expect(mockDestroy).toBeCalledTimes(1)
     })
@@ -335,7 +335,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.send).toBeCalledWith('Sign out failed')
+      expect(mockRes.json).toBeCalledWith({ message: 'Sign out failed' })
       expect(mockDestroyWithErr).toBeCalledTimes(1)
       expect(mockClearCookie).not.toBeCalled()
     })

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -35,7 +35,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -49,7 +51,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -124,7 +128,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -138,7 +144,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -256,7 +264,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.otp is not provided as a param', async () => {
@@ -267,7 +277,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -281,7 +293,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.otp is less than 6 digits', async () => {
@@ -293,7 +307,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 400 when body.otp is 6 characters but does not consist purely of digits', async () => {
@@ -305,7 +321,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual('Some required parameters are missing')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Some required parameters are missing' }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -487,7 +505,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(200)
-      expect(response.text).toEqual('Sign out successful')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Sign out successful' }),
+      )
       // connect.sid should now be empty.
       expect(response.header['set-cookie'][0]).toEqual(
         expect.stringContaining('connect.sid=;'),
@@ -504,7 +524,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(200)
-      expect(response.text).toEqual('Sign out successful')
+      expect(response.text).toEqual(
+        JSON.stringify({ message: 'Sign out successful' }),
+      )
     })
   })
 })

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -212,11 +212,11 @@ export const handleSignout: RequestHandler = async (req, res) => {
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .send('Sign out failed')
+        .json({ message: 'Sign out failed' })
     }
 
     // No error.
     res.clearCookie('connect.sid')
-    return res.status(StatusCodes.OK).send('Sign out successful')
+    return res.status(StatusCodes.OK).json({ message: 'Sign out successful' })
   })
 }

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -115,7 +115,9 @@ export const handleContactVerifyOtp: RequestHandler<
 export const handleFetchUser: RequestHandler = async (req, res) => {
   const sessionUserId = getUserIdFromSession(req.session)
   if (!sessionUserId) {
-    return res.status(StatusCodes.UNAUTHORIZED).send('User is unauthorized.')
+    return res
+      .status(StatusCodes.UNAUTHORIZED)
+      .json({ message: 'User is unauthorized.' })
   }
 
   // Retrieve user with id in session
@@ -132,7 +134,7 @@ export const handleFetchUser: RequestHandler = async (req, res) => {
     })
     return res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .send('Unable to retrieve user')
+      .json({ message: 'Unable to retrieve user' })
   }
 
   return res.json(retrievedUser)

--- a/src/loaders/express/error-handler.ts
+++ b/src/loaders/express/error-handler.ts
@@ -42,7 +42,7 @@ const errorHandlerMiddlewares = (): (
         })
         return res
           .status(StatusCodes.BAD_REQUEST)
-          .send('Some required parameters are missing')
+          .json({ message: 'Some required parameters are missing' })
       }
 
       logger.error({

--- a/tests/unit/backend/controllers/public-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/public-forms.server.controller.spec.js
@@ -170,7 +170,7 @@ describe('Public-Forms Controller', () => {
         expect(args).toBe(StatusCodes.OK)
         return res
       })
-      res.send.and.callFake(() => {
+      res.json.and.callFake(() => {
         FormFeedback.findOne(
           {
             formId: req.params.formId,

--- a/tests/unit/backend/controllers/spcp.server.controller.spec.js
+++ b/tests/unit/backend/controllers/spcp.server.controller.spec.js
@@ -181,25 +181,33 @@ describe('SPCP Controller', () => {
       req.query.target = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(res.status).toHaveBeenCalledWith(400)
-      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Redirect URL malformed',
+      })
     })
 
     it('should return 400 if authType not provided', () => {
       req.query.authType = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(res.status).toHaveBeenCalledWith(400)
-      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Redirect URL malformed',
+      })
     })
     it('should return 400 if esrvcId not provided', () => {
       req.query.esrvcId = ''
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(res.status).toHaveBeenCalledWith(400)
-      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Redirect URL malformed',
+      })
     })
     it('should return 400 if authType is NIL', () => {
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(res.status).toHaveBeenCalledWith(400)
-      expect(res.send).toHaveBeenCalledWith('Redirect URL malformed')
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Redirect URL malformed',
+      })
     })
     it('should return 200 and redirectUrl if authType is SP', () => {
       req.query.authType = 'SP'

--- a/tests/unit/backend/modules/user/user.controller.spec.ts
+++ b/tests/unit/backend/modules/user/user.controller.spec.ts
@@ -368,7 +368,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNAUTHORIZED)
-      expect(mockRes.send).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith({ message: 'User is unauthorized.' })
     })
 
     it('should return 500 when retrieved user is null', async () => {
@@ -382,7 +382,9 @@ describe('user.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(StatusCodes.INTERNAL_SERVER_ERROR)
-      expect(mockRes.send).toBeCalledWith('Unable to retrieve user')
+      expect(mockRes.json).toBeCalledWith({
+        message: 'Unable to retrieve user',
+      })
     })
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Usage of `res.send` creates the risk of HTML injection attacks if not used with care. Using `res.json` is better practice.

## Solution
<!-- How did you solve the problem? -->
**This PR addresses the cases where changing from `res.status` to `res.json` is compatible with the client.**
When the client does not use the content of the response body, it is safe to change `res.send` to `res.json`, wrapping the original string in an object. For example, the client sometimes does its own success/error handling, or simply logs errors to the console. This applies to the following API endpoints:
- `GET /billing`
- `POST /:formId/adminform/feedback`
- `POST /:formId/feedback`
- `GET /spcp/redirect`
- `GET /spcp/validate`
- `GET /auth/signout`
- `GET /user`
- Generic error handling for `celebrate` errors