### PR TITLE
fix: protect against potentially unsafe external links

### DIFF
--- a/src/public/modules/forms/admin/componentViews/share-form.client.view.html
+++ b/src/public/modules/forms/admin/componentViews/share-form.client.view.html
@@ -50,7 +50,11 @@
           </button>
         </div>
         <div id="open-link" class="col-md-6 col-sm-6 col-xs-12">
-          <a href="{{vm.sharedFormUrl}}" target="_blank" class=""
+          <a
+            href="{{vm.sharedFormUrl}}"
+            target="_blank"
+            class=""
+            rel="noopener noreferrer"
             >Open in new window</a
           >
         </div>

--- a/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
@@ -122,7 +122,11 @@
             <i class="bx bx-info-circle bx-md icon-spacing"></i>
             <span class="alert-msg">
               Your link is not hosted with us.
-              <a ng-href="{{vm.myform.customLogo}}" target="_blank">Visit it </a
+              <a
+                ng-href="{{vm.myform.customLogo}}"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Visit it </a
               >, save it and upload here!
             </span>
           </div>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This protection is applied by default in modern browsers, but may not in legacy browsers.

Closes https://github.com/datagovsg/formsg-private/issues/100

## Solution
<!-- How did you solve the problem? -->

**Fixes**:

- Prevent potential exposure of the window object via `rel='noopener noreferrer'`
