### PR TITLE
fix: upgrade myinfo-gov-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4061,43 +4061,13 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-1.0.4.tgz",
-      "integrity": "sha512-ScKPI9sAxlbfNQMnzjZ5+LPGyT3TS1utlepCTJmHrPkQzS0GGXW6M4IfCbEfdq0K6eJYIUdZvjyOPklYPnuVkQ==",
+      "version": "github:opengovsg/myinfo-gov-client#11eb956d99a622870ccd11d6b97d4dfe7f32832e",
+      "from": "github:opengovsg/myinfo-gov-client#master",
       "requires": {
         "jose": "^0.3.2",
-        "node-jose": "^1.1.0",
+        "node-jose": "^2.0.0",
         "path": "^0.12.7",
         "request": "^2.88.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        },
-        "node-jose": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-1.1.4.tgz",
-          "integrity": "sha512-L31IFwL3pWWcMHxxidCY51ezqrDXMkvlT/5pLTfNw5sXmmOLJuN6ug7txzF/iuZN55cRpyOmoJrotwBQIoo5Lw==",
-          "requires": {
-            "base64url": "^3.0.1",
-            "browserify-zlib": "^0.2.0",
-            "buffer": "^5.5.0",
-            "es6-promise": "^4.2.8",
-            "lodash": "^4.17.15",
-            "long": "^4.0.0",
-            "node-forge": "^0.8.5",
-            "process": "^0.11.10",
-            "react-zlib-js": "^1.0.4",
-            "uuid": "^3.3.3"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "@opengovsg/ng-file-upload": {
@@ -7608,6 +7578,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
       "requires": {
         "pako": "~1.0.5"
       }
@@ -19316,7 +19287,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.0.0.tgz",
       "integrity": "sha512-j8zoFze1gijl8+DK/dSXXqX7+o2lMYv1XS+ptnXgGV/eloQaqq1YjNtieepbKs9jBS4WTnMOqyKSaQuunJzx0A==",
-      "dev": true,
       "requires": {
         "base64url": "^3.0.1",
         "buffer": "^5.5.0",
@@ -19332,8 +19302,7 @@
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -21382,11 +21351,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "react-zlib-js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/react-zlib-js/-/react-zlib-js-1.0.5.tgz",
-      "integrity": "sha512-TLcPdmqhIl+ylwOwlfm1WUuI7NVvhAv3L74d1AabhjyaAbmLOROTA/Q4EQ/UMCFCOjIkVim9fT3UZOQSFk/mlA=="
     },
     "read-file-relative": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4061,8 +4061,9 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "github:opengovsg/myinfo-gov-client#11eb956d99a622870ccd11d6b97d4dfe7f32832e",
-      "from": "github:opengovsg/myinfo-gov-client#master",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-2.0.0.tgz",
+      "integrity": "sha512-pRkBhSGIDDq8S2YFhfEGc9toqwm1D0uKhG/U+etjSbp13UXj/8TvLK1dQwTFCJ9NAgSO/S3M6UWrGdUoboUAkw==",
       "requires": {
         "jose": "^0.3.2",
         "node-jose": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "0.8.2",
-    "@opengovsg/myinfo-gov-client": "^1.0.4",
+    "@opengovsg/myinfo-gov-client": "opengovsg/myinfo-gov-client#master",
     "@opengovsg/ng-file-upload": "^12.2.14",
     "@opengovsg/spcp-auth-client": "^1.3.5",
     "@sentry/browser": "^5.24.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "0.8.2",
-    "@opengovsg/myinfo-gov-client": "opengovsg/myinfo-gov-client#master",
+    "@opengovsg/myinfo-gov-client": "^2.0.0",
     "@opengovsg/ng-file-upload": "^12.2.14",
     "@opengovsg/spcp-auth-client": "^1.3.5",
     "@sentry/browser": "^5.24.2",


### PR DESCRIPTION
Upgrades myinfo-gov-client to use the latest patch.

TODO:

1. test in staging environment
2. publish new myinfo-gov-client in npm
3. update package.json in this PR to use published package instead of installing from github branch