### PR TITLE
test: add Joi integration tests for email submissions

### DIFF
--- a/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
@@ -1,6 +1,7 @@
 import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import { celebrate, Joi } from 'celebrate'
 import { RequestHandler, Router } from 'express'
+import { omit } from 'lodash'
 import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 
@@ -12,10 +13,24 @@ import * as SpcpController from 'src/app/modules/spcp/spcp.controller'
 import * as EmailSubmissionsMiddleware from 'src/app/modules/submission/email-submission/email-submission.middleware'
 import { CaptchaFactory } from 'src/app/services/captcha/captcha.factory'
 import * as CaptchaMiddleware from 'src/app/services/captcha/captcha.middleware'
-import { AuthType, BasicField, Status } from 'src/types'
+import { AuthType, BasicField, IFieldSchema, Status } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import {
+  MOCK_ATTACHMENT_FIELD,
+  MOCK_ATTACHMENT_RESPONSE,
+  MOCK_CHECKBOX_FIELD,
+  MOCK_CHECKBOX_RESPONSE,
+  MOCK_NO_RESPONSES_BODY,
+  MOCK_OPTIONAL_VERIFIED_FIELD,
+  MOCK_OPTIONAL_VERIFIED_RESPONSE,
+  MOCK_SECTION_FIELD,
+  MOCK_SECTION_RESPONSE,
+  MOCK_TEXT_FIELD,
+  MOCK_TEXTFIELD_RESPONSE,
+} from './email-submission.test.constants'
 
 jest.mock('@opengovsg/spcp-auth-client')
 const MockAuthClient = mocked(SPCPAuthClient, true)
@@ -31,11 +46,6 @@ jest.mock('nodemailer', () => ({
 // TODO (#149): Import router instead of creating it here
 const SUBMISSIONS_ENDPT_BASE = '/v2/submissions/email'
 const SUBMISSIONS_ENDPT = `${SUBMISSIONS_ENDPT_BASE}/:formId([a-fA-F0-9]{24})`
-
-const MOCK_SUBMISSION_BODY = {
-  responses: [],
-  isPreview: false,
-}
 
 const EmailSubmissionsRouter = Router()
 EmailSubmissionsRouter.post(
@@ -53,7 +63,9 @@ EmailSubmissionsRouter.post(
           Joi.object()
             .keys({
               _id: Joi.string().required(),
-              question: Joi.string().required(),
+              // Question is optional in anticipation of the same change
+              // when merging middlewares into controller
+              question: Joi.string(),
               fieldType: Joi.string()
                 .required()
                 .valid(...Object.values(BasicField)),
@@ -97,6 +109,395 @@ describe('email-submission.routes', () => {
   })
   afterAll(async () => await dbHandler.closeDatabase())
 
+  describe('Joi validation', () => {
+    it('should return 200 when submission is valid', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [MOCK_TEXT_FIELD],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        // MOCK_RESPONSE contains all required keys
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [MOCK_TEXTFIELD_RESPONSE],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 200 when answer is empty string for optional field', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [
+            { ...MOCK_TEXT_FIELD, required: false } as IFieldSchema,
+          ],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [{ ...MOCK_TEXTFIELD_RESPONSE, answer: '' }],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 200 when attachment response has filename and content', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [MOCK_ATTACHMENT_FIELD],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [
+              {
+                ...MOCK_ATTACHMENT_RESPONSE,
+                content: MOCK_ATTACHMENT_RESPONSE.content.toString('binary'),
+              },
+            ],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 200 when response has isHeader key', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [MOCK_SECTION_FIELD],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [{ ...MOCK_SECTION_RESPONSE, isHeader: true }],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 200 when signature is empty string for optional verified field', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [MOCK_OPTIONAL_VERIFIED_FIELD],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [{ ...MOCK_OPTIONAL_VERIFIED_RESPONSE, signature: '' }],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 200 when response has answerArray and no answer', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+          form_fields: [MOCK_CHECKBOX_FIELD],
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [MOCK_CHECKBOX_RESPONSE],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        message: 'Form submission successful.',
+        submissionId: expect.any(String),
+      })
+    })
+
+    it('should return 400 when isPreview key is missing', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        // Note missing isPreview
+        .field('body', JSON.stringify({ responses: [] }))
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when responses key is missing', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        // Note missing responses
+        .field('body', JSON.stringify({ isPreview: false }))
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when response is missing _id', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [omit(MOCK_TEXTFIELD_RESPONSE, '_id')],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when response is missing fieldType', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [omit(MOCK_TEXTFIELD_RESPONSE, 'fieldType')],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when response has invalid fieldType', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [
+              { ...MOCK_TEXTFIELD_RESPONSE, fieldType: 'definitelyInvalid' },
+            ],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when response is missing answer', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [omit(MOCK_TEXTFIELD_RESPONSE, 'answer')],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when response has both answer and answerArray', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [{ ...MOCK_TEXTFIELD_RESPONSE, answerArray: [] }],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when attachment response has filename but not content', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [omit(MOCK_ATTACHMENT_RESPONSE), 'content'],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+
+    it('should return 400 when attachment response has content but not filename', async () => {
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+
+      const response = await request
+        .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+        .field(
+          'body',
+          JSON.stringify({
+            isPreview: false,
+            responses: [omit(MOCK_ATTACHMENT_RESPONSE), 'filename'],
+          }),
+        )
+        .query({ captchaResponse: 'null' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.message).toEqual(
+        'celebrate request validation failed',
+      )
+    })
+  })
+
   describe('SPCP authentication', () => {
     describe('SingPass', () => {
       it('should return 200 when submission is valid', async () => {
@@ -116,7 +517,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -139,7 +540,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
         // Note cookie is not set
 
@@ -163,7 +564,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           // Note cookie is for CorpPass, not SingPass
           .set('Cookie', ['jwtCp=mockJwt'])
@@ -192,7 +593,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -222,7 +623,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -254,7 +655,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtCp=mockJwt'])
 
@@ -277,7 +678,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
         // Note cookie is not set
 
@@ -301,7 +702,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           // Note cookie is for SingPass, not CorpPass
           .set('Cookie', ['jwtSp=mockJwt'])
@@ -330,7 +731,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtCp=mockJwt'])
 
@@ -360,7 +761,7 @@ describe('email-submission.routes', () => {
 
         const response = await request
           .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
-          .field('body', JSON.stringify(MOCK_SUBMISSION_BODY))
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtCp=mockJwt'])
 

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.test.constants.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.test.constants.ts
@@ -1,0 +1,54 @@
+import fs from 'fs'
+
+import {
+  BasicField,
+  IAttachmentFieldSchema,
+  ICheckboxFieldSchema,
+  IField,
+} from 'src/types'
+
+import {
+  generateAttachmentResponse,
+  generateCheckboxResponse,
+  generateDefaultField,
+  generateSingleAnswerResponse,
+} from 'tests/unit/backend/helpers/generate-form-data'
+
+export const MOCK_NO_RESPONSES_BODY = {
+  responses: [],
+  isPreview: false,
+}
+
+export const MOCK_TEXT_FIELD = generateDefaultField(BasicField.ShortText)
+export const MOCK_TEXTFIELD_RESPONSE = generateSingleAnswerResponse(
+  MOCK_TEXT_FIELD,
+)
+
+export const MOCK_ATTACHMENT_FIELD = generateDefaultField(BasicField.Attachment)
+export const MOCK_ATTACHMENT_RESPONSE = generateAttachmentResponse(
+  MOCK_ATTACHMENT_FIELD as IAttachmentFieldSchema,
+  'valid.txt',
+  fs.readFileSync('tests/unit/backend/resources/valid.txt'),
+)
+
+export const MOCK_SECTION_FIELD = generateDefaultField(BasicField.Section)
+export const MOCK_SECTION_RESPONSE = generateSingleAnswerResponse(
+  MOCK_SECTION_FIELD,
+)
+
+export const MOCK_CHECKBOX_FIELD = generateDefaultField(BasicField.Checkbox)
+export const MOCK_CHECKBOX_RESPONSE = generateCheckboxResponse(
+  MOCK_CHECKBOX_FIELD as ICheckboxFieldSchema,
+)
+
+export const MOCK_OPTIONAL_VERIFIED_FIELD = generateDefaultField(
+  BasicField.Email,
+  {
+    isVerifiable: true,
+    required: false,
+  } as Partial<IField>,
+)
+export const MOCK_OPTIONAL_VERIFIED_RESPONSE = generateSingleAnswerResponse(
+  MOCK_OPTIONAL_VERIFIED_FIELD,
+  '',
+)

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -10,7 +10,9 @@ import {
   AttachmentSize,
   BasicField,
   IAttachmentFieldSchema,
+  IAttachmentResponse,
   ICheckboxFieldSchema,
+  ICheckboxResponse,
   IDecimalFieldSchema,
   IDropdownField,
   IField,
@@ -54,6 +56,13 @@ export const generateDefaultField = (
         ...defaultParams,
         ...customParams,
       } as ITableFieldSchema
+    case BasicField.Checkbox:
+      return {
+        ...defaultParams,
+        fieldOptions: ['Option 1', 'Option 2'],
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as ICheckboxFieldSchema
     case BasicField.Attachment:
       return {
         ...defaultParams,
@@ -126,7 +135,7 @@ export const generateProcessedSingleAnswerResponse = (
 
 export const generateSingleAnswerResponse = (
   field: IFieldSchema,
-  answer = 'answer',
+  answer = field.fieldType === BasicField.Section ? '' : 'answer',
 ): ISingleAnswerResponse => {
   if (
     [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
@@ -166,7 +175,7 @@ export const generateNewSingleAnswerResponse = (
     answer: `${fieldType} answer`,
     fieldType: fieldType as Exclude<
       BasicField,
-      BasicField.Table | BasicField.Checkbox
+      BasicField.Table | BasicField.Checkbox | BasicField.Attachment
     >,
     isVisible: true,
     ...customParams,
@@ -177,14 +186,12 @@ export const generateAttachmentResponse = (
   field: IAttachmentFieldSchema,
   filename = 'filename',
   content = Buffer.from('content'),
-): ProcessedAttachmentResponse => ({
+): IAttachmentResponse => ({
   _id: field._id,
-  question: field.title,
   answer: 'answer',
   fieldType: BasicField.Attachment,
   filename,
   content,
-  isVisible: true,
 })
 
 export const generateNewAttachmentResponse = (
@@ -203,12 +210,10 @@ export const generateNewAttachmentResponse = (
 export const generateCheckboxResponse = (
   field: ICheckboxFieldSchema,
   answerArray?: string[],
-): ProcessedCheckboxResponse => ({
+): ICheckboxResponse => ({
   _id: field._id,
-  question: field.title,
   answerArray: answerArray ?? [field.fieldOptions[0]],
   fieldType: BasicField.Checkbox,
-  isVisible: true,
 })
 
 export const generateNewCheckboxResponse = (


### PR DESCRIPTION
Adds integration tests for Joi validation at the email submissions endpoint, in anticipation of merging all the middleware into a single controller.