### PR TITLE
fix: add ie11 specific styling for new template forms

### DIFF
--- a/src/public/modules/users/css/examples-card.css
+++ b/src/public/modules/users/css/examples-card.css
@@ -1,15 +1,35 @@
+/*
+* Prefixed by https://autoprefixer.github.io
+* PostCSS: v7.0.29,
+* Autoprefixer: v9.7.6
+* Browsers: last 4 version,IE 11
+*/
+
+/* ie11 specific css */
+.examples-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
 @media all and (min-width: 768px) and (max-width: 992px) {
   @supports (display: grid) {
     .examples-container {
+      display: -ms-grid;
       display: grid;
       grid-template-columns: repeat(auto-fill, 320px);
       grid-gap: 1rem;
+      -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
       justify-content: space-between;
     }
   }
 
   .examples-container #form-card {
     width: 320px;
+    min-width: 320px;
     display: inline-block;
     margin-left: 10px;
     margin-right: 10px;
@@ -19,15 +39,19 @@
 @media all and (min-width: 992px) {
   @supports (display: grid) {
     .examples-container {
+      display: -ms-grid;
       display: grid;
       grid-template-columns: repeat(auto-fill, 265px);
       grid-gap: 1rem;
+      -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
       justify-content: space-between;
     }
   }
 
   .examples-container #form-card {
     width: 265px;
+    min-width: 265px;
     display: inline-block;
     margin-left: 5px;
     margin-right: 5px;
@@ -36,14 +60,27 @@
 
 @media not all and (min-width: 768px) {
   .examples-container {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
     justify-content: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
     align-items: center;
   }
 
   .examples-container examples-card {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
     justify-content: center;
   }
 
@@ -87,8 +124,14 @@
 }
 
 #form-card .middle-section {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
   height: 115px;
   font-weight: 200;
@@ -109,15 +152,22 @@
 }
 
 #form-card {
+  -webkit-box-shadow: 1px 2px 6px 0 rgba(0, 0, 0, 0.1);
   box-shadow: 1px 2px 6px 0 rgba(0, 0, 0, 0.1);
   margin-bottom: 30px;
   cursor: pointer;
   position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
   flex-direction: column;
 }
 
 #form-card:hover {
+  -webkit-box-shadow: 1px 2px 6px 0 rgba(0, 0, 0, 0.3);
   box-shadow: 1px 2px 6px 0 rgba(0, 0, 0, 0.3);
 }
 
@@ -149,8 +199,15 @@
 .full-screen-template .template-header {
   background-color: white;
   width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   height: 80px;
   border-bottom: solid 1px #e4e4e4;
@@ -158,7 +215,12 @@
 }
 
 .template-header .header-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
   flex-direction: row;
 }
 
@@ -173,10 +235,19 @@
 }
 
 .template-header .header-stat {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
   align-items: flex-start;
   height: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
   margin-right: 27px;
 }
@@ -198,7 +269,11 @@
 
 .template-header .header-stat .stat-value .rating-value {
   white-space: nowrap;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
 }
 
@@ -230,14 +305,23 @@
 }
 
 .template-header .use-template-btn {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
   margin-right: 70px;
 }
 
 @media (max-width: 768px) {
   .full-screen-template .template-header {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
     height: 140px;
   }
@@ -252,9 +336,15 @@
   cursor: pointer;
   height: 48px;
   width: 48px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   font-size: 28px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
   color: #979797;
   margin-left: 27px;


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR correctly aligns our covid template layout on ie11.

Closes #775

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- Correctly align COVID templates layout in IE11

## Before & After Screenshots

**BEFORE**:
(in ie11)
![image](https://user-images.githubusercontent.com/22133008/101605463-27cb8f00-3a3d-11eb-8d21-500cf9a49592.png)


**AFTER**:
(in ie11)
![image](https://user-images.githubusercontent.com/22133008/101605362-0bc7ed80-3a3d-11eb-87d8-581c68160a80.png)
![image](https://user-images.githubusercontent.com/22133008/101605373-0e2a4780-3a3d-11eb-9f85-fc4486defb0e.png)
