### PR TITLE
feat: require non-empty domains if restrict domain is toggled on

### DIFF
--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -961,6 +961,10 @@
   resize: vertical;
 }
 
+.edit-modal-window .edit-panel textarea.ng-invalid {
+  border: 2px solid #a94442 !important;
+}
+
 #admin-form .ui-sortable-placeholder {
   visibility: visible !important;
   border: none;

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -635,13 +635,14 @@
         >
           <br />
           <div class="row label-custom label-medium">
-            <div class="col-md-12">Domains allowed</div>
+            <div class="col-md-12 label-bottom">Domains allowed</div>
           </div>
           <div class="row">
             <div class="col-md-12">
               <textarea
                 class="input-custom input-medium"
                 ng-disabled="!vm.field.isVerifiable || !vm.field.hasAllowedEmailDomains"
+                ng-required="vm.field.hasAllowedEmailDomains"
                 ng-model="vm.field.allowedEmailDomainsFromText"
                 name="allowedEmailDomainsFromText"
                 validate-email-domain-from-text
@@ -663,6 +664,12 @@
                   <span class="alert-msg">
                     You may have duplicate or invalid email domains. Please
                     check that all the domains start with @.
+                  </span>
+                </div>
+                <div class="alert-custom alert-error" ng-message="required">
+                  <i class="bx bx-exclamation bx-md icon-spacing"></i>
+                  <span class="alert-msg">
+                    Allowed domains cannot be empty.
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Form admins should not be able to save empty allowed domains list on the front-end. This prevents user confusion, and also makes it easier to query for usage without having to ignore empty arrays.

Related to https://github.com/datagovsg/formsg-private/issues/53

## Solution
<!-- How did you solve the problem? -->

**Features**:

- Require non-empty domains if restrict domain is toggled on

**Improvements**:

- Add red error border to edit panel textareas if input is invalid (via `ng-invalid`). 

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Can be saved even if textarea is invalid
![Screenshot 2020-10-22 at 1 12 17 PM](https://user-images.githubusercontent.com/22133008/96827894-22a08980-1469-11eb-9349-b54c13b4301a.png)

**AFTER**:
<!-- [insert screenshot here] -->
Error prevents form saving
![Screenshot 2020-10-22 at 1 11 41 PM](https://user-images.githubusercontent.com/22133008/96827907-29c79780-1469-11eb-9de2-2fbd38f28583.png)

