### PR TITLE
fix: early return when validating empty email string

### DIFF
--- a/src/public/modules/forms/base/directives/validate-email-domain.client.directive.js
+++ b/src/public/modules/forms/base/directives/validate-email-domain.client.directive.js
@@ -12,6 +12,10 @@ function validateEmailDomain() {
           ? new Set(scope.vm.field.allowedEmailDomains)
           : new Set()
       ngModel.$validators.emailDomainValidator = (emailAddress) => {
+        // Early return, do not even check domains if string is empty.
+        if (!emailAddress) {
+          return true
+        }
         if (allowedEmailDomains.size) {
           const emailDomain = emailAddress.split('@').pop()
           return allowedEmailDomains.has('@' + emailDomain)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Fixes bug where optional email fields are still failing validation for restricted email domains even when they are empty.

Closes #431

## Solution
<!-- How did you solve the problem? -->
**Bug Fixes**:

- Remove restricted email domain field validation when field is an empty string (on required fields, the required validator will still fire) 

## After Screenshots
**AFTER**:
<!-- [insert screenshot here] -->
Required fields will have error when field is empty when submitting
![Screenshot 2020-10-08 at 12 31 13 PM](https://user-images.githubusercontent.com/22133008/95415168-29f06f00-0962-11eb-82c7-92e02a5fbc77.png)

Optional field will have no error when field is empty when submitting
![Screenshot 2020-10-08 at 12 31 37 PM](https://user-images.githubusercontent.com/22133008/95415191-370d5e00-0962-11eb-8c32-52be45df301a.png)

