### PR TITLE
fix(AdminFormRoutes): add Joi validation on /submissions endpoint

### DIFF
--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -400,12 +400,17 @@ module.exports = function (app) {
    * @returns {Object} 200 - Response document
    * @security OTP
    */
-  app
-    .route('/:formId([a-fA-F0-9]{24})/adminform/submissions')
-    .get(
-      authEncryptedResponseAccess,
-      EncryptSubmissionController.handleGetEncryptedResponse,
-    )
+  app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions').get(
+    authEncryptedResponseAccess,
+    celebrate({
+      [Segments.QUERY]: {
+        submissionId: Joi.string()
+          .regex(/^[0-9a-fA-F]{24}$/)
+          .required(),
+      },
+    }),
+    EncryptSubmissionController.handleGetEncryptedResponse,
+  )
 
   /**
    * Count the number of submissions for a public form


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds Joi validation on `adminform/submissions` endpoint. The handler is expecting a string based submissionId.

No issues regardless on prod, since all errors are caught properly. 

Current behavior (prior to this fix):
- If submissionId is not provided, 404 will be returned.
- If submissionId is malformed (i.e. not a 24length string), 500 will be returned due to inability to cast the id to an object.
- Frontend always passes query.submissionId to request string.
