### PR TITLE
test: raise test coverage threshold

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   coverageReporters: ['lcov', 'text'],
   coverageThreshold: {
     global: {
-      statements: 25, // Increase this percentage as test coverage improves
+      statements: 38, // Increase this percentage as test coverage improves
     },
   },
   testEnvironment: 'node',


### PR DESCRIPTION
The team's effort in refactoring and writing tests has raised the test coverage threshold from 25% to 38%.

Given that around half of the codebase comprises of backend code, this also means that backend test coverage currently stands at ~70% (not counting Jasmine tests).

