### PR TITLE
fix(prefill): do not disable textfield due to phishing concerns

### DIFF
--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -50,7 +50,6 @@ function fieldDirective(FormFields, $location, $sanitize) {
           // Only support unique query params. If query params are duplicated,
           // none of the duplicated keys will be prefilled
           scope.field.fieldValue = $sanitize(prefillValue) // $sanitize as a precaution to prevent xss
-          scope.field.disabled = true
         }
       }
 


### PR DESCRIPTION
## Problem
Potential phishing concerns from disabling editing of prefill.

## Solution
Do not disable the input box after prefill.

