### PR TITLE
ref: convert req.hashedFields to Set

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -598,13 +598,13 @@ function makeModule(connection) {
       switch (authType) {
         case 'SP': {
           res.locals.uinFin = 'S1234567A'
-          req.hashedFields = {}
+          req.hashedFields = new Set()
           let actualFormFields = req.form.form_fields
           let actualMyInfoFields = actualFormFields.filter(
             (field) => field.myInfo && field.myInfo.attr,
           )
           for (let field of actualMyInfoFields) {
-            req.hashedFields[field.myInfo.attr] = true
+            req.hashedFields.add(field.myInfo.attr)
           }
           break
         }

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -598,13 +598,13 @@ function makeModule(connection) {
       switch (authType) {
         case 'SP': {
           res.locals.uinFin = 'S1234567A'
-          req.hashedFields = new Set()
+          res.locals.hashedFields = new Set()
           let actualFormFields = req.form.form_fields
           let actualMyInfoFields = actualFormFields.filter(
             (field) => field.myInfo && field.myInfo.attr,
           )
           for (let field of actualMyInfoFields) {
-            req.hashedFields.add(field.myInfo.attr)
+            res.locals.hashedFields.add(field.myInfo.attr)
           }
           break
         }

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -281,7 +281,7 @@ exports.validateEmailSubmission = function (req, res, next) {
  * @param  {Function} next - Express next middleware function
  */
 exports.prepareEmailSubmission = (req, res, next) => {
-  const { hashedFields } = req
+  const { hashedFields } = res.locals
 
   const concatArray = (dataValue, srcValue) => {
     if (_.isArray(dataValue)) {

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -332,11 +332,11 @@ exports.prepareEmailSubmission = (req, res, next) => {
  * @param {String} response.fieldType
  * @param {Object} response.myInfo
  * @param {String} response.myInfo.attr
- * @param {Object} hashedFields req.hashedFields
+ * @param {Set} hashedFields req.hashedFields
  * @returns {Boolean} true if response is verified
  */
 const isMyInfoVerifiedResponse = (response, hashedFields) => {
-  return !!(hashedFields && hashedFields[_.get(response, 'myInfo.attr')])
+  return !!(hashedFields && hashedFields.has(_.get(response, 'myInfo.attr')))
 }
 
 /**
@@ -382,7 +382,7 @@ const getAnswerForCheckbox = (response) => {
  * @param {String} response.answer
  * @param {String} response.fieldType
  * @param {Boolean} response.isVisible
- * @param {Boolean} hashedFields Fields hashed to verify answers provided by MyInfo
+ * @param {Set} hashedFields Fields hashed to verify answers provided by MyInfo
  * @returns {Object} an object containing three sets of formatted responses
  */
 const getFormattedResponse = (response, hashedFields) => {
@@ -418,7 +418,7 @@ const getFormattedResponse = (response, hashedFields) => {
 /**
  * Transforms a question for inclusion in the admin email table.
  * @param {Object} response
- * @param {Object} hashedFields
+ * @param {Set} hashedFields
  */
 const getFormDataPrefixedQuestion = (response, hashedFields) => {
   const { question, fieldType, isUserVerified } = response
@@ -472,7 +472,7 @@ const getFieldTypePrefix = (fieldType) => {
  * Determines the prefix for a question based on whether it is verified
  * by MyInfo.
  * @param {Object} response
- * @param {Object} hashedFields Hash for verifying MyInfo fields
+ * @param {Set} hashedFields Hash for verifying MyInfo fields
  * @returns {String}
  */
 const getMyInfoPrefix = (response, hashedFields) => {

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -218,7 +218,7 @@ exports.verifyMyInfoVals = async function (req, res, next) {
             _.uniq(clientMyInfoFields.map((field) => field.attr)),
             _.keys(hashedFields),
           )
-          req.hashedFields = _.pick(hashedFields, verifiedKeys)
+          req.hashedFields = new Set(verifiedKeys)
           return next()
         }
       })

--- a/src/app/controllers/myinfo.server.controller.js
+++ b/src/app/controllers/myinfo.server.controller.js
@@ -218,7 +218,7 @@ exports.verifyMyInfoVals = async function (req, res, next) {
             _.uniq(clientMyInfoFields.map((field) => field.attr)),
             _.keys(hashedFields),
           )
-          req.hashedFields = new Set(verifiedKeys)
+          res.locals.hashedFields = new Set(verifiedKeys)
           return next()
         }
       })

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -981,9 +981,7 @@ describe('Email Submissions Controller', () => {
       const fieldId = new ObjectID()
 
       const attr = 'passportnumber'
-      reqFixtures.hashedFields = {
-        [attr]: 'foobar',
-      }
+      reqFixtures.hashedFields = new Set([attr])
       const responseField = {
         _id: String(fieldId),
         question: 'myinfo',

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -981,7 +981,7 @@ describe('Email Submissions Controller', () => {
       const fieldId = new ObjectID()
 
       const attr = 'passportnumber'
-      reqFixtures.hashedFields = new Set([attr])
+      resLocalFixtures.hashedFields = new Set([attr])
       const responseField = {
         _id: String(fieldId),
         question: 'myinfo',

--- a/tests/unit/backend/controllers/myinfo.server.controller.spec.js
+++ b/tests/unit/backend/controllers/myinfo.server.controller.spec.js
@@ -677,7 +677,10 @@ describe('MyInfo Controller', () => {
 
             next = jasmine.createSpy().and.callFake(() => {
               expect(
-                _.isEqual(req.hashedFields, new Set(_.keys(ALL_MYINFO_HASHES))),
+                _.isEqual(
+                  res.locals.hashedFields,
+                  new Set(_.keys(ALL_MYINFO_HASHES)),
+                ),
               ).toBeTruthy()
               expect(res.send).not.toHaveBeenCalled()
               expect(res.json).not.toHaveBeenCalled()

--- a/tests/unit/backend/controllers/myinfo.server.controller.spec.js
+++ b/tests/unit/backend/controllers/myinfo.server.controller.spec.js
@@ -677,10 +677,7 @@ describe('MyInfo Controller', () => {
 
             next = jasmine.createSpy().and.callFake(() => {
               expect(
-                _.isEqual(
-                  new Set(_.keys(req.hashedFields)),
-                  new Set(_.keys(ALL_MYINFO_HASHES)),
-                ),
+                _.isEqual(req.hashedFields, new Set(_.keys(ALL_MYINFO_HASHES))),
               ).toBeTruthy()
               expect(res.send).not.toHaveBeenCalled()
               expect(res.json).not.toHaveBeenCalled()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`myinfo.server.controller` assigns a `hashedFields` key to the Express request object in order for subsequent middlewares to keep track of which MyInfo attributes have been verified through their hashes. `hashedFields` is an object which maps the MyInfo attribute to the corresponding client response, but subsequent middlewares have no need for the values of this object, since they only check that the value corresponding to each key is truthy, i.e. that the object contains the key.

## Solution
<!-- How did you solve the problem? -->
Convert `hashedFields` into a Set, which is the more correct data structure for this case. This ensures that subsequent refactors (#560) don't have to bend over backwards just to get `hashedFields` into the right format.

Also, assign `hashedFields` to `res.locals` instead of `req`. 