### PR TITLE
chore: update test coverage threshold to 25

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['./node_modules/', './tests'],
   coverageThreshold: {
     global: {
-      statements: 12, // Increase this percentage as test coverage improves
+      statements: 25, // Increase this percentage as test coverage improves
     },
   },
 }


### PR DESCRIPTION
The current test coverage is about 28%, so we can safely set the minimum to 25.

From the latest `develop` build:
![Screenshot 2020-10-12 at 4 03 15 PM](https://user-images.githubusercontent.com/29480346/95720906-71e5fd80-0ca4-11eb-8077-bc9bd37c9af7.png)
