### PR TITLE
style: make transfer ownership email more prominent

### DIFF
--- a/src/public/modules/core/css/admin-form-header.css
+++ b/src/public/modules/core/css/admin-form-header.css
@@ -289,7 +289,7 @@
   z-index: 750;
 }
 
-#collaborator-modal-body #transfer-owner-email {
+#collaborator-modal-body .transfer-owner-email {
   color: #dc2a2a;
 }
 

--- a/src/public/modules/core/css/admin-form-header.css
+++ b/src/public/modules/core/css/admin-form-header.css
@@ -289,6 +289,10 @@
   z-index: 750;
 }
 
+#collaborator-modal-body #transfer-owner-email {
+  color: #dc2a2a;
+}
+
 @media all and (min-width: 768px) {
   #collaborator-modal-body #bottom-section {
     padding-bottom: 30px;

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -11,7 +11,7 @@
     <div ng-if="isDisplayTransferOwnerModal">
       <div class="label-custom" id="invite-title">
         Transfer ownership to
-        <span id="transfer-owner-email">{{transferOwnerEmail}}</span>
+        <span class="transfer-owner-email">{{transferOwnerEmail}}</span>
       </div>
       <div class="" id="collab-title">
         Are you sure? You will lose form ownership and the right to delete this

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -10,7 +10,8 @@
   >
     <div ng-if="isDisplayTransferOwnerModal">
       <div class="label-custom" id="invite-title">
-        Transfer ownership to {{transferOwnerEmail}}
+        Transfer ownership to
+        <span id="transfer-owner-email">{{transferOwnerEmail}}</span>
       </div>
       <div class="" id="collab-title">
         Are you sure? You will lose form ownership and the right to delete this


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Closes #499 

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

![Screenshot 2020-11-13 at 11 07 02 AM](https://user-images.githubusercontent.com/63710093/99023964-a8af7c00-25a0-11eb-8f5f-c0ed903beec3.png)

**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot 2020-11-13 at 11 06 14 AM](https://user-images.githubusercontent.com/63710093/99023979-ad743000-25a0-11eb-91a9-585107815e0e.png)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Open form transfer ownership. Check that the new email address is in red.

