### PR TITLE
ref: migrate admin preview submit feedback endpoint to TypeScript

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -463,29 +463,6 @@ function makeModule(connection) {
       })
     },
     /**
-     * Submit feedback when previewing forms
-     * Preview feedback is not stored
-     * @param  {Object} req - Express request object
-     * @param  {Object} res - Express response object
-     */
-    passThroughFeedback: function (req, res) {
-      if (
-        !req.params ||
-        !('formId' in req.params) ||
-        !req.body ||
-        !('rating' in req.body) ||
-        !('comment' in req.body)
-      ) {
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Form feedback data not passed in' })
-      } else {
-        return res
-          .status(StatusCodes.OK)
-          .json({ message: 'Successfully received feedback' })
-      }
-    },
-    /**
      * Pass through save new Submission object to db
      * Simply create and pass forward a submissions object w/o saving to db
      * @param {Object} req - Express request object

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -270,7 +270,20 @@ module.exports = function (app) {
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback')
     .get(authActiveForm(PermissionLevel.Read), adminForms.getFeedback)
-    .post(authActiveForm(PermissionLevel.Read), adminForms.passThroughFeedback)
+    .post(
+      authActiveForm(PermissionLevel.Read),
+      celebrate({
+        [Segments.BODY]: Joi.object()
+          .keys({
+            rating: Joi.number().min(1).max(5).required(),
+            comment: Joi.string().allow('').required(),
+          })
+          // Allow other keys for backwards compability as frontend might put
+          // extra keys in the body.
+          .unknown(true),
+      }),
+      adminForms.passThroughFeedback,
+    )
 
   /**
    * Count the number of feedback for a form

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -271,7 +271,7 @@ module.exports = function (app) {
     .route('/:formId([a-fA-F0-9]{24})/adminform/feedback')
     .get(authActiveForm(PermissionLevel.Read), adminForms.getFeedback)
     .post(
-      authActiveForm(PermissionLevel.Read),
+      withUserAuthentication,
       celebrate({
         [Segments.BODY]: Joi.object()
           .keys({
@@ -282,7 +282,7 @@ module.exports = function (app) {
           // extra keys in the body.
           .unknown(true),
       }),
-      adminForms.passThroughFeedback,
+      AdminFormController.handlePreviewFeedbackSubmission,
     )
 
   /**

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -93,7 +93,7 @@ module.exports = function (app) {
     celebrate({
       [Segments.BODY]: Joi.object()
         .keys({
-          rating: Joi.number().min(1).max(5).cast('string').required(),
+          rating: Joi.number().min(1).max(5).required(),
           comment: Joi.string().allow('').required(),
         })
         // Allow other keys for backwards compability as frontend might put


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates the old controller function `passThroughFeedback` into its TypeScript and Joi validated equivalent.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `AdminFormCtl#handlePreviewFeedbackSubmission` handler fn

**Improvements**:

- use new TypeScript handler for feedback passthrough endpoint

**Bug Fixes**:

- remove cast to `string` for `req.body.rating` when Joi validating `POST /:formId/feedback`.
