### PR TITLE
fix: close create form modal when create form fails

### DIFF
--- a/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/create-form-modal.client.controller.js
@@ -212,6 +212,8 @@ function CreateFormModalController(
       Toastr.error(errorResponse.data.message)
     }
     GTag.createFormFailed()
+
+    vm.closeCreateModal()
   }
 
   vm.createNewForm = function () {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Small fix to close modal on any errors instead of leaving the modal open with a perpetual spinning loader. The error can be triggered by duplicate or create form backend failure.
