### PR TITLE
refactor: convert remaining res.send to res.json

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -663,7 +663,7 @@ function makeModule(connection) {
       if (!VALID_UPLOAD_FILE_TYPES.includes(req.body.fileType)) {
         return res
           .status(StatusCodes.BAD_REQUEST)
-          .send(`Your file type "${req.body.fileType}" is not supported`)
+          .json(`Your file type "${req.body.fileType}" is not supported`)
       }
 
       s3.createPresignedPost(
@@ -710,7 +710,7 @@ function makeModule(connection) {
       if (!VALID_UPLOAD_FILE_TYPES.includes(req.body.fileType)) {
         return res
           .status(StatusCodes.BAD_REQUEST)
-          .send(`Your file type "${req.body.fileType}" is not supported`)
+          .json(`Your file type "${req.body.fileType}" is not supported`)
       }
 
       s3.createPresignedPost(

--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -60,7 +60,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(expectedError.status)
-      expect(mockRes.send).toBeCalledWith(expectedError.message)
+      expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
   })
 
@@ -85,7 +85,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.send).toBeCalledWith(`OTP sent to ${VALID_EMAIL}!`)
+      expect(mockRes.json).toBeCalledWith(`OTP sent to ${VALID_EMAIL}!`)
       // Services should have been invoked.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockMailService.sendLoginOtp).toHaveBeenCalledTimes(1)
@@ -104,7 +104,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(expectedError.status)
-      expect(mockRes.send).toBeCalledWith(expectedError.message)
+      expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
 
     it('should return 500 when there is an error generating login OTP', async () => {
@@ -123,7 +123,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.send).toBeCalledWith(
+      expect(mockRes.json).toBeCalledWith(
         'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
       // Sending login OTP should not have been called.
@@ -148,7 +148,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.send).toBeCalledWith(
+      expect(mockRes.json).toBeCalledWith(
         'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
       // Services should have been invoked.
@@ -200,7 +200,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(expectedError.status)
-      expect(mockRes.send).toBeCalledWith(expectedError.message)
+      expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
 
     it('should return 422 when verifying login OTP returns an InvalidOtpError', async () => {
@@ -220,7 +220,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(422)
-      expect(mockRes.send).toBeCalledWith(expectedInvalidOtpError.message)
+      expect(mockRes.json).toBeCalledWith(expectedInvalidOtpError.message)
       // Check that the correct services have been called or not called.
       expect(MockAuthService.verifyLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockUserService.retrieveUser).not.toHaveBeenCalled()
@@ -242,7 +242,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.send).toBeCalledWith(
+      expect(mockRes.json).toBeCalledWith(
         expect.stringContaining('Failed to process OTP.'),
       )
       // Check that the correct services have been called or not called.
@@ -266,7 +266,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.send).toBeCalledWith(
+      expect(mockRes.json).toBeCalledWith(
         // Use stringContaining here due to dynamic text and out of test scope.
         expect.stringContaining('Failed to process OTP.'),
       )

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -38,9 +38,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -54,9 +54,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -70,7 +70,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(401)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
       )
     })
@@ -112,7 +112,7 @@ describe('auth.routes', () => {
       // Assert
       expect(getAgencySpy).toBeCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual(mockErrorString)
+      expect(response.body).toEqual(mockErrorString)
     })
   })
 
@@ -131,9 +131,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -147,9 +147,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -164,7 +164,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(401)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
       )
     })
@@ -183,7 +183,7 @@ describe('auth.routes', () => {
       // Assert
       expect(createLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
     })
@@ -202,7 +202,7 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
     })
@@ -221,7 +221,7 @@ describe('auth.routes', () => {
       // Assert
       expect(getAgencySpy).toBeCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
     })
@@ -240,7 +240,7 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.text).toEqual(`OTP sent to ${VALID_EMAIL}!`)
+      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}!`)
     })
   })
 
@@ -267,9 +267,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.otp is not provided as a param', async () => {
@@ -280,9 +280,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -296,9 +296,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.otp is less than 6 digits', async () => {
@@ -310,9 +310,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 400 when body.otp is 6 characters but does not consist purely of digits', async () => {
@@ -324,9 +324,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Some required parameters are missing' }),
-      )
+      expect(response.body).toEqual({
+        message: 'Some required parameters are missing',
+      })
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -341,7 +341,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(401)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
       )
     })
@@ -360,7 +360,7 @@ describe('auth.routes', () => {
       // Assert
       expect(getAgencySpy).toBeCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual('Something went wrong. Please try again.')
+      expect(response.body).toEqual('Something went wrong. Please try again.')
     })
 
     it('should return 422 when hash does not exist for body.otp', async () => {
@@ -371,7 +371,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(422)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         expect.stringContaining(
           'OTP has expired. Please request for a new OTP.',
         ),
@@ -391,10 +391,10 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(422)
-      expect(response.text).toEqual('OTP is invalid. Please try again.')
+      expect(response.body).toEqual('OTP is invalid. Please try again.')
     })
 
-    it('should should return 422 when invalid body.otp has been attempted too many times', async () => {
+    it('should return 422 when invalid body.otp has been attempted too many times', async () => {
       // Arrange
       const invalidOtp = '654321'
       // Request for OTP so the hash exists.
@@ -417,7 +417,7 @@ describe('auth.routes', () => {
       expect(results).toEqual(
         Array(AuthService.MAX_OTP_ATTEMPTS).fill({
           status: 422,
-          text: 'OTP is invalid. Please try again.',
+          text: JSON.stringify('OTP is invalid. Please try again.'),
         }),
       )
 
@@ -429,7 +429,7 @@ describe('auth.routes', () => {
       // Assert
       // Should still reject with max OTP attempts error.
       expect(response.status).toEqual(422)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         'You have hit the max number of attempts. Please request for a new OTP.',
       )
     })
@@ -480,7 +480,7 @@ describe('auth.routes', () => {
       // Should have reached this spy.
       expect(upsertSpy).toBeCalled()
       expect(response.status).toEqual(500)
-      expect(response.text).toEqual(
+      expect(response.body).toEqual(
         expect.stringContaining('Failed to process OTP.'),
       )
     })
@@ -508,9 +508,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(200)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Sign out successful' }),
-      )
+      expect(response.body).toEqual({ message: 'Sign out successful' })
       // connect.sid should now be empty.
       expect(response.header['set-cookie'][0]).toEqual(
         expect.stringContaining('connect.sid=;'),
@@ -524,9 +522,7 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(200)
-      expect(response.text).toEqual(
-        JSON.stringify({ message: 'Sign out successful' }),
-      )
+      expect(response.body).toEqual({ message: 'Sign out successful' })
     })
   })
 
@@ -536,7 +532,7 @@ describe('auth.routes', () => {
     jest.spyOn(MailService, 'sendLoginOtp').mockReturnValue(okAsync(true))
 
     const response = await request.post('/auth/sendotp').send({ email })
-    expect(response.text).toEqual(`OTP sent to ${email}!`)
+    expect(response.body).toEqual(`OTP sent to ${email}!`)
   }
 
   const signInUser = async (email: string, otp: string) => {

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -411,13 +411,13 @@ describe('auth.routes', () => {
         )
       }
       const results = (await Promise.all(verifyPromises)).map((resolve) =>
-        pick(resolve, ['status', 'text']),
+        pick(resolve, ['status', 'body']),
       )
       // Should be all invalid OTP responses.
       expect(results).toEqual(
         Array(AuthService.MAX_OTP_ATTEMPTS).fill({
           status: 422,
-          text: JSON.stringify('OTP is invalid. Please try again.'),
+          body: 'OTP is invalid. Please try again.',
         }),
       )
 

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -42,7 +42,7 @@ export const handleCheckUser: RequestHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).send(errorMessage)
+      return res.status(statusCode).json(errorMessage)
     })
 }
 
@@ -86,7 +86,7 @@ export const handleLoginSendOtp: RequestHandler<
           meta: logMeta,
         })
 
-        return res.status(StatusCodes.OK).send(`OTP sent to ${email}!`)
+        return res.status(StatusCodes.OK).json(`OTP sent to ${email}!`)
       })
       // Step 4b: Error occurred whilst sending otp.
       .mapErr((error) => {
@@ -99,7 +99,7 @@ export const handleLoginSendOtp: RequestHandler<
           error,
           /* coreErrorMessage=*/ 'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
         )
-        return res.status(statusCode).send(errorMessage)
+        return res.status(statusCode).json(errorMessage)
       })
   )
 }
@@ -135,7 +135,7 @@ export const handleLoginVerifyOtp: RequestHandler<
       error,
     })
     const { errorMessage, statusCode } = mapRouteError(error)
-    return res.status(statusCode).send(errorMessage)
+    return res.status(statusCode).json(errorMessage)
   }
 
   // Since there is no error, agency is retrieved from validation.
@@ -156,7 +156,7 @@ export const handleLoginVerifyOtp: RequestHandler<
 
           return res
             .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .send(coreErrorMessage)
+            .json(coreErrorMessage)
         }
 
         // TODO(#212): Should store only userId in session.
@@ -182,7 +182,7 @@ export const handleLoginVerifyOtp: RequestHandler<
           error,
           coreErrorMessage,
         )
-        return res.status(statusCode).send(errorMessage)
+        return res.status(statusCode).json(errorMessage)
       })
   )
 }

--- a/tests/integration/helpers/express-auth.ts
+++ b/tests/integration/helpers/express-auth.ts
@@ -35,7 +35,7 @@ export const createAuthedSession = async (
 
   const sendOtpResponse = await request.post('/auth/sendotp').send({ email })
   expect(sendOtpResponse.status).toEqual(200)
-  expect(sendOtpResponse.text).toEqual(`OTP sent to ${email}!`)
+  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email}!`)
 
   // Act
   await request.post('/auth/verifyotp').send({ email, otp: MOCK_VALID_OTP })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Usage of `res.send` creates the risk of HTML injection attacks if not used with care. Using `res.json` is better practice.

## Solution
This PR covers all remaining cases in the codebase where `res.send` is used. All these cases pass strings into `res.send`, hence these changes are backwards-compatible. The client sees the same response except with the `Content-Type` header changed from `text/html` to `application/json`.