### PR TITLE
chore: shift webhook field to bottom of settings page, update copy

### DIFF
--- a/src/public/modules/forms/admin/css/settings-form.css
+++ b/src/public/modules/forms/admin/css/settings-form.css
@@ -15,6 +15,17 @@
   margin: 0;
 }
 
+#settings-form #enable-webhooks .field-optional {
+  font-size: 15px;
+  font-weight: normal;
+  color: #b8b8b8;
+  margin-left: 10px;
+}
+
+#settings-form .webhook-divider {
+  margin-top: 40px;
+}
+
 #settings-form #enable-webhooks .glyphicon {
   margin-left: 40px !important;
 }

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -251,6 +251,39 @@
 
       <div class="settings-divider"></div>
 
+      <!-- Form name and emails -->
+      <form-title-input-component
+        form-data="tempForm"
+        form-controller="settingsForm"
+        save-form="saveForm()"
+      >
+      </form-title-input-component>
+      <form-emails-input-component
+        form-data="tempForm"
+        form-controller="settingsForm"
+        save-form="saveForm()"
+        ng-if="!isFormEncrypt()"
+      >
+      </form-emails-input-component>
+
+      <div class="row form-option">
+        <div class="col-xs-9 label-custom label-large">
+          Mode for receiving form data<i
+            class="glyphicon glyphicon-question-sign"
+            uib-tooltip="This setting can't be changed after form creation. To change it, duplicate this form."
+            tooltip-trigger="'click mouseenter'"
+          ></i>
+        </div>
+        <div class="col-xs-3">
+          <span class="pull-right label-custom label-large">
+            <span ng-if="isFormEncrypt()">Storage</span>
+            <span ng-if="!isFormEncrypt()">Email</span>
+          </span>
+        </div>
+      </div>
+
+      <div class="settings-divider webhook-divider"></div>
+
       <!-- Webhooks for encrypted forms -->
       <div
         ng-if="isFormEncrypt()"
@@ -266,9 +299,10 @@
             <span class="beta-icon"> beta </span>
             <i
               class="glyphicon glyphicon-question-sign"
-              uib-tooltip="If specified, we will POST encrypted form submissions to a REST API supplied by you."
+              uib-tooltip="For developers and IT officers. We will POST encrypted form responses in real-time to the HTTPS endpoint specified here."
               tooltip-trigger="'click mouseenter'"
             ></i>
+            <span class="field-optional">(optional)</span>
           </label>
         </div>
         <div
@@ -319,39 +353,6 @@
               </span>
             </div>
           </div>
-        </div>
-      </div>
-
-      <div class="settings-divider"></div>
-
-      <!-- Form name and emails -->
-      <form-title-input-component
-        form-data="tempForm"
-        form-controller="settingsForm"
-        save-form="saveForm()"
-      >
-      </form-title-input-component>
-      <form-emails-input-component
-        form-data="tempForm"
-        form-controller="settingsForm"
-        save-form="saveForm()"
-        ng-if="!isFormEncrypt()"
-      >
-      </form-emails-input-component>
-
-      <div class="row form-option">
-        <div class="col-xs-9 label-custom label-large">
-          Mode for receiving form data<i
-            class="glyphicon glyphicon-question-sign"
-            uib-tooltip="This setting can't be changed after form creation. To change it, duplicate this form."
-            tooltip-trigger="'click mouseenter'"
-          ></i>
-        </div>
-        <div class="col-xs-3">
-          <span class="pull-right label-custom label-large">
-            <span ng-if="isFormEncrypt()">Storage</span>
-            <span ng-if="!isFormEncrypt()">Email</span>
-          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Closes #542


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![Screenshot 2020-10-30 at 7 33 57 PM](https://user-images.githubusercontent.com/63710093/97701349-39d61b80-1ae8-11eb-9ccf-60acdbae8a64.png)
**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot 2020-10-30 at 7 41 12 PM](https://user-images.githubusercontent.com/63710093/97701330-3478d100-1ae8-11eb-9c74-5202d53eea9f.png)


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create storage mode form. Add any webhook url. Submit form. Check in the logs that attempt was made to post the response to webhook url.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
