### PR TITLE
refactor: use celebrate error handler

### DIFF
--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -38,8 +38,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -54,8 +54,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -131,8 +131,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -147,8 +147,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -267,8 +267,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -280,8 +280,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -296,8 +296,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -310,8 +310,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -324,8 +324,8 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -8,6 +8,7 @@ import * as OtpUtils from 'src/app/utils/otp'
 import { IAgencySchema } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
+import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { MailSendError } from '../../../services/mail/mail.errors'
@@ -38,9 +39,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'email' } }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -54,9 +55,11 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: { key: 'email', message: 'Please enter a valid email' },
+        }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -131,9 +134,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'email' } }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -147,9 +150,11 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: { key: 'email', message: 'Please enter a valid email' },
+        }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {
@@ -267,9 +272,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'email' } }),
+      )
     })
 
     it('should return 400 when body.otp is not provided as a param', async () => {
@@ -280,9 +285,9 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'otp' } }),
+      )
     })
 
     it('should return 400 when body.email is invalid', async () => {
@@ -296,9 +301,11 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: { key: 'email', message: 'Please enter a valid email' },
+        }),
+      )
     })
 
     it('should return 400 when body.otp is less than 6 digits', async () => {
@@ -310,9 +317,11 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: { key: 'otp', message: 'Please enter a valid otp' },
+        }),
+      )
     })
 
     it('should return 400 when body.otp is 6 characters but does not consist purely of digits', async () => {
@@ -324,9 +333,11 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: { key: 'otp', message: 'Please enter a valid otp' },
+        }),
+      )
     })
 
     it('should return 401 when domain of body.email does not exist in Agency collection', async () => {

--- a/src/app/modules/user/__tests__/user.routes.spec.ts
+++ b/src/app/modules/user/__tests__/user.routes.spec.ts
@@ -135,8 +135,8 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -148,8 +148,8 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -284,8 +284,8 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -298,8 +298,8 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 
@@ -312,8 +312,8 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toEqual({
-        message: 'Some required parameters are missing',
+      expect(response.body).toMatchObject({
+        message: 'celebrate request validation failed',
       })
     })
 

--- a/src/app/modules/user/__tests__/user.routes.spec.ts
+++ b/src/app/modules/user/__tests__/user.routes.spec.ts
@@ -12,6 +12,7 @@ import { IAgencySchema, IUserSchema } from 'src/types'
 
 import { createAuthedSession } from 'tests/integration/helpers/express-auth'
 import { setupApp } from 'tests/integration/helpers/express-setup'
+import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { DatabaseError } from '../../core/core.errors'
@@ -135,9 +136,9 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'contact' } }),
+      )
     })
 
     it('should return 400 when body.userId is not provided as a param', async () => {
@@ -148,9 +149,9 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'userId' } }),
+      )
     })
 
     it('should return 401 when body.userId does not match current session userId', async () => {
@@ -284,9 +285,9 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'contact' } }),
+      )
     })
 
     it('should return 400 when body.userId is not provided as a param', async () => {
@@ -298,9 +299,9 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'userId' } }),
+      )
     })
 
     it('should return 400 when body.otp is not provided as a param', async () => {
@@ -312,9 +313,9 @@ describe('user.routes', () => {
 
       // Assert
       expect(response.status).toEqual(400)
-      expect(response.body).toMatchObject({
-        message: 'celebrate request validation failed',
-      })
+      expect(response.body).toEqual(
+        buildCelebrateError({ body: { key: 'otp' } }),
+      )
     })
 
     it('should return 401 when body.userId does not match current session userId', async () => {

--- a/src/loaders/express/error-handler.ts
+++ b/src/loaders/express/error-handler.ts
@@ -1,4 +1,4 @@
-import { isCelebrateError } from 'celebrate'
+import { errors, isCelebrateError } from 'celebrate'
 import { ErrorRequestHandler, RequestHandler } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import get from 'lodash/get'
@@ -6,6 +6,7 @@ import get from 'lodash/get'
 import { createLoggerWithLabel } from '../../config/logger'
 
 const logger = createLoggerWithLabel(module)
+const celebrateErrorHandler = errors()
 
 const errorHandlerMiddlewares = (): (
   | ErrorRequestHandler
@@ -37,12 +38,11 @@ const errorHandlerMiddlewares = (): (
             action: 'genericErrorHandlerMiddleware',
             // formId is only present for Joi validated routes that require it
             formId: get(req, 'form._id', null),
+            details: Object.fromEntries(err.details),
           },
           error: err,
         })
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Some required parameters are missing' })
+        return celebrateErrorHandler(err, req, res, next)
       }
 
       logger.error({

--- a/tests/unit/backend/helpers/celebrate.ts
+++ b/tests/unit/backend/helpers/celebrate.ts
@@ -1,0 +1,42 @@
+import { Segments } from 'celebrate'
+import { getReasonPhrase } from 'http-status-codes'
+import { mapValues } from 'lodash'
+/**
+ * Maps the key type (e.g. param, body) to the required keys
+ */
+type ICelebrateSpec = {
+  [s in Segments]?: {
+    key: string
+    message?: string
+  }
+}
+
+/**
+ * Options for customising celebrate error
+ */
+interface ICelebrateOpts {
+  message?: string
+  statusCode?: number
+}
+
+export const buildCelebrateError = (
+  spec: ICelebrateSpec,
+  opts: ICelebrateOpts = {},
+) => {
+  opts.message ??= 'celebrate request validation failed'
+  opts.statusCode ??= 400
+  return {
+    statusCode: opts.statusCode,
+    message: opts.message,
+    error: getReasonPhrase(opts.statusCode),
+    validation: mapValues(spec, (requirements, keyType) => {
+      return (
+        requirements && {
+          source: keyType,
+          keys: [requirements.key],
+          message: requirements.message ?? `"${requirements.key}" is required`,
+        }
+      )
+    }),
+  }
+}


### PR DESCRIPTION
This PR uses the default [`celebrate` error handler](https://github.com/arb/celebrate#errorsopts) to handle validation errors instead of rolling our own generic one. This gives the client more informative error messages when validation fails. Logging was also improved to include the details of the validation error.

**Why not use the celebrate error handler as a middleware?**
Using `isCelebrateError` allows us to retain control over the error object before passing it to the celebrate error handler, which allows us to perform customised actions, e.g. logging. Moreover, I thought it was cleaner to use the celebrate error handler within the `if (isCelebrateError)` block rather than calling `next`, because that allows our error handler to retain control of the error object rather than calling `next` and trusting that the celebrate error handler will be called.

## Before
![image](https://user-images.githubusercontent.com/29480346/95725962-e459dc00-0caa-11eb-908e-518d40fb4467.png)
![image](https://user-images.githubusercontent.com/29480346/95738881-8635f480-0cbc-11eb-9a7a-bd248ca6fe46.png)


## After
![image](https://user-images.githubusercontent.com/29480346/95726014-f50a5200-0caa-11eb-8ec2-a7b5b1bf9f13.png)
![image](https://user-images.githubusercontent.com/29480346/95738888-89c97b80-0cbc-11eb-9f55-84a9844e2070.png)
