### PR TITLE
feat: tighten isUserInSession conditional for protected routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
     on_failure: always
 
 before_script:
-  - export NODE_OPTIONS=–max_old_space_size=4096
+  - export NODE_OPTIONS=--max-old-space-size=4096
 
 script:
   - set -e

--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -55,5 +55,5 @@ export const mapRouteError = (
 }
 
 export const isUserInSession = (req: Request): boolean => {
-  return !!req.session?.user
+  return !!req.session?.user?._id
 }

--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -1,4 +1,3 @@
-import { Request } from 'express'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -54,6 +53,8 @@ export const mapRouteError = (
   }
 }
 
-export const isUserInSession = (req: Request): boolean => {
-  return !!req.session?.user?._id
+export const isUserInSession = (
+  session?: Express.Session,
+): session is Express.AuthedSession => {
+  return !!session?.user?._id
 }

--- a/src/app/modules/billing/__tests__/billing.controller.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.controller.spec.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'bson-ext'
 import moment from 'moment-timezone'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
@@ -26,7 +27,9 @@ describe('billing.controller', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       query: MOCK_REQ_QUERY,
       session: {
-        user: 'exists',
+        user: {
+          _id: new ObjectId().toHexString(),
+        },
       },
     })
 

--- a/src/app/modules/billing/billing.controller.ts
+++ b/src/app/modules/billing/billing.controller.ts
@@ -28,7 +28,7 @@ export const handleGetBillInfo: RequestHandler<
   }
 > = async (req, res) => {
   // Restricted route.
-  if (!isUserInSession(req)) {
+  if (!isUserInSession(req.session)) {
     return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
   }
 
@@ -62,9 +62,7 @@ export const handleGetBillInfo: RequestHandler<
 
   // Retrieved login stats successfully.
   logger.info({
-    message: `Billing search for ${esrvcId} by ${
-      req.session?.user && req.session.user.email
-    }`,
+    message: `Billing search for ${esrvcId} by ${req.session.user.email}`,
     meta: {
       action: 'handleGetBillInfo',
       ...createReqMeta(req),

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -9,5 +9,9 @@ declare global {
     export interface Session {
       user?: IUserSchema
     }
+
+    export interface AuthedSession extends Session {
+      user: IUserSchema
+    }
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR tightens the check to see if a user is logged in. 

## Solution
<!-- How did you solve the problem? -->


**Improvements**:

- Tighten checks on whether user is in session by checking for existence of `user._id` instead of just the `user` object.
