### PR TITLE
fix: add additional startsWith('@') check when validating domain

### DIFF
--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -662,7 +662,7 @@
                   <i class="bx bx-exclamation bx-md icon-spacing"></i>
                   <span class="alert-msg">
                     You may have duplicate or invalid email domains. Please
-                    check.
+                    check that all the domains start with @.
                   </span>
                 </div>
               </div>

--- a/src/shared/util/email-domain-validation.ts
+++ b/src/shared/util/email-domain-validation.ts
@@ -2,13 +2,14 @@ import { isEmpty } from 'lodash'
 import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
-  // We need to prepend "bob" to the email domain so that it can form an email address and can be
-  // validated by validator.isEmail.
   return (
     isEmpty(emailDomains) ||
     (new Set(emailDomains).size === emailDomains.length &&
-      emailDomains.every((emailDomain) =>
-        validator.isEmail('bob' + emailDomain),
+      emailDomains.every(
+        (emailDomain) =>
+          // We need to prepend "bob" to the email domain so that it can form an
+          // email address and can be validated by validator.isEmail.
+          emailDomain.startsWith('@') && validator.isEmail('bob' + emailDomain),
       ))
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds an additional check for the allowed domains entered by the user to enforce starting with an '@' symbol. This prevents a form admin from adding a complete email address such as `test@example.com` into the allowed domain field.

Related to https://github.com/datagovsg/formsg-private/issues/53

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix: add additional startsWith('@') check when validating domain

## Before & After Screenshots

**BEFORE**:
Allows full email domains
![Screenshot 2020-10-19 at 5 26 32 PM](https://user-images.githubusercontent.com/22133008/96426767-3d3bee00-1230-11eb-8842-4fa3b0058715.png)


**AFTER**:
Prevents full email addresses
![Screenshot 2020-10-19 at 3 51 58 PM](https://user-images.githubusercontent.com/22133008/96426703-2b5a4b00-1230-11eb-9690-3f5258af59f5.png)
