### PR TITLE
feat: migrate get encrypt metadata endpoint controller to TypeScript

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -22,6 +22,7 @@ import {
   getEncryptedSubmissionData,
   getSubmissionCursor,
   getSubmissionMetadata,
+  getSubmissionMetadataList,
   transformAttachmentMetasToSignedUrls,
   transformAttachmentMetaStream,
 } from '../encrypt-submission.service'
@@ -611,6 +612,84 @@ describe('encrypt-submission.service', () => {
         new DatabaseError(mockErrorString),
       )
       expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
+    })
+  })
+
+  describe('getSubmissionMetadataList', () => {
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+
+    it('should return metadata list successfully without page param', async () => {
+      // Arrange
+      const expectedResult = {
+        metadata: [
+          {
+            number: 200,
+            refNo: new ObjectId().toHexString(),
+            submissionTime: 'some submission time',
+          },
+        ],
+        count: 1,
+      }
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findAllMetadataByFormId')
+        .mockResolvedValueOnce(expectedResult)
+
+      // Act
+      const actualResult = await getSubmissionMetadataList(MOCK_FORM_ID)
+
+      // Arrange
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedResult)
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, { page: undefined })
+    })
+
+    it('should return metadata list successfully with page param', async () => {
+      // Arrange
+      const mockPageNumber = 200
+      const expectedResult = {
+        metadata: [
+          {
+            number: 9,
+            refNo: new ObjectId().toHexString(),
+            submissionTime: 'another submission time',
+          },
+        ],
+        count: 1,
+      }
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findAllMetadataByFormId')
+        .mockResolvedValueOnce(expectedResult)
+
+      // Act
+      const actualResult = await getSubmissionMetadataList(
+        MOCK_FORM_ID,
+        mockPageNumber,
+      )
+
+      // Arrange
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedResult)
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, {
+        page: mockPageNumber,
+      })
+    })
+
+    it('should return DatabaseError when database error occurs', async () => {
+      // Arrange
+      const mockErrorString = 'some database error message'
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findAllMetadataByFormId')
+        .mockRejectedValueOnce(new Error(mockErrorString))
+
+      // Act
+      const actualResult = await getSubmissionMetadataList(MOCK_FORM_ID)
+
+      // Arrange
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(mockErrorString),
+      )
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, { page: undefined })
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -11,12 +11,17 @@ import {
 } from 'src/app/modules/core/core.errors'
 import { CreatePresignedUrlError } from 'src/app/modules/form/admin-form/admin-form.errors'
 import { aws } from 'src/config/config'
-import { SubmissionCursorData, SubmissionData } from 'src/types'
+import {
+  SubmissionCursorData,
+  SubmissionData,
+  SubmissionMetadata,
+} from 'src/types'
 
 import { SubmissionNotFoundError } from '../../submission.errors'
 import {
   getEncryptedSubmissionData,
   getSubmissionCursor,
+  getSubmissionMetadata,
   transformAttachmentMetasToSignedUrls,
   transformAttachmentMetaStream,
 } from '../encrypt-submission.service'
@@ -522,6 +527,90 @@ describe('encrypt-submission.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toEqual(
         new CreatePresignedUrlError('Failed to create attachment URL'),
       )
+    })
+  })
+
+  describe('getSubmissionMetadata', () => {
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+
+    it('should return metadata successfully', async () => {
+      // Arrange
+      const mockSubmissionId = new ObjectId().toHexString()
+      const expectedMetadata: SubmissionMetadata = {
+        number: 200,
+        refNo: mockSubmissionId,
+        submissionTime: 'some submission time',
+      }
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findSingleMetadata')
+        .mockResolvedValueOnce(expectedMetadata)
+
+      // Act
+      const actualResult = await getSubmissionMetadata(
+        MOCK_FORM_ID,
+        mockSubmissionId,
+      )
+
+      // Arrange
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedMetadata)
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
+    })
+
+    it('should return null when given submissionId is not valid', async () => {
+      // Arrange
+      const invalidSubmissionId = 'not an id at all'
+
+      // Act
+      const actualResult = await getSubmissionMetadata(
+        MOCK_FORM_ID,
+        invalidSubmissionId,
+      )
+
+      // Arrange
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(null)
+    })
+
+    it('should return null when query returns null', async () => {
+      // Arrange
+      const mockSubmissionId = new ObjectId().toHexString()
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findSingleMetadata')
+        .mockResolvedValueOnce(null)
+
+      // Act
+      const actualResult = await getSubmissionMetadata(
+        MOCK_FORM_ID,
+        mockSubmissionId,
+      )
+
+      // Arrange
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(null)
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
+    })
+
+    it('should return DatabaseError when database error occurs', async () => {
+      // Arrange
+      const mockSubmissionId = new ObjectId().toHexString()
+      const mockErrorString = 'some database error message'
+      const getMetaSpy = jest
+        .spyOn(EncryptSubmission, 'findSingleMetadata')
+        .mockRejectedValueOnce(new Error(mockErrorString))
+
+      // Act
+      const actualResult = await getSubmissionMetadata(
+        MOCK_FORM_ID,
+        mockSubmissionId,
+      )
+
+      // Arrange
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(mockErrorString),
+      )
+      expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -216,7 +216,7 @@ export const handleGetMetadata: RequestHandler<
   { formId: string },
   unknown,
   unknown,
-  Query & { page: number; submissionId?: string }
+  Query & { page?: number; submissionId?: string }
 > = async (req, res) => {
   const { formId } = req.params
   const { page, submissionId } = req.query

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -11,6 +11,8 @@ import { createReqMeta } from '../../../utils/request'
 import {
   getEncryptedSubmissionData,
   getSubmissionCursor,
+  getSubmissionMetadata,
+  getSubmissionMetadataList,
   transformAttachmentMetasToSignedUrls,
   transformAttachmentMetaStream,
 } from './encrypt-submission.service'
@@ -201,4 +203,67 @@ export const handleGetEncryptedResponse: RequestHandler<
   }
 
   return res.json(responseData)
+}
+
+/**
+ * Handler for GET /:formId([a-fA-F0-9]{24})/adminform/submissions/metadata
+ *
+ * @returns 200 with single submission metadata if query.submissionId is provided
+ * @returns 200 with list of submission metadata with total count (and optional offset if query.page is provided) if query.submissionId is not provided
+ * @returns 500 if any errors occurs whilst querying database
+ */
+export const handleGetMetadata: RequestHandler<
+  { formId: string },
+  unknown,
+  unknown,
+  Query & { page: number; submissionId?: string }
+> = async (req, res) => {
+  const { formId } = req.params
+  const { page, submissionId } = req.query
+
+  const logMeta = {
+    action: 'handleGetMetadata',
+    formId,
+    submissionId,
+    page,
+    ...createReqMeta(req),
+  }
+
+  // Specific query.
+  if (submissionId) {
+    return getSubmissionMetadata(formId, submissionId)
+      .map((metadata) => {
+        return metadata
+          ? res.json({ metadata: [metadata], count: 1 })
+          : res.json({ metadata: [], count: 0 })
+      })
+      .mapErr((error) => {
+        logger.error({
+          message: 'Failure retrieving metadata from database',
+          meta: logMeta,
+          error,
+        })
+
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      })
+  }
+
+  // General query
+  return getSubmissionMetadataList(formId, page)
+    .map((result) => res.json(result))
+    .mapErr((error) => {
+      logger.error({
+        message: 'Failure retrieving metadata list from database',
+        meta: logMeta,
+        error,
+      })
+
+      const { statusCode, errorMessage } = mapRouteError(error)
+      return res.status(statusCode).json({
+        message: errorMessage,
+      })
+    })
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -235,3 +235,27 @@ export const getSubmissionMetadata = (
     },
   )
 }
+
+export const getSubmissionMetadataList = (
+  formId: string,
+  page?: number,
+): ResultAsync<
+  { metadata: SubmissionMetadata[]; count: number },
+  DatabaseError
+> => {
+  return ResultAsync.fromPromise(
+    EncryptSubmissionModel.findAllMetadataByFormId(formId, { page }),
+    (error) => {
+      logger.error({
+        message: 'Failure retrieving metadata page from database',
+        meta: {
+          action: 'getSubmissionMetadataList',
+          formId,
+          page,
+        },
+        error,
+      })
+      return new DatabaseError(getMongoErrorMessage(error))
+    },
+  )
+}

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -452,8 +452,11 @@ module.exports = function (app) {
     authEncryptedResponseAccess,
     celebrate({
       [Segments.QUERY]: {
-        page: Joi.number().min(1).required(),
         submissionId: Joi.string().optional(),
+        page: Joi.number().min(1).when('submissionId', {
+          not: Joi.exist(),
+          then: Joi.required(),
+        }),
       },
     }),
     EncryptSubmissionController.handleGetMetadata,

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -456,7 +456,7 @@ module.exports = function (app) {
         submissionId: Joi.string().optional(),
       },
     }),
-    encryptSubmissions.getMetadata,
+    EncryptSubmissionController.handleGetMetadata,
   )
 
   /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Building upon #601, this PR migrates the rest of the controller into Typescript.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `EncryptSubSvc#getSubmissionMetadata` service fn to use model static method
- add `EncryptSubSvc#getSubmissionMetadataList` service fn to use model static method
- add `EncryptSubCtl#handleGetMetadata` handler fn for route endpoint

**Improvements**:

- Tighten (or relax depending on your POV) Joi validation on metadata retrieval endpoint
  - `query.page` is now optional iff `query.submissionId` exists, since singular submission metadata search does not require the page parameter.

## Tests
<!-- What tests should be run to confirm functionality? -->
Add tests for all new methods. 
Note that route integration tests are not done in this PR, and will be done when route also gets refactored.
