### PR TITLE
ref: migrate inline queries for retrieval of submissions metadata to model static methods

### DIFF
--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -44,6 +44,11 @@ const SubmissionSchema = new Schema<ISubmissionSchema>(
         },
       ],
     },
+    submissionType: {
+      type: String,
+      enum: Object.values(SubmissionType),
+      required: true,
+    },
   },
   {
     timestamps: {

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -177,7 +177,7 @@ EncryptSubmissionSchema.methods.getWebhookView = function (
   }
 }
 
-EncryptSubmissionSchema.statics.findMetadataById = function (
+EncryptSubmissionSchema.statics.findSingleMetadata = function (
   this: IEncryptSubmissionModel,
   formId: string,
   submissionId: string,

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -219,6 +219,15 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
   )
 }
 
+/**
+ * Unexported as the type is only used in {@see findAllMetadataByFormId} for
+ * now.
+ */
+type MetadataAggregateResult = {
+  pageResults: Pick<ISubmissionSchema, '_id' | 'created'>[]
+  allResults: FixedLengthArray<{ count: number }, 1> | []
+}
+
 EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
   this: IEncryptSubmissionModel,
   formId: string,
@@ -234,11 +243,6 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
   count: number
 }> {
   const numToSkip = (page - 1) * pageSize
-
-  type MetadataAggregateResult = {
-    pageResults: Pick<ISubmissionSchema, '_id' | 'created'>[]
-    allResults: FixedLengthArray<{ count: number }, 1> | []
-  }
 
   return (
     this.aggregate()

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -3,7 +3,7 @@
 /**
  * Module dependencies.
  */
-const { celebrate, Joi } = require('celebrate')
+const { celebrate, Joi, Segments } = require('celebrate')
 
 let forms = require('../../app/controllers/forms.server.controller')
 let adminForms = require('../../app/controllers/admin-forms.server.controller')

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -424,9 +424,16 @@ module.exports = function (app) {
    * @returns {metadataResponse.model} 200 - Metadata of responses
    * @security OTP
    */
-  app
-    .route('/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata')
-    .get(authEncryptedResponseAccess, encryptSubmissions.getMetadata)
+  app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata').get(
+    authEncryptedResponseAccess,
+    celebrate({
+      [Segments.QUERY]: {
+        page: Joi.number().min(1).required(),
+        submissionId: Joi.string().optional(),
+      },
+    }),
+    encryptSubmissions.getMetadata,
+  )
 
   /**
    * Stream download all encrypted responses for a form

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -118,6 +118,23 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       formId: string,
       submissionId: string,
     ): Promise<SubmissionMetadata | null>
+
+    /**
+     * Returns all submission metadata of the form for the given formId. The
+     * metadata returned is offset by the page and the pageSize options.
+     * @param formId the form id to return submission metadata for
+     * @param options.page the page of metadata list to return
+     * @param options.pageSize the number of metadata per page
+     *
+     * @returns limited list of metadata, along with the total number of metadata count
+     */
+    findAllMetadataByFormId(
+      formId: string,
+      params?: { page?: number; pageSize?: number },
+    ): Promise<{
+      metadata: SubmissionMetadata[]
+      count: number
+    }>
   }
 
 export interface IWebhookResponseSchema extends IWebhookResponse, Document {}

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -108,13 +108,13 @@ export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
 export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
   ISubmissionModel & {
     /**
-     * Return metadata for the submissionId of form with formId.
+     * Return submission metadata for a single submissionId of form with formId.
      * @param formId formId to filter submissions for
      * @param submissionId specific submissionId to retrieve metadata for
      *
      * @returns submission metadata if available, `null` otherwise.
      */
-    findMetadataById(
+    findSingleMetadata(
       formId: string,
       submissionId: string,
     ): Promise<SubmissionMetadata | null>

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -67,7 +67,7 @@ export interface IEmailSubmission extends ISubmission {
   recipientEmails: string[]
   responseHash: string
   responseSalt: string
-  hasBounced: boolean
+  hasBounced?: boolean
   encryptedContent: never
   verifiedContent: never
   version: never
@@ -87,7 +87,7 @@ export interface IEncryptedSubmission extends ISubmission {
   verifiedContent?: string
   version: number
   attachmentMetadata?: Map<string, string>
-  webhookResponses: IWebhookResponse[]
+  webhookResponses?: IWebhookResponse[]
   getWebhookView(): WebhookView | null
 }
 

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -9,6 +9,12 @@ export enum SubmissionType {
   Encrypt = 'encryptSubmission',
 }
 
+export type SubmissionMetadata = {
+  number: number
+  refNo: IEncryptedSubmissionSchema['_id']
+  submissionTime: string
+}
+
 export interface ISubmission {
   form: IFormSchema['_id']
   authType?: AuthType
@@ -100,6 +106,18 @@ export interface IWebhookResponse {
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
   ISubmissionModel
 export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
-  ISubmissionModel
+  ISubmissionModel & {
+    /**
+     * Return metadata for the submissionId of form with formId.
+     * @param formId formId to filter submissions for
+     * @param submissionId specific submissionId to retrieve metadata for
+     *
+     * @returns submission metadata if available, `null` otherwise.
+     */
+    findMetadataById(
+      formId: string,
+      submissionId: string,
+    ): Promise<SubmissionMetadata | null>
+  }
 
 export interface IWebhookResponseSchema extends IWebhookResponse, Document {}

--- a/tests/unit/backend/controllers/submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/submissions.server.controller.spec.js
@@ -299,9 +299,16 @@ describe('Submissions Controller', () => {
     })
 
     it('returns count if > 0 submissions', (done) => {
-      new Submission({ form: testForm._id }).save().then(() => {
-        request(app).get(endpointPath).expect(200, '1').end(done)
+      new Submission({
+        form: testForm._id,
+        submissionType: 'emailSubmission',
+        responseHash: 'any hash',
+        responseSalt: 'any salt',
       })
+        .save()
+        .then(() => {
+          request(app).get(endpointPath).expect(200, '1').end(done)
+        })
     })
 
     it('errors with 500 if count retrieve fail', (done) => {

--- a/tests/unit/backend/models/encrypt-submission.server.model.spec.ts
+++ b/tests/unit/backend/models/encrypt-submission.server.model.spec.ts
@@ -24,7 +24,7 @@ describe('Encrypt Submission Model', () => {
   const MOCK_ENCRYPTED_CONTENT = 'abcdefg encryptedContent'
 
   describe('Statics', () => {
-    describe('findMetadataById', () => {
+    describe('findSingleMetadata', () => {
       it('should return submission metadata', async () => {
         // Arrange
         const validFormId = new ObjectId().toHexString()
@@ -43,7 +43,7 @@ describe('Encrypt Submission Model', () => {
         })
 
         // Act
-        const result = await EncryptSubmission.findMetadataById(
+        const result = await EncryptSubmission.findSingleMetadata(
           validFormId,
           validSubmission._id,
         )
@@ -73,7 +73,7 @@ describe('Encrypt Submission Model', () => {
         })
 
         // Act
-        const result = await EncryptSubmission.findMetadataById(
+        const result = await EncryptSubmission.findSingleMetadata(
           validFormId,
           validSubmission._id,
         )
@@ -87,7 +87,7 @@ describe('Encrypt Submission Model', () => {
         const validFormId = new ObjectId().toHexString()
         const invalidSubmissionId = new ObjectId().toHexString()
         // Act
-        const result = await EncryptSubmission.findMetadataById(
+        const result = await EncryptSubmission.findSingleMetadata(
           validFormId,
           invalidSubmissionId,
         )

--- a/tests/unit/backend/models/encrypt-submission.server.model.spec.ts
+++ b/tests/unit/backend/models/encrypt-submission.server.model.spec.ts
@@ -1,0 +1,100 @@
+import { ObjectId } from 'bson-ext'
+import moment from 'moment-timezone'
+import mongoose from 'mongoose'
+
+import getSubmissionModel, {
+  getEncryptSubmissionModel,
+} from 'src/app/models/submission.server.model'
+import {
+  IEncryptedSubmissionSchema,
+  SubmissionMetadata,
+  SubmissionType,
+} from 'src/types'
+
+import dbHandler from '../helpers/jest-db'
+
+const Submission = getSubmissionModel(mongoose)
+const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+
+describe('Encrypt Submission Model', () => {
+  beforeAll(async () => await dbHandler.connect())
+  afterEach(async () => await dbHandler.clearDatabase())
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  const MOCK_ENCRYPTED_CONTENT = 'abcdefg encryptedContent'
+
+  describe('Statics', () => {
+    describe('findMetadataById', () => {
+      it('should return submission metadata', async () => {
+        // Arrange
+        const validFormId = new ObjectId().toHexString()
+        const createdDate = new Date()
+        // Add valid encrypt submission.
+        const validSubmission = await Submission.create<
+          IEncryptedSubmissionSchema
+        >({
+          form: validFormId,
+          myInfoFields: [],
+          // Email type.
+          submissionType: SubmissionType.Encrypt,
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          created: createdDate,
+        })
+
+        // Act
+        const result = await EncryptSubmission.findMetadataById(
+          validFormId,
+          validSubmission._id,
+        )
+
+        // Assert
+        const expected: SubmissionMetadata = {
+          number: 1,
+          refNo: validSubmission._id,
+          submissionTime: moment(createdDate)
+            .tz('Asia/Singapore')
+            .format('Do MMM YYYY, h:mm:ss a'),
+        }
+        expect(result).toEqual(expected)
+      })
+
+      it('should return null when submission is of SubmissionType.Email', async () => {
+        // Arrange
+        const validFormId = new ObjectId().toHexString()
+        // Add email submission.
+        const validSubmission = await Submission.create({
+          form: validFormId,
+          myInfoFields: [],
+          // Email type.
+          submissionType: SubmissionType.Email,
+          responseHash: 'hash',
+          responseSalt: 'salt',
+        })
+
+        // Act
+        const result = await EncryptSubmission.findMetadataById(
+          validFormId,
+          validSubmission._id,
+        )
+
+        // Assert
+        expect(result).toBeNull()
+      })
+
+      it('should return null if no submission metadata is retrieved', async () => {
+        // Arrange
+        const validFormId = new ObjectId().toHexString()
+        const invalidSubmissionId = new ObjectId().toHexString()
+        // Act
+        const result = await EncryptSubmission.findMetadataById(
+          validFormId,
+          invalidSubmissionId,
+        )
+
+        // Assert
+        expect(result).toBeNull()
+      })
+    })
+  })
+})

--- a/tests/unit/backend/modules/webhook/webhook.service.spec.ts
+++ b/tests/unit/backend/modules/webhook/webhook.service.spec.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
-import dbHandler from 'tests/unit/backend/helpers/jest-db'
 import { mocked } from 'ts-jest/utils'
 
 import getFormModel from 'src/app/models/form.server.model'
@@ -17,13 +16,15 @@ import {
   WebhookView,
 } from 'src/types'
 
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
 const Form = getFormModel(mongoose)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 
 // Define constants
 const MOCK_ADMIN_OBJ_ID = new ObjectID()
-const MOCK_WEBHOOK_URL: string = 'https://form.gov.sg/endpoint'
-const ERROR_MSG: string = 'test-message'
+const MOCK_WEBHOOK_URL = 'https://form.gov.sg/endpoint'
+const ERROR_MSG = 'test-message'
 const MOCK_SUCCESS_RESPONSE: AxiosResponse = {
   data: {
     result: 'test-result',
@@ -58,7 +59,7 @@ const MOCK_STRINGIFIED_FAILURE_RESPONSE: Pick<IWebhookResponse, 'response'> = {
     headers: '{}',
   },
 }
-const MOCK_EPOCH: number = 1487076708000
+const MOCK_EPOCH = 1487076708000
 
 // Set up mocks
 jest.mock('axios')
@@ -83,7 +84,7 @@ describe('WebhooksService', () => {
     const preloaded = await dbHandler.insertFormCollectionReqs({
       userId: MOCK_ADMIN_OBJ_ID,
     })
-    let testEncryptForm = new Form({
+    const testEncryptForm = new Form({
       title: 'Test Form',
       admin: preloaded.user._id,
       responseMode: ResponseMode.Encrypt,
@@ -144,10 +145,10 @@ describe('WebhooksService', () => {
       await pushData(MOCK_WEBHOOK_URL, testSubmissionWebhookView)
 
       // Assert
-      let submission = await EncryptSubmission.findById(
+      const submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission!.webhookResponses[0]).toEqual(
+      expect(submission?.webhookResponses![0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,
@@ -169,10 +170,10 @@ describe('WebhooksService', () => {
       await pushData(MOCK_WEBHOOK_URL, testSubmissionWebhookView)
 
       // Assert
-      let submission = await EncryptSubmission.findById(
+      const submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission!.webhookResponses[0]).toEqual(
+      expect(submission?.webhookResponses![0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,
@@ -186,7 +187,7 @@ describe('WebhooksService', () => {
       class MockAxiosError extends Error {
         isAxiosError: boolean
         toJSON: () => {}
-        config: object
+        config: Record<string, unknown>
         response: AxiosResponse
         constructor(msg: string, response: AxiosResponse) {
           super(msg)
@@ -198,7 +199,7 @@ describe('WebhooksService', () => {
           this.config = {}
         }
       }
-      let mockAxiosError: AxiosError = new MockAxiosError(
+      const mockAxiosError: AxiosError = new MockAxiosError(
         ERROR_MSG,
         MOCK_FAILURE_RESPONSE,
       )
@@ -217,10 +218,10 @@ describe('WebhooksService', () => {
       await pushData(MOCK_WEBHOOK_URL, testSubmissionWebhookView)
 
       // Assert
-      let submission = await EncryptSubmission.findById(
+      const submission = await EncryptSubmission.findById(
         testEncryptSubmission._id,
       )
-      expect(submission!.webhookResponses[0]).toEqual(
+      expect(submission?.webhookResponses![0]).toEqual(
         expect.objectContaining({
           webhookUrl: MOCK_WEBHOOK_URL,
           signature: testSignature,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR extracts out the inlined mongoose queries in the `/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata` controller handler. Also adds `celebrate` middleware validation for the route.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- Add `EncryptSubmissionModel#findSingleMetadata` static method to retrieve metadata for a single submission
- Add `EncryptSubmissionModel#findAllMetadatabyFormId` static method to retrieve all submission metadatas for the given form id.
- Add celebrate middleware validation to `/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata` endpoint.

**Improvements**:

- Replace inlined queries in the controller handler for `/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata` endpoint with `EncryptSubmissionModel` static methods.


