### PR TITLE
refactor(field-validation): simplify

### DIFF
--- a/src/app/utils/field-validation/validators/nricValidator.ts
+++ b/src/app/utils/field-validation/validators/nricValidator.ts
@@ -1,5 +1,5 @@
 import { chain, left, right } from 'fp-ts/lib/Either'
-import { pipe } from 'fp-ts/lib/function'
+import { flow } from 'fp-ts/lib/function'
 
 import { ResponseValidator } from 'src/types/field/utils/validation'
 import { ISingleAnswerResponse } from 'src/types/response'
@@ -17,6 +17,5 @@ const nricValidator: NricValidator = (response) => {
     : left(`NricValidator:\tanswer is not a valid NRIC`)
 }
 
-export const constructNricValidator: NricValidatorConstructor = () => (
-  response,
-) => pipe(notEmptySingleAnswerResponse(response), chain(nricValidator))
+export const constructNricValidator: NricValidatorConstructor = () =>
+  flow(notEmptySingleAnswerResponse, chain(nricValidator))

--- a/src/app/utils/field-validation/validators/radioButtonValidator.ts
+++ b/src/app/utils/field-validation/validators/radioButtonValidator.ts
@@ -1,5 +1,5 @@
 import { chain, left, right } from 'fp-ts/lib/Either'
-import { pipe } from 'fp-ts/lib/function'
+import { flow } from 'fp-ts/lib/function'
 
 import { IRadioField } from 'src/types/field'
 import { ResponseValidator } from 'src/types/field/utils/validation'
@@ -13,7 +13,7 @@ type RadioButtonValidatorConstructor = (
   radioButtonField: IRadioField,
 ) => RadioButtonValidator
 
-const radioButtonValidator: RadioButtonValidatorConstructor = (
+const makeRadioOptionsValidator: RadioButtonValidatorConstructor = (
   radioButtonField,
 ) => (response) => {
   const { answer } = response
@@ -29,8 +29,8 @@ const radioButtonValidator: RadioButtonValidatorConstructor = (
 
 export const constructRadioButtonValidator: RadioButtonValidatorConstructor = (
   radioButtonField,
-) => (response) =>
-  pipe(
-    notEmptySingleAnswerResponse(response),
-    chain(radioButtonValidator(radioButtonField)),
+) =>
+  flow(
+    notEmptySingleAnswerResponse,
+    chain(makeRadioOptionsValidator(radioButtonField)),
   )

--- a/src/app/utils/field-validation/validators/ratingValidator.ts
+++ b/src/app/utils/field-validation/validators/ratingValidator.ts
@@ -1,5 +1,5 @@
 import { chain, left, right } from 'fp-ts/lib/Either'
-import { pipe } from 'fp-ts/lib/function'
+import { flow } from 'fp-ts/lib/function'
 import isInt from 'validator/lib/isInt'
 
 import { IRatingField } from 'src/types/field'
@@ -11,7 +11,7 @@ import { notEmptySingleAnswerResponse } from './common'
 type RatingValidator = ResponseValidator<ISingleAnswerResponse>
 type RatingValidatorConstructor = (ratingField: IRatingField) => RatingValidator
 
-const ratingValidator: RatingValidatorConstructor = (ratingField) => (
+const makeRatingLimitsValidator: RatingValidatorConstructor = (ratingField) => (
   response,
 ) => {
   const { answer } = response
@@ -30,8 +30,8 @@ const ratingValidator: RatingValidatorConstructor = (ratingField) => (
 
 export const constructRatingValidator: RatingValidatorConstructor = (
   ratingField,
-) => (response) =>
-  pipe(
-    notEmptySingleAnswerResponse(response),
-    chain(ratingValidator(ratingField)),
+) =>
+  flow(
+    notEmptySingleAnswerResponse,
+    chain(makeRatingLimitsValidator(ratingField)),
   )

--- a/src/app/utils/field-validation/validators/textValidator.ts
+++ b/src/app/utils/field-validation/validators/textValidator.ts
@@ -1,5 +1,5 @@
 import { chain, left, right } from 'fp-ts/lib/Either'
-import { pipe } from 'fp-ts/lib/function'
+import { flow } from 'fp-ts/lib/function'
 
 import { ILongTextField, IShortTextField } from 'src/types/field'
 import { ResponseValidator } from 'src/types/field/utils/validation'
@@ -66,13 +66,8 @@ const lengthValidator: TextFieldValidatorConstructor = (textField) => {
   }
 }
 
-const constructTextValidator: TextFieldValidatorConstructor = (textField) => (
-  response,
-) => {
-  return pipe(
-    notEmptySingleAnswerResponse(response),
-    chain(lengthValidator(textField)),
-  )
+const constructTextValidator: TextFieldValidatorConstructor = (textField) => {
+  return flow(notEmptySingleAnswerResponse, chain(lengthValidator(textField)))
 }
 
 export default constructTextValidator

--- a/src/app/utils/field-validation/validators/textValidator.ts
+++ b/src/app/utils/field-validation/validators/textValidator.ts
@@ -53,7 +53,7 @@ const exactLengthValidator: TextFieldValidatorConstructor = (textField) => (
       )
 }
 
-const lengthValidator: TextFieldValidatorConstructor = (textField) => {
+const getLengthValidator: TextFieldValidatorConstructor = (textField) => {
   switch (textField.ValidationOptions.selectedValidation) {
     case TextSelectedValidation.Exact:
       return exactLengthValidator(textField)
@@ -67,7 +67,10 @@ const lengthValidator: TextFieldValidatorConstructor = (textField) => {
 }
 
 const constructTextValidator: TextFieldValidatorConstructor = (textField) => {
-  return flow(notEmptySingleAnswerResponse, chain(lengthValidator(textField)))
+  return flow(
+    notEmptySingleAnswerResponse,
+    chain(getLengthValidator(textField)),
+  )
 }
 
 export default constructTextValidator

--- a/src/app/utils/field-validation/validators/textValidator.ts
+++ b/src/app/utils/field-validation/validators/textValidator.ts
@@ -53,18 +53,16 @@ const exactLengthValidator: TextFieldValidatorConstructor = (textField) => (
       )
 }
 
-const lengthValidator: TextFieldValidatorConstructor = (textField) => (
-  response,
-) => {
+const lengthValidator: TextFieldValidatorConstructor = (textField) => {
   switch (textField.ValidationOptions.selectedValidation) {
     case TextSelectedValidation.Exact:
-      return exactLengthValidator(textField)(response)
+      return exactLengthValidator(textField)
     case TextSelectedValidation.Minimum:
-      return minLengthValidator(textField)(response)
+      return minLengthValidator(textField)
     case TextSelectedValidation.Maximum:
-      return maxLengthValidator(textField)(response)
+      return maxLengthValidator(textField)
     default:
-      return right(response)
+      return right
   }
 }
 


### PR DESCRIPTION
This is a series of small (and somewhat vain) refactors to the existing TypeScript field validators.

## `pipe` vs `flow`

This code:
```
(field) => (response) => pipe(validator1(response), makeValidator2(field))
```
is the same as this:
```
(field) => (response) => pipe(response, validator1, makeValidator2(field))
```
where, instead of explicitly calling `validator1` with `response`, we just `pipe` `response` through `validator1`. Notice that all the inner anonymous function is doing is passing on its argument as the first argument to `pipe`. In fact, this is why the `flow` function exists: instead of calling a series of unary functions, chain them together and return a unary function whose argument is the input of the first function in the chain. We end up with:
```
(field) => flow(validator1, makeValidator2(field))
```
which imo is much cleaner.

## Reducing indirection
- In `textValidator`, the `lengthValidator` goes up two levels of indirection (`field => response => {...}`) and then back down two levels of indirection (by calling a bunch of higher-order functions twice). To me, it makes more sense for `lengthValidator` to just return the correct validator function (`field => callCorrectValidatorConstructor(field)`). Obviously the amount of indirection is still the same in the end, but I think it reads more clearly this way.
- Both `homePhoneNumberValidator` and `mobilePhoneNumberValidator` were higher-order functions where the outer function didn't take an argument. This means they don't need to be higher-order functions, and we can cut one level of indirection and just work with the validator function as first-class.

## Variable naming
Having a mix of functions which create validators and functions which are themselves validators can be confusing if they are all named the same way. I tried to prefix all validator constructors with the prefix `make` (e.g. `makeRatingLimitsValidator` instead of `ratingValidator`) to clarify this distinction.