### PR TITLE
fix: Travis Jest test not downloading mongo binary fast enough

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ jobs:
       workspaces:
         use: build
       script:
-        - travis_retry npm run test-backend-jasmine
+        - npm run test-backend-jasmine
         - npm run test-frontend
     - name: Typescript tests
       workspaces:
         use: build
       script:
-        - travis_retry npm run test-backend-jest
+        - npm run test-backend-jest
       after_success:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
     - name: End-to-end tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testMatch: ['**/?(*.)+(spec|test).[t]s?(x)'],
   modulePaths: ['<rootDir>'],
   testEnvironment: 'node',
+  globalSetup: '<rootDir>/tests/jest-global-setup.js',
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
   collectCoverageFrom: ['./src/**/*.{ts,js}', '!**/__tests__/**'],
   coveragePathIgnorePatterns: ['./node_modules/', './tests'],

--- a/tests/jest-global-setup.js
+++ b/tests/jest-global-setup.js
@@ -1,0 +1,13 @@
+module.exports = async () => {
+  const MongoBinary = require('mongodb-memory-server-core').MongoBinary
+  if (!process.env.MONGO_BINARY_VERSION) {
+    console.error('Environment var MONGO_BINARY_VERSION is missing')
+    process.exit(1)
+  }
+
+  // Trigger download of binary before tests run as `mongodb-memory-server-core`
+  // does not automatically download any binary version.
+  await MongoBinary.getPath({
+    version: String(process.env.MONGO_BINARY_VERSION),
+  })
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our Jest tests are failing and require multiple retries due to tests encountering timeout due to only starting the mongo binary download in the tests themselves (if the binary does not exist). 

This change allows for the binary to be downloaded if not yet cached before the individual tests even run

Also remove travis_retry, since the flaky form model test has been fixed.

See:
![Screenshot 2020-12-09 at 11 09 29 AM](https://user-images.githubusercontent.com/22133008/101569237-09e73580-3a0f-11eb-8621-8275cf5da87e.png)
