### PR TITLE
fix: correctly show decrypt progress modal after 3 seconds when downloading storage mode responses

### DIFF
--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -412,7 +412,7 @@ function ViewResponsesController(
   // passed and is still downloading after export button click.
   let timeoutPromise
   let progressModal
-  $scope.$watch('csvDownloading', function (csvDownloading) {
+  $scope.$watch('vm.csvDownloading', function (csvDownloading) {
     if (!csvDownloading) {
       if (timeoutPromise) {
         $timeout.cancel(timeoutPromise)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Missed adding `vm`... seems like that came back to bite us in the butt.

## Solution
<!-- How did you solve the problem? -->
**Bug Fixes**:

- fix: correctly show decrypt progress modal when downloading storage mode responses

## Tests
<!-- What tests should be run to confirm functionality? -->
> For local testing, I've set the timeout before the modal appears to 0 milliseconds (i.e instantly).
> For release testing, a test form with >100k responses should be used so the decrypting takes more than 3 seconds.
- [ ] Decrypt modal should show up after 3 seconds if downloading storage mode responses has not completed in that timeframe.