### PR TITLE
ref: extract assert permission levels helper functions

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -24,7 +24,7 @@ import {
   InvalidFileTypeError,
 } from '../admin-form.errors'
 import * as AdminFormService from '../admin-form.service'
-import * as AuthUtils from '../admin-form.utils'
+import * as AdminFormUtils from '../admin-form.utils'
 
 jest.mock('src/app/modules/submission/submission.service')
 const MockSubmissionService = mocked(SubmissionService)
@@ -301,7 +301,7 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM as IPopulatedForm),
       )
       const readPermsSpy = jest
-        .spyOn(AuthUtils, 'assertHasReadPermissions')
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
         .mockReturnValueOnce(ok(true))
       MockSubmissionService.getFormSubmissionsCount.mockReturnValueOnce(
         okAsync(expectedSubmissionCount),
@@ -352,7 +352,7 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM as IPopulatedForm),
       )
       const readPermsSpy = jest
-        .spyOn(AuthUtils, 'assertHasReadPermissions')
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
         .mockReturnValueOnce(ok(true))
       MockSubmissionService.getFormSubmissionsCount.mockReturnValueOnce(
         okAsync(expectedSubmissionCount),
@@ -394,7 +394,7 @@ describe('admin-form.controller', () => {
       // Mock error here.
       const expectedErrorString = 'no read access'
       const readPermsSpy = jest
-        .spyOn(AuthUtils, 'assertHasReadPermissions')
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
         .mockReturnValueOnce(err(new ForbiddenFormError(expectedErrorString)))
 
       // Act
@@ -606,7 +606,7 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM as IPopulatedForm),
       )
       const readPermsSpy = jest
-        .spyOn(AuthUtils, 'assertHasReadPermissions')
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
         .mockReturnValueOnce(ok(true))
       const expectedErrorString = 'database goes boom'
       MockSubmissionService.getFormSubmissionsCount.mockReturnValueOnce(

--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'bson-ext'
 
 import { IPopulatedForm, IPopulatedUser, Permission, Status } from 'src/types'
 
-import { ForbiddenFormError, FormDeletedError } from '../../form.errors'
+import { ForbiddenFormError } from '../../form.errors'
 import {
   assertHasDeletePermissions,
   assertHasReadPermissions,
@@ -57,26 +57,6 @@ describe('admin-form.utils', () => {
       // Assert
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(true)
-    })
-
-    it('should return FormDeletedError when given form is archived', async () => {
-      // Arrange
-      // Form is archived.
-      const mockForm = {
-        title: 'mockForm',
-        status: Status.Archived,
-        _id: new ObjectId(),
-        admin: MOCK_USER,
-      } as IPopulatedForm
-
-      // Act
-      const actualResult = assertHasReadPermissions(MOCK_USER, mockForm)
-
-      // Assert
-      expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new FormDeletedError('Form has been archived'),
-      )
     })
 
     it('should return ForbiddenFormError when user does not have read permissions', async () => {
@@ -147,26 +127,6 @@ describe('admin-form.utils', () => {
       // Assert
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(true)
-    })
-
-    it('should return FormDeletedError when given form is archived', async () => {
-      // Arrange
-      // Form is archived.
-      const mockForm = {
-        title: 'mockForm',
-        status: Status.Archived,
-        _id: new ObjectId(),
-        admin: MOCK_USER,
-      } as IPopulatedForm
-
-      // Act
-      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
-
-      // Assert
-      expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new FormDeletedError('Form has been archived'),
-      )
     })
 
     it('should return ForbiddenFormError when user has read but not write permissions', async () => {
@@ -242,26 +202,6 @@ describe('admin-form.utils', () => {
       // Assert
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(true)
-    })
-
-    it('should return FormDeletedError when given form is archived', async () => {
-      // Arrange
-      // Form is archived.
-      const mockForm = {
-        title: 'mockForm',
-        status: Status.Archived,
-        _id: new ObjectId(),
-        admin: MOCK_USER,
-      } as IPopulatedForm
-
-      // Act
-      const actualResult = assertHasDeletePermissions(MOCK_USER, mockForm)
-
-      // Assert
-      expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new FormDeletedError('Form has been archived'),
-      )
     })
 
     it('should return ForbiddenFormError when user is not admin even with read permissions', async () => {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -3,18 +3,22 @@ import { ObjectId } from 'bson-ext'
 import { IPopulatedForm, IPopulatedUser, Permission, Status } from 'src/types'
 
 import { ForbiddenFormError, FormDeletedError } from '../../form.errors'
-import { assertHasReadPermissions } from '../admin-form.utils'
+import {
+  assertHasDeletePermissions,
+  assertHasReadPermissions,
+  assertHasWritePermissions,
+} from '../admin-form.utils'
 
 describe('admin-form.utils', () => {
-  describe('assertHasReadPermissions', () => {
-    const MOCK_VALID_ADMIN_ID = new ObjectId()
-    const MOCK_VALID_ADMIN_EMAIL = 'test@example.com'
-    const MOCK_USER = {
-      _id: MOCK_VALID_ADMIN_ID,
-      email: MOCK_VALID_ADMIN_EMAIL,
-    } as IPopulatedUser
+  const MOCK_VALID_ADMIN_ID = new ObjectId()
+  const MOCK_VALID_ADMIN_EMAIL = 'test@example.com'
+  const MOCK_USER = {
+    _id: MOCK_VALID_ADMIN_ID,
+    email: MOCK_VALID_ADMIN_EMAIL,
+  } as IPopulatedUser
 
-    it('should return true if user is form admin', async () => {
+  describe('assertHasReadPermissions', () => {
+    it('should return true when user is form admin', async () => {
       // Arrange
       const mockForm = {
         title: 'mockForm',
@@ -32,7 +36,7 @@ describe('admin-form.utils', () => {
       expect(actualResult._unsafeUnwrap()).toEqual(true)
     })
 
-    it('should return true if user has read permissions', async () => {
+    it('should return true when user has read permissions', async () => {
       // Arrange
       // Form is owned by another admin, but MOCK_USER has permissions.
       const mockForm = {
@@ -75,7 +79,7 @@ describe('admin-form.utils', () => {
       )
     })
 
-    it('should return ForbiddenFormError if user does not have read permissions', async () => {
+    it('should return ForbiddenFormError when user does not have read permissions', async () => {
       // Arrange
       // Form is owned by another admin, and MOCK_USER does not have
       // permissions.
@@ -98,6 +102,218 @@ describe('admin-form.utils', () => {
       expect(actualResult._unsafeUnwrapErr()).toEqual(
         new ForbiddenFormError(
           `User ${MOCK_USER.email} not authorized to perform read operation on Form ${mockForm._id} with title: ${mockForm.title}.`,
+        ),
+      )
+    })
+  })
+
+  describe('assertHasWritePermissions', () => {
+    it('should return true when user is form admin', async () => {
+      // Arrange
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Private,
+        _id: new ObjectId(),
+        // User is form admin.
+        admin: MOCK_USER,
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should return true when user has write permissions', async () => {
+      // Arrange
+      // Form is owned by another admin, but MOCK_USER has permissions.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Public,
+        _id: new ObjectId(),
+        // New admin.
+        admin: {
+          _id: new ObjectId(),
+        } as IPopulatedUser,
+        // But MOCK_USER has write permissions.
+        permissionList: [{ email: MOCK_USER.email, write: true }],
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should return FormDeletedError when given form is archived', async () => {
+      // Arrange
+      // Form is archived.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Archived,
+        _id: new ObjectId(),
+        admin: MOCK_USER,
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new FormDeletedError('Form has been archived'),
+      )
+    })
+
+    it('should return ForbiddenFormError when user has read but not write permissions', async () => {
+      // Arrange
+      // Form is owned by another admin, and MOCK_USER does not have
+      // permissions.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Public,
+        _id: new ObjectId(),
+        // New admin, no permissionsList.
+        admin: {
+          _id: new ObjectId(),
+        } as IPopulatedUser,
+        // Only read permissions.
+        permissionList: [{ email: MOCK_USER.email }],
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new ForbiddenFormError(
+          `User ${MOCK_USER.email} not authorized to perform write operation on Form ${mockForm._id} with title: ${mockForm.title}.`,
+        ),
+      )
+    })
+
+    it('should return ForbiddenFormError when user does not exist in permission list', async () => {
+      // Arrange
+      // Form is owned by another admin, and MOCK_USER does not have
+      // permissions.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Public,
+        _id: new ObjectId(),
+        // New admin, no permissionsList.
+        admin: {
+          _id: new ObjectId(),
+        } as IPopulatedUser,
+        permissionList: [] as Permission[],
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasWritePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new ForbiddenFormError(
+          `User ${MOCK_USER.email} not authorized to perform write operation on Form ${mockForm._id} with title: ${mockForm.title}.`,
+        ),
+      )
+    })
+  })
+
+  describe('assertHasDeletePermissions', () => {
+    it('should return true when user is form admin', async () => {
+      // Arrange
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Private,
+        _id: new ObjectId(),
+        // User is form admin.
+        admin: MOCK_USER,
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasDeletePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should return FormDeletedError when given form is archived', async () => {
+      // Arrange
+      // Form is archived.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Archived,
+        _id: new ObjectId(),
+        admin: MOCK_USER,
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasDeletePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new FormDeletedError('Form has been archived'),
+      )
+    })
+
+    it('should return ForbiddenFormError when user is not admin even with read permissions', async () => {
+      // Arrange
+      // Form is owned by another admin, but MOCK_USER has permissions.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Public,
+        _id: new ObjectId(),
+        // New admin.
+        admin: {
+          _id: new ObjectId(),
+        } as IPopulatedUser,
+        // But MOCK_USER has permissions..
+        permissionList: [{ email: MOCK_USER.email }],
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasDeletePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new ForbiddenFormError(
+          `User ${MOCK_USER.email} not authorized to perform delete operation on Form ${mockForm._id} with title: ${mockForm.title}.`,
+        ),
+      )
+    })
+
+    it('should return ForbiddenFormError when user is not admin even with write permissions', async () => {
+      // Arrange
+      // Form is owned by another admin, but MOCK_USER has permissions.
+      const mockForm = {
+        title: 'mockForm',
+        status: Status.Public,
+        _id: new ObjectId(),
+        // New admin.
+        admin: {
+          _id: new ObjectId(),
+        } as IPopulatedUser,
+        // But MOCK_USER has permissions.
+        permissionList: [{ email: MOCK_USER.email, write: true }],
+      } as IPopulatedForm
+
+      // Act
+      const actualResult = assertHasDeletePermissions(MOCK_USER, mockForm)
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new ForbiddenFormError(
+          `User ${MOCK_USER.email} not authorized to perform delete operation on Form ${mockForm._id} with title: ${mockForm.title}.`,
         ),
       )
     })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -12,7 +12,11 @@ import {
   createPresignedPostForLogos,
   getDashboardForms,
 } from './admin-form.service'
-import { assertHasReadPermissions, mapRouteError } from './admin-form.utils'
+import {
+  assertFormAvailable,
+  assertHasReadPermissions,
+  mapRouteError,
+} from './admin-form.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -138,16 +142,20 @@ export const handleCountFormSubmissions: RequestHandler<
   const { startDate, endDate } = req.query
   const sessionUserId = (req.session as Express.AuthedSession).user._id
 
+  const logMeta = {
+    action: 'handleCountFormSubmissions',
+    ...createReqMeta(req),
+    userId: sessionUserId,
+    formId,
+  }
+
   // Step 1: Retrieve currently logged in user.
   const adminResult = await UserService.getPopulatedUserById(sessionUserId)
   // Step 1a: Error retrieving logged in user.
   if (adminResult.isErr()) {
     logger.error({
       message: 'Error occurred whilst retrieving user',
-      meta: {
-        action: 'handleCountFormSubmissions',
-        userId: sessionUserId,
-      },
+      meta: logMeta,
       error: adminResult.error,
     })
 
@@ -163,11 +171,7 @@ export const handleCountFormSubmissions: RequestHandler<
   if (formResult.isErr()) {
     logger.error({
       message: 'Failed to retrieve form',
-      meta: {
-        action: 'handleCountFormSubmissions',
-        ...createReqMeta(req),
-        formId,
-      },
+      meta: logMeta,
       error: formResult.error,
     })
     const { errorMessage, statusCode } = mapRouteError(formResult.error)
@@ -176,30 +180,38 @@ export const handleCountFormSubmissions: RequestHandler<
   // Step 2b: Successfully retrieved form.
   const form = formResult.value
 
-  // Step 3: Check form permissions.
+  // Step 3: Check whether form is already archived.
+  const availableResult = assertFormAvailable(form)
+  // Step 3a: Form is already archived.
+  if (availableResult.isErr()) {
+    logger.warn({
+      message: 'User attempted to retrieve archived form',
+      meta: logMeta,
+      error: availableResult.error,
+    })
+    const { errorMessage, statusCode } = mapRouteError(availableResult.error)
+    return res.status(statusCode).json({ message: errorMessage })
+  }
+
+  // Step 4: Form is still available for retrieval, check form permissions.
   const permissionResult = assertHasReadPermissions(admin, form)
-  // Step 3a: Read permission error.
+  // Step 4a: Read permission error.
   if (permissionResult.isErr()) {
-    logger.error({
+    logger.warn({
       message: 'User does not have read permissions',
-      meta: {
-        action: 'handleCountFormSubmissions',
-        ...createReqMeta(req),
-        userId: sessionUserId,
-        formId,
-      },
+      meta: logMeta,
       error: permissionResult.error,
     })
     const { errorMessage, statusCode } = mapRouteError(permissionResult.error)
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  // Step 4: has permissions, continue to retrieve submission counts.
+  // Step 5: Has permissions, continue to retrieve submission counts.
   const countResult = await SubmissionService.getFormSubmissionsCount(
     String(form._id),
     { startDate, endDate },
   )
-  // Step 4a: Error retrieving form submissions counts.
+  // Step 5a: Error retrieving form submissions counts.
   if (countResult.isErr()) {
     logger.error({
       message: 'Error retrieving form submission count',

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -1,5 +1,14 @@
+import { Result } from 'neverthrow'
+
+import { ForbiddenFormError, FormDeletedError } from '../form.errors'
+
 export enum PermissionLevel {
   Read = 'read',
   Write = 'write',
   Delete = 'delete',
 }
+
+export type FormPermissionResult = Result<
+  true,
+  ForbiddenFormError | FormDeletedError
+>

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -1,6 +1,6 @@
 import { Result } from 'neverthrow'
 
-import { ForbiddenFormError, FormDeletedError } from '../form.errors'
+import { ForbiddenFormError } from '../form.errors'
 
 export enum PermissionLevel {
   Read = 'read',
@@ -8,7 +8,4 @@ export enum PermissionLevel {
   Delete = 'delete',
 }
 
-export type FormPermissionResult = Result<
-  true,
-  ForbiddenFormError | FormDeletedError
->
+export type FormPermissionResult = Result<true, ForbiddenFormError>

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -87,7 +87,15 @@ export const mapRouteError = (
   }
 }
 
-const isFormActive = (form: IPopulatedForm): Result<true, FormDeletedError> => {
+/**
+ * Asserts whether a form is available for retrieval by users.
+ * @param form the form to check
+ * @returns ok(true) if form status is not archived.
+ * @returns err(FormDeletedError) if the form has already been archived
+ */
+export const assertFormAvailable = (
+  form: IPopulatedForm,
+): Result<true, FormDeletedError> => {
   return form.status === Status.Archived
     ? err(new FormDeletedError('Form has been archived'))
     : ok(true)
@@ -96,85 +104,76 @@ const isFormActive = (form: IPopulatedForm): Result<true, FormDeletedError> => {
 /**
  * Asserts that the given user has read access for the form.
  * @returns ok(true) if given user has read permissions
- * @returns err(FormDeletedError) if form has already been archived
  * @returns err(ForbiddenFormError) if user does not have read permissions
  */
 export const assertHasReadPermissions = (
   user: IUserSchema,
   form: IPopulatedForm,
 ): FormPermissionResult => {
-  return isFormActive(form).andThen(() => {
-    // Is form admin. Automatically has permissions.
-    if (String(user._id) === String(form.admin._id)) {
-      return ok(true)
-    }
+  // Is form admin. Automatically has permissions.
+  if (String(user._id) === String(form.admin._id)) {
+    return ok(true)
+  }
 
-    // Check if user email is currently in form's allowed list.
-    const hasReadPermissions = !!form.permissionList?.find(
-      (allowedUser) => allowedUser.email === user.email,
-    )
+  // Check if user email is currently in form's allowed list.
+  const hasReadPermissions = !!form.permissionList?.find(
+    (allowedUser) => allowedUser.email === user.email,
+  )
 
-    return hasReadPermissions
-      ? ok(true)
-      : err(
-          new ForbiddenFormError(
-            `User ${user.email} not authorized to perform read operation on Form ${form._id} with title: ${form.title}.`,
-          ),
-        )
-  })
+  return hasReadPermissions
+    ? ok(true)
+    : err(
+        new ForbiddenFormError(
+          `User ${user.email} not authorized to perform read operation on Form ${form._id} with title: ${form.title}.`,
+        ),
+      )
 }
 
 /**
  * Asserts that the given user has delete permissions for the form.
  * @returns ok(true) if given user has delete permissions
- * @returns err(FormDeletedError) if form has already been archived
  * @returns err(ForbiddenFormError) if user does not have delete permissions
  */
 export const assertHasDeletePermissions = (
   user: IUserSchema,
   form: IPopulatedForm,
 ): FormPermissionResult => {
-  return isFormActive(form).andThen(() => {
-    const isFormAdmin = String(user._id) === String(form.admin._id)
-    // If form admin
-    return isFormAdmin
-      ? ok(true)
-      : err(
-          new ForbiddenFormError(
-            `User ${user.email} not authorized to perform delete operation on Form ${form._id} with title: ${form.title}.`,
-          ),
-        )
-  })
+  const isFormAdmin = String(user._id) === String(form.admin._id)
+  // If form admin
+  return isFormAdmin
+    ? ok(true)
+    : err(
+        new ForbiddenFormError(
+          `User ${user.email} not authorized to perform delete operation on Form ${form._id} with title: ${form.title}.`,
+        ),
+      )
 }
 
 /**
  * Asserts that the given user has write permissions for the form.
  * @returns ok(true) if given user has write permissions
- * @returns err(FormDeletedError) if form has already been archived
  * @returns err(ForbiddenFormError) if user does not have write permissions
  */
 export const assertHasWritePermissions = (
   user: IUserSchema,
   form: IPopulatedForm,
 ): FormPermissionResult => {
-  return isFormActive(form).andThen(() => {
-    // Is form admin. Automatically has permissions.
-    if (String(user._id) === String(form.admin._id)) {
-      return ok(true)
-    }
+  // Is form admin. Automatically has permissions.
+  if (String(user._id) === String(form.admin._id)) {
+    return ok(true)
+  }
 
-    // Check if user email is currently in form's allowed list, and has write
-    // permissions.
-    const hasWritePermissions = !!form.permissionList?.find(
-      (allowedUser) => allowedUser.email === user.email && allowedUser.write,
-    )
+  // Check if user email is currently in form's allowed list, and has write
+  // permissions.
+  const hasWritePermissions = !!form.permissionList?.find(
+    (allowedUser) => allowedUser.email === user.email && allowedUser.write,
+  )
 
-    return hasWritePermissions
-      ? ok(true)
-      : err(
-          new ForbiddenFormError(
-            `User ${user.email} not authorized to perform write operation on Form ${form._id} with title: ${form.title}.`,
-          ),
-        )
-  })
+  return hasWritePermissions
+    ? ok(true)
+    : err(
+        new ForbiddenFormError(
+          `User ${user.email} not authorized to perform write operation on Form ${form._id} with title: ${form.title}.`,
+        ),
+      )
 }

--- a/tests/unit/backend/controllers/authentication.server.controller.spec.js
+++ b/tests/unit/backend/controllers/authentication.server.controller.spec.js
@@ -66,7 +66,7 @@ describe('Authentication Controller', () => {
       let next = jasmine.createSpy()
       // Populate admin with partial user object
       let testFormObj = testForm.toObject()
-      testFormObj.admin = { id: req.session.user._id }
+      testFormObj.admin = { _id: req.session.user._id }
       req.form = testFormObj
       Controller.verifyPermission(PermissionLevel.Delete)(req, res, next)
       expect(next).toHaveBeenCalled()
@@ -75,7 +75,7 @@ describe('Authentication Controller', () => {
       let next = jasmine.createSpy()
       // Populate admin with partial user object
       let testFormObj = testForm.toObject()
-      testFormObj.admin = { id: mongoose.Types.ObjectId('000000000002') }
+      testFormObj.admin = { _id: mongoose.Types.ObjectId('000000000002') }
       testFormObj.permissionList.push(
         roles.collaborator(req.session.user.email),
       )
@@ -90,7 +90,7 @@ describe('Authentication Controller', () => {
       })
       // Populate admin with partial user object
       let testFormObj = testForm.toObject()
-      testFormObj.admin = { id: mongoose.Types.ObjectId('000000000002') }
+      testFormObj.admin = { _id: mongoose.Types.ObjectId('000000000002') }
       req.form = testFormObj
       Controller.verifyPermission(PermissionLevel.Write)(req, res, () => {})
     })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR extracts out the logic in `authentication.server.controller.js#verifyPermissions` into their own utility functions so other services can use those instead of passing through the middleware.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add methods to assert user permissions on forms in `admin-form.utils`
- use adminForm permission util fns when verifying form permissions

