### PR TITLE
build: pin mongoose version to 5.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lodash": "^4.17.20",
     "moment-timezone": "0.5.31",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "^5.10.0",
+    "mongoose": "5.10.0",
     "multiparty": ">=4.2.2",
     "neverthrow": "^2.7.1",
     "ng-infinite-scroll": "^1.3.0",


### PR DESCRIPTION
## Problem
Upgrading mongoose beyond 5.10.0 breaks server deployment. It is probable that deployments have not been affected only because TravisCI caches node_modules.

## Solution
Pin mongoose version to 5.10.0 until we can figure out the root cause.
