### PR TITLE
fix: unclickable submissionId search button

### DIFF
--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -102,7 +102,7 @@
 
 #responses-tab .response-stats {
   white-space: nowrap;
-  min-width: 240px;
+  min-width: 280px;
 }
 
 #responses-tab .datepicker-export-container {


### PR DESCRIPTION
## Problem
Submission search button was overlapped by other elements resulting it in being unclickable when screen width was between 768px to ~1500px

Closes [#439]

## Solution
Increase minimum width of search button's container

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![Screenshot from 2020-10-19 20-25-44](https://user-images.githubusercontent.com/63710093/96450855-569d6400-1249-11eb-8ce4-7144075b58fa.png)


**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot from 2020-10-19 20-25-57](https://user-images.githubusercontent.com/63710093/96450870-5ac98180-1249-11eb-9488-8659f0b62713.png)
## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create storage mode form. Submit response. Go to admin view data tab. Check that submissionId search button in clickable in various screen sizes.

