### PR TITLE
fix: local builds failing to transpile due to breaking change in tsnd + Travis JS heap increase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ notifications:
     on_success: always
     on_failure: always
 
+before_script:
+  - export NODE_OPTIONS=–max_old_space_size=4096
+
 script:
   - set -e
   - npm run lint-ci

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-frontend-dev:watch": "webpack --config webpack.dev.js --watch",
     "start": "node dist/backend/server.js",
     "dev": "docker-compose up --build",
-    "docker-dev": "npm run build-frontend-dev:watch & ts-node-dev --respawn --transpileOnly --inspect=0.0.0.0 --exit-child -- src/server.ts",
+    "docker-dev": "npm run build-frontend-dev:watch & ts-node-dev --respawn --transpile-only --inspect=0.0.0.0 --exit-child -- src/server.ts",
     "test-backend": "npm run test-backend-jasmine && npm run test-backend-jest",
     "test-backend-jest": "env-cmd -f tests/.test-full-env jest --coverage --maxWorkers=2",
     "test-backend-jest:watch": "env-cmd -f tests/.test-full-env jest --watch",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Local builds are failing with an error (but no steps to fix it):

```
bad option: --transpileOnly
```

The fix is to change the `--transpileOnly` flag to `--transpile-only`.

See https://github.com/whitecolor/ts-node-dev/issues/223

Travis also failed to build due to Javascript heap being out of memory. This PR also increases the heap size Javascript can use.
