### PR TITLE
fix: backend validation does not prevent responses on hidden fields

### DIFF
--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -40,7 +40,7 @@ export class ProcessingError extends ApplicationError {
  * A custom error class returned when given submission has field validation failure
  */
 export class ValidateFieldError extends ApplicationError {
-  constructor(message = 'Error validating field.') {
-    super(message)
+  constructor(message = 'Error validating field.', status = 400) {
+    super(message, status)
   }
 }

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -1,4 +1,5 @@
 import { Either, isLeft, left, right } from 'fp-ts/lib/Either'
+import { flattenDeep } from 'lodash'
 import { err, ok, Result } from 'neverthrow'
 
 import {
@@ -61,7 +62,7 @@ const isResponsePresentOnHiddenField = (response: FieldResponse): boolean => {
       return true
     }
   } else if (isProcessedTableResponse(response)) {
-    if (!response.isVisible && response.answerArray[0].length > 0) {
+    if (!response.isVisible && flattenDeep(response.answerArray).length > 0) {
       return true
     }
   } else if (isProcessedAttachmentResponse(response)) {

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -1,5 +1,4 @@
 import { Either, isLeft, left, right } from 'fp-ts/lib/Either'
-import { flattenDeep } from 'lodash'
 import { err, ok, Result } from 'neverthrow'
 
 import {
@@ -64,7 +63,7 @@ const isResponsePresentOnHiddenField = (response: FieldResponse): boolean => {
   } else if (isProcessedTableResponse(response)) {
     if (
       !response.isVisible &&
-      flattenDeep(response.answerArray).join('').length > 0
+      !response.answerArray.every((row) => row.every((elem) => elem === ''))
     ) {
       return true
     }

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -56,18 +56,15 @@ const isResponsePresentOnHiddenField = (response: FieldResponse): boolean => {
     if (!response.isVisible && response.answer.trim() !== '') {
       return true
     }
-  }
-  if (isProcessedCheckboxResponse(response)) {
+  } else if (isProcessedCheckboxResponse(response)) {
     if (!response.isVisible && response.answerArray.length > 0) {
       return true
     }
-  }
-  if (isProcessedTableResponse(response)) {
+  } else if (isProcessedTableResponse(response)) {
     if (!response.isVisible && response.answerArray[0].length > 0) {
       return true
     }
-  }
-  if (isProcessedAttachmentResponse(response)) {
+  } else if (isProcessedAttachmentResponse(response)) {
     if (!response.isVisible && response.filename.trim() !== '') {
       return true
     }

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -8,13 +8,7 @@ import {
 import { createLoggerWithLabel } from '../../../config/logger'
 import { IField } from '../../../types/field/baseField'
 import { BasicField } from '../../../types/field/fieldTypes'
-import {
-  FieldResponse,
-  IAttachmentResponse,
-  ICheckboxResponse,
-  ISingleAnswerResponse,
-  ITableResponse,
-} from '../../../types/response'
+import { FieldResponse } from '../../../types/response'
 import {
   isProcessedAttachmentResponse,
   isProcessedCheckboxResponse,
@@ -57,13 +51,7 @@ const doFieldTypesMatch = (
  * This may happen if a submission is made programatically to try and bypass form logic.
  * @param response The submitted response
  */
-const isResponsePresentOnHiddenField = (
-  response:
-    | ISingleAnswerResponse
-    | ICheckboxResponse
-    | ITableResponse
-    | IAttachmentResponse,
-): boolean => {
+const isResponsePresentOnHiddenField = (response: FieldResponse): boolean => {
   if (isProcessedSingleAnswerResponse(response)) {
     if (!response.isVisible && response.answer.trim() !== '') {
       return true

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -62,7 +62,10 @@ const isResponsePresentOnHiddenField = (response: FieldResponse): boolean => {
       return true
     }
   } else if (isProcessedTableResponse(response)) {
-    if (!response.isVisible && flattenDeep(response.answerArray).length > 0) {
+    if (
+      !response.isVisible &&
+      flattenDeep(response.answerArray).join('').length > 0
+    ) {
       return true
     }
   } else if (isProcessedAttachmentResponse(response)) {

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -6,6 +6,8 @@ import {
   ProcessedTableResponse,
 } from 'src/app/modules/submission/submission.types'
 
+import { ITableRow } from './index'
+
 const isProcessedFieldResponse = (
   response: any,
 ): response is ProcessedFieldResponse => {
@@ -39,19 +41,21 @@ export const isProcessedCheckboxResponse = (
   )
 }
 
+export const isTableRow = (row: any): row is ITableRow => {
+  return (
+    // Check that the row contains a single array of only string (including empty string)
+    Array.isArray(row) && row.every((elem: any) => typeof elem === 'string')
+  )
+}
+
 export const isProcessedTableResponse = (
   response: any,
 ): response is ProcessedTableResponse => {
   return (
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
-    // Check that all elements in answerArray are array (including empty array), and that
-    // all nested arrays contain only string (including empty string)
-    response.answerArray.every(
-      (arr: any) =>
-        Array.isArray(arr) &&
-        arr.every((elem: any) => typeof elem === 'string'),
-    ) &&
+    // Check that all elements in answerArray are table rows
+    response.answerArray.every((arr: any) => isTableRow(arr)) &&
     isProcessedFieldResponse(response)
   )
 }

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -51,13 +51,19 @@ export const isTableRow = (row: any): row is ITableRow => {
 export const isProcessedTableResponse = (
   response: any,
 ): response is ProcessedTableResponse => {
-  return (
+  if (
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
     // Check that all elements in answerArray are table rows
-    response.answerArray.every((arr: any) => isTableRow(arr)) &&
-    isProcessedFieldResponse(response)
-  )
+    response.answerArray.every((arr: any) => isTableRow(arr))
+  ) {
+    // Check that all arrays in answerArray have the same length
+    const subArrLength: number = response.answerArray[0].length
+    return response.answerArray
+      .map((arr: ITableRow): number => arr.length)
+      .every((length: number): boolean => length === subArrLength)
+  }
+  return false
 }
 
 export const isProcessedAttachmentResponse = (

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -33,6 +33,8 @@ export const isProcessedCheckboxResponse = (
   return (
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
+    // Check that all elements in answerArray are string (including empty string)
+    response.answerArray.every((elem: any) => typeof elem === 'string') &&
     isProcessedFieldResponse(response)
   )
 }
@@ -43,7 +45,13 @@ export const isProcessedTableResponse = (
   return (
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
-    Array.isArray(response.answerArray[0]) &&
+    // Check that all elements in answerArray are array (including empty array), and that
+    // all nested arrays contain only string (including empty string)
+    response.answerArray.every(
+      (arr: any) =>
+        Array.isArray(arr) &&
+        arr.every((elem: any) => typeof elem === 'string'),
+    ) &&
     isProcessedFieldResponse(response)
   )
 }

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -55,7 +55,9 @@ export const isProcessedTableResponse = (
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
     // Check that all elements in answerArray are table rows
-    response.answerArray.every((arr: any) => isTableRow(arr))
+    // Necessary to check answerArray[0] separately as every() returns true on empty array
+    response.answerArray.every((arr: any) => isTableRow(arr)) &&
+    isTableRow(response.answerArray[0])
   ) {
     // Check that all arrays in answerArray have the same length
     const subArrLength: number = response.answerArray[0].length

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -1,6 +1,9 @@
 import {
+  ProcessedAttachmentResponse,
+  ProcessedCheckboxResponse,
   ProcessedFieldResponse,
   ProcessedSingleAnswerResponse,
+  ProcessedTableResponse,
 } from 'src/app/modules/submission/submission.types'
 
 const isProcessedFieldResponse = (
@@ -20,6 +23,37 @@ export const isProcessedSingleAnswerResponse = (
   return (
     'answer' in response &&
     typeof response.answer === 'string' &&
+    isProcessedFieldResponse(response)
+  )
+}
+
+export const isProcessedCheckboxResponse = (
+  response: any,
+): response is ProcessedCheckboxResponse => {
+  return (
+    'answerArray' in response &&
+    Array.isArray(response.answerArray) &&
+    isProcessedFieldResponse(response)
+  )
+}
+
+export const isProcessedTableResponse = (
+  response: any,
+): response is ProcessedTableResponse => {
+  return (
+    'answerArray' in response &&
+    Array.isArray(response.answerArray) &&
+    Array.isArray(response.answerArray[0]) &&
+    isProcessedFieldResponse(response)
+  )
+}
+
+export const isProcessedAttachmentResponse = (
+  response: any,
+): response is ProcessedAttachmentResponse => {
+  return (
+    'filename' in response &&
+    typeof response.filename === 'string' &&
     isProcessedFieldResponse(response)
   )
 }

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -22,8 +22,12 @@ export interface ICheckboxResponse extends IBaseResponse {
   answerArray: string[]
 }
 
+export interface ITableRow {
+  [index: number]: string
+}
+
 export interface ITableResponse extends IBaseResponse {
-  answerArray: string[][]
+  answerArray: ITableRow[]
 }
 
 export type FieldResponse =

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -22,9 +22,7 @@ export interface ICheckboxResponse extends IBaseResponse {
   answerArray: string[]
 }
 
-export interface ITableRow {
-  [index: number]: string
-}
+export type ITableRow = Array<string>
 
 export interface ITableResponse extends IBaseResponse {
   answerArray: ITableRow[]

--- a/tests/unit/backend/utils/field-validation/attachment-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/attachment-validation.spec.js
@@ -108,4 +108,15 @@ describe('Attachment validation', () => {
       expect(validateResult._unsafeUnwrap()).toEqual(true)
     })
   })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = makeField(fieldId, '3')
+    const response = makeResponse(fieldId, Buffer.alloc(2000000))
+    response.isVisible = false
+    const validateResult = validateField(formId, formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/checkbox-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/checkbox-validation.spec.js
@@ -238,4 +238,15 @@ describe('Checkbox validation', () => {
       )
     })
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const fieldOptions = ['a', 'b', 'c']
+    const formField = makeCheckboxField(fieldId, fieldOptions)
+    const response = makeCheckboxResponse(fieldId, ['a'])
+    response.isVisible = false
+    const validateResult = validateField(formId, formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/date-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/date-validation.spec.js
@@ -462,4 +462,34 @@ describe('Date field validation', () => {
 
     jasmine.clock().uninstall()
   })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    jasmine.clock().install()
+    jasmine.clock().mockDate(new Date('2020-01-01'))
+
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'date',
+      dateValidation: {
+        customMinDate: '2020-06-25',
+        customMaxDate: '2020-06-28',
+      },
+      required: true,
+    }
+
+    const response = {
+      _id: 'abc123',
+      fieldType: 'date',
+      isVisible: false,
+      answer: '22 Jun 2020',
+    }
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+
+    jasmine.clock().uninstall()
+  })
 })

--- a/tests/unit/backend/utils/field-validation/date-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/date-validation.spec.js
@@ -7,6 +7,13 @@ const {
 } = require('../../../../../dist/backend/app/modules/submission/submission.errors')
 
 describe('Date field validation', () => {
+  beforeAll(() => {
+    jasmine.clock().install()
+    jasmine.clock().mockDate(new Date('2020-01-01'))
+  })
+  afterAll(() => {
+    jasmine.clock().uninstall()
+  })
   it('should allow valid date <DD MMM YYYY>', () => {
     const formField = {
       _id: 'abc123',
@@ -287,9 +294,6 @@ describe('Date field validation', () => {
   })
 
   it('should allow past dates for normal date fields', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -305,14 +309,9 @@ describe('Date field validation', () => {
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
-
-    jasmine.clock().uninstall()
   })
 
   it('should allow past dates if disallow past dates is not set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -328,14 +327,9 @@ describe('Date field validation', () => {
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
-
-    jasmine.clock().uninstall()
   })
 
   it('should disallow past dates if disallow past dates is set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -354,14 +348,9 @@ describe('Date field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Invalid answer submitted'),
     )
-
-    jasmine.clock().uninstall()
   })
 
   it('should allow future dates if disallow future dates is not set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -377,14 +366,9 @@ describe('Date field validation', () => {
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
-
-    jasmine.clock().uninstall()
   })
 
   it('should disallow future dates if disallow future dates is set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -403,14 +387,9 @@ describe('Date field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Invalid answer submitted'),
     )
-
-    jasmine.clock().uninstall()
   })
 
   it('should allow dates inside of Custom Date Range if set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -430,14 +409,9 @@ describe('Date field validation', () => {
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
-
-    jasmine.clock().uninstall()
   })
 
   it('should disallow dates outside of Custom Date Range if set', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -459,14 +433,9 @@ describe('Date field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Invalid answer submitted'),
     )
-
-    jasmine.clock().uninstall()
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date('2020-01-01'))
-
     const formField = {
       _id: 'abc123',
       fieldType: 'date',
@@ -489,7 +458,5 @@ describe('Date field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Attempted to submit response on a hidden field'),
     )
-
-    jasmine.clock().uninstall()
   })
 })

--- a/tests/unit/backend/utils/field-validation/decimal-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/decimal-validation.spec.js
@@ -402,4 +402,27 @@ describe('Decimal Validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'decimal',
+      required: true,
+      ValidationOptions: {
+        customMin: 0,
+        customMax: null,
+      },
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'decimal',
+      isVisible: false,
+      answer: '-0.2',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
@@ -133,4 +133,22 @@ describe('Dropdown validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'ddID',
+      fieldType: 'dropdown',
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    }
+    const response = {
+      _id: 'ddID',
+      fieldType: 'dropdown',
+      answer: 'KISS',
+      isVisible: false,
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/email-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/email-validation.spec.ts
@@ -203,4 +203,30 @@ describe('Email field validation', () => {
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      description: 'random',
+      required: true,
+      disabled: false,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@example.com'],
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: false,
+      answer: 'volunteer-testing@test.gov.sg',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/home-num-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/home-num-validation.spec.js
@@ -156,4 +156,23 @@ describe('Home phone number validation tests', () => {
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'homeno',
+      required: true,
+      allowIntlNumbers: true,
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'homeno',
+      isVisible: false,
+      answer: '+441285291028',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/home-num-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/home-num-validation.spec.js
@@ -34,7 +34,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '',
     }
     const validateResult = validateField('formId', formField, response)
@@ -71,7 +71,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '+6565656565',
     }
     const validateResult = validateField('formId', formField, response)
@@ -89,7 +89,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '6567772918',
     }
     const validateResult = validateField('formId', formField, response)
@@ -109,7 +109,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '+6598765432',
     }
     const validateResult = validateField('formId', formField, response)
@@ -129,7 +129,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '+441285291028',
     }
     const validateResult = validateField('formId', formField, response)
@@ -149,7 +149,7 @@ describe('Home phone number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'homeno',
-      isVisible: false,
+      isVisible: true,
       answer: '+441285291028',
     }
     const validateResult = validateField('formId', formField, response)

--- a/tests/unit/backend/utils/field-validation/mobile-num-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/mobile-num-validation.spec.js
@@ -34,7 +34,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '',
     }
     const validateResult = validateField('formId', formField, response)
@@ -72,7 +72,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '+6598765432',
     }
     const validateResult = validateField('formId', formField, response)
@@ -90,7 +90,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '6598765432',
     }
     const validateResult = validateField('formId', formField, response)
@@ -110,7 +110,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '+6565656565',
     }
     const validateResult = validateField('formId', formField, response)
@@ -130,7 +130,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '+447851315617',
     }
     const validateResult = validateField('formId', formField, response)
@@ -150,7 +150,7 @@ describe('Mobile number validation tests', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'mobile',
-      isVisible: false,
+      isVisible: true,
       answer: '+447851315617',
     }
     const validateResult = validateField('formId', formField, response)

--- a/tests/unit/backend/utils/field-validation/mobile-num-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/mobile-num-validation.spec.js
@@ -157,4 +157,23 @@ describe('Mobile number validation tests', () => {
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'mobile',
+      required: true,
+      allowIntlNumbers: true,
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'mobile',
+      isVisible: false,
+      answer: '+447851315617',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/nric-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/nric-validation.spec.js
@@ -186,4 +186,23 @@ describe('NRIC field validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'nric',
+      required: true,
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'nric',
+      answer: 'S0000000X',
+      isVisible: false,
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/number-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/number-validation.spec.js
@@ -20,7 +20,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '5',
     }
     const validateResult = validateField('formId', formField, response)
@@ -43,7 +43,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -66,7 +66,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '555',
     }
     const validateResult = validateField('formId', formField, response)
@@ -91,7 +91,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '555',
     }
     const validateResult = validateField('formId', formField, response)
@@ -114,7 +114,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -137,7 +137,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -160,7 +160,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '5',
     }
     const validateResult = validateField('formId', formField, response)
@@ -185,7 +185,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -208,7 +208,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -231,7 +231,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -254,7 +254,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '55',
     }
     const validateResult = validateField('formId', formField, response)
@@ -277,7 +277,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '',
     }
     const validateResult = validateField('formId', formField, response)
@@ -300,7 +300,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '0',
     }
     const validateResult = validateField('formId', formField, response)
@@ -323,7 +323,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '-5',
     }
     const validateResult = validateField('formId', formField, response)
@@ -348,7 +348,7 @@ describe('Number field validation', () => {
     const response = {
       _id: 'abc123',
       fieldType: 'number',
-      isVisible: false,
+      isVisible: true,
       answer: '05',
     }
     const validateResult = validateField('formId', formField, response)

--- a/tests/unit/backend/utils/field-validation/number-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/number-validation.spec.js
@@ -355,4 +355,28 @@ describe('Number field validation', () => {
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'number',
+      required: false,
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'number',
+      isVisible: false,
+      answer: '05',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/radio-button-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/radio-button-validation.spec.js
@@ -192,4 +192,24 @@ describe('Radio button validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'radioID',
+      fieldType: 'radiobutton',
+      fieldOptions: ['a', 'b', 'c'],
+      othersRadioButton: true,
+      required: true,
+    }
+    const response = {
+      _id: 'radioID',
+      fieldType: 'radiobutton',
+      answer: 'Others: ',
+      isVisible: false,
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/rating-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/rating-validation.spec.js
@@ -192,4 +192,25 @@ describe('Rating field validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'rating',
+      required: true,
+      ratingOptions: {
+        steps: 5,
+      },
+    }
+    const response = {
+      _id: 'abc123',
+      fieldType: 'rating',
+      isVisible: false,
+      answer: '5',
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/table-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/table-validation.spec.js
@@ -230,4 +230,15 @@ describe('Table validation', () => {
       )
     })
   })
+  it('should disallow responses submitted for hidden fields', () => {
+    const columns = [makeTextFieldColumn()]
+    const formField = makeTableField(fieldId, columns)
+    const response = makeTableResponse(fieldId, Array(4).fill(['hello']))
+    response.isVisible = false
+    const validateResult = validateField(formId, formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })

--- a/tests/unit/backend/utils/field-validation/text-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/text-validation.spec.js
@@ -155,6 +155,21 @@ describe('Text validation', () => {
         new ValidateFieldError('Invalid answer submitted'),
       )
     })
+    it('should disallow responses submitted for hidden fields', () => {
+      const formField = makeShortTextField(fieldId, {
+        customMax: 10,
+        selectedValidation: 'Maximum',
+      })
+      const response = makeShortTextResponse(fieldId, 'many more characters')
+      response.isVisible = false
+      const validateResult = validateField(formId, formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError(
+          'Attempted to submit response on a hidden field',
+        ),
+      )
+    })
   })
 
   describe('Long text', () => {
@@ -275,6 +290,21 @@ describe('Text validation', () => {
       expect(validateResult.isErr()).toBe(true)
       expect(validateResult._unsafeUnwrapErr()).toEqual(
         new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+    it('should disallow responses submitted for hidden fields', () => {
+      const formField = makeLongTextField(fieldId, {
+        customMax: 10,
+        selectedValidation: 'Maximum',
+      })
+      const response = makeLongTextResponse(fieldId, 'many more characters')
+      response.isVisible = false
+      const validateResult = validateField(formId, formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError(
+          'Attempted to submit response on a hidden field',
+        ),
       )
     })
   })

--- a/tests/unit/backend/utils/field-validation/yesno-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/yesno-validation.spec.js
@@ -89,4 +89,23 @@ describe('Yes/No field validation', () => {
       new ValidateFieldError('Invalid answer submitted'),
     )
   })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const response = {
+      _id: 'abc123',
+      fieldType: 'yes_no',
+      answer: 'somethingRandom',
+      isVisible: false,
+    }
+    const formField = {
+      _id: 'abc123',
+      fieldType: 'yes_no',
+      required: true,
+    }
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Closes #732
## Solution
- Add check for isVisible in validateField()
- Also updated unit tests

## Tests
- [ ] Create a form with Yes/No field, and a Number Field hidden behind it. Attempt to submit a response programatically with the number field still hidden. Submission should fail.
- [ ] Now unhide the Number Field. Attempt to submit a response on the number field normally. Submission should pass.
- [ ] Create email mode form with all field types (including Yes/No) hidden behind a Yes/No field. Submit while keeping the fields hidden. Submission should pass.