### PR TITLE
feat(monitoring): add memory monitoring to EC2 instances

### DIFF
--- a/.ebextensions/eb-memory-monitor.config
+++ b/.ebextensions/eb-memory-monitor.config
@@ -10,7 +10,7 @@ packages:
     perl-LWP-Protocol-https: []
     perl-Switch: []
     perl-URI: []
-    perl-Bundle-LWP: []
+    perl-Bundle-LWP: [] # TODO(#638): Replace this yum package with perl-Digest-SHA.x86_64 for Amazon Linux 2 instances
 sources:
   /opt/cloudwatch: https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip
 

--- a/.ebextensions/eb-memory-monitor.config
+++ b/.ebextensions/eb-memory-monitor.config
@@ -1,24 +1,29 @@
 ###################################################################################################
 #### Memory monitoring for Elastic Beanstalk
-#### https://medium.com/tomincode/cloudwatch-memory-monitoring-for-elastic-beanstalk-1caa98d57d5c
+#### https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-memory-monitoring/
 ###################################################################################################
 
+packages:
+  yum:
+    perl-DateTime: []
+    perl-Sys-Syslog: []
+    perl-LWP-Protocol-https: []
+    perl-Switch: []
+    perl-URI: []
+    perl-Bundle-LWP: []
+sources:
+  /opt/cloudwatch: https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip
+
 container_commands:
-  00download:
-    command: "wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip"
-    ignoreErrors: true
-  01extract:
-    command: "unzip -o CloudWatchMonitoringScripts-1.2.2.zip"
-    ignoreErrors: true
-  02rmzip:
-    command: "rm CloudWatchMonitoringScripts-1.2.2.zip"
-    ignoreErrors: true
-  03prereq:
-    command: "yum install -y perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https"
-    ignoreErrors: false
-  04cdinto:
-    command: "mv aws-scripts-mon/ /home/ec2-user"
-    ignoreErrors: true
-  05cron:
-    command: "crontab -l | grep -q 'mon-put-instance-data.pl' || crontab -l | { cat; echo '* * * * * /home/ec2-user/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail'; } | crontab -"
-    ignoreErrors: false
+  01-setupcron:
+    command: |
+      echo '*/5 * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
+  02-changeperm:
+    command: chmod 644 /etc/cron.d/cwpump
+  03-changeperm:
+    command: chmod u+x /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl
+option_settings:
+  "aws:autoscaling:launchconfiguration" :
+    IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
+  "aws:elasticbeanstalk:customoption" :
+    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling"


### PR DESCRIPTION
## Problem
EC2 memory monitoring was previously relying on an unofficial 3rd party solution, which at one point was working intermittently.

The problem has become more pressing since PR #555 was merged, which reported a 19 MB increase in memory usage for a single bulk download of 10,000 submissions.

## Solution

Upgrade to use an official solution provided by AWS [here](https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-memory-monitoring/), which provides both memory and disk monitoring. The only change made was to the cron expression, which has been updated to report every minute instead of every 5 minutes.

The requisite permissions have been granted to our Elastic Beanstalk instance profiles.
