### PR TITLE
feat: implement circuit breaker for storage mode downloads

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -444,6 +444,22 @@ function GTag(Auth, $rootScope, $window) {
   }
 
   /**
+   * Logs an attempt to start storage mode responses download when circuit breaker is in open state.
+   * @param {Object} params The response params object
+   * @param {String} params.formId ID of the form
+   * @param {String} params.formTitle The title of the form
+   * @return {Void}
+   */
+  gtagService.downloadWhenBreakerOpen = (params) => {
+    _gtagEvents('storage', {
+      event_category: 'Storage Mode Form',
+      event_action: 'Attempt Download In Breaker Open State',
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
+      form_id: params.formId,
+    })
+  }
+
+  /**
    * Logs partial (or full) decryption failure when downloading responses.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes [#2](https://github.com/datagovsg/formsg-private/issues/2)

## Solution

- Implements circuit breaker pattern for storage mode downloads
- During the soft launch, upon failure, further attempts during the next 10 minutes will be logged but not prevented
- TODO: Enforce circuit breaker during hard launch, i.e. upon failure, further attempts will be prevented for 10 minutes. Depending on the soft launch stats, if such failures are prevalent, we may need to consider more user-friendly interventions e.g. queue system, instead of blocking users

## Tests

**Circuit breaker does not trip when download is successful**
- [ ] Create a storage mode form. Submit a response. Download responses. Download should complete normally and success toastr should appear.
- [ ] Check GA. The count of Download start and Download success should increment by 1.


**Circuit breaker trips when download fails; further attempts are logged**
- [ ] In the db, add an arbitrary character to the submission's `encryptedContent` field. Download responses. Responses should fail to download and failure toastr should appear.
- [ ] Check GA. The count of Download start and Partial decrypt error should increment by 1.
- [ ] Download responses again. Responses should fail to download and failure toastr should appear.
- [ ] Check GA. This time, the count of Download start, Partial decrypt error and **Attempt Download In Breaker Open State** should increment by 1.

**Circuit breaker resets when download is successful**
- [ ] In the db, remove the extra character earlier added to the `encryptedContent` field. Download responses. Download should complete normally and success toastr should appear.
- [ ] Check GA. The count of Download start, Download success and Attempt Download In Breaker Open State should increment by 1.
- [ ] Download responses again. Download should complete normally and success toastr should appear.
- [ ] Check GA. The count of Download start, Download success should increment by 1, but Attempt Download In Breaker Open State should not increment


