### PR TITLE
refactor: create addLoginFromForm static method

### DIFF
--- a/src/app/controllers/spcp.server.controller.js
+++ b/src/app/controllers/spcp.server.controller.js
@@ -22,26 +22,6 @@ const jwtNames = {
 }
 const destinationRegex = /^\/([\w]+)\/?/
 
-const addLoginToDB = function (form) {
-  let login = new Login({
-    form: form._id,
-    admin: form.admin._id,
-    agency: form.admin.agency._id,
-    authType: form.authType,
-    esrvcId: form.esrvcId,
-  })
-  return login.save().catch((err) => {
-    logger.error({
-      message: 'Error adding login to database',
-      meta: {
-        action: 'addLoginToDB',
-        formId: form._id,
-      },
-      error: err,
-    })
-  })
-}
-
 const getForm = function (destination, cb) {
   let formId = destinationRegex.exec(destination)[1]
   Form.findById({ _id: formId })
@@ -176,7 +156,7 @@ const handleOOBAuthenticationWith = (ndiConfig, authType, extractUser) => {
             // NOTE: cookieDuration is interpreted as a seconds count if numeric.
           )
           // Add login to DB
-          addLoginToDB(form).then(() => {
+          Login.addLoginFromForm(form).then(() => {
             const spcpSettings = spcpCookieDomain
               ? { domain: spcpCookieDomain, path: '/' }
               : {}

--- a/src/app/models/login.server.model.ts
+++ b/src/app/models/login.server.model.ts
@@ -57,14 +57,18 @@ LoginSchema.statics.addLoginFromForm = function (
   this: ILoginModel,
   form: IPopulatedForm,
 ): Promise<ILoginSchema> {
-  const login = new this({
+  if (!form.authType || !form.esrvcId) {
+    return Promise.reject(
+      new Error('Form does not contain authType or e-service ID'),
+    )
+  }
+  return this.create({
     form: form._id,
     admin: form.admin._id,
     agency: form.admin.agency._id,
     authType: form.authType,
     esrvcId: form.esrvcId,
   })
-  return login.save()
 }
 
 LoginSchema.statics.aggregateLoginStats = function (

--- a/src/app/models/login.server.model.ts
+++ b/src/app/models/login.server.model.ts
@@ -4,6 +4,7 @@ import {
   AuthType,
   ILoginModel,
   ILoginSchema,
+  IPopulatedForm,
   LoginStatistic,
 } from '../../types'
 
@@ -51,6 +52,20 @@ const LoginSchema = new Schema<ILoginSchema>(
     },
   },
 )
+
+LoginSchema.statics.addLoginFromForm = function (
+  this: ILoginModel,
+  form: IPopulatedForm,
+): Promise<ILoginSchema> {
+  const login = new this({
+    form: form._id,
+    admin: form.admin._id,
+    agency: form.admin.agency._id,
+    authType: form.authType,
+    esrvcId: form.esrvcId,
+  })
+  return login.save()
+}
 
 LoginSchema.statics.aggregateLoginStats = function (
   this: ILoginModel,

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,7 +1,7 @@
 import { Document, Model } from 'mongoose'
 
 import { IAgencySchema } from './agency'
-import { AuthType, IFormSchema } from './form'
+import { AuthType, IFormSchema, IPopulatedForm } from './form'
 import { IUserSchema } from './user'
 
 export interface ILogin {
@@ -32,4 +32,5 @@ export interface ILoginModel extends Model<ILoginSchema> {
     gte: Date,
     lte: Date,
   ) => Promise<LoginStatistic[]>
+  addLoginFromForm: (form: IPopulatedForm) => Promise<ILoginSchema>
 }

--- a/tests/unit/backend/models/login.server.model.spec.ts
+++ b/tests/unit/backend/models/login.server.model.spec.ts
@@ -126,20 +126,19 @@ describe('login.server.model', () => {
       const agencyId = new ObjectId()
       const mockEsrvcId = 'esrvcid'
       const mockAuthType = 'SP'
+      const fullForm = ({
+        _id: formId,
+        admin: {
+          _id: adminId,
+          agency: {
+            _id: agencyId,
+          },
+        },
+        authType: mockAuthType,
+        esrvcId: mockEsrvcId,
+      } as unknown) as IPopulatedForm
 
       it('should save the correct form data', async () => {
-        const fullForm = ({
-          _id: formId,
-          admin: {
-            _id: adminId,
-            agency: {
-              _id: agencyId,
-            },
-          },
-          authType: mockAuthType,
-          esrvcId: mockEsrvcId,
-        } as unknown) as IPopulatedForm
-
         const saved = await LoginModel.addLoginFromForm(fullForm)
         const found = await LoginModel.findOne({ form: formId })
         // Returned document should match
@@ -154,6 +153,18 @@ describe('login.server.model', () => {
         expect(found!.agency).toEqual(agencyId)
         expect(found!.authType).toBe(mockAuthType)
         expect(found!.esrvcId).toBe(mockEsrvcId)
+      })
+
+      it('should reject when the form does not contain an e-service ID', async () => {
+        await expect(
+          LoginModel.addLoginFromForm(omit(fullForm, 'esrvcId')),
+        ).rejects.toThrow('Form does not contain authType or e-service ID')
+      })
+
+      it('should reject when the form does not contain an authType', async () => {
+        await expect(
+          LoginModel.addLoginFromForm(omit(fullForm, 'authType')),
+        ).rejects.toThrow('Form does not contain authType or e-service ID')
       })
     })
 

--- a/tests/unit/backend/models/login.server.model.spec.ts
+++ b/tests/unit/backend/models/login.server.model.spec.ts
@@ -5,7 +5,13 @@ import moment from 'moment-timezone'
 import mongoose from 'mongoose'
 
 import getLoginModel from 'src/app/models/login.server.model'
-import { AuthType, IFormSchema, ILogin, IUserSchema } from 'src/types'
+import {
+  AuthType,
+  IFormSchema,
+  ILogin,
+  IPopulatedForm,
+  IUserSchema,
+} from 'src/types'
 
 import dbHandler from '../helpers/jest-db'
 
@@ -114,6 +120,43 @@ describe('login.server.model', () => {
   })
 
   describe('Statics', () => {
+    describe('addLoginFromForm', () => {
+      const adminId = new ObjectId()
+      const formId = new ObjectId()
+      const agencyId = new ObjectId()
+      const mockEsrvcId = 'esrvcid'
+      const mockAuthType = 'SP'
+
+      it('should save the correct form data', async () => {
+        const fullForm = ({
+          _id: formId,
+          admin: {
+            _id: adminId,
+            agency: {
+              _id: agencyId,
+            },
+          },
+          authType: mockAuthType,
+          esrvcId: mockEsrvcId,
+        } as unknown) as IPopulatedForm
+
+        const saved = await LoginModel.addLoginFromForm(fullForm)
+        const found = await LoginModel.findOne({ form: formId })
+        // Returned document should match
+        expect(saved.form).toEqual(formId)
+        expect(saved.admin).toEqual(adminId)
+        expect(saved.agency).toEqual(agencyId)
+        expect(saved.authType).toBe(mockAuthType)
+        expect(saved.esrvcId).toBe(mockEsrvcId)
+        // Found document should match
+        expect(found!.form).toEqual(formId)
+        expect(found!.admin).toEqual(adminId)
+        expect(found!.agency).toEqual(agencyId)
+        expect(found!.authType).toBe(mockAuthType)
+        expect(found!.esrvcId).toBe(mockEsrvcId)
+      })
+    })
+
     describe('aggregateLoginStats', () => {
       const VALID_ESRVC_ID = 'MOCK-ESRVC-ID'
       const CURR_MOMENT = moment()


### PR DESCRIPTION
This PR moves the logic for creating a new Login document from the SPCP controller to a Login model static method.