### PR TITLE
refactor: hash uinFin in domain layer

### DIFF
--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -143,9 +143,9 @@ exports.verifyMyInfoVals = async function (req, res, next) {
   if (authType === 'SP' && actualMyInfoFields.length > 0) {
     const uinFin = res.locals.uinFin
     const formObjId = req.form._id
-    let hashedObj
+    let hashedFields
     try {
-      hashedObj = await MyInfoHash.findHashes(uinFin, formObjId)
+      hashedFields = await MyInfoHash.findHashes(uinFin, formObjId)
     } catch (error) {
       logger.error({
         message: 'Error retrieving MyInfo hash from database',
@@ -160,7 +160,7 @@ exports.verifyMyInfoVals = async function (req, res, next) {
         spcpSubmissionFailure: true,
       })
     }
-    if (!hashedObj) {
+    if (!hashedFields) {
       logger.error({
         message: `Unable to find MyInfo hashes for ${formObjId}`,
         meta: {
@@ -180,8 +180,6 @@ exports.verifyMyInfoVals = async function (req, res, next) {
       .filter((field) => field.isVisible && field.myInfo && field.myInfo.attr)
       .map(_preHashCheckConversion)
 
-    // Fields from saved hash
-    let hashedFields = hashedObj.fields
     // compare hashed values to submission values
     const bcryptCompares = clientMyInfoFields.map((clientField) => {
       const expected = hashedFields[clientField.attr]

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -76,15 +76,10 @@ exports.addMyInfo = (myInfoService) => async (req, res, next) => {
   // Set current form fields to the new prefilledFields.
   req.form.form_fields = prefilledFields
 
-  const hashedUinFin = crypto
-    .createHmac('sha256', sessionSecret)
-    .update(uinFin)
-    .digest('hex')
-
   Promise.props(readOnlyHashPromises)
     .then((readOnlyHashes) => {
       return MyInfoHash.updateHashes(
-        hashedUinFin,
+        uinFin,
         formId,
         readOnlyHashes,
         myInfoService.spCookieMaxAge,

--- a/src/app/models/myinfo_hash.server.model.ts
+++ b/src/app/models/myinfo_hash.server.model.ts
@@ -75,15 +75,16 @@ MyInfoHashSchema.statics.findHashes = async function (
   this: IMyInfoHashModel,
   uinFin: string,
   formId: string,
-): Promise<IMyInfoHashSchema | null> {
+): Promise<IHashes | null> {
   const hashedUinFin = crypto
     .createHmac('sha256', sessionSecret)
     .update(uinFin)
     .digest('hex')
-  return this.findOne({
+  const hashInfo = await this.findOne({
     uinFin: hashedUinFin,
     form: formId,
   })
+  return hashInfo ? hashInfo.fields : null
 }
 
 const compileMyInfoHashModel = (db: Mongoose) =>

--- a/src/app/models/myinfo_hash.server.model.ts
+++ b/src/app/models/myinfo_hash.server.model.ts
@@ -71,6 +71,21 @@ MyInfoHashSchema.statics.updateHashes = async function (
   )
 }
 
+MyInfoHashSchema.statics.findHashes = async function (
+  this: IMyInfoHashModel,
+  uinFin: string,
+  formId: string,
+): Promise<IMyInfoHashSchema | null> {
+  const hashedUinFin = crypto
+    .createHmac('sha256', sessionSecret)
+    .update(uinFin)
+    .digest('hex')
+  return this.findOne({
+    uinFin: hashedUinFin,
+    form: formId,
+  })
+}
+
 const compileMyInfoHashModel = (db: Mongoose) =>
   db.model<IMyInfoHashSchema, IMyInfoHashModel>(
     MYINFO_HASH_SCHEMA_ID,

--- a/src/app/models/myinfo_hash.server.model.ts
+++ b/src/app/models/myinfo_hash.server.model.ts
@@ -1,5 +1,7 @@
+import crypto from 'crypto'
 import { Mongoose, Schema } from 'mongoose'
 
+import { sessionSecret } from '../../config/config'
 import { IHashes, IMyInfoHashModel, IMyInfoHashSchema } from '../../types'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -45,11 +47,15 @@ MyInfoHashSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 })
 
 MyInfoHashSchema.statics.updateHashes = async function (
   this: IMyInfoHashModel,
-  hashedUinFin: string,
+  uinFin: string,
   formId: string,
   readOnlyHashes: IHashes,
   spCookieMaxAge: number,
 ): Promise<IMyInfoHashSchema | null> {
+  const hashedUinFin = crypto
+    .createHmac('sha256', sessionSecret)
+    .update(uinFin)
+    .digest('hex')
   return this.findOneAndUpdate(
     {
       uinFin: hashedUinFin,

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -22,7 +22,7 @@ export interface IMyInfoHashSchema extends IMyInfoHash, Document {}
 
 export interface IMyInfoHashModel extends Model<IMyInfoHashSchema> {
   updateHashes: (
-    hashedUinFin: string,
+    uinFin: string,
     formId: string,
     readOnlyHashes: IHashes,
     spCookieMaxAge: number,

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -27,4 +27,8 @@ export interface IMyInfoHashModel extends Model<IMyInfoHashSchema> {
     readOnlyHashes: IHashes,
     spCookieMaxAge: number,
   ) => Promise<IMyInfoHashSchema | null>
+  findHashes: (
+    uinFin: string,
+    formId: string,
+  ) => Promise<IMyInfoHashSchema | null>
 }

--- a/src/types/myinfo_hash.ts
+++ b/src/types/myinfo_hash.ts
@@ -27,8 +27,5 @@ export interface IMyInfoHashModel extends Model<IMyInfoHashSchema> {
     readOnlyHashes: IHashes,
     spCookieMaxAge: number,
   ) => Promise<IMyInfoHashSchema | null>
-  findHashes: (
-    uinFin: string,
-    formId: string,
-  ) => Promise<IMyInfoHashSchema | null>
+  findHashes: (uinFin: string, formId: string) => Promise<IHashes | null>
 }

--- a/tests/unit/backend/controllers/myinfo.server.controller.spec.js
+++ b/tests/unit/backend/controllers/myinfo.server.controller.spec.js
@@ -495,7 +495,7 @@ const ALL_MYINFO_HASHES = {
     '$2b$10$eLakOm88NEuUawlGHsiPjeaImpYT5ZBH1JyZUseIRL9kCtDRIKdCe',
 }
 
-const SESSION_SECRET = 'secret'
+const SESSION_SECRET = process.env.SESSION_SECRET
 
 const User = dbHandler.makeModel('user.server.model', 'User')
 const Agency = dbHandler.makeModel('agency.server.model', 'Agency')
@@ -506,9 +506,6 @@ const Controller = spec(
   'dist/backend/app/controllers/myinfo.server.controller',
   {
     mongoose: Object.assign(mongoose, { '@noCallThru': true }),
-    '../../config/config': {
-      sessionSecret: SESSION_SECRET,
-    },
   },
 )
 

--- a/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
+++ b/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
@@ -171,5 +171,28 @@ describe('MyInfo Hash Model', () => {
         expect(found!.uinFin).toEqual(DEFAULT_HASHED_UINFIN)
       })
     })
+
+    describe('findHashes', () => {
+      it('should find the correct document', async () => {
+        // Arrange
+        // Insert mock document into collection.
+        // Note: we are inserting the HASHED uinFin directly.
+        await MyInfoHash.create(DEFAULT_SAVED_PARAMS)
+        // Should have the added document.
+        await expect(MyInfoHash.countDocuments()).resolves.toEqual(1)
+
+        // Act
+        // Note: we are passing the PLAIN uinFin and checking that it gets hashed
+        const actual = await MyInfoHash.findHashes(
+          DEFAULT_INPUT_PARAMS.uinFin,
+          DEFAULT_INPUT_PARAMS.form.toHexString(),
+        )
+        // Assert
+        // Both the returned document and the found document should match
+        expect(pick(actual, ['uinFin', 'form', 'fields'])).toEqual(
+          pick(DEFAULT_SAVED_PARAMS, ['uinFin', 'form', 'fields']),
+        )
+      })
+    })
   })
 })

--- a/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
+++ b/tests/unit/backend/models/myinfo_hash.server.model.spec.ts
@@ -189,9 +189,7 @@ describe('MyInfo Hash Model', () => {
         )
         // Assert
         // Both the returned document and the found document should match
-        expect(pick(actual, ['uinFin', 'form', 'fields'])).toEqual(
-          pick(DEFAULT_SAVED_PARAMS, ['uinFin', 'form', 'fields']),
-        )
+        expect(actual).toEqual(DEFAULT_SAVED_PARAMS.fields)
       })
     })
   })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The MyInfo controller currently has the responsibility of hashing the user's ID (`uinFin`) in order to search and update the `MyInfoHash` collection. However, hashing is really a concern of how the data is stored, not the business logic of the application. It would be better if the service and controller layers could deal with the ID as-is, instead of having to worry about transforming it so the model can store it correctly.

## Solution
<!-- How did you solve the problem? -->
Move the responsibility of hashing the uinFin into model static methods, and have the controller interact with the model through those methods.