### PR TITLE
fix(deps): unpin and bump mongoose from 5.10.0 to 5.10.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19001,13 +19001,13 @@
       "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
     },
     "mongoose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.0.tgz",
-      "integrity": "sha512-5itAvBMVDG4+zTDtuLg/IyoTxEMgvpOSHnigQ9Cyh8LR4BEgMAChJj7JSaGkg+tr1AjCSY9DgSdU8bHqCOoxXg==",
+      "version": "5.10.10",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.10.tgz",
+      "integrity": "sha512-KjCbWXTJ36RHMe0g31UG0/sANpJ9ekCIena7FkrCFlq5E9gJj/B2SgE5XQzIEiR1h4xMOVGKzyenCnyTw9UHZQ==",
       "requires": {
         "bson": "^1.1.4",
         "kareem": "2.3.1",
-        "mongodb": "3.6.0",
+        "mongodb": "3.6.2",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.7.0",
         "mquery": "3.2.2",
@@ -19024,11 +19024,11 @@
           "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         },
         "mongodb": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.0.tgz",
-          "integrity": "sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+          "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
           "requires": {
-            "bl": "^2.2.0",
+            "bl": "^2.2.1",
             "bson": "^1.1.4",
             "denque": "^1.4.1",
             "require_optional": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lodash": "^4.17.20",
     "moment-timezone": "0.5.31",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "5.10.0",
+    "mongoose": "^5.10.10",
     "multiparty": ">=4.2.2",
     "neverthrow": "^2.7.1",
     "ng-infinite-scroll": "^1.3.0",


### PR DESCRIPTION
Able to unpin mongoose since `await mongoose.connection` in `5.10.10` now correctly returns the connection in and not `undefined`.

Closes #506.


Bumps [mongoose](https://github.com/Automattic/mongoose) from 5.10.0 to 5.10.10.

# Changelog
<p><em>Sourced from <a href="https://github.com/Automattic/mongoose/blob/master/History.md">mongoose's changelog</a>.</em></p>

5.10.10 / 2020-10-23
====================
 * fix(schema): handle merging schemas from separate Mongoose module instances when schema has a virtual #9471
 * fix(connection): make connection.then(...) resolve to a connection instance #9497 [AbdelrahmanHafez](https://github.com/AbdelrahmanHafez)
 * fix(aggregate): when using $search with discriminators, add `$match` as the 2nd stage in pipeline rather than 1st #9487
 * fix(query): cast $nor within $elemMatch #9479
 * docs(connection): add note about 'error' event versus 'disconnected' event #9488 [tareqdayya](https://github.com/tareqdayya)

5.10.9 / 2020-10-09
===================
 * fix(update): strip out unused array filters to avoid "filter was not used in the update" error #9468
 * fix(mongoose): allow setting `autoCreate` as a global option to be consistent with `autoIndex` #9466

5.10.8 / 2020-10-05
===================
 * fix(schema): handle setting nested paths underneath single nested subdocs #9459
 * fix(schema+index): allow calling `mongoose.model()` with schema from a different Mongoose module instance #9449
 * fix(transaction): fix saving new documents w/ arrays in transactions #9457 [PenguinToast](https://github.com/PenguinToast)
 * fix(document): track `reason` on cast errors that occur while init-ing a document #9448
 * fix(model): make `createCollection()` not throw error when collection already exists to be consistent with v5.9 #9447
 * docs(connections): add SSL connections docs #9443
 * docs(query_casting): fix typo #9458 [craig-davis](https://github.com/craig-davis)

5.10.7 / 2020-09-24
===================
 * fix(schema): set correct path and schema on nested primitive arrays #9429
 * fix(document): pass document to required validator so `required` can use arrow functions #9435 [AbdelrahmanHafez](https://github.com/AbdelrahmanHafez)
 * fix(document): handle required when schema has property named `isSelected` #9438
 * fix(timestamps): allow using timestamps when schema has a property named 'set' #9428
 * fix(schema): make `Schema#clone()` use parent Mongoose instance's Schema constructor #9426

5.10.6 / 2020-09-18
===================
 * fix(populate): handle `options.perDocumentLimit` option same as `perDocumentLimit` when calling `populate()` #9418
 * fix(document): invalidate path if default function throws an error #9408
 * fix: ensure subdocument defaults run after initial values are set when initing #9408
 * docs(faq+queries): add more detail about duplicate queries, including an faq entry #9386
 * docs: replace var with let and const in docs and test files #9414 [jmadankumar](https://github.com/jmadankumar)
 * docs(model+query): document using array of strings as projection #9413
 * docs(middleware): add missing backtick #9425 [tphobe9312](https://github.com/tphobe9312)

5.10.5 / 2020-09-11
===================
 * fix: bump mongodb -> 3.6.2 #9411 [AbdelrahmanHafez](https://github.com/AbdelrahmanHafez)
 * fix(query+aggregate+cursor): support async iteration over a cursor instance as opposed to a Query or Aggregate instance #9403
 * fix(document): respect child schema `minimize` if `toObject()` is called without an explicit `minimize` #9405
 * docs(guide): use const instead of var #9394 [nainardev](https://github.com/nainardev)
 * docs(query): link to lean, findOneAndUpdate, query casting tutorials from query docs #9410

5.10.4 / 2020-09-09
===================
 * fix(document): allow setting nested path to instance of model #9392
 * fix: handle `findOneAndRemove()` with `orFail()` #9381
 * fix(schema): support setting `_id` option to `false` after instantiating schema #9390
 * docs(document): fix formatting on `getChanges()` #9376

5.10.3 / 2020-09-03
===================
 * fix: upgrade mongodb -> 3.6.1 #9380 [lamhieu-vk](https://github.com/lamhieu-vk)
 * fix(populate): allow populating paths underneath subdocument maps #9359
 * fix(update): handle casting map paths when map is underneath a single nested subdoc #9298
 * fix(discriminator): avoid removing nested path if both base and discriminator schema have the same nested path #9362
 * fix(schema): support `Schema#add()` with schematype instances with different paths #9370
 * docs(api): fix typo in `Query#get()` example #9372 [elainewlin](https://github.com/elainewlin)

5.10.2 / 2020-08-28
===================
 * fix(model): avoid uncaught error if `insertMany()` fails due to server selection error #9355
 * fix(aggregate): automatically convert accumulator function options to strings #9364
 * fix(document): handle `pull()` on a document array when `_id` is an alias #9319
 * fix(queryhelpers): avoid path collision error when projecting in discriminator key with `.$` #9361
 * fix: fix typo in error message thrown by unimplemented createIndex #9367 [timhaley94](https://github.com/timhaley94)
 * docs(plugins): note that plugins should be applied before you call `mongoose.model()` #7723

5.10.1 / 2020-08-26
===================
 * fix(mongoose): fix `.then()` is not a function error when calling `mongoose.connect()` multiple times #9358 #9335 #9331
 * fix: allow calling `create()` after `bulkWrite()` by clearing internal casting context #9350
 * fix(model): dont wipe out changes made while `save()` is in-flight #9327
 * fix(populate): skip checking `refPath` if the path to populate is undefined #9340
 * fix(document): allow accessing document values from function `default` on array #9351
 * fix(model): skip applying init hook if called with `schema.pre(..., { document: false })` #9316
 * fix(populate): support `retainNullValues` when setting `_id` to `false` for subdocument #9337 #9336 [FelixRe0](https://github.com/FelixRe0)
 * docs: update connect example to avoid deprecation warnings #9332 [moander](https://github.com/moander)