### PR TITLE
refactor: remove unused verified mobile beta check

### DIFF
--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -584,7 +584,4 @@ function EditFieldsModalController(
     // On error, we explicitly clear the files stored in the model, as the library does not always automatically do this
     field.uploadedFile = ''
   }
-
-  vm.userHasAccessToVerifiedMobileOrAutoreply = () =>
-    Betas.userHasAccessToVerifiedMobileOrAutoreply(Auth.getUser())
 }

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -858,7 +858,6 @@
         <configure-mobile-directive
           ng-if="vm.field.fieldType === 'mobile'"
           field="vm.field"
-          allow-sms="vm.userHasAccessToVerifiedMobileOrAutoreply()"
           name="'SMS'"
           character-limit="300"
           feature-toggle

--- a/src/public/modules/forms/services/betas.client.factory.js
+++ b/src/public/modules/forms/services/betas.client.factory.js
@@ -42,14 +42,9 @@ function Betas() {
     )
   }
 
-  const userHasAccessToVerifiedMobileOrAutoreply = (user) => {
-    return get(user, ['betaFlags', BETA_FEATURES_FIELD.sms.flag])
-  }
-
   return {
     getMissingFieldPermissions,
     isBetaField,
     userHasAccessToFieldType,
-    userHasAccessToVerifiedMobileOrAutoreply,
   }
 }


### PR DESCRIPTION
The function `userHasAccessToVerifiedMobileOrAutoreply` was created as part of the verified mobile release, but was later missed during the code cleanup when verified mobile was released to all users. This PR removes references to that function.