### PR TITLE
feat: allow .oa files to be attached

### DIFF
--- a/src/shared/util/file-validation.ts
+++ b/src/shared/util/file-validation.ts
@@ -34,6 +34,7 @@ const validExtensions = [
   '.mpp',
   '.msg',
   '.mso',
+  '.oa',
   '.odb',
   '.odf',
   '.odg',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Tested on Intranet in addition to public internet.

- [x] Storage mode download works fine
- [x] Email attachment works fine

## Solution
<!-- How did you solve the problem? -->

**Features**:

- Allow `<filename>.oa` files to be used in the attachment fields.
