### PR TITLE
chore: set datepicker default view to minimum date

### DIFF
--- a/src/public/modules/forms/base/components/field-date.client.component.js
+++ b/src/public/modules/forms/base/components/field-date.client.component.js
@@ -24,6 +24,7 @@ function dateFieldComponentController() {
     yearColumns: 3,
     minDate: null,
     maxDate: null,
+    initDate: null,
   }
 
   vm.$onChanges = (changesObj) => {
@@ -55,6 +56,9 @@ function dateFieldComponentController() {
       if (get(vm.field, 'dateValidation.customMaxDate')) {
         vm.dateOptions.maxDate = new Date(vm.field.dateValidation.customMaxDate)
       }
+
+      // Set default view upon opening datepicker to be month of minDate
+      vm.dateOptions.initDate = vm.dateOptions.minDate
     }
   }
 

--- a/src/public/modules/forms/base/components/field-date.client.component.js
+++ b/src/public/modules/forms/base/components/field-date.client.component.js
@@ -57,8 +57,10 @@ function dateFieldComponentController() {
         vm.dateOptions.maxDate = new Date(vm.field.dateValidation.customMaxDate)
       }
 
-      // Set default view upon opening datepicker to be month of minDate
-      vm.dateOptions.initDate = vm.dateOptions.minDate
+      // If minDate is set, default view upon opening datepicker to be month of minDate
+      if (vm.dateOptions.minDate) {
+        vm.dateOptions.initDate = vm.dateOptions.minDate
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Closes #377

## Solution
- set dateOptions.initDate = dateOptions.minDate

## Tests
- [ ] Create date field. Set custom date range with minimum date in the distant past (e.g. 2015). Open the form in public view. Check that the datepicker opens to the month of the minimum date by default. 
- [ ] Create date field with no date validation. Open in public view. Check that the datepicker opens to the current month by default.

