### PR TITLE
refactor: validate MyInfo env vars using Convict

### DIFF
--- a/src/app/factories/spcp-myinfo.factory.js
+++ b/src/app/factories/spcp-myinfo.factory.js
@@ -6,10 +6,12 @@ const featureManager = require('../../config/feature-manager').default
 const config = require('../../config/config')
 const fs = require('fs')
 const SPCPAuthClient = require('@opengovsg/spcp-auth-client')
-const { MyInfoGovClient } = require('@opengovsg/myinfo-gov-client')
+const {
+  MyInfoGovClient,
+  Mode: MyInfoClientMode,
+} = require('@opengovsg/myinfo-gov-client')
 const MyInfoService = require('../services/myinfo.service')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
-const { Mode: MyInfoClientMode } = require('@opengovsg/myinfo-gov-client')
 
 const spcpFactory = ({ isEnabled, props }) => {
   if (isEnabled && props) {

--- a/src/app/factories/spcp-myinfo.factory.js
+++ b/src/app/factories/spcp-myinfo.factory.js
@@ -9,6 +9,7 @@ const SPCPAuthClient = require('@opengovsg/spcp-auth-client')
 const { MyInfoGovClient } = require('@opengovsg/myinfo-gov-client')
 const MyInfoService = require('../services/myinfo.service')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
+const { Mode: MyInfoClientMode } = require('@opengovsg/myinfo-gov-client')
 
 const spcpFactory = ({ isEnabled, props }) => {
   if (isEnabled && props) {
@@ -59,12 +60,10 @@ const spcpFactory = ({ isEnabled, props }) => {
     // as part of convict (Issue #255)
     if (config.nodeEnv === 'production') {
       let myInfoPrefix =
-        process.env.MYINFO_CLIENT_CONFIG === 'stg' ? 'STG2-' : 'PROD2-'
-      myInfoConfig.privateKey = fs.readFileSync(
-        process.env.MYINFO_FORMSG_KEY_PATH,
-      )
+        props.myInfoClientMode === MyInfoClientMode.Staging ? 'STG2-' : 'PROD2-'
+      myInfoConfig.privateKey = fs.readFileSync(props.myInfoKeyPath)
       myInfoConfig.appId = myInfoPrefix + myInfoConfig.singpassEserviceId
-      myInfoConfig.mode = process.env.MYINFO_CLIENT_CONFIG
+      myInfoConfig.mode = props.myInfoClientMode
       myInfoGovClient = new MyInfoGovClient(myInfoConfig)
     } else {
       logger.warn({

--- a/src/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/config/feature-manager/spcp-myinfo.config.ts
@@ -157,7 +157,7 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
       doc:
         'Configures MyInfoGovClient. Set this to either `stg` or `prod` to fetch MyInfo data from the corresponding endpoints.',
       format: Object.values(MyInfoClientMode),
-      default: null,
+      default: MyInfoClientMode.Production,
       env: 'MYINFO_CLIENT_CONFIG',
     },
     myInfoKeyPath: {

--- a/src/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/config/feature-manager/spcp-myinfo.config.ts
@@ -1,3 +1,5 @@
+import { Mode as MyInfoClientMode } from '@opengovsg/myinfo-gov-client'
+
 import { FeatureNames, RegisterableFeature } from './types'
 
 const HOUR_IN_MILLIS = 1000 * 60 * 60
@@ -150,6 +152,20 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
       format: String,
       default: null,
       env: 'CP_IDP_CERT_PATH',
+    },
+    myInfoClientMode: {
+      doc:
+        'Configures MyInfoGovClient. Set this to either `stg` or `prod` to fetch MyInfo data from the corresponding endpoints.',
+      format: Object.values(MyInfoClientMode),
+      default: null,
+      env: 'MYINFO_CLIENT_CONFIG',
+    },
+    myInfoKeyPath: {
+      doc:
+        'Filepath to MyInfo private key, which is used to decrypt returned responses.',
+      format: String,
+      default: null,
+      env: 'MYINFO_FORMSG_KEY_PATH',
     },
   },
 }

--- a/src/config/feature-manager/types.ts
+++ b/src/config/feature-manager/types.ts
@@ -1,3 +1,4 @@
+import { Mode as MyInfoClientMode } from '@opengovsg/myinfo-gov-client'
 import { Schema } from 'convict'
 
 export enum FeatureNames {
@@ -36,7 +37,7 @@ export interface ISms {
   twilioMsgSrvcSid: string
 }
 
-export interface ISpcpMyInfo {
+export interface ISpcpConfig {
   isSPMaintenance: string
   isCPMaintenance: string
   spCookieMaxAge: number
@@ -60,6 +61,13 @@ export interface ISpcpMyInfo {
   spIdpCertPath: string
   cpIdpCertPath: string
 }
+
+export interface IMyInfoConfig {
+  myInfoClientMode: MyInfoClientMode
+  myInfoKeyPath: string
+}
+
+export type ISpcpMyInfo = ISpcpConfig & IMyInfoConfig
 
 export interface IVerifiedFields {
   verificationSecretKey: string

--- a/tests/.test-full-env
+++ b/tests/.test-full-env
@@ -10,6 +10,9 @@ SINGPASS_IDP_ID=https://saml-internet.singpass.gov.sg/FIM/sps/SingpassIDPFed/sam
 MOCKPASS_PORT=5156
 SINGPASS_ESRVC_ID=Test-eServiceId-Sp
 
+MYINFO_CLIENT_CONFIG=stg
+MYINFO_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
+
 CP_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
 CP_FORMSG_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/server.crt
 CP_IDP_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/spcp.crt
@@ -26,7 +29,6 @@ SHOW_LOGIN_PAGE=true
 IS_SP_MAINTENANCE=Date/Time-SP
 IS_CP_MAINTENANCE=Date/Time-CP
 
-MYINFO_CLIENT_CONFIG=stg
 MOCKPASS_NRIC=S6005038D
 MOCKPASS_UEN=123456789A
 


### PR DESCRIPTION
## Problem

MyInfo environment variables are currently not being read and validated by Convict like all the others. Instead, they are read directly from `process.env`. This also means the `spcp-myinfo` feature is activated even when the MyInfo environment variables are missing.

## Solution
Integrate the MyInfo environment variables into the existing Convict framework.