### PR TITLE
feat: allow form transfer for email mode forms

### DIFF
--- a/src/public/modules/core/css/admin-form-header.css
+++ b/src/public/modules/core/css/admin-form-header.css
@@ -365,7 +365,7 @@
   #collaborator-modal-body #collab-list {
     /* Max height should avoid extending the screen, because if the modal + dropdown menu is taller than
       the current screen's height, the bottom of the page will just appear white and not load. */
-    max-height: calc(100vh - 608px);
+    max-height: calc(100vh - 450px);
     overflow-y: auto;
     padding-right: 39px;
   }

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -48,11 +48,10 @@
             class="row inputs-container inputs-container--{{myform.responseMode}}"
             ng-init="collab.form.role = ROLES.EDITOR"
           >
-            <!-- The email input takes up the full row if it's read-only user, three quarters otherwise -->
             <div
               id="collab-email"
-              class="col-xs-12"
-              ng-class="(userCanEdit) ? 'col-sm-9' : ''"
+              ng-if="userCanEdit"
+              class="col-sm-9 col-xs-12"
             >
               <input
                 ng-model="collab.form.email"

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -48,7 +48,7 @@
             class="row inputs-container inputs-container--{{myform.responseMode}}"
             ng-init="collab.form.role = ROLES.EDITOR"
           >
-            <!-- The email input takes up the full row if it's email mode/non-beta user, three quarters otherwise -->
+            <!-- The email input takes up the full row if it's read-only user, three quarters otherwise -->
             <div
               id="collab-email"
               class="col-xs-12"
@@ -217,7 +217,7 @@
                 id="existing-collab-role"
                 class="col-xs-5 col-sm-3 role-column"
               >
-                <!-- Text only, for email or view-only collaborators list, as well as own email, since you cannot edit your own rights -->
+                <!-- Text only, for view-only collaborators list, as well as own email, since you cannot edit your own rights -->
                 <div
                   id="role-text-only"
                   ng-if="!userCanEdit || user.email === userObj.email.toLowerCase()"

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -52,7 +52,7 @@
             <div
               id="collab-email"
               class="col-xs-12"
-              ng-class="(userCanEdit && myform.responseMode === 'encrypt') ? 'col-sm-9' : ''"
+              ng-class="(userCanEdit) ? 'col-sm-9' : ''"
             >
               <input
                 ng-model="collab.form.email"
@@ -75,7 +75,7 @@
             <!-- Viewer mode only dropdown menu-->
             <div
               id="collab-role"
-              ng-if="userCanEdit && myform.responseMode === 'encrypt'"
+              ng-if="userCanEdit"
               class="col-xs-12 col-sm-3 role-column"
             >
               <div
@@ -220,7 +220,7 @@
                 <!-- Text only, for email or view-only collaborators list, as well as own email, since you cannot edit your own rights -->
                 <div
                   id="role-text-only"
-                  ng-if="!userCanEdit || myform.responseMode === 'email' || user.email === userObj.email.toLowerCase()"
+                  ng-if="!userCanEdit || user.email === userObj.email.toLowerCase()"
                 >
                   <span class="pull-left current-role-text"
                     >{{ permissionsToRole(userObj) }}</span
@@ -234,7 +234,7 @@
                     on-toggle stops being called, hence we call toggleScrollLock using the is-open's property. -->
                 <div
                   id="role-dropdown"
-                  ng-if="userCanEdit && myform.responseMode === 'encrypt' && user.email !== userObj.email.toLowerCase()"
+                  ng-if="userCanEdit && user.email !== userObj.email.toLowerCase()"
                   uib-dropdown
                   uib-dropdown-toggle
                   dropdown-append-to-body


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/FormSG/issues/214

## Solution

Extend form transfer functionality to email mode forms

## Tests

- [x]  Mobile view of collaborator modal works

_Encrypt Forms_
- [x]  Able to transfer ownership to collaborator (existing owner should become collaborator and only have edit access)
- [x]  Able to add a collaborator with read access
- [x]  Able to add a collaborator with edit access

_Email Forms_
- [x]  Able to transfer ownership to collaborator (existing owner should become collaborator and only have edit access)
- [x]  Able to add a collaborator with read access
- [x]  Able to add a collaborator with edit access