### PR TITLE
ref: migrate feedback/count endpoint handler flow to TypeScript

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -464,35 +464,6 @@ function makeModule(connection) {
       })
     },
     /**
-     * Count number of form feedbacks for Feedback tab
-     * @param  {Object} req - Express request object
-     * @param  {Object} req.form - the form to download
-     * @param  {Object} res - Express response object
-     */
-    countFeedback: function (req, res) {
-      let FormFeedback = getFormFeedbackModel(connection)
-      FormFeedback.countDocuments({ formId: req.form._id }, function (
-        err,
-        count,
-      ) {
-        if (err) {
-          logger.error({
-            message: 'Error counting documents in FormFeedback',
-            meta: {
-              action: 'makeModule.countFeedback',
-              ...createReqMeta(req),
-            },
-            error: err,
-          })
-          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            message: errorHandler.getMongoErrorMessage(err),
-          })
-        } else {
-          return res.json(count)
-        }
-      })
-    },
-    /**
      * Stream download feedback for a form
      * @param  {Object} req - Express request object
      * @param  {Object} req.form - the form to download

--- a/src/app/modules/feedback/__tests__/feedback.service.spec.ts
+++ b/src/app/modules/feedback/__tests__/feedback.service.spec.ts
@@ -1,0 +1,88 @@
+import { ObjectId } from 'bson-ext'
+import { times } from 'lodash'
+import mongoose from 'mongoose'
+
+import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import { DatabaseError } from '../../core/core.errors'
+import * as FeedbackService from '../feedback.service'
+
+const FormFeedback = getFormFeedbackModel(mongoose)
+
+describe('feedback.service', () => {
+  beforeAll(() => dbHandler.connect())
+  afterAll(() => dbHandler.closeDatabase())
+
+  describe('getFormFeedbackCount', () => {
+    const countSpy = jest.spyOn(FormFeedback, 'countDocuments')
+    beforeEach(async () => {
+      await dbHandler.clearCollection(FormFeedback.collection.name)
+    })
+    afterEach(() => jest.clearAllMocks())
+
+    it('should return correct feedback counts', async () => {
+      // Arrange
+      // Insert 3 form feedbacks.
+      const validFormId = new ObjectId()
+      const expectedFeedbackCount = 3
+      const feedbackPromises = times(expectedFeedbackCount, (count) =>
+        FormFeedback.create({
+          comment: `test feedback ${count}`,
+          formId: validFormId,
+          rating: 5,
+        }),
+      )
+      await Promise.all(feedbackPromises)
+
+      // Act
+      const actualResult = await FeedbackService.getFormFeedbackCount(
+        validFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedFeedbackCount)
+      expect(countSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return 0 feedback count when form has no feedback', async () => {
+      // Arrange
+      const formWithNoFeedback = new ObjectId().toHexString()
+
+      // Act
+      const actualResult = await FeedbackService.getFormFeedbackCount(
+        formWithNoFeedback,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(0)
+      expect(countSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return DatabaseError when error occurs whilst querying database', async () => {
+      // Arrange
+      const validFormId = new ObjectId().toHexString()
+      countSpy.mockImplementationOnce(
+        () =>
+          (({
+            exec: () => Promise.reject(new Error('boom')),
+          } as unknown) as mongoose.Query<any>),
+      )
+
+      // Act
+      const actualResult = await FeedbackService.getFormFeedbackCount(
+        validFormId,
+      )
+
+      // Assert
+      expect(countSpy).toHaveBeenCalledWith({
+        formId: validFormId,
+      })
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+  })
+})

--- a/src/app/modules/feedback/feedback.service.ts
+++ b/src/app/modules/feedback/feedback.service.ts
@@ -15,7 +15,6 @@ const logger = createLoggerWithLabel(module)
  * @param formId the form id to retrieve feedback counts for
  * @returns ok(form feedback count)
  * @returns err(DatabaseError) if database query errors
- * @
  */
 export const getFormFeedbackCount = (
   formId: string,

--- a/src/app/modules/feedback/feedback.service.ts
+++ b/src/app/modules/feedback/feedback.service.ts
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose'
+import { ResultAsync } from 'neverthrow'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import getFormFeedbackModel from '../../models/form_feedback.server.model'
+import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
+import { DatabaseError } from '../core/core.errors'
+
+const FormFeedbackModel = getFormFeedbackModel(mongoose)
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Returns number of form feedback for given form id.
+ *
+ * @param formId the form id to retrieve feedback counts for
+ * @returns ok(form feedback count)
+ * @returns err(DatabaseError) if database query errors
+ * @
+ */
+export const getFormFeedbackCount = (
+  formId: string,
+): ResultAsync<number, DatabaseError> => {
+  return ResultAsync.fromPromise(
+    FormFeedbackModel.countDocuments({ formId }).exec(),
+    (error) => {
+      logger.error({
+        message: 'Error counting feedback documents from database',
+        meta: {
+          action: 'getFormFeedbackCount',
+          formId,
+        },
+        error,
+      })
+
+      return new DatabaseError(getMongoErrorMessage(error))
+    },
+  )
+}

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -5,6 +5,7 @@ import { err, errAsync, ok, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
 import { DatabaseError } from 'src/app/modules/core/core.errors'
+import * as FeedbackService from 'src/app/modules/feedback/feedback.service'
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 import { IPopulatedForm, IPopulatedUser } from 'src/types'
@@ -26,6 +27,8 @@ import {
 import * as AdminFormService from '../admin-form.service'
 import * as AdminFormUtils from '../admin-form.utils'
 
+jest.mock('src/app/modules/feedback/feedback.service')
+const MockFeedbackService = mocked(FeedbackService)
 jest.mock('src/app/modules/submission/submission.service')
 const MockSubmissionService = mocked(SubmissionService)
 jest.mock('../admin-form.service')
@@ -264,6 +267,7 @@ describe('admin-form.controller', () => {
       })
     })
   })
+
   describe('handleCountFormSubmissions', () => {
     const MOCK_USER_ID = new ObjectId()
     const MOCK_FORM_ID = new ObjectId()
@@ -415,7 +419,7 @@ describe('admin-form.controller', () => {
       expect(readPermsSpy).toHaveBeenCalledWith(MOCK_USER, MOCK_FORM)
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(403)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -452,7 +456,7 @@ describe('admin-form.controller', () => {
       )
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -489,7 +493,7 @@ describe('admin-form.controller', () => {
       )
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(410)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -561,7 +565,7 @@ describe('admin-form.controller', () => {
       expect(MockFormService.retrieveFullFormById).not.toHaveBeenCalled()
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(422)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -592,7 +596,7 @@ describe('admin-form.controller', () => {
       expect(MockFormService.retrieveFullFormById).not.toHaveBeenCalled()
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -629,7 +633,7 @@ describe('admin-form.controller', () => {
       )
       expect(
         MockSubmissionService.getFormSubmissionsCount,
-      ).not.toHaveBeenCalledWith()
+      ).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,
@@ -676,6 +680,318 @@ describe('admin-form.controller', () => {
         startDate: undefined,
         endDate: undefined,
       })
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+  })
+
+  describe('handleCountFormFeedback', () => {
+    const MOCK_USER_ID = new ObjectId()
+    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER: Partial<IPopulatedUser> = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    }
+    const MOCK_FORM: Partial<IPopulatedForm> = {
+      admin: MOCK_USER as IPopulatedUser,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    }
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID.toHexString(),
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    it('should return 200 with feedback counts of given form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock return count.
+      const expectedFeedbackCount = 53
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      const readPermsSpy = jest
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
+        .mockReturnValueOnce(ok(true))
+      MockFeedbackService.getFormFeedbackCount.mockReturnValueOnce(
+        okAsync(expectedFeedbackCount),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(readPermsSpy).toHaveBeenCalledWith(MOCK_USER, MOCK_FORM)
+      expect(MockFeedbackService.getFormFeedbackCount).toHaveBeenCalledWith(
+        String(MOCK_FORM._id),
+      )
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith(expectedFeedbackCount)
+    })
+
+    it('should return 403 when ForbiddenFormError is returned when verifying user permissions', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      // Mock error here.
+      const expectedErrorString = 'no read access'
+      const readPermsSpy = jest
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
+        .mockReturnValueOnce(err(new ForbiddenFormError(expectedErrorString)))
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(readPermsSpy).toHaveBeenCalledWith(MOCK_USER, MOCK_FORM)
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 404 when FormNotFoundError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is not found'
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 410 when FormDeletedError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is deleted'
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 422 when MissingUserError is returned when retrieving logged in user', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'user is not found'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).not.toHaveBeenCalled()
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving user in session', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'database goes boom'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).not.toHaveBeenCalled()
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving populated form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'database goes boom'
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving form feedback count', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      const readPermsSpy = jest
+        .spyOn(AdminFormUtils, 'assertHasReadPermissions')
+        .mockReturnValueOnce(ok(true))
+      const expectedErrorString = 'database goes boom'
+      MockFeedbackService.getFormFeedbackCount.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(readPermsSpy).toHaveBeenCalledWith(MOCK_USER, MOCK_FORM)
+      expect(MockFeedbackService.getFormFeedbackCount).toHaveBeenCalledWith(
+        String(MOCK_FORM._id),
+      )
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expectedErrorString,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -862,6 +862,45 @@ describe('admin-form.controller', () => {
       })
     })
 
+    it('should return 410 when FormDeletedError is returned when checking form availability', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      // Mock error when checking form availability.
+      const expectedErrorString = 'form is archived'
+      const utilSpy = jest
+        .spyOn(AdminFormUtils, 'assertFormAvailable')
+        .mockReturnValueOnce(err(new FormDeletedError(expectedErrorString)))
+
+      // Act
+      await AdminFormController.handleCountFormFeedback(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID.toHexString(),
+      )
+      expect(utilSpy).toHaveBeenCalledWith(MOCK_FORM)
+      expect(MockFeedbackService.getFormFeedbackCount).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
     it('should return 422 when MissingUserError is returned when retrieving logged in user', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -4,6 +4,7 @@ import { ParamsDictionary } from 'express-serve-static-core'
 import { createLoggerWithLabel } from '../../../../config/logger'
 import { AuthType, WithForm } from '../../../../types'
 import { createReqMeta } from '../../../utils/request'
+import * as FeedbackService from '../../feedback/feedback.service'
 import * as SubmissionService from '../../submission/submission.service'
 import * as UserService from '../../user/user.service'
 import * as FormService from '../form.service'
@@ -251,4 +252,52 @@ export const passThroughSpcp: RequestHandler = (req, res, next) => {
     }
   }
   return next()
+}
+
+/**
+ * Handler for GET /{formId}/adminform/feedback/count.
+ * @security session
+ *
+ * @returns 200 with feedback counts of given form
+ * @returns 403 when user does not have permissions to access form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+export const handleCountFormFeedback: RequestHandler<{
+  formId: string
+}> = async (req, res) => {
+  const { formId } = req.params
+  const sessionUserId = (req.session as Express.AuthedSession).user._id
+
+  return (
+    // Step 1: Retrieve currently logged in user.
+    UserService.getPopulatedUserById(sessionUserId)
+      .andThen((user) =>
+        // Step 2: Retrieve full form.
+        FormService.retrieveFullFormById(formId).andThen((fullForm) =>
+          // Step 3: Check whether current user has read permissions to form.
+          assertHasReadPermissions(user, fullForm),
+        ),
+      )
+      // Step 4: Retrieve form feedback counts.
+      .andThen(() => FeedbackService.getFormFeedbackCount(formId))
+      .map((feedbackCount) => res.json(feedbackCount))
+      // Some error occurred earlier in the chain.
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error retrieving form feedback count',
+          meta: {
+            action: 'handleCountFormFeedback',
+            ...createReqMeta(req),
+            userId: sessionUserId,
+            formId,
+          },
+          error,
+        })
+        const { errorMessage, statusCode } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
 }

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -277,11 +277,14 @@ export const handleCountFormFeedback: RequestHandler<{
       .andThen((user) =>
         // Step 2: Retrieve full form.
         FormService.retrieveFullFormById(formId).andThen((fullForm) =>
-          // Step 3: Check whether current user has read permissions to form.
-          assertHasReadPermissions(user, fullForm),
+          // Step 3: Check whether form is active.
+          assertFormAvailable(fullForm).andThen(() =>
+            // Step 4: Check whether current user has read permissions to form.
+            assertHasReadPermissions(user, fullForm),
+          ),
         ),
       )
-      // Step 4: Retrieve form feedback counts.
+      // Step 5: Retrieve form feedback counts.
       .andThen(() => FeedbackService.getFormFeedbackCount(formId))
       .map((feedbackCount) => res.json(feedbackCount))
       // Some error occurred earlier in the chain.

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -284,7 +284,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback/count')
-    .get(authActiveForm(PermissionLevel.Read), adminForms.countFeedback)
+    .get(withUserAuthentication, AdminFormController.handleCountFormFeedback)
 
   /**
    * Stream download all feedback for a form


### PR DESCRIPTION
This PR builds upon the work done in #703 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates the old controller functions for the `/:formId([a-fA-F0-9]{24})/adminform/feedback/count` endpoint.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- Add `FeedbackService#getFormFeedbackCount` function
- Add `AdminFormController#handleCountFormFeedback` handler function

**Improvements**:

- Use new `AdminFormController#handleCountFormFeedback` function in admin form route for retrieving feedback counts.

## Tests
<!-- What tests should be run to confirm functionality? -->
New tests have been written for all the new migrated functions.
Note that route level integration tests have not been written yet.