### PR TITLE
chore: add lint error for unused variables

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
         "import/newline-after-import": "error",
         "import/no-duplicates": "error",
         "@typescript-eslint/no-floating-promises": 2,
+        "@typescript-eslint/no-unused-vars": 2
       }
     },
     { "files": ["*.spec.ts"], "extends": ["plugin:jest/recommended"] }

--- a/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
+++ b/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'bson'
-import { cloneDeep, merge, pick } from 'lodash'
+import { merge, pick } from 'lodash'
 
 import { EmailType } from 'src/app/constants/mail'
 import {

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -12,12 +12,7 @@ import { EMAIL_HEADERS, EmailType } from 'src/app/constants/mail'
 import getFormModel from 'src/app/models/form.server.model'
 import MailService from 'src/app/services/mail.service'
 import * as LoggerModule from 'src/config/logger'
-import {
-  BounceType,
-  IFormSchema,
-  ISnsNotification,
-  IUserSchema,
-} from 'src/types'
+import { BounceType, ISnsNotification, IUserSchema } from 'src/types'
 
 import { makeBounceNotification, MOCK_SNS_BODY } from './bounce-test-helpers'
 

--- a/src/loaders/express/error-handler.ts
+++ b/src/loaders/express/error-handler.ts
@@ -1,4 +1,4 @@
-import { isCelebrateError, Segments } from 'celebrate'
+import { isCelebrateError } from 'celebrate'
 import { ErrorRequestHandler, RequestHandler } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import get from 'lodash/get'


### PR DESCRIPTION
Unused imports are building up around the codebase. This PR upgrades the linting rule from "warn" to "error", and fixes the resulting lint errors.