### PR TITLE
fix: use maildev for dev environment emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Run the following shell command to build the Docker image from scratch. This wil
 npm run dev
 ```
 
+After the Docker image has finished building, the application can be accessed at [localhost:5000](localhost:5000).
+
 If there have been no dependency changes in `package.json` or changes in the
 `src/server.ts` file, you can run
 
@@ -70,6 +72,10 @@ docker-compose up
 
 which does **not** rebuild the Docker image from scratch. This command usually
 only takes ~15 seconds to finish starting up the image.
+
+### Accessing email locally
+
+We use [MailDev](https://github.com/maildev/maildev) to access emails in the development environment. The MailDev UI can be accessed at [localhost:1080](localhost:1080) when the Docker container is running.
 
 ### Environment variables
 
@@ -195,7 +201,7 @@ Please contact FormSG (formsg@tech.gov.sg) for any details.
 
 ## Acknowledgements
 
-FormSG acknowledges the work done by [Arielle Baldwynn](https://github.com/whitef0x0) to build and maintain [TellForm](https://github.com/tellform), on which FormSG is based. 
+FormSG acknowledges the work done by [Arielle Baldwynn](https://github.com/whitef0x0) to build and maintain [TellForm](https://github.com/tellform), on which FormSG is based.
 
 Contributions have also been made by:  
 [@RyanAngJY](https://github.com/RyanAngJY)  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,16 +32,16 @@ services:
       - AWS_ENDPOINT=http://localhost:4566
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60
+      - SES_PORT=25
+      - SES_HOST=maildev
       - GA_TRACKING_ID
       - SENTRY_CONFIG_URL
       - TWILIO_ACCOUNT_SID
       - TWILIO_API_KEY
       - TWILIO_API_SECRET
       - TWILIO_MESSAGING_SERVICE_SID
-      - SES_HOST
       - SES_PASS
       - SES_USER
-      - SES_PORT
       - OTP_LIFE_SPAN
       - AWS_REGION
       - GOOGLE_CAPTCHA
@@ -111,6 +111,11 @@ services:
       # Docs: https://github.com/localstack/localstack#initializing-a-fresh-instance
       - './docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d'
     network_mode: 'service:formsg' # reuse formsg service's network stack so that it can resolve localhost:4566 to localstack:4566
+
+  maildev:
+    image: maildev/maildev
+    ports:
+      - '1080:80'
 
 volumes:
   mongodata:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,7 +3,6 @@ import convict from 'convict'
 import { SessionOptions } from 'express-session'
 import { merge } from 'lodash'
 import nodemailer from 'nodemailer'
-import directTransport from 'nodemailer-direct-transport'
 import Mail from 'nodemailer/lib/mailer'
 import SMTPPool from 'nodemailer/lib/smtp-pool'
 
@@ -149,20 +148,11 @@ const mailConfig: MailConfig = (function () {
     }
     transporter = nodemailer.createTransport(options)
   } else {
-    if (basicVars.core.nodeEnv === Environment.Dev) {
-      // Falls back to direct transport
-      transporter = nodemailer.createTransport(directTransport({}))
-    } else if (
-      basicVars.core.nodeEnv === Environment.Test &&
-      prodOnlyVars.port
-    ) {
-      transporter = nodemailer.createTransport({
-        port: prodOnlyVars.port,
-        ignoreTLS: true,
-      })
-    } else {
-      throw new Error('Nodemailer configuration is missing')
-    }
+    transporter = nodemailer.createTransport({
+      port: prodOnlyVars.port,
+      host: prodOnlyVars.host,
+      ignoreTLS: true,
+    })
   }
 
   return {


### PR DESCRIPTION
## Problem
`nodemailer-direct-transport` has been failing intermittently, preventing emails from being sent in the dev environment. Moreover, the package is not currently maintained and is not keeping pace with changes in `nodemailer`.

## Solution
Add `maildev` to our dev environment. In addition to being a well-maintained package, this allows us to completely isolate our dev environment to our local machines.

## Screenshots
### OTP email
![image](https://user-images.githubusercontent.com/29480346/98636238-6c420d00-2361-11eb-9584-f0d5f6c5381d.png)

### Response email
<img width="1181" alt="Screenshot 2020-11-10 at 7 51 11 PM" src="https://user-images.githubusercontent.com/29480346/98670734-1768bb80-238e-11eb-8f95-e96fd4e55e81.png">

### Attachments
![image](https://user-images.githubusercontent.com/29480346/98670690-0324be80-238e-11eb-9960-ae5d6545fea6.png)