### PR TITLE
ref: migrate GET adminform/template endpoint to TypeScript

### DIFF
--- a/src/app/modules/auth/__tests__/auth.service.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.service.spec.ts
@@ -395,10 +395,7 @@ describe('auth.service', () => {
       // Assert
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
-      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
-        expectedForm,
-        'Cannot access private form',
-      )
+      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(expectedForm)
     })
 
     it('should return PrivateFormError when form is private', async () => {
@@ -411,7 +408,10 @@ describe('auth.service', () => {
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
         okAsync(expectedForm),
       )
-      const expectedError = new PrivateFormError('you have no access')
+      const expectedError = new PrivateFormError(
+        'you have no access',
+        expectedForm.title,
+      )
       MockFormService.isFormPublic.mockReturnValueOnce(err(expectedError))
 
       // Act
@@ -422,10 +422,7 @@ describe('auth.service', () => {
       // Assert
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toEqual(expectedError)
-      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(
-        expectedForm,
-        'Cannot access private form',
-      )
+      expect(MockFormService.isFormPublic).toHaveBeenCalledWith(expectedForm)
     })
 
     it('should return DatabaseError when database error occurs when retrieving form', async () => {

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -316,8 +316,6 @@ export const getFormIfPublic = (
   FormNotFoundError | FormDeletedError | PrivateFormError | DatabaseError
 > => {
   return FormService.retrieveFullFormById(formId).andThen((form) =>
-    FormService.isFormPublic(form, 'Cannot access private form')
-      // Form is public, return form.
-      .map(() => form),
+    FormService.isFormPublic(form).map(() => form),
   )
 }

--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -233,7 +233,7 @@ describe('FormService', () => {
       expect(actual._unsafeUnwrapErr()).toEqual(new FormDeletedError())
     })
 
-    it('should return PrivateFormError with form inactive message when form is private', async () => {
+    it('should return PrivateFormError with form inactive message and title when form is private', async () => {
       // Arrange
       const form = {
         _id: new ObjectId(),
@@ -247,38 +247,19 @@ describe('FormService', () => {
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toEqual(
-        new PrivateFormError(form.inactiveMessage),
-      )
-    })
-
-    it('should return error with error message override when available', async () => {
-      // Arrange
-      const expectedErrorMessage = 'test error message override'
-      const form = {
-        _id: new ObjectId(),
-        // Form deleted.
-        status: Status.Archived,
-      } as IPopulatedForm
-
-      // Act
-      const actual = FormService.isFormPublic(form, expectedErrorMessage)
-
-      // Assert
-      expect(actual._unsafeUnwrapErr()).toEqual(
-        new FormDeletedError(expectedErrorMessage),
+        new PrivateFormError(form.inactiveMessage, form.title),
       )
     })
 
     it('should return ApplicationError when form does not have status', async () => {
       // Arrange
-      const expectedErrorMessage = 'test error message override'
       const form = {
         _id: new ObjectId(),
         // Form without status.
       } as IPopulatedForm
 
       // Act
-      const actual = FormService.isFormPublic(form, expectedErrorMessage)
+      const actual = FormService.isFormPublic(form)
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toEqual(new ApplicationError())

--- a/src/app/modules/form/__tests__/form.utils.spec.ts
+++ b/src/app/modules/form/__tests__/form.utils.spec.ts
@@ -1,0 +1,104 @@
+import { ObjectId } from 'bson-ext'
+import { pick } from 'lodash'
+
+import {
+  AuthType,
+  BasicField,
+  Colors,
+  FormLogoState,
+  IFieldSchema,
+  IPopulatedForm,
+  IPopulatedUser,
+  ResponseMode,
+  Status,
+} from 'src/types'
+
+import { removePrivateDetailsFromForm } from '../form.utils'
+
+const MOCK_POPULATED_FORM = ({
+  startPage: {
+    colorTheme: Colors.Blue,
+    logo: { state: FormLogoState.Default },
+    estTimeTaken: 5,
+    paragraph: 'For testing.',
+  },
+  endPage: {
+    title: 'Thank you for submitting your declaration.',
+    buttonText: 'Submit another form',
+    buttonLink: '',
+  },
+  webhook: { url: '' },
+  emails: ['test@example.com'],
+  hasCaptcha: true,
+  authType: AuthType.NIL,
+  status: Status.Private,
+  inactiveMessage:
+    'If you think this is a mistake, please contact the agency that gave you the form link.',
+  isListed: true,
+  responseMode: ResponseMode.Email,
+  form_fields: [
+    {
+      title: 'Personal Particulars',
+      description: '',
+      required: true,
+      disabled: false,
+      fieldType: BasicField.Section,
+      _id: new ObjectId(),
+      globalId: '5DXH7jXlJRTBKVGimIMRilyxBfVjMe9myJqon0HzClS',
+    } as IFieldSchema,
+  ],
+  form_logics: [],
+  permissionList: [],
+  _id: new ObjectId(),
+  admin: {
+    _id: new ObjectId(),
+    email: 'test@example.com',
+    __v: 0,
+    agency: {
+      emailDomain: ['example.com'],
+      _id: new ObjectId(),
+      lastModified: new Date('2017-09-15T06:03:58.803Z'),
+      shortName: 'test',
+      fullName: 'Test Agency',
+      logo: 'path/to/nowhere',
+      created: new Date('2017-09-15T06:03:58.792Z'),
+      __v: 0,
+    },
+    created: new Date('2020-05-14T05:09:40.502Z'),
+    lastAccessed: new Date('2020-12-07T15:33:49.079Z'),
+    updatedAt: new Date('2020-12-08T02:52:27.637Z'),
+  } as IPopulatedUser,
+  title: 'test form',
+  created: new Date('2020-12-07T15:34:21.426Z'),
+  lastModified: new Date('2020-12-07T15:34:21.426Z'),
+  __v: 0,
+} as unknown) as IPopulatedForm
+
+describe('form.utils', () => {
+  describe('removePrivateDetailsFromForm', () => {
+    it('should correctly remove private details', async () => {
+      // Act
+      const actual = removePrivateDetailsFromForm(MOCK_POPULATED_FORM)
+
+      // Assert
+      expect(actual).toEqual({
+        ...pick(MOCK_POPULATED_FORM, [
+          'admin',
+          'authType',
+          'endPage',
+          'esrvcId',
+          'form_fields',
+          'form_logics',
+          'hasCaptcha',
+          'publicKey',
+          'startPage',
+          'status',
+          'title',
+          '_id',
+          'responseMode',
+        ]),
+        admin: pick(MOCK_POPULATED_FORM.admin, 'agency'),
+      })
+    })
+  })
+})

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -2680,12 +2680,11 @@ describe('admin-form.controller', () => {
     it('should return 403 when form is private', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
-      const mockErrorString = 'form is private'
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
         okAsync(MOCK_USER),
       )
       MockAuthService.getFormIfPublic.mockReturnValueOnce(
-        errAsync(new PrivateFormError(mockErrorString)),
+        errAsync(new PrivateFormError(undefined, 'some random title')),
       )
 
       // Act
@@ -2697,8 +2696,9 @@ describe('admin-form.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(403)
+      // Should return specific message.
       expect(mockRes.json).toHaveBeenCalledWith({
-        message: mockErrorString,
+        message: 'Form must be public to be copied',
       })
       expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
         MOCK_USER_ID,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -10,6 +10,7 @@ import * as AuthService from '../../auth/auth.service'
 import * as FeedbackService from '../../feedback/feedback.service'
 import * as SubmissionService from '../../submission/submission.service'
 import * as UserService from '../../user/user.service'
+import { PrivateFormError } from '../form.errors'
 
 import {
   archiveForm,
@@ -548,7 +549,7 @@ export const handleDuplicateAdminForm: RequestHandler<
           meta: {
             action: 'handleDuplicateAdminForm',
             ...createReqMeta(req),
-            userId: userId,
+            userId,
             formId,
           },
           error,
@@ -619,6 +620,13 @@ export const handleCopyTemplateForm: RequestHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
+
+        // Specialized error response for PrivateFormError.
+        if (error instanceof PrivateFormError) {
+          return res.status(statusCode).json({
+            message: 'Form must be public to be copied',
+          })
+        }
         return res.status(statusCode).json({ message: errorMessage })
       })
   )

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -573,7 +573,9 @@ export const handleGetTemplateForm: RequestHandler<{ formId: string }> = (
     AuthService.getFormIfPublic(formId)
       // Step 2: Remove private form details before being returned.
       .map(removePrivateDetailsFromForm)
-      .map((scrubbedForm) => res.json({ form: scrubbedForm }))
+      .map((scrubbedForm) =>
+        res.status(StatusCodes.OK).json({ form: scrubbedForm }),
+      )
       .mapErr((error) => {
         logger.error({
           message: 'Error retrieving form template',

--- a/src/app/modules/form/form.errors.ts
+++ b/src/app/modules/form/form.errors.ts
@@ -17,13 +17,19 @@ export class FormDeletedError extends ApplicationError {
  * that is to be returned for public consumption when its status is PRIVATE.
  */
 export class PrivateFormError extends ApplicationError {
+  /** Extra meta for form title. */
+  formTitle: string
+
   /**
    * @param message Message used should be the form's inactive message.
+   * @param formTitle Extra meta for form title
    */
   constructor(
     message = 'If you think this is a mistake, please contact the agency that gave you the form link.',
+    formTitle: string,
   ) {
     super(message)
+    this.formTitle = formTitle
   }
 }
 

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -97,15 +97,13 @@ export const retrieveFormById = (
 /**
  * Method to ensure given form is available to the public.
  * @param form the form to check
- * @param errMessageOverride optional, overrides error message with given string
  * @returns ok(true) if form is public
  * @returns err(FormDeletedError) if form has been deleted
- * @returns err(PrivateFormError) if form is private
+ * @returns err(PrivateFormError) if form is private, the message will be the form inactive message
  * @returns err(ApplicationError) if form has an invalid state
  */
 export const isFormPublic = (
   form: IPopulatedForm,
-  errMessageOverride?: string,
 ): Result<true, FormDeletedError | PrivateFormError | ApplicationError> => {
   if (!form.status) {
     return err(new ApplicationError())
@@ -115,11 +113,9 @@ export const isFormPublic = (
     case Status.Public:
       return ok(true)
     case Status.Archived:
-      return err(new FormDeletedError(errMessageOverride))
+      return err(new FormDeletedError())
     case Status.Private:
-      return err(
-        new PrivateFormError(errMessageOverride ?? form.inactiveMessage),
-      )
+      return err(new PrivateFormError(form.inactiveMessage, form.title))
     default:
       return assertUnreachable(form.status)
   }

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,0 +1,57 @@
+import { pick } from 'lodash'
+import { Merge } from 'type-fest'
+
+import { IPopulatedForm } from 'src/types'
+
+// Kept in this file instead of form.types.ts so that this can be kept in sync
+// with FORM_PUBLIC_FIELDS more easily.
+type PublicFormValues = Pick<
+  IPopulatedForm,
+  | 'authType'
+  | 'endPage'
+  | 'esrvcId'
+  | 'form_fields'
+  | 'form_logics'
+  | 'hasCaptcha'
+  | 'publicKey'
+  | 'startPage'
+  | 'status'
+  | 'title'
+  | '_id'
+  | 'responseMode'
+>
+
+type PublicForm = Merge<
+  PublicFormValues,
+  { admin: Pick<IPopulatedForm['admin'], 'agency'> }
+>
+
+const FORM_PUBLIC_FIELDS = [
+  'admin',
+  'authType',
+  'endPage',
+  'esrvcId',
+  'form_fields',
+  'form_logics',
+  'hasCaptcha',
+  'publicKey',
+  'startPage',
+  'status',
+  'title',
+  '_id',
+  'responseMode',
+]
+
+/**
+ * Removes all private details such as admin email from given form.
+ * @param form the form to scrub
+ * @returns form with only public details
+ */
+export const removePrivateDetailsFromForm = (
+  form: IPopulatedForm,
+): PublicForm => {
+  return {
+    ...(pick(form, FORM_PUBLIC_FIELDS) as PublicFormValues),
+    admin: pick(form.admin, 'agency'),
+  }
+}

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -129,7 +129,7 @@ describe('public-form.controller', () => {
       )
       // Mock return error.
       MockFormService.isFormPublic.mockReturnValueOnce(
-        err(new PrivateFormError()),
+        err(new PrivateFormError(MOCK_FORM.inactiveMessage, MOCK_FORM.title)),
       )
 
       // Act

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -68,11 +68,11 @@ export const handleSubmitFeedback: RequestHandler<
     // Specialized error response for PrivateFormError.
     if (error instanceof PrivateFormError) {
       return res.status(statusCode).json({
-        message: form.inactiveMessage,
+        message: error.message,
         // Flag to prevent default 404 subtext ("please check link") from
         // showing.
         isPageFound: true,
-        formTitle: form.title,
+        formTitle: error.formTitle,
       })
     }
     return res.status(statusCode).json({ message: errorMessage })

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -7,7 +7,6 @@ const { celebrate, Joi, Segments } = require('celebrate')
 
 let forms = require('../../app/controllers/forms.server.controller')
 let adminForms = require('../../app/controllers/admin-forms.server.controller')
-let publicForms = require('../../app/controllers/public-forms.server.controller')
 let auth = require('../../app/controllers/authentication.server.controller')
 let submissions = require('../../app/controllers/submissions.server.controller')
 const emailSubmissions = require('../../app/controllers/email-submissions.server.controller')
@@ -41,15 +40,6 @@ let authActiveForm = (requiredPermission) => [
   forms.formById,
   adminForms.isFormActive,
   auth.verifyPermission(requiredPermission),
-]
-
-/**
- * Authenticates logged in user, before retrieving non-archived form.
- */
-let authAdminActiveAnyForm = [
-  withUserAuthentication,
-  forms.formById,
-  adminForms.isFormActive,
 ]
 
 /**
@@ -247,11 +237,7 @@ module.exports = function (app) {
    */
   app
     .route('/:formId([a-fA-F0-9]{24})/adminform/template')
-    .get(
-      authAdminActiveAnyForm,
-      publicForms.isFormPublic,
-      forms.read(forms.REQUEST_TYPE.ADMIN),
-    )
+    .get(withUserAuthentication, AdminFormController.handleGetTemplateForm)
 
   /**
    * Return the preview form to the user.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR migrates the `GET /:formId/adminform/template` use case to Typescript. 
Further improvements to the handling of the requests to this endpoint is also made. Form admins' extraneous details (leaving agency, which is needed for showing the form logo) are stripped from the returned form to be used as a template. This increases the consistency of the form shape returned from the other endpoints such as /publicform.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(formUtils): add removePrivateDetailsFromForm utility function
- feat: add formTitle variable to PrivateFormError and remove override
  - The error message should default to the form's inactive message, and should be separately handled by the controller if that is not the expected behavior.
- feat(AdminFormCtl): add (and use) handleGetTemplateForm handler

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests have been added for all new methods. Integration tests are not yet written as the router has not been migrated yet.
