### PR TITLE
fix: tear out response hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16624,11 +16624,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-stringify-deterministic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.1.tgz",
-      "integrity": "sha512-9Fg0OY3uyzozpvJ8TVbUk09PjzhT7O2Q5kEe30g6OrKhbA/Is92igcx0XDDX7E3yAwnIlUcYLRl+ZkVrBYVP7A=="
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "helmet": "^4.2.0",
     "http-status-codes": "^2.1.4",
     "intl-tel-input": "~12.1.6",
-    "json-stringify-deterministic": "^1.0.1",
     "json-stringify-safe": "^5.0.1",
     "jszip": "^3.2.2",
     "jwt-decode": "^3.1.2",

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -1,10 +1,6 @@
-import crypto from 'crypto'
 import { readFileSync } from 'fs'
-import stringify from 'json-stringify-deterministic'
 import { omit } from 'lodash'
-import { mocked } from 'ts-jest/utils'
 
-import config from 'src/config/config'
 import { types as basicTypes } from 'src/shared/resources/basic'
 import { BasicField, MyInfoAttribute } from 'src/types'
 
@@ -31,11 +27,8 @@ import {
   InvalidFileExtensionError,
 } from '../email-submission.errors'
 import * as EmailSubmissionService from '../email-submission.service'
-import { ParsedMultipartForm } from '../email-submission.types'
 
 jest.mock('src/config/config')
-const MockConfig = mocked(config, true)
-const MOCK_SESSION_SECRET = 'secret'
 
 const ALL_SINGLE_SUBMITTED_RESPONSES = basicTypes
   // Attachments are special cases, requiring filename and content
@@ -454,42 +447,6 @@ describe('email-submission.service', () => {
         response1,
       ])
       expect(result._unsafeUnwrap()).toEqual(true)
-    })
-  })
-
-  describe('hashSubmission', () => {
-    beforeAll(() => {
-      MockConfig.sessionSecret = MOCK_SESSION_SECRET
-    })
-
-    beforeEach(() => jest.restoreAllMocks())
-    it('should hash both responses and attachments', () => {
-      const mockUinFin = 'uinFin'
-      const response = generateNewAttachmentResponse()
-      const mockBody: ParsedMultipartForm = {
-        responses: [omit(response, ['isVisible', 'isUserVerified'])],
-      }
-      const submissionToHash =
-        stringify(mockBody) +
-        stringify([
-          {
-            fieldId: response._id,
-            filename: response.filename,
-            content: response.content,
-          },
-        ])
-      const hashedUinFin = crypto
-        .createHmac('sha256', MOCK_SESSION_SECRET)
-        .update(mockUinFin)
-        .digest('hex')
-      const hashedSubmission = crypto
-        .createHmac('sha256', MOCK_SESSION_SECRET)
-        .update(submissionToHash)
-        .digest('hex')
-
-      const result = EmailSubmissionService.hashSubmission(mockBody, mockUinFin)
-      expect(result.hashedUinFin).toBe(hashedUinFin)
-      expect(result.hashedSubmission).toBe(hashedSubmission)
     })
   })
 })

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -71,11 +71,6 @@ export const receiveEmailSubmission: RequestHandler<
     })
     .map((parsed) => {
       req.body = parsed
-      const hashes = EmailSubmissionService.hashSubmission(parsed)
-      logger.info({
-        message: 'Submission successfully hashed',
-        meta: { ...logMeta, ...hashes },
-      })
       return next()
     })
     .mapErr((error) => {

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -1,9 +1,6 @@
-import crypto from 'crypto'
-import stringify from 'json-stringify-deterministic'
 import { sumBy } from 'lodash'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
-import { sessionSecret } from '../../../../config/config'
 import { createLoggerWithLabel } from '../../../../config/logger'
 import { FieldResponse } from '../../../../types'
 import {
@@ -22,7 +19,6 @@ import {
   EmailDataForOneField,
   EmailFormField,
   EmailJsonField,
-  ParsedMultipartForm,
 } from './email-submission.types'
 import {
   getAnswerForCheckbox,
@@ -135,27 +131,4 @@ export const validateAttachments = (
     }
     return okAsync(true)
   })
-}
-
-/**
- * Hashes a submission for logging purposes
- * @param body Response body
- * @param uinFin UIN or FIN if present
- */
-export const hashSubmission = (
-  body: ParsedMultipartForm,
-  uinFin?: string,
-): { hashedUinFin?: string; hashedSubmission?: string } => {
-  const hashedUinFin = uinFin
-    ? crypto.createHmac('sha256', sessionSecret).update(uinFin).digest('hex')
-    : undefined
-  const attachments = mapAttachmentsFromResponses(body.responses)
-  const concatenatedResponse = stringify(body) + stringify(attachments)
-  const hashedSubmission = concatenatedResponse
-    ? crypto
-        .createHmac('sha256', sessionSecret)
-        .update(concatenatedResponse)
-        .digest('hex')
-    : undefined
-  return { hashedUinFin, hashedSubmission }
 }

--- a/src/types/vendor/json-stringify-deterministic.d.ts
+++ b/src/types/vendor/json-stringify-deterministic.d.ts
@@ -1,3 +1,0 @@
-declare module 'json-stringify-deterministic' {
-  export default stringify = JSON.stringify
-}


### PR DESCRIPTION
Tears out the response hashing in `receiveEmailSubmission` which is causing staging to fail on attachments >5MB.