### PR TITLE
Show OTP delay notification

### DIFF
--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -85,7 +85,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.json).toBeCalledWith(`OTP sent to ${VALID_EMAIL}!`)
+      expect(mockRes.json).toBeCalledWith(`OTP sent to ${VALID_EMAIL}`)
       // Services should have been invoked.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockMailService.sendLoginOtp).toHaveBeenCalledTimes(1)

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -247,7 +247,7 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}!`)
+      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
     })
   })
 
@@ -545,7 +545,7 @@ describe('auth.routes', () => {
     jest.spyOn(MailService, 'sendLoginOtp').mockReturnValue(okAsync(true))
 
     const response = await request.post('/auth/sendotp').send({ email })
-    expect(response.body).toEqual(`OTP sent to ${email}!`)
+    expect(response.body).toEqual(`OTP sent to ${email}`)
   }
 
   const signInUser = async (email: string, otp: string) => {

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -86,7 +86,7 @@ export const handleLoginSendOtp: RequestHandler<
           meta: logMeta,
         })
 
-        return res.status(StatusCodes.OK).json(`OTP sent to ${email}!`)
+        return res.status(StatusCodes.OK).json(`OTP sent to ${email}`)
       })
       // Step 4b: Error occurred whilst sending otp.
       .mapErr((error) => {

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -162,37 +162,43 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
     vm.signInMsg.isMsg = false
     vm.isOtpSending = true
     vm.buttonClicked = true
+    vm.showOtpDelayNotification = false
     const { email } = vm.credentials
-    Auth.sendOtp({ email }).then(
-      function (success) {
-        vm.isOtpSending = false
-        vm.buttonClicked = false
-        // Configure message to be show
-        vm.signInMsg = {
-          isMsg: true,
-          isError: false,
-          msg: success,
-        }
+    Auth.sendOtp({ email })
+      .then(
+        function (success) {
+          vm.isOtpSending = false
+          vm.buttonClicked = false
+          // Configure message to be show
+          vm.signInMsg = {
+            isMsg: true,
+            isError: false,
+            msg: success,
+          }
+          $timeout(function () {
+            angular.element('#otp-input').focus()
+            angular.element('#otp-input').select()
+          }, 100)
+        },
+        function (error) {
+          vm.isOtpSending = false
+          vm.buttonClicked = false
+          // Configure message to be shown
+          const msg =
+            (error && error.data && error.data.message) ||
+            'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
+          vm.signInMsg = {
+            isMsg: true,
+            isError: true,
+            msg,
+          }
+        },
+      )
+      .finally(function () {
         $timeout(function () {
-          angular.element('#otp-input').focus()
-          angular.element('#otp-input').select()
-        }, 100)
-      },
-      function (error) {
-        vm.isOtpSending = false
-        vm.buttonClicked = false
-        // Configure message to be shown
-        const msg =
-          (error && error.data && error.data.message) ||
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
-        vm.signInMsg = {
-          isMsg: true,
-          isError: true,
-          msg,
-        }
-        $timeout(function () {
+          vm.signInMsg.isMsg = false
           vm.showOtpDelayNotification = true
-        }, 45000)
+        }, 20000)
       })
   }
 

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -18,6 +18,7 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
 
   vm.credentials = {}
   vm.buttonClicked = false
+  vm.showOtpDelayNotification = false
 
   // logic/booleans to show sign in process sequentially. 2 possible values.
   // 'email' - email input
@@ -194,7 +195,11 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
           angular.element('#otp-input').select()
         }, 100)
       },
-    )
+    ).finally(function () {
+      $timeout(function () {
+        vm.showOtpDelayNotification = true
+      }, 45000)
+    })
   }
 
   /**

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -191,15 +191,9 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
           msg,
         }
         $timeout(function () {
-          angular.element('#otp-input').focus()
-          angular.element('#otp-input').select()
-        }, 100)
-      },
-    ).finally(function () {
-      $timeout(function () {
-        vm.showOtpDelayNotification = true
-      }, 45000)
-    })
+          vm.showOtpDelayNotification = true
+        }, 45000)
+      })
   }
 
   /**

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -92,7 +92,10 @@
           ></i>
           <span class="alert-msg">{{vm.signInMsg.msg}}</span>
         </div>
-        <div ng-if="!vm.showOtpDelayNotification && vm.isOtpSending" class="alert-custom alert-info">
+        <div
+          ng-if="!vm.showOtpDelayNotification && vm.isOtpSending"
+          class="alert-custom alert-info"
+        >
           <i class="bx bx-loader bx-spin bx-md icon-spacing"></i>
           <span class="alert-msg">Sending OTP...</span>
         </div>
@@ -102,7 +105,8 @@
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>
           <span class="alert-msg">
-            OTP might be delayed due to government email traffic. Please try again later, or contact us if issue persists.
+            OTP might be delayed due to government email traffic. Please try
+            again later, or contact us if issue persists.
           </span>
         </div>
         <div class="btn-grp">

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -82,7 +82,7 @@
           ng-keyup="$event.keyCode == 13 && vm.credentials.otp.length === 6 && vm.verifyOtp()"
         />
         <div
-          ng-if="vm.signInMsg.isMsg"
+          ng-if="!vm.showOtpDelayNotification && vm.signInMsg.isMsg"
           ng-class="vm.signInMsg.isError ? 'alert-error' : 'alert-success'"
           class="alert-custom"
         >
@@ -92,9 +92,18 @@
           ></i>
           <span class="alert-msg">{{vm.signInMsg.msg}}</span>
         </div>
-        <div ng-if="vm.isOtpSending" class="alert-custom alert-info">
+        <div ng-if="!vm.showOtpDelayNotification && vm.isOtpSending" class="alert-custom alert-info">
           <i class="bx bx-loader bx-spin bx-md icon-spacing"></i>
           <span class="alert-msg">Sending OTP...</span>
+        </div>
+        <div
+          ng-if="vm.showOtpDelayNotification"
+          class="alert-custom alert-info"
+        >
+          <i class="bx bx-info-circle bx-md icon-spacing"></i>
+          <span class="alert-msg">
+            OTP might be delayed due to government email traffic. Please try again later, or contact us if issue persists.
+          </span>
         </div>
         <div class="btn-grp">
           <button

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -105,8 +105,8 @@
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>
           <span class="alert-msg">
-            OTP might be delayed due to government email traffic. Please try
-            again later, or contact us if you're unable to log in.
+            OTP might be delayed due to government email traffic. If you are
+            unable to sign in, please try again later, or contact us.
           </span>
         </div>
         <div class="btn-grp">

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -93,14 +93,14 @@
           <span class="alert-msg">{{vm.signInMsg.msg}}</span>
         </div>
         <div
-          ng-if="!vm.showOtpDelayNotification && vm.isOtpSending"
+          ng-if="!vm.signInMsg.isMsg && !vm.showOtpDelayNotification && vm.isOtpSending"
           class="alert-custom alert-info"
         >
           <i class="bx bx-loader bx-spin bx-md icon-spacing"></i>
           <span class="alert-msg">Sending OTP...</span>
         </div>
         <div
-          ng-if="!vm.signInMsg.isMsg && vm.showOtpDelayNotification && !vm.isOtpSending"
+          ng-if="!vm.signInMsg.isMsg && vm.showOtpDelayNotification"
           class="alert-custom alert-info"
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -105,7 +105,8 @@
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>
           <span class="alert-msg">
-            OTP might be delayed due to government email traffic. Please try again later, or contact us if you're unable to log in.
+            OTP might be delayed due to government email traffic. Please try
+            again later, or contact us if you're unable to log in.
           </span>
         </div>
         <div class="btn-grp">

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -82,7 +82,7 @@
           ng-keyup="$event.keyCode == 13 && vm.credentials.otp.length === 6 && vm.verifyOtp()"
         />
         <div
-          ng-if="!vm.showOtpDelayNotification && vm.signInMsg.isMsg"
+          ng-if="vm.signInMsg.isMsg"
           ng-class="vm.signInMsg.isError ? 'alert-error' : 'alert-success'"
           class="alert-custom"
         >
@@ -100,13 +100,12 @@
           <span class="alert-msg">Sending OTP...</span>
         </div>
         <div
-          ng-if="vm.showOtpDelayNotification"
+          ng-if="!vm.signInMsg.isMsg && vm.showOtpDelayNotification && !vm.isOtpSending"
           class="alert-custom alert-info"
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>
           <span class="alert-msg">
-            OTP might be delayed due to government email traffic. Please try
-            again later, or contact us if issue persists.
+            OTP might be delayed due to government email traffic. Please try again later, or contact us if you're unable to log in.
           </span>
         </div>
         <div class="btn-grp">

--- a/tests/integration/helpers/express-auth.ts
+++ b/tests/integration/helpers/express-auth.ts
@@ -35,7 +35,7 @@ export const createAuthedSession = async (
 
   const sendOtpResponse = await request.post('/auth/sendotp').send({ email })
   expect(sendOtpResponse.status).toEqual(200)
-  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email}!`)
+  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email}`)
 
   // Act
   await request.post('/auth/verifyotp').send({ email, otp: MOCK_VALID_OTP })


### PR DESCRIPTION
## Problem

Closes #629

## Solution

At the finally clause of the send OTP function, add a timeout function which sets the show OTP delay notification flag to true after 20 seconds.

Priority of `vm.signInMsg.isMsg`, `vm.showOtpDelayNotification` and `vm.isOtpSending` is described in the conversation below ([link](https://github.com/opengovsg/FormSG/pull/748#discussion_r537451785)).

## Before & After Screenshots

**AFTER**:

https://user-images.githubusercontent.com/14961285/103256818-84c9bd80-49c9-11eb-9a4e-afa63584e3ac.mov
