### PR TITLE
build: Release 4.42.0 hotfix

### DIFF
--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -617,6 +617,7 @@
                 <input
                   type="checkbox"
                   ng-model="vm.field.hasAllowedEmailDomains"
+                  ng-disabled="!vm.field.isVerifiable"
                 />
                 <div class="toggle-selector-switch">
                   <i


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- For email form field Restrict Email Domains, it is still possible to toggle Restrict Email Domains even when OTP verification is toggled false, although visually Restrict Email Domains remains shown as toggle false. This results in Restrict Email Domains toggled to true and subsequently, field validation fails as the domain list is empty. 

## Solution
- Disable Restrict Email Domains toggle if OTP verification is not toggled true

**BEFORE**:
<!-- [insert screenshot here] -->
![Screenshot from 2020-10-27 13-20-35](https://user-images.githubusercontent.com/63710093/97260902-b357da80-1858-11eb-92a8-655691b61604.png)

**AFTER**
(no longer possible to get into the 'BEFORE' state)
![Screenshot from 2020-10-27 13-37-03](https://user-images.githubusercontent.com/63710093/97261312-85bf6100-1859-11eb-9a87-c5bfd7f982c5.png)

