### PR TITLE
feat: misc UX fixes

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/verify-secret-key-activation.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/verify-secret-key-activation.client.view.html
@@ -60,10 +60,9 @@
       Key safely:
     </div>
     <div class="instructions-caption">
-      <b class="agree-text no-select"
-        >I understand the consequences and have<br />
-        stored my secret key in 2 other places</b
-      >
+      <b class="agree-text no-select">
+        I have shared my secret key with a colleague
+      </b>
     </div>
     <div ng-form name="acknowledgementForm">
       <input
@@ -72,7 +71,7 @@
         name="acknowledgementInput"
         type="text"
         autocomplete="off"
-        placeholder="I understand the consequences and have stored my secret key in 2 other places"
+        placeholder="I have shared my secret key with a colleague"
         ng-paste="$event.preventDefault()"
         ng-model="inputAcknowledgement"
       />

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -18,6 +18,9 @@ const createTempSettings = (myform) => {
   let tempForm = {}
   SETTINGS_PATH.forEach((path) => set(tempForm, path, get(myform, path)))
   tempForm.mode = 'edit'
+  if (Array.isArray(tempForm.emails)) {
+    tempForm.emails = tempForm.emails.join(', ')
+  }
   return tempForm
 }
 

--- a/src/public/modules/forms/admin/directives/verify-secret-key.client.directive.js
+++ b/src/public/modules/forms/admin/directives/verify-secret-key.client.directive.js
@@ -68,8 +68,7 @@ function verifySecretKeyDirective(FormSgSdk) {
               .toLowerCase()
               .replace(/\./g, '')
               .replace(/  +/g, ' ')
-              .trim() !==
-            'i understand the consequences and have stored my secret key in 2 other places'
+              .trim() !== 'i have shared my secret key with a colleague'
           )
           //Allow regardless of whether user types in upper / lowercase, ignore full stops and multiple spaces
         }

--- a/src/public/modules/forms/admin/directives/verify-secret-key.client.directive.js
+++ b/src/public/modules/forms/admin/directives/verify-secret-key.client.directive.js
@@ -85,9 +85,7 @@ function verifySecretKeyDirective(FormSgSdk) {
           }
 
           const encryptionKey = createEncryptionKey($scope.publicKey, secretKey)
-          if (encryptionKey !== null) {
-            Toastr.success('Verified!')
-          } else {
+          if (!encryptionKey) {
             Toastr.error(getErrorMessage('invalid-key'))
           }
           $scope.callback({ encryptionKey })

--- a/src/public/modules/forms/admin/views/create-form.client.modal.html
+++ b/src/public/modules/forms/admin/views/create-form.client.modal.html
@@ -115,11 +115,11 @@
           <div class="alert-msg">
             <span class="alert-content">
               <b>Ways to safekeep</b>
-              <a
+              (<a
                 translate-attr="{ href: 'LINKS.GUIDE.SECRET_KEY_SAFEKEEPING' }"
                 target="_blank"
-                >(guide)</a
-              >
+                >guide</a
+              >)
               <ul>
                 <li>
                   <a

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -630,7 +630,7 @@ async function addSettings(t, formOptions, captchaEnabled, webhookUrl) {
       .typeText(activateFormModal.secretKeyInput, formOptions.secretKey)
       .typeText(
         activateFormModal.acknowledgementInput,
-        'I understand the consequences and have stored my secret key in 2 other places',
+        'I have shared my secret key with a colleague',
       )
       .click(activateFormModal.activateFormBtn)
   } else if (formOptions.authType !== 'NIL') {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
A bunch of small UX fixes. 
Closes #571

## Solution
<!-- How did you solve the problem? -->
**Improvements**:

- feat: change storage mode form typed declaration from "i understand the consequences and have stored my secret key in 2 other places" to a simpler "I have shared my secret key with a colleague"
- remove verified toast on secret key verification success so only one success toast shows on activation
- feat: update storage mode guide link styling to not include the parenthesises 
- feat: add spacing between each email in email form email list

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Initial load has no spacing

![Screenshot 2020-12-09 at 2 08 57 PM](https://user-images.githubusercontent.com/22133008/101591725-175ce980-3a28-11eb-9d86-f381ebf8759a.png)
Original text
![Screenshot 2020-12-09 at 2 10 25 PM](https://user-images.githubusercontent.com/22133008/101591881-4b380f00-3a28-11eb-9505-a459ca93a767.png)

Two toasts on storage activation
![Screenshot 2020-12-09 at 2 11 41 PM](https://user-images.githubusercontent.com/22133008/101591980-7884bd00-3a28-11eb-97c7-d013ed3de890.png)

Link to guide includes parenthesis
![Screenshot 2020-12-09 at 2 13 28 PM](https://user-images.githubusercontent.com/22133008/101592152-b8e43b00-3a28-11eb-9ddb-2bf398078fb6.png)


**AFTER**:
<!-- [insert screenshot here] -->
Initial load now separates emails by a space.
![Screenshot 2020-12-09 at 2 07 58 PM](https://user-images.githubusercontent.com/22133008/101591647-f3010d00-3a27-11eb-932f-64306e5bf98b.png)

Shorter storage mode confirmation text
![Screenshot 2020-12-09 at 2 10 54 PM](https://user-images.githubusercontent.com/22133008/101591920-5be88500-3a28-11eb-918e-851ed7d6abf6.png)

SIngle toast on storage activation
![Screenshot 2020-12-09 at 2 12 18 PM](https://user-images.githubusercontent.com/22133008/101592055-92be9b00-3a28-11eb-8ab0-bbf6eef2d271.png)

Link to guide now excludes the parenthesis
![Screenshot 2020-12-09 at 2 12 51 PM](https://user-images.githubusercontent.com/22133008/101592090-a10cb700-3a28-11eb-8e76-2f5f98c48638.png)


