### PR TITLE
feat: return 200 for Bounce collection VersionError

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -1,5 +1,4 @@
 import { ObjectId } from 'bson'
-import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 import { mocked } from 'ts-jest/utils'
 
@@ -85,7 +84,7 @@ describe('handleSns', () => {
     expect(MockBounceService.logEmailNotification).not.toHaveBeenCalled()
     expect(MockBounceService.notifyAdminOfBounce).not.toHaveBeenCalled()
     expect(MockBounceService.logCriticalBounce).not.toHaveBeenCalled()
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.FORBIDDEN)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(403)
   })
 
   it('should return 400 when errors are thrown in isValidSnsRequest', async () => {
@@ -99,7 +98,7 @@ describe('handleSns', () => {
     expect(MockBounceService.logEmailNotification).not.toHaveBeenCalled()
     expect(MockBounceService.notifyAdminOfBounce).not.toHaveBeenCalled()
     expect(MockBounceService.logCriticalBounce).not.toHaveBeenCalled()
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('should call services correctly for permanent critical bounces', async () => {
@@ -146,7 +145,7 @@ describe('handleSns', () => {
       true,
     )
     expect(mockBounceDoc.save).toHaveBeenCalled()
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
   })
 
   it('should return 400 when errors are thrown in getUpdatedBounceDoc', async () => {
@@ -170,7 +169,7 @@ describe('handleSns', () => {
     expect(MockBounceService.getUpdatedBounceDoc).toHaveBeenCalledWith(
       MOCK_NOTIFICATION,
     )
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('should return 400 when errors are thrown in deactivateForm', async () => {
@@ -202,7 +201,7 @@ describe('handleSns', () => {
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,
     )
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('should return 400 when errors are thrown in notifyAdminOfBounce', async () => {
@@ -239,7 +238,7 @@ describe('handleSns', () => {
     expect(MockBounceService.notifyAdminOfBounce).toHaveBeenCalledWith(
       mockBounceDoc,
     )
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('should return 200 when VersionErrors are thrown', async () => {

--- a/tests/unit/backend/modules/verification/verification.controller.spec.ts
+++ b/tests/unit/backend/modules/verification/verification.controller.spec.ts
@@ -1,5 +1,4 @@
 import { ObjectId } from 'bson'
-import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 import { mocked } from 'ts-jest/utils'
 
@@ -17,6 +16,7 @@ import expressHandler from '../../helpers/jest-express'
 
 jest.mock('src/app/modules/verification/verification.service')
 const MockVfnService = mocked(VfnService, true)
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
 const MOCK_FORM_ID = 'formId'
 const MOCK_TRANSACTION_ID = 'transactionId'
@@ -50,7 +50,7 @@ describe('Verification controller', () => {
       expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.CREATED)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(201)
       expect(MOCK_RES.json).toHaveBeenCalledWith(returnValue)
     })
 
@@ -60,7 +60,7 @@ describe('Verification controller', () => {
       expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
-      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
     })
   })
 
@@ -83,7 +83,7 @@ describe('Verification controller', () => {
       expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(200)
       expect(MOCK_RES.json).toHaveBeenCalledWith(transaction)
     })
 
@@ -97,7 +97,7 @@ describe('Verification controller', () => {
       expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
       expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
     })
   })
@@ -122,7 +122,7 @@ describe('Verification controller', () => {
         transaction,
         MOCK_FIELD_ID,
       )
-      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
     })
 
     it('should return 404 when service throws error', async () => {
@@ -135,7 +135,7 @@ describe('Verification controller', () => {
       expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
         MOCK_TRANSACTION_ID,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
       expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
     })
   })
@@ -163,7 +163,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
-      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(201)
     })
 
     it('should return 404 when service throws not found error', async () => {
@@ -181,7 +181,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
       expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
     })
 
@@ -200,7 +200,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.ACCEPTED)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(202)
       expect(MOCK_RES.json).toHaveBeenCalledWith(waitOtpError)
     })
 
@@ -219,7 +219,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_ANSWER,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(400)
       expect(MOCK_RES.json).toHaveBeenCalledWith(sendOtpError)
     })
   })
@@ -250,7 +250,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_OTP,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(MOCK_RES.status).toHaveBeenCalledWith(200)
       expect(MOCK_RES.json).toHaveBeenCalledWith(MOCK_DATA)
     })
 
@@ -269,9 +269,7 @@ describe('Verification controller', () => {
         MOCK_FIELD_ID,
         MOCK_OTP,
       )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(
-        StatusCodes.UNPROCESSABLE_ENTITY,
-      )
+      expect(MOCK_RES.status).toHaveBeenCalledWith(422)
       expect(MOCK_RES.json).toHaveBeenCalledWith(invalidOtpError)
     })
   })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Email notifications arrive at our `/emailnotifications` endpoint asynchronously, and processing them involves retrieving documents from the Bounce collection. This means that multiple server instances sometimes attempt to access and modify the same Bounce document concurrently, resulting in Mongoose throwing `VersionErrors`. These errors are caught and HTTP 400 is returned, sometimes resulting in false HTTP 400 alarms.

## Solution
<!-- How did you solve the problem? -->

Check if the error is a `VersionError`, and return 200 if it is. The idea here is that we accept the risk of `VersionErrors` as a limitation of our system, and return an OK response since the error is on our end.

### Other improvements
Tests for the Bounce and Verification controllers were updated with hardcoded numbers for HTTP status codes instead of using the `http-status-codes` package.