### PR TITLE
chore: log errors from concatResponse

### DIFF
--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -380,6 +380,10 @@ exports.saveMetadataToDb = function (req, res, next) {
       },
       error: err,
     })
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      message:
+        'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
+    })
   }
 
   createHash(concatenatedResponse)

--- a/src/app/controllers/email-submissions.server.controller.js
+++ b/src/app/controllers/email-submissions.server.controller.js
@@ -366,7 +366,21 @@ exports.saveMetadataToDb = function (req, res, next) {
   })
 
   // Create submission hash
-  let concatenatedResponse = concatResponse(formData, attachments)
+  let concatenatedResponse
+
+  try {
+    concatenatedResponse = concatResponse(formData, attachments)
+  } catch (err) {
+    logger.error({
+      message: 'Error concatenating response for submission hash',
+      meta: {
+        action: 'concatResponse',
+        ...createReqMeta(req),
+        formId: req.form._id,
+      },
+      error: err,
+    })
+  }
 
   createHash(concatenatedResponse)
     .then((result) => {


### PR DESCRIPTION
_(to rebase after #755)_
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Undefined answers are being passed into submission
Part of #808

## Solution
- Not immediately apparent where the validation gap is as unable to replicate
- Propose to log errors from concatResponse first so that we have more details to replicate and debug
- TODO: Review logs in 1 weeks' time