### PR TITLE
fix: automatic security patches from NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13667,9 +13667,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "interpret": {
       "version": "1.4.0",


### PR DESCRIPTION
The `ini` package was flagged as causing 4 low-severity security vulnerabilities due to prototype pollution to the following packages:

- bcrypt
- bson-ext
- stylelint
- webpack-cli

These have been automatically fixed via `npm audit fix`.


