### PR TITLE
refactor: remove unused SPCP factory function

### DIFF
--- a/src/app/factories/spcp-myinfo.factory.js
+++ b/src/app/factories/spcp-myinfo.factory.js
@@ -108,7 +108,6 @@ const spcpFactory = ({ isEnabled, props }) => {
     return {
       getRequestedAttributes: spcp.getRequestedAttributes,
       appendVerifiedSPCPResponses: spcp.appendVerifiedSPCPResponses,
-      encryptedVerifiedFields: spcp.encryptedVerifiedFields,
       passThroughSpcp: admin.passThroughSpcp,
       verifyMyInfoVals: myInfo.verifyMyInfoVals,
       returnSpcpRedirectURL: spcp.returnSpcpRedirectURL,
@@ -128,7 +127,6 @@ const spcpFactory = ({ isEnabled, props }) => {
         return next()
       },
       appendVerifiedSPCPResponses: (req, res, next) => next(),
-      encryptedVerifiedFields: (req, res, next) => next(),
       passThroughSpcp: (req, res, next) => next(),
       verifyMyInfoVals: (req, res, next) => next(),
       returnSpcpRedirectURL: (req, res) =>


### PR DESCRIPTION
The `encryptedVerifiedFields` function in the SPCP controller is no longer accessed through the SPCP factory, and is now accessed through the `WebhookVerifiedFactory`. Hence there is no need for the SPCP factory to export this function.