### PR TITLE
feat: remove hashbang from URLs

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -391,7 +391,7 @@ function makeModule(connection) {
 
           // Prevent buttonLink from being copied over if same as formHash (for old forms)
           if (form.endPage && form.endPage.buttonLink) {
-            let oldFormHash = '#!/' + id
+            let oldFormHash = '/' + id
             if (form.endPage.buttonLink === oldFormHash) {
               overrideProps.endPage = form.endPage
               delete overrideProps.endPage.buttonLink

--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -70,9 +70,9 @@ module.exports.environment = function (req, res) {
 module.exports.redirectLayer = function (req, res) {
   const js = `
     // Update hash to match form id
-    window.location.hash = "#!/<%= redirectPath%>"
-    // Change url from form.gov.sg/123#!123 to form.gov.sg/#!/123
-    window.history.replaceState("","", "/#!/<%= redirectPath%>")
+    window.location.hash = "/<%= redirectPath%>"
+    // Change url from form.gov.sg/123#!123 to form.gov.sg/123
+    window.history.replaceState("","", "/<%= redirectPath%>")
   `
   // If there are multiple query params, '&' is html-encoded as '&amp;', which is not valid URI
   // Prefer to replace just '&' instead of using <%- to output unescaped values into the template

--- a/src/app/views/index.server.view.html
+++ b/src/app/views/index.server.view.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html ng-csp>
   <head>
+    <base href="/">
+
     <%if (GATrackingID) { %>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -100,7 +100,7 @@ app.constant('moment', require('moment-timezone'))
 angular.module(appName).config([
   '$locationProvider',
   function ($locationProvider) {
-    $locationProvider.hashPrefix('!')
+    $locationProvider.html5Mode(true)
   },
 ])
 
@@ -716,7 +716,7 @@ app.run([
   function ($rootScope, $uibModalStack) {
     $rootScope.$on('$locationChangeStart', (event, newUrl, oldUrl) => {
       const splitPath = oldUrl.split(location.host)
-      if (splitPath.length > 1 && splitPath[1] === '/#!/signin') {
+      if (splitPath.length > 1 && splitPath[1] === '/signin') {
         return
       }
 

--- a/src/public/modules/core/resources/landing-examples.js
+++ b/src/public/modules/core/resources/landing-examples.js
@@ -3,37 +3,37 @@ const examples = [
     img: '/public/modules/core/img/landing/restricted__1-MOM.png',
     agency: 'MOM',
     title: 'Report an Employment Act violation',
-    formLink: 'https://form.gov.sg/#!/5a0ae8bb66545d85005daf6f',
+    formLink: 'https://form.gov.sg/5a0ae8bb66545d85005daf6f',
   },
   {
     img: '/public/modules/core/img/landing/restricted__3-NEA.png',
     agency: 'NEA',
     title: 'Update particulars of deceased next-of-kin',
-    formLink: 'https://form.gov.sg/#!/5a9e53d0b3a3b6006e6e0b74',
+    formLink: 'https://form.gov.sg/5a9e53d0b3a3b6006e6e0b74',
   },
   {
     img: '/public/modules/core/img/landing/restricted__7-MFA.png',
     agency: 'MFA',
     title: 'Scholarship Mailing List',
-    formLink: 'https://form.gov.sg/#!/5a9f3906b3a3b6006e6ee595',
+    formLink: 'https://form.gov.sg/5a9f3906b3a3b6006e6ee595',
   },
   {
     img: '/public/modules/core/img/landing/restricted__8-IPOS.png',
     agency: 'IPOS',
     title: 'FinTech Fast Track Initiative Registration',
-    formLink: 'https://form.gov.sg/#!/5ac6cced5eaf2b0030597aaa',
+    formLink: 'https://form.gov.sg/5ac6cced5eaf2b0030597aaa',
   },
   {
     img: '/public/modules/core/img/landing/restricted__9-SCB.png',
     agency: 'SCB',
     title: 'National Science Challenge Registration',
-    formLink: 'https://form.gov.sg/#!/5a813986c860b96e00a3026d',
+    formLink: 'https://form.gov.sg/5a813986c860b96e00a3026d',
   },
   {
     img: '/public/modules/core/img/landing/restricted__2-MOE.png',
     agency: 'MOE',
     title: 'School placement for returning Singaporeans',
-    formLink: 'https://form.gov.sg/#!/5aa5e5b1dcff52006dfd5f86',
+    formLink: 'https://form.gov.sg/5aa5e5b1dcff52006dfd5f86',
   },
 ]
 

--- a/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
@@ -17,7 +17,7 @@ function EditEndPageController($uibModalInstance, myform, updateField) {
   vm.logoUrl = getFormLogo(myform)
   // Make a copy so nothing is changed in the original.
   vm.myform = angular.copy(myform)
-  const formHash = '#!/' + vm.myform._id
+  const formHash = '/' + vm.myform._id
 
   // If buttonLink is empty or formHash (default for old forms), set to empty string
   if (

--- a/src/public/modules/users/config/users.client.config.js
+++ b/src/public/modules/users/config/users.client.config.js
@@ -14,9 +14,9 @@ angular.module('users').config([
           responseError: function (response) {
             if (response.status === HttpStatus.UNAUTHORIZED) {
               $window.localStorage.removeItem('user')
-              $window.location.assign('/#!/signin')
+              $window.location.assign('/signin')
             } else if (response.status === HttpStatus.FORBIDDEN) {
-              $window.location.assign('/#!/forms')
+              $window.location.assign('/forms')
             }
             return $q.reject(response)
           },

--- a/src/public/sitemap.xml
+++ b/src/public/sitemap.xml
@@ -22,7 +22,7 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://form.gov.sg/#!/signin</loc>
+    <loc>https://form.gov.sg/signin</loc>
     <priority>1.0</priority>
   </url>
 </urlset>

--- a/tests/end-to-end/helpers/encrypt-mode.js
+++ b/tests/end-to-end/helpers/encrypt-mode.js
@@ -168,7 +168,7 @@ async function clickResponseRow(t, index) {
 
 // Navigate to the results tab
 async function navigateToResults(t, id) {
-  await t.navigateTo(`${appUrl}/#!/${id}/admin`).click(adminTabs.data)
+  await t.navigateTo(`${appUrl}/${id}/admin`).click(adminTabs.data)
 }
 
 // Type in the secretKey

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -173,7 +173,7 @@ async function enterOTPAndExpect({ t, otp, isValid, email }) {
   if (isValid) {
     await t
       .expect(getPageUrl())
-      .eql(appUrl + '/#!/forms')
+      .eql(appUrl + '/forms')
       .expect(formList.welcomeMessage.textContent)
       .contains('Welcome ' + userName + '!')
   } else {
@@ -254,7 +254,7 @@ function makeModel(db, modelFilename, modelName) {
  * @param {string} email
  */
 const logInWithEmail = async (t, email) => {
-  await t.navigateTo(`${appUrl}/#!/signin`)
+  await t.navigateTo(`${appUrl}/signin`)
   await enterEmail(t, email)
   await expectOtpSent(t, email)
   const otp = await extractOTP(email)
@@ -700,7 +700,7 @@ async function expectStartPage(t, testForm, testFormData, appUrl) {
   await t
     .navigateTo(`${appUrl}/${_id}`)
     .expect(getPageUrl())
-    .eql(`${appUrl}/#!/${_id}`)
+    .eql(`${appUrl}/${_id}`)
     .expect(formPage.startTitle.textContent)
     .contains(formOptions.title)
 }

--- a/tests/end-to-end/login.e2e.js
+++ b/tests/end-to-end/login.e2e.js
@@ -19,7 +19,7 @@ let govTech
 let createUser
 let deleteToken
 fixture('login')
-  .page(appUrl + '/#!/signin')
+  .page(appUrl + '/signin')
   .before(async () => {
     db = await makeMongooseFixtures()
     Agency = makeModel(db, 'agency.server.model', 'Agency')
@@ -197,7 +197,7 @@ test
   await t.click(formList.logOutBtn)
   await t
     .expect(getPageUrl())
-    .eql(appUrl + '/#!/')
+    .eql(appUrl + '/')
     // Due to text spanning multiple spans, remove all whitespace
     .expect((await landingPage.tagline.textContent).replace(/  +/g, ' '))
     .contains('Build government forms in minutes')


### PR DESCRIPTION
## Problem
Closes #53 

## Solution
Remove hashbang from URL. Applied suggestion from [Stack Overflow](https://stackoverflow.com/questions/35787016/angularjs-locationprovider-html5mode-not-working-on-localhost).

This approach may not be the most appropriate. Hope to have some insights from the team on what to watch out for.

**Features**:

- Links for the admin routes do not have hashbang anymore (this is good).
- When pasting `http://localhost:5000/5fa0d3053e7f95002aa1aa57` into the address bar and pressing Enter, the address changes to `http://localhost:5000/#!/5fa0d3053e7f95002aa1aa57` when loading. The address reverts to `http://localhost:5000/5fa0d3053e7f95002aa1aa57` when the page finishes loading.
- When pasting `http://localhost:5000/#!/5fa0d3053e7f95002aa1aa57`, the address changes to `http://localhost:5000/5fa0d3053e7f95002aa1aa57` when the page finishes loading.
- Same observation when refreshing the page.
- There may be more cleanup needed as there are several instances of `'#!'` string throughout the codebase. See below for screenshot.
![image](https://user-images.githubusercontent.com/14961285/97976345-8336ab80-1e05-11eb-9300-a4f3dbf7f549.png)

## Before & After Screenshots

**BEFORE**:
Address bar shows `.../#!/...` as usual.

**AFTER**:
Screenshot of address bar:
![image](https://user-images.githubusercontent.com/14961285/97975438-1969d200-1e04-11eb-87bb-f0dabd7bea8c.png)

## Tests
Not done yet. Need advice on this too.
