### PR TITLE
feat: add FIXED_LINE_OR_MOBILE numbers to pass homeno validation

### DIFF
--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -59,10 +59,17 @@ export const isMobilePhoneNumber = (mobileNumber: string): boolean => {
  */
 export const isHomePhoneNumber = (phoneNum: string): boolean => {
   const parsedNumber = parsePhoneNumberFromString(phoneNum)
-
   if (!parsedNumber) return false
 
-  return isPhoneNumber(phoneNum) && 'FIXED_LINE' === parsedNumber.getType()
+  const parsedType = parsedNumber.getType()
+  if (!parsedType) return false
+
+  return (
+    isPhoneNumber(phoneNum) &&
+    // Have to include both FIXED_LINE, FIXED_LINE_OR_MOBILE as some countries lump
+    // the types together.
+    ['FIXED_LINE', 'FIXED_LINE_OR_MOBILE'].includes(parsedType)
+  )
 }
 
 export const startsWithSgPrefix = (mobileNumber: string): boolean => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some legit office landline numbers are being marked as invalid due to not being labeled as FIXED_LINE numbers by google's libphonenumber, but as FIXED_LINE_OR_MOBILE. This PR loosens the homeno validation to allow for the latter type.

## Solution
<!-- How did you solve the problem? -->

**Features**:
- feat: add FIXED_LINE_OR_MOBILE numbers to pass homeno validation

## Before & After Screenshots

**BEFORE**:
![Screenshot 2020-12-15 at 10 11 29 AM](https://user-images.githubusercontent.com/22133008/102159140-e7956200-3ebd-11eb-89df-e2cb923cafad.png)


**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot 2020-12-15 at 10 11 41 AM](https://user-images.githubusercontent.com/22133008/102159151-eebc7000-3ebd-11eb-8743-3105a62e3d10.png)

