### PR TITLE
fix: improve arrangement of response tab elements

### DIFF
--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -105,6 +105,10 @@
   width: 300px;
 }
 
+#responses-tab .search-icon {
+  font-size: 20px;
+}
+
 #responses-tab .datepicker-export-container {
   display: flex;
   align-items: center;

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -102,7 +102,7 @@
 
 #responses-tab .response-stats {
   white-space: nowrap;
-  min-width: 280px;
+  width: 300px;
 }
 
 #responses-tab .datepicker-export-container {

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -738,12 +738,19 @@
 #filter-by-submission-filter-textbox-container {
   display: flex;
   min-width: 240px;
+  margin-right: 20px;
 }
 
 #responses-tab .response-search {
   flex-direction: row;
 }
 
-#responses-tab .input-custom {
+#responses-tab #filter-by-submission-filter-textbox {
   width: inherit;
+}
+
+@media (max-width: 1200px) {
+  #responses-tab .response-search {
+    width: 100%;
+  }
 }

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -754,3 +754,15 @@
     width: 100%;
   }
 }
+
+@media (max-width: 720px) {
+  #responses-tab .hide-count {
+    display: none;
+  }
+}
+
+@media (max-width: 1200px) {
+  #responses-tab #filter-by-submission-filter-textbox {
+    width: 600px;
+  }
+}

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -739,3 +739,7 @@
   display: flex;
   min-width: 240px;
 }
+
+#responses-tab .response-search {
+  flex-direction: row;
+}

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -743,3 +743,7 @@
 #responses-tab .response-search {
   flex-direction: row;
 }
+
+#responses-tab .input-custom {
+  width: inherit;
+}

--- a/src/public/modules/forms/admin/css/view-responses.css
+++ b/src/public/modules/forms/admin/css/view-responses.css
@@ -102,11 +102,11 @@
 
 #responses-tab .response-stats {
   white-space: nowrap;
-  width: 300px;
+  width: 240px;
 }
 
 #responses-tab .search-icon {
-  font-size: 20px;
+  font-size: 30px;
 }
 
 #responses-tab .datepicker-export-container {

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -68,7 +68,10 @@
       <div class="flex-row">
         <!-- Response and Search -->
         <div class="flex-row response-search">
-          <div class="response-stats">
+          <div
+            class="response-stats"
+            ng-class="{'hide-count': vm.filterBySubmissionShowFilterBox}"
+          >
             <span class="stats-text">
               <span
                 ><span class="stats">{{vm.responsesCount}}</span> response(s) to

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -66,42 +66,45 @@
     </div>
     <div ng-if="vm.currentView === 2">
       <div class="flex-row">
-        <!-- Response stats -->
-        <div class="response-stats">
-          <span class="stats-text">
-            <span
-              ><span class="stats">{{vm.responsesCount}}</span> response(s) to
-              date</span
+        <!-- Response and Search -->
+        <div class="flex-row response-search">
+          <div class="response-stats">
+            <span class="stats-text">
+              <span
+                ><span class="stats">{{vm.responsesCount}}</span> response(s) to
+                date</span
+              >
+            </span>
+          </div>
+
+          <div>
+            <a
+              id="filter-by-submission-filter-link"
+              ng-show="!vm.filterBySubmissionShowFilterBox"
+              ng-click="vm.filterBySubmissionShowFilterBox = true"
             >
-          </span>
-        </div>
+              <i class="bx bx-search search-icon"></i>
+            </a>
+          </div>
 
-        <a
-          id="filter-by-submission-filter-link"
-          ng-show="!vm.filterBySubmissionShowFilterBox"
-          ng-click="vm.filterBySubmissionShowFilterBox = true"
-        >
-          <i class="bx bx-search search-icon"></i>
-        </a>
-
-        <div
-          class="col-xl-6"
-          ng-show="vm.filterBySubmissionShowFilterBox"
-          id="filter-by-submission-filter-textbox-container"
-        >
-          <input
-            class="input-custom input-medium"
-            ng-model="vm.filterBySubmissionRefIdTextbox"
-            ng-change="vm.filterBySubmissionChanged()"
-            ng-model-options="{ debounce: 150 }"
-            placeholder="Search by reference no."
-          />
-          <span
-            id="filter-by-submission-reset-link"
-            ng-show="vm.filterBySubmissionRefId !== ''"
+          <div
+            ng-show="vm.filterBySubmissionShowFilterBox"
+            id="filter-by-submission-filter-textbox-container"
           >
-            <a ng-click="vm.filterBySubmissionReset()">View&nbsp;All</a>
-          </span>
+            <input
+              class="input-custom input-medium"
+              ng-model="vm.filterBySubmissionRefIdTextbox"
+              ng-change="vm.filterBySubmissionChanged()"
+              ng-model-options="{ debounce: 150 }"
+              placeholder="Search by reference no."
+            />
+            <span
+              id="filter-by-submission-reset-link"
+              ng-show="vm.filterBySubmissionRefId !== ''"
+            >
+              <a ng-click="vm.filterBySubmissionReset()">View&nbsp;All</a>
+            </span>
+          </div>
         </div>
         <div class="datepicker-export-container col-xl-3">
           <date-range-picker-directive

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -81,7 +81,7 @@
           ng-show="!vm.filterBySubmissionShowFilterBox"
           ng-click="vm.filterBySubmissionShowFilterBox = true"
         >
-          <i class="bx bx-search"></i>
+          <i class="bx bx-search search-icon"></i>
         </a>
 
         <div

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -92,6 +92,7 @@
             id="filter-by-submission-filter-textbox-container"
           >
             <input
+              id="filter-by-submission-filter-textbox"
               class="input-custom input-medium"
               ng-model="vm.filterBySubmissionRefIdTextbox"
               ng-change="vm.filterBySubmissionChanged()"

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -66,21 +66,24 @@
     </div>
     <div ng-if="vm.currentView === 2">
       <div class="flex-row">
-        <div class="col-xl-3 response-stats">
+        <!-- Response stats -->
+        <div class="response-stats">
           <span class="stats-text">
             <span
               ><span class="stats">{{vm.responsesCount}}</span> response(s) to
               date</span
             >
-            <a
-              id="filter-by-submission-filter-link"
-              ng-show="!vm.filterBySubmissionShowFilterBox"
-              ng-click="vm.filterBySubmissionShowFilterBox = true"
-            >
-              <i class="bx bx-search"></i>
-            </a>
           </span>
         </div>
+
+        <a
+          id="filter-by-submission-filter-link"
+          ng-show="!vm.filterBySubmissionShowFilterBox"
+          ng-click="vm.filterBySubmissionShowFilterBox = true"
+        >
+          <i class="bx bx-search"></i>
+        </a>
+
         <div
           class="col-xl-6"
           ng-show="vm.filterBySubmissionShowFilterBox"


### PR DESCRIPTION
wip - issues with IE

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Closes #489

## Solution
- Used the wireframes for reference but made adjustment to align the search box to the left, to accommodate 'View All' button when the ref number is filled in
<!-- How did you solve the problem? -->

**Screenshots**
![Screenshot 2020-11-08 at 8 22 09 PM](https://user-images.githubusercontent.com/63710093/98464914-08083780-2201-11eb-86e8-19a9ebc57d35.png)
![Screenshot 2020-11-08 at 8 22 16 PM](https://user-images.githubusercontent.com/63710093/98464918-0b032800-2201-11eb-97e6-7983200609b0.png)
![Screenshot 2020-11-08 at 8 22 36 PM](https://user-images.githubusercontent.com/63710093/98464921-0c345500-2201-11eb-8175-bd7c6310c9c0.png)
![Screenshot 2020-11-08 at 8 22 29 PM](https://user-images.githubusercontent.com/63710093/98464920-0b9bbe80-2201-11eb-9520-b35bfdc78121.png)
![Screenshot 2020-11-08 at 8 22 55 PM](https://user-images.githubusercontent.com/63710093/98464924-0ccceb80-2201-11eb-9275-ee21876635f3.png)
![Screenshot 2020-11-08 at 8 23 00 PM](https://user-images.githubusercontent.com/63710093/98464925-0ccceb80-2201-11eb-8ae3-0ff737eef74d.png)


## Tests
- [ ] Create storage mode form and submit response. Open the response tab using multiple screen sizes. Check that none of the elements overflow the page
- [ ] Test that filter by submission id still works
- [ ] Test that export by date range still works 
<!-- What tests should be run to confirm functionality? -->
