### PR TITLE
ref: migrate /spcp/redirect endpoint to TypeScript

### DIFF
--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -223,10 +223,6 @@ exports.createSpcpRedirectURL = (authClients) => {
   }
 }
 
-exports.returnSpcpRedirectURL = function (req, res) {
-  return res.status(StatusCodes.OK).json({ redirectURL: req.redirectURL })
-}
-
 const getSubstringBetween = (text, markerStart, markerEnd) => {
   const start = text.indexOf(markerStart)
   if (start === -1) {

--- a/src/app/factories/spcp.factory.js
+++ b/src/app/factories/spcp.factory.js
@@ -67,7 +67,6 @@ const spcpFactory = ({ isEnabled, props }) => {
     return {
       appendVerifiedSPCPResponses: spcp.appendVerifiedSPCPResponses,
       passThroughSpcp: admin.passThroughSpcp,
-      returnSpcpRedirectURL: spcp.returnSpcpRedirectURL,
       singPassLogin: spcp.singPassLogin(ndiConfig),
       corpPassLogin: spcp.corpPassLogin(ndiConfig),
       addSpcpSessionInfo: spcp.addSpcpSessionInfo(authClients),
@@ -80,8 +79,6 @@ const spcpFactory = ({ isEnabled, props }) => {
     return {
       appendVerifiedSPCPResponses: (req, res, next) => next(),
       passThroughSpcp: (req, res, next) => next(),
-      returnSpcpRedirectURL: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       singPassLogin: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       corpPassLogin: (req, res) =>

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -1,0 +1,67 @@
+import { err, ok } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
+
+import { AuthType } from 'src/types'
+
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+
+import * as SpcpController from '../spcp.controller'
+import { CreateRedirectUrlError } from '../spcp.errors'
+import { SpcpFactory } from '../spcp.factory'
+
+import {
+  MOCK_ESRVCID,
+  MOCK_REDIRECT_URL,
+  MOCK_TARGET,
+} from './spcp.test.constants'
+
+jest.mock('../spcp.factory')
+const MockSpcpFactory = mocked(SpcpFactory, true)
+
+const MOCK_RESPONSE = expressHandler.mockResponse()
+
+describe('spcp.controller', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe('handleRedirect', () => {
+    it('should return the redirect URL correctly', () => {
+      const mockReq = expressHandler.mockRequest({
+        query: {
+          target: MOCK_TARGET,
+          authType: AuthType.SP,
+          esrvcId: MOCK_ESRVCID,
+        },
+      })
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+
+      SpcpController.handleRedirect(mockReq, MOCK_RESPONSE, jest.fn())
+
+      expect(MOCK_RESPONSE.status).toHaveBeenLastCalledWith(200)
+      expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+
+    it('should return 500 if auth client throws an error', () => {
+      const mockReq = expressHandler.mockRequest({
+        query: {
+          target: MOCK_TARGET,
+          authType: AuthType.SP,
+          esrvcId: MOCK_ESRVCID,
+        },
+      })
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        err(new CreateRedirectUrlError()),
+      )
+
+      SpcpController.handleRedirect(mockReq, MOCK_RESPONSE, jest.fn())
+
+      expect(MOCK_RESPONSE.status).toHaveBeenLastCalledWith(500)
+      expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
+        message: 'Sorry, something went wrong. Please try again.',
+      })
+    })
+  })
+})

--- a/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
@@ -1,0 +1,54 @@
+import { mocked } from 'ts-jest/utils'
+
+import { ISpcpMyInfo } from 'src/config/feature-manager'
+import { AuthType } from 'src/types'
+
+import { createSpcpFactory } from '../spcp.factory'
+import { SpcpService } from '../spcp.service'
+
+import { MOCK_SERVICE_PARAMS } from './spcp.test.constants'
+
+jest.mock('../spcp.service')
+const MockSpcpService = mocked(SpcpService, true)
+
+describe('spcp.factory', () => {
+  it('should return error functions when isEnabled is false', () => {
+    const MyInfoFactory = createSpcpFactory({
+      isEnabled: false,
+      props: {} as ISpcpMyInfo,
+    })
+    const error = new Error(
+      'spcp-myinfo is not activated, but a feature-specific function was called.',
+    )
+    const createRedirectUrlResult = MyInfoFactory.createRedirectUrl(
+      AuthType.SP,
+      '',
+      '',
+    )
+    expect(createRedirectUrlResult._unsafeUnwrapErr()).toEqual(error)
+  })
+
+  it('should return error functions when props is undefined', () => {
+    const MyInfoFactory = createSpcpFactory({
+      isEnabled: true,
+      props: undefined,
+    })
+    const error = new Error(
+      'spcp-myinfo is not activated, but a feature-specific function was called.',
+    )
+    const createRedirectUrlResult = MyInfoFactory.createRedirectUrl(
+      AuthType.SP,
+      '',
+      '',
+    )
+    expect(createRedirectUrlResult._unsafeUnwrapErr()).toEqual(error)
+  })
+
+  it('should call the SpcpService constructor when isEnabled is true and props is truthy', () => {
+    createSpcpFactory({
+      isEnabled: true,
+      props: MOCK_SERVICE_PARAMS,
+    })
+    expect(MockSpcpService).toHaveBeenCalledWith(MOCK_SERVICE_PARAMS)
+  })
+})

--- a/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
@@ -1,8 +1,9 @@
 import { mocked } from 'ts-jest/utils'
 
-import { ISpcpMyInfo } from 'src/config/feature-manager'
+import { FeatureNames, ISpcpMyInfo } from 'src/config/feature-manager'
 import { AuthType } from 'src/types'
 
+import { MissingFeatureError } from '../../core/core.errors'
 import { createSpcpFactory } from '../spcp.factory'
 import { SpcpService } from '../spcp.service'
 
@@ -17,9 +18,7 @@ describe('spcp.factory', () => {
       isEnabled: false,
       props: {} as ISpcpMyInfo,
     })
-    const error = new Error(
-      'spcp-myinfo is not activated, but a feature-specific function was called.',
-    )
+    const error = new MissingFeatureError(FeatureNames.SpcpMyInfo)
     const createRedirectUrlResult = MyInfoFactory.createRedirectUrl(
       AuthType.SP,
       '',

--- a/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
@@ -1,0 +1,92 @@
+import session, { Session } from 'supertest-session'
+
+import { setupApp } from 'tests/integration/helpers/express-setup'
+import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
+
+import { SpcpRouter } from '../spcp.routes'
+
+import { MOCK_ESRVCID, MOCK_TARGET } from './spcp.test.constants'
+
+const spcpApp = setupApp('/spcp', SpcpRouter)
+
+describe('GET /spcp/redirect', () => {
+  let request: Session
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    request = session(spcpApp)
+  })
+
+  it('should return 400 when authType is not provided as a query param', async () => {
+    const response = await request
+      .get('/spcp/redirect')
+      .query({ target: MOCK_TARGET, esrvcId: MOCK_ESRVCID })
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual(
+      buildCelebrateError({ query: { key: 'authType' } }),
+    )
+  })
+
+  it('should return 400 when authType is malformed', async () => {
+    const response = await request.get('/spcp/redirect').query({
+      authType: 'malformed',
+      target: MOCK_TARGET,
+      esrvcId: MOCK_ESRVCID,
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual(
+      buildCelebrateError({
+        query: {
+          key: 'authType',
+          message: '"authType" must be one of [SP, CP]',
+        },
+      }),
+    )
+  })
+
+  it('should return 400 when target is not provided as a query param', async () => {
+    const response = await request
+      .get('/spcp/redirect')
+      .query({ authType: 'SP', esrvcId: MOCK_ESRVCID })
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual(
+      buildCelebrateError({ query: { key: 'target' } }),
+    )
+  })
+
+  it('should return 400 when esrvcId is not provided as a query param', async () => {
+    const response = await request
+      .get('/spcp/redirect')
+      .query({ authType: 'CP', target: MOCK_TARGET })
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual(
+      buildCelebrateError({ query: { key: 'esrvcId' } }),
+    )
+  })
+
+  it('should return 200 with the redirect URL when Singpass request is valid', async () => {
+    const response = await request
+      .get('/spcp/redirect')
+      .query({ authType: 'SP', target: MOCK_TARGET, esrvcId: MOCK_ESRVCID })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({
+      redirectURL: expect.any(String),
+    })
+  })
+
+  it('should return 200 with the redirect URL when Corppass request is valid', async () => {
+    const response = await request
+      .get('/spcp/redirect')
+      .query({ authType: 'CP', target: MOCK_TARGET, esrvcId: MOCK_ESRVCID })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({
+      redirectURL: expect.any(String),
+    })
+  })
+})

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -3,6 +3,7 @@ import { mocked } from 'ts-jest/utils'
 
 import { AuthType } from 'src/types'
 
+import { CreateRedirectUrlError } from '../spcp.errors'
 import { SpcpService } from '../spcp.service'
 
 import {
@@ -101,7 +102,7 @@ describe('spcp.service', () => {
         MOCK_ESRVCID,
       )
       expect(redirectUrl._unsafeUnwrapErr()).toEqual(
-        new Error('Error while creating redirect URL'),
+        new CreateRedirectUrlError(),
       )
     })
   })

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -1,0 +1,108 @@
+import SPCPAuthClient from '@opengovsg/spcp-auth-client'
+import { mocked } from 'ts-jest/utils'
+
+import { AuthType } from 'src/types'
+
+import { SpcpService } from '../spcp.service'
+
+import {
+  MOCK_ESRVCID,
+  MOCK_REDIRECT_URL,
+  MOCK_SERVICE_PARAMS as MOCK_PARAMS,
+  MOCK_TARGET,
+} from './spcp.test.constants'
+
+jest.mock('@opengovsg/spcp-auth-client')
+const MockAuthClient = mocked(SPCPAuthClient, true)
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockImplementation((v) => v),
+}))
+
+describe('spcp.service', () => {
+  beforeEach(() => jest.clearAllMocks())
+  describe('class constructor', () => {
+    it('should instantiate auth clients with the correct params', () => {
+      const spcpService = new SpcpService(MOCK_PARAMS)
+      expect(spcpService).toBeTruthy()
+      expect(MockAuthClient).toHaveBeenCalledTimes(2)
+      expect(MockAuthClient).toHaveBeenCalledWith({
+        partnerEntityId: MOCK_PARAMS.spPartnerEntityId,
+        idpLoginURL: MOCK_PARAMS.spIdpLoginUrl,
+        idpEndpoint: MOCK_PARAMS.spIdpEndpoint,
+        esrvcID: MOCK_PARAMS.spEsrvcId,
+        appKey: MOCK_PARAMS.spFormSgKeyPath,
+        appCert: MOCK_PARAMS.spFormSgCertPath,
+        spcpCert: MOCK_PARAMS.spIdpCertPath,
+        extract: SPCPAuthClient.extract.SINGPASS,
+      })
+      expect(MockAuthClient).toHaveBeenCalledWith({
+        partnerEntityId: MOCK_PARAMS.cpPartnerEntityId,
+        idpLoginURL: MOCK_PARAMS.cpIdpLoginUrl,
+        idpEndpoint: MOCK_PARAMS.cpIdpEndpoint,
+        esrvcID: MOCK_PARAMS.cpEsrvcId,
+        appKey: MOCK_PARAMS.cpFormSgKeyPath,
+        appCert: MOCK_PARAMS.cpFormSgCertPath,
+        spcpCert: MOCK_PARAMS.cpIdpCertPath,
+        extract: SPCPAuthClient.extract.CORPPASS,
+      })
+    })
+  })
+
+  describe('createRedirectUrl', () => {
+    it('should call SP auth client createRedirectUrl with the correct params', () => {
+      const spcpService = new SpcpService(MOCK_PARAMS)
+      // Assumes that SP auth client was instantiated first
+      const mockSpClient = mocked(MockAuthClient.mock.instances[0], true)
+      mockSpClient.createRedirectURL.mockReturnValueOnce(MOCK_REDIRECT_URL)
+      const redirectUrl = spcpService.createRedirectUrl(
+        AuthType.SP,
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(mockSpClient.createRedirectURL).toHaveBeenCalledTimes(1)
+      expect(mockSpClient.createRedirectURL).toHaveBeenCalledWith(
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(redirectUrl._unsafeUnwrap()).toBe(MOCK_REDIRECT_URL)
+    })
+
+    it('should call CP auth client createRedirectUrl with the correct params', () => {
+      const spcpService = new SpcpService(MOCK_PARAMS)
+      // Assumes that SP auth client was instantiated first
+      const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
+      mockCpClient.createRedirectURL.mockReturnValueOnce(MOCK_REDIRECT_URL)
+      const redirectUrl = spcpService.createRedirectUrl(
+        AuthType.CP,
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(mockCpClient.createRedirectURL).toHaveBeenCalledTimes(1)
+      expect(mockCpClient.createRedirectURL).toHaveBeenCalledWith(
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(redirectUrl._unsafeUnwrap()).toBe(MOCK_REDIRECT_URL)
+    })
+
+    it('should return CreateRedirectUrlError if auth client returns error', () => {
+      const spcpService = new SpcpService(MOCK_PARAMS)
+      // Assumes that SP auth client was instantiated first
+      const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
+      mockCpClient.createRedirectURL.mockReturnValueOnce(new Error())
+      const redirectUrl = spcpService.createRedirectUrl(
+        AuthType.CP,
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(mockCpClient.createRedirectURL).toHaveBeenCalledTimes(1)
+      expect(mockCpClient.createRedirectURL).toHaveBeenCalledWith(
+        MOCK_TARGET,
+        MOCK_ESRVCID,
+      )
+      expect(redirectUrl._unsafeUnwrapErr()).toEqual(
+        new Error('Error while creating redirect URL'),
+      )
+    })
+  })
+})

--- a/src/app/modules/spcp/__tests__/spcp.test.constants.ts
+++ b/src/app/modules/spcp/__tests__/spcp.test.constants.ts
@@ -1,0 +1,35 @@
+import { Mode as MyInfoClientMode } from '@opengovsg/myinfo-gov-client'
+import { ObjectId } from 'bson'
+
+import { ISpcpMyInfo } from 'src/config/feature-manager'
+
+export const MOCK_SERVICE_PARAMS: ISpcpMyInfo = {
+  isSPMaintenance: 'isSPMaintenance',
+  isCPMaintenance: 'isCPMaintenance',
+  spCookieMaxAge: 1,
+  spCookieMaxAgePreserved: 2,
+  spcpCookieDomain: 'spcpCookieDomain',
+  cpCookieMaxAge: 3,
+  spIdpId: 'spIdpId',
+  cpIdpId: 'cpIdpId',
+  spPartnerEntityId: 'spPartnerEntityId',
+  cpPartnerEntityId: 'cpPartnerEntityId',
+  spIdpLoginUrl: 'spIdpLoginUrl',
+  cpIdpLoginUrl: 'cpIdpLoginUrl',
+  spIdpEndpoint: 'spIdpEndpoint',
+  cpIdpEndpoint: 'cpIdpEndpoint',
+  spEsrvcId: 'spEsrvcId',
+  cpEsrvcId: 'cpEsrvcId',
+  spFormSgKeyPath: 'spFormSgKeyPath',
+  cpFormSgKeyPath: 'cpFormSgKeyPath',
+  spFormSgCertPath: 'spFormSgCertPath',
+  cpFormSgCertPath: 'cpFormSgCertPath',
+  spIdpCertPath: 'spIdpCertPath',
+  cpIdpCertPath: 'cpIdpCertPath',
+  myInfoClientMode: MyInfoClientMode.Dev,
+  myInfoKeyPath: 'myInfoKeyPath',
+}
+
+export const MOCK_ESRVCID = 'eServiceId'
+export const MOCK_TARGET = new ObjectId().toHexString()
+export const MOCK_REDIRECT_URL = 'redirectUrl'

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -1,0 +1,37 @@
+import { RequestHandler } from 'express'
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import { AuthType } from '../../../types'
+
+import { SpcpFactory } from './spcp.factory'
+import { mapRouteError } from './spcp.util'
+
+const logger = createLoggerWithLabel(module)
+
+export const handleRedirect: RequestHandler<
+  unknown,
+  unknown,
+  unknown,
+  { authType: AuthType; target: string; esrvcId: string }
+> = (req, res) => {
+  const { target, authType, esrvcId } = req.query
+  SpcpFactory.createRedirectUrl(authType, target, esrvcId)
+    .map((redirectURL) => {
+      return res.status(StatusCodes.OK).json({ redirectURL })
+    })
+    .mapErr((error) => {
+      logger.error({
+        message: 'Error while creating redirect URL',
+        meta: {
+          action: 'handleRedirect',
+          authType,
+          target,
+          esrvcId,
+        },
+        error,
+      })
+      const { statusCode, errorMessage } = mapRouteError(error)
+      return res.status(statusCode).json({ message: errorMessage })
+    })
+}

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -9,6 +9,11 @@ import { mapRouteError } from './spcp.util'
 
 const logger = createLoggerWithLabel(module)
 
+/**
+ * Generates redirect URL to Official SingPass/CorpPass log in page
+ * @param req - Express request object
+ * @param res - Express response object
+ */
 export const handleRedirect: RequestHandler<
   unknown,
   unknown,

--- a/src/app/modules/spcp/spcp.errors.ts
+++ b/src/app/modules/spcp/spcp.errors.ts
@@ -7,3 +7,12 @@ export class CreateRedirectUrlError extends ApplicationError {
     super(message)
   }
 }
+
+/**
+ * Invalid authType given.
+ */
+export class InvalidAuthTypeError extends ApplicationError {
+  constructor(authType: unknown) {
+    super(`Invalid authType: ${authType}`)
+  }
+}

--- a/src/app/modules/spcp/spcp.errors.ts
+++ b/src/app/modules/spcp/spcp.errors.ts
@@ -1,0 +1,9 @@
+import { ApplicationError } from '../../modules/core/core.errors'
+/**
+ * Error while creating redirect URL
+ */
+export class CreateRedirectUrlError extends ApplicationError {
+  constructor(message?: string) {
+    super(message ?? 'Error while creating redirect URL')
+  }
+}

--- a/src/app/modules/spcp/spcp.errors.ts
+++ b/src/app/modules/spcp/spcp.errors.ts
@@ -3,7 +3,7 @@ import { ApplicationError } from '../../modules/core/core.errors'
  * Error while creating redirect URL
  */
 export class CreateRedirectUrlError extends ApplicationError {
-  constructor(message?: string) {
-    super(message ?? 'Error while creating redirect URL')
+  constructor(message = 'Error while creating redirect URL') {
+    super(message)
   }
 }

--- a/src/app/modules/spcp/spcp.factory.ts
+++ b/src/app/modules/spcp/spcp.factory.ts
@@ -7,7 +7,7 @@ import FeatureManager, {
 import { AuthType } from '../../../types'
 import { MissingFeatureError } from '../core/core.errors'
 
-import { CreateRedirectUrlError } from './spcp.errors'
+import { CreateRedirectUrlError, InvalidAuthTypeError } from './spcp.errors'
 import { SpcpService } from './spcp.service'
 
 interface ISpcpFactory {
@@ -15,7 +15,10 @@ interface ISpcpFactory {
     authType: AuthType,
     target: string,
     eSrvcId: string,
-  ): Result<string, CreateRedirectUrlError | MissingFeatureError>
+  ): Result<
+    string,
+    CreateRedirectUrlError | InvalidAuthTypeError | MissingFeatureError
+  >
 }
 
 export const createSpcpFactory = ({

--- a/src/app/modules/spcp/spcp.factory.ts
+++ b/src/app/modules/spcp/spcp.factory.ts
@@ -1,0 +1,35 @@
+import { err, Result } from 'neverthrow'
+
+import FeatureManager, {
+  FeatureNames,
+  RegisteredFeature,
+} from '../../../config/feature-manager'
+import { AuthType } from '../../../types'
+import { MissingFeatureError } from '../core/core.errors'
+
+import { CreateRedirectUrlError } from './spcp.errors'
+import { SpcpService } from './spcp.service'
+
+interface ISpcpFactory {
+  createRedirectUrl(
+    authType: AuthType,
+    target: string,
+    eSrvcId: string,
+  ): Result<string, CreateRedirectUrlError | MissingFeatureError>
+}
+
+export const createSpcpFactory = ({
+  isEnabled,
+  props,
+}: RegisteredFeature<FeatureNames.SpcpMyInfo>): ISpcpFactory => {
+  if (!isEnabled || !props) {
+    const error = new MissingFeatureError(FeatureNames.SpcpMyInfo)
+    return {
+      createRedirectUrl: () => err(error),
+    }
+  }
+  return new SpcpService(props)
+}
+
+const spcpFeature = FeatureManager.get(FeatureNames.SpcpMyInfo)
+export const SpcpFactory = createSpcpFactory(spcpFeature)

--- a/src/app/modules/spcp/spcp.routes.ts
+++ b/src/app/modules/spcp/spcp.routes.ts
@@ -7,6 +7,20 @@ import * as SpcpController from './spcp.controller'
 // Shared routes for Singpass and Corppass
 export const SpcpRouter = Router()
 
+/**
+ * Provide a URL that web agents are obliged to redirect users to.
+ * Due to cross-origin restrictions in place by SingPass/CorpPass,
+ * this endpoint cannot and should not issue a 302 redirect
+ * @route GET /spcp/redirect
+ * @group SPCP - SingPass/CorpPass logins for form-fillers
+ * @param target.query.required - the destination URL after login
+ * @param authType.query.required - `SP` for SingPass or `CP` for CorpPass
+ * @param esrvcId.query.required - e-service id
+ * @produces application/json
+ * @returns 200 - contains the URL to redirect to
+ * @returns 400 - the redirect URL will be malformed due to missing parameters
+ * @returns 500 - an error occurred while creating the URL
+ */
 SpcpRouter.get(
   '/redirect',
   celebrate({

--- a/src/app/modules/spcp/spcp.routes.ts
+++ b/src/app/modules/spcp/spcp.routes.ts
@@ -1,0 +1,20 @@
+import { celebrate, Joi, Segments } from 'celebrate'
+import { Router } from 'express'
+
+import { AuthType } from '../../../types'
+
+import * as SpcpController from './spcp.controller'
+// Shared routes for Singpass and Corppass
+export const SpcpRouter = Router()
+
+SpcpRouter.get(
+  '/redirect',
+  celebrate({
+    [Segments.QUERY]: Joi.object({
+      target: Joi.string().required(),
+      authType: Joi.string().required().valid(AuthType.SP, AuthType.CP),
+      esrvcId: Joi.string().required(),
+    }),
+  }),
+  SpcpController.handleRedirect,
+)

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -1,0 +1,59 @@
+import SPCPAuthClient from '@opengovsg/spcp-auth-client'
+import fs from 'fs'
+import { err, ok, Result } from 'neverthrow'
+
+import { ISpcpMyInfo } from '../../../config/feature-manager'
+
+import { CreateRedirectUrlError } from './spcp.errors'
+
+export class SpcpService {
+  #singpassAuthClient: SPCPAuthClient
+  #corppassAuthClient: SPCPAuthClient
+
+  constructor(props: ISpcpMyInfo) {
+    this.#singpassAuthClient = new SPCPAuthClient({
+      partnerEntityId: props.spPartnerEntityId,
+      idpLoginURL: props.spIdpLoginUrl,
+      idpEndpoint: props.spIdpEndpoint,
+      esrvcID: props.spEsrvcId,
+      appKey: fs.readFileSync(props.spFormSgKeyPath),
+      appCert: fs.readFileSync(props.spFormSgCertPath),
+      spcpCert: fs.readFileSync(props.spIdpCertPath),
+      extract: SPCPAuthClient.extract.SINGPASS,
+    })
+    this.#corppassAuthClient = new SPCPAuthClient({
+      partnerEntityId: props.cpPartnerEntityId,
+      idpLoginURL: props.cpIdpLoginUrl,
+      idpEndpoint: props.cpIdpEndpoint,
+      esrvcID: props.cpEsrvcId,
+      appKey: fs.readFileSync(props.cpFormSgKeyPath),
+      appCert: fs.readFileSync(props.cpFormSgCertPath),
+      spcpCert: fs.readFileSync(props.cpIdpCertPath),
+      extract: SPCPAuthClient.extract.CORPPASS,
+    })
+  }
+
+  createSingpassRedirectUrl(
+    target: string,
+    eSrvcId: string,
+  ): Result<string, CreateRedirectUrlError> {
+    const result = this.#singpassAuthClient.createRedirectURL(target, eSrvcId)
+    if (typeof result === 'string') {
+      return ok(result)
+    } else {
+      return err(new CreateRedirectUrlError())
+    }
+  }
+
+  createCorppassRedirectUrl(
+    target: string,
+    eSrvcId: string,
+  ): Result<string, CreateRedirectUrlError> {
+    const result = this.#corppassAuthClient.createRedirectURL(target, eSrvcId)
+    if (typeof result === 'string') {
+      return ok(result)
+    } else {
+      return err(new CreateRedirectUrlError())
+    }
+  }
+}

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -3,10 +3,12 @@ import fs from 'fs'
 import { err, ok, Result } from 'neverthrow'
 
 import { ISpcpMyInfo } from '../../../config/feature-manager'
+import { createLoggerWithLabel } from '../../../config/logger'
 import { AuthType } from '../../../types'
 
 import { CreateRedirectUrlError } from './spcp.errors'
 
+const logger = createLoggerWithLabel(module)
 export class SpcpService {
   #singpassAuthClient: SPCPAuthClient
   #corppassAuthClient: SPCPAuthClient
@@ -37,17 +39,27 @@ export class SpcpService {
   createRedirectUrl(
     authType: AuthType.SP | AuthType.CP,
     target: string,
-    eSrvcId: string,
+    esrvcId: string,
   ): Result<string, CreateRedirectUrlError> {
     let result: string | Error
     if (authType === AuthType.SP) {
-      result = this.#singpassAuthClient.createRedirectURL(target, eSrvcId)
+      result = this.#singpassAuthClient.createRedirectURL(target, esrvcId)
     } else {
-      result = this.#corppassAuthClient.createRedirectURL(target, eSrvcId)
+      result = this.#corppassAuthClient.createRedirectURL(target, esrvcId)
     }
     if (typeof result === 'string') {
       return ok(result)
     } else {
+      logger.error({
+        message: 'Error while creating redirect URL',
+        meta: {
+          action: 'createRedirectUrl',
+          authType,
+          target,
+          esrvcId,
+        },
+        error: result,
+      })
       return err(new CreateRedirectUrlError())
     }
   }

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { err, ok, Result } from 'neverthrow'
 
 import { ISpcpMyInfo } from '../../../config/feature-manager'
+import { AuthType } from '../../../types'
 
 import { CreateRedirectUrlError } from './spcp.errors'
 
@@ -33,23 +34,17 @@ export class SpcpService {
     })
   }
 
-  createSingpassRedirectUrl(
+  createRedirectUrl(
+    authType: AuthType.SP | AuthType.CP,
     target: string,
     eSrvcId: string,
   ): Result<string, CreateRedirectUrlError> {
-    const result = this.#singpassAuthClient.createRedirectURL(target, eSrvcId)
-    if (typeof result === 'string') {
-      return ok(result)
+    let result: string | Error
+    if (authType === AuthType.SP) {
+      result = this.#singpassAuthClient.createRedirectURL(target, eSrvcId)
     } else {
-      return err(new CreateRedirectUrlError())
+      result = this.#corppassAuthClient.createRedirectURL(target, eSrvcId)
     }
-  }
-
-  createCorppassRedirectUrl(
-    target: string,
-    eSrvcId: string,
-  ): Result<string, CreateRedirectUrlError> {
-    const result = this.#corppassAuthClient.createRedirectURL(target, eSrvcId)
     if (typeof result === 'string') {
       return ok(result)
     } else {

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -1,0 +1,32 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import { MapRouteError } from '../../../types'
+import { MissingFeatureError } from '../core/core.errors'
+
+import { CreateRedirectUrlError } from './spcp.errors'
+
+const logger = createLoggerWithLabel(module)
+
+export const mapRouteError: MapRouteError = (error) => {
+  switch (error.constructor) {
+    case MissingFeatureError:
+    case CreateRedirectUrlError:
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: 'Sorry, something went wrong. Please try again.',
+      }
+    default:
+      logger.error({
+        message: 'Unknown route error observed',
+        meta: {
+          action: 'mapRouteError',
+        },
+        error,
+      })
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: 'Sorry, something went wrong. Please try again.',
+      }
+  }
+}

--- a/src/app/routes/spcp.server.routes.js
+++ b/src/app/routes/spcp.server.routes.js
@@ -8,28 +8,6 @@ const spcpFactory = require('../factories/spcp.factory')
 
 module.exports = function (app) {
   /**
-   * @typedef RedirectURL
-   * @property {string} redirectURL.required - the SingPass/CorpPass IDP URL to redirect to
-   */
-
-  /**
-   * Provide a URL that web agents are obliged to redirect users to.
-   * Due to cross-origin restrictions in place by SingPass/CorpPass,
-   * this endpoint cannot and should not issue a 302 redirect
-   * @route GET /spcp/redirect
-   * @group SPCP - SingPass/CorpPass logins for form-fillers
-   * @param {string} target.query.required - the destination URL after login
-   * @param {string} authType.query.required - `SP` for SingPass or `CP` for CorpPass
-   * @param {string} esrvcId.query.required - e-service id
-   * @produces application/json
-   * @returns {RedirectURL.model} 200 - contains the URL to redirect to
-   * @returns {string} 400 - the redirect URL will be malformed due to missing parameters
-   */
-  app
-    .route('/spcp/redirect')
-    .get(spcpFactory.createSpcpRedirectURL, spcpFactory.returnSpcpRedirectURL)
-
-  /**
    * Gets the spcp redirect URL and parses the returned page to check for error codes
    * @route GET /spcp/validate
    * @group SPCP - SingPass/CorpPass logins for form-fillers

--- a/src/loaders/express/index.ts
+++ b/src/loaders/express/index.ts
@@ -13,6 +13,7 @@ import { AuthRouter } from '../../app/modules/auth/auth.routes'
 import { BillingRouter } from '../../app/modules/billing/billing.routes'
 import { BounceRouter } from '../../app/modules/bounce/bounce.routes'
 import { ExamplesRouter } from '../../app/modules/examples/examples.routes'
+import { SpcpRouter } from '../../app/modules/spcp/spcp.routes'
 import UserRouter from '../../app/modules/user/user.routes'
 import { VfnRouter } from '../../app/modules/verification/verification.routes'
 import apiRoutes from '../../app/routes'
@@ -140,6 +141,7 @@ const loadExpressApp = async (connection: Connection) => {
   app.use('/billing', BillingRouter)
   app.use('/analytics', AnalyticsRouter)
   app.use('/examples', ExamplesRouter)
+  app.use('/spcp', SpcpRouter)
 
   app.use(sentryMiddlewares())
 

--- a/tests/unit/backend/controllers/spcp.server.controller.spec.js
+++ b/tests/unit/backend/controllers/spcp.server.controller.spec.js
@@ -221,8 +221,6 @@ describe('SPCP Controller', () => {
       })
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(next).toHaveBeenCalled()
-      Controller.returnSpcpRedirectURL(req, res)
-      expectResponse(StatusCodes.OK, expectedUrl)
     })
     it('should return 200 and redirectUrl if authType is CP', () => {
       req.query.authType = 'CP'
@@ -236,8 +234,6 @@ describe('SPCP Controller', () => {
       })
       Controller.createSpcpRedirectURL(authClients)(req, res, next)
       expect(next).toHaveBeenCalled()
-      Controller.returnSpcpRedirectURL(req, res)
-      expectResponse(StatusCodes.OK, expectedUrl)
     })
   })
 


### PR DESCRIPTION
This PR migrates the `/spcp/redirect` endpoint to TypeScript. Note that the base branch is `ref/ts-spcp`, which will be eventually merged into `develop` after all the SPCP functionality has been migrated.