### PR TITLE
ref: migrate endpoint for getting admin form to TypeScript 

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -484,13 +484,15 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     this: IFormModel,
     formId: string,
   ): Promise<IPopulatedForm | null> {
-    const data: IPopulatedForm | null = await this.findById(formId).populate({
+    return this.findById(formId).populate({
       path: 'admin',
+      // Remove irrelevant keys from populated fields of form admin and agency.
+      select: '-__v -created -lastModified -updatedAt -lastAccessed',
       populate: {
         path: 'agency',
+        select: '-__v -created -lastModified -updatedAt',
       },
     })
-    return data
   }
 
   // Deactivate form by ID

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -109,8 +109,8 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleGetAdminForm', () => {
-    const MOCK_USER_ID = new ObjectId()
-    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
@@ -123,7 +123,7 @@ describe('admin-form.controller', () => {
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
-        formId: MOCK_FORM_ID.toHexString(),
+        formId: MOCK_FORM_ID,
       },
       session: {
         user: {
@@ -154,7 +154,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -186,7 +186,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -220,7 +220,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -254,7 +254,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -340,7 +340,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -514,8 +514,8 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleCountFormSubmissions', () => {
-    const MOCK_USER_ID = new ObjectId()
-    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER: Partial<IPopulatedUser> = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
@@ -528,7 +528,7 @@ describe('admin-form.controller', () => {
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
-        formId: MOCK_FORM_ID.toHexString(),
+        formId: MOCK_FORM_ID,
       },
       session: {
         user: {
@@ -568,7 +568,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -619,7 +619,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -658,7 +658,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -699,7 +699,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -740,7 +740,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -847,7 +847,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -890,7 +890,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -908,8 +908,8 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleCountFormFeedback', () => {
-    const MOCK_USER_ID = new ObjectId()
-    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER: Partial<IPopulatedUser> = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
@@ -922,7 +922,7 @@ describe('admin-form.controller', () => {
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
-        formId: MOCK_FORM_ID.toHexString(),
+        formId: MOCK_FORM_ID,
       },
       session: {
         user: {
@@ -962,7 +962,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1000,7 +1000,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1039,7 +1039,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1078,7 +1078,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1179,7 +1179,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1220,7 +1220,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1235,8 +1235,8 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleStreamFormFeedback', () => {
-    const MOCK_USER_ID = new ObjectId()
-    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER: Partial<IPopulatedUser> = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
@@ -1249,7 +1249,7 @@ describe('admin-form.controller', () => {
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
-        formId: MOCK_FORM_ID.toHexString(),
+        formId: MOCK_FORM_ID,
       },
       session: {
         user: {
@@ -1290,7 +1290,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1326,7 +1326,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1365,7 +1365,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1404,7 +1404,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1505,7 +1505,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Read,
         },
       )
@@ -1825,8 +1825,8 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleArchiveForm', () => {
-    const MOCK_USER_ID = new ObjectId()
-    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
       _id: MOCK_USER_ID,
       email: 'another@example.com',
@@ -1839,7 +1839,7 @@ describe('admin-form.controller', () => {
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
-        formId: MOCK_FORM_ID.toHexString(),
+        formId: MOCK_FORM_ID,
       },
       session: {
         user: {
@@ -1871,7 +1871,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )
@@ -1905,7 +1905,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )
@@ -1940,7 +1940,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )
@@ -1975,7 +1975,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )
@@ -2064,7 +2064,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )
@@ -2101,7 +2101,7 @@ describe('admin-form.controller', () => {
       expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
         {
           user: MOCK_USER,
-          formId: MOCK_FORM_ID.toHexString(),
+          formId: MOCK_FORM_ID,
           level: PermissionLevel.Delete,
         },
       )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -108,6 +108,249 @@ describe('admin-form.controller', () => {
     })
   })
 
+  describe('handleGetAdminForm', () => {
+    const MOCK_USER_ID = new ObjectId()
+    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    } as IPopulatedForm
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID.toHexString(),
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    it('should return 200 with queried admin form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith({ form: MOCK_FORM })
+    })
+
+    it('should return 403 when ForbiddenFormError is returned when verifying user permissions', async () => {
+      // Arrange
+      const expectedErrorString = 'no read access'
+
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 404 when FormNotFoundError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is not found'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 410 when FormDeletedError is returned when retrieving form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'form is deleted'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 422 when MissingUserError is returned when retrieving logged in user', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'user is not found'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving user in session', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'database goes boom'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving populated form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      // Mock error when retrieving form.
+      const expectedErrorString = 'database goes boom'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleGetAdminForm(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      // Check all arguments of called services.
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID.toHexString(),
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+    })
+  })
+
   describe('handleCreatePresignedPostForImages', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       body: {

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -54,6 +54,52 @@ export const handleListDashboardForms: RequestHandler = async (req, res) => {
 }
 
 /**
+ * Handler for GET /:formId/adminform.
+ * @security session
+ *
+ * @returns 200 with retrieved form with formId if user has read permissions
+ * @returns 403 when user does not have permissions to access form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+export const handleGetAdminForm: RequestHandler<{ formId: string }> = (
+  req,
+  res,
+) => {
+  const { formId } = req.params
+  const sessionUserId = (req.session as Express.AuthedSession).user._id
+
+  return (
+    // Step 1: Retrieve currently logged in user.
+    UserService.getPopulatedUserById(sessionUserId)
+      .andThen((user) =>
+        // Step 2: Check whether user has read permissions to form
+        AuthService.getFormAfterPermissionChecks({
+          user,
+          formId,
+          level: PermissionLevel.Read,
+        }),
+      )
+      .map((form) => res.json({ form }))
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error retrieving single form',
+          meta: {
+            action: 'handleGetSingleForm',
+            ...createReqMeta(req),
+          },
+          error,
+        })
+
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
+}
+
+/**
  * Handler for POST /:formId([a-fA-F0-9]{24})/adminform/images.
  * @security session
  *

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -82,7 +82,7 @@ export const handleGetAdminForm: RequestHandler<{ formId: string }> = (
           level: PermissionLevel.Read,
         }),
       )
-      .map((form) => res.json({ form }))
+      .map((form) => res.status(StatusCodes.OK).json({ form }))
       .mapErr((error) => {
         logger.error({
           message: 'Error retrieving single form',

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -162,10 +162,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform')
-    .get(
-      authActiveForm(PermissionLevel.Read),
-      forms.read(forms.REQUEST_TYPE.ADMIN),
-    )
+    .get(withUserAuthentication, AdminFormController.handleGetAdminForm)
     .put(authActiveForm(PermissionLevel.Write), adminForms.update)
     .delete(withUserAuthentication, AdminFormController.handleArchiveForm)
     .post(authActiveForm(PermissionLevel.Read), adminForms.duplicate)

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,4 +1,5 @@
 import { Document, Model } from 'mongoose'
+import { Merge } from 'type-fest'
 
 import { IFieldSchema, MyInfoAttribute } from './field'
 import { ILogicSchema } from './form_logic'
@@ -115,7 +116,19 @@ export interface IFormSchema extends IForm, Document {
 }
 
 export interface IPopulatedForm extends IFormSchema {
-  admin: IPopulatedUser
+  // Remove extraneous keys that the populated form should not require.
+  admin: Merge<
+    Omit<
+      IPopulatedUser,
+      '__v' | 'created' | 'lastModified' | 'updatedAt' | 'lastAccessed'
+    >,
+    {
+      agency: Omit<
+        IPopulatedUser['agency'],
+        '__v' | 'created' | 'lastModified' | 'updatedAt'
+      >
+    }
+  >
 }
 
 export interface IEncryptedForm extends IForm {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR migrates `GET /adminform` to the new layered architecture and Typescript.
Additional refactor to remove extraneous information of admin/agency when retrieving the populated form version.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(FormModel): remove unneeded agency/admin keys in `getFullFormById` such as the document version, the referenced admin and agency's creation or last modified dates
- add `handleGetAdminForm` handler fn
- use new `handleGetAdminForm` handler fn to handle `GET /adminform` endpoint

## Tests
<!-- What tests should be run to confirm functionality? -->
Relevant tests have been added.
