### PR TITLE
fix: prevent undefined split errors when vm.user does not exist

### DIFF
--- a/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const get = require('lodash/get')
+
 // Forms controller
 angular
   .module('forms')
@@ -80,7 +82,7 @@ function ListFormsController(
 
   function turnEmailToName() {
     vm.userName = 'how are you?' // Placeholder
-    let name = vm.user.email.split('@')
+    let name = get(vm, 'user.email', '').split('@')
     if (name.length >= 1) {
       let nameParts = name[0].split('_')
       let userName = ''


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Fixes error that occurs when user session expires, resulting in `String.split` being performed on a `vm.user` that is `undefined`.

![Screenshot 2020-10-12 at 2 58 07 PM](https://user-images.githubusercontent.com/22133008/95714809-5a564700-0c9b-11eb-9324-be70ea949bff.png)


## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix: safely retrieve user's name from email before attempting to split the resulting name string.
