### PR TITLE
ref: migrate get single encrypt submission flow to TypeScript

### DIFF
--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -320,6 +320,25 @@ const getSubmissionCursorByFormId: IEncryptSubmissionModel['getSubmissionCursorB
 
 EncryptSubmissionSchema.statics.getSubmissionCursorByFormId = getSubmissionCursorByFormId
 
+EncryptSubmissionSchema.statics.findEncryptedSubmissionById = function (
+  this: IEncryptSubmissionModel,
+  formId: string,
+  submissionId: string,
+) {
+  return this.findOne({
+    _id: submissionId,
+    form: formId,
+    submissionType: SubmissionType.Encrypt,
+  })
+    .select({
+      encryptedContent: 1,
+      verifiedContent: 1,
+      attachmentMetadata: 1,
+      created: 1,
+    })
+    .exec()
+}
+
 const compileSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const Submission = db.model('Submission', SubmissionSchema)
   Submission.discriminator(SubmissionType.Email, EmailSubmissionSchema)

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -1,0 +1,117 @@
+import { errAsync, okAsync } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
+
+import { DatabaseError } from 'src/app/modules/core/core.errors'
+import { CreatePresignedUrlError } from 'src/app/modules/form/admin-form/admin-form.errors'
+import { SubmissionData } from 'src/types'
+
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+
+import { SubmissionNotFoundError } from '../../submission.errors'
+import { handleGetEncryptedResponse } from '../encrypt-submission.controller'
+import * as EncryptSubmissionService from '../encrypt-submission.service'
+
+jest.mock('../encrypt-submission.service')
+const MockEncryptSubService = mocked(EncryptSubmissionService)
+
+describe('encrypt-submission.controller', () => {
+  describe('handleGetEncryptedResponse', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: { formId: 'mockFormId' },
+      query: { submissionId: 'mockSubmissionId' },
+      session: {
+        cookie: {
+          maxAge: 20000,
+        },
+      },
+    })
+
+    it('should return 200 with encrypted response', async () => {
+      // Arrange
+      const mockSubData: SubmissionData = {
+        _id: 'some id',
+        encryptedContent: 'some encrypted content',
+        verifiedContent: 'some verified content',
+        created: new Date('2020-10-10'),
+      } as SubmissionData
+      const mockSignedUrls = {
+        someKey1: 'some-signed-url',
+        someKey2: 'another-signed-url',
+      }
+      const mockRes = expressHandler.mockResponse()
+
+      // Mock service responses.
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        okAsync(mockSubData),
+      )
+      MockEncryptSubService.transformAttachmentMetasToSignedUrls.mockReturnValueOnce(
+        okAsync(mockSignedUrls),
+      )
+
+      // Act
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      const expected = {
+        refNo: mockSubData._id,
+        submissionTime: 'Sat, 10 Oct 2020, 08:00:00 AM',
+        content: mockSubData.encryptedContent,
+        verified: mockSubData.verifiedContent,
+        attachmentMetadata: mockSignedUrls,
+      }
+      expect(mockRes.json).toHaveBeenCalledWith(expected)
+    })
+
+    it('should return 404 when submissionId cannot be found in the database', async () => {
+      // Arrange
+      const mockErrorString = 'not found'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        errAsync(new SubmissionNotFoundError(mockErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      // Arrange
+      const mockErrorString = 'database error occurred'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 500 when error occurs when generating presigned URLs', async () => {
+      // Arrange
+      const mockErrorString = 'presigned url error occured'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        okAsync({} as SubmissionData),
+      )
+      MockEncryptSubService.transformAttachmentMetasToSignedUrls.mockReturnValueOnce(
+        errAsync(new CreatePresignedUrlError(mockErrorString)),
+      )
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+    })
+  })
+})

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -438,6 +438,42 @@ describe('encrypt-submission.service', () => {
       })
     })
 
+    it('should return empty object when given attachmentMetadata is undefined', async () => {
+      // Arrange
+      // Mock promise implementation.
+      const awsSpy = jest.spyOn(aws.s3, 'getSignedUrlPromise')
+
+      // Act
+      const actualResult = await transformAttachmentMetasToSignedUrls(
+        undefined,
+        200,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      // Should return empty object.
+      expect(actualResult._unsafeUnwrap()).toEqual({})
+      expect(awsSpy).not.toHaveBeenCalled()
+    })
+
+    it('should return empty object when given attachmentMetadata is empty map', async () => {
+      // Arrange
+      // Mock promise implementation.
+      const awsSpy = jest.spyOn(aws.s3, 'getSignedUrlPromise')
+
+      // Act
+      const actualResult = await transformAttachmentMetasToSignedUrls(
+        new Map(),
+        200,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      // Should return empty object.
+      expect(actualResult._unsafeUnwrap()).toEqual({})
+      expect(awsSpy).not.toHaveBeenCalled()
+    })
+
     it('should return CreatePresignedUrlError when error occurs during the signed url creation process', async () => {
       // Arrange
       jest

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -168,9 +168,12 @@ export const getEncryptedSubmissionData = (
  * @returns err(CreatePresignedUrlError) if any of the signed url creation processes results in an error
  */
 export const transformAttachmentMetasToSignedUrls = (
-  attachmentMetadata: Map<string, string>,
+  attachmentMetadata: Map<string, string> | undefined,
   urlValidDuration: number,
 ): ResultAsync<Record<string, string>, CreatePresignedUrlError> => {
+  if (!attachmentMetadata) {
+    return okAsync({})
+  }
   const keyToSignedUrlPromises: Record<string, Promise<string>> = {}
 
   for (const [key, objectPath] of attachmentMetadata) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -1,0 +1,35 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../../../config/logger'
+import { MapRouteError } from '../../../../types/routing'
+import { MalformedParametersError } from '../../core/core.errors'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Handler to map ApplicationErrors to their correct status code and error
+ * messages.
+ * @param error The error to retrieve the status codes and error messages
+ */
+export const mapRouteError: MapRouteError = (error) => {
+  switch (error.constructor) {
+    case MalformedParametersError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    default:
+      logger.error({
+        message: 'Unknown route error observed',
+        meta: {
+          action: 'mapRouteError',
+        },
+        error,
+      })
+
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: 'Something went wrong. Please try again.',
+      }
+  }
+}

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -2,7 +2,9 @@ import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
 import { MapRouteError } from '../../../../types/routing'
-import { MalformedParametersError } from '../../core/core.errors'
+import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
+import { CreatePresignedUrlError } from '../../form/admin-form/admin-form.errors'
+import { SubmissionNotFoundError } from '../submission.errors'
 
 const logger = createLoggerWithLabel(module)
 
@@ -16,6 +18,17 @@ export const mapRouteError: MapRouteError = (error) => {
     case MalformedParametersError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    case SubmissionNotFoundError:
+      return {
+        statusCode: StatusCodes.NOT_FOUND,
+        errorMessage: error.message,
+      }
+    case CreatePresignedUrlError:
+    case DatabaseError:
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: error.message,
       }
     default:

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -11,3 +11,9 @@ export class ConflictError extends ApplicationError {
     super(message, StatusCodes.CONFLICT, meta)
   }
 }
+
+export class SubmissionNotFoundError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -395,7 +395,10 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/submissions')
-    .get(authEncryptedResponseAccess, encryptSubmissions.getEncryptedResponse)
+    .get(
+      authEncryptedResponseAccess,
+      EncryptSubmissionController.handleGetEncryptedResponse,
+    )
 
   /**
    * Count the number of submissions for a public form

--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -30,7 +30,7 @@ export const getMongoErrorMessage = (
     return joinedMessage ?? err.message ?? defaultErrorMessage
   }
 
-  if (err instanceof MongooseError) {
+  if (err instanceof MongooseError || err instanceof Error) {
     return err.message ?? defaultErrorMessage
   }
 

--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -2,7 +2,7 @@ import { MongoError } from 'mongodb'
 import { Error as MongooseError } from 'mongoose'
 
 export const getMongoErrorMessage = (
-  err?: MongoError | MongooseError | string,
+  err?: unknown,
   // Default error message if no more specific error
   defaultErrorMessage = 'An unexpected error happened. Please try again.',
 ): string => {
@@ -34,5 +34,9 @@ export const getMongoErrorMessage = (
     return err.message ?? defaultErrorMessage
   }
 
-  return err ?? defaultErrorMessage
+  if (typeof err === 'string') {
+    return err ?? defaultErrorMessage
+  }
+
+  return defaultErrorMessage
 }

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -158,6 +158,11 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
         endDate?: string
       },
     ): QueryCursor<SubmissionCursorData>
+
+    findEncryptedSubmissionById(
+      formId: string,
+      submissionId: string,
+    ): Promise<IEncryptedSubmissionSchema | null>
   }
 
 export interface IWebhookResponseSchema extends IWebhookResponse, Document {}

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -110,6 +110,11 @@ export type SubmissionCursorData = Pick<
   'encryptedContent' | 'verifiedContent' | 'created' | 'id'
 > & { attachmentMetadata: Record<string, string> } & Document
 
+export type SubmissionData = Omit<
+  IEncryptedSubmissionSchema,
+  'version' | 'webhookResponses'
+>
+
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
   ISubmissionModel
 export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
@@ -162,7 +167,7 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
     findEncryptedSubmissionById(
       formId: string,
       submissionId: string,
-    ): Promise<IEncryptedSubmissionSchema | null>
+    ): Promise<SubmissionData | null>
   }
 
 export interface IWebhookResponseSchema extends IWebhookResponse, Document {}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates all the inlined services in the old `encrypt-submissions.server.controller.js#getEncryptedResponse` function into the layered architecture design with Typescript.

PS: Abbreviating `EncryptSubmission` to `ES` for ease of typing.

## Solution
<!-- How did you solve the problem? -->

**Features**:
- Add `ESModel#findEncryptedSubmissionById` static method
- Add `ESService#getEncryptedSubmissionData` function that calls the above method
- Add `ESService#transformAttachmentMetasToSignedUrls` function to have a better chunk out work in the controller
- Add `ESController#handleGetEncryptedResponse` function for route to use

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests are written for all the newly added code
- `ESModel#findEncryptedSubmissionById`
- `ESService#getEncryptedSubmissionData`
- `ESService#transformAttachmentMetasToSignedUrls`
- `ESController#handleGetEncryptedResponse`
