### PR TITLE
feat: upgrade spcp-auth-client to TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4067,25 +4067,35 @@
       "integrity": "sha512-YZx96jBfRCgIbGErhYLfnsdZ199laYJt6zknI/ea17tPhWw4+kYE09a6G5dckiN/QCBxHeZRsjLU6WRRKHleKw=="
     },
     "@opengovsg/spcp-auth-client": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@opengovsg/spcp-auth-client/-/spcp-auth-client-1.3.6.tgz",
-      "integrity": "sha512-fOycaYcrCmtd3fUUjxO/P8VS8Hc4o8kR4mO7L+hcXMRgIwgd+YKwIaV5Z2IV1NEVSwOSR9UCtBuNaJ6LrcJm7w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/spcp-auth-client/-/spcp-auth-client-1.4.0.tgz",
+      "integrity": "sha512-5dstOdhAPGgFMLaYJgHBOSL/y7GiMM+rj9cFqOiKYuFQl4uMrkgPij1yTlxLe3NVXBjuhVS0ZiEyV/EUtnF13g==",
       "requires": {
-        "base-64": "^0.1.0",
+        "base-64": "^1.0.0",
         "jsonwebtoken": "^8.3.0",
         "lodash": "^4.17.11",
         "request": "^2.87.0",
         "xml-crypto": "^2.0.0",
         "xml-encryption": "^1.2.1",
         "xml2json-light": "^1.0.6",
-        "xmldom": "^0.3.0",
-        "xpath": "0.0.29"
+        "xmldom": "^0.4.0",
+        "xpath": "0.0.32"
       },
       "dependencies": {
+        "base-64": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+          "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+        },
+        "xmldom": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+          "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+        },
         "xpath": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.29.tgz",
-          "integrity": "sha512-W6vSxu0tmHCW01EwDXx45/BAAl8lBJjcRB6eSswMuycOVbUkYskG3W1LtCxcesVel/RaNe/pxtd3FWLiqHGweA=="
+          "version": "0.0.32",
+          "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+          "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
         }
       }
     },
@@ -7284,7 +7294,8 @@
     "base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs=",
+      "dev": true
     },
     "base32.js": {
       "version": "0.1.0",
@@ -27129,7 +27140,8 @@
     "xmldom": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@opengovsg/formsg-sdk": "0.8.2",
     "@opengovsg/myinfo-gov-client": "^2.1.2",
     "@opengovsg/ng-file-upload": "^12.2.14",
-    "@opengovsg/spcp-auth-client": "^1.3.6",
+    "@opengovsg/spcp-auth-client": "^1.4.0",
     "@sentry/browser": "^5.27.3",
     "@sentry/integrations": "^5.27.3",
     "@stablelib/base64": "^1.0.0",


### PR DESCRIPTION
This PR upgrades @opengovsg/spcp-auth-client to the latest, typed version.

## Tests
- [ ] Create an email mode form. Change the auth type to SingPass. Activate the form and submit it.
- [ ] Create an email mode form. Change the auth type to CorpPass. Activate the form and submit it.
- [ ] Create a storage mode form. Change the auth type to SingPass. Activate the form and submit it.
- [ ] Create a storage mode form. Change the auth type to CorpPass. Activate the form and submit it.