### PR TITLE
refactor: migrate utils/permission-levels to admin-form.types

### DIFF
--- a/src/app/controllers/authentication.server.controller.js
+++ b/src/app/controllers/authentication.server.controller.js
@@ -4,7 +4,9 @@
  * Module dependencies.
  */
 const { StatusCodes } = require('http-status-codes')
-const PERMISSIONS = require('../utils/permission-levels').default
+const {
+  PermissionLevel,
+} = require('../modules/form/admin-form/admin-form.types')
 const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 
@@ -59,7 +61,7 @@ exports.verifyPermission = (requiredPermission) =>
       String(req.form.admin.id) === String(req.session.user._id)
 
     // Forbidden if requiredPersmission is admin but user is not
-    if (!isFormAdmin && requiredPermission === PERMISSIONS.DELETE) {
+    if (!isFormAdmin && requiredPermission === PermissionLevel.Delete) {
       logUnauthorizedAccess(req, 'verifyPermission', requiredPermission)
       return res.status(StatusCodes.FORBIDDEN).json({
         message: makeUnauthorizedMessage(
@@ -74,8 +76,8 @@ exports.verifyPermission = (requiredPermission) =>
 
     // Write users can access forms that require write/read
     if (
-      requiredPermission === PERMISSIONS.WRITE ||
-      requiredPermission === PERMISSIONS.READ
+      requiredPermission === PermissionLevel.Write ||
+      requiredPermission === PermissionLevel.Read
     ) {
       hasSufficientPermission =
         hasSufficientPermission ||
@@ -85,7 +87,7 @@ exports.verifyPermission = (requiredPermission) =>
         )
     }
     // Read users can access forms that require read permissions
-    if (requiredPermission === PERMISSIONS.READ) {
+    if (requiredPermission === PermissionLevel.Read) {
       hasSufficientPermission =
         hasSufficientPermission ||
         req.form.permissionList.find(

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -1,0 +1,5 @@
+export enum PermissionLevel {
+  Read = 'read',
+  Write = 'write',
+  Delete = 'delete',
+}

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -12,12 +12,14 @@ let auth = require('../../app/controllers/authentication.server.controller')
 let submissions = require('../../app/controllers/submissions.server.controller')
 const emailSubmissions = require('../../app/controllers/email-submissions.server.controller')
 let encryptSubmissions = require('../../app/controllers/encrypt-submissions.server.controller')
-let PERMISSIONS = require('../utils/permission-levels').default
 const spcpFactory = require('../factories/spcp.factory')
 const webhookVerifiedContentFactory = require('../factories/webhook-verified-content.factory')
 const AdminFormController = require('../modules/form/admin-form/admin-form.controller')
 const { withUserAuthentication } = require('../modules/auth/auth.middlewares')
 const EncryptSubmissionController = require('../modules/submission/encrypt-submission/encrypt-submission.controller')
+const {
+  PermissionLevel,
+} = require('../modules/form/admin-form/admin-form.types')
 
 const YYYY_MM_DD_REGEX = /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/
 
@@ -53,7 +55,7 @@ let authAdminActiveAnyForm = [
  * form admin is encrypt beta-enabled.
  */
 const authEncryptedResponseAccess = [
-  authActiveForm(PERMISSIONS.READ),
+  authActiveForm(PermissionLevel.Read),
   adminForms.isFormEncryptMode,
 ]
 
@@ -161,10 +163,13 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform')
-    .get(authActiveForm(PERMISSIONS.READ), forms.read(forms.REQUEST_TYPE.ADMIN))
-    .put(authActiveForm(PERMISSIONS.WRITE), adminForms.update)
-    .delete(authActiveForm(PERMISSIONS.DELETE), adminForms.delete)
-    .post(authActiveForm(PERMISSIONS.READ), adminForms.duplicate)
+    .get(
+      authActiveForm(PermissionLevel.Read),
+      forms.read(forms.REQUEST_TYPE.ADMIN),
+    )
+    .put(authActiveForm(PermissionLevel.Write), adminForms.update)
+    .delete(authActiveForm(PermissionLevel.Delete), adminForms.delete)
+    .post(authActiveForm(PermissionLevel.Read), adminForms.duplicate)
 
   /**
    * Return the template form to the user.
@@ -204,7 +209,10 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/preview')
-    .get(authActiveForm(PERMISSIONS.READ), forms.read(forms.REQUEST_TYPE.ADMIN))
+    .get(
+      authActiveForm(PermissionLevel.Read),
+      forms.read(forms.REQUEST_TYPE.ADMIN),
+    )
 
   /**
    * Duplicate a specified form and return that form to the user.
@@ -262,8 +270,8 @@ module.exports = function (app) {
 
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback')
-    .get(authActiveForm(PERMISSIONS.READ), adminForms.getFeedback)
-    .post(authActiveForm(PERMISSIONS.READ), adminForms.passThroughFeedback)
+    .get(authActiveForm(PermissionLevel.Read), adminForms.getFeedback)
+    .post(authActiveForm(PermissionLevel.Read), adminForms.passThroughFeedback)
 
   /**
    * Count the number of feedback for a form
@@ -277,7 +285,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback/count')
-    .get(authActiveForm(PERMISSIONS.READ), adminForms.countFeedback)
+    .get(authActiveForm(PermissionLevel.Read), adminForms.countFeedback)
 
   /**
    * Stream download all feedback for a form
@@ -291,7 +299,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback/download')
-    .get(authActiveForm(PERMISSIONS.READ), adminForms.streamFeedback)
+    .get(authActiveForm(PermissionLevel.Read), adminForms.streamFeedback)
 
   /**
    * Transfer form ownership to another user
@@ -304,7 +312,7 @@ module.exports = function (app) {
    * @returns {Object} 200 - Response document
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/transfer-owner').post(
-    authActiveForm(PERMISSIONS.DELETE),
+    authActiveForm(PermissionLevel.Delete),
     celebrate({
       body: Joi.object().keys({
         email: Joi.string()
@@ -337,7 +345,7 @@ module.exports = function (app) {
   app
     .route('/v2/submissions/email/preview/:formId([a-fA-F0-9]{24})')
     .post(
-      authActiveForm(PERMISSIONS.READ),
+      authActiveForm(PermissionLevel.Read),
       emailSubmissions.receiveEmailSubmissionUsingBusBoy,
       emailSubmissions.validateEmailSubmission,
       spcpFactory.passThroughSpcp,
@@ -372,7 +380,7 @@ module.exports = function (app) {
   app
     .route('/v2/submissions/encrypt/preview/:formId([a-fA-F0-9]{24})')
     .post(
-      authActiveForm(PERMISSIONS.READ),
+      authActiveForm(PermissionLevel.Read),
       encryptSubmissions.validateEncryptSubmission,
       spcpFactory.passThroughSpcp,
       submissions.injectAutoReplyInfo,
@@ -499,7 +507,7 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    authActiveForm(PERMISSIONS.WRITE),
+    authActiveForm(PermissionLevel.Write),
     AdminFormController.handleCreatePresignedPostForImages,
   )
 
@@ -527,7 +535,7 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    authActiveForm(PERMISSIONS.WRITE),
+    authActiveForm(PermissionLevel.Write),
     AdminFormController.handleCreatePresignedPostForLogos,
   )
 }

--- a/src/app/utils/permission-levels.ts
+++ b/src/app/utils/permission-levels.ts
@@ -1,7 +1,0 @@
-enum PERMISSION_LEVELS {
-  READ = 'read',
-  WRITE = 'write',
-  DELETE = 'delete',
-}
-
-export default PERMISSION_LEVELS

--- a/tests/unit/backend/controllers/authentication.server.controller.spec.js
+++ b/tests/unit/backend/controllers/authentication.server.controller.spec.js
@@ -1,10 +1,11 @@
 const { StatusCodes } = require('http-status-codes')
 const mongoose = require('mongoose')
+const {
+  PermissionLevel,
+} = require('../../../../dist/backend/app/modules/form/admin-form/admin-form.types')
 
 const dbHandler = require('../helpers/db-handler')
 let roles = require('../helpers/roles')
-let permissionLevels = require('../../../../dist/backend/app/utils/permission-levels')
-  .default
 
 describe('Authentication Controller', () => {
   const TEST_OTP = '123456'
@@ -67,7 +68,7 @@ describe('Authentication Controller', () => {
       let testFormObj = testForm.toObject()
       testFormObj.admin = { id: req.session.user._id }
       req.form = testFormObj
-      Controller.verifyPermission(permissionLevels.DELETE)(req, res, next)
+      Controller.verifyPermission(PermissionLevel.Delete)(req, res, next)
       expect(next).toHaveBeenCalled()
     })
     it('should authorize if session user is a collaborator', () => {
@@ -79,7 +80,7 @@ describe('Authentication Controller', () => {
         roles.collaborator(req.session.user.email),
       )
       req.form = testFormObj
-      Controller.verifyPermission(permissionLevels.WRITE)(req, res, next)
+      Controller.verifyPermission(PermissionLevel.Write)(req, res, next)
       expect(next).toHaveBeenCalled()
     })
     it('should not authorize if session user is not a collaborator nor admin', () => {
@@ -91,7 +92,7 @@ describe('Authentication Controller', () => {
       let testFormObj = testForm.toObject()
       testFormObj.admin = { id: mongoose.Types.ObjectId('000000000002') }
       req.form = testFormObj
-      Controller.verifyPermission(permissionLevels.WRITE)(req, res, () => {})
+      Controller.verifyPermission(PermissionLevel.Write)(req, res, () => {})
     })
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates the sole enum in `utils/permission-levels` to `form/admin-form/admin-form.types`

Also updated the casing of the enum to PascalCase following standard practices