### PR TITLE
build: add lockfile-lint to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
 
 script:
   - set -e
+  - npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
   - npm run lint-ci
   - npm run build
   - npm run test-ci


### PR DESCRIPTION
This PR adds lockfile-lint to our CI to prevent potential [malicious injections through our lockfile](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/).