### PR TITLE
feat: harden rate limits

### DIFF
--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -104,7 +104,7 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(expectedError.status)
-      expect(mockRes.json).toBeCalledWith(expectedError.message)
+      expect(mockRes.json).toBeCalledWith({ message: expectedError.message })
     })
 
     it('should return 500 when there is an error generating login OTP', async () => {
@@ -123,9 +123,10 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.json).toBeCalledWith(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
+      expect(mockRes.json).toBeCalledWith({
+        message:
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+      })
       // Sending login OTP should not have been called.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockMailService.sendLoginOtp).not.toHaveBeenCalled()
@@ -148,9 +149,10 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toBeCalledWith(500)
-      expect(mockRes.json).toBeCalledWith(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
+      expect(mockRes.json).toBeCalledWith({
+        message:
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+      })
       // Services should have been invoked.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockMailService.sendLoginOtp).toHaveBeenCalledTimes(1)

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -167,9 +167,10 @@ describe('auth.routes', () => {
 
       // Assert
       expect(response.status).toEqual(401)
-      expect(response.body).toEqual(
-        'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
-      )
+      expect(response.body).toEqual({
+        message:
+          'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
+      })
     })
 
     it('should return 500 when error occurs whilst creating OTP', async () => {
@@ -186,9 +187,10 @@ describe('auth.routes', () => {
       // Assert
       expect(createLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(500)
-      expect(response.body).toEqual(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
+      expect(response.body).toEqual({
+        message:
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+      })
     })
 
     it('should return 500 when error occurs whilst sending login OTP', async () => {
@@ -205,9 +207,10 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(500)
-      expect(response.body).toEqual(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
+      expect(response.body).toEqual({
+        message:
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+      })
     })
 
     it('should return 500 when validating domain returns a database error', async () => {
@@ -224,9 +227,10 @@ describe('auth.routes', () => {
       // Assert
       expect(getAgencySpy).toBeCalled()
       expect(response.status).toEqual(500)
-      expect(response.body).toEqual(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
+      expect(response.body).toEqual({
+        message:
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+      })
     })
 
     it('should return 200 when otp is sent successfully', async () => {

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -54,7 +54,7 @@ export const handleCheckUser: RequestHandler<
  */
 export const handleLoginSendOtp: RequestHandler<
   ParamsDictionary,
-  string,
+  { message: string } | string,
   { email: string }
 > = async (req, res) => {
   // Joi validation ensures existence.
@@ -99,7 +99,7 @@ export const handleLoginSendOtp: RequestHandler<
           error,
           /* coreErrorMessage=*/ 'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
         )
-        return res.status(statusCode).json(errorMessage)
+        return res.status(statusCode).json({ message: errorMessage })
       })
   )
 }

--- a/src/app/utils/__tests__/limit-rate.spec.ts
+++ b/src/app/utils/__tests__/limit-rate.spec.ts
@@ -30,15 +30,17 @@ describe('limitRate', () => {
     )
   })
 
-  it('should call next() in the handler', () => {
-    limitRate()
+  it('should return 429 when the rate limit is exceeded', () => {
+    limitRate({ max: 0 })
     const handler = MockRateLimit.mock.calls[0][0]!.handler!
     const mockNext = jest.fn()
-    handler(
-      expressHandler.mockRequest(),
-      expressHandler.mockResponse(),
-      mockNext,
-    )
-    expect(mockNext).toHaveBeenCalled()
+    const mockRes = expressHandler.mockResponse()
+    handler(expressHandler.mockRequest(), mockRes, mockNext)
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(mockRes.status).toHaveBeenCalledWith(429)
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message:
+        'We are experiencing a temporary issue. Please try again in one minute.',
+    })
   })
 })

--- a/src/app/utils/limit-rate.ts
+++ b/src/app/utils/limit-rate.ts
@@ -2,6 +2,7 @@ import RateLimit, {
   Options as RateLimitOptions,
   RateLimit as RateLimitFn,
 } from 'express-rate-limit'
+import { StatusCodes } from 'http-status-codes'
 import { merge } from 'lodash'
 
 import { createLoggerWithLabel } from '../../config/logger'
@@ -21,7 +22,7 @@ export const limitRate = (options: RateLimitOptions = {}): RateLimitFn => {
   const defaultOptions: RateLimitOptions = {
     windowMs: 60 * 1000, // Apply rate per-minute
     max: 1200,
-    handler: (req, _res, next) => {
+    handler: (req, res) => {
       logger.warn({
         message: 'Rate limit exceeded',
         meta: {
@@ -31,8 +32,10 @@ export const limitRate = (options: RateLimitOptions = {}): RateLimitFn => {
           rateLimitInfo: req.rateLimit,
         },
       })
-      // TODO (private #49): terminate the request with HTTP 429
-      return next()
+      return res.status(StatusCodes.TOO_MANY_REQUESTS).json({
+        message:
+          'We are experiencing a temporary issue. Please try again in one minute.',
+      })
     },
   }
   return RateLimit(merge(defaultOptions, options))

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -268,9 +268,10 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
   },
   rateLimit: {
     submissions: {
-      doc: 'Per-minute, per-IP request limit for submissions endpoints',
+      doc:
+        'Per-minute, per-IP, per-instance request limit for submissions endpoints',
       format: 'int',
-      default: 200,
+      default: 80,
       env: 'SUBMISSIONS_RATE_LIMIT',
     },
     sendAuthOtp: {

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -183,7 +183,7 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
         // Configure message to be shown
         const msg =
           (error && error.data && error.data.message) ||
-          'There was an error. Please try again.'
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
         vm.signInMsg = {
           isMsg: true,
           isError: true,

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -180,11 +180,14 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
       function (error) {
         vm.isOtpSending = false
         vm.buttonClicked = false
-        // Configure message to be show
+        // Configure message to be shown
+        const msg =
+          (error && error.data && error.data.message) ||
+          'There was an error. Please try again.'
         vm.signInMsg = {
           isMsg: true,
           isError: true,
-          msg: error.data,
+          msg,
         }
         $timeout(function () {
           angular.element('#otp-input').focus()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We currently do not limit the number of submissions per IP per minute. Instead, we only log a message when a threshold is exceeded. This means that in case of a DDoS attempt, there is a risk of downstream systems (particularly those linked via webhook) being affected indirectly.

## Solution
<!-- How did you solve the problem? -->
Harden the rate-limiting by return HTTP 429.

Some UI issues surfaced as a result of this change. In particular, the `/auth/sendotp` and `submissions` endpoints return different error message shapes. As a result, it was not clear what shape the `limitRate` message should return, since it is shared between those two endpoints.

I decided to change the `/auth/sendotp` endpoint to return an object with a `message` key instead of a plain string since this gives us the flexibility to return more error metadata in future. **This was technically a backwards-incompatible change**, but the impact is minimal since old clients will simply see the default error message if their OTP emails fail to be sent, which is a rare situation anyway.

## Screenshots
![image](https://user-images.githubusercontent.com/29480346/102733508-726fd400-4378-11eb-8b9d-709af6175943.png)


![Screenshot 2020-12-21 at 9 30 06 AM](https://user-images.githubusercontent.com/29480346/102732963-f88b1b00-4376-11eb-839e-1feead89b993.png)

## Tests
- [ ] Change the SUBMISSIONS_RATE_LIMIT and AUTH_OTP_RATE_LIMIT env vars to 3 each (choosing 3 instead of 0/1/2 so that hopefully it won't affect the other tests running concurrently)
- [ ] Attempt to make 4 email mode submissions across at least 2 different forms within 1 minute. The 4th submission should return 429 with a "please try again in one minute" error message. Cloudwatch should contain a `limitRate` log message with your IP address.
- [ ] Make 3 email mode submissions within 1 minute, then another one from a different IP address . The one from the different IP address should go through.
- [ ] Attempt to make 4 encrypt mode submissions across at least 2 different forms within 1 minute. The 4th submission should return 429 with a "please try again in one minute" error message. Cloudwatch should contain a `limitRate` log message with your IP address.
- [ ] Make 3 email encrypt submissions within 1 minute, then another one from a different IP address . The one from the different IP address should go through.
- [ ] Attempt to resend auth OTP 4 times within 1 minute. The 4th submission should return 429 with a "please try again in one minute" error message. Cloudwatch should contain a `limitRate` log message with your IP address.