### PR TITLE
refactor: inline form permissions check for presigned POST URL endpoints

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -550,7 +550,7 @@ describe('admin-form.controller', () => {
     })
   })
 
-  describe('handleCreatePresignedPostForImages', () => {
+  describe('handleCreatePresignedPostUrlForImages', () => {
     const MOCK_USER_ID = new ObjectId().toHexString()
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
@@ -578,7 +578,7 @@ describe('admin-form.controller', () => {
       },
     })
 
-    it('should return 200 with presigned POST object when successful', async () => {
+    it('should return 200 with presigned POST URL object when successful', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
       // Mock various services to return expected results.
@@ -595,12 +595,12 @@ describe('admin-form.controller', () => {
         },
         url: 'some url',
       }
-      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForImages.mockReturnValueOnce(
         okAsync(expectedPresignedPost),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -610,7 +610,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
     })
 
-    it('should return 400 when InvalidFileTypeError is returned when creating presigned POST', async () => {
+    it('should return 400 when InvalidFileTypeError is returned when creating presigned POST URL', async () => {
       // Arrange
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
@@ -622,12 +622,12 @@ describe('admin-form.controller', () => {
       // Mock error
       const mockErrorString = 'bad file type, bad!'
       const mockRes = expressHandler.mockResponse()
-      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForImages.mockReturnValueOnce(
         errAsync(new InvalidFileTypeError(mockErrorString)),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -640,7 +640,7 @@ describe('admin-form.controller', () => {
       })
     })
 
-    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST', async () => {
+    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST URL', async () => {
       // Arrange
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
@@ -650,14 +650,14 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM),
       )
       // Mock error
-      const mockErrorString = 'creating presigned post failed, oh no'
+      const mockErrorString = 'creating presigned post url failed, oh no'
       const mockRes = expressHandler.mockResponse()
-      MockAdminFormService.createPresignedPostForImages.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForImages.mockReturnValueOnce(
         errAsync(new CreatePresignedUrlError(mockErrorString)),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -683,7 +683,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -695,7 +695,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForImages,
+        MockAdminFormService.createPresignedPostUrlForImages,
       ).not.toHaveBeenCalled()
     })
 
@@ -712,7 +712,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -724,7 +724,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForImages,
+        MockAdminFormService.createPresignedPostUrlForImages,
       ).not.toHaveBeenCalled()
     })
 
@@ -741,7 +741,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -753,7 +753,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForImages,
+        MockAdminFormService.createPresignedPostUrlForImages,
       ).not.toHaveBeenCalled()
     })
 
@@ -767,7 +767,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForImages(
+      await AdminFormController.handleCreatePresignedPostUrlForImages(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -780,12 +780,12 @@ describe('admin-form.controller', () => {
       })
       expect(AuthService.getFormAfterPermissionChecks).not.toHaveBeenCalled()
       expect(
-        MockAdminFormService.createPresignedPostForImages,
+        MockAdminFormService.createPresignedPostUrlForImages,
       ).not.toHaveBeenCalled()
     })
   })
 
-  describe('handleCreatePresignedPostForLogos', () => {
+  describe('handleCreatePresignedPostUrlForLogos', () => {
     const MOCK_USER_ID = new ObjectId().toHexString()
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
@@ -813,7 +813,7 @@ describe('admin-form.controller', () => {
       },
     })
 
-    it('should return 200 with presigned POST object when successful', async () => {
+    it('should return 200 with presigned POST URL object when successful', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
       // Mock various services to return expected results.
@@ -830,12 +830,12 @@ describe('admin-form.controller', () => {
         },
         url: 'some url',
       }
-      MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForLogos.mockReturnValueOnce(
         okAsync(expectedPresignedPost),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -845,7 +845,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
     })
 
-    it('should return 400 when InvalidFileTypeError is returned when creating presigned POST', async () => {
+    it('should return 400 when InvalidFileTypeError is returned when creating presigned POST URL', async () => {
       // Arrange
       // Mock error
       const mockErrorString = 'bad file type, bad!'
@@ -857,12 +857,12 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM),
       )
       const mockRes = expressHandler.mockResponse()
-      MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForLogos.mockReturnValueOnce(
         errAsync(new InvalidFileTypeError(mockErrorString)),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -875,11 +875,11 @@ describe('admin-form.controller', () => {
       })
     })
 
-    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST', async () => {
+    it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST URL', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
       // Mock error
-      const mockErrorString = 'creating presigned post failed, oh no'
+      const mockErrorString = 'creating presigned post url failed, oh no'
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
         okAsync(MOCK_USER),
@@ -887,12 +887,12 @@ describe('admin-form.controller', () => {
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM),
       )
-      MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
+      MockAdminFormService.createPresignedPostUrlForLogos.mockReturnValueOnce(
         errAsync(new CreatePresignedUrlError(mockErrorString)),
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -918,7 +918,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -930,7 +930,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForLogos,
+        MockAdminFormService.createPresignedPostUrlForLogos,
       ).not.toHaveBeenCalled()
     })
 
@@ -947,7 +947,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -959,7 +959,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForLogos,
+        MockAdminFormService.createPresignedPostUrlForLogos,
       ).not.toHaveBeenCalled()
     })
 
@@ -976,7 +976,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -988,7 +988,7 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(
-        MockAdminFormService.createPresignedPostForLogos,
+        MockAdminFormService.createPresignedPostUrlForLogos,
       ).not.toHaveBeenCalled()
     })
 
@@ -1002,7 +1002,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCreatePresignedPostForLogos(
+      await AdminFormController.handleCreatePresignedPostUrlForLogos(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -1015,7 +1015,7 @@ describe('admin-form.controller', () => {
       })
       expect(AuthService.getFormAfterPermissionChecks).not.toHaveBeenCalled()
       expect(
-        MockAdminFormService.createPresignedPostForLogos,
+        MockAdminFormService.createPresignedPostUrlForLogos,
       ).not.toHaveBeenCalled()
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -786,7 +786,26 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleCreatePresignedPostForLogos', () => {
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    } as IPopulatedForm
     const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID,
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
       body: {
         fileId: 'any file id',
         fileMd5Hash: 'any hash',
@@ -797,6 +816,13 @@ describe('admin-form.controller', () => {
     it('should return 200 with presigned POST object when successful', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
       const expectedPresignedPost: PresignedPost = {
         fields: {
           'X-Amz-Signature': 'some-amz-signature',
@@ -823,6 +849,13 @@ describe('admin-form.controller', () => {
       // Arrange
       // Mock error
       const mockErrorString = 'bad file type, bad!'
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
       const mockRes = expressHandler.mockResponse()
       MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
         errAsync(new InvalidFileTypeError(mockErrorString)),
@@ -844,9 +877,16 @@ describe('admin-form.controller', () => {
 
     it('should return 400 when CreatePresignedUrlError is returned when creating presigned POST', async () => {
       // Arrange
+      const mockRes = expressHandler.mockResponse()
       // Mock error
       const mockErrorString = 'creating presigned post failed, oh no'
-      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
       MockAdminFormService.createPresignedPostForLogos.mockReturnValueOnce(
         errAsync(new CreatePresignedUrlError(mockErrorString)),
       )
@@ -863,6 +903,120 @@ describe('admin-form.controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith({
         message: mockErrorString,
       })
+    })
+
+    it('should return 403 when user does not have write permissions to form', async () => {
+      // Arrange
+      const expectedErrorString = 'no write permissions'
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController.handleCreatePresignedPostForLogos(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAdminFormService.createPresignedPostForLogos,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when form cannot be found', async () => {
+      // Arrange
+      const expectedErrorString = 'no form found'
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController.handleCreatePresignedPostForLogos(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAdminFormService.createPresignedPostForLogos,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 410 when form is archived', async () => {
+      // Arrange
+      const expectedErrorString = 'form deleted'
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController.handleCreatePresignedPostForLogos(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAdminFormService.createPresignedPostForLogos,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 422 when MissingUserError is returned when retrieving logged in user', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      const expectedErrorString = 'user is not found'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleCreatePresignedPostForLogos(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(AuthService.getFormAfterPermissionChecks).not.toHaveBeenCalled()
+      expect(
+        MockAdminFormService.createPresignedPostForLogos,
+      ).not.toHaveBeenCalled()
     })
   })
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -39,8 +39,8 @@ import {
 import {
   archiveForm,
   createForm,
-  createPresignedPostForImages,
-  createPresignedPostForLogos,
+  createPresignedPostUrlForImages,
+  createPresignedPostUrlForLogos,
   duplicateForm,
   getDashboardForms,
   transferFormOwnership,
@@ -134,10 +134,10 @@ describe('admin-form.service', () => {
     })
   })
 
-  describe('createPresignedPostForImages', () => {
+  describe('createPresignedPostUrlForImages', () => {
     it('should successfully create presigned POST URL', async () => {
       // Arrange
-      const expectedPresignedPost: PresignedPost = {
+      const expectedPresignedPostUrl: PresignedPost = {
         fields: {
           'X-Amz-Signature': 'some-amz-signature',
           Policy: 'some policy',
@@ -150,11 +150,11 @@ describe('admin-form.service', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         .mockImplementationOnce((_obj, cb) => {
-          cb(null, expectedPresignedPost)
+          cb(null, expectedPresignedPostUrl)
         })
 
       // Act
-      const actualResult = await createPresignedPostForImages({
+      const actualResult = await createPresignedPostUrlForImages({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: VALID_UPLOAD_FILE_TYPES[0],
@@ -169,7 +169,7 @@ describe('admin-form.service', () => {
         expect.any(Function),
       )
       expect(actualResult.isOk()).toEqual(true)
-      expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPost)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPostUrl)
     })
 
     it('should return InvalidFileTypeError when given file type is not supported', async () => {
@@ -178,7 +178,7 @@ describe('admin-form.service', () => {
       expect(VALID_UPLOAD_FILE_TYPES.includes(invalidFileType)).toEqual(false)
 
       // Act
-      const actualResult = await createPresignedPostForImages({
+      const actualResult = await createPresignedPostUrlForImages({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: invalidFileType,
@@ -203,7 +203,7 @@ describe('admin-form.service', () => {
         })
 
       // Act
-      const actualResult = await createPresignedPostForImages({
+      const actualResult = await createPresignedPostUrlForImages({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: VALID_UPLOAD_FILE_TYPES[0],
@@ -224,10 +224,10 @@ describe('admin-form.service', () => {
     })
   })
 
-  describe('createPresignedPostForLogos', () => {
+  describe('createPresignedPostUrlForLogos', () => {
     it('should successfully create presigned POST URL', async () => {
       // Arrange
-      const expectedPresignedPost: PresignedPost = {
+      const expectedPresignedPostUrl: PresignedPost = {
         fields: {
           'X-Amz-Signature': 'some-amz-signature',
           Policy: 'some policy',
@@ -240,11 +240,11 @@ describe('admin-form.service', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         .mockImplementationOnce((_obj, cb) => {
-          cb(null, expectedPresignedPost)
+          cb(null, expectedPresignedPostUrl)
         })
 
       // Act
-      const actualResult = await createPresignedPostForLogos({
+      const actualResult = await createPresignedPostUrlForLogos({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: VALID_UPLOAD_FILE_TYPES[0],
@@ -259,7 +259,7 @@ describe('admin-form.service', () => {
         expect.any(Function),
       )
       expect(actualResult.isOk()).toEqual(true)
-      expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPost)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedPresignedPostUrl)
     })
 
     it('should return InvalidFileTypeError when given file type is not supported', async () => {
@@ -268,7 +268,7 @@ describe('admin-form.service', () => {
       expect(VALID_UPLOAD_FILE_TYPES.includes(invalidFileType)).toEqual(false)
 
       // Act
-      const actualResult = await createPresignedPostForLogos({
+      const actualResult = await createPresignedPostUrlForLogos({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: invalidFileType,
@@ -293,7 +293,7 @@ describe('admin-form.service', () => {
         })
 
       // Act
-      const actualResult = await createPresignedPostForLogos({
+      const actualResult = await createPresignedPostUrlForLogos({
         fileId: 'any id',
         fileMd5Hash: 'any hash',
         fileType: VALID_UPLOAD_FILE_TYPES[0],

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -16,8 +16,8 @@ import { removePrivateDetailsFromForm } from '../form.utils'
 import {
   archiveForm,
   createForm,
-  createPresignedPostForImages,
-  createPresignedPostForLogos,
+  createPresignedPostUrlForImages,
+  createPresignedPostUrlForLogos,
   duplicateForm,
   getDashboardForms,
   getMockSpcpLocals,
@@ -108,14 +108,14 @@ export const handleGetAdminForm: RequestHandler<{ formId: string }> = (
  * Handler for POST /:formId([a-fA-F0-9]{24})/adminform/images.
  * @security session
  *
- * @returns 200 with presigned POST object
- * @returns 400 when error occurs whilst creating presigned POST object
+ * @returns 200 with presigned POST URL object
+ * @returns 400 when error occurs whilst creating presigned POST URL object
  * @returns 403 when user does not have write permissions for form
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived
  * @returns 422 when user in session cannot be retrieved from the database
  */
-export const handleCreatePresignedPostForImages: RequestHandler<
+export const handleCreatePresignedPostUrlForImages: RequestHandler<
   { formId: string },
   unknown,
   {
@@ -141,14 +141,14 @@ export const handleCreatePresignedPostForImages: RequestHandler<
       )
       // Step 3: Has write permissions, generate presigned POST URL.
       .andThen(() =>
-        createPresignedPostForImages({ fileId, fileMd5Hash, fileType }),
+        createPresignedPostUrlForImages({ fileId, fileMd5Hash, fileType }),
       )
-      .map((presignedPost) => res.json(presignedPost))
+      .map((presignedPostUrl) => res.json(presignedPostUrl))
       .mapErr((error) => {
         logger.error({
           message: 'Presigning post data encountered an error',
           meta: {
-            action: 'handleCreatePresignedPostForImages',
+            action: 'handleCreatePresignedPostUrlForImages',
             ...createReqMeta(req),
           },
           error,
@@ -164,14 +164,14 @@ export const handleCreatePresignedPostForImages: RequestHandler<
  * Handler for POST /:formId([a-fA-F0-9]{24})/adminform/logos.
  * @security session
  *
- * @returns 200 with presigned POST object
- * @returns 400 when error occurs whilst creating presigned POST object
+ * @returns 200 with presigned POST URL object
+ * @returns 400 when error occurs whilst creating presigned POST URL object
  * @returns 403 when user does not have write permissions for form
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived
  * @returns 422 when user in session cannot be retrieved from the database
  */
-export const handleCreatePresignedPostForLogos: RequestHandler<
+export const handleCreatePresignedPostUrlForLogos: RequestHandler<
   ParamsDictionary,
   unknown,
   {
@@ -197,14 +197,14 @@ export const handleCreatePresignedPostForLogos: RequestHandler<
       )
       // Step 3: Has write permissions, generate presigned POST URL.
       .andThen(() =>
-        createPresignedPostForLogos({ fileId, fileMd5Hash, fileType }),
+        createPresignedPostUrlForLogos({ fileId, fileMd5Hash, fileType }),
       )
-      .map((presignedPost) => res.json(presignedPost))
+      .map((presignedPostUrl) => res.json(presignedPostUrl))
       .mapErr((error) => {
         logger.error({
           message: 'Presigning post data encountered an error',
           meta: {
-            action: 'handleCreatePresignedPostForLogos',
+            action: 'handleCreatePresignedPostUrlForLogos',
             ...createReqMeta(req),
           },
           error,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -110,7 +110,7 @@ export const handleGetAdminForm: RequestHandler<{ formId: string }> = (
  *
  * @returns 200 with presigned POST object
  * @returns 400 when error occurs whilst creating presigned POST object
- * @returns 403 when user does not have permissions to access form
+ * @returns 403 when user does not have write permissions for form
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived
  * @returns 422 when user in session cannot be retrieved from the database
@@ -166,6 +166,10 @@ export const handleCreatePresignedPostForImages: RequestHandler<
  *
  * @returns 200 with presigned POST object
  * @returns 400 when error occurs whilst creating presigned POST object
+ * @returns 403 when user does not have write permissions for form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
  */
 export const handleCreatePresignedPostForLogos: RequestHandler<
   ParamsDictionary,

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -644,6 +644,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/images').post(
+    withUserAuthentication,
     celebrate({
       [Segments.BODY]: {
         fileId: Joi.string()
@@ -658,7 +659,6 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    authActiveForm(PermissionLevel.Write),
     AdminFormController.handleCreatePresignedPostForImages,
   )
 

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -659,7 +659,7 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    AdminFormController.handleCreatePresignedPostForImages,
+    AdminFormController.handleCreatePresignedPostUrlForImages,
   )
 
   /**
@@ -687,6 +687,6 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    AdminFormController.handleCreatePresignedPostForLogos,
+    AdminFormController.handleCreatePresignedPostUrlForLogos,
   )
 }

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -672,6 +672,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/logos').post(
+    withUserAuthentication,
     celebrate({
       [Segments.BODY]: {
         fileId: Joi.string()
@@ -686,7 +687,6 @@ module.exports = function (app) {
           .error(() => 'Error - your file could not be verified'),
       },
     }),
-    authActiveForm(PermissionLevel.Write),
     AdminFormController.handleCreatePresignedPostForLogos,
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Remove reliance on `authActiveForm` middleware and inline form permission checks in their respective controller handler functions.


## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- ref(AdminFormCtl): inline middleware for create presigned img url
- ref(AdminFormCtl): inline middleware for create presigned logo url

## Tests
<!-- What tests should be run to confirm functionality? -->
Additional tests have been added to the controller tests due to the inlining of checks.
