### PR TITLE
feat: remove exclamation when user updates contact

### DIFF
--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -98,6 +98,7 @@ function avatarDropdownController(
         if (returnVal) {
           vm.user = returnVal
           Auth.setUser(returnVal)
+          vm.showExclamation = !returnVal.contact
         }
       })
       .finally(angular.noop)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR fixes the issue where the `!` exclamation mark sign does not disappear from user profile icon after emergency contact number has been added, until page is refreshed. 

Related to #369
