### PR TITLE
refactor: move passThroughSpcp business logic into service

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -27,7 +27,6 @@ const getFormFeedbackModel = require('../models/form_feedback.server.model')
   .default
 const getSubmissionModel = require('../models/submission.server.model').default
 const { ResponseMode } = require('../../types')
-const { getMockSpcpLocals } = require('../modules/spcp/spcp.util')
 
 // Export individual functions (i.e. create, delete)
 // and makeModule function that takes in connection object
@@ -582,21 +581,6 @@ function makeModule(connection) {
       let Submission = getSubmissionModel(connection)
       let submission = new Submission({})
       req.submission = submission
-      return next()
-    },
-    /**
-     * Allow submission in preview without Spcp authentication by providing default values
-     * @param {Object} req - Express request object
-     * @param {Object} res - Express response object
-     * @param {Object} next - the next expressjs callback
-     */
-    passThroughSpcp: function (req, res, next) {
-      const { authType } = req.form
-      const myInfoAttrs = req.form.getUniqueMyInfoAttrs()
-      res.locals = {
-        ...res.locals,
-        ...getMockSpcpLocals(authType, myInfoAttrs),
-      }
       return next()
     },
     /**

--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -27,6 +27,7 @@ const getFormFeedbackModel = require('../models/form_feedback.server.model')
   .default
 const getSubmissionModel = require('../models/submission.server.model').default
 const { ResponseMode } = require('../../types')
+const { getMockSpcpLocals } = require('../modules/spcp/spcp.util')
 
 // Export individual functions (i.e. create, delete)
 // and makeModule function that takes in connection object
@@ -591,25 +592,10 @@ function makeModule(connection) {
      */
     passThroughSpcp: function (req, res, next) {
       const { authType } = req.form
-      switch (authType) {
-        case 'SP': {
-          res.locals.uinFin = 'S1234567A'
-          res.locals.hashedFields = new Set()
-          let actualFormFields = req.form.form_fields
-          let actualMyInfoFields = actualFormFields.filter(
-            (field) => field.myInfo && field.myInfo.attr,
-          )
-          for (let field of actualMyInfoFields) {
-            res.locals.hashedFields.add(field.myInfo.attr)
-          }
-          break
-        }
-        case 'CP':
-          res.locals.uinFin = '123456789A'
-          res.locals.userInfo = 'ABC'
-          break
-        default:
-          break
+      const myInfoAttrs = req.form.getUniqueMyInfoAttrs()
+      res.locals = {
+        ...res.locals,
+        ...getMockSpcpLocals(authType, myInfoAttrs),
       }
       return next()
     },

--- a/src/app/factories/spcp.factory.js
+++ b/src/app/factories/spcp.factory.js
@@ -1,5 +1,4 @@
 const spcp = require('../controllers/spcp.server.controller')
-const admin = require('../controllers/admin-forms.server.controller')
 const { StatusCodes } = require('http-status-codes')
 const featureManager = require('../../config/feature-manager').default
 const fs = require('fs')
@@ -66,7 +65,6 @@ const spcpFactory = ({ isEnabled, props }) => {
 
     return {
       appendVerifiedSPCPResponses: spcp.appendVerifiedSPCPResponses,
-      passThroughSpcp: admin.passThroughSpcp,
       singPassLogin: spcp.singPassLogin(ndiConfig),
       corpPassLogin: spcp.corpPassLogin(ndiConfig),
     }
@@ -74,7 +72,6 @@ const spcpFactory = ({ isEnabled, props }) => {
     const errMsg = 'SPCP/MyInfo feature is not enabled'
     return {
       appendVerifiedSPCPResponses: (req, res, next) => next(),
-      passThroughSpcp: (req, res, next) => next(),
       singPassLogin: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       corpPassLogin: (req, res) =>

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express'
 import { ParamsDictionary } from 'express-serve-static-core'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
+import { AuthType, IPopulatedForm } from '../../../../types'
 import { createReqMeta } from '../../../utils/request'
 import * as SubmissionService from '../../submission/submission.service'
 import * as UserService from '../../user/user.service'
@@ -11,11 +12,13 @@ import {
   createPresignedPostForImages,
   createPresignedPostForLogos,
   getDashboardForms,
+  getMockSpcpLocals,
 } from './admin-form.service'
 import { assertHasReadPermissions, mapRouteError } from './admin-form.utils'
 
 const logger = createLoggerWithLabel(module)
 
+type WithForm<T> = T & { form: IPopulatedForm }
 /**
  * Handler for GET /adminform endpoint.
  * @security session
@@ -217,4 +220,24 @@ export const handleCountFormSubmissions: RequestHandler<
 
   // Successfully retrieved count.
   return res.json(countResult.value)
+}
+
+/**
+ * Allow submission in preview without Spcp authentication by providing default values
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Object} next - the next expressjs callback
+ */
+export const passThroughSpcp: RequestHandler = (req, res, next) => {
+  const { authType } = (req as WithForm<typeof req>).form
+  if (authType === AuthType.SP || authType === AuthType.CP) {
+    const myInfoAttrs = (req as WithForm<
+      typeof req
+    >).form.getUniqueMyInfoAttrs()
+    res.locals = {
+      ...res.locals,
+      ...getMockSpcpLocals(authType, myInfoAttrs),
+    }
+  }
+  return next()
 }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -8,7 +8,7 @@ import {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../shared/constants'
-import { DashboardFormView } from '../../../../types'
+import { AuthType, DashboardFormView, MyInfoAttribute } from '../../../../types'
 import getFormModel from '../../../models/form.server.model'
 import { DatabaseError } from '../../core/core.errors'
 import { MissingUserError } from '../../user/user.errors'
@@ -165,4 +165,31 @@ export const createPresignedPostForLogos = (
   InvalidFileTypeError | CreatePresignedUrlError
 > => {
   return createPresignedPost(AwsConfig.logoS3Bucket, uploadParams)
+}
+
+type SpcpLocals =
+  | {
+      uinFin: string
+      hashedFields: Set<MyInfoAttribute>
+    }
+  | { uinFin: string; userInfo: string }
+  | { [key: string]: never } // empty object
+export const getMockSpcpLocals = (
+  authType: AuthType,
+  myInfoAttrs: MyInfoAttribute[],
+): SpcpLocals => {
+  switch (authType) {
+    case AuthType.SP:
+      return {
+        uinFin: 'S1234567A',
+        hashedFields: new Set(myInfoAttrs),
+      }
+    case AuthType.CP:
+      return {
+        uinFin: '123456789A',
+        userInfo: 'ABC',
+      }
+    default:
+      return {}
+  }
 }

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -2,7 +2,7 @@ import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import { AuthType, MapRouteError, MyInfoAttribute } from '../../../types'
+import { AuthType, MapRouteError } from '../../../types'
 import { MissingFeatureError } from '../core/core.errors'
 
 import {
@@ -55,33 +55,6 @@ export const extractJwt = (
       return cookies[JwtName.CP]
     default:
       return undefined
-  }
-}
-
-type SpcpLocals =
-  | {
-      uinFin: string
-      hashedFields: Set<MyInfoAttribute>
-    }
-  | { uinFin: string; userInfo: string }
-  | { [key: string]: never } // empty object
-export const getMockSpcpLocals = (
-  authType: AuthType,
-  myInfoAttrs: MyInfoAttribute[],
-): SpcpLocals => {
-  switch (authType) {
-    case AuthType.SP:
-      return {
-        uinFin: 'S1234567A',
-        hashedFields: new Set(myInfoAttrs),
-      }
-    case AuthType.CP:
-      return {
-        uinFin: '123456789A',
-        userInfo: 'ABC',
-      }
-    default:
-      return {}
   }
 }
 

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -2,7 +2,7 @@ import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import { AuthType, MapRouteError } from '../../../types'
+import { AuthType, MapRouteError, MyInfoAttribute } from '../../../types'
 import { MissingFeatureError } from '../core/core.errors'
 
 import {
@@ -55,6 +55,33 @@ export const extractJwt = (
       return cookies[JwtName.CP]
     default:
       return undefined
+  }
+}
+
+type SpcpLocals =
+  | {
+      uinFin: string
+      hashedFields: Set<MyInfoAttribute>
+    }
+  | { uinFin: string; userInfo: string }
+  | { [key: string]: never } // empty object
+export const getMockSpcpLocals = (
+  authType: AuthType,
+  myInfoAttrs: MyInfoAttribute[],
+): SpcpLocals => {
+  switch (authType) {
+    case AuthType.SP:
+      return {
+        uinFin: 'S1234567A',
+        hashedFields: new Set(myInfoAttrs),
+      }
+    case AuthType.CP:
+      return {
+        uinFin: '123456789A',
+        userInfo: 'ABC',
+      }
+    default:
+      return {}
   }
 }
 

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -340,7 +340,7 @@ module.exports = function (app) {
       authActiveForm(PERMISSIONS.READ),
       emailSubmissions.receiveEmailSubmissionUsingBusBoy,
       emailSubmissions.validateEmailSubmission,
-      spcpFactory.passThroughSpcp,
+      adminForms.passThroughSpcp,
       submissions.injectAutoReplyInfo,
       spcpFactory.appendVerifiedSPCPResponses,
       emailSubmissions.prepareEmailSubmission,
@@ -374,7 +374,7 @@ module.exports = function (app) {
     .post(
       authActiveForm(PERMISSIONS.READ),
       encryptSubmissions.validateEncryptSubmission,
-      spcpFactory.passThroughSpcp,
+      adminForms.passThroughSpcp,
       submissions.injectAutoReplyInfo,
       webhookVerifiedContentFactory.encryptedVerifiedFields,
       encryptSubmissions.prepareEncryptSubmission,

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -340,7 +340,7 @@ module.exports = function (app) {
       authActiveForm(PERMISSIONS.READ),
       emailSubmissions.receiveEmailSubmissionUsingBusBoy,
       emailSubmissions.validateEmailSubmission,
-      adminForms.passThroughSpcp,
+      AdminFormController.passThroughSpcp,
       submissions.injectAutoReplyInfo,
       spcpFactory.appendVerifiedSPCPResponses,
       emailSubmissions.prepareEmailSubmission,
@@ -374,7 +374,7 @@ module.exports = function (app) {
     .post(
       authActiveForm(PERMISSIONS.READ),
       encryptSubmissions.validateEncryptSubmission,
-      adminForms.passThroughSpcp,
+      AdminFormController.passThroughSpcp,
       submissions.injectAutoReplyInfo,
       webhookVerifiedContentFactory.encryptedVerifiedFields,
       encryptSubmissions.prepareEncryptSubmission,


### PR DESCRIPTION
The `passThroughSpcp` function serves to populate mock SingPass and CorpPass authentication info when admins submit the form in the preview. This functionality will eventually be subsumed under a single controller function, so this PR migrates the business logic into a util which can easily be called by that controller in future.