### PR TITLE
fix: disallow past date and custom min date sets min date incorrectly

### DIFF
--- a/src/public/modules/forms/base/components/field-date.client.component.js
+++ b/src/public/modules/forms/base/components/field-date.client.component.js
@@ -58,8 +58,17 @@ function dateFieldComponentController() {
       }
 
       // If minDate is set, default view upon opening datepicker to be month of minDate
+      // Setting vm.dateOptions.initDate = vm.dateOptions.minDate directly leads to a bug
+      // whereby after a date is selected on the datepicker,minDate is set to the start of
+      // the month of the selected date.
+      // This is possibly because init date is automatically updated to the month of
+      // the latest date selection (did not find more details in documentation);
+      // since object properties are passed by reference, this led to dateOptions.minDate
+      // also being updated to the start of the selected month
       if (vm.dateOptions.minDate) {
-        vm.dateOptions.initDate = vm.dateOptions.minDate
+        vm.dateOptions.initDate = new Date(vm.dateOptions.minDate)
+      } else {
+        vm.dateOptions.initDate = null
       }
     }
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #805

- Setting vm.dateOptions.initDate = vm.dateOptions.minDate directly leads to a bug whereby after a date is selected on the datepicker,minDate is set to the start of the month of the selected date.
- This is possibly because init date is automatically updated to the month of the latest date selection (did not find more details in documentation); since object properties are passed by reference, this led to dateOptions.minDate also being updated to the start of the selected month

## Solution
- Wrap value of vm.dateOptions.initDate in a new Date object to avoid reference to vm.dateOptions.minDate

## Tests
**(Tested on IE)**
- [ ] Create date field. Set custom date range with minimum date in the distant past (e.g. 2015). Open the form in public view. Check that the datepicker opens to the month of the minimum date by default. 
- [ ] Select a date on the date picker 1 year in the future. Check that there is no change to the minimum date.
- [ ] Repeat the above with disallow past dates.
- [ ] Create date field with no date validation. Open in public view. Check that the datepicker opens to the current month by default.