### PR TITLE
docs: add script for unlisting array of forms

### DIFF
--- a/docs/MONGODB.md
+++ b/docs/MONGODB.md
@@ -35,6 +35,34 @@ function unlistFormFromExamples(id) {
 // unlistFormFromExamples("form id")
 ```
 
+```javascript
+/**
+ * Unlist an array of forms from the examples page
+ * @param  {String[]} ids of the forms. These can be any string
+ * where the first sequence of 24 consecutive alphanumerics is the
+ * form ID, e.g. the form link.
+ */
+function unlistFormArrayFromExamples(ids) {
+  const formIdRegex = /[0-9a-fA-F]{24}/
+  // Wrap all ids in ObjectId
+  const objectIds = []
+  for (let id of ids) {
+    const parsed = formIdRegex.exec(id)
+    if (parsed) {
+      objectIds.push(ObjectId(parsed[0]))
+    } else {
+      throw new Error(`${id} does not contain a valid form ID.`)
+    }
+  }
+  const result = db
+    .getCollection('forms')
+    .updateMany({ _id: { $in: objectIds } }, { $set: { isListed: false } })
+  return `${ids.length} forms given, ${result.matchedCount} matched, ${result.modifiedCount} modified`
+}
+// const ids = ['https://some.url/5f8817b7bde9d4002a800d78', 'some.url/#!/5f9a587b119c07002b56124f']
+// unlistFormArrayFromExamples(ids)
+```
+
 - **Create new agency**
 
 ```javascript


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Unlisting several forms at once is a common database operation which can take prohibitively long if there are many (e.g. hundreds) of forms to unlist at once.

## Solution
<!-- How did you solve the problem? -->

Add a function to our MongoDB scripts which unlists an array of form IDs. Since the forms to unlist are often given as form links and not object IDs, include a parsing step so any string can be passed into the function as an array element, as long as it contains the form ID.