### PR TITLE
refactor: convert MyInfo hash update to domain method

### DIFF
--- a/src/app/models/myinfo_hash.server.model.ts
+++ b/src/app/models/myinfo_hash.server.model.ts
@@ -66,7 +66,10 @@ MyInfoHashSchema.statics.updateHashes = async function (
 }
 
 const compileMyInfoHashModel = (db: Mongoose) =>
-  db.model<IMyInfoHashSchema>(MYINFO_HASH_SCHEMA_ID, MyInfoHashSchema)
+  db.model<IMyInfoHashSchema, IMyInfoHashModel>(
+    MYINFO_HASH_SCHEMA_ID,
+    MyInfoHashSchema,
+  )
 
 /**
  * Retrieves the MyInfoHash model on the given Mongoose instance. If the model is
@@ -74,7 +77,7 @@ const compileMyInfoHashModel = (db: Mongoose) =>
  * @param db The mongoose instance to retrieve the MyInfoHash model from
  * @returns The MyInfoHash model
  */
-const getMyInfoHashModel = (db: Mongoose) => {
+const getMyInfoHashModel = (db: Mongoose): IMyInfoHashModel => {
   try {
     return db.model(MYINFO_HASH_SCHEMA_ID) as IMyInfoHashModel
   } catch {

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -1,9 +1,9 @@
-import { Document } from 'mongoose'
+import { Document, Model } from 'mongoose'
 
 import { MyInfoAttribute } from './field'
 import { IFormSchema } from './form'
 
-type IHashes = {
+export type IHashes = {
   [key in MyInfoAttribute]: string
 }
 
@@ -17,3 +17,12 @@ interface IMyInfoHash {
 }
 
 export interface IMyInfoHashSchema extends IMyInfoHash, Document {}
+
+export interface IMyInfoHashModel extends Model<IMyInfoHashSchema> {
+  updateHashes: (
+    hashedUinFin: string,
+    formId: string,
+    readOnlyHashes: IHashes,
+    spCookieMaxAge: number,
+  ) => Promise<IMyInfoHashSchema | null>
+}

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -3,9 +3,11 @@ import { Document, Model } from 'mongoose'
 import { MyInfoAttribute } from './field'
 import { IFormSchema } from './form'
 
-export type IHashes = {
-  [key in MyInfoAttribute]: string
-}
+export type IHashes = Partial<
+  {
+    [key in MyInfoAttribute]: string
+  }
+>
 
 interface IMyInfoHash {
   uinFin: string

--- a/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
+++ b/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
@@ -1,0 +1,148 @@
+import { ObjectId } from 'bson'
+import { omit, pick } from 'lodash'
+import mongoose from 'mongoose'
+
+import getMyInfoHashModel from 'src/app/models/myinfo_hash.server.model'
+
+import dbHandler from '../helpers/jest-db'
+
+const MyInfoHash = getMyInfoHashModel(mongoose)
+
+const DEFAULT_PARAMS = {
+  uinFin: 'testUinFin',
+  form: new ObjectId(),
+  fields: { name: 'mockHash' },
+  expireAt: new Date(Date.now()),
+  created: new Date(Date.now()),
+}
+const DEFAULT_COOKIE_MAX_AGE = 5
+
+describe('MyInfo Hash Model', () => {
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(async () => await dbHandler.clearDatabase())
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('Schema', () => {
+    it('should create and save successfully', async () => {
+      // Act
+      const actual = await MyInfoHash.create(DEFAULT_PARAMS)
+
+      // Assert
+      // All fields should exist
+      // Object Id should be defined when successfully saved to MongoDB.
+      expect(actual._id).toBeDefined()
+      expect(
+        pick(actual, ['uinFin', 'form', 'fields', 'created', 'expireAt']),
+      ).toEqual(DEFAULT_PARAMS)
+    })
+
+    it('should throw validation error on missing uinFin', async () => {
+      // Arrange
+      const missingParams = omit(DEFAULT_PARAMS, 'uinFin')
+
+      // Act
+      const myInfoHash = new MyInfoHash(missingParams)
+      const actualPromise = myInfoHash.save()
+
+      // Assert
+      await expect(actualPromise).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should throw validation error on missing form', async () => {
+      // Arrange
+      const missingParams = omit(DEFAULT_PARAMS, 'form')
+
+      // Act
+      const myInfoHash = new MyInfoHash(missingParams)
+      const actualPromise = myInfoHash.save()
+
+      // Assert
+      await expect(actualPromise).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should throw validation error on missing fields', async () => {
+      // Arrange
+      const missingParams = omit(DEFAULT_PARAMS, 'fields')
+
+      // Act
+      const myInfoHash = new MyInfoHash(missingParams)
+      const actualPromise = myInfoHash.save()
+
+      // Assert
+      await expect(actualPromise).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should throw validation error on missing expireAt', async () => {
+      // Arrange
+      const missingParams = omit(DEFAULT_PARAMS, 'expireAt')
+
+      // Act
+      const myInfoHash = new MyInfoHash(missingParams)
+      const actualPromise = myInfoHash.save()
+
+      // Assert
+      await expect(actualPromise).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+  })
+
+  describe('Statics', () => {
+    describe('updateHashes', () => {
+      it('should create successfully when document does not exist', async () => {
+        // Should have no documents yet.
+        await expect(MyInfoHash.countDocuments()).resolves.toEqual(0)
+
+        // Act
+        const actual = await MyInfoHash.updateHashes(
+          DEFAULT_PARAMS.uinFin,
+          DEFAULT_PARAMS.form.toHexString(),
+          DEFAULT_PARAMS.fields,
+          DEFAULT_COOKIE_MAX_AGE,
+        )
+
+        // Assert
+        // Should now have one document.
+        await expect(MyInfoHash.countDocuments()).resolves.toEqual(1)
+        const found = await MyInfoHash.findOne({})
+        // Both the returned document and the found document should match
+        expect(pick(actual, ['uinFin', 'form', 'fields'])).toEqual(
+          pick(DEFAULT_PARAMS, ['uinFin', 'form', 'fields']),
+        )
+        expect(pick(found, ['uinFin', 'form', 'fields'])).toEqual(
+          pick(DEFAULT_PARAMS, ['uinFin', 'form', 'fields']),
+        )
+      })
+
+      it('should update successfully when a document already exists', async () => {
+        // Arrange
+        // Insert mock document into collection.
+        await MyInfoHash.create(DEFAULT_PARAMS)
+        // Should have the added document.
+        await expect(MyInfoHash.countDocuments()).resolves.toEqual(1)
+
+        const mockFields = { sex: 'F' }
+
+        // Act
+        const actual = await MyInfoHash.updateHashes(
+          DEFAULT_PARAMS.uinFin,
+          DEFAULT_PARAMS.form.toHexString(),
+          mockFields,
+          DEFAULT_COOKIE_MAX_AGE,
+        )
+        // Assert
+        await expect(MyInfoHash.countDocuments()).resolves.toEqual(1)
+        const found = await MyInfoHash.findOne({})
+        // Both the returned document and the found document should match
+        expect(actual!.fields).toEqual(mockFields)
+        expect(found!.fields).toEqual(mockFields)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Problem

MyInfo controller interacts directly with the model to update the field hashes, which makes it hard to refactor the logic into a clean service.

## Solution
This PR moves the logic for updating MyInfo field value hashes from the controller into a model static method, and adds test for the MyInfoHash model.