### PR TITLE
feat: tighten submission validation

### DIFF
--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -160,7 +160,7 @@ export const createSingpassParsedResponses = (
     {
       _id: '',
       question: 'SingPass Validated NRIC',
-      fieldType: BasicField.ShortText,
+      fieldType: BasicField.Nric,
       isVisible: true,
       answer: uinFin,
     },
@@ -187,7 +187,7 @@ export const createCorppassParsedResponses = (
     {
       _id: '',
       question: 'CorpPass Validated UID',
-      fieldType: BasicField.ShortText,
+      fieldType: BasicField.Nric,
       isVisible: true,
       answer: userInfo,
     },

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -160,7 +160,7 @@ export const createSingpassParsedResponses = (
     {
       _id: '',
       question: 'SingPass Validated NRIC',
-      fieldType: 'authenticationSp' as BasicField,
+      fieldType: BasicField.ShortText,
       isVisible: true,
       answer: uinFin,
     },
@@ -180,14 +180,14 @@ export const createCorppassParsedResponses = (
     {
       _id: '',
       question: 'CorpPass Validated UEN',
-      fieldType: 'authenticationCp' as BasicField,
+      fieldType: BasicField.ShortText,
       isVisible: true,
       answer: uinFin,
     },
     {
       _id: '',
       question: 'CorpPass Validated UID',
-      fieldType: 'authenticationCp' as BasicField,
+      fieldType: BasicField.ShortText,
       isVisible: true,
       answer: userInfo,
     },

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -347,7 +347,7 @@ module.exports = function (app) {
     authActiveForm(PermissionLevel.Read),
     emailSubmissions.receiveEmailSubmissionUsingBusBoy,
     celebrate({
-      body: Joi.object({
+      [Segments.BODY]: Joi.object({
         responses: Joi.array()
           .items(
             Joi.object()
@@ -406,7 +406,7 @@ module.exports = function (app) {
     authActiveForm(PermissionLevel.Read),
     encryptSubmissions.validateEncryptSubmission,
     celebrate({
-      body: Joi.object({
+      [Segments.BODY]: Joi.object({
         responses: Joi.array()
           .items(
             Joi.object().keys({

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -356,7 +356,7 @@ module.exports = function (app) {
                 question: Joi.string().required(),
                 fieldType: Joi.string()
                   .required()
-                  .valid(Object.values(BasicField)),
+                  .valid(...Object.values(BasicField)),
                 answer: Joi.string().allow(''),
                 answerArray: Joi.array(),
                 filename: Joi.string(),
@@ -414,7 +414,7 @@ module.exports = function (app) {
               answer: Joi.string().allow('').required(),
               fieldType: Joi.string()
                 .required()
-                .valid(Object.values(BasicField)),
+                .valid(...Object.values(BasicField)),
               signature: Joi.string().allow(''),
             }),
           )

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -16,6 +16,7 @@ const { limitRate } = require('../utils/limit-rate')
 const { rateLimitConfig } = require('../../config/config')
 const PublicFormController = require('../modules/form/public-form/public-form.controller')
 const SpcpController = require('../modules/spcp/spcp.controller')
+const { BasicField } = require('../../types')
 
 module.exports = function (app) {
   /**
@@ -172,7 +173,9 @@ module.exports = function (app) {
               .keys({
                 _id: Joi.string().required(),
                 question: Joi.string().required(),
-                fieldType: Joi.string().required(),
+                fieldType: Joi.string()
+                  .required()
+                  .valid(Object.values(BasicField)),
                 answer: Joi.string().allow(''),
                 answerArray: Joi.array(),
                 filename: Joi.string(),
@@ -227,7 +230,9 @@ module.exports = function (app) {
             Joi.object().keys({
               _id: Joi.string().required(),
               answer: Joi.string().allow('').required(),
-              fieldType: Joi.string().required(),
+              fieldType: Joi.string()
+                .required()
+                .valid(Object.values(BasicField)),
               signature: Joi.string().allow(''),
             }),
           )

--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -175,7 +175,7 @@ module.exports = function (app) {
                 question: Joi.string().required(),
                 fieldType: Joi.string()
                   .required()
-                  .valid(Object.values(BasicField)),
+                  .valid(...Object.values(BasicField)),
                 answer: Joi.string().allow(''),
                 answerArray: Joi.array(),
                 filename: Joi.string(),
@@ -232,7 +232,7 @@ module.exports = function (app) {
               answer: Joi.string().allow('').required(),
               fieldType: Joi.string()
                 .required()
-                .valid(Object.values(BasicField)),
+                .valid(...Object.values(BasicField)),
               signature: Joi.string().allow(''),
             }),
           )

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -15,7 +15,7 @@ const answerArrayFieldTypes = basicTypes
   .map((f) => f.name)
 
 const isProcessedFieldResponse = (
-  response: any,
+  response: ProcessedFieldResponse,
 ): response is ProcessedFieldResponse => {
   return (
     'fieldType' in response &&
@@ -26,7 +26,7 @@ const isProcessedFieldResponse = (
 }
 
 export const isProcessedSingleAnswerResponse = (
-  response: any,
+  response: ProcessedFieldResponse,
 ): response is ProcessedSingleAnswerResponse => {
   return (
     'answer' in response &&
@@ -37,7 +37,7 @@ export const isProcessedSingleAnswerResponse = (
 }
 
 export const isProcessedCheckboxResponse = (
-  response: any,
+  response: ProcessedFieldResponse,
 ): response is ProcessedCheckboxResponse => {
   return (
     !!response &&
@@ -55,7 +55,7 @@ export const isTableRow = (row: unknown): row is ITableRow =>
   isStringArray(row) && row.length > 0
 
 export const isProcessedTableResponse = (
-  response: any,
+  response: ProcessedFieldResponse,
 ): response is ProcessedTableResponse => {
   if (
     !!response &&

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -12,25 +12,13 @@ const singleAnswerFieldTypes = basicTypes
   .filter((field) => !field.answerArray)
   .map((f) => f.name)
 
-const isProcessedFieldResponse = (
-  response: ProcessedFieldResponse,
-): response is ProcessedFieldResponse => {
-  return (
-    'fieldType' in response &&
-    typeof response.fieldType === 'string' &&
-    'isVisible' in response &&
-    typeof response.isVisible === 'boolean'
-  )
-}
-
 export const isProcessedSingleAnswerResponse = (
   response: ProcessedFieldResponse,
 ): response is ProcessedSingleAnswerResponse => {
   return (
+    singleAnswerFieldTypes.includes(response.fieldType) &&
     'answer' in response &&
-    typeof response.answer === 'string' &&
-    isProcessedFieldResponse(response) &&
-    singleAnswerFieldTypes.includes(response.fieldType)
+    typeof response.answer === 'string'
   )
 }
 
@@ -38,11 +26,9 @@ export const isProcessedCheckboxResponse = (
   response: ProcessedFieldResponse,
 ): response is ProcessedCheckboxResponse => {
   return (
-    !!response &&
+    response.fieldType === BasicField.Checkbox &&
     'answerArray' in response &&
-    isStringArray(response.answerArray) &&
-    isProcessedFieldResponse(response) &&
-    response.fieldType === BasicField.Checkbox
+    isStringArray(response.answerArray)
   )
 }
 
@@ -57,13 +43,11 @@ export const isProcessedTableResponse = (
   response: ProcessedFieldResponse,
 ): response is ProcessedTableResponse => {
   if (
-    !!response &&
     response.fieldType === BasicField.Table &&
     'answerArray' in response &&
     Array.isArray(response.answerArray) &&
     response.answerArray.length > 0 &&
-    response.answerArray.every(isTableRow) &&
-    isProcessedFieldResponse(response)
+    response.answerArray.every(isTableRow)
   ) {
     // Check that all arrays in answerArray have the same length
     const subArrLength: number = response.answerArray[0].length
@@ -76,8 +60,10 @@ export const isProcessedAttachmentResponse = (
   response: ProcessedFieldResponse,
 ): response is ProcessedAttachmentResponse => {
   return (
+    response.fieldType === BasicField.Attachment &&
     'filename' in response &&
     typeof response.filename === 'string' &&
-    isProcessedFieldResponse(response)
+    'answer' in response &&
+    typeof response.answer === 'string'
   )
 }

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -1,5 +1,5 @@
 import { types as basicTypes } from '../../../shared/resources/basic'
-import { BasicField } from '../../../types/field'
+import { BasicField, ITableRow } from '../../../types'
 import {
   ProcessedAttachmentResponse,
   ProcessedCheckboxResponse,
@@ -8,10 +8,8 @@ import {
   ProcessedTableResponse,
 } from '../../modules/submission/submission.types'
 
-import { ITableRow } from './index'
-
-const answerArrayFieldTypes = basicTypes
-  .filter((field) => field.answerArray)
+const singleAnswerFieldTypes = basicTypes
+  .filter((field) => !field.answerArray)
   .map((f) => f.name)
 
 const isProcessedFieldResponse = (
@@ -32,7 +30,7 @@ export const isProcessedSingleAnswerResponse = (
     'answer' in response &&
     typeof response.answer === 'string' &&
     isProcessedFieldResponse(response) &&
-    !answerArrayFieldTypes.includes(response.fieldType)
+    singleAnswerFieldTypes.includes(response.fieldType)
   )
 }
 
@@ -41,6 +39,7 @@ export const isProcessedCheckboxResponse = (
 ): response is ProcessedCheckboxResponse => {
   return (
     !!response &&
+    'answerArray' in response &&
     isStringArray(response.answerArray) &&
     isProcessedFieldResponse(response) &&
     response.fieldType === BasicField.Checkbox
@@ -59,11 +58,12 @@ export const isProcessedTableResponse = (
 ): response is ProcessedTableResponse => {
   if (
     !!response &&
+    response.fieldType === BasicField.Table &&
+    'answerArray' in response &&
     Array.isArray(response.answerArray) &&
     response.answerArray.length > 0 &&
     response.answerArray.every(isTableRow) &&
-    isProcessedFieldResponse(response) &&
-    response.fieldType === BasicField.Table
+    isProcessedFieldResponse(response)
   ) {
     // Check that all arrays in answerArray have the same length
     const subArrLength: number = response.answerArray[0].length
@@ -73,7 +73,7 @@ export const isProcessedTableResponse = (
 }
 
 export const isProcessedAttachmentResponse = (
-  response: any,
+  response: ProcessedFieldResponse,
 ): response is ProcessedAttachmentResponse => {
   return (
     'filename' in response &&

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -1,13 +1,12 @@
+import { types as basicTypes } from '../../../shared/resources/basic'
+import { BasicField } from '../../../types/field'
 import {
   ProcessedAttachmentResponse,
   ProcessedCheckboxResponse,
   ProcessedFieldResponse,
   ProcessedSingleAnswerResponse,
   ProcessedTableResponse,
-} from 'src/app/modules/submission/submission.types'
-
-import { types as basicTypes } from '../../shared/resources/basic'
-import { BasicField } from '../field'
+} from '../../modules/submission/submission.types'
 
 import { ITableRow } from './index'
 

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -9,10 +9,10 @@ import { createLoggerWithLabel } from '../../../config/logger'
 import { IField } from '../../../types/field/baseField'
 import { BasicField } from '../../../types/field/fieldTypes'
 import { FieldResponse } from '../../../types/response'
-import { isProcessedSingleAnswerResponse } from '../../../types/response/guards'
 import { ValidateFieldError } from '../../modules/submission/submission.errors'
 
 import { ALLOWED_VALIDATORS, FIELDS_TO_REJECT } from './config'
+import { isProcessedSingleAnswerResponse } from './field-validation.guards'
 import fieldValidatorFactory from './FieldValidatorFactory.class' // Deprecated
 import { constructSingleAnswerValidator } from './singleAnswerValidator.factory'
 

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -88,7 +88,7 @@ const logInvalidAnswer = (
 export const validateField = (
   formId: string,
   formField: IField,
-  response: FieldResponse,
+  response: ProcessedFieldResponse,
 ): Result<true, ValidateFieldError> => {
   if (!isValidResponseFieldType(response)) {
     return err(

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -12,7 +12,11 @@ import { FieldResponse } from '../../../types/response'
 import { ValidateFieldError } from '../../modules/submission/submission.errors'
 
 import { ALLOWED_VALIDATORS, FIELDS_TO_REJECT } from './config'
-import { isProcessedSingleAnswerResponse } from './field-validation.guards'
+import {
+  isProcessedCheckboxResponse,
+  isProcessedSingleAnswerResponse,
+  isProcessedTableResponse,
+} from './field-validation.guards'
 import fieldValidatorFactory from './FieldValidatorFactory.class' // Deprecated
 import { constructSingleAnswerValidator } from './singleAnswerValidator.factory'
 

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -128,9 +128,15 @@ export const validateField = (
         }
       }
     }
-  } else {
-    // fallback for processed checkbox/table/attachment responses
+  } else if (
+    isProcessedCheckboxResponse(response) ||
+    isProcessedTableResponse(response)
+  ) {
+    // fallback for processed checkbox/table responses
     return classBasedValidation(formId, formField, response)
+  } else {
+    logInvalidAnswer(formId, formField, 'Invalid response shape')
+    return err(new ValidateFieldError('Response has invalid shape'))
   }
   return ok(true)
 }

--- a/src/shared/resources/basic/index.ts
+++ b/src/shared/resources/basic/index.ts
@@ -4,6 +4,7 @@ interface IBasicFieldType {
   name: BasicField
   value: string
   submitted: boolean
+  answerArray: boolean
 }
 
 export const types: IBasicFieldType[] = [
@@ -11,95 +12,114 @@ export const types: IBasicFieldType[] = [
     name: BasicField.Section,
     value: 'Header',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Statement,
     value: 'Statement',
     submitted: false,
+    answerArray: false,
   },
   {
     name: BasicField.Email,
     value: 'Email',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Mobile,
     value: 'Mobile Number',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.HomeNo,
     value: 'Home Number',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Number,
     value: 'Number',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Decimal,
     value: 'Decimal',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Image,
     value: 'Image',
     submitted: false,
+    answerArray: false,
   },
   {
     name: BasicField.ShortText,
     value: 'Short Text',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.LongText,
     value: 'Long Text',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Dropdown,
     value: 'Dropdown',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.YesNo,
     value: 'Yes/No',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Checkbox,
     value: 'Checkbox',
     submitted: true,
+    answerArray: true,
   },
   {
     name: BasicField.Radio,
     value: 'Radio',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Attachment,
     value: 'Attachment',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Date,
     value: 'Date',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Rating,
     value: 'Rating',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Nric,
     value: 'NRIC',
     submitted: true,
+    answerArray: false,
   },
   {
     name: BasicField.Table,
     value: 'Table',
     submitted: true,
+    answerArray: true,
   },
 ]

--- a/src/types/field/index.ts
+++ b/src/types/field/index.ts
@@ -1,23 +1,3 @@
-import { IAttachmentField } from './attachmentField'
-import { ICheckboxField } from './checkboxField'
-import { IDateField } from './dateField'
-import { IDecimalField } from './decimalField'
-import { IDropdownField } from './dropdownField'
-import { IEmailField } from './emailField'
-import { IHomenoField } from './homeNoField'
-import { IImageField } from './imageField'
-import { ILongTextField } from './longTextField'
-import { IMobileField } from './mobileField'
-import { INricField } from './nricField'
-import { INumberField } from './numberField'
-import { IRadioField } from './radioField'
-import { IRatingField } from './ratingField'
-import { ISectionField } from './sectionField'
-import { IShortTextField } from './shortTextField'
-import { IStatementField } from './statementField'
-import { ITableField } from './tableField'
-import { IYesNoField } from './yesNoField'
-
 export * from './fieldTypes'
 export * from './baseField'
 export * from './attachmentField'
@@ -39,24 +19,3 @@ export * from './shortTextField'
 export * from './statementField'
 export * from './tableField'
 export * from './yesNoField'
-
-export type PossibleField =
-  | IAttachmentField
-  | ICheckboxField
-  | IDateField
-  | IDecimalField
-  | IDropdownField
-  | IEmailField
-  | IHomenoField
-  | IImageField
-  | ILongTextField
-  | IMobileField
-  | INricField
-  | INumberField
-  | IRadioField
-  | IRatingField
-  | ISectionField
-  | IShortTextField
-  | IStatementField
-  | ITableField
-  | IYesNoField

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -3,6 +3,12 @@ import {
   ProcessedSingleAnswerResponse,
 } from 'src/app/modules/submission/submission.types'
 
+import { types as basicTypes } from '../../shared/resources/basic'
+
+const answerArrayFieldTypes = basicTypes
+  .filter((field) => field.answerArray)
+  .map((f) => f.name)
+
 const isProcessedFieldResponse = (
   response: any,
 ): response is ProcessedFieldResponse => {
@@ -20,6 +26,7 @@ export const isProcessedSingleAnswerResponse = (
   return (
     'answer' in response &&
     typeof response.answer === 'string' &&
-    isProcessedFieldResponse(response)
+    isProcessedFieldResponse(response) &&
+    !answerArrayFieldTypes.includes(response.fieldType)
   )
 }

--- a/src/types/response/guards.ts
+++ b/src/types/response/guards.ts
@@ -1,9 +1,15 @@
 import {
+  ProcessedAttachmentResponse,
+  ProcessedCheckboxResponse,
   ProcessedFieldResponse,
   ProcessedSingleAnswerResponse,
+  ProcessedTableResponse,
 } from 'src/app/modules/submission/submission.types'
 
 import { types as basicTypes } from '../../shared/resources/basic'
+import { BasicField } from '../field'
+
+import { ITableRow } from './index'
 
 const answerArrayFieldTypes = basicTypes
   .filter((field) => field.answerArray)
@@ -28,5 +34,51 @@ export const isProcessedSingleAnswerResponse = (
     typeof response.answer === 'string' &&
     isProcessedFieldResponse(response) &&
     !answerArrayFieldTypes.includes(response.fieldType)
+  )
+}
+
+export const isProcessedCheckboxResponse = (
+  response: any,
+): response is ProcessedCheckboxResponse => {
+  return (
+    !!response &&
+    isStringArray(response.answerArray) &&
+    isProcessedFieldResponse(response) &&
+    response.fieldType === BasicField.Checkbox
+  )
+}
+
+const isStringArray = (arr: unknown): arr is string[] =>
+  Array.isArray(arr) && arr.every((item) => typeof item === 'string')
+
+// Check that the row contains a single array of only string (including empty string)
+export const isTableRow = (row: unknown): row is ITableRow =>
+  isStringArray(row) && row.length > 0
+
+export const isProcessedTableResponse = (
+  response: any,
+): response is ProcessedTableResponse => {
+  if (
+    !!response &&
+    Array.isArray(response.answerArray) &&
+    response.answerArray.length > 0 &&
+    response.answerArray.every(isTableRow) &&
+    isProcessedFieldResponse(response) &&
+    response.fieldType === BasicField.Table
+  ) {
+    // Check that all arrays in answerArray have the same length
+    const subArrLength: number = response.answerArray[0].length
+    return response.answerArray.every((arr) => arr.length === subArrLength)
+  }
+  return false
+}
+
+export const isProcessedAttachmentResponse = (
+  response: any,
+): response is ProcessedAttachmentResponse => {
+  return (
+    'filename' in response &&
+    typeof response.filename === 'string' &&
+    isProcessedFieldResponse(response)
   )
 }

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -10,20 +10,26 @@ interface IBaseResponse {
 }
 
 export interface ISingleAnswerResponse extends IBaseResponse {
+  fieldType: Exclude<BasicField, BasicField.Table | BasicField.Checkbox>
   answer: string
 }
 
 export interface IAttachmentResponse extends ISingleAnswerResponse {
+  fieldType: BasicField.Attachment
   filename: string
   content: Buffer
 }
 
 export interface ICheckboxResponse extends IBaseResponse {
+  fieldType: BasicField.Checkbox
   answerArray: string[]
 }
 
+export type ITableRow = string[]
+
 export interface ITableResponse extends IBaseResponse {
-  answerArray: string[][]
+  fieldType: BasicField.Table
+  answerArray: ITableRow[]
 }
 
 export type FieldResponse =

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -902,7 +902,7 @@ describe('Email Submissions Controller', () => {
           question: 'SingPass Validated NRIC',
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
-          fieldType: 'authenticationSp',
+          fieldType: 'textfield',
         },
       ]
       const expectedAutoReplyData = [
@@ -935,13 +935,13 @@ describe('Email Submissions Controller', () => {
           question: 'CorpPass Validated UEN',
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
-          fieldType: 'authenticationCp',
+          fieldType: 'textfield',
         },
         {
           question: 'CorpPass Validated UID',
           answerTemplate: [resLocalFixtures.userInfo],
           answer: resLocalFixtures.userInfo,
-          fieldType: 'authenticationCp',
+          fieldType: 'textfield',
         },
       ]
       const expectedAutoReplyData = [
@@ -1203,7 +1203,7 @@ describe('Email Submissions Controller', () => {
         question: 'a table',
         fieldType: 'table',
         isHeader: false,
-        answer: '',
+        answerArray: [['', '']],
       })
       reqFixtures.form.form_fields.push({
         _id: fieldId,
@@ -1213,25 +1213,26 @@ describe('Email Submissions Controller', () => {
           { title: 'Name', fieldType: 'textfield' },
           { title: 'Age', fieldType: 'textfield' },
         ],
+        minimumRows: 1,
       })
       const expectedJsonData = [
         {
           question: '[table] a table (Name, Age)',
-          answer: '',
+          answer: ',',
         },
       ]
       const expectedFormData = [
         {
           question: '[table] a table (Name, Age)',
-          answerTemplate: [''],
-          answer: '',
+          answerTemplate: [','],
+          answer: ',',
           fieldType: 'table',
         },
       ]
       const expectedAutoReplyData = [
         {
           question: 'a table (Name, Age)',
-          answerTemplate: [''],
+          answerTemplate: [','],
         },
       ]
       const expected = {

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -902,7 +902,7 @@ describe('Email Submissions Controller', () => {
           question: 'SingPass Validated NRIC',
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
-          fieldType: 'textfield',
+          fieldType: 'nric',
         },
       ]
       const expectedAutoReplyData = [
@@ -941,7 +941,7 @@ describe('Email Submissions Controller', () => {
           question: 'CorpPass Validated UID',
           answerTemplate: [resLocalFixtures.userInfo],
           answer: resLocalFixtures.userInfo,
-          fieldType: 'textfield',
+          fieldType: 'nric',
         },
       ]
       const expectedAutoReplyData = [

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -1,0 +1,160 @@
+import { ObjectID } from 'bson'
+
+import {
+  ProcessedAttachmentResponse,
+  ProcessedCheckboxResponse,
+  ProcessedSingleAnswerResponse,
+  ProcessedTableResponse,
+} from 'src/app/modules/submission/submission.types'
+import {
+  AttachmentSize,
+  BasicField,
+  IAttachmentFieldSchema,
+  ICheckboxFieldSchema,
+  IDropdownField,
+  IField,
+  IFieldSchema,
+  IImageFieldSchema,
+  IShortTextFieldSchema,
+  ITableFieldSchema,
+} from 'src/types'
+
+export const generateDefaultField = (
+  fieldType: BasicField,
+  customParams?: Partial<IField>,
+): IFieldSchema => {
+  const defaultParams = {
+    title: `test ${fieldType} field title`,
+    _id: new ObjectID().toHexString(),
+    description: `${fieldType} description`,
+    globalId: new ObjectID().toHexString(),
+    fieldType,
+    required: true,
+    disabled: false,
+  }
+  switch (fieldType) {
+    case BasicField.Table:
+      return {
+        minimumRows: 1,
+        columns: [
+          {
+            title: 'Test Column Title 1',
+            required: true,
+            columnType: BasicField.ShortText,
+          },
+          {
+            title: 'Test Column Title 2',
+            required: true,
+            columnType: BasicField.Dropdown,
+          },
+        ],
+        getQuestion: () => 'title (Column 1, Column 2)',
+        ...defaultParams,
+        ...customParams,
+      } as ITableFieldSchema
+    case BasicField.Attachment:
+      return {
+        ...defaultParams,
+        attachmentSize: AttachmentSize.ThreeMb,
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as IAttachmentFieldSchema
+    case BasicField.Image:
+      return {
+        ...defaultParams,
+        url: 'http://example.com',
+        fileMd5Hash: 'some hash',
+        name: 'test image name',
+        size: 'some size',
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as IImageFieldSchema
+    case BasicField.ShortText:
+      return {
+        ...defaultParams,
+        ValidationOptions: {
+          selectedValidation: null,
+        },
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as IShortTextFieldSchema
+    default:
+      return {
+        ...defaultParams,
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as IFieldSchema
+  }
+}
+
+export const generateSingleAnswerResponse = (
+  field: IFieldSchema,
+  answer = 'answer',
+): ProcessedSingleAnswerResponse => {
+  if (
+    [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
+      field.fieldType,
+    )
+  ) {
+    throw new Error(
+      'Call the custom response generator functions for attachment, table and checkbox.',
+    )
+  }
+  return {
+    _id: field._id,
+    question: field.title,
+    answer,
+    fieldType: field.fieldType as Exclude<
+      BasicField,
+      BasicField.Table | BasicField.Checkbox
+    >,
+  }
+}
+
+export const generateAttachmentResponse = (
+  field: IAttachmentFieldSchema,
+  filename = 'filename',
+  content = Buffer.from('content'),
+): ProcessedAttachmentResponse => ({
+  _id: field._id,
+  question: field.title,
+  answer: 'answer',
+  fieldType: BasicField.Attachment,
+  filename,
+  content,
+})
+
+export const generateCheckboxResponse = (
+  field: ICheckboxFieldSchema,
+  answerArray?: string[],
+): ProcessedCheckboxResponse => ({
+  _id: field._id,
+  question: field.title,
+  answerArray: answerArray ?? [field.fieldOptions[0]],
+  fieldType: BasicField.Checkbox,
+})
+
+export const generateTableResponse = (
+  field: ITableFieldSchema,
+  answerArray?: string[][],
+): ProcessedTableResponse => {
+  if (!answerArray) {
+    const rowAnswer: string[] = []
+    field.columns.forEach((col) => {
+      switch (col.columnType) {
+        case BasicField.ShortText:
+          rowAnswer.push('answer')
+          break
+        case BasicField.Dropdown:
+          rowAnswer.push(((col as unknown) as IDropdownField).fieldOptions[0])
+      }
+    })
+    answerArray = Array(field.minimumRows).fill(rowAnswer)
+  }
+  return {
+    _id: field._id,
+    question: field.title,
+    answerArray,
+    fieldType: BasicField.Table,
+  }
+}

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -169,6 +169,46 @@ const insertEmailForm = async ({
   }
 }
 
+const insertEncryptForm = async ({
+  formId,
+  userId,
+  mailDomain = 'test.gov.sg',
+  mailName = 'test',
+  shortName = 'govtest',
+}: {
+  formId?: ObjectID
+  userId?: ObjectID
+  mailName?: string
+  mailDomain?: string
+  shortName?: string
+} = {}): Promise<{
+  form: IFormSchema
+  user: IUserSchema
+  agency: IAgencySchema
+}> => {
+  const { user, agency } = await insertFormCollectionReqs({
+    userId,
+    mailDomain,
+    mailName,
+    shortName,
+  })
+
+  const Form = getFormModel(mongoose)
+
+  const form = await Form.create({
+    title: 'example form title',
+    admin: user._id,
+    responseMode: ResponseMode.Encrypt,
+    _id: formId,
+  })
+
+  return {
+    form,
+    user,
+    agency,
+  }
+}
+
 const generateDefaultField = (
   fieldType: BasicField,
   customParams?: Partial<IField>,
@@ -217,6 +257,7 @@ const dbHandler = {
   insertFormCollectionReqs,
   clearCollection,
   insertEmailForm,
+  insertEncryptForm,
   generateDefaultField,
 }
 

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -7,8 +7,11 @@ import getAgencyModel from 'src/app/models/agency.server.model'
 import getFormModel from 'src/app/models/form.server.model'
 import getUserModel from 'src/app/models/user.server.model'
 import {
+  BasicField,
   IAgencySchema,
+  IField,
   IFormSchema,
+  ITableField,
   IUserSchema,
   ResponseMode,
 } from 'src/types'
@@ -166,6 +169,45 @@ const insertEmailForm = async ({
   }
 }
 
+const generateDefaultField = (
+  fieldType: BasicField,
+  customParams?: Partial<IField>,
+): IField | ITableField => {
+  const defaultParams = {
+    title: `test ${fieldType} field title`,
+    _id: new ObjectID().toHexString(),
+    description: `${fieldType} description`,
+    globalId: new ObjectID().toHexString(),
+    fieldType,
+    required: true,
+    disabled: false,
+  }
+  if (fieldType === BasicField.Table) {
+    return {
+      minimumRows: 1,
+      columns: [
+        {
+          title: 'Test Column Title 1',
+          required: true,
+          columnType: BasicField.ShortText,
+        },
+        {
+          title: 'Test Column Title 2',
+          required: true,
+          columnType: BasicField.Dropdown,
+        },
+      ],
+      ...defaultParams,
+      ...customParams,
+    }
+  }
+
+  return {
+    ...defaultParams,
+    ...customParams,
+  }
+}
+
 const dbHandler = {
   connect,
   closeDatabase,
@@ -175,6 +217,7 @@ const dbHandler = {
   insertFormCollectionReqs,
   clearCollection,
   insertEmailForm,
+  generateDefaultField,
 }
 
 export default dbHandler

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -4,14 +4,15 @@ import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
 
 import getAgencyModel from 'src/app/models/agency.server.model'
-import getFormModel from 'src/app/models/form.server.model'
+import {
+  getEmailFormModel,
+  getEncryptedFormModel,
+} from 'src/app/models/form.server.model'
 import getUserModel from 'src/app/models/user.server.model'
 import {
-  BasicField,
   IAgencySchema,
-  IField,
-  IFormSchema,
-  ITableField,
+  IEmailFormSchema,
+  IEncryptedFormSchema,
   IUserSchema,
   ResponseMode,
 } from 'src/types'
@@ -141,7 +142,7 @@ const insertEmailForm = async ({
   mailDomain?: string
   shortName?: string
 } = {}): Promise<{
-  form: IFormSchema
+  form: IEmailFormSchema
   user: IUserSchema
   agency: IAgencySchema
 }> => {
@@ -152,9 +153,9 @@ const insertEmailForm = async ({
     shortName,
   })
 
-  const Form = getFormModel(mongoose)
+  const EmailFormModel = getEmailFormModel(mongoose)
 
-  const form = await Form.create({
+  const form = await EmailFormModel.create({
     title: 'example form title',
     admin: user._id,
     responseMode: ResponseMode.Email,
@@ -182,7 +183,7 @@ const insertEncryptForm = async ({
   mailDomain?: string
   shortName?: string
 } = {}): Promise<{
-  form: IFormSchema
+  form: IEncryptedFormSchema
   user: IUserSchema
   agency: IAgencySchema
 }> => {
@@ -193,58 +194,20 @@ const insertEncryptForm = async ({
     shortName,
   })
 
-  const Form = getFormModel(mongoose)
+  const EncryptFormModel = getEncryptedFormModel(mongoose)
 
-  const form = await Form.create({
+  const form = await EncryptFormModel.create({
     title: 'example form title',
     admin: user._id,
     responseMode: ResponseMode.Encrypt,
     _id: formId,
+    publicKey: 'publicKey',
   })
 
   return {
     form,
     user,
     agency,
-  }
-}
-
-const generateDefaultField = (
-  fieldType: BasicField,
-  customParams?: Partial<IField>,
-): IField | ITableField => {
-  const defaultParams = {
-    title: `test ${fieldType} field title`,
-    _id: new ObjectID().toHexString(),
-    description: `${fieldType} description`,
-    globalId: new ObjectID().toHexString(),
-    fieldType,
-    required: true,
-    disabled: false,
-  }
-  if (fieldType === BasicField.Table) {
-    return {
-      minimumRows: 1,
-      columns: [
-        {
-          title: 'Test Column Title 1',
-          required: true,
-          columnType: BasicField.ShortText,
-        },
-        {
-          title: 'Test Column Title 2',
-          required: true,
-          columnType: BasicField.Dropdown,
-        },
-      ],
-      ...defaultParams,
-      ...customParams,
-    }
-  }
-
-  return {
-    ...defaultParams,
-    ...customParams,
   }
 }
 
@@ -258,7 +221,6 @@ const dbHandler = {
   clearCollection,
   insertEmailForm,
   insertEncryptForm,
-  generateDefaultField,
 }
 
 export default dbHandler

--- a/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
@@ -130,7 +130,7 @@ describe('Dropdown validation', () => {
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isErr()).toBe(true)
     expect(validateResult._unsafeUnwrapErr()).toEqual(
-      new ValidateFieldError('Invalid answer submitted'),
+      new ValidateFieldError('Response has invalid shape'),
     )
   })
 })

--- a/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/dropdown-validation.spec.js
@@ -17,6 +17,7 @@ describe('Dropdown validation', () => {
       _id: 'ddID',
       fieldType: 'dropdown',
       answer: 'KISS',
+      isVisible: true,
     }
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
@@ -33,6 +34,7 @@ describe('Dropdown validation', () => {
       _id: 'ddID',
       fieldType: 'dropdown',
       answer: 'invalid',
+      isVisible: true,
     }
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isErr()).toBe(true)

--- a/tests/unit/backend/utils/field-validation/email-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/email-validation.spec.ts
@@ -47,7 +47,7 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'invalidemail.com',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isErr()).toBe(true)
     expect(validateResult._unsafeUnwrapErr()).toEqual(
@@ -71,7 +71,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: false,
       answer: '',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
@@ -96,7 +96,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
@@ -121,7 +121,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isErr()).toBe(true)
     expect(validateResult._unsafeUnwrapErr()).toEqual(
@@ -148,7 +148,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
@@ -173,7 +173,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
@@ -198,7 +198,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    }
+    } as ISingleAnswerResponse
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)

--- a/tests/unit/backend/utils/field-validation/table-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/table-validation.spec.js
@@ -226,7 +226,7 @@ describe('Table validation', () => {
       const validateResult = validateField(formId, formField, response)
       expect(validateResult.isErr()).toBe(true)
       expect(validateResult._unsafeUnwrapErr()).toEqual(
-        new ValidateFieldError('Invalid answer submitted'),
+        new ValidateFieldError('Response has invalid shape'),
       )
     })
   })

--- a/tests/unit/backend/utils/field-validation/yesno-validation.spec.js
+++ b/tests/unit/backend/utils/field-validation/yesno-validation.spec.js
@@ -10,6 +10,7 @@ describe('Yes/No field validation', () => {
       _id: 'abc123',
       fieldType: 'yes_no',
       answer: 'Yes',
+      isVisible: 'true',
     }
     const formField = {
       _id: 'abc123',
@@ -26,6 +27,7 @@ describe('Yes/No field validation', () => {
       _id: 'abc123',
       fieldType: 'yes_no',
       answer: 'No',
+      isVisible: 'true',
     }
     const formField = {
       _id: 'abc123',
@@ -77,6 +79,7 @@ describe('Yes/No field validation', () => {
       _id: 'abc123',
       fieldType: 'yes_no',
       answer: 'somethingRandom',
+      isVisible: 'true',
     }
     const formField = {
       _id: 'abc123',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Field validation has various related issues (described below) which allow responses with invalid shapes to slip past. This means that code after the validation step incorrectly assumes that the responses have a fixed shape, which can lead to null pointer exceptions.

## Solution
<!-- How did you solve the problem? -->
**Joi validation on field types**
The Joi validation on the submission endpoints enforces that `fieldType` is a string, but not that it matches one of our valid field types. Subsequent code simply assumes that the field type is a valid member of our `BasicField` enum.

The solution was to add the list of valid field types to our Joi validation on the `fieldType` key in each response.

**Joi validation on admin preview endpoint**
The preview submissions endpoint did not have any Joi validation, even though it called the same middleware functions as the public submissions endpoint. Hence identical validation was added at the preview endpoint.

**Response type guards**
The old `src/types/response/guards.ts` had a `isProcessedSingleAnswerResponse` function which took an argument of type `any` and checked if it was a valid `ProcessedSingleAnswerResponse`. I thought this function could be improved in the following ways:
1. Since it is currently only called with an argument of type `ProcessedFieldResponse`, its argument can be scoped to that type.
2. It should check that the field type is actually a single answer field type, so that for e.g. you can't submit a response of fieldType `checkbox` but with `answer` instead of `answerArray`.

To this end, I made the following changes:
- Changed the argument of `isProcessedSingleAnswerResponse` to be of type `ProcessedFieldResponse`, and removed the helper function `isProcessedFieldResponse` which checks for the shape of `ProcessedFieldResponse`. Together, the validation steps proceed as follows:
    1. Joi validation ensures that each response has a minimum of `_id`, `question` and `fieldType`, which is the minimum for a `FieldResponse`.
    2. The `getProcessedResponses` function turns the `FieldResponse` into a `ProcessedFieldResponse` by adding on the optional `isVisible` and `isUserVerified` booleans.
    3. The `isProcessedSingleAnswerResponse` type guard ensures that the response contains a string `answer` and that the field type is a single-answer field type.
- Added an `answerArray` boolean to `shared/resources/basic` to differentiate between fields with answer vs answerArray.
- Restricted the types in `src/types/response/index.ts` to accept only valid field types for each type of response.

**Control flow in `validateField`**
The old control flow in the `validateField` function worked as follows:
1. If the response has the correct shape for a single answer response, perform either FP or class-based validation.
2. Else, default to class-based validation.

The problem here is that we are defaulting to class-based validation for table/checkbox fields, without checking that the answers have the correct shape. This can lead to null-pointer exceptions if, say, someone submits a single-answer field with `answerArray` instead of `answer`.

The solution was to add type guards for `ProcessedCheckboxResponse` and `ProcessedTableResponse`, and explicitly check for the correct shape before defaulting to class-based validation. If none of the valid shapes are matched, an error is returned.

**SPCP fake field types**
For SPCP forms, the NRIC or UEN/UID are appended to the parsed responses with the same shape as regular responses so that they can be rendered in the email or the data tab. Previously, they were given fake `authenticationSp` and `authenticationCp` field types, which no longer worked after the Response field types were restricted. Since the field types are not used anyway, these were changed to `BasicField.Nric` (for NRIC and UID) and `BasicField.ShortText` (for UEN).

**Jasmine tests**
The tighter validation resulted in some Jasmine tests breaking because our tests are somehow checking that validation passes when a `table` field is submitted with `answer` instead of `answerArray`. These tests were updated.

**Jest tests**
The tests for `submission.service` failed to compile after I tightened the types. I found these tests quite difficult to work with due to the complexity of the input data, so I extracted a bunch of helper functions to generate fake form fields and responses, and simplified the input data of the tests.

## Tests
- [ ] Submit an email mode form with all form fields in preview mode.
- [ ] Submit a storage mode form with all form fields in preview mode.
- [ ] Create a Singpass email mode form with an autoreply email field. Submit the form and check that the NRIC is rendered correctly in both the admin response email and the autoreply email.
- [ ] Create a Corppass email mode form with an autoreply email field. Submit the form and check that the UEN and UID are rendered correctly in both the admin response email and the autoreply email.
- [ ] Create a Singpass storage mode form. Submit the form and check that the NRIC is rendered correctly in the data tab and the exported CSV. Add a form field and submit the form again. Check that the exported CSV has all the NRICs in the same column.
- [ ] Programmatically submit a table field with no `answerArray`, but with `answer` as an empty string. Check that you get a 400 and not a 500 response.
- [ ] Programmatically submit a table field with no `answerArray`, but with `answer` as a non-empty string. Check that you get a 400 and not a 500 response.
- [ ] Programmatically submit a short text field with no `answer`, but with `answerArray` as an empty array. Check that you get a 400 and not a 500 response.
- [ ] Programmatically submit a short text field with no `answer`, but with `answerArray` as a non-empty array. Check that you get a 400 and not a 500 response.