### PR TITLE
chore: use travis_retry to retry flaky tests automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - set -e
   - npm run lint-ci
   - npm run build
-  - npm run test-ci
+  - travis_retry npm run test-ci
   - npm run test-e2e-ci
 
 before_deploy:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some tests are flaky (mostly form server model admin checks), resulting in failed tests that developers have to manually retry (either via an empty commit push or via trigger build).

This PR adds a retry mechanism using [`travis_retry`](https://docs.travis-ci.com/user/common-build-problems/#travis_retry) to automatically retry failed tests up to 3 times.

