### PR TITLE
fix: breakage of add collaborator styling on ie11

### DIFF
--- a/src/public/modules/core/css/admin-form-header.css
+++ b/src/public/modules/core/css/admin-form-header.css
@@ -202,7 +202,7 @@
   #collaborator-modal-body {
     width: 100%;
     top: 0;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   #collab-list .role-column {
@@ -363,11 +363,7 @@
 
 @media all and (min-width: 768px) {
   #collaborator-modal-body #collab-list {
-    /* Max height should avoid extending the screen, because if the modal + dropdown menu is taller than
-      the current screen's height, the bottom of the page will just appear white and not load. */
-    max-height: calc(100vh - 450px);
     overflow-y: auto;
-    padding-right: 39px;
   }
 
   #collaborator-modal-body .secret-key-warning {

--- a/src/public/modules/forms/admin/css/pop-up-modal.css
+++ b/src/public/modules/forms/admin/css/pop-up-modal.css
@@ -51,6 +51,8 @@
 .submit-progress-modal-window .modal-content,
 .delete-field-modal-window .modal-content,
 .pop-up-modal-window .modal-content {
+  overflow-y: auto;
+  overflow-x: hidden;
   border-radius: 0;
   border-width: 0;
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Hotfix PR to fix ie11 incorrectly resizing modal due to overflow


