### PR TITLE
ref: migrate createPresignedPost endpoint for images to TypeScript

### DIFF
--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -32,3 +32,9 @@ export class DatabaseError extends ApplicationError {
     super(message)
   }
 }
+
+export class ExternalError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -1,18 +1,25 @@
+import { PresignedPost } from 'aws-sdk/clients/s3'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { DatabaseError } from 'src/app/modules/core/core.errors'
+import { DatabaseError, ExternalError } from 'src/app/modules/core/core.errors'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
-import { handleListDashboardForms } from '../admin-form.controller'
+import {
+  handleCreatePresignedPostForImages,
+  handleListDashboardForms,
+} from '../admin-form.controller'
+import { InvalidFileTypeError } from '../admin-form.errors'
 import * as AdminFormService from '../admin-form.service'
 
 jest.mock('../admin-form.service')
 const MockAdminFormService = mocked(AdminFormService)
 
 describe('admin-form.controller', () => {
+  beforeEach(() => jest.restoreAllMocks())
+
   describe('handleListDashboardForms', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       session: {
@@ -63,6 +70,75 @@ describe('admin-form.controller', () => {
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
       expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+  })
+
+  describe('handleCreatePresignedPostForImages', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: {
+        fileId: 'any file id',
+        fileMd5Hash: 'any hash',
+        fileType: 'any type',
+      },
+    })
+
+    it('should return 200 with presigned POST object when successful', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const expectedPresignedPost: PresignedPost = {
+        fields: {
+          'X-Amz-Signature': 'some-amz-signature',
+          Policy: 'some policy',
+        },
+        url: 'some url',
+      }
+      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+        okAsync(expectedPresignedPost),
+      )
+
+      // Act
+      await handleCreatePresignedPostForImages(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
+    })
+
+    it('should return 400 when InvalidFileTypeError is returned when creating presigned POST', async () => {
+      // Arrange
+      // Mock error
+      const mockErrorString = 'bad file type, bad!'
+      const mockRes = expressHandler.mockResponse()
+      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+        errAsync(new InvalidFileTypeError(mockErrorString)),
+      )
+
+      // Act
+      await handleCreatePresignedPostForImages(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+    })
+
+    it('should return 400 when ExternalError is returned when creating presigned POST', async () => {
+      // Arrange
+      // Mock error
+      const mockErrorString = 'creating presigned post failed, oh no'
+      const mockRes = expressHandler.mockResponse()
+      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+        errAsync(new ExternalError(mockErrorString)),
+      )
+
+      // Act
+      await handleCreatePresignedPostForImages(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
     })
   })
 })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -172,7 +172,7 @@ describe('admin-form.service', () => {
       // Assert
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new ExternalError('Error occurred whilst uploading image'),
+        new ExternalError('Error occurred whilst uploading file'),
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -109,7 +109,7 @@ describe('admin-form.service', () => {
         url: 'some url',
       }
       // Mock external service success.
-      jest
+      const s3Spy = jest
         .spyOn(aws.s3, 'createPresignedPost')
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -125,6 +125,11 @@ describe('admin-form.service', () => {
       })
 
       // Assert
+      // Check that the correct bucket was used.
+      expect(s3Spy).toHaveBeenCalledWith(
+        expect.objectContaining({ Bucket: aws.imageS3Bucket }),
+        expect.any(Function),
+      )
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPost)
     })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1,14 +1,21 @@
+import { PresignedPost } from 'aws-sdk/clients/s3'
 import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
 import getFormModel from 'src/app/models/form.server.model'
-import { DatabaseError } from 'src/app/modules/core/core.errors'
+import { DatabaseError, ExternalError } from 'src/app/modules/core/core.errors'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
+import { aws } from 'src/config/config'
+import { VALID_UPLOAD_FILE_TYPES } from 'src/shared/constants'
 import { DashboardFormView, IPopulatedUser, IUserSchema } from 'src/types'
 
-import { getDashboardForms } from '../admin-form.service'
+import { InvalidFileTypeError } from '../admin-form.errors'
+import {
+  createPresignedPostForImages,
+  getDashboardForms,
+} from '../admin-form.service'
 
 const FormModel = getFormModel(mongoose)
 
@@ -16,6 +23,7 @@ jest.mock('src/app/modules/user/user.service')
 const MockUserService = mocked(UserService)
 
 describe('admin-form.service', () => {
+  beforeEach(() => jest.restoreAllMocks())
   describe('getDashboardForms', () => {
     it('should return list of forms user is authorized to view', async () => {
       // Arrange
@@ -87,6 +95,80 @@ describe('admin-form.service', () => {
       expect(getSpy).toHaveBeenCalledWith(mockUserId, mockUser.email)
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(new DatabaseError())
+    })
+  })
+
+  describe('createPresignedPostForImages', () => {
+    it('should successfully create presigned POST URL', async () => {
+      // Arrange
+      const expectedPresignedPost: PresignedPost = {
+        fields: {
+          'X-Amz-Signature': 'some-amz-signature',
+          Policy: 'some policy',
+        },
+        url: 'some url',
+      }
+      // Mock external service success.
+      jest
+        .spyOn(aws.s3, 'createPresignedPost')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce((_obj, cb) => {
+          cb(null, expectedPresignedPost)
+        })
+
+      // Act
+      const actualResult = await createPresignedPostForImages({
+        fileId: 'any id',
+        fileMd5Hash: 'any hash',
+        fileType: VALID_UPLOAD_FILE_TYPES[0],
+      })
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPost)
+    })
+
+    it('should return InvalidFileTypeError when given file type is not supported', async () => {
+      // Arrange
+      const invalidFileType = 'something'
+      expect(VALID_UPLOAD_FILE_TYPES.includes(invalidFileType)).toEqual(false)
+
+      // Act
+      const actualResult = await createPresignedPostForImages({
+        fileId: 'any id',
+        fileMd5Hash: 'any hash',
+        fileType: invalidFileType,
+      })
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new InvalidFileTypeError(
+          `"${invalidFileType}" is not a supported file type`,
+        ),
+      )
+    })
+
+    it('should return ExternalError when error occurs whilst creating presigned POST URL', async () => {
+      // Arrange
+      // Mock external service failure.
+      jest.spyOn(aws.s3, 'createPresignedPost').mockImplementationOnce(() => {
+        throw new Error('boom')
+      })
+
+      // Act
+      const actualResult = await createPresignedPostForImages({
+        fileId: 'any id',
+        fileMd5Hash: 'any hash',
+        fileType: VALID_UPLOAD_FILE_TYPES[0],
+      })
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new ExternalError('Error occurred whilst uploading image'),
+      )
     })
   })
 })

--- a/src/app/modules/form/admin-form/admin-form.constants.ts
+++ b/src/app/modules/form/admin-form/admin-form.constants.ts
@@ -1,0 +1,4 @@
+/**
+ * 900 seconds = 15 minutes. The expiry time for presigned POST URLs.
+ */
+export const PRESIGNED_POST_EXPIRY_SECS = 900

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from '../../core/core.errors'
+
+export class InvalidFileTypeError extends ApplicationError {
+  constructor(message = 'Unsupported file type') {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -55,6 +55,17 @@ export const getDashboardForms = (
   )
 }
 
+/**
+ * Creates a S3 presigned POST URL for the client to upload images directly to.
+ *
+ * @param param.fileId key of the file
+ * @param param.fileMd5Hash the MD5 hash of the file
+ * @param param.fileType the file type of the file
+ *
+ * @returns ok(presigned post url) when creation is successful
+ * @returns err(InvalidFileTypeError) when given file type is not supported
+ * @returns err(ExternalError) when errors occurs on S3 side whilst creating presigned post url.
+ */
 export const createPresignedPostForImages = ({
   fileId,
   fileMd5Hash,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -117,7 +117,7 @@ const createPresignedPost = (
       error,
     })
 
-    return new ExternalError('Error occurred whilst uploading image')
+    return new ExternalError('Error occurred whilst uploading file')
   })
 }
 

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -1,9 +1,15 @@
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
-import { ApplicationError, DatabaseError } from '../../core/core.errors'
+import {
+  ApplicationError,
+  DatabaseError,
+  ExternalError,
+} from '../../core/core.errors'
 import { ErrorResponseData } from '../../core/core.types'
 import { MissingUserError } from '../../user/user.errors'
+
+import { InvalidFileTypeError } from './admin-form.errors'
 
 const logger = createLoggerWithLabel(module)
 
@@ -18,6 +24,12 @@ export const mapRouteError = (
   coreErrorMessage?: string,
 ): ErrorResponseData => {
   switch (error.constructor) {
+    case InvalidFileTypeError:
+    case ExternalError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
     case MissingUserError:
       return {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -3,7 +3,7 @@
 /**
  * Module dependencies.
  */
-const { celebrate, Joi } = require('celebrate')
+const { celebrate, Joi, Segments } = require('celebrate')
 
 let forms = require('../../app/controllers/forms.server.controller')
 let adminForms = require('../../app/controllers/admin-forms.server.controller')
@@ -456,7 +456,7 @@ module.exports = function (app) {
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/images').post(
     celebrate({
-      body: Joi.object().keys({
+      [Segments.BODY]: {
         fileId: Joi.string()
           .required()
           .error(() => 'Please enter a valid file id'),
@@ -467,10 +467,10 @@ module.exports = function (app) {
         fileType: Joi.string()
           .required()
           .error(() => 'Error - your file could not be verified'),
-      }),
+      },
     }),
     authActiveForm(PERMISSIONS.WRITE),
-    adminForms.createPresignedPostForImages,
+    AdminFormController.handleCreatePresignedPostForImages,
   )
 
   /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates the createPresignedPost endpoint flow to Typescript (barring router layer).
Adds tests for all the new migrated functions.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `ExternalError` class for errors arising externally (like S3)
- add `AdminFormService#createPresignedPostForImages` function
- add `AdminFormController#handleCreatePresignedPostForImages` function

**Improvements**:

- replace controller handler function used for `POST /:formId([a-fA-F0-9]{24})/adminform/images` route with migrated TypeScript function
- Remove all traces of old Javascript handler function
