### PR TITLE
ref: migrate DELETE /{formId}/adminform endpoint flow to TypeScript

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -334,22 +334,6 @@ function makeModule(connection) {
       })
     },
     /**
-     * Deletes a form from list forms page (no delete on view form)
-     * @param  {Object} req - Express request object
-     * @param  {Object} res - Express response object
-     */
-    delete: function (req, res) {
-      let form = req.form
-      // Set form to inactive
-      form.status = 'ARCHIVED'
-      form.save(function (err, savedForm) {
-        if (err) {
-          return respondOnMongoError(req, res, err)
-        }
-        return res.json(savedForm)
-      })
-    },
-    /**
      * Duplicates an entire form from list forms page
      * Duplicating non-admin form, makes you admin of duplicated form
      * @param  {Object} req - Express request object

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -419,6 +419,17 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return newForm
   }
 
+  // Archives form.
+  FormSchema.methods.archive = function (this: IFormSchema) {
+    // Return instantly when form is already archived.
+    if (this.status === Status.Archived) {
+      return Promise.resolve(this)
+    }
+
+    this.status = Status.Archived
+    return this.save()
+  }
+
   // Transfer ownership of the form to another user
   FormSchema.methods.transferOwner = async function (
     currentOwner: IUserSchema,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -11,7 +11,7 @@ import * as FeedbackService from 'src/app/modules/feedback/feedback.service'
 import { FeedbackResponse } from 'src/app/modules/feedback/feedback.types'
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
-import { IPopulatedForm, IPopulatedUser, Status } from 'src/types'
+import { IPopulatedForm, IPopulatedUser } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -1608,11 +1608,6 @@ describe('admin-form.controller', () => {
     it('should return 200 with archived form', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
-      // Mock return count.
-      const expectedArchivedForm = {
-        _id: new ObjectId(),
-        status: Status.Archived,
-      } as IPopulatedForm
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
         okAsync(MOCK_USER as IPopulatedUser),
@@ -1620,9 +1615,7 @@ describe('admin-form.controller', () => {
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM as IPopulatedForm),
       )
-      MockAdminFormService.archiveForm.mockReturnValueOnce(
-        okAsync(expectedArchivedForm),
-      )
+      MockAdminFormService.archiveForm.mockReturnValueOnce(okAsync(true))
 
       // Act
       await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
@@ -1641,7 +1634,9 @@ describe('admin-form.controller', () => {
       )
       expect(MockAdminFormService.archiveForm).toHaveBeenCalledWith(MOCK_FORM)
       expect(mockRes.status).not.toHaveBeenCalled()
-      expect(mockRes.json).toHaveBeenCalledWith(expectedArchivedForm)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Form has been archived',
+      })
     })
 
     it('should return 403 when ForbiddenFormError is returned when verifying user permissions', async () => {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -11,7 +11,7 @@ import * as FeedbackService from 'src/app/modules/feedback/feedback.service'
 import { FeedbackResponse } from 'src/app/modules/feedback/feedback.types'
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
-import { IPopulatedForm, IPopulatedUser } from 'src/types'
+import { IPopulatedForm, IPopulatedUser, Status } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -1578,6 +1578,300 @@ describe('admin-form.controller', () => {
       expect(MockFeedbackService.getFormFeedbacks).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
+    })
+  })
+
+  describe('handleArchiveForm', () => {
+    const MOCK_USER_ID = new ObjectId()
+    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'another@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER as IPopulatedUser,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    } as IPopulatedForm
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID.toHexString(),
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    it('should return 200 with archived form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock return count.
+      const expectedArchivedForm = {
+        _id: new ObjectId(),
+        status: Status.Archived,
+      } as IPopulatedForm
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      MockAdminFormService.archiveForm.mockReturnValueOnce(
+        okAsync(expectedArchivedForm),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).toHaveBeenCalledWith(MOCK_FORM)
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith(expectedArchivedForm)
+    })
+
+    it('should return 403 when ForbiddenFormError is returned when verifying user permissions', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      const expectedErrorString = 'no archive access'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 404 when FormNotFoundError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is not found'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 410 when FormDeletedError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is deleted'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 422 when MissingUserError is returned when retrieving logged in user', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'user is not found'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving user in session', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'database goes boom'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving form after checking permissions', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'database goes boom'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst archiving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER as IPopulatedUser),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM as IPopulatedForm),
+      )
+      const expectedErrorString = 'database goes boom'
+      MockAdminFormService.archiveForm.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleArchiveForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Delete,
+        },
+      )
+      expect(MockAdminFormService.archiveForm).toHaveBeenCalledWith(MOCK_FORM)
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
     })
   })
 })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -284,7 +284,7 @@ describe('admin-form.service', () => {
   })
 
   describe('archiveForm', () => {
-    it('should successfully archive form', async () => {
+    it('should true when form is successfully archived', async () => {
       // Arrange
       const mockArchivedForm = {
         _id: new ObjectId(),
@@ -301,7 +301,7 @@ describe('admin-form.service', () => {
 
       // Assert
       expect(actual.isOk()).toEqual(true)
-      expect(actual._unsafeUnwrap()).toEqual(mockArchivedForm)
+      expect(actual._unsafeUnwrap()).toEqual(true)
     })
 
     it('should return DatabaseError if any database errors occur', async () => {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1,4 +1,5 @@
 import { PresignedPost } from 'aws-sdk/clients/s3'
+import { ObjectId } from 'bson-ext'
 import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
@@ -9,13 +10,21 @@ import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
 import { aws } from 'src/config/config'
 import { VALID_UPLOAD_FILE_TYPES } from 'src/shared/constants'
-import { DashboardFormView, IPopulatedUser, IUserSchema } from 'src/types'
+import {
+  DashboardFormView,
+  IEmailFormSchema,
+  IEncryptedFormSchema,
+  IPopulatedUser,
+  IUserSchema,
+  Status,
+} from 'src/types'
 
 import {
   CreatePresignedUrlError,
   InvalidFileTypeError,
 } from '../admin-form.errors'
 import {
+  archiveForm,
   createPresignedPostForImages,
   createPresignedPostForLogos,
   getDashboardForms,
@@ -270,6 +279,48 @@ describe('admin-form.service', () => {
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(
         new CreatePresignedUrlError('Error occurred whilst uploading file'),
+      )
+    })
+  })
+
+  describe('archiveForm', () => {
+    it('should successfully archive form', async () => {
+      // Arrange
+      const mockArchivedForm = {
+        _id: new ObjectId(),
+        admin: new ObjectId(),
+        status: Status.Archived,
+      } as IEmailFormSchema
+      const mockArchiveFn = jest.fn().mockResolvedValue(mockArchivedForm)
+      const mockInitialForm = ({
+        archive: mockArchiveFn,
+      } as unknown) as IEmailFormSchema
+
+      // Act
+      const actual = await archiveForm(mockInitialForm)
+
+      // Assert
+      expect(actual.isOk()).toEqual(true)
+      expect(actual._unsafeUnwrap()).toEqual(mockArchivedForm)
+    })
+
+    it('should return DatabaseError if any database errors occur', async () => {
+      // Arrange
+      const mockErrorString = 'database went wrong something'
+      const mockArchiveFn = jest
+        .fn()
+        .mockRejectedValue(new Error(mockErrorString))
+      const mockInitialForm = ({
+        archive: mockArchiveFn,
+      } as unknown) as IEncryptedFormSchema
+
+      // Act
+      const actual = await archiveForm(mockInitialForm)
+
+      // Assert
+      expect(actual.isErr()).toEqual(true)
+      expect(actual._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(mockErrorString),
       )
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -406,7 +406,7 @@ export const handleGetFormFeedbacks: RequestHandler<{
  * Handler for DELETE /{formId}/adminform.
  * @security session
  *
- * @returns 200 with archived form
+ * @returns 200 with success message when successfully archived
  * @returns 403 when user does not have permissions to archive form
  * @returns 404 when form cannot be found
  * @returns 410 when form is already archived
@@ -433,7 +433,7 @@ export const handleArchiveForm: RequestHandler<{ formId: string }> = async (
       )
       // Step 3: Currently logged in user has permissions to archive form.
       .andThen((formToArchive) => archiveForm(formToArchive))
-      .map((archivedForm) => res.json(archivedForm))
+      .map(() => res.json({ message: 'Form has been archived' }))
       .mapErr((error) => {
         logger.warn({
           message: 'Error occurred when archiving form',

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -12,9 +12,12 @@ import {
   AuthType,
   DashboardFormView,
   IFieldSchema,
+  IFormSchema,
+  IPopulatedForm,
   SpcpLocals,
 } from '../../../../types'
 import getFormModel from '../../../models/form.server.model'
+import { getMongoErrorMessage } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { MissingUserError } from '../../user/user.errors'
 import { findAdminById } from '../../user/user.service'
@@ -195,4 +198,27 @@ export const getMockSpcpLocals = (
     default:
       return {}
   }
+}
+
+/**
+ * Archives given form.
+ * @param form the form to archive
+ * @returns ok(archived form) if successful
+ * @returns err(DatabaseError) if any database errors occur
+ */
+export const archiveForm = (
+  form: IPopulatedForm,
+): ResultAsync<IFormSchema, DatabaseError> => {
+  return ResultAsync.fromPromise(form.archive(), (error) => {
+    logger.error({
+      message: 'Database error encountered when archiving form',
+      meta: {
+        action: 'archiveForm',
+        form,
+      },
+      error,
+    })
+
+    return new DatabaseError(getMongoErrorMessage(error))
+  })
 }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -12,7 +12,6 @@ import {
   AuthType,
   DashboardFormView,
   IFieldSchema,
-  IFormSchema,
   IPopulatedForm,
   SpcpLocals,
 } from '../../../../types'
@@ -203,12 +202,12 @@ export const getMockSpcpLocals = (
 /**
  * Archives given form.
  * @param form the form to archive
- * @returns ok(archived form) if successful
+ * @returns ok(true) if successful
  * @returns err(DatabaseError) if any database errors occur
  */
 export const archiveForm = (
   form: IPopulatedForm,
-): ResultAsync<IFormSchema, DatabaseError> => {
+): ResultAsync<true, DatabaseError> => {
   return ResultAsync.fromPromise(form.archive(), (error) => {
     logger.error({
       message: 'Database error encountered when archiving form',
@@ -220,5 +219,6 @@ export const archiveForm = (
     })
 
     return new DatabaseError(getMongoErrorMessage(error))
-  })
+    // On success, return true
+  }).map(() => true)
 }

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -167,7 +167,7 @@ module.exports = function (app) {
       forms.read(forms.REQUEST_TYPE.ADMIN),
     )
     .put(authActiveForm(PermissionLevel.Write), adminForms.update)
-    .delete(authActiveForm(PermissionLevel.Delete), adminForms.delete)
+    .delete(withUserAuthentication, AdminFormController.handleArchiveForm)
     .post(authActiveForm(PermissionLevel.Read), adminForms.duplicate)
 
   /**

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -106,6 +106,11 @@ export interface IFormSchema extends IForm, Document {
   getMainFields(): Pick<IFormSchema, '_id' | 'title' | 'status'>
   getUniqueMyInfoAttrs(): MyInfoAttribute[]
   duplicate(overrideProps: Partial<IForm>): Partial<IFormSchema>
+  /**
+   * Archives form.
+   * @returns form that has been archived
+   */
+  archive(): Promise<IFormSchema>
   transferOwner(currentOwner: IUserSchema, newOwnerEmail: string): void
 }
 

--- a/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
@@ -185,24 +185,6 @@ describe('Admin-Forms Controller', () => {
     })
   })
 
-  describe('delete', () => {
-    it('should delete from by setting status to archived', (done) => {
-      req.form = testForm
-      res.json.and.callFake(() => {
-        Form.findOne({ _id: testForm._id }, (err, foundForm) => {
-          if (err || !foundForm) {
-            done(err || new Error('Form not found'))
-          } else {
-            let foundFormObj = foundForm.toObject()
-            expect(foundFormObj.status).toEqual('ARCHIVED')
-            done()
-          }
-        })
-      })
-      Controller.delete(req, res)
-    })
-  })
-
   describe('duplicate', () => {
     it('should duplicate form with correct title, new admin and no collaborators', async (done) => {
       // Insert collaborator into User collection before duplicating form.

--- a/tests/unit/backend/models/form.server.model.spec.ts
+++ b/tests/unit/backend/models/form.server.model.spec.ts
@@ -7,6 +7,7 @@ import getFormModel, {
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
 import {
+  IEmailForm,
   IEncryptedForm,
   IPopulatedUser,
   Permission,
@@ -973,6 +974,64 @@ describe('Form Model', () => {
       await expect(Form.countDocuments()).resolves.toEqual(5)
       expect(actual.length).toEqual(3)
       expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('Methods', () => {
+    describe('archive', () => {
+      it('should successfully set email form status to archived', async () => {
+        // Arrange
+        const form = await Form.create<IEmailForm>({
+          admin: populatedAdmin._id,
+          emails: [populatedAdmin.email],
+          responseMode: ResponseMode.Email,
+          title: 'mock email form',
+          status: Status.Private,
+        })
+        expect(form).toBeDefined()
+
+        // Act
+        const actual = await form.archive()
+
+        // Assert
+        expect(actual.status).toEqual(Status.Archived)
+      })
+
+      it('should successfully set encrypt form status to archived', async () => {
+        // Arrange
+        const form = await Form.create<IEncryptedForm>({
+          admin: populatedAdmin._id,
+          publicKey: 'any public key',
+          responseMode: ResponseMode.Encrypt,
+          title: 'mock encrypt form',
+          status: Status.Public,
+        })
+        expect(form).toBeDefined()
+
+        // Act
+        const actual = await form.archive()
+
+        // Assert
+        expect(actual.status).toEqual(Status.Archived)
+      })
+
+      it('should stay archived if original form is already archived', async () => {
+        // Arrange
+        const form = await Form.create<IEncryptedForm>({
+          admin: populatedAdmin._id,
+          publicKey: 'any public key',
+          responseMode: ResponseMode.Encrypt,
+          title: 'mock encrypt form',
+          status: Status.Archived,
+        })
+        expect(form).toBeDefined()
+
+        // Act
+        const actual = await form.archive()
+
+        // Assert
+        expect(actual.status).toEqual(Status.Archived)
+      })
     })
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates the `DELETE /{formId}/adminform` endpoint to TypeScript

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add `FormModel.archive()` instance method
- add `AdminFormSvc#archiveForm` service function
- add `AdminFormCtl#handleArchiveForm` handler function
- use new \^ handler function in AdminFormRoutes to handle archiving of form

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests have been written for all new functions. 

Integration tests have not been written for the router since it has not been migrated yet.
