### PR TITLE
feat(utils): add exhaustive switch case typeguard

### DIFF
--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -4,6 +4,7 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { IFormSchema, IPopulatedForm, Status } from '../../../types'
 import getFormModel from '../../models/form.server.model'
+import { assertUnreachable } from '../../utils/assert-unreachable'
 import { ApplicationError, DatabaseError } from '../core/core.errors'
 
 import {
@@ -67,6 +68,10 @@ export const retrieveFullFormById = (
 export const isFormPublic = (
   form: IPopulatedForm,
 ): Result<true, FormDeletedError | PrivateFormError | ApplicationError> => {
+  if (!form.status) {
+    return err(new ApplicationError())
+  }
+
   switch (form.status) {
     case Status.Public:
       return ok(true)
@@ -75,14 +80,6 @@ export const isFormPublic = (
     case Status.Private:
       return err(new PrivateFormError(form.inactiveMessage))
     default:
-      logger.error({
-        message: 'Encountered invalid form status',
-        meta: {
-          action: 'isFormPublic',
-          formStatus: form.status,
-          form,
-        },
-      })
-      return err(new ApplicationError())
+      return assertUnreachable(form.status)
   }
 }

--- a/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
@@ -46,9 +46,11 @@ describe('submission.utils', () => {
     })
 
     it('should throw error if called with invalid responseMode', async () => {
+      // Arrange
+      const invalidResponseMode = 'something' as ResponseMode
       // Act + Assert
-      expect(() => getModeFilter(undefined!)).toThrowError(
-        'getResponsesForEachField: Invalid response mode parameter',
+      expect(() => getModeFilter(invalidResponseMode)).toThrowError(
+        `This should never be reached in TypeScript: "${invalidResponseMode}"`,
       )
     })
   })

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -1,18 +1,21 @@
 import { BasicField, ResponseMode } from '../../../types'
+import { assertUnreachable } from '../../utils/assert-unreachable'
 import { FIELDS_TO_REJECT } from '../../utils/field-validation/config'
 
 type ModeFilterParam = {
   fieldType: BasicField
 }
 
-export const getModeFilter = (responseMode: ResponseMode) => {
+export const getModeFilter = (
+  responseMode: ResponseMode,
+): (<T extends ModeFilterParam>(responses: T[]) => T[]) => {
   switch (responseMode) {
     case ResponseMode.Email:
       return emailModeFilter
     case ResponseMode.Encrypt:
       return encryptModeFilter
     default:
-      throw Error('getResponsesForEachField: Invalid response mode parameter')
+      return assertUnreachable(responseMode)
   }
 }
 

--- a/src/app/utils/assert-unreachable.ts
+++ b/src/app/utils/assert-unreachable.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript type guard that asserts that all switch cases are exhaustive.
+ * Use to get compile-time safety for making sure all the cases are handled.
+ *
+ * See:
+ * https://stackoverflow.com/questions/39419170/how-do-i-check-that-a-switch-block-is-exhaustive-in-typescript
+ */
+export const assertUnreachable = (switchCase: never): never => {
+  throw new Error(`This should never be reached in TypeScript: "${switchCase}"`)
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds an utility to allow for compile time checks to switch blocks if the switch cases should be exhaustive.
Application will fail to compile if the switch cases are not exhaustive.