### PR TITLE
ref: migrate get feedback flow to TypeScript

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -4,7 +4,6 @@
  * Module dependencies.
  */
 const mongoose = require('mongoose')
-const moment = require('moment-timezone')
 const _ = require('lodash')
 const { StatusCodes } = require('http-status-codes')
 
@@ -22,8 +21,6 @@ const {
   getEmailFormModel,
 } = require('../models/form.server.model')
 const getFormModel = require('../models/form.server.model').default
-const getFormFeedbackModel = require('../models/form_feedback.server.model')
-  .default
 const getSubmissionModel = require('../models/submission.server.model').default
 const { ResponseMode } = require('../../types')
 
@@ -413,51 +410,6 @@ function makeModule(connection) {
           )
           discriminatedForm.save(function (sErr, duplicated) {
             return sErr ? onError(sErr) : onSuccess(duplicated)
-          })
-        }
-      })
-    },
-    /**
-     * Return form feedback matching query
-     * @param  {Object} req - Express request object
-     * @param  {Object} res - Express response object
-     */
-    getFeedback: function (req, res) {
-      let FormFeedback = getFormFeedbackModel(connection)
-      let query = FormFeedback.find({ formId: req.form._id }).sort({
-        created: 1,
-      })
-      query.exec(function (err, feedback) {
-        if (err) {
-          return respondOnMongoError(req, res, err)
-        } else if (!feedback) {
-          return res
-            .status(StatusCodes.NOT_FOUND)
-            .json({ message: 'No feedback found' })
-        } else {
-          let sum = 0
-          let count = 0
-          feedback = feedback.map(function (element) {
-            sum += element.rating
-            count += 1
-            return {
-              index: count,
-              timestamp: moment(element.created).valueOf(),
-              rating: element.rating,
-              comment: element.comment,
-              date: moment(element.created)
-                .tz('Asia/Singapore')
-                .format('D MMM YYYY'),
-              dateShort: moment(element.created)
-                .tz('Asia/Singapore')
-                .format('D MMM'),
-            }
-          })
-          let average = count > 0 ? (sum / count).toFixed(2) : undefined
-          return res.json({
-            average: average,
-            count: count,
-            feedback: feedback,
           })
         }
       })

--- a/src/app/modules/feedback/feedback.service.ts
+++ b/src/app/modules/feedback/feedback.service.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash'
+import moment from 'moment-timezone'
 import mongoose from 'mongoose'
 import { ResultAsync } from 'neverthrow'
 
@@ -6,6 +8,8 @@ import { IFormFeedbackSchema } from '../../../types'
 import getFormFeedbackModel from '../../models/form_feedback.server.model'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
 import { DatabaseError } from '../core/core.errors'
+
+import { FeedbackResponse, ProcessedFeedback } from './feedback.types'
 
 const FormFeedbackModel = getFormFeedbackModel(mongoose)
 const logger = createLoggerWithLabel(module)
@@ -46,4 +50,62 @@ export const getFormFeedbackStream = (
   formId: string,
 ): mongoose.QueryCursor<IFormFeedbackSchema> => {
   return FormFeedbackModel.getFeedbackCursorByFormId(formId)
+}
+
+/**
+ * Returned processed object containing count of feedback, average rating, and
+ * list of feedback.
+ * @param formId the form to retrieve feedback for
+ * @returns ok(feedback response object) on success
+ * @returns err(DatabaseError) if database error occurs during query
+ */
+export const getFormFeedbacks = (
+  formId: string,
+): ResultAsync<FeedbackResponse, DatabaseError> => {
+  return ResultAsync.fromPromise(
+    FormFeedbackModel.find({ formId }).sort({ created: 1 }).exec(),
+    (error) => {
+      logger.error({
+        message: 'Error retrieving feedback documents from database',
+        meta: {
+          action: 'getFormFeedbacks',
+          formId,
+        },
+        error,
+      })
+
+      return new DatabaseError(getMongoErrorMessage(error))
+    },
+  ).map((feedbacks) => {
+    if (isEmpty(feedbacks)) {
+      return {
+        count: 0,
+        feedback: [],
+      }
+    }
+
+    // Process retrieved feedback.
+    const totalFeedbackCount = feedbacks.length
+    let totalRating = 0
+    const processedFeedback = feedbacks.map((fb, idx) => {
+      totalRating += fb.rating
+      const response: ProcessedFeedback = {
+        // 1-based indexing.
+        index: idx + 1,
+        timestamp: moment(fb.created).valueOf(),
+        rating: fb.rating,
+        comment: fb.comment ?? '',
+        date: moment(fb.created).tz('Asia/Singapore').format('D MMM YYYY'),
+        dateShort: moment(fb.created).tz('Asia/Singapore').format('D MMM'),
+      }
+
+      return response
+    })
+    const averageRating = (totalRating / totalFeedbackCount).toFixed(2)
+    return {
+      average: averageRating,
+      count: totalFeedbackCount,
+      feedback: processedFeedback,
+    }
+  })
 }

--- a/src/app/modules/feedback/feedback.types.ts
+++ b/src/app/modules/feedback/feedback.types.ts
@@ -1,0 +1,14 @@
+export type ProcessedFeedback = {
+  index: number
+  timestamp: number
+  rating: number
+  comment: string
+  date: string
+  dateShort: string
+}
+
+export type FeedbackResponse = {
+  average?: string
+  count: number
+  feedback: ProcessedFeedback[]
+}

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -269,7 +269,7 @@ module.exports = function (app) {
 
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback')
-    .get(authActiveForm(PermissionLevel.Read), adminForms.getFeedback)
+    .get(withUserAuthentication, AdminFormController.handleGetFormFeedbacks)
     .post(authActiveForm(PermissionLevel.Read), adminForms.passThroughFeedback)
 
   /**

--- a/src/types/form_feedback.ts
+++ b/src/types/form_feedback.ts
@@ -11,6 +11,8 @@ export interface IFormFeedback {
 
 export interface IFormFeedbackSchema extends IFormFeedback, Document {
   _id: Document['_id']
+  created?: Date
+  lastModified?: Date
 }
 export interface IFormFeedbackDocument extends IFormFeedbackSchema {
   created: Date

--- a/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
@@ -6,10 +6,6 @@ const roles = require('../helpers/roles')
 
 const User = dbHandler.makeModel('user.server.model', 'User')
 const Form = dbHandler.makeModel('form.server.model', 'Form')
-const FormFeedback = dbHandler.makeModel(
-  'form_feedback.server.model',
-  'FormFeedback',
-)
 const EmailForm = mongoose.model('email')
 
 const Controller = spec(
@@ -289,59 +285,6 @@ describe('Admin-Forms Controller', () => {
         })
       })
       Controller.transferOwner(req, res)
-    })
-  })
-
-  describe('getFeedback', () => {
-    it('should retrieve correct response based on saved FormFeedbacks', (done) => {
-      // Define feedback to be added to MongoMemoryServer db
-      let p1 = new FormFeedback({
-        formId: mongoose.Types.ObjectId('4edd40c86762e0fb12000003'),
-        rating: 2,
-        comment: 'nice',
-        created: '2018-05-18 09:12:07.126Z',
-      }).save()
-      let p2 = new FormFeedback({
-        formId: mongoose.Types.ObjectId('4edd40c86762e0fb12000003'),
-        rating: 5,
-        comment: 'great',
-        created: '2018-03-15 03:52:07.126Z',
-      }).save()
-
-      Promise.all([p1, p2]).then(([_r1, _r2]) => {
-        req.form = { _id: '4edd40c86762e0fb12000003' }
-        let expected = {
-          average: '3.50',
-          count: 2,
-          feedback: [
-            {
-              index: 2,
-              timestamp: 1526634727126,
-              rating: 2,
-              comment: 'nice',
-              date: '18 May 2018',
-              dateShort: '18 May',
-            },
-            {
-              index: 1,
-              timestamp: 1521085927126,
-              rating: 5,
-              comment: 'great',
-              date: '15 Mar 2018',
-              dateShort: '15 Mar',
-            },
-          ],
-        }
-        res.json.and.callFake((args) => {
-          expect(args.average).toEqual(expected.average)
-          expect(args.count).toEqual(expected.count)
-          expect(args.feedback.length).toEqual(2)
-          expect(args.feedback).toContain(expected.feedback[0])
-          expect(args.feedback).toContain(expected.feedback[1])
-          done()
-        })
-        Controller.getFeedback(req, res)
-      })
     })
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Same old, same old. This PR migrates the god controller function for getFeedback into the DDD architecture we all know and love.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `AdminFormCtl#handleGetFormFeedbacks` handler fn
- add `FeedbackSvc#getFormFeedbacks` fn

**Improvements**:

- Remove old Javascript `getFeedback` controller handler and replace with `AdminFormCtl#handleGetFormFeedbacks`

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests have been written for all new functions.
Note that integration tests are not written yet as the router is not yet migrated.
