### PR TITLE
fix: ensure [MyInfo] prefix appears in admin preview

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -177,7 +177,9 @@ export const getMockSpcpLocals = (
   formFields: IFieldSchema[] | undefined,
 ): SpcpLocals => {
   const myInfoFieldIds: string[] = formFields
-    ? formFields.filter((field) => field.myInfo?.attr).map((field) => field._id)
+    ? formFields
+        .filter((field) => field.myInfo?.attr)
+        .map((field) => field._id.toString())
     : []
   switch (authType) {
     case AuthType.SP:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The [MyInfo] prefix is supposed to show for all MyInfo fields for admin preview submissions in email mode, but they currently do not.

## Solution
<!-- How did you solve the problem? -->

The bug was that ObjectIds were not being converted to strings before being added to the set of hashed fields.

## Screenshots
![image](https://user-images.githubusercontent.com/29480346/100040219-ca7eed80-2e41-11eb-94bd-9110704968bf.png)
