### PR TITLE
feat: display a Toast when reCAPTCHA fails while users are filling up a form

### DIFF
--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -134,6 +134,7 @@
           size="invisible"
           on-create="captchaService.setWidget(widgetId)"
           on-success="captchaService.onSuccess(response, submitForm)"
+          on-error="captchaService.onError()"
           on-expire="captchaService.expire()"
           data-badge="inline"
         ></div>

--- a/src/public/modules/forms/services/captcha.client.service.js
+++ b/src/public/modules/forms/services/captcha.client.service.js
@@ -64,6 +64,12 @@ function captchaService($window, vcRecaptchaService, Toastr) {
     cb()
   }
 
+  this.onError = function () {
+    Toastr.error(
+      'Error: Cannot connect to reCAPTCHA. Please check your internet connectivity or try submitting on another device.',
+    )
+  }
+
   /**
    * Expire captcha if captcha enabled
    */


### PR DESCRIPTION
## Problem
Closes #31 

## Solution
Display a Toast when the captcha module's `on-error` handler is fired.

**Features**:
1. The Toast does not show up immediately upon page load. It takes a bit of time (5 seconds) to show up after a user first touches the form (e.g. clicking on a form field). User does not need to fill up anything. He/she just needs to touch the form.
1. The Toast shows up at the same time as the reCAPTCHA failure at the bottom of the form (this is good).

## Before & After Screenshots

**BEFORE**:
Only the reCAPTCHA failure at the bottom of the form will be observed after the user touches the form.

**AFTER**:
Both Toast at the top and reCAPTCHA failure at the bottom will be observed.

![photo6134426425541896706](https://user-images.githubusercontent.com/14961285/98236654-a9438380-1f9e-11eb-88e4-fe0f67b844bd.jpg)
