### PR TITLE
feat: implement timeout for storage mode downloads

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -444,6 +444,22 @@ function GTag(Auth, $rootScope, $window) {
   }
 
   /**
+   * Logs an attempt to start storage mode responses download when circuit breaker is in open state.
+   * @param {Object} params The response params object
+   * @param {String} params.formId ID of the form
+   * @param {String} params.formTitle The title of the form
+   * @return {Void}
+   */
+  gtagService.downloadWhenBreakerOpen = (params) => {
+    _gtagEvents('storage', {
+      event_category: 'Storage Mode Form',
+      event_action: 'Attempt Download In Breaker Open State',
+      event_label: `${params.formTitle} (${params.formId}), ${getUserEmail()}`,
+      form_id: params.formId,
+    })
+  }
+
+  /**
    * Logs partial (or full) decryption failure when downloading responses.
    * @param {Object} params The response params object
    * @param {String} params.formId ID of the form

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -157,19 +157,29 @@ function ViewResponsesController(
   // Helper function for handling download error
 
   const handleDownloadError = (error) => {
-    try {
-      const { errorCount, errorMessage } = JSON.parse(error.message)
+    if (error.toString() === 'Error: countFailed') {
       Toastr.error(
-        errorMessage ||
-          `Error downloading. ${errorCount} response(s) could not be decrypted. Please try again later.`,
-        { timeOut: 3000 },
+        `Error downloading, failed to receive a response. Please try again later.`,
+        {
+          timeOut: 5000,
+        },
       )
-    } catch (error) {
-      Toastr.error(`Error downloading. Please try again later.`, {
-        // Should still show error message to let user know download has failed
-        timeOut: 3000,
-      })
-      console.error('Unknown download encrypted responses error:\t', error)
+      console.error('Failed to retrieve count')
+    } else {
+      try {
+        const { errorCount, errorMessage } = JSON.parse(error.message)
+        Toastr.error(
+          errorMessage ||
+            `Error downloading. ${errorCount} response(s) could not be decrypted. Please try again later.`,
+          { timeOut: 3000 },
+        )
+      } catch (error) {
+        Toastr.error(`Error downloading. Please try again later.`, {
+          // Should still show error message to let user know download has failed
+          timeOut: 3000,
+        })
+        console.error('Unknown download encrypted responses error:\t', error)
+      }
     }
   }
 


### PR DESCRIPTION
(to be merged in after #471)

## Problem

Closes #[67](https://github.com/datagovsg/formsg-private/issues/67)

## Solution

- Timeout if Submissions.downloadEncryptedResponses does not receive a response within 15 seconds. A rejected promise is returned.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create storage mode form. Submit response. In admin view, go to data. In browser developer tab, set network throttling to latency of 600000 (10 mins). Click export. Modal with 'downloading' will appear. After 15 seconds, modal should disappear and an error toaster should appear ('Error downloading, failed to receive a response. Please try again later.')
- [ ] Remove network throttling. The download should not start.