### PR TITLE
ref: migrate createPresignedPost endpoint for logos to TypeScript 

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -15,13 +15,9 @@ const { createReqMeta } = require('../utils/request')
 const { FormLogoState } = require('../../types')
 
 const {
-  aws: { logoS3Bucket, logoBucketUrl, s3 },
+  aws: { logoBucketUrl },
 } = require('../../config/config')
-const {
-  VALID_UPLOAD_FILE_TYPES,
-  MAX_UPLOAD_FILE_SIZE,
-  EditFieldActions,
-} = require('../../shared/constants')
+const { EditFieldActions } = require('../../shared/constants')
 const {
   getEncryptedFormModel,
   getEmailFormModel,
@@ -617,53 +613,6 @@ function makeModule(connection) {
       }
       return next()
     },
-    /**
-     * Return presigned post data of logo S3 bucket
-     * @param {Object} req - Express request object
-     * @param {String} req.body.fileId - Name of the file to save. Is somewhat unique (see frontend code)
-     * @param {String} req.body.fileMd5Hash - MD5 hash of the file to save. To ensure file is not corrupted while uploading
-     * @param {String} req.body.fileType - Mime type of the file to save. To enforce file format
-     * @param {Object} res - Express response object
-     */
-    createPresignedPostForLogos: function (req, res) {
-      if (!VALID_UPLOAD_FILE_TYPES.includes(req.body.fileType)) {
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json(`Your file type "${req.body.fileType}" is not supported`)
-      }
-
-      s3.createPresignedPost(
-        {
-          Bucket: logoS3Bucket,
-          Expires: 900, // Expires in 15 mins
-          Conditions: [
-            ['content-length-range', 0, MAX_UPLOAD_FILE_SIZE], // content length restrictions: 0-MAX_UPLOAD_FILE_SIZE
-          ],
-          Fields: {
-            acl: 'public-read',
-            key: req.body.fileId,
-            'Content-MD5': req.body.fileMd5Hash,
-            'Content-Type': req.body.fileType,
-          },
-        },
-        function (err, presignedPostObject) {
-          if (err) {
-            logger.error({
-              message: 'Presigning post data encountered an error',
-              meta: {
-                action: 'makeModule.streamFeedback',
-                ...createReqMeta(req),
-              },
-              error: err,
-            })
-            return res.status(StatusCodes.BAD_REQUEST).json(err)
-          } else {
-            return res.status(StatusCodes.OK).json(presignedPostObject)
-          }
-        },
-      )
-    },
-
     /**
      * Transfer a form to another user
      * @param  {Object} req - Express request object

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -32,9 +32,3 @@ export class DatabaseError extends ApplicationError {
     super(message)
   }
 }
-
-export class ExternalError extends ApplicationError {
-  constructor(message: string) {
-    super(message)
-  }
-}

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -2,7 +2,7 @@ import { PresignedPost } from 'aws-sdk/clients/s3'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { DatabaseError, ExternalError } from 'src/app/modules/core/core.errors'
+import { DatabaseError } from 'src/app/modules/core/core.errors'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
@@ -12,7 +12,10 @@ import {
   handleCreatePresignedPostForLogos,
   handleListDashboardForms,
 } from '../admin-form.controller'
-import { InvalidFileTypeError } from '../admin-form.errors'
+import {
+  CreatePresignedUrlError,
+  InvalidFileTypeError,
+} from '../admin-form.errors'
 import * as AdminFormService from '../admin-form.service'
 
 jest.mock('../admin-form.service')
@@ -123,13 +126,13 @@ describe('admin-form.controller', () => {
       })
     })
 
-    it('should return 400 when ExternalError is returned when creating presigned POST', async () => {
+    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST', async () => {
       // Arrange
       // Mock error
       const mockErrorString = 'creating presigned post failed, oh no'
       const mockRes = expressHandler.mockResponse()
       MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
-        errAsync(new ExternalError(mockErrorString)),
+        errAsync(new CreatePresignedUrlError(mockErrorString)),
       )
 
       // Act
@@ -192,13 +195,13 @@ describe('admin-form.controller', () => {
       })
     })
 
-    it('should return 400 when ExternalError is returned when creating presigned POST', async () => {
+    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST', async () => {
       // Arrange
       // Mock error
       const mockErrorString = 'creating presigned post failed, oh no'
       const mockRes = expressHandler.mockResponse()
       MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
-        errAsync(new ExternalError(mockErrorString)),
+        errAsync(new CreatePresignedUrlError(mockErrorString)),
       )
 
       // Act

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -4,14 +4,17 @@ import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
 import getFormModel from 'src/app/models/form.server.model'
-import { DatabaseError, ExternalError } from 'src/app/modules/core/core.errors'
+import { DatabaseError } from 'src/app/modules/core/core.errors'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
 import { aws } from 'src/config/config'
 import { VALID_UPLOAD_FILE_TYPES } from 'src/shared/constants'
 import { DashboardFormView, IPopulatedUser, IUserSchema } from 'src/types'
 
-import { InvalidFileTypeError } from '../admin-form.errors'
+import {
+  CreatePresignedUrlError,
+  InvalidFileTypeError,
+} from '../admin-form.errors'
 import {
   createPresignedPostForImages,
   createPresignedPostForLogos,
@@ -156,7 +159,7 @@ describe('admin-form.service', () => {
       )
     })
 
-    it('should return ExternalError when error occurs whilst creating presigned POST URL', async () => {
+    it('should return CreatePresignedUrlError when error occurs whilst creating presigned POST URL', async () => {
       // Arrange
       // Mock external service failure.
       const s3Spy = jest
@@ -180,7 +183,7 @@ describe('admin-form.service', () => {
       )
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new ExternalError('Error occurred whilst uploading file'),
+        new CreatePresignedUrlError('Error occurred whilst uploading file'),
       )
     })
   })
@@ -242,7 +245,7 @@ describe('admin-form.service', () => {
       )
     })
 
-    it('should return ExternalError when error occurs whilst creating presigned POST URL', async () => {
+    it('should return CreatePresignedUrlError when error occurs whilst creating presigned POST URL', async () => {
       // Arrange
       // Mock external service failure.
       const s3Spy = jest
@@ -266,7 +269,7 @@ describe('admin-form.service', () => {
       )
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new ExternalError('Error occurred whilst uploading file'),
+        new CreatePresignedUrlError('Error occurred whilst uploading file'),
       )
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -6,6 +6,7 @@ import { createReqMeta } from '../../../utils/request'
 
 import {
   createPresignedPostForImages,
+  createPresignedPostForLogos,
   getDashboardForms,
 } from './admin-form.service'
 import { mapRouteError } from './admin-form.utils'
@@ -67,6 +68,41 @@ export const handleCreatePresignedPostForImages: RequestHandler<
         message: 'Presigning post data encountered an error',
         meta: {
           action: 'handleCreatePresignedPostForImages',
+          ...createReqMeta(req),
+        },
+        error,
+      })
+
+      const { statusCode, errorMessage } = mapRouteError(error)
+      return res.status(statusCode).json({ message: errorMessage })
+    })
+}
+
+/**
+ * Handler for POST /:formId([a-fA-F0-9]{24})/adminform/logos.
+ * @security session
+ *
+ * @returns 200 with presigned POST object
+ * @returns 400 when error occurs whilst creating presigned POST object
+ */
+export const handleCreatePresignedPostForLogos: RequestHandler<
+  ParamsDictionary,
+  unknown,
+  {
+    fileId: string
+    fileMd5Hash: string
+    fileType: string
+  }
+> = async (req, res) => {
+  const { fileId, fileMd5Hash, fileType } = req.body
+
+  return createPresignedPostForLogos({ fileId, fileMd5Hash, fileType })
+    .map((presignedPost) => res.json(presignedPost))
+    .mapErr((error) => {
+      logger.error({
+        message: 'Presigning post data encountered an error',
+        meta: {
+          action: 'handleCreatePresignedPostForLogos',
           ...createReqMeta(req),
         },
         error,

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -5,3 +5,9 @@ export class InvalidFileTypeError extends ApplicationError {
     super(message)
   }
 }
+
+export class CreatePresignedUrlError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -10,12 +10,15 @@ import {
 } from '../../../../shared/constants'
 import { DashboardFormView } from '../../../../types'
 import getFormModel from '../../../models/form.server.model'
-import { DatabaseError, ExternalError } from '../../core/core.errors'
+import { DatabaseError } from '../../core/core.errors'
 import { MissingUserError } from '../../user/user.errors'
 import { findAdminById } from '../../user/user.service'
 
 import { PRESIGNED_POST_EXPIRY_SECS } from './admin-form.constants'
-import { InvalidFileTypeError } from './admin-form.errors'
+import {
+  CreatePresignedUrlError,
+  InvalidFileTypeError,
+} from './admin-form.errors'
 
 const logger = createLoggerWithLabel(module)
 const FormModel = getFormModel(mongoose)
@@ -73,7 +76,10 @@ export const getDashboardForms = (
 const createPresignedPost = (
   bucketName: string,
   { fileId, fileMd5Hash, fileType }: PresignedPostParams,
-): ResultAsync<PresignedPost, InvalidFileTypeError | ExternalError> => {
+): ResultAsync<
+  PresignedPost,
+  InvalidFileTypeError | CreatePresignedUrlError
+> => {
   if (!VALID_UPLOAD_FILE_TYPES.includes(fileType)) {
     return errAsync(
       new InvalidFileTypeError(`"${fileType}" is not a supported file type`),
@@ -117,7 +123,7 @@ const createPresignedPost = (
       error,
     })
 
-    return new ExternalError('Error occurred whilst uploading file')
+    return new CreatePresignedUrlError('Error occurred whilst uploading file')
   })
 }
 
@@ -130,11 +136,14 @@ const createPresignedPost = (
  *
  * @returns ok(presigned post url) when creation is successful
  * @returns err(InvalidFileTypeError) when given file type is not supported
- * @returns err(ExternalError) when errors occurs on S3 side whilst creating presigned post url.
+ * @returns err(CreatePresignedUrlError) when errors occurs on S3 side whilst creating presigned post url.
  */
 export const createPresignedPostForImages = (
   uploadParams: PresignedPostParams,
-): ResultAsync<PresignedPost, InvalidFileTypeError | ExternalError> => {
+): ResultAsync<
+  PresignedPost,
+  InvalidFileTypeError | CreatePresignedUrlError
+> => {
   return createPresignedPost(AwsConfig.imageS3Bucket, uploadParams)
 }
 
@@ -147,10 +156,13 @@ export const createPresignedPostForImages = (
  *
  * @returns ok(presigned post url) when creation is successful
  * @returns err(InvalidFileTypeError) when given file type is not supported
- * @returns err(ExternalError) when errors occurs on S3 side whilst creating presigned post url.
+ * @returns err(CreatePresignedUrlError) when errors occurs on S3 side whilst creating presigned post url.
  */
 export const createPresignedPostForLogos = (
   uploadParams: PresignedPostParams,
-): ResultAsync<PresignedPost, InvalidFileTypeError | ExternalError> => {
+): ResultAsync<
+  PresignedPost,
+  InvalidFileTypeError | CreatePresignedUrlError
+> => {
   return createPresignedPost(AwsConfig.logoS3Bucket, uploadParams)
 }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -137,3 +137,20 @@ export const createPresignedPostForImages = (
 ): ResultAsync<PresignedPost, InvalidFileTypeError | ExternalError> => {
   return createPresignedPost(AwsConfig.imageS3Bucket, uploadParams)
 }
+
+/**
+ * Creates a S3 presigned POST URL for the client to upload logos directly to.
+ *
+ * @param param.fileId key of the file
+ * @param param.fileMd5Hash the MD5 hash of the file
+ * @param param.fileType the file type of the file
+ *
+ * @returns ok(presigned post url) when creation is successful
+ * @returns err(InvalidFileTypeError) when given file type is not supported
+ * @returns err(ExternalError) when errors occurs on S3 side whilst creating presigned post url.
+ */
+export const createPresignedPostForLogos = (
+  uploadParams: PresignedPostParams,
+): ResultAsync<PresignedPost, InvalidFileTypeError | ExternalError> => {
+  return createPresignedPost(AwsConfig.logoS3Bucket, uploadParams)
+}

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -1,15 +1,14 @@
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
-import {
-  ApplicationError,
-  DatabaseError,
-  ExternalError,
-} from '../../core/core.errors'
+import { ApplicationError, DatabaseError } from '../../core/core.errors'
 import { ErrorResponseData } from '../../core/core.types'
 import { MissingUserError } from '../../user/user.errors'
 
-import { InvalidFileTypeError } from './admin-form.errors'
+import {
+  CreatePresignedUrlError,
+  InvalidFileTypeError,
+} from './admin-form.errors'
 
 const logger = createLoggerWithLabel(module)
 
@@ -25,7 +24,7 @@ export const mapRouteError = (
 ): ErrorResponseData => {
   switch (error.constructor) {
     case InvalidFileTypeError:
-    case ExternalError:
+    case CreatePresignedUrlError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -491,7 +491,7 @@ module.exports = function (app) {
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/logos').post(
     celebrate({
-      body: Joi.object().keys({
+      [Segments.BODY]: {
         fileId: Joi.string()
           .required()
           .error(() => 'Please enter a valid file id'),
@@ -502,9 +502,9 @@ module.exports = function (app) {
         fileType: Joi.string()
           .required()
           .error(() => 'Error - your file could not be verified'),
-      }),
+      },
     }),
     authActiveForm(PERMISSIONS.WRITE),
-    adminForms.createPresignedPostForLogos,
+    AdminFormController.handleCreatePresignedPostForLogos,
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Continuation of #604, this time for creating presigned urls for **logo** uploads.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `AdminFormController#handleCreatePresignedPostForLogos` handler for presigning logos upload POST url
- add `AdminFormService#createPresignedPostForLogos` function
- add and use `CreatePresignedUrlError` instead of `ExternalError`
  - ExternalError seemed too general for use, and could conflict in the future if other external services also error

**Improvements**:

- replace controller handler function used for `POST /:formId([a-fA-F0-9]{24})/adminform/logos` route with migrated TypeScript function
- Remove all traces of old Javascript handler function
