### PR TITLE
feat: validate that webhook does not point back to app

### DIFF
--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -1,6 +1,7 @@
 import { promises as dns } from 'dns'
 import ip from 'ip'
 
+import config from '../../../config/config'
 import { isValidHttpsUrl } from '../../../shared/util/url-validation'
 
 import { WebhookValidationError } from './webhook.errors'
@@ -19,6 +20,13 @@ export const validateWebhookUrl = (webhookUrl: string): Promise<any> => {
       )
     }
     const urlParsed = new URL(webhookUrl)
+    if (urlParsed.origin === config.app.appUrl) {
+      return reject(
+        new WebhookValidationError(
+          `You cannot send responses back to ${config.app.appUrl}.`,
+        ),
+      )
+    }
     dns
       .resolve(urlParsed.hostname)
       .then((addresses) => {

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -19,8 +19,9 @@ export const validateWebhookUrl = (webhookUrl: string): Promise<any> => {
         new WebhookValidationError(`${webhookUrl} is not a valid HTTPS URL.`),
       )
     }
-    const urlParsed = new URL(webhookUrl)
-    if (urlParsed.origin === config.app.appUrl) {
+    const webhookUrlParsed = new URL(webhookUrl)
+    const appUrlParsed = new URL(config.app.appUrl)
+    if (webhookUrlParsed.hostname === appUrlParsed.hostname) {
       return reject(
         new WebhookValidationError(
           `You cannot send responses back to ${config.app.appUrl}.`,
@@ -28,7 +29,7 @@ export const validateWebhookUrl = (webhookUrl: string): Promise<any> => {
       )
     }
     dns
-      .resolve(urlParsed.hostname)
+      .resolve(webhookUrlParsed.hostname)
       .then((addresses) => {
         if (!addresses.length) {
           return reject(

--- a/tests/.test-basic-env
+++ b/tests/.test-basic-env
@@ -17,3 +17,4 @@ AWS_SECRET_ACCESS_KEY=fakeSecretAccessKey
 SESSION_SECRET=sandcrawler-138577
 
 AWS_ENDPOINT=http://localhost:4566
+APP_URL=https://example.com

--- a/tests/.test-full-env
+++ b/tests/.test-full-env
@@ -65,3 +65,5 @@ AWS_ACCESS_KEY_ID=fakeAccessKeyId
 AWS_SECRET_ACCESS_KEY=fakeSecretAccessKey
 
 AWS_ENDPOINT=http://localhost:4566
+
+APP_URL=https://example.com

--- a/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
+++ b/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
@@ -37,4 +37,14 @@ describe('Webhook URL validation', () => {
       ),
     )
   })
+
+  it('should reject URLs which start with the app URL', async () => {
+    await expect(
+      validateWebhookUrl('https://example.com/test'),
+    ).rejects.toStrictEqual(
+      new WebhookValidationError(
+        'You cannot send responses back to https://example.com.',
+      ),
+    )
+  })
 })

--- a/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
+++ b/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
@@ -38,7 +38,7 @@ describe('Webhook URL validation', () => {
     )
   })
 
-  it('should reject URLs which start with the app URL', async () => {
+  it('should reject URLs in the same domain as the app URL', async () => {
     await expect(
       validateWebhookUrl('https://example.com/test'),
     ).rejects.toStrictEqual(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users are allowed to enter webhook URLs which point back to the app, which results in 404 errors when our servers POST back to themselves.

## Solution
<!-- How did you solve the problem? -->

Validate that the webhook URL domain is not the same as the app URL.

## Screenshots
![image](https://user-images.githubusercontent.com/29480346/96108075-c345f500-0f0f-11eb-8947-ff8df64f4515.png)
