### PR TITLE
feat: move public spcp login form messaging

### DIFF
--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -95,27 +95,14 @@
               <i class="bx bx-log-out"></i>
             </span>
           </button>
-          <div>
-            <div
-              ng-if="vm.authType==='SP' && !vm.userName && !vm.isTemplate"
-              class="form-locked-msg"
-            >
+          <div ng-if="!vm.userName && !vm.isTemplate">
+            <div ng-if="vm.authType==='SP'" class="form-locked-msg">
               Login with SingPass to access this form. Your SingPass ID will be
               included with your form submission.
             </div>
-            <div
-              ng-if="vm.authType==='CP' && !vm.userName && !vm.isTemplate"
-              class="form-locked-msg"
-            >
+            <div ng-if="vm.authType==='CP'" class="form-locked-msg">
               Login with CorpPass to access this form. Your Entity ID and
               CorpPass ID will be included with your form submission.
-            </div>
-            <div ng-if="vm.myInfoError" class="form-locked-msg myinfo-error">
-              <i class="bx bx-exclamation"></i>
-              <span>
-                An error occurred while retrieving your MyInfo details. Kindly
-                refresh your browser, or try again later.
-              </span>
             </div>
           </div>
           <label
@@ -141,6 +128,13 @@
           </label>
         </div>
       </div>
+    </div>
+    <div ng-if="vm.myInfoError" class="form-locked-msg myinfo-error">
+      <i class="bx bx-exclamation"></i>
+      <span>
+        An error occurred while retrieving your MyInfo details. Kindly refresh
+        your browser, or try again later.
+      </span>
     </div>
     <div ng-if="vm.paragraph" id="start-page-req" class="padded-view row">
       <div class="standard-padding">

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -95,6 +95,29 @@
               <i class="bx bx-log-out"></i>
             </span>
           </button>
+          <div>
+            <div
+              ng-if="vm.authType==='SP' && !vm.userName && !vm.isTemplate"
+              class="form-locked-msg"
+            >
+              Login with SingPass to access this form. Your SingPass ID will be
+              included with your form submission.
+            </div>
+            <div
+              ng-if="vm.authType==='CP' && !vm.userName && !vm.isTemplate"
+              class="form-locked-msg"
+            >
+              Login with CorpPass to access this form. Your Entity ID and
+              CorpPass ID will be included with your form submission.
+            </div>
+            <div ng-if="vm.myInfoError" class="form-locked-msg myinfo-error">
+              <i class="bx bx-exclamation"></i>
+              <span>
+                An error occurred while retrieving your MyInfo details. Kindly
+                refresh your browser, or try again later.
+              </span>
+            </div>
+          </div>
           <label
             class="remember-me-btn"
             ng-if="(vm.authType==='SP') && !vm.userName && !vm.isTemplate && !vm.hasMyinfoFields"

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -96,11 +96,11 @@
             </span>
           </button>
           <div ng-if="!vm.userName && !vm.isTemplate">
-            <div ng-if="vm.authType==='SP'" class="form-locked-msg">
+            <div ng-if="vm.authType==='SP'" class="form-locked-msg padded-view">
               Login with SingPass to access this form. Your SingPass ID will be
               included with your form submission.
             </div>
-            <div ng-if="vm.authType==='CP'" class="form-locked-msg">
+            <div ng-if="vm.authType==='CP'" class="form-locked-msg padded-view">
               Login with CorpPass to access this form. Your Entity ID and
               CorpPass ID will be included with your form submission.
             </div>
@@ -129,7 +129,10 @@
         </div>
       </div>
     </div>
-    <div ng-if="vm.myInfoError" class="form-locked-msg myinfo-error">
+    <div
+      ng-if="vm.myInfoError"
+      class="form-locked-msg myinfo-error padded-view"
+    >
       <i class="bx bx-exclamation"></i>
       <span>
         An error occurred while retrieving your MyInfo details. Kindly refresh

--- a/src/public/modules/forms/base/components/start-page.client.component.js
+++ b/src/public/modules/forms/base/components/start-page.client.component.js
@@ -12,6 +12,7 @@ angular.module('forms').component('startPageComponent', {
     logoState: '@',
     formTitle: '@',
     authType: '<',
+    myInfoError: '<',
     isAdminPreview: '<',
     hasMyinfoFields: '<',
     isTemplate: '<',

--- a/src/public/modules/forms/base/css/form.css
+++ b/src/public/modules/forms/base/css/form.css
@@ -87,15 +87,21 @@
 
 .public-form .form-locked-msg {
   text-align: center;
-  color: #484848;
+  color: white;
   font-size: 18px;
-  margin-bottom: 70px;
-  margin-left: 15px;
-  margin-right: 15px;
+  margin-bottom: 0;
+  margin-top: 40px;
+
+  /* Offset container padding */
+  margin-left: -35px;
+  margin-right: -35px;
 }
 
 .public-form.submit-form .form-locked-msg.myinfo-error {
   color: #a94442;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 40px;
 }
 
 .public-form.submit-form .form-locked-msg.myinfo-error i {

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -7,6 +7,7 @@
       paragraph="{{ form.startPage.paragraph }}"
       logo-state="{{ form.startPage.logo.state }}"
       form-title="{{ form.title }}"
+      my-info-error="myInfoError"
       auth-type="form.authType"
       is-admin-preview="false"
       has-myinfo-fields="hasMyInfoFields"
@@ -61,29 +62,6 @@
           </button>
         </div>
       </div>
-    </div>
-  </div>
-  <div ng-if="!uiState.formSubmitted">
-    <div
-      ng-if="form.authType==='SP' && !SpcpSession.userName && !form.isTemplate"
-      class="form-locked-msg padded-view"
-    >
-      Login with SingPass to access this form. Your SingPass ID will be included
-      with your form submission.
-    </div>
-    <div
-      ng-if="form.authType==='CP' && !SpcpSession.userName && !form.isTemplate"
-      class="form-locked-msg padded-view"
-    >
-      Login with CorpPass to access this form. Your Entity ID and CorpPass ID
-      will be included with your form submission.
-    </div>
-    <div ng-if="myInfoError" class="form-locked-msg myinfo-error padded-view">
-      <i class="bx bx-exclamation"></i
-      ><span
-        >An error occurred while retrieving your MyInfo details. Kindly refresh
-        your browser, or try again later.</span
-      >
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

![recording](https://user-images.githubusercontent.com/22133008/98076740-d104ef80-1ea9-11eb-9500-798f6d47f728.gif)


In forms with long set of Instructions, SPCP login note is pushed all the way to the bottom and also exceeds the instructions container.

Related to #369

## Solution
<!-- How did you solve the problem? -->

**Features**:

- Move SPCP gated message to start page section
- Move MyInfo error messaging to above instructions

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
See above

**AFTER**:
<!-- [insert screenshot here] -->
SP Logins

![localhost_5000_ (9)](https://user-images.githubusercontent.com/22133008/98076897-204b2000-1eaa-11eb-83a7-ea35079cf23e.png)
![localhost_5000_ (2)](https://user-images.githubusercontent.com/22133008/98076953-3bb62b00-1eaa-11eb-85d0-eb013c76805f.png)

CP Logins
![localhost_5000_ (3)](https://user-images.githubusercontent.com/22133008/98076969-4375cf80-1eaa-11eb-83d2-c09024e72543.png)

MyInfo errors
![localhost_5000_ (5)](https://user-images.githubusercontent.com/22133008/98076984-496bb080-1eaa-11eb-8597-6f64c1b16270.png)
![localhost_5000_ (6)](https://user-images.githubusercontent.com/22133008/98076986-4b357400-1eaa-11eb-8448-91576fbd18cd.png)
![localhost_5000_ (7)](https://user-images.githubusercontent.com/22133008/98076993-4e306480-1eaa-11eb-8513-f203fda8fcbf.png)

