### PR TITLE
feat: improve email mode messaging

### DIFF
--- a/src/public/modules/core/css/core.css
+++ b/src/public/modules/core/css/core.css
@@ -284,6 +284,7 @@ textarea.input-custom {
 .alert-custom .bx-check,
 .alert-custom .bx-loader,
 .alert-custom .bx-exclamation,
+.alert-custom .bx-error-circle,
 .alert-custom .bx-info-circle {
   float: left;
 }

--- a/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
+++ b/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
@@ -41,6 +41,13 @@
   </div>
 
   <div
+    ng-show="vm.formController.emailList.$valid && vm.emailInfoMsg"
+    class="alert-custom alert-info"
+  >
+    <i class="bx bx-error-circle bx-md icon-spacing"></i>
+    <span class="alert-msg"> {{vm.emailInfoMsg}} </span>
+  </div>
+  <div
     ng-show="vm.formController.emailList.$invalid && vm.formController.emailList.$dirty"
     class="alert-custom alert-error"
   >

--- a/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
+++ b/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
@@ -16,10 +16,10 @@
       id="email-reliability-link"
     >
       <a
-        translate-attr="{ href: 'LINKS.GUIDE.EMAIL_RELIABILITY' }"
+        translate-attr="{ href: 'LINKS.GUIDE.GUARD_EMAIL_BOUNCE' }"
         target="_blank"
         class=""
-        >Read about email reliability</a
+        >Guarding against bounces</a
       >
     </div>
   </div>

--- a/src/public/modules/forms/admin/components/form-emails-input.client.component.js
+++ b/src/public/modules/forms/admin/components/form-emails-input.client.component.js
@@ -9,29 +9,32 @@ angular.module('forms').component('formEmailsInputComponent', {
     saveForm: '&',
   },
   controllerAs: 'vm',
-  controller: formEmailsInputController,
+  controller: ['$scope', formEmailsInputController],
 })
 
-function formEmailsInputController() {
+function formEmailsInputController($scope) {
   const vm = this
+
+  $scope.$watch('vm.formData.emails', (newEmails) => {
+    vm.emailInfoMsg =
+      newEmails && String(newEmails).split(',').length === 1
+        ? 'Recommended: at least 2 recipients to prevent response loss from bounced emails'
+        : null
+  })
+
   vm.validateEmails = (emails) => {
-    if (!emails) {
-      vm.emailErrorMsg =
-        'You must at least enter one email to receive responses'
-      return
-    }
-
-    const err = checkForErrors(String(emails).split(','))
-
-    if (err) {
-      vm.emailErrorMsg = err
-      vm.formController.emailList.$setValidity('text', false)
-    } else {
-      vm.formController.emailList.$setValidity('text', true)
-    }
+    const emailsToCheck = emails ? String(emails).split(',') : undefined
+    vm.emailErrorMsg = checkForErrors(emailsToCheck)
+    vm.formController.emailList.$setValidity('text', !vm.emailErrorMsg)
   }
 
-  function checkForErrors(emails) {
+  function checkForErrors(emailsToCheck) {
+    if (!emailsToCheck) {
+      return 'You must at least enter one email to receive responses'
+    }
+
+    const emails = String(emailsToCheck).split(',')
+
     if (emails.some((email) => isInvalid(email))) {
       return 'Please enter valid email(s) (e.g. me@example.com) separated by commas'
     }

--- a/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/activate-form-modal.client.controller.js
@@ -60,7 +60,16 @@ function ActivateFormController(
           } else {
             // Save
             vm.savingStatus = 1
-            updateFormStatusAndSave().then(() => {
+            const toastMessage = dedent`
+              Congrats! Your form is now live.<br/>For high-traffic forms,
+              <a href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-ensure-my-form-responses-will-not-bounce" target="_blank">
+                AutoArchive your mailbox</a> to prevent lost responses.
+            `
+            return updateFormStatusAndSave(toastMessage, {
+              timeOut: 10000,
+              extendedTimeOut: 10000,
+              skipLinky: true,
+            }).then(() => {
               vm.savingStatus = 2
             })
           }
@@ -121,7 +130,7 @@ function ActivateFormController(
       )
         .then((mailToUri) => {
           const toastMessage = dedent`
-            Congrats! Your form has gone live.<br/>
+            Congrats! Your form is now live.<br/>
             <a href=${mailToUri}>
               Email secret key to colleagues for safekeeping.
             </a>

--- a/src/public/modules/forms/admin/directiveViews/configure-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-form.client.view.html
@@ -77,8 +77,8 @@
             your form responses.
           </p>
           <p>
-            <b>Not recommended</b> for most uses, especially high-volume forms,
-            as responses bouncing from your inbox are <b>permanently lost</b>.
+            <b>Not recommended</b> usually, especially for high-volume forms, as
+            responses bouncing from your inbox are <b>permanently lost</b>.
           </p>
           <p>
             Please only choose Email mode if you need any of these features:

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -149,10 +149,9 @@
               class="alert-custom alert-info spcp-warning"
             >
               <i class="bx bx-info-circle bx-md icon-spacing"></i>
-              <span class="alert-msg"
-                >Authentication method cannot be changed unless your form is
-                deactivated.</span
-              >
+              <span class="alert-msg">
+                Deactivate your form to change authentication method.
+              </span>
             </div>
 
             <div

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const dedent = require('dedent-js')
 const { get, set, isEqual } = require('lodash')
 
 const SETTINGS_PATH = [
@@ -299,7 +299,22 @@ function settingsFormDirective(
             }
             openActivateFormModal(checks)
           } else {
-            updateFormStatusAndSave()
+            // Email form
+            // Next state will be public, show better toast message.
+            if ($scope.tempForm.status === 'PRIVATE') {
+              const toastMessage = dedent`
+                Congrats! Your form is now live.<br/>For high-traffic forms,
+                <a href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-ensure-my-form-responses-will-not-bounce" target="_blank">
+                  AutoArchive your mailbox</a> to prevent lost responses.
+              `
+              updateFormStatusAndSave(toastMessage, {
+                timeOut: 10000,
+                extendedTimeOut: 10000,
+                skipLinky: true,
+              })
+            } else {
+              updateFormStatusAndSave('Form deactivated!')
+            }
           }
         }
       },

--- a/src/public/translations/en-SG/main.json
+++ b/src/public/translations/en-SG/main.json
@@ -3,7 +3,7 @@
   "LINKS": {
     "GUIDE": {
       "ROOT": "https://guide.form.gov.sg/",
-      "EMAIL_RELIABILITY": "https://go.gov.sg/formsg-email-reliability",
+      "GUARD_EMAIL_BOUNCE": "https://go.gov.sg/form-prevent-bounces",
       "STORAGE_MODE": "https://guide.form.gov.sg/AdvancedGuide.html#storage-mode",
       "SECRET_KEY_SAFEKEEPING": "https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-make-sure-i-dont-lose-my-secret-key"
     },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR finally closes the first issue created in this repo.


Closes #1

## Solution
<!-- How did you solve the problem? -->

**Features**:
**Settings page**
- when only 1 recipient email is entered, display "Recommended: at least 2 recipients to prevent response loss from bounced emails" info box.
- update 'Read about email reliability' link to Guarding against bounces' with new valid link
- change the toaster under 'authentication' to say 'Deactivate your form to change authentication method'

**Create form modal**
- amend copy of email mode slightly to "...**Not recommended** usually, especially for high volume forms...

**Activation** Email mode only
- New toaster messaging for email mode form activation that lasts for 10 seconds with link to autoarchive help.
- update deactivation toast messaging

## Before & After Screenshots
### BEFORE
<!-- [insert screenshot here] -->
**Create form (Display text on only 1 email, new link and text, new discouragement copy)**
![Screenshot 2020-12-09 at 10 17 44 AM](https://user-images.githubusercontent.com/22133008/101565334-ca691b00-3a07-11eb-99fa-70626efe6a45.png)
**Settings page (Display text on only 1 email, new link and text)**
![Screenshot 2020-12-09 at 10 19 54 AM](https://user-images.githubusercontent.com/22133008/101565492-1916b500-3a08-11eb-84a8-a25bf18acf8a.png)
**Settings page (new deactivation messaging)**
![Screenshot 2020-12-09 at 10 26 36 AM](https://user-images.githubusercontent.com/22133008/101565916-0781dd00-3a09-11eb-9a44-30d5c33cff12.png)
**Activation and deactivation text**
Both have same text
![Screenshot 2020-12-09 at 10 31 55 AM](https://user-images.githubusercontent.com/22133008/101566333-c5a56680-3a09-11eb-862c-2370f683e829.png)


### AFTER
<!-- [insert screenshot here] -->
**Create form (Display text on only 1 email, new link and text, new discouragement copy)**
![Screenshot 2020-12-09 at 10 16 38 AM](https://user-images.githubusercontent.com/22133008/101565258-a3aae480-3a07-11eb-88ca-a87313182722.png)
**Settings page (Display text on only 1 email, new link and text)**
![Screenshot 2020-12-09 at 10 18 57 AM](https://user-images.githubusercontent.com/22133008/101565423-f97f8c80-3a07-11eb-869b-edad80598deb.png)
**Settings page (new deactivation messaging)**
![Screenshot 2020-12-09 at 10 25 36 AM](https://user-images.githubusercontent.com/22133008/101565884-f46f0d00-3a08-11eb-947a-2c5a56d0dd58.png)

**Activation and deactivation text**
![Screenshot 2020-12-09 at 10 31 12 AM](https://user-images.githubusercontent.com/22133008/101566290-b45c5a00-3a09-11eb-9067-e48d159157e9.png)
![Screenshot 2020-12-09 at 10 31 37 AM](https://user-images.githubusercontent.com/22133008/101566309-ba523b00-3a09-11eb-8aaf-9654843a47f0.png)
