### PR TITLE
chore: extend namespace globally for request properties and log info utility function

### DIFF
--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -20,7 +20,7 @@ const Form = getFormModel(mongoose)
 const _ = require('lodash')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getMeta, getTrace } = require('../utils/request')
 
 // Examples search-specific constants
 const PAGE_SIZE = 16 // maximum number of results to return
@@ -576,10 +576,7 @@ exports.getExampleFormsUsingAggregateCollection = function (req, res) {
           message: 'Failed to retrieve example forms',
           meta: {
             action: 'getExampleFormsUsingAggregateCollection',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           error,
         })
@@ -609,10 +606,7 @@ exports.getExampleFormsUsingSubmissionsCollection = function (req, res) {
           message: 'Failed to retrieve example forms',
           meta: {
             action: 'getExampleFormsUsingSubmissionsCollection',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           error,
         })
@@ -700,10 +694,7 @@ exports.getSingleExampleFormUsingSubmissionCollection = function (req, res) {
           message: 'Failed to retrieve a single example form',
           meta: {
             action: 'getSingleExampleFormUsingSubmissionCollection',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           error,
         })
@@ -729,10 +720,7 @@ exports.getSingleExampleFormUsingAggregateCollection = function (req, res) {
           message: 'Failed to retrieve single example form',
           meta: {
             action: 'getSingleExampleFormUsingAggregateCollection',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           error: err,
         })
@@ -811,10 +799,7 @@ exports.getLoginStats = function (req, res) {
           message: 'Failed to retrieve billing records',
           meta: {
             action: 'getLoginStats',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           error,
         })

--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -20,7 +20,7 @@ const Form = getFormModel(mongoose)
 const _ = require('lodash')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
-const { createReqMeta, getTrace } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 
 // Examples search-specific constants
 const PAGE_SIZE = 16 // maximum number of results to return
@@ -817,7 +817,7 @@ exports.getLoginStats = function (req, res) {
           }`,
           meta: {
             action: 'getLoginStats',
-            trace: getTrace(req),
+            ...createReqMeta(req),
           },
         })
 

--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -20,7 +20,7 @@ const Form = getFormModel(mongoose)
 const _ = require('lodash')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
-const { getMeta, getTrace } = require('../utils/request')
+const { createReqMeta, getTrace } = require('../utils/request')
 
 // Examples search-specific constants
 const PAGE_SIZE = 16 // maximum number of results to return
@@ -576,7 +576,7 @@ exports.getExampleFormsUsingAggregateCollection = function (req, res) {
           message: 'Failed to retrieve example forms',
           meta: {
             action: 'getExampleFormsUsingAggregateCollection',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           error,
         })
@@ -606,7 +606,7 @@ exports.getExampleFormsUsingSubmissionsCollection = function (req, res) {
           message: 'Failed to retrieve example forms',
           meta: {
             action: 'getExampleFormsUsingSubmissionsCollection',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           error,
         })
@@ -694,7 +694,7 @@ exports.getSingleExampleFormUsingSubmissionCollection = function (req, res) {
           message: 'Failed to retrieve a single example form',
           meta: {
             action: 'getSingleExampleFormUsingSubmissionCollection',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           error,
         })
@@ -720,7 +720,7 @@ exports.getSingleExampleFormUsingAggregateCollection = function (req, res) {
           message: 'Failed to retrieve single example form',
           meta: {
             action: 'getSingleExampleFormUsingAggregateCollection',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           error: err,
         })
@@ -799,7 +799,7 @@ exports.getLoginStats = function (req, res) {
           message: 'Failed to retrieve billing records',
           meta: {
             action: 'getLoginStats',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           error,
         })

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -11,7 +11,7 @@ const { StatusCodes } = require('http-status-codes')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const errorHandler = require('./errors.server.controller')
-const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const { FormLogoState } = require('../../types')
 
 const {
@@ -287,8 +287,7 @@ function makeModule(connection) {
             message: 'form_fields should not exist in updatedForm',
             meta: {
               action: 'makeModule.update',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
               formId: form._id,
             },
           })
@@ -305,8 +304,7 @@ function makeModule(connection) {
               message: 'Error getting edited form fields',
               meta: {
                 action: 'makeModule.update',
-                ip: getRequestIp(req),
-                trace: getTrace(req),
+                ...createReqMeta(req),
                 formId: form._id,
               },
               error,
@@ -547,8 +545,7 @@ function makeModule(connection) {
             message: 'Error streaming feedback from MongoDB',
             meta: {
               action: 'makeModule.streamFeedback',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -562,8 +559,7 @@ function makeModule(connection) {
             message: 'Error converting feedback to JSON',
             meta: {
               action: 'makeModule.streamFeedback',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -577,8 +573,7 @@ function makeModule(connection) {
             message: 'Error writing feedback to HTTP stream',
             meta: {
               action: 'makeModule.streamFeedback',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -691,8 +686,7 @@ function makeModule(connection) {
               message: 'Presigning post data encountered an error',
               meta: {
                 action: 'makeModule.streamFeedback',
-                ip: getRequestIp(req),
-                trace: getTrace(req),
+                ...createReqMeta(req),
               },
               error: err,
             })
@@ -739,8 +733,7 @@ function makeModule(connection) {
               message: 'Presigning post data encountered an error',
               meta: {
                 action: 'makeModule.streamFeedback',
-                ip: getRequestIp(req),
-                trace: getTrace(req),
+                ...createReqMeta(req),
               },
               error: err,
             })

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -11,7 +11,7 @@ const { StatusCodes } = require('http-status-codes')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const errorHandler = require('./errors.server.controller')
-const { getRequestIp, getTrace, getMeta } = require('../utils/request')
+const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
 const { FormLogoState } = require('../../types')
 
 const {
@@ -68,7 +68,7 @@ function makeModule(connection) {
         message: 'Responding to Mongo error',
         meta: {
           action: 'respondOnMongoError',
-          ...getMeta(req),
+          ...createReqMeta(req),
         },
         error: err,
       })
@@ -520,7 +520,7 @@ function makeModule(connection) {
             message: 'Error counting documents in FormFeedback',
             meta: {
               action: 'makeModule.countFeedback',
-              ...getMeta(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -768,7 +768,7 @@ function makeModule(connection) {
           message: err.message,
           meta: {
             action: 'makeModule.transferOwner',
-            ...getMeta(req),
+            ...createReqMeta(req),
           },
           err,
         })

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -11,7 +11,7 @@ const { StatusCodes } = require('http-status-codes')
 
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const errorHandler = require('./errors.server.controller')
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getRequestIp, getTrace, getMeta } = require('../utils/request')
 const { FormLogoState } = require('../../types')
 
 const {
@@ -68,10 +68,7 @@ function makeModule(connection) {
         message: 'Responding to Mongo error',
         meta: {
           action: 'respondOnMongoError',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
-          url: req.url,
-          headers: req.headers,
+          ...getMeta(req),
         },
         error: err,
       })
@@ -523,10 +520,7 @@ function makeModule(connection) {
             message: 'Error counting documents in FormFeedback',
             meta: {
               action: 'makeModule.countFeedback',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
-              url: req.url,
-              headers: req.headers,
+              ...getMeta(req),
             },
             error: err,
           })
@@ -774,10 +768,7 @@ function makeModule(connection) {
           message: err.message,
           meta: {
             action: 'makeModule.transferOwner',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
-            url: req.url,
-            headers: req.headers,
+            ...getMeta(req),
           },
           err,
         })

--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -5,7 +5,7 @@
  */
 const { StatusCodes } = require('http-status-codes')
 const PERMISSIONS = require('../utils/permission-levels').default
-const { getMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 
 /**
@@ -49,7 +49,7 @@ const logUnauthorizedAccess = (req, action, requiredPermission) => {
     message: msg,
     meta: {
       action: action,
-      ...getMeta(req),
+      ...createReqMeta(req),
     },
     error: Error(msg),
   })

--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -5,7 +5,7 @@
  */
 const { StatusCodes } = require('http-status-codes')
 const PERMISSIONS = require('../utils/permission-levels').default
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 
 /**
@@ -49,10 +49,7 @@ const logUnauthorizedAccess = (req, action, requiredPermission) => {
     message: msg,
     meta: {
       action: action,
-      ip: getRequestIp(req),
-      trace: getTrace(req),
-      url: req.url,
-      headers: req.headers,
+      ...getMeta(req),
     },
     error: Error(msg),
   })

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose')
 const { getEmailSubmissionModel } = require('../models/submission.server.model')
 const emailSubmission = getEmailSubmissionModel(mongoose)
 const { StatusCodes } = require('http-status-codes')
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getRequestIp, getTrace, getMeta } = require('../utils/request')
 const { ConflictError } = require('../modules/submission/submission.errors')
 const { MB } = require('../constants/filesize')
 const {
@@ -509,10 +509,7 @@ function onSubmissionEmailFailure(err, req, res, submission) {
     message: 'Error submitting email form',
     meta: {
       action: 'onSubmissionEmailFailure',
-      ip: getRequestIp(req),
-      trace: getTrace(req),
-      url: req.url,
-      headers: req.headers,
+      ...getMeta(req),
     },
     error: err,
   })

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose')
 const { getEmailSubmissionModel } = require('../models/submission.server.model')
 const emailSubmission = getEmailSubmissionModel(mongoose)
 const { StatusCodes } = require('http-status-codes')
-const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const { ConflictError } = require('../modules/submission/submission.errors')
 const { MB } = require('../constants/filesize')
 const {
@@ -56,8 +56,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       message: 'Busboy error',
       meta: {
         action: 'receiveEmailSubmissionUsingBusBoy',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         formId: _.get(req, 'form._id'),
       },
       error: err,
@@ -108,8 +107,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
           message: 'Invalid form data',
           meta: {
             action: 'receiveEmailSubmissionUsingBusBoy',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
+            ...createReqMeta(req),
             formId: req.form._id,
           },
           error: err,
@@ -126,8 +124,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
         message: 'Content is too large',
         meta: {
           action: 'receiveEmailSubmissionUsingBusBoy',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           formId: req.form._id,
         },
       })
@@ -157,8 +154,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       meta: {
         action: 'receiveEmailSubmissionUsingBusBoy',
         formId: req.form._id,
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         uin: hashedUinFin,
         submission: hashedSubmission,
       },
@@ -171,8 +167,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
           message: 'Invalid attachments',
           meta: {
             action: 'receiveEmailSubmissionUsingBusBoy',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
+            ...createReqMeta(req),
             formId: req.form._id,
           },
         })
@@ -196,8 +191,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
         message: 'receiveSubmission error',
         meta: {
           action: 'receiveEmailSubmissionUsingBusBoy',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           formId: req.form._id,
           uin: hashedUinFin,
           submission: hashedSubmission,
@@ -215,8 +209,7 @@ exports.receiveEmailSubmissionUsingBusBoy = function (req, res, next) {
       message: 'Multipart error',
       meta: {
         action: 'receiveEmailSubmissionUsingBusBoy',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         formId: req.form._id,
       },
       error: err,
@@ -252,8 +245,7 @@ exports.validateEmailSubmission = function (req, res, next) {
             : 'Error processing responses',
         meta: {
           action: 'validateEmailSubmission',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           formId: req.form._id,
         },
         error: err,
@@ -606,8 +598,7 @@ exports.saveMetadataToDb = function (req, res, next) {
           action: 'saveMetadataToDb',
           submissionId: submission.id,
           formId: form._id,
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           responseHash: submission.responseHash,
         },
       })
@@ -649,8 +640,7 @@ exports.sendAdminEmail = async function (req, res, next) {
         action: 'sendAdminEmail',
         submissionId: submission.id,
         formId: form._id,
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         submissionHash: submission.responseHash,
       },
     })
@@ -672,8 +662,7 @@ exports.sendAdminEmail = async function (req, res, next) {
         action: 'sendAdminEmail',
         submissionId: submission.id,
         formId: form._id,
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         submissionHash: submission.responseHash,
       },
       error: err,

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose')
 const { getEmailSubmissionModel } = require('../models/submission.server.model')
 const emailSubmission = getEmailSubmissionModel(mongoose)
 const { StatusCodes } = require('http-status-codes')
-const { getRequestIp, getTrace, getMeta } = require('../utils/request')
+const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
 const { ConflictError } = require('../modules/submission/submission.errors')
 const { MB } = require('../constants/filesize')
 const {
@@ -509,7 +509,7 @@ function onSubmissionEmailFailure(err, req, res, submission) {
     message: 'Error submitting email form',
     meta: {
       action: 'onSubmissionEmailFailure',
-      ...getMeta(req),
+      ...createReqMeta(req),
     },
     error: err,
   })

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -15,7 +15,7 @@ const encryptSubmission = getEncryptSubmissionModel(mongoose)
 
 const { checkIsEncryptedEncoding } = require('../utils/encryption')
 const { ConflictError } = require('../modules/submission/submission.errors')
-const { getRequestIp, getTrace, getMeta } = require('../utils/request')
+const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const {
@@ -114,7 +114,7 @@ function onEncryptSubmissionFailure(err, req, res, submission) {
     message: 'Encrypt submission error',
     meta: {
       action: 'onEncryptSubmissionFailure',
-      ...getMeta(req),
+      ...createReqMeta(req),
     },
     error: err,
   })
@@ -246,7 +246,7 @@ exports.getMetadata = function (req, res) {
               message: 'Failure retrieving metadata from database',
               meta: {
                 action: 'getMetadata',
-                ...getMeta(req),
+                ...createReqMeta(req),
               },
               error: err,
             })
@@ -378,7 +378,7 @@ exports.getEncryptedResponse = function (req, res) {
         message: 'Failure retrieving encrypted submission from database',
         meta: {
           action: 'getEncryptedResponse',
-          ...getMeta(req),
+          ...createReqMeta(req),
         },
         error: err,
       })

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -15,7 +15,7 @@ const encryptSubmission = getEncryptSubmissionModel(mongoose)
 
 const { checkIsEncryptedEncoding } = require('../utils/encryption')
 const { ConflictError } = require('../modules/submission/submission.errors')
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getRequestIp, getTrace, getMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const {
@@ -114,10 +114,7 @@ function onEncryptSubmissionFailure(err, req, res, submission) {
     message: 'Encrypt submission error',
     meta: {
       action: 'onEncryptSubmissionFailure',
-      ip: getRequestIp(req),
-      trace: getTrace(req),
-      url: req.url,
-      headers: req.headers,
+      ...getMeta(req),
     },
     error: err,
   })
@@ -249,10 +246,7 @@ exports.getMetadata = function (req, res) {
               message: 'Failure retrieving metadata from database',
               meta: {
                 action: 'getMetadata',
-                ip: getRequestIp(req),
-                trace: getTrace(req),
-                url: req.url,
-                headers: req.headers,
+                ...getMeta(req),
               },
               error: err,
             })
@@ -384,10 +378,7 @@ exports.getEncryptedResponse = function (req, res) {
         message: 'Failure retrieving encrypted submission from database',
         meta: {
           action: 'getEncryptedResponse',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
-          url: req.url,
-          headers: req.headers,
+          ...getMeta(req),
         },
         error: err,
       })

--- a/src/app/controllers/encrypt-submissions.server.controller.js
+++ b/src/app/controllers/encrypt-submissions.server.controller.js
@@ -15,7 +15,7 @@ const encryptSubmission = getEncryptSubmissionModel(mongoose)
 
 const { checkIsEncryptedEncoding } = require('../utils/encryption')
 const { ConflictError } = require('../modules/submission/submission.errors')
-const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const {
@@ -45,8 +45,7 @@ exports.validateEncryptSubmission = function (req, res, next) {
       message: 'Invalid encryption',
       meta: {
         action: 'validateEncryptSubmission',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         formId: form._id,
       },
       error,
@@ -65,8 +64,7 @@ exports.validateEncryptSubmission = function (req, res, next) {
         message: 'Error processing responses',
         meta: {
           action: 'validateEncryptSubmission',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           formId: form._id,
         },
         error: err,
@@ -185,7 +183,7 @@ exports.saveResponseToDb = function (req, res, next) {
             message: 'Attachment upload error',
             meta: {
               action: 'saveResponseToDb',
-              trace: getTrace(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -318,10 +316,7 @@ exports.getMetadata = function (req, res) {
             message: 'Failure retrieving metadata from database',
             meta: {
               action: 'getMetadata',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
-              url: req.url,
-              headers: req.headers,
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -452,8 +447,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         message: 'Error streaming submissions from database',
         meta: {
           action: 'streamEncryptedResponse',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
         },
         error: err,
       })
@@ -469,8 +463,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         message: 'Error converting submissions to JSON',
         meta: {
           action: 'streamEncryptedResponse',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
         },
         error: err,
       })
@@ -484,8 +477,7 @@ exports.streamEncryptedResponses = async function (req, res) {
         message: 'Error writing submissions to HTTP stream',
         meta: {
           action: 'streamEncryptedResponse',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
         },
         error: err,
       })

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -7,7 +7,7 @@ const mongoose = require('mongoose')
 const _ = require('lodash')
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormModel = require('../models/form.server.model').default
 
@@ -120,10 +120,7 @@ exports.formById = async function (req, res, next) {
       message: 'Error retrieving form from database',
       meta: {
         action: 'formById',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
-        url: req.url,
-        headers: req.headers,
+        ...getMeta(req),
       },
       error: err,
     })

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -7,7 +7,7 @@ const mongoose = require('mongoose')
 const _ = require('lodash')
 const { StatusCodes } = require('http-status-codes')
 
-const { getMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormModel = require('../models/form.server.model').default
 
@@ -120,7 +120,7 @@ exports.formById = async function (req, res, next) {
       message: 'Error retrieving form from database',
       meta: {
         action: 'formById',
-        ...getMeta(req),
+        ...createReqMeta(req),
       },
       error: err,
     })

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -11,7 +11,7 @@ const moment = require('moment')
 const { StatusCodes } = require('http-status-codes')
 
 const { sessionSecret } = require('../../config/config')
-const { getRequestIp, getTrace } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getMyInfoHashModel = require('../models/myinfo_hash.server.model').default
 const MyInfoHash = getMyInfoHashModel(mongoose)
@@ -57,8 +57,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
       message: logMessage,
       meta: {
         action: 'addMyInfo',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         formId,
         esrvcId,
       },
@@ -110,8 +109,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
               message: 'Error writing to DB',
               meta: {
                 action: 'addMyInfo',
-                ip: getRequestIp(req),
-                trace: getTrace(req),
+                ...createReqMeta(req),
                 formId,
               },
               error: err,
@@ -126,8 +124,7 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
         message: 'Error hashing MyInfo fields',
         meta: {
           action: 'addMyInfo',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           formId,
         },
         error,
@@ -194,8 +191,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
             message: 'Error retrieving MyInfo hash from database',
             meta: {
               action: 'verifyMyInfoVals',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -210,8 +206,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
             message: `Unable to find MyInfo hashes for ${formObjId}`,
             meta: {
               action: 'verifyMyInfoVals',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
+              ...createReqMeta(req),
               formId: formObjId,
             },
           })
@@ -259,8 +254,7 @@ exports.verifyMyInfoVals = function (req, res, next) {
                 message: `Hash did not match for form ${formObjId}`,
                 meta: {
                   action: 'verifyMyInfoVals',
-                  ip: getRequestIp(req),
-                  trace: getTrace(req),
+                  ...createReqMeta(req),
                   failedFields: hashFailedAttrs,
                 },
               })

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -3,7 +3,7 @@
 const mongoose = require('mongoose')
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp, getTrace } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormFeedbackModel = require('../models/form_feedback.server.model')
   .default
@@ -58,7 +58,7 @@ exports.redirect = async function (req, res) {
       message: 'Error fetching metatags',
       meta: {
         action: 'redirect',
-        trace: getTrace(req),
+        ...createReqMeta(req),
       },
       error: err,
     })
@@ -97,8 +97,7 @@ exports.submitFeedback = function (req, res) {
           message: 'Error creating form feedback',
           meta: {
             action: 'submitFeedback',
-            ip: getRequestIp(req),
-            trace: getTrace(req),
+            ...createReqMeta(req),
           },
           error: err,
         })

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -9,7 +9,7 @@ const crypto = require('crypto')
 const { StatusCodes } = require('http-status-codes')
 const axios = require('axios')
 
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getRequestIp, getTrace, getMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const { mapDataToKey } = require('../../shared/util/verified-content')
 const getFormModel = require('../models/form.server.model').default
@@ -147,10 +147,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
             message: 'Error retrieving attributes from auth client',
             meta: {
               action: 'handleOOBAuthenticationWith',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
-              url: req.url,
-              headers: req.headers,
+              ...getMeta(req),
             },
             error: err,
           })
@@ -357,10 +354,7 @@ exports.addSpcpSessionInfo = (authClients) => {
             message: 'Failed to verify JWT with auth client',
             meta: {
               action: 'addSpcpSessionInfo',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
-              url: req.url,
-              headers: req.headers,
+              ...getMeta(req),
             },
             error: err,
           })
@@ -489,10 +483,7 @@ exports.isSpcpAuthenticated = (authClients) => {
             message: 'Failed to verify JWT with auth client',
             meta: {
               action: 'isSpcpAuthenticated',
-              ip: getRequestIp(req),
-              trace: getTrace(req),
-              url: req.url,
-              headers: req.headers,
+              ...getMeta(req),
             },
             error: err,
           })

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -9,7 +9,7 @@ const crypto = require('crypto')
 const { StatusCodes } = require('http-status-codes')
 const axios = require('axios')
 
-const { getRequestIp, getTrace, getMeta } = require('../utils/request')
+const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const { mapDataToKey } = require('../../shared/util/verified-content')
 const getFormModel = require('../models/form.server.model').default
@@ -147,7 +147,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
             message: 'Error retrieving attributes from auth client',
             meta: {
               action: 'handleOOBAuthenticationWith',
-              ...getMeta(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -354,7 +354,7 @@ exports.addSpcpSessionInfo = (authClients) => {
             message: 'Failed to verify JWT with auth client',
             meta: {
               action: 'addSpcpSessionInfo',
-              ...getMeta(req),
+              ...createReqMeta(req),
             },
             error: err,
           })
@@ -483,7 +483,7 @@ exports.isSpcpAuthenticated = (authClients) => {
             message: 'Failed to verify JWT with auth client',
             meta: {
               action: 'isSpcpAuthenticated',
-              ...getMeta(req),
+              ...createReqMeta(req),
             },
             error: err,
           })

--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -9,7 +9,7 @@ const crypto = require('crypto')
 const { StatusCodes } = require('http-status-codes')
 const axios = require('axios')
 
-const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const { mapDataToKey } = require('../../shared/util/verified-content')
 const getFormModel = require('../models/form.server.model').default
@@ -260,7 +260,7 @@ exports.validateESrvcId = (req, res) => {
           message: 'Could not find title',
           meta: {
             action: 'validateESrvcId',
-            trace: getTrace(req),
+            ...createReqMeta(req),
             redirectUrl: redirectURL,
             data,
           },
@@ -292,7 +292,7 @@ exports.validateESrvcId = (req, res) => {
         message: 'Could not contact singpass to validate eservice id',
         meta: {
           action: 'validateESrvcId',
-          trace: getTrace(req),
+          ...createReqMeta(req),
           redirectUrl: redirectURL,
           statusCode,
         },
@@ -414,8 +414,7 @@ exports.encryptedVerifiedFields = (signingSecretKey) => {
         meta: {
           action: 'encryptedVerifiedFields',
           formId: req.form._id,
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
         },
         error,
       })

--- a/src/app/controllers/submissions.server.controller.js
+++ b/src/app/controllers/submissions.server.controller.js
@@ -9,7 +9,7 @@ const Submission = getSubmissionModel(mongoose)
 
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp, getTrace, getMeta } = require('../utils/request')
+const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const MailService = require('../services/mail/mail.service').default
@@ -226,7 +226,7 @@ exports.count = function (req, res) {
         message: 'Error counting submission documents from database',
         meta: {
           action: 'count',
-          ...getMeta(req),
+          ...createReqMeta(req),
         },
         error: err,
       })

--- a/src/app/controllers/submissions.server.controller.js
+++ b/src/app/controllers/submissions.server.controller.js
@@ -9,7 +9,7 @@ const Submission = getSubmissionModel(mongoose)
 
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp, getTrace } = require('../utils/request')
+const { getRequestIp, getTrace, getMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const MailService = require('../services/mail/mail.service').default
@@ -226,10 +226,7 @@ exports.count = function (req, res) {
         message: 'Error counting submission documents from database',
         meta: {
           action: 'count',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
-          url: req.url,
-          headers: req.headers,
+          ...getMeta(req),
         },
         error: err,
       })

--- a/src/app/controllers/submissions.server.controller.js
+++ b/src/app/controllers/submissions.server.controller.js
@@ -9,7 +9,7 @@ const Submission = getSubmissionModel(mongoose)
 
 const { StatusCodes } = require('http-status-codes')
 
-const { getRequestIp, getTrace, createReqMeta } = require('../utils/request')
+const { createReqMeta } = require('../utils/request')
 const { isMalformedDate, createQueryWithDateParam } = require('../utils/date')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const MailService = require('../services/mail/mail.service').default
@@ -37,8 +37,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
           meta: {
             action: 'captchaCheck',
             formId: req.form._id,
-            ip: getRequestIp(req),
-            trace: getTrace(req),
+            ...createReqMeta(req),
           },
         })
         return res.status(StatusCodes.BAD_REQUEST).json({
@@ -60,8 +59,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
                 meta: {
                   action: 'captchaCheck',
                   formId: req.form._id,
-                  ip: getRequestIp(req),
-                  trace: getTrace(req),
+                  ...createReqMeta(req),
                 },
               })
               return res.status(StatusCodes.BAD_REQUEST).json({
@@ -77,8 +75,7 @@ exports.captchaCheck = (captchaPrivateKey) => {
               meta: {
                 action: 'captchaCheck',
                 formId: req.form._id,
-                ip: getRequestIp(req),
-                trace: getTrace(req),
+                ...createReqMeta(req),
               },
               error: err,
             })
@@ -182,8 +179,7 @@ const sendEmailAutoReplies = async function (req) {
       message: 'Failed to send autoreply emails',
       meta: {
         action: 'sendEmailAutoReplies',
-        ip: getRequestIp(req),
-        trace: getTrace(req),
+        ...createReqMeta(req),
         formId: req.form._id,
         submissionId: submission.id,
       },

--- a/src/app/modules/analytics/analytics.controller.ts
+++ b/src/app/modules/analytics/analytics.controller.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { submissionsTopUp } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
-import { getRequestIp, getTrace } from '../../utils/request'
+import { getMeta, getRequestIp, getTrace } from '../../utils/request'
 
 import { AnalyticsFactory } from './analytics.factory'
 import { getSubmissionCount, getUserCount } from './analytics.service'
@@ -24,10 +24,7 @@ export const handleGetUserCount: RequestHandler = async (req, res) => {
       message: 'Mongo user count error',
       meta: {
         action: 'handleGetUserCount',
-        ip: getRequestIp(req),
-        url: req.url,
-        headers: req.headers,
-        trace: getTrace(req),
+        ...getMeta(req),
       },
       error: countResult.error,
     })
@@ -54,10 +51,7 @@ export const handleGetSubmissionCount: RequestHandler = async (req, res) => {
       message: 'Mongo submissions count error',
       meta: {
         action: 'handleGetSubmissionCount',
-        ip: getRequestIp(req),
-        url: req.url,
-        headers: req.headers,
-        trace: getTrace(req),
+        ...getMeta(req),
       },
       error: countResult.error,
     })
@@ -87,10 +81,7 @@ export const handleGetFormCount: RequestHandler = async (req, res) => {
       message: 'Mongo form count error',
       meta: {
         action: 'handleGetFormCount',
-        ip: getRequestIp(req),
-        url: req.url,
-        headers: req.headers,
-        trace: getTrace(req),
+        ...getMeta(req),
       },
       error: countResult.error,
     })

--- a/src/app/modules/analytics/analytics.controller.ts
+++ b/src/app/modules/analytics/analytics.controller.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { submissionsTopUp } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
-import { getMeta, getRequestIp, getTrace } from '../../utils/request'
+import { createReqMeta, getRequestIp, getTrace } from '../../utils/request'
 
 import { AnalyticsFactory } from './analytics.factory'
 import { getSubmissionCount, getUserCount } from './analytics.service'
@@ -24,7 +24,7 @@ export const handleGetUserCount: RequestHandler = async (req, res) => {
       message: 'Mongo user count error',
       meta: {
         action: 'handleGetUserCount',
-        ...getMeta(req),
+        ...createReqMeta(req),
       },
       error: countResult.error,
     })
@@ -51,7 +51,7 @@ export const handleGetSubmissionCount: RequestHandler = async (req, res) => {
       message: 'Mongo submissions count error',
       meta: {
         action: 'handleGetSubmissionCount',
-        ...getMeta(req),
+        ...createReqMeta(req),
       },
       error: countResult.error,
     })
@@ -81,7 +81,7 @@ export const handleGetFormCount: RequestHandler = async (req, res) => {
       message: 'Mongo form count error',
       meta: {
         action: 'handleGetFormCount',
-        ...getMeta(req),
+        ...createReqMeta(req),
       },
       error: countResult.error,
     })

--- a/src/app/modules/analytics/analytics.controller.ts
+++ b/src/app/modules/analytics/analytics.controller.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { submissionsTopUp } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
-import { createReqMeta, getRequestIp, getTrace } from '../../utils/request'
+import { createReqMeta } from '../../utils/request'
 
 import { AnalyticsFactory } from './analytics.factory'
 import { getSubmissionCount, getUserCount } from './analytics.service'

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { LINKS } from '../../../shared/constants'
 import MailService from '../../services/mail/mail.service'
-import { getRequestIp, getTrace } from '../../utils/request'
+import { createReqMeta, getRequestIp } from '../../utils/request'
 import * as UserService from '../user/user.service'
 
 import * as AuthService from './auth.service'
@@ -36,8 +36,7 @@ export const handleCheckUser: RequestHandler<
         message: 'Domain validation error',
         meta: {
           action: 'handleCheckUser',
-          ip: getRequestIp(req),
-          trace: getTrace(req),
+          ...createReqMeta(req),
           email,
         },
         error,
@@ -64,8 +63,7 @@ export const handleLoginSendOtp: RequestHandler<
   const logMeta = {
     action: 'handleLoginSendOtp',
     email,
-    ip: requestIp,
-    trace: getTrace(req),
+    ...createReqMeta(req),
   }
 
   return (
@@ -124,8 +122,7 @@ export const handleLoginVerifyOtp: RequestHandler<
   const logMeta = {
     action: 'handleLoginVerifyOtp',
     email,
-    ip: getRequestIp(req),
-    trace: getTrace(req),
+    ...createReqMeta(req),
   }
   const coreErrorMessage = `Failed to process OTP. Please try again later and if the problem persists, submit our Support Form (${LINKS.supportFormLink}).`
 

--- a/src/app/utils/limit-rate.ts
+++ b/src/app/utils/limit-rate.ts
@@ -6,7 +6,7 @@ import { merge } from 'lodash'
 
 import { createLoggerWithLabel } from '../../config/logger'
 
-import { getRequestIp } from './request'
+import { getMeta } from './request'
 
 const logger = createLoggerWithLabel(module)
 
@@ -26,8 +26,7 @@ export const limitRate = (options: RateLimitOptions = {}): RateLimitFn => {
         message: 'Rate limit exceeded',
         meta: {
           action: 'limitRate',
-          url: req.url,
-          ip: getRequestIp(req),
+          ...getMeta(req),
           method: req.method,
           rateLimitInfo: req.rateLimit,
         },

--- a/src/app/utils/limit-rate.ts
+++ b/src/app/utils/limit-rate.ts
@@ -6,7 +6,7 @@ import { merge } from 'lodash'
 
 import { createLoggerWithLabel } from '../../config/logger'
 
-import { getMeta } from './request'
+import { createReqMeta } from './request'
 
 const logger = createLoggerWithLabel(module)
 
@@ -26,7 +26,7 @@ export const limitRate = (options: RateLimitOptions = {}): RateLimitFn => {
         message: 'Rate limit exceeded',
         meta: {
           action: 'limitRate',
-          ...getMeta(req),
+          ...createReqMeta(req),
           method: req.method,
           rateLimitInfo: req.rateLimit,
         },

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -1,14 +1,19 @@
 import { Request } from 'express'
+import { IncomingHttpHeaders } from 'http'
 
-interface IRequestWithId extends Request {
-  // Need to extend Request interface as id is not present in native express
-  id?: string
-}
-
-export const getRequestIp = (req: IRequestWithId) => {
+export const getRequestIp = (req: Request) => {
   return req.get('cf-connecting-ip') ?? req.ip
 }
 
-export const getTrace = (req: IRequestWithId) => {
+export const getTrace = (req: Request) => {
   return req.get('cf-ray') ?? req.id // trace using cloudflare cf-ray header, with x-request-id header as backup
+}
+
+export const getMeta = (req: Request) => {
+  return {
+    ip: req.get('cf-connecting-ip') ?? req.ip,
+    trace: req.get('cf-ray') ?? req.id, // trace using cloudflare cf-ray header, with x-request-id header as backup
+    url: req.url,
+    headers: req.headers,
+  }
 }

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -9,7 +9,7 @@ export const getTrace = (req: Request) => {
   return req.get('cf-ray') ?? req.id // trace using cloudflare cf-ray header, with x-request-id header as backup
 }
 
-export const getMeta = (req: Request) => {
+export const createReqMeta = (req: Request) => {
   return {
     ip: req.get('cf-connecting-ip') ?? req.ip,
     trace: req.get('cf-ray') ?? req.id, // trace using cloudflare cf-ray header, with x-request-id header as backup

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -2,6 +2,15 @@ import { Request } from 'express'
 import { IncomingHttpHeaders } from 'http'
 
 export const getRequestIp = (req: Request) => {
+  // Define our own token for client ip
+  // req.headers['cf-connecting-ip'] : Cloudflare
+  // req.ip : Contains the remote IP address of the request.
+  // If trust proxy setting is true, the value of this property is
+  // derived from the left-most entry in the X-Forwarded-For header.
+  // This header can be set by the client or by the proxy.
+  // If trust proxy setting is false, the app is understood as directly
+  // facing the Internet and the client’s IP address is derived from
+  // req.connection.remoteAddress.
   return req.get('cf-connecting-ip') ?? req.ip
 }
 
@@ -11,8 +20,8 @@ export const getTrace = (req: Request) => {
 
 export const createReqMeta = (req: Request) => {
   return {
-    ip: req.get('cf-connecting-ip') ?? req.ip,
-    trace: req.get('cf-ray') ?? req.id, // trace using cloudflare cf-ray header, with x-request-id header as backup
+    ip: getRequestIp(req),
+    trace: getTrace(req), // trace using cloudflare cf-ray header, with x-request-id header as backup
     url: req.url,
     headers: req.headers,
   }

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -1,5 +1,4 @@
 import { Request } from 'express'
-import { IncomingHttpHeaders } from 'http'
 
 export const getRequestIp = (req: Request) => {
   // Define our own token for client ip

--- a/src/loaders/express/logging.ts
+++ b/src/loaders/express/logging.ts
@@ -2,7 +2,7 @@ import expressWinston from 'express-winston'
 import get from 'lodash/get'
 import winston from 'winston'
 
-import { getTrace } from '../../app/utils/request'
+import { getRequestIp, getTrace } from '../../app/utils/request'
 import config from '../../config/config'
 import { customFormat } from '../../config/logger'
 
@@ -43,18 +43,11 @@ const loggingMiddleware = () => {
     },
     dynamicMeta: (req, res) => {
       const meta: LogMeta = {
-        // Define our own token for client ip
-        // req.headers['cf-connecting-ip'] : Cloudflare
-        // req.ip : Contains the remote IP address of the request.
-        // trace: use cloudflare cf-ray header, with x-request-id header as backup
-        // If trust proxy setting is true, the value of this property is
-        // derived from the left-most entry in the X-Forwarded-For header.
-        // This header can be set by the client or by the proxy.
-        // If trust proxy setting is false, the app is understood as directly
-        // facing the Internet and the client’s IP address is derived from
-        // req.connection.remoteAddress.
-        clientIp: req.get('cf-connecting-ip') || req.ip,
         userId: get(req, 'session.user._id', ''),
+        // Don't use ...createReqMeta(req) here because
+        // headers and url are already in meta;
+        // dynamicMeta is for additional information
+        clientIp: getRequestIp(req),
         trace: getTrace(req),
       }
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  export interface Request {
+    id?: string
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,5 +1,13 @@
-declare namespace Express {
-  export interface Request {
-    id?: string
+import { IUserSchema } from 'src/types'
+
+declare global {
+  namespace Express {
+    export interface Request {
+      id?: string
+    }
+
+    export interface Session {
+      user?: IUserSchema
+    }
   }
 }


### PR DESCRIPTION
## Problem

Closes #415 and #416

## Solution
- create getMeta() utility function to extract relevant log info (i.e. ip, trace, url, header) instead of specifying at each logger function call
- extend Request interface globally

## Tests

**On staging**
- [ ] At the login page, key in an invalid email address abc@abc.com. Check that the value of cf-ray header is logged under trace in the server logs error message.
- [ ] Access a public form. Check that the value of cf-ray header is logged under trace in the server logs for the get request.

**On localhost**
- [ ] At the login page, key in an invalid email address abc@abc.com. Check that the value of x-request-id header is logged under trace in the server logs error message.
- [ ] In L25-L27 of `logging.ts`, replace
```
isDev
  ? format.combine(format.colorize(), errorPrinter(), customFormat)
  : format.json({ replacer: jsonErrorReplacer }),
```
with 
``` 
format.json({ replacer: jsonErrorReplacer }),
```
Access a public form. Check that the value of x-request-id header is logged under trace in the server logs for the get request. 
