### PR TITLE
feat: stealth textfield prefill feature from query parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12974,8 +12974,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "helmet": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "font-awesome": "4.7.0",
     "fp-ts": "^2.8.3",
     "has-ansi": "^4.0.0",
+    "he": "^1.2.0",
     "helmet": "^4.1.1",
     "http-status-codes": "^2.1.4",
     "intl-tel-input": "~12.1.6",

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -44,9 +44,19 @@ exports.isFormPublic = function (req, res, next) {
  * @param  {Object} res - Express response object
  */
 exports.redirect = async function (req, res) {
+  const queryPortion = req.url ? req.url.split('?', 2)[1] : undefined
   let redirectPath = req.params.state
     ? req.params.Id + '/' + req.params.state
     : req.params.Id
+  if (
+    queryPortion &&
+    queryPortion.length > 0 &&
+    queryPortion.match(
+      /^(([0-9A-Za-z]+=[0-9A-Za-z]+)(&[0-9A-Za-z]+=[0-9A-Za-z]+)*)?$/,
+    ) // Append only if queryPortion is formatted correctly
+  ) {
+    redirectPath = redirectPath + '?' + encodeURIComponent(queryPortion)
+  }
   try {
     const metaTags = await fetchMetatags(req)
     return res.render('index', {

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -2,6 +2,7 @@
 
 const mongoose = require('mongoose')
 const { StatusCodes } = require('http-status-codes')
+const querystring = require('querystring')
 
 const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
@@ -44,12 +45,12 @@ exports.isFormPublic = function (req, res, next) {
  * @param  {Object} res - Express response object
  */
 exports.redirect = async function (req, res) {
-  const queryPortion = req.url ? req.url.split('?', 2)[1] : undefined
   let redirectPath = req.params.state
     ? req.params.Id + '/' + req.params.state
     : req.params.Id
-  if (queryPortion && queryPortion.length > 0) {
-    redirectPath = redirectPath + '?' + encodeURIComponent(queryPortion)
+  const reqQuery = querystring.stringify(req.query)
+  if (reqQuery.length > 0) {
+    redirectPath = redirectPath + '?' + encodeURIComponent(reqQuery)
   }
   try {
     const metaTags = await fetchMetatags(req)

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -48,13 +48,7 @@ exports.redirect = async function (req, res) {
   let redirectPath = req.params.state
     ? req.params.Id + '/' + req.params.state
     : req.params.Id
-  if (
-    queryPortion &&
-    queryPortion.length > 0 &&
-    queryPortion.match(
-      /^(([0-9A-Za-z]+=[0-9A-Za-z]+)(&[0-9A-Za-z]+=[0-9A-Za-z]+)*)?$/,
-    ) // Append only if queryPortion is formatted correctly
-  ) {
+  if (queryPortion && queryPortion.length > 0) {
     redirectPath = redirectPath + '?' + encodeURIComponent(queryPortion)
   }
   try {

--- a/src/app/controllers/public-forms.server.controller.js
+++ b/src/app/controllers/public-forms.server.controller.js
@@ -67,8 +67,9 @@ exports.redirect = async function (req, res) {
       },
       error: err,
     })
+    res.redirect('/#!/' + redirectPath)
+    return
   }
-  res.redirect('/#!/' + redirectPath)
 }
 
 /**

--- a/src/app/routes/frontend.server.routes.js
+++ b/src/app/routes/frontend.server.routes.js
@@ -14,7 +14,9 @@ module.exports = function (app) {
     celebrate({
       [Segments.QUERY]: {
         redirectPath: Joi.string()
-          .regex(/^[a-fA-F0-9]{24}(\/(preview|template|use-template))?$/)
+          .regex(
+            /^[a-fA-F0-9]{24}(\/(preview|template|use-template))?(\?([0-9A-Za-z]+=[0-9A-Za-z]+)(&[0-9A-Za-z]+=[0-9A-Za-z]+)*)?$/,
+          )
           .required(),
       },
     }),

--- a/src/app/routes/frontend.server.routes.js
+++ b/src/app/routes/frontend.server.routes.js
@@ -14,9 +14,7 @@ module.exports = function (app) {
     celebrate({
       [Segments.QUERY]: {
         redirectPath: Joi.string()
-          .regex(
-            /^[a-fA-F0-9]{24}(\/(preview|template|use-template))?(\?([0-9A-Za-z]+=[0-9A-Za-z]+)(&[0-9A-Za-z]+=[0-9A-Za-z]+)*)?$/,
-          )
+          .regex(/^[a-fA-F0-9]{24}(\/(preview|template|use-template))?/)
           .required(),
       },
     }),

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -1,13 +1,17 @@
 'use strict'
 
 const { get } = require('lodash')
-// const queryString = require('query-string')
 
 angular
   .module('forms')
-  .directive('fieldDirective', ['FormFields', '$location', fieldDirective])
+  .directive('fieldDirective', [
+    'FormFields',
+    '$location',
+    '$sanitize',
+    fieldDirective,
+  ])
 
-function fieldDirective(FormFields, $location) {
+function fieldDirective(FormFields, $location, $sanitize) {
   return {
     restrict: 'E',
     templateUrl:
@@ -30,12 +34,18 @@ function fieldDirective(FormFields, $location) {
       // Then prefill and disable editing the corresponding form field on the frontend
 
       const queryParams = $location.search()
+      console.log(queryParams)
 
       if (
         scope.field._id in queryParams &&
         scope.field.fieldType === 'textfield'
       ) {
-        scope.field.fieldValue = queryParams[scope.field._id]
+        let prefillValue = queryParams[scope.field._id]
+        prefillValue = Array.isArray(prefillValue)
+          ? prefillValue[prefillValue.length - 1] // use last value in array if param key repeated
+          : // but note that there is no specification that the last value will definitely be last in order in the url string
+            prefillValue
+        scope.field.fieldValue = $sanitize(prefillValue) // sanitize prefillValue as a precaution, but this means "<>& cannot be used
         scope.field.disabled = true
       }
 

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const { get } = require('lodash')
+// const queryString = require('query-string')
 
 angular
   .module('forms')
-  .directive('fieldDirective', ['FormFields', fieldDirective])
+  .directive('fieldDirective', ['FormFields', '$location', fieldDirective])
 
-function fieldDirective(FormFields) {
+function fieldDirective(FormFields, $location) {
   return {
     restrict: 'E',
     templateUrl:
@@ -23,6 +24,21 @@ function fieldDirective(FormFields) {
       isValidateDate: '<',
     },
     link: function (scope) {
+      // Stealth prefill feature
+      // If a query parameter is provided to a form URL in the form ?<fieldId1>=<value1>&<fieldId2>=<value2>...
+      // And if the fieldIds are valid mongoose object IDs and refer to a short text field,
+      // Then prefill and disable editing the corresponding form field on the frontend
+
+      const queryParams = $location.search()
+
+      if (
+        scope.field._id in queryParams &&
+        scope.field.fieldType === 'textfield'
+      ) {
+        scope.field.fieldValue = queryParams[scope.field._id]
+        scope.field.disabled = true
+      }
+
       if ((scope.isadminpreview || scope.isTemplate) && scope.field.myInfo) {
         // Determine whether to disable field in preview
         if (

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -6,14 +6,9 @@ const querystring = require('querystring')
 
 angular
   .module('forms')
-  .directive('fieldDirective', [
-    'FormFields',
-    '$location',
-    '$sanitize',
-    fieldDirective,
-  ])
+  .directive('fieldDirective', ['FormFields', '$location', fieldDirective])
 
-function fieldDirective(FormFields, $location, $sanitize) {
+function fieldDirective(FormFields, $location) {
   return {
     restrict: 'E',
     templateUrl:
@@ -47,7 +42,7 @@ function fieldDirective(FormFields, $location, $sanitize) {
         if (typeof prefillValue === 'string') {
           // Only support unique query params. If query params are duplicated,
           // none of the duplicated keys will be prefilled
-          scope.field.fieldValue = $sanitize(prefillValue) // sanitize prefillValue as a precaution, but this means "<>& cannot be used
+          scope.field.fieldValue = prefillValue // do not use $sanitize as it removes non-english characters, tested that script and html tags do not work
           scope.field.disabled = true
         }
       }

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -36,8 +36,9 @@ function fieldDirective(FormFields, $location, $sanitize) {
       // Then prefill and disable editing the corresponding form field on the frontend
 
       const decodedUrl = he.decode($location.url()) // tech debt; after redirect, & is encoded as &amp; in the query string
-      const query = decodedUrl.split('?')[1]
-      const queryParams = querystring.parse(query)
+      const query = decodedUrl.split('?')
+      const queryParams =
+        query.length > 1 ? querystring.parse(query[1]) : undefined
 
       if (
         scope.field._id in queryParams &&

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -41,6 +41,7 @@ function fieldDirective(FormFields, $location, $sanitize) {
         query.length > 1 ? querystring.parse(query[1]) : undefined
 
       if (
+        queryParams &&
         scope.field._id in queryParams &&
         scope.field.fieldType === 'textfield'
       ) {

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -6,9 +6,14 @@ const querystring = require('querystring')
 
 angular
   .module('forms')
-  .directive('fieldDirective', ['FormFields', '$location', fieldDirective])
+  .directive('fieldDirective', [
+    'FormFields',
+    '$location',
+    '$sanitize',
+    fieldDirective,
+  ])
 
-function fieldDirective(FormFields, $location) {
+function fieldDirective(FormFields, $location, $sanitize) {
   return {
     restrict: 'E',
     templateUrl:
@@ -42,7 +47,7 @@ function fieldDirective(FormFields, $location) {
         if (typeof prefillValue === 'string') {
           // Only support unique query params. If query params are duplicated,
           // none of the duplicated keys will be prefilled
-          scope.field.fieldValue = prefillValue // do not use $sanitize as it removes non-english characters, tested that script and html tags do not work
+          scope.field.fieldValue = $sanitize(prefillValue) // $sanitize as a precaution to prevent xss
           scope.field.disabled = true
         }
       }

--- a/tests/unit/backend/controllers/public-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/public-forms.server.controller.spec.js
@@ -30,6 +30,7 @@ describe('Public-Forms Controller', () => {
       params: {},
       body: {},
       headers: {},
+      url: '',
       ip: '127.0.0.1',
       get: () => '',
     }
@@ -85,6 +86,33 @@ describe('Public-Forms Controller', () => {
         expect(res.redirect).toHaveBeenCalledWith(
           '/#!/321564654f65we4f65e4f5/preview',
         )
+        done()
+      })
+      Controller.redirect(req, res)
+    })
+
+    it('should redirect to form with query params retained if they are valid format', (done) => {
+      req.params = {
+        Id: '321564654f65we4f65e4f5',
+      }
+      req.url = '/321564654f65we4f65e4f5?abc=def&zzz=yyy'
+      const uriString = encodeURIComponent('abc=def&zzz=yyy')
+      res.redirect = jasmine.createSpy().and.callFake(() => {
+        expect(res.redirect).toHaveBeenCalledWith(
+          `/#!/321564654f65we4f65e4f5?${uriString}`,
+        )
+        done()
+      })
+      Controller.redirect(req, res)
+    })
+
+    it('should redirect to form without query params if they are invalid format', (done) => {
+      req.params = {
+        Id: '321564654f65we4f65e4f5',
+      }
+      req.url = '/321564654f65we4f65e4f5?abc'
+      res.redirect = jasmine.createSpy().and.callFake(() => {
+        expect(res.redirect).toHaveBeenCalledWith('/#!/321564654f65we4f65e4f5')
         done()
       })
       Controller.redirect(req, res)

--- a/tests/unit/backend/controllers/public-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/public-forms.server.controller.spec.js
@@ -91,7 +91,7 @@ describe('Public-Forms Controller', () => {
       Controller.redirect(req, res)
     })
 
-    it('should redirect to form with query params retained if they are valid format', (done) => {
+    it('should redirect to form with query params retained', (done) => {
       req.params = {
         Id: '321564654f65we4f65e4f5',
       }
@@ -101,18 +101,6 @@ describe('Public-Forms Controller', () => {
         expect(res.redirect).toHaveBeenCalledWith(
           `/#!/321564654f65we4f65e4f5?${uriString}`,
         )
-        done()
-      })
-      Controller.redirect(req, res)
-    })
-
-    it('should redirect to form without query params if they are invalid format', (done) => {
-      req.params = {
-        Id: '321564654f65we4f65e4f5',
-      }
-      req.url = '/321564654f65we4f65e4f5?abc'
-      res.redirect = jasmine.createSpy().and.callFake(() => {
-        expect(res.redirect).toHaveBeenCalledWith('/#!/321564654f65we4f65e4f5')
         done()
       })
       Controller.redirect(req, res)

--- a/tests/unit/backend/controllers/public-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/public-forms.server.controller.spec.js
@@ -96,14 +96,14 @@ describe('Public-Forms Controller', () => {
         Id: '321564654f65we4f65e4f5',
       }
       req.query = {
-        p1: 'v1',
+        p1: 'v1-_',
         p2: 'v2',
         p3: ['v3', 'v4'],
       }
 
       res.redirect = jasmine.createSpy().and.callFake(() => {
         expect(res.redirect).toHaveBeenCalledWith(
-          jasmine.stringMatching(/\?.*p1%3Dv1/),
+          jasmine.stringMatching(/\?.*p1%3Dv1-_/),
         )
         expect(res.redirect).toHaveBeenCalledWith(
           jasmine.stringMatching(/\?.*p2%3Dv2/),

--- a/tests/unit/backend/controllers/public-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/public-forms.server.controller.spec.js
@@ -91,18 +91,32 @@ describe('Public-Forms Controller', () => {
       Controller.redirect(req, res)
     })
 
-    it('should redirect to form with query params retained', (done) => {
+    it('should redirect to form with correct query params retained', (done) => {
       req.params = {
         Id: '321564654f65we4f65e4f5',
       }
-      req.url = '/321564654f65we4f65e4f5?abc=def&zzz=yyy'
-      const uriString = encodeURIComponent('abc=def&zzz=yyy')
+      req.query = {
+        p1: 'v1',
+        p2: 'v2',
+        p3: ['v3', 'v4'],
+      }
+
       res.redirect = jasmine.createSpy().and.callFake(() => {
         expect(res.redirect).toHaveBeenCalledWith(
-          `/#!/321564654f65we4f65e4f5?${uriString}`,
+          jasmine.stringMatching(/\?.*p1%3Dv1/),
+        )
+        expect(res.redirect).toHaveBeenCalledWith(
+          jasmine.stringMatching(/\?.*p2%3Dv2/),
+        )
+        expect(res.redirect).toHaveBeenCalledWith(
+          jasmine.stringMatching(/\?.*p3%3Dv3/),
+        )
+        expect(res.redirect).toHaveBeenCalledWith(
+          jasmine.stringMatching(/\?.*p3%3Dv4/),
         )
         done()
       })
+
       Controller.redirect(req, res)
     })
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #498

## Solution
- Retain query params when redirecting from non-hashbang url
- On public form route, extract query params using $location service on frontend to stealth prefill forms

TODO:

- Test that special characters in query param values work correctly and that they are passed correctly to redirect endpoint

## Screenshots

**AFTER**:
With the query param string: `?<fieldId2>=yes&<fieldId4>=hello`
![Screenshot from 2020-10-27 16-29-33](https://user-images.githubusercontent.com/63710093/97276106-be6b3480-1871-11eb-9f72-19a8a3aaee61.png)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a form with short text field. Open in public view with the query params `<shortTextFieldId>=<value1>`, where `<value1>` comprises alphanumeric/hyphen/underscore characters. Check that the short text field is prefilled with value1
- [ ] Add a duplicate query param `<shortTextFieldId>=<value1a>`. Check that the short text field is not prefilled with any value
- [ ] Add a long text field. Add the query params `<otherFieldId>=<value2>`. Check that the long text field is not prefilled
- [ ] Check that prefilling works even without the hashbang in the url
- [ ] Add radio button to the form. Set form logic to hide the short text field conditional on the radio button. Check that the short text field is prefilled when it is unhidden
