### PR TITLE
fix(prefill): allow prefill only if allowPrefill flag is set to true

### DIFF
--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -41,6 +41,8 @@ function fieldDirective(FormFields, $location, $sanitize) {
         query.length > 1 ? querystring.parse(query[1]) : undefined
 
       if (
+        scope.field.allowPrefill &&
+        scope.field.allowPrefill === true &&
         queryParams &&
         scope.field._id in queryParams &&
         scope.field.fieldType === 'textfield'


### PR DESCRIPTION
## Problem
- Potential phishing concerns as:
  - User may not notice that field has been prefilled, and/or assume that the prefilled value is officially verified / endorsed
  - After submission, admin is unable to verify if field value was prefilled, or provided by user

## Solution
- Allow prefill only if field.allowPrefill flag is set to true