### PR TITLE
feat: upgrade myinfo-gov-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4127,14 +4127,36 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-2.0.0.tgz",
-      "integrity": "sha512-pRkBhSGIDDq8S2YFhfEGc9toqwm1D0uKhG/U+etjSbp13UXj/8TvLK1dQwTFCJ9NAgSO/S3M6UWrGdUoboUAkw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-2.1.2.tgz",
+      "integrity": "sha512-YrHswABeH1Gcl3ga6onQOMa09Ohqe57a+lrCOdFcehlvNSc6QOmN8Sd8Z/nkFJr2xOsgPGl+kcRTYfK4vooV9g==",
       "requires": {
+        "axios": "^0.21.0",
         "jose": "^0.3.2",
         "node-jose": "^2.0.0",
         "path": "^0.12.7",
+        "qs": "^6.9.4",
         "request": "^2.88.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+          "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+        },
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        }
       }
     },
     "@opengovsg/ng-file-upload": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "0.8.2",
-    "@opengovsg/myinfo-gov-client": "^2.0.0",
+    "@opengovsg/myinfo-gov-client": "^2.1.2",
     "@opengovsg/ng-file-upload": "^12.2.14",
     "@opengovsg/spcp-auth-client": "^1.3.6",
     "@sentry/browser": "^5.24.2",


### PR DESCRIPTION
This PR bumps myinfo-gov-client to v2.1.2 so we can take advantage of the newly exported types.