### PR TITLE
doc(public-form): add warning comment to GET /publicform endpoint in case of API refactor

### DIFF
--- a/src/app/routes/public-forms.server.routes.js
+++ b/src/app/routes/public-forms.server.routes.js
@@ -116,6 +116,11 @@ module.exports = function (app) {
    * Returns the specified form to the user, along with any
    * identity information obtained from SingPass/CorpPass,
    * and MyInfo details, if any.
+   *
+   * WARNING: TemperatureSG batch jobs rely on this endpoint to
+   * retrieve the master list of personnel for daily reporting.
+   * Please strictly ensure backwards compatibility.
+   *
    * @route GET /{formId}/publicform
    * @group forms - endpoints to serve forms
    * @param {string} formId.path.required - the form id


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The team may not be aware that TemperatureSG relies on the `GET /publicform` endpoint to retrieve the master list of personnel for temperature reporting.

## Solution
<!-- How did you solve the problem? -->

Document its existence as a warning, and in preparation for future backend API refactoring.
