### PR TITLE
fix: resolve &amp; in url upon redirect, shift prefill to textfield component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13010,7 +13010,8 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "helmet": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "font-awesome": "4.7.0",
     "fp-ts": "^2.8.5",
     "has-ansi": "^4.0.0",
-    "he": "^1.2.0",
     "helmet": "^4.2.0",
     "http-status-codes": "^2.1.4",
     "intl-tel-input": "~12.1.6",

--- a/src/app/controllers/__tests__/frontend.server.controller.spec.ts
+++ b/src/app/controllers/__tests__/frontend.server.controller.spec.ts
@@ -7,63 +7,74 @@ import frontendServerController from '../frontend.server.controller'
 describe('frontend.server.controller', () => {
   afterEach(() => jest.clearAllMocks())
   const mockRes = expressHandler.mockResponse()
-
-  it('should return the correct response when the request is valid', () => {
-    const mockReq = {
-      app: {
-        locals: {
-          GATrackingID: 'abc',
-          appName: 'xyz',
-          environment: 'efg',
-        },
+  const mockReq = {
+    app: {
+      locals: {
+        GATrackingID: 'abc',
+        appName: 'xyz',
+        environment: 'efg',
       },
-      query: {
-        redirectPath: 'formId?fieldId1=abc&fieldId2=xyz',
-      },
-    }
-    // datalayer
-    frontendServerController.datalayer(mockReq, mockRes)
-    expect(mockRes.send).toHaveBeenCalledWith(
-      expect.stringContaining("'app_name': 'xyz'"),
-    )
-    expect(mockRes.send).toHaveBeenCalledWith(
-      expect.stringContaining("'config', 'abc'"),
-    )
-    expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
-
-    // environment
-    frontendServerController.environment(mockReq, mockRes)
-    expect(mockRes.send).toHaveBeenCalledWith('efg')
-    expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
-
-    //redirectLayer
-    const mockReqModified = {
-      // Test other special characters
-      query: {
-        redirectPath: 'formId?fieldId1=abc&fieldId2=<>\'"',
-      },
-    }
-    const redirectString =
-      'window.location.hash = "#!/formId?fieldId1=abc&fieldId2=&lt;&gt;&#39;&#34;'
-    // Note this is different from mockReqModified.query.redirectPath as
-    // there are html-encoded characters
-    frontendServerController.redirectLayer(mockReqModified, mockRes)
-    expect(mockRes.send).toHaveBeenCalledWith(
-      expect.stringContaining(redirectString),
-    )
-    expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    },
+    query: {
+      redirectPath: 'formId?fieldId1=abc&fieldId2=xyz',
+    },
+  }
+  const mockBadReq = {
+    get: jest.fn().mockImplementation(() => 'abc'),
+  }
+  describe('datalayer', () => {
+    it('should return the correct response when the request is valid', () => {
+      frontendServerController.datalayer(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining("'app_name': 'xyz'"),
+      )
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining("'config', 'abc'"),
+      )
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+    it('should return BAD_REQUEST if the request is not valid', () => {
+      frontendServerController.datalayer(mockBadReq, mockRes)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
   })
 
-  it('should return BAD_REQUEST if the request is not valid', () => {
-    const mockReq = undefined
-    frontendServerController.datalayer(mockReq, mockRes)
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
-    frontendServerController.environment(mockReq, mockRes)
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
-    frontendServerController.redirectLayer(mockReq, mockRes)
-    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+  describe('environment', () => {
+    it('should return the correct response when the request is valid', () => {
+      frontendServerController.environment(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith('efg')
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+    it('should return BAD_REQUEST if the request is not valid', () => {
+      frontendServerController.environment(mockBadReq, mockRes)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
+  })
+
+  describe('redirectLayer', () => {
+    it('should return the correct response when the request is valid', () => {
+      const mockReqModified = {
+        // Test other special characters
+        query: {
+          redirectPath: 'formId?fieldId1=abc&fieldId2=<>\'"',
+        },
+      }
+      const redirectString =
+        'window.location.hash = "#!/formId?fieldId1=abc&fieldId2=&lt;&gt;&#39;&#34;'
+      // Note this is different from mockReqModified.query.redirectPath as
+      // there are html-encoded characters
+      frontendServerController.redirectLayer(mockReqModified, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining(redirectString),
+      )
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+    it('should return BAD_REQUEST if the request is not valid', () => {
+      frontendServerController.redirectLayer(mockBadReq, mockRes)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
   })
 })

--- a/src/app/controllers/__tests__/frontend.server.controller.spec.ts
+++ b/src/app/controllers/__tests__/frontend.server.controller.spec.ts
@@ -1,0 +1,80 @@
+import { StatusCodes } from 'http-status-codes'
+
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+
+import frontendServerController from '../frontend.server.controller'
+
+describe('frontend.server.controller', () => {
+  afterEach(() => jest.clearAllMocks())
+  const mockRes = expressHandler.mockResponse()
+  const mockReq = {
+    app: {
+      locals: {
+        GATrackingID: 'abc',
+        appName: 'xyz',
+        environment: 'efg',
+      },
+    },
+    query: {
+      redirectPath: 'formId?fieldId1=abc&fieldId2=xyz',
+    },
+  }
+  describe('datalayer', () => {
+    it('should return the correct value', () => {
+      frontendServerController.datalayer(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining("'app_name': 'xyz'"),
+      )
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining("'config', 'abc'"),
+      )
+    })
+
+    it('should call type and status correctly', () => {
+      frontendServerController.datalayer(mockReq, mockRes)
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+  })
+
+  describe('environment', () => {
+    it('should return the correct environment', () => {
+      frontendServerController.environment(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith('efg')
+    })
+
+    it('should call type and status correctly', () => {
+      frontendServerController.environment(mockReq, mockRes)
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+  })
+
+  describe('redirectLayer', () => {
+    it('should not convert & character to html encoding', () => {
+      const redirectString =
+        'window.location.hash = "#!/formId?fieldId1=abc&fieldId2=xyz"'
+      frontendServerController.redirectLayer(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining(redirectString),
+      )
+    })
+
+    it('should convert other special characters to html encoding', () => {
+      mockReq.query.redirectPath = 'formId?fieldId1=abc&fieldId2=<>\'"'
+
+      const redirectString =
+        'window.location.hash = "#!/formId?fieldId1=abc&fieldId2=&lt;&gt;&#39;&#34;'
+      frontendServerController.redirectLayer(mockReq, mockRes)
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringContaining(redirectString),
+      )
+    })
+
+    it('should call type and status correctly', () => {
+      frontendServerController.redirectLayer(mockReq, mockRes)
+      expect(mockRes.type).toHaveBeenCalledWith('text/javascript')
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+  })
+})

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -27,7 +27,7 @@ module.exports.datalayer = function (req, res) {
     logger.error({
       message: 'Error returning datalayer',
       meta: {
-        action: 'ejs.render(js, req.app.locals)',
+        action: 'datalayer',
         ...createReqMeta(req),
       },
       error: err,
@@ -52,7 +52,7 @@ module.exports.environment = function (req, res) {
     logger.error({
       message: 'Error returning environment',
       meta: {
-        action: 'res.send(req.app.locals.environment',
+        action: 'environment',
         ...createReqMeta(req),
       },
       error: err,
@@ -86,7 +86,7 @@ module.exports.redirectLayer = function (req, res) {
     logger.error({
       message: 'Error returning redirectLayer',
       meta: {
-        action: 'ejs.render(js, req.query)',
+        action: 'redirectlayer',
         ...createReqMeta(req),
       },
       error: err,

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -2,8 +2,8 @@
 
 const ejs = require('ejs')
 const { StatusCodes } = require('http-status-codes')
-const logger = require('src/config/logger').createLoggerWithLabel(module)
-const { createReqMeta } = require('src/app/utils/request')
+const logger = require('../../config/logger').createLoggerWithLabel(module)
+const { createReqMeta } = require('../utils/request')
 
 /**
  * Google Tag Manager initialisation Javascript code templated

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -18,10 +18,12 @@ module.exports.datalayer = function (req, res) {
         'app_name': '<%= appName%>'
       });
     `
-  res
-    .type('text/javascript')
-    .status(StatusCodes.OK)
-    .send(ejs.render(js, req.app.locals))
+  try {
+    const ejsRendered = ejs.render(js, req.app.locals)
+    res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
+  } catch (err) {
+    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+  }
 }
 
 /**
@@ -29,10 +31,14 @@ module.exports.datalayer = function (req, res) {
  * @returns {String} Templated Javascript code for the frontend
  */
 module.exports.environment = function (req, res) {
-  res
-    .type('text/javascript')
-    .status(StatusCodes.OK)
-    .send(req.app.locals.environment)
+  try {
+    res
+      .type('text/javascript')
+      .status(StatusCodes.OK)
+      .send(req.app.locals.environment)
+  } catch (err) {
+    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+  }
 }
 
 /**
@@ -50,6 +56,11 @@ module.exports.redirectLayer = function (req, res) {
   // Prefer to replace just '&' instead of using <%- to output unescaped values into the template
   // As this could potentially introduce security vulnerability
   // See https://ejs.co/#docs for tags
-  const ejsRendered = ejs.render(js, req.query).replace(/&amp;/g, '&')
-  res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
+
+  try {
+    const ejsRendered = ejs.render(js, req.query).replace(/&amp;/g, '&')
+    res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
+  } catch (err) {
+    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+  }
 }

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -2,6 +2,8 @@
 
 const ejs = require('ejs')
 const { StatusCodes } = require('http-status-codes')
+const logger = require('src/config/logger').createLoggerWithLabel(module)
+const { createReqMeta } = require('src/app/utils/request')
 
 /**
  * Google Tag Manager initialisation Javascript code templated
@@ -22,7 +24,17 @@ module.exports.datalayer = function (req, res) {
     const ejsRendered = ejs.render(js, req.app.locals)
     res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
   } catch (err) {
-    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+    logger.error({
+      message: 'Error returning datalayer',
+      meta: {
+        action: 'ejs.render(js, req.app.locals)',
+        ...createReqMeta(req),
+      },
+      error: err,
+    })
+    res.status(StatusCodes.BAD_REQUEST).json({
+      message: 'There was an unexpected error. Please refresh and try again.',
+    })
   }
 }
 
@@ -37,7 +49,17 @@ module.exports.environment = function (req, res) {
       .status(StatusCodes.OK)
       .send(req.app.locals.environment)
   } catch (err) {
-    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+    logger.error({
+      message: 'Error returning environment',
+      meta: {
+        action: 'res.send(req.app.locals.environment',
+        ...createReqMeta(req),
+      },
+      error: err,
+    })
+    res.status(StatusCodes.BAD_REQUEST).json({
+      message: 'There was an unexpected error. Please refresh and try again.',
+    })
   }
 }
 
@@ -61,6 +83,16 @@ module.exports.redirectLayer = function (req, res) {
     const ejsRendered = ejs.render(js, req.query).replace(/&amp;/g, '&')
     res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
   } catch (err) {
-    res.status(StatusCodes.BAD_REQUEST).json({ message: err })
+    logger.error({
+      message: 'Error returning redirectLayer',
+      meta: {
+        action: 'ejs.render(js, req.query)',
+        ...createReqMeta(req),
+      },
+      error: err,
+    })
+    res.status(StatusCodes.BAD_REQUEST).json({
+      message: 'There was an unexpected error. Please refresh and try again.',
+    })
   }
 }

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -46,8 +46,10 @@ module.exports.redirectLayer = function (req, res) {
     // Change url from form.gov.sg/123#!123 to form.gov.sg/#!/123
     window.history.replaceState("","", "/#!/<%= redirectPath%>")
   `
-  res
-    .type('text/javascript')
-    .status(StatusCodes.OK)
-    .send(ejs.render(js, req.query))
+  // If there are multiple query params, '&' is html-encoded as '&amp;', which is not valid URI
+  // Prefer to replace just '&' instead of using <%- to output unescaped values into the template
+  // As this could potentially introduce security vulnerability
+  // See https://ejs.co/#docs for tags
+  const ejsRendered = ejs.render(js, req.query).replace(/&amp;/g, '&')
+  res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
 }

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -22,7 +22,7 @@ module.exports.datalayer = function (req, res) {
     `
   try {
     const ejsRendered = ejs.render(js, req.app.locals)
-    res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
+    return res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
   } catch (err) {
     logger.error({
       message: 'Error returning datalayer',
@@ -32,7 +32,7 @@ module.exports.datalayer = function (req, res) {
       },
       error: err,
     })
-    res.status(StatusCodes.BAD_REQUEST).json({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'There was an unexpected error. Please refresh and try again.',
     })
   }
@@ -44,7 +44,7 @@ module.exports.datalayer = function (req, res) {
  */
 module.exports.environment = function (req, res) {
   try {
-    res
+    return res
       .type('text/javascript')
       .status(StatusCodes.OK)
       .send(req.app.locals.environment)
@@ -57,7 +57,7 @@ module.exports.environment = function (req, res) {
       },
       error: err,
     })
-    res.status(StatusCodes.BAD_REQUEST).json({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'There was an unexpected error. Please refresh and try again.',
     })
   }
@@ -81,7 +81,7 @@ module.exports.redirectLayer = function (req, res) {
 
   try {
     const ejsRendered = ejs.render(js, req.query).replace(/&amp;/g, '&')
-    res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
+    return res.type('text/javascript').status(StatusCodes.OK).send(ejsRendered)
   } catch (err) {
     logger.error({
       message: 'Error returning redirectLayer',
@@ -91,7 +91,7 @@ module.exports.redirectLayer = function (req, res) {
       },
       error: err,
     })
-    res.status(StatusCodes.BAD_REQUEST).json({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       message: 'There was an unexpected error. Please refresh and try again.',
     })
   }

--- a/src/public/modules/forms/base/components/field-textfield.client.component.js
+++ b/src/public/modules/forms/base/components/field-textfield.client.component.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const querystring = require('querystring')
+
 angular.module('forms').component('textFieldComponent', {
   templateUrl:
     'modules/forms/base/componentViews/field-textfield.client.view.html',
@@ -8,5 +10,35 @@ angular.module('forms').component('textFieldComponent', {
     forms: '<',
     placeholder: '<',
   },
+  controller: ['$location', '$sanitize', textFieldComponentController],
   controllerAs: 'vm',
 })
+
+function textFieldComponentController($location, $sanitize) {
+  // Stealth prefill feature
+  // If a query parameter is provided to a form URL in the form ?<fieldId1>=<value1>&<fieldId2>=<value2>...
+  // And if the fieldIds are valid mongoose object IDs and refer to a short text field,
+  // Then prefill and disable editing the corresponding form field on the frontend
+
+  const vm = this
+  vm.$onInit = () => {
+    const query = $location.url().split('?')
+    const queryParams =
+      query.length > 1 ? querystring.parse(query[1]) : undefined
+
+    if (
+      !vm.field.myInfo && // disallow prefill for myinfo
+      vm.field.allowPrefill && // allow prefill only if flag enabled
+      queryParams &&
+      vm.field._id in queryParams
+    ) {
+      const prefillValue = queryParams[vm.field._id]
+      if (typeof prefillValue === 'string') {
+        // Only support unique query params. If query params are duplicated,
+        // none of the duplicated keys will be prefilled
+        vm.field.fieldValue = $sanitize(prefillValue) // $sanitize as a precaution to prevent xss
+        // note that there are currently no unit tests to ensure that value is sanitized correctly; manual testing required
+      }
+    }
+  }
+}

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -1,18 +1,12 @@
 'use strict'
 
 const { get } = require('lodash')
-const querystring = require('querystring')
 
 angular
   .module('forms')
-  .directive('fieldDirective', [
-    'FormFields',
-    '$location',
-    '$sanitize',
-    fieldDirective,
-  ])
+  .directive('fieldDirective', ['FormFields', fieldDirective])
 
-function fieldDirective(FormFields, $location, $sanitize) {
+function fieldDirective(FormFields) {
   return {
     restrict: 'E',
     templateUrl:
@@ -29,31 +23,6 @@ function fieldDirective(FormFields, $location, $sanitize) {
       isValidateDate: '<',
     },
     link: function (scope) {
-      // Stealth prefill feature
-      // If a query parameter is provided to a form URL in the form ?<fieldId1>=<value1>&<fieldId2>=<value2>...
-      // And if the fieldIds are valid mongoose object IDs and refer to a short text field,
-      // Then prefill and disable editing the corresponding form field on the frontend
-
-      const query = $location.url().split('?')
-      const queryParams =
-        query.length > 1 ? querystring.parse(query[1]) : undefined
-
-      if (
-        !scope.field.myInfo && // disallow prefill for myinfo
-        scope.field.allowPrefill && // allow prefill only if flag enabled
-        queryParams &&
-        scope.field._id in queryParams &&
-        scope.field.fieldType === 'textfield'
-      ) {
-        const prefillValue = queryParams[scope.field._id]
-        if (typeof prefillValue === 'string') {
-          // Only support unique query params. If query params are duplicated,
-          // none of the duplicated keys will be prefilled
-          scope.field.fieldValue = $sanitize(prefillValue) // $sanitize as a precaution to prevent xss
-          // note that there are currently no unit tests to ensure that value is sanitized correctly; manual testing required
-        }
-      }
-
       if ((scope.isadminpreview || scope.isTemplate) && scope.field.myInfo) {
         // Determine whether to disable field in preview
         if (

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { get } = require('lodash')
-const he = require('he')
 const querystring = require('querystring')
 
 angular
@@ -35,8 +34,7 @@ function fieldDirective(FormFields, $location, $sanitize) {
       // And if the fieldIds are valid mongoose object IDs and refer to a short text field,
       // Then prefill and disable editing the corresponding form field on the frontend
 
-      const decodedUrl = he.decode($location.url()) // tech debt; after redirect, & is encoded as &amp; in the query string
-      const query = decodedUrl.split('?')
+      const query = $location.url().split('?')
       const queryParams =
         query.length > 1 ? querystring.parse(query[1]) : undefined
 

--- a/tests/unit/backend/helpers/jest-express.ts
+++ b/tests/unit/backend/helpers/jest-express.ts
@@ -38,6 +38,7 @@ const mockResponse = (
     status: jest.fn().mockReturnThis(),
     send: jest.fn().mockReturnThis(),
     sendStatus: jest.fn().mockReturnThis(),
+    type: jest.fn().mockReturnThis(),
     json: jest.fn(),
     render: jest.fn(),
     redirect: jest.fn(),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- This PR resolves the issue of `&` being html-encoded as `&amp;` upon redirect, which is not valid URI
- Also shifts the stealth prefill feature from the field directive to the textfield component 
- Closes #531 

## Solution
- Replace `&amp;` with `&` in the ejs template. This was preferred to allowing all characters to be escaped, which may possibly introduce a security vulnerability

## Before & After

The following non-hashbang URL will be redirected as follows:
`https://form.gov.sg/<formId>?<fieldId1>=abc&<fieldId2>=xyz`

**BEFORE**:
`https://form.gov.sg/#!/<formId>?<fieldId1>=abc&amp;<fieldId2>=xyz`

**AFTER**:
`https://form.gov.sg/#!/<formId>?<fieldId1>=abc&<fieldId2>=xyz`

## Tests

- [ ] Create a form with short text field. Open in public view with the query params <shortTextFieldId>=<value1>, where <value1> comprises alphanumeric/hyphen/underscore characters. Check that the short text field is not prefilled with value1
- [ ] In the db, check that allowPrefill is set to false for the short text field. set allowPrefill = true. Check that prefill now works.
- [ ] Create myinfo field. Set allowPrefill = true for the myinfo field. Access form on public view and login to singpass. Check that prefill does not work on the myinfo field.
- [ ] Check that prefilling works even without the hashbang in the url
- [ ] Check that for non-hashbang url with two query params, upon redirection, the redirect path uses `&` to separate the query params instead of `&amp;`
- [ ] Add radio button to the form. Set form logic to hide the short text field conditional on the radio button. Check that the short text field is prefilled when it is unhidden
- [ ] Prefilled field value is cleared when field is hidden by logic at the point of submission

## Deploy Notes

**dependencies**
- he module has been removed
