### PR TITLE
chore: improve logging when answer is undefined

### DIFF
--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -200,16 +200,17 @@ export class SpcpService {
     jwt: string,
     authType: AuthType.SP | AuthType.CP,
   ): ResultAsync<JwtPayload, VerifyJwtError> {
+    const logMeta = {
+      action: 'extractPayload',
+      authType,
+    }
     const authClient = this.getAuthClient(authType)
     return ResultAsync.fromPromise(
       verifyJwtPromise(authClient, jwt),
       (error) => {
         logger.error({
           message: 'Failed to verify JWT with auth client',
-          meta: {
-            action: 'extractPayload',
-            authType,
-          },
+          meta: logMeta,
           error,
         })
         return new VerifyJwtError()
@@ -218,6 +219,17 @@ export class SpcpService {
       if (isJwtPayload(payload, authType)) {
         return okAsync(payload)
       }
+      const payloadIsDefined = !!payload
+      const payloadKeys =
+        typeof payload === 'object' && !!payload && Object.keys(payload)
+      logger.error({
+        message: 'JWT has incorrect shape',
+        meta: {
+          ...logMeta,
+          payloadIsDefined,
+          payloadKeys,
+        },
+      })
       return errAsync(new InvalidJwtError())
     })
   }

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -201,7 +201,7 @@ export class SpcpService {
     authType: AuthType.SP | AuthType.CP,
   ): ResultAsync<JwtPayload, VerifyJwtError> {
     const logMeta = {
-      action: 'extractPayload',
+      action: 'extractJwtPayload',
       authType,
     }
     const authClient = this.getAuthClient(authType)

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -56,8 +56,13 @@ export const prepareEmailSubmission: RequestHandler<
         responseMetaData: req.body.parsedResponses.map((response) => ({
           question: response?.question,
           // Cast just for logging purposes
-          answerTruthy: !!(response as ProcessedSingleAnswerResponse)?.answer,
-          answerArrayTruthy: !!(response as ProcessedCheckboxResponse)
+          answerType: typeof (response as ProcessedSingleAnswerResponse)
+            ?.answer,
+          isAnswerTruthy: !!(response as ProcessedSingleAnswerResponse)?.answer,
+          isAnswerArrayAnArray: Array.isArray(
+            (response as ProcessedCheckboxResponse)?.answerArray,
+          ),
+          isAnswerArrayTruthy: !!(response as ProcessedCheckboxResponse)
             ?.answerArray,
           _id: response?._id,
           fieldType: response?.fieldType,

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -4,15 +4,14 @@ import { StatusCodes } from 'http-status-codes'
 import { Merge, SetOptional } from 'type-fest'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
-import {
-  BasicField,
-  FieldResponse,
-  ResWithHashedFields,
-  WithForm,
-} from '../../../../types'
+import { FieldResponse, ResWithHashedFields, WithForm } from '../../../../types'
 import { createReqMeta } from '../../../utils/request'
 import { getProcessedResponses } from '../submission.service'
-import { ProcessedFieldResponse } from '../submission.types'
+import {
+  ProcessedCheckboxResponse,
+  ProcessedFieldResponse,
+  ProcessedSingleAnswerResponse,
+} from '../submission.types'
 
 import * as EmailSubmissionReceiver from './email-submission.receiver'
 import * as EmailSubmissionService from './email-submission.service'
@@ -56,14 +55,10 @@ export const prepareEmailSubmission: RequestHandler<
         action: 'prepareEmailSubmission',
         responseMetaData: req.body.parsedResponses.map((response) => ({
           question: response?.question,
-          answerTruthy:
-            response.fieldType !== BasicField.Table &&
-            response.fieldType !== BasicField.Checkbox &&
-            !!response?.answer,
-          answerArrayTruthy:
-            (response.fieldType === BasicField.Table ||
-              response.fieldType === BasicField.Checkbox) &&
-            !!response?.answerArray,
+          // Cast just for logging purposes
+          answerTruthy: !!(response as ProcessedSingleAnswerResponse)?.answer,
+          answerArrayTruthy: !!(response as ProcessedCheckboxResponse)
+            ?.answerArray,
           _id: response?._id,
           fieldType: response?.fieldType,
         })),

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -64,8 +64,9 @@ export const prepareEmailSubmission: RequestHandler<
             (response.fieldType === BasicField.Table ||
               response.fieldType === BasicField.Checkbox) &&
             !!response?.answerArray,
+          _id: response?._id,
+          fieldType: response?.fieldType,
         })),
-        keys: req.body.parsedResponses.map(Object.keys),
       },
       error,
     })

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -51,9 +51,9 @@ export const prepareEmailSubmission: RequestHandler<
     )
   } catch (error) {
     logger.error({
-      message: 'Failed to create answer template',
+      message: 'Failed to create email data',
       meta: {
-        action: 'getFormattedResponse',
+        action: 'prepareEmailSubmission',
         responseMetaData: req.body.parsedResponses.map((response) => ({
           question: response?.question,
           answerTruthy:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Release 4.49.1 caught null pointer exceptions when `answer` was undefined, but the logging does not allow us to pinpoint exactly which question has an undefined answer.

## Solution
<!-- How did you solve the problem? -->
1. Log the keys in the payload of the JWT when it does not have the correct shape.
2. Log the truthiness of `answer` and `answerArray` for each question when `createEmailData` fails.