### PR TITLE
ref: migrate copy template form flow to TypeScript 

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -20,7 +20,6 @@ const {
   getEncryptedFormModel,
   getEmailFormModel,
 } = require('../models/form.server.model')
-const getFormModel = require('../models/form.server.model').default
 const getSubmissionModel = require('../models/submission.server.model').default
 const { ResponseMode } = require('../../types')
 
@@ -331,68 +330,6 @@ function makeModule(connection) {
       form.save(function (err, savedForm) {
         if (err) return respondOnMongoError(req, res, err)
         return res.json(savedForm)
-      })
-    },
-    /**
-     * Duplicates an entire form from list forms page
-     * Duplicating non-admin form, makes you admin of duplicated form
-     * @param  {Object} req - Express request object
-     * @param  {Object} res - Express response object
-     */
-    duplicate: function (req, res) {
-      let Form = getFormModel(connection)
-      let id = req.form._id
-      Form.findById({ _id: id }).exec(function (err, form) {
-        if (err) {
-          return respondOnMongoError(req, res, err)
-        } else if (!form) {
-          return res
-            .status(StatusCodes.NOT_FOUND)
-            .json({ message: 'Form not found for duplication' })
-        } else {
-          let responseMode = req.body.responseMode || 'email'
-          // Custom properties on the new form
-          const overrideProps = {
-            responseMode,
-            admin: req.session.user._id,
-            title: req.body.title,
-            isNew: true,
-          }
-          if (responseMode === 'encrypt') {
-            overrideProps.publicKey = req.body.publicKey
-          } else {
-            if (req.body.emails) {
-              overrideProps.emails = req.body.emails
-            }
-          }
-          if (req.body.isTemplate) {
-            overrideProps.customLogo = undefined
-          }
-
-          // Prevent buttonLink from being copied over if same as formHash (for old forms)
-          if (form.endPage && form.endPage.buttonLink) {
-            let oldFormHash = '#!/' + id
-            if (form.endPage.buttonLink === oldFormHash) {
-              overrideProps.endPage = form.endPage
-              delete overrideProps.endPage.buttonLink
-            }
-          }
-
-          const onError = (error) => respondOnMongoError(req, res, error)
-
-          const onSuccess = (successForm) => {
-            const dupedDashView = successForm.getDashboardView(req.session.user)
-            return res.json(dupedDashView)
-          }
-
-          const DiscriminatedForm = getDiscriminatedFormModel(responseMode)
-          const discriminatedForm = new DiscriminatedForm(
-            form.getDuplicateParams(overrideProps),
-          )
-          discriminatedForm.save(function (sErr, duplicated) {
-            return sErr ? onError(sErr) : onSuccess(duplicated)
-          })
-        }
       })
     },
     /**

--- a/src/app/modules/auth/__tests__/auth.service.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.service.spec.ts
@@ -397,7 +397,7 @@ describe('auth.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
       expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
         expectedForm,
-        'Form must be public to be copied',
+        'Cannot access private form',
       )
     })
 
@@ -424,7 +424,7 @@ describe('auth.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
       expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
         expectedForm,
-        'Form must be public to be copied',
+        'Cannot access private form',
       )
     })
 

--- a/src/app/modules/auth/__tests__/auth.service.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.service.spec.ts
@@ -17,6 +17,7 @@ import {
   ForbiddenFormError,
   FormDeletedError,
   FormNotFoundError,
+  PrivateFormError,
 } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
 import { InvalidDomainError, InvalidOtpError } from '../auth.errors'
@@ -327,6 +328,123 @@ describe('auth.service', () => {
       // Assert
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
+    })
+  })
+
+  describe('getFormIfPublic', () => {
+    it('should return populated form when form to retrieve is public', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const expectedForm = {
+        _id: mockFormId,
+        title: 'some form',
+      } as IPopulatedForm
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(expectedForm),
+      )
+      MockFormService.isFormPublic.mockReturnValueOnce(ok(true))
+
+      // Act
+      const actualResult = await AuthService.getFormIfPublic(
+        mockFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
+    })
+
+    it('should return FormNotFoundError when returned form is not found', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const expectedError = new FormNotFoundError('no form')
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      const actualResult = await AuthService.getFormIfPublic(
+        mockFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
+      expect(MockFormService.isFormPublic).not.toHaveBeenCalled()
+    })
+
+    it('should return FormDeletedError when form is already archived', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const expectedForm = {
+        _id: mockFormId,
+        title: 'some form',
+      } as IPopulatedForm
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(expectedForm),
+      )
+      const expectedError = new FormDeletedError('gone')
+      MockFormService.isFormPublic.mockReturnValueOnce(err(expectedError))
+
+      // Act
+      const actualResult = await AuthService.getFormIfPublic(
+        mockFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
+      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
+        expectedForm,
+        'Form must be public to be copied',
+      )
+    })
+
+    it('should return PrivateFormError when form is private', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const expectedForm = {
+        _id: mockFormId,
+        title: 'some form',
+      } as IPopulatedForm
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(expectedForm),
+      )
+      const expectedError = new PrivateFormError('you have no access')
+      MockFormService.isFormPublic.mockReturnValueOnce(err(expectedError))
+
+      // Act
+      const actualResult = await AuthService.getFormIfPublic(
+        mockFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
+      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
+        expectedForm,
+        'Form must be public to be copied',
+      )
+    })
+
+    it('should return DatabaseError when database error occurs when retrieving form', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const expectedError = new DatabaseError('bam goes the database')
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      const actualResult = await AuthService.getFormIfPublic(
+        mockFormId.toHexString(),
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
+      expect(MockFormService.isFormPublic).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -25,6 +25,7 @@ import {
   ForbiddenFormError,
   FormDeletedError,
   FormNotFoundError,
+  PrivateFormError,
 } from '../form/form.errors'
 import * as FormService from '../form/form.service'
 
@@ -295,6 +296,28 @@ export const getFormAfterPermissionChecks = ({
       getAssertPermissionFn(level)(user, fullForm)
         // Step 4: If success, return retrieved form.
         .map(() => fullForm),
+    ),
+  )
+}
+
+/**
+ * Retrieves the form of given formId provided that the form is public.
+ *
+ * @returns ok(form) if the form is public
+ * @returns err(FormNotFoundError) if form (or form admin) does not exist
+ * @returns err(FormDeletedError) if form is already archived
+ * @returns err(PrivateFormError) if form is private
+ * @returns err(DatabaseError) if database error occurs
+ */
+export const getFormIfPublic = (
+  formId: string,
+): ResultAsync<
+  IPopulatedForm,
+  FormNotFoundError | FormDeletedError | PrivateFormError | DatabaseError
+> => {
+  return FormService.retrieveFullFormById(formId).andThen((form) =>
+    FormService.isFormPublic(form, 'Form must be public to be copied').map(
+      () => form,
     ),
   )
 }

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -316,8 +316,8 @@ export const getFormIfPublic = (
   FormNotFoundError | FormDeletedError | PrivateFormError | DatabaseError
 > => {
   return FormService.retrieveFullFormById(formId).andThen((form) =>
-    FormService.isFormPublic(form, 'Cannot access private form').map(
-      () => form,
-    ),
+    FormService.isFormPublic(form, 'Cannot access private form')
+      // Form is public, return form.
+      .map(() => form),
   )
 }

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -316,7 +316,7 @@ export const getFormIfPublic = (
   FormNotFoundError | FormDeletedError | PrivateFormError | DatabaseError
 > => {
   return FormService.retrieveFullFormById(formId).andThen((form) =>
-    FormService.isFormPublic(form, 'Form must be public to be copied').map(
+    FormService.isFormPublic(form, 'Cannot access private form').map(
       () => form,
     ),
   )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -25,6 +25,7 @@ import {
   ForbiddenFormError,
   FormDeletedError,
   FormNotFoundError,
+  PrivateFormError,
 } from '../../form.errors'
 import * as AdminFormController from '../admin-form.controller'
 import {
@@ -2392,6 +2393,297 @@ describe('admin-form.controller', () => {
 
       // Act
       await AdminFormController.handleDuplicateAdminForm(
+        mockReqWithParams,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_USER_ID,
+        expectedParams,
+      )
+    })
+  })
+
+  describe('handleCopyTemplateForm', () => {
+    const MOCK_USER_ID = new ObjectId()
+    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'andanother@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      title: 'mock title again',
+    } as IPopulatedForm
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID.toHexString(),
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+      body: {} as DuplicateFormBody,
+    })
+
+    it('should return copied template form view on duplicate success', async () => {
+      // Arrange
+      const expectedParams: DuplicateFormBody = {
+        responseMode: ResponseMode.Email,
+        emails: ['some-email@example.com'],
+        title: 'mock new template title',
+      }
+      const mockDupedFormView = {
+        title: 'mock template view',
+      } as DashboardFormView
+      const mockDupedForm = merge({}, MOCK_FORM, {
+        title: 'duped form with new title',
+        _id: new ObjectId(),
+        getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+      })
+      const mockRes = expressHandler.mockResponse()
+      const mockReqWithParams = merge({}, MOCK_REQ, {
+        body: expectedParams,
+      })
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(okAsync(MOCK_FORM))
+      MockAdminFormService.duplicateForm.mockReturnValueOnce(
+        okAsync(mockDupedForm),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        mockReqWithParams,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_USER_ID,
+        expectedParams,
+      )
+    })
+
+    it('should return 403 when form is private', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'form is private'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(
+        errAsync(new PrivateFormError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+    })
+
+    it('should return 404 when form to duplicate cannot be found', async () => {
+      // Arrange
+      const expectedParams: DuplicateFormBody = {
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'some public key',
+        title: 'mock title',
+      }
+      const mockRes = expressHandler.mockResponse()
+      const mockReqWithParams = merge({}, MOCK_REQ, {
+        body: expectedParams,
+      })
+      const mockErrorString = 'cannot find form to duplicate suddenly'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(okAsync(MOCK_FORM))
+      MockAdminFormService.duplicateForm.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        mockReqWithParams,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_USER_ID,
+        expectedParams,
+      )
+    })
+
+    it('should return 410 when form to duplicate is archived', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'form archived error'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(
+        errAsync(new FormDeletedError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'oh no user'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+    })
+
+    it('should return 500 when database error occurs whilst retrieving logged  in user', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'db error retrieving user'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+    })
+
+    it('should return 500 when database error occurs whilst retrieving form to duplicate', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'db error retrieving form'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: mockErrorString,
+      })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+    })
+
+    it('should return 500 when database error occurs whilst duplicating form', async () => {
+      // Arrange
+      const expectedParams: DuplicateFormBody = {
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'some public key',
+        title: 'mock title',
+      }
+      const mockRes = expressHandler.mockResponse()
+      const mockReqWithParams = merge({}, MOCK_REQ, {
+        body: expectedParams,
+      })
+      const mockErrorString = 'db error duplicating form'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(okAsync(MOCK_FORM))
+      MockAdminFormService.duplicateForm.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
         mockReqWithParams,
         mockRes,
         jest.fn(),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -580,6 +580,16 @@ export const handleCopyTemplateForm: RequestHandler<
   const userId = (req.session as Express.AuthedSession).user._id
   const overrideParams = req.body
 
+  // TODO(#792): Remove when frontend has stopped sending isTemplate.
+  if ('isTemplate' in req.body) {
+    logger.info({
+      message: 'isTemplate is still being sent by the frontend',
+      meta: {
+        action: 'handleCopyTemplateForm',
+      },
+    })
+  }
+
   return (
     // Step 1: Retrieve currently logged in user.
     UserService.getPopulatedUserById(userId)

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -565,7 +565,7 @@ export const handleDuplicateAdminForm: RequestHandler<
  * @security session
  *
  * @returns 200 with the duplicate form dashboard view
- * @returns 403 when user does not have permissions to access form
+ * @returns 403 when form is private
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived
  * @returns 422 when user in session cannot be retrieved from the database

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -556,3 +556,58 @@ export const handleDuplicateAdminForm: RequestHandler<
       })
   )
 }
+
+/**
+ * Handler for POST /:formId/adminform/copy
+ * Duplicates the form corresponding to the formId. The form must be public to
+ * be copied.
+ * @note The current user will be the admin of the new duplicated form
+ * @security session
+ *
+ * @returns 200 with the duplicate form dashboard view
+ * @returns 403 when user does not have permissions to access form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+export const handleCopyTemplateForm: RequestHandler<
+  { formId: string },
+  unknown,
+  DuplicateFormBody
+> = (req, res) => {
+  const { formId } = req.params
+  const userId = (req.session as Express.AuthedSession).user._id
+  const overrideParams = req.body
+
+  return (
+    // Step 1: Retrieve currently logged in user.
+    UserService.getPopulatedUserById(userId)
+      .andThen((user) =>
+        // Step 2: Check if form is currently public.
+        AuthService.getFormIfPublic(formId).andThen((originalForm) =>
+          // Step 3: Duplicate form.
+          duplicateForm(originalForm, userId, overrideParams)
+            // Step 4: Retrieve dashboard view of duplicated form.
+            .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
+        ),
+      )
+      // Success; return duplicated form's dashboard view.
+      .map((dupedDashView) => res.json(dupedDashView))
+      // Error; some error occurred in the chain.
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error copying template form',
+          meta: {
+            action: 'handleCopyTemplateForm',
+            ...createReqMeta(req),
+            userId: userId,
+            formId,
+          },
+          error,
+        })
+        const { errorMessage, statusCode } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
+}

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -530,12 +530,13 @@ export const handleDuplicateAdminForm: RequestHandler<
           user,
           formId,
           level: PermissionLevel.Read,
-        }).andThen((originalForm) =>
-          // Step 3: Duplicate form.
-          duplicateForm(originalForm, userId, overrideParams)
-            // Step 4: Retrieve dashboard view of duplicated form.
-            .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
-        ),
+        })
+          .andThen((originalForm) =>
+            // Step 3: Duplicate form.
+            duplicateForm(originalForm, userId, overrideParams),
+          )
+          // Step 4: Retrieve dashboard view of duplicated form.
+          .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
       )
       // Success; return duplicated form's dashboard view.
       .map((dupedDashView) => res.json(dupedDashView))

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -15,6 +15,7 @@ import {
   ForbiddenFormError,
   FormDeletedError,
   FormNotFoundError,
+  PrivateFormError,
 } from '../form.errors'
 
 import {
@@ -57,6 +58,7 @@ export const mapRouteError = (
         statusCode: StatusCodes.GONE,
         errorMessage: error.message,
       }
+    case PrivateFormError:
     case ForbiddenFormError:
       return {
         statusCode: StatusCodes.FORBIDDEN,

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -97,6 +97,7 @@ export const retrieveFormById = (
 /**
  * Method to ensure given form is available to the public.
  * @param form the form to check
+ * @param errMessageOverride optional, overrides error message with given string
  * @returns ok(true) if form is public
  * @returns err(FormDeletedError) if form has been deleted
  * @returns err(PrivateFormError) if form is private
@@ -104,6 +105,7 @@ export const retrieveFormById = (
  */
 export const isFormPublic = (
   form: IPopulatedForm,
+  errMessageOverride?: string,
 ): Result<true, FormDeletedError | PrivateFormError | ApplicationError> => {
   if (!form.status) {
     return err(new ApplicationError())
@@ -113,9 +115,11 @@ export const isFormPublic = (
     case Status.Public:
       return ok(true)
     case Status.Archived:
-      return err(new FormDeletedError())
+      return err(new FormDeletedError(errMessageOverride))
     case Status.Private:
-      return err(new PrivateFormError(form.inactiveMessage))
+      return err(
+        new PrivateFormError(errMessageOverride ?? form.inactiveMessage),
+      )
     default:
       return assertUnreachable(form.status)
   }

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -254,7 +254,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/copy').post(
-    authAdminActiveAnyForm,
+    withUserAuthentication,
     celebrate({
       [Segments.BODY]: {
         // Require valid responsesMode field.
@@ -282,7 +282,7 @@ module.exports = function (app) {
         isTemplate: Joi.boolean(),
       },
     }),
-    adminForms.duplicate,
+    AdminFormController.handleCopyTemplateForm,
   )
 
   /**

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -253,9 +253,37 @@ module.exports = function (app) {
    * @returns {AdminForm.model} 200 - the form
    * @security OTP
    */
-  app
-    .route('/:formId([a-fA-F0-9]{24})/adminform/copy')
-    .post(authAdminActiveAnyForm, adminForms.duplicate)
+  app.route('/:formId([a-fA-F0-9]{24})/adminform/copy').post(
+    authAdminActiveAnyForm,
+    celebrate({
+      [Segments.BODY]: {
+        // Require valid responsesMode field.
+        responseMode: Joi.string()
+          .valid(...Object.values(ResponseMode))
+          .required(),
+        // Require title field.
+        title: Joi.string().min(4).max(200).required(),
+        // Require emails string (for backwards compatibility) or string array
+        // if form to be duplicated in Email mode.
+        emails: Joi.alternatives()
+          .try(Joi.array().items(Joi.string()), Joi.string())
+          .when('responseMode', {
+            is: ResponseMode.Email,
+            then: Joi.required(),
+          }),
+        // Require publicKey field if form to be duplicated in Storage mode.
+        publicKey: Joi.string()
+          .allow('')
+          .when('responseMode', {
+            is: ResponseMode.Encrypt,
+            then: Joi.string().required().disallow(''),
+          }),
+        // TODO(#792): Remove when frontend has stopped sending isTemplate.
+        isTemplate: Joi.boolean(),
+      },
+    }),
+    adminForms.duplicate,
+  )
 
   /**
    * @typedef FeedbackResponse

--- a/src/public/modules/forms/services/form-factory.client.service.js
+++ b/src/public/modules/forms/services/form-factory.client.service.js
@@ -19,7 +19,7 @@ function FormFactory(FormApi) {
       case 'duplicate':
         return FormApi.save({ formId }, params)
       case 'useTemplate':
-        return FormApi.useTemplate({ formId }, { ...params, isTemplate: true })
+        return FormApi.useTemplate({ formId }, params)
       default:
         throw new Error('Unsupported mode of form generation.')
     }

--- a/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/admin-forms.server.controller.spec.js
@@ -6,7 +6,6 @@ const roles = require('../helpers/roles')
 
 const User = dbHandler.makeModel('user.server.model', 'User')
 const Form = dbHandler.makeModel('form.server.model', 'Form')
-const EmailForm = mongoose.model('email')
 
 const Controller = spec(
   'dist/backend/app/controllers/admin-forms.server.controller',
@@ -182,45 +181,6 @@ describe('Admin-Forms Controller', () => {
         return res
       })
       Controller.update(req, res)
-    })
-  })
-
-  describe('duplicate', () => {
-    it('should duplicate form with correct title, new admin and no collaborators', async (done) => {
-      // Insert collaborator into User collection before duplicating form.
-      const collabAdmin = await User.create({
-        email: 'test1@test.gov.sg',
-        _id: mongoose.Types.ObjectId('000000000002'),
-        agency: testAgency._id,
-      })
-
-      let collaboratedForm = new EmailForm({
-        title: 'Form to duplicate',
-        emails: 'test1@test.gov.sg',
-        admin: collabAdmin._id,
-        permissionList: [roles.collaborator(testUser.email)],
-      })
-      req.form = collaboratedForm
-      // Passed in create-form-modal.client.controller
-      req.body.emails = testUser.email
-      req.body.title = 'Form to duplicate_3'
-
-      collaboratedForm.save().then(() => {
-        res.json.and.callFake((args) => {
-          expect(args.title).toEqual(collaboratedForm.title + '_' + 3)
-          Form.findOne({ _id: args._id }, (err, foundForm) => {
-            if (!err) {
-              let duplicatedForm = foundForm.toObject()
-              expect(duplicatedForm.admin.toString()).toEqual(
-                req.session.user._id.toString(),
-              )
-              expect(duplicatedForm.permissionList).toEqual([])
-            }
-            done(err)
-          })
-        })
-        Controller.duplicate(req, res)
-      })
     })
   })
 


### PR DESCRIPTION
This PR builds upon #789

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds a separate controller for copying of templates. Unlike the controller in #789 (which checks if the currently logged in user has read permissions to the form), this handler only checks if the form is public prior to allowing the duplication of the form.

In addition, this PR also removes the usage of `isTemplate`, and updates frontend clients to stop sending that parameter. Tracked by issue #792.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(AuthSvc): add `getFormIfPublic` service fn
- feat(AdminFormCtl): add `handleCopyTemplateForm` handler fn
- feat(AdminFormRoutes): add Joi validation to the `/adminform/copy` endpoint
- feat: remove and track sending of isTemplate param when using template 

**Improvements**:
- ref(AdminFormRoutes): use new `handleCopyTemplateForm` handler

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests are added for all the newly added functions. No integration tests yet since router has not been migrated.
