### PR TITLE
chore(examples-search): log failures from database

### DIFF
--- a/src/app/controllers/admin-console.server.controller.js
+++ b/src/app/controllers/admin-console.server.controller.js
@@ -548,8 +548,15 @@ const getExampleFormsUsing = (
       })
   }
 
-  mongoQuery.catch((err) => {
-    return cb(err, StatusCodes.INTERNAL_SERVER_ERROR, {
+  mongoQuery.catch((error) => {
+    logger.error({
+      message: 'Error with Examples Search query',
+      meta: {
+        action: 'getExampleFormsUsing',
+      },
+      error,
+    })
+    return cb(error, StatusCodes.INTERNAL_SERVER_ERROR, {
       message: 'Error in retrieving example forms.',
     })
   })


### PR DESCRIPTION
This PR simply logs the error message from mongoose for the examples search endpoint.