### PR TITLE
feat: send SMS notification when submissions bounce

### DIFF
--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -130,7 +130,7 @@ const compileUserModel = (db: Mongoose) => {
     return this.find()
       .where('email')
       .in(emails)
-      .distinct('contact')
+      .select('email contact -_id')
       .lean()
       .exec()
   }

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -119,6 +119,22 @@ const compileUserModel = (db: Mongoose) => {
     })
   }
 
+  /**
+   * Finds the contact numbers for all given email addresses which exist in the
+   * User collection.
+   */
+  UserSchema.statics.findContactNumbersByEmails = async function (
+    this: IUserModel,
+    emails: string[],
+  ) {
+    return this.find()
+      .where('email')
+      .in(emails)
+      .distinct('contact')
+      .lean()
+      .exec()
+  }
+
   return db.model<IUserSchema, IUserModel>(USER_SCHEMA_ID, UserSchema)
 }
 

--- a/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
+++ b/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
@@ -138,6 +138,7 @@ export const extractBounceObject = (
   const extracted = pick(bounce.toObject(), [
     'formId',
     'hasAutoEmailed',
+    'hasAutoSmsed',
     'expireAt',
     'bounces',
   ])

--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -198,13 +198,13 @@ describe('handleSns', () => {
       mockForm,
       MOCK_CONTACTS,
     )
-    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith(
-      mockBounceDoc,
-      MOCK_NOTIFICATION,
-      MOCK_EMAIL_RECIPIENTS,
-      MOCK_CONTACTS,
-      true,
-    )
+    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith({
+      bounceDoc: mockBounceDoc,
+      notification: MOCK_NOTIFICATION,
+      autoEmailRecipients: MOCK_EMAIL_RECIPIENTS,
+      autoSmsRecipients: MOCK_CONTACTS,
+      hasDeactivated: true,
+    })
     expect(mockBounceDoc.save).toHaveBeenCalled()
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
   })
@@ -247,13 +247,13 @@ describe('handleSns', () => {
     // Deactivation functions are not called
     expect(MockFormService.deactivateForm).not.toHaveBeenCalled()
     expect(MockBounceService.notifyAdminsOfDeactivation).not.toHaveBeenCalled()
-    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith(
-      mockBounceDoc,
-      MOCK_NOTIFICATION,
-      MOCK_EMAIL_RECIPIENTS,
-      MOCK_CONTACTS,
-      false,
-    )
+    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith({
+      bounceDoc: mockBounceDoc,
+      notification: MOCK_NOTIFICATION,
+      autoEmailRecipients: MOCK_EMAIL_RECIPIENTS,
+      autoSmsRecipients: MOCK_CONTACTS,
+      hasDeactivated: false,
+    })
     expect(mockBounceDoc.save).toHaveBeenCalled()
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
   })
@@ -414,13 +414,13 @@ describe('handleSns', () => {
       MOCK_EMAIL_RECIPIENTS,
       MOCK_CONTACTS,
     )
-    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith(
-      mockBounceDoc,
-      MOCK_NOTIFICATION,
-      MOCK_EMAIL_RECIPIENTS,
-      MOCK_CONTACTS,
-      true,
-    )
+    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith({
+      bounceDoc: mockBounceDoc,
+      notification: MOCK_NOTIFICATION,
+      autoEmailRecipients: MOCK_EMAIL_RECIPIENTS,
+      autoSmsRecipients: MOCK_CONTACTS,
+      hasDeactivated: true,
+    })
     expect(mockBounceDoc.save).toHaveBeenCalled()
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
   })

--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -82,7 +82,7 @@ describe('handleSns', () => {
       MOCK_REQ.body,
     )
     expect(MockBounceService.logEmailNotification).not.toHaveBeenCalled()
-    expect(MockBounceService.notifyAdminOfBounce).not.toHaveBeenCalled()
+    expect(MockBounceService.notifyAdminsOfBounce).not.toHaveBeenCalled()
     expect(MockBounceService.logCriticalBounce).not.toHaveBeenCalled()
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(403)
   })
@@ -96,7 +96,7 @@ describe('handleSns', () => {
       MOCK_REQ.body,
     )
     expect(MockBounceService.logEmailNotification).not.toHaveBeenCalled()
-    expect(MockBounceService.notifyAdminOfBounce).not.toHaveBeenCalled()
+    expect(MockBounceService.notifyAdminsOfBounce).not.toHaveBeenCalled()
     expect(MockBounceService.logCriticalBounce).not.toHaveBeenCalled()
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
   })
@@ -110,7 +110,7 @@ describe('handleSns', () => {
     mockBounceDoc.areAllPermanentBounces.mockReturnValueOnce(true)
     mockBounceDoc.isCriticalBounce.mockReturnValueOnce(true)
     mockBounceDoc.hasNotified.mockReturnValueOnce(false)
-    MockBounceService.notifyAdminOfBounce.mockResolvedValueOnce(
+    MockBounceService.notifyAdminsOfBounce.mockResolvedValueOnce(
       MOCK_EMAIL_RECIPIENTS,
     )
 
@@ -132,7 +132,7 @@ describe('handleSns', () => {
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,
     )
-    expect(MockBounceService.notifyAdminOfBounce).toHaveBeenCalledWith(
+    expect(MockBounceService.notifyAdminsOfBounce).toHaveBeenCalledWith(
       mockBounceDoc,
     )
     expect(mockBounceDoc.setNotificationState).toHaveBeenCalledWith(
@@ -213,7 +213,7 @@ describe('handleSns', () => {
     mockBounceDoc.areAllPermanentBounces.mockReturnValueOnce(true)
     mockBounceDoc.isCriticalBounce.mockReturnValueOnce(true)
     mockBounceDoc.hasNotified.mockReturnValueOnce(false)
-    MockBounceService.notifyAdminOfBounce.mockImplementationOnce(() => {
+    MockBounceService.notifyAdminsOfBounce.mockImplementationOnce(() => {
       throw new Error()
     })
 
@@ -235,7 +235,7 @@ describe('handleSns', () => {
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,
     )
-    expect(MockBounceService.notifyAdminOfBounce).toHaveBeenCalledWith(
+    expect(MockBounceService.notifyAdminsOfBounce).toHaveBeenCalledWith(
       mockBounceDoc,
     )
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(400)
@@ -250,7 +250,7 @@ describe('handleSns', () => {
     mockBounceDoc.areAllPermanentBounces.mockReturnValueOnce(true)
     mockBounceDoc.isCriticalBounce.mockReturnValueOnce(true)
     mockBounceDoc.hasNotified.mockReturnValueOnce(false)
-    MockBounceService.notifyAdminOfBounce.mockResolvedValue(
+    MockBounceService.notifyAdminsOfBounce.mockResolvedValue(
       MOCK_EMAIL_RECIPIENTS,
     )
     mockBounceDoc.save.mockImplementationOnce(() => {
@@ -275,7 +275,7 @@ describe('handleSns', () => {
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,
     )
-    expect(MockBounceService.notifyAdminOfBounce).toHaveBeenCalledWith(
+    expect(MockBounceService.notifyAdminsOfBounce).toHaveBeenCalledWith(
       mockBounceDoc,
     )
     expect(mockBounceDoc.setNotificationState).toHaveBeenCalledWith(

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -39,7 +39,7 @@ import {
   isValidSnsRequest,
   logCriticalBounce,
   logEmailNotification,
-  notifyAdminOfBounce,
+  notifyAdminsOfBounce,
 } from 'src/app/modules/bounce/bounce.service'
 
 const Form = getFormModel(mongoose)
@@ -267,7 +267,7 @@ describe('BounceService', () => {
           { email: MOCK_EMAIL, hasBounced: true, bounceType: 'Permanent' },
         ],
       })
-      const emailRecipients = await notifyAdminOfBounce(bounceDoc)
+      const emailRecipients = await notifyAdminsOfBounce(bounceDoc)
       expect(MockMailService.sendBounceNotification).toHaveBeenCalledWith({
         emailRecipients: [testUser.email],
         bouncedRecipients: [MOCK_EMAIL],
@@ -292,7 +292,7 @@ describe('BounceService', () => {
           { email: testUser.email, hasBounced: true, bounceType: 'Permanent' },
         ],
       })
-      const emailRecipients = await notifyAdminOfBounce(bounceDoc)
+      const emailRecipients = await notifyAdminsOfBounce(bounceDoc)
       expect(MockMailService.sendBounceNotification).toHaveBeenCalledWith({
         emailRecipients: [collabEmail],
         bouncedRecipients: [testUser.email],
@@ -315,7 +315,7 @@ describe('BounceService', () => {
           { email: testUser.email, hasBounced: true, bounceType: 'Permanent' },
         ],
       })
-      const emailRecipients = await notifyAdminOfBounce(bounceDoc)
+      const emailRecipients = await notifyAdminsOfBounce(bounceDoc)
       expect(MockMailService.sendBounceNotification).not.toHaveBeenCalled()
       expect(emailRecipients).toEqual([])
     })
@@ -335,7 +335,7 @@ describe('BounceService', () => {
           { email: collabEmail, hasBounced: true, bounceType: 'Permanent' },
         ],
       })
-      const emailRecipients = await notifyAdminOfBounce(bounceDoc)
+      const emailRecipients = await notifyAdminsOfBounce(bounceDoc)
       expect(MockMailService.sendBounceNotification).not.toHaveBeenCalled()
       expect(emailRecipients).toEqual([])
     })

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -21,6 +21,8 @@ import {
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 import getMockLogger from 'tests/unit/backend/helpers/jest-logger'
 
+import { UserWithContactNumber } from '../bounce.types'
+
 import { makeBounceNotification, MOCK_SNS_BODY } from './bounce-test-helpers'
 
 jest.mock('axios')
@@ -471,6 +473,7 @@ describe('BounceService', () => {
           { email: MOCK_EMAIL_2, hasBounced: true, bounceType: 'Transient' },
         ],
         hasAutoEmailed: true,
+        hasAutoSmsed: true,
       })
       const snsInfo = makeBounceNotification({
         formId: MOCK_FORM_ID,
@@ -479,12 +482,20 @@ describe('BounceService', () => {
         bouncedList: [MOCK_EMAIL],
       })
       const autoEmailRecipients = [MOCK_EMAIL, MOCK_EMAIL_2]
-      logCriticalBounce(bounceDoc, snsInfo, autoEmailRecipients, false)
+      const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
+      logCriticalBounce(
+        bounceDoc,
+        snsInfo,
+        autoEmailRecipients,
+        autoSmsRecipients,
+        false,
+      )
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
           action: 'logCriticalBounce',
           hasAutoEmailed: true,
+          hasAutoSmsed: true,
           hasDeactivated: false,
           formId: String(MOCK_FORM_ID),
           submissionId: String(MOCK_SUBMISSION_ID),
@@ -493,6 +504,7 @@ describe('BounceService', () => {
           numTransient: 2,
           numPermanent: 0,
           autoEmailRecipients,
+          autoSmsRecipients,
           bounceInfo: snsInfo.bounce,
         },
       })
@@ -506,6 +518,7 @@ describe('BounceService', () => {
           { email: MOCK_EMAIL_2, hasBounced: true, bounceType: 'Permanent' },
         ],
         hasAutoEmailed: true,
+        hasAutoSmsed: true,
       })
       const snsInfo = makeBounceNotification({
         formId: MOCK_FORM_ID,
@@ -514,12 +527,20 @@ describe('BounceService', () => {
         bouncedList: [MOCK_EMAIL],
       })
       const autoEmailRecipients: string[] = []
-      logCriticalBounce(bounceDoc, snsInfo, autoEmailRecipients, true)
+      const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
+      logCriticalBounce(
+        bounceDoc,
+        snsInfo,
+        autoEmailRecipients,
+        autoSmsRecipients,
+        true,
+      )
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
           action: 'logCriticalBounce',
           hasAutoEmailed: true,
+          hasAutoSmsed: true,
           hasDeactivated: true,
           formId: String(MOCK_FORM_ID),
           submissionId: String(MOCK_SUBMISSION_ID),
@@ -528,6 +549,7 @@ describe('BounceService', () => {
           numTransient: 0,
           numPermanent: 2,
           autoEmailRecipients,
+          autoSmsRecipients,
           bounceInfo: snsInfo.bounce,
         },
       })
@@ -541,6 +563,7 @@ describe('BounceService', () => {
           { email: MOCK_EMAIL_2, hasBounced: true, bounceType: 'Transient' },
         ],
         hasAutoEmailed: true,
+        hasAutoSmsed: true,
       })
       const snsInfo = makeBounceNotification({
         formId: MOCK_FORM_ID,
@@ -549,12 +572,20 @@ describe('BounceService', () => {
         bouncedList: [MOCK_EMAIL],
       })
       const autoEmailRecipients: string[] = []
-      logCriticalBounce(bounceDoc, snsInfo, autoEmailRecipients, false)
+      const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
+      logCriticalBounce(
+        bounceDoc,
+        snsInfo,
+        autoEmailRecipients,
+        autoSmsRecipients,
+        false,
+      )
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
           action: 'logCriticalBounce',
           hasAutoEmailed: true,
+          hasAutoSmsed: true,
           hasDeactivated: false,
           formId: String(MOCK_FORM_ID),
           submissionId: String(MOCK_SUBMISSION_ID),
@@ -563,6 +594,91 @@ describe('BounceService', () => {
           numTransient: 1,
           numPermanent: 1,
           autoEmailRecipients,
+          autoSmsRecipients,
+          bounceInfo: snsInfo.bounce,
+        },
+      })
+    })
+
+    it('should log correctly when hasAutoEmailed is false', () => {
+      const bounceDoc = new Bounce({
+        formId: MOCK_FORM_ID,
+        bounces: [],
+        hasAutoEmailed: false,
+        hasAutoSmsed: true,
+      })
+      const snsInfo = makeBounceNotification({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+        recipientList: [MOCK_EMAIL, MOCK_EMAIL_2],
+        bouncedList: [],
+      })
+      const autoEmailRecipients: string[] = []
+      const autoSmsRecipients: UserWithContactNumber[] = []
+      logCriticalBounce(
+        bounceDoc,
+        snsInfo,
+        autoEmailRecipients,
+        autoSmsRecipients,
+        false,
+      )
+      expect(mockLogger.warn).toHaveBeenCalledWith({
+        message: 'Bounced submission',
+        meta: {
+          action: 'logCriticalBounce',
+          hasAutoEmailed: false,
+          hasAutoSmsed: true,
+          hasDeactivated: false,
+          formId: String(MOCK_FORM_ID),
+          submissionId: String(MOCK_SUBMISSION_ID),
+          recipients: [],
+          numRecipients: 0,
+          numTransient: 0,
+          numPermanent: 0,
+          autoEmailRecipients,
+          autoSmsRecipients,
+          bounceInfo: snsInfo.bounce,
+        },
+      })
+    })
+
+    it('should log correctly when hasAutoSmsed is false', () => {
+      const bounceDoc = new Bounce({
+        formId: MOCK_FORM_ID,
+        bounces: [],
+        hasAutoEmailed: true,
+        hasAutoSmsed: false,
+      })
+      const snsInfo = makeBounceNotification({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+        recipientList: [MOCK_EMAIL, MOCK_EMAIL_2],
+        bouncedList: [],
+      })
+      const autoEmailRecipients: string[] = []
+      const autoSmsRecipients: UserWithContactNumber[] = []
+      logCriticalBounce(
+        bounceDoc,
+        snsInfo,
+        autoEmailRecipients,
+        autoSmsRecipients,
+        false,
+      )
+      expect(mockLogger.warn).toHaveBeenCalledWith({
+        message: 'Bounced submission',
+        meta: {
+          action: 'logCriticalBounce',
+          hasAutoEmailed: true,
+          hasAutoSmsed: false,
+          hasDeactivated: false,
+          formId: String(MOCK_FORM_ID),
+          submissionId: String(MOCK_SUBMISSION_ID),
+          recipients: [],
+          numRecipients: 0,
+          numTransient: 0,
+          numPermanent: 0,
+          autoEmailRecipients,
+          autoSmsRecipients,
           bounceInfo: snsInfo.bounce,
         },
       })

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -485,13 +485,13 @@ describe('BounceService', () => {
       })
       const autoEmailRecipients = [MOCK_EMAIL, MOCK_EMAIL_2]
       const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
-      logCriticalBounce(
+      logCriticalBounce({
         bounceDoc,
-        snsInfo,
+        notification: snsInfo,
         autoEmailRecipients,
         autoSmsRecipients,
-        false,
-      )
+        hasDeactivated: false,
+      })
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
@@ -530,13 +530,13 @@ describe('BounceService', () => {
       })
       const autoEmailRecipients: string[] = []
       const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
-      logCriticalBounce(
+      logCriticalBounce({
         bounceDoc,
-        snsInfo,
+        notification: snsInfo,
         autoEmailRecipients,
         autoSmsRecipients,
-        true,
-      )
+        hasDeactivated: true,
+      })
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
@@ -575,13 +575,13 @@ describe('BounceService', () => {
       })
       const autoEmailRecipients: string[] = []
       const autoSmsRecipients = [MOCK_CONTACT, MOCK_CONTACT_2]
-      logCriticalBounce(
+      logCriticalBounce({
         bounceDoc,
-        snsInfo,
+        notification: snsInfo,
         autoEmailRecipients,
         autoSmsRecipients,
-        false,
-      )
+        hasDeactivated: false,
+      })
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
@@ -617,13 +617,13 @@ describe('BounceService', () => {
       })
       const autoEmailRecipients: string[] = []
       const autoSmsRecipients: UserWithContactNumber[] = []
-      logCriticalBounce(
+      logCriticalBounce({
         bounceDoc,
-        snsInfo,
+        notification: snsInfo,
         autoEmailRecipients,
         autoSmsRecipients,
-        false,
-      )
+        hasDeactivated: false,
+      })
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {
@@ -659,13 +659,13 @@ describe('BounceService', () => {
       })
       const autoEmailRecipients: string[] = []
       const autoSmsRecipients: UserWithContactNumber[] = []
-      logCriticalBounce(
+      logCriticalBounce({
         bounceDoc,
-        snsInfo,
+        notification: snsInfo,
         autoEmailRecipients,
         autoSmsRecipients,
-        false,
-      )
+        hasDeactivated: false,
+      })
       expect(mockLogger.warn).toHaveBeenCalledWith({
         message: 'Bounced submission',
         meta: {

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -50,11 +50,8 @@ export const handleSns: RequestHandler<
     }
     const form = formResult.value
 
-    const shouldDeactivate = bounceDoc.areAllPermanentBounces()
-    if (shouldDeactivate) {
-      await FormService.deactivateForm(bounceDoc.formId)
-    }
     if (bounceDoc.isCriticalBounce()) {
+      // Notify admin and collaborators
       let emailRecipients: string[] = []
       const smsRecipients: UserContactView[] = []
       if (!bounceDoc.hasNotified()) {
@@ -64,6 +61,14 @@ export const handleSns: RequestHandler<
         )
         bounceDoc.setNotificationState(emailRecipients, smsRecipients)
       }
+
+      // Deactivate if all bounces are permanent
+      const shouldDeactivate = bounceDoc.areAllPermanentBounces()
+      if (shouldDeactivate) {
+        await FormService.deactivateForm(bounceDoc.formId)
+      }
+
+      // Important log message for user follow-ups
       BounceService.logCriticalBounce(
         bounceDoc,
         notification,

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -74,6 +74,10 @@ export const handleSns: RequestHandler<
       const shouldDeactivate = bounceDoc.areAllPermanentBounces()
       if (shouldDeactivate) {
         await FormService.deactivateForm(bounceDoc.formId)
+        await BounceService.notifyAdminsOfDeactivation(
+          form,
+          possibleSmsRecipients,
+        )
       }
 
       // Important log message for user follow-ups

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -73,7 +73,7 @@ export const handleSns: RequestHandler<
         smsRecipients: [],
       }
       if (!bounceDoc.hasNotified()) {
-        notificationRecipients = await BounceService.notifyAdminOfBounce(
+        notificationRecipients = await BounceService.notifyAdminsOfBounce(
           bounceDoc,
           form,
           possibleSmsRecipients,

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -4,15 +4,9 @@ import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import {
-  IEmailNotification,
-  ISnsNotification,
-  UserContactView,
-} from '../../../types'
+import { IEmailNotification, ISnsNotification } from '../../../types'
 import { EmailType } from '../../services/mail/mail.constants'
 import * as FormService from '../form/form.service'
-import { getCollabEmailsWithPermission } from '../form/form.utils'
-import * as UserService from '../user/user.service'
 
 import * as BounceService from './bounce.service'
 import { AdminNotificationResult } from './bounce.types'
@@ -55,17 +49,9 @@ export const handleSns: RequestHandler<
 
     if (bounceDoc.isCriticalBounce()) {
       // Get contact numbers
-      let possibleSmsRecipients: UserContactView[] = []
-      const usersToSms = [
-        form.admin.email,
-        ...getCollabEmailsWithPermission(form.permissionList, true),
-      ]
-      const smsRecipientsResult = await UserService.findContactsForEmails(
-        usersToSms,
+      const possibleSmsRecipients = await BounceService.getEditorsWithContactNumbers(
+        form,
       )
-      if (smsRecipientsResult.isOk()) {
-        possibleSmsRecipients = smsRecipientsResult.value
-      }
 
       // Notify admin and collaborators
       let notificationRecipients: AdminNotificationResult = {

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -91,13 +91,13 @@ export const handleSns: RequestHandler<
       }
 
       // Important log message for user follow-ups
-      BounceService.logCriticalBounce(
+      BounceService.logCriticalBounce({
         bounceDoc,
         notification,
-        notificationRecipients.emailRecipients,
-        notificationRecipients.smsRecipients,
-        shouldDeactivate,
-      )
+        autoEmailRecipients: notificationRecipients.emailRecipients,
+        autoSmsRecipients: notificationRecipients.smsRecipients,
+        hasDeactivated: shouldDeactivate,
+      })
     }
     await bounceDoc.save()
     return res.sendStatus(StatusCodes.OK)

--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -4,7 +4,11 @@ import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import { IEmailNotification, ISnsNotification } from '../../../types'
+import {
+  IEmailNotification,
+  ISnsNotification,
+  UserContactView,
+} from '../../../types'
 import { EmailType } from '../../services/mail/mail.constants'
 import * as FormService from '../form/form.service'
 
@@ -52,17 +56,19 @@ export const handleSns: RequestHandler<
     }
     if (bounceDoc.isCriticalBounce()) {
       let emailRecipients: string[] = []
+      const smsRecipients: UserContactView[] = []
       if (!bounceDoc.hasNotified()) {
         emailRecipients = await BounceService.notifyAdminOfBounce(
           bounceDoc,
           form,
         )
-        bounceDoc.setNotificationState(emailRecipients)
+        bounceDoc.setNotificationState(emailRecipients, smsRecipients)
       }
       BounceService.logCriticalBounce(
         bounceDoc,
         notification,
         emailRecipients,
+        smsRecipients,
         shouldDeactivate,
       )
     }

--- a/src/app/modules/bounce/bounce.model.ts
+++ b/src/app/modules/bounce/bounce.model.ts
@@ -8,6 +8,7 @@ import {
   IBounceSchema,
   IEmailNotification,
   ISingleBounce,
+  UserContactView,
 } from '../../../types'
 import { FORM_SCHEMA_ID } from '../../models/form.server.model'
 
@@ -29,6 +30,10 @@ const BounceSchema = new Schema<IBounceSchema>({
     required: 'Form ID is required',
   },
   hasAutoEmailed: {
+    type: Boolean,
+    default: false,
+  },
+  hasAutoSmsed: {
     type: Boolean,
     default: false,
   },
@@ -169,9 +174,13 @@ BounceSchema.methods.getEmails = function (this: IBounceSchema): string[] {
 BounceSchema.methods.setNotificationState = function (
   this: IBounceSchema,
   emailRecipients: string[],
+  smsRecipients: UserContactView[],
 ): void {
   if (emailRecipients.length > 0) {
     this.hasAutoEmailed = true
+  }
+  if (smsRecipients.length > 0) {
+    this.hasAutoSmsed = true
   }
 }
 
@@ -180,7 +189,7 @@ BounceSchema.methods.setNotificationState = function (
  * false otherwise.
  */
 BounceSchema.methods.hasNotified = function (this: IBounceSchema): boolean {
-  return this.hasAutoEmailed
+  return this.hasAutoEmailed || this.hasAutoSmsed
 }
 
 const getBounceModel = (db: Mongoose): IBounceModel => {

--- a/src/app/modules/bounce/bounce.model.ts
+++ b/src/app/modules/bounce/bounce.model.ts
@@ -100,6 +100,7 @@ BounceSchema.statics.fromSnsNotification = function (
 /**
  * Updates an old bounce document with info from an SNS notification.
  * @param snsInfo the notification information to merge
+ * @returns the updated document
  */
 BounceSchema.methods.updateBounceInfo = function (
   this: IBounceSchema,
@@ -138,6 +139,7 @@ BounceSchema.methods.updateBounceInfo = function (
 /**
  * Returns true if the document indicates a critical bounce (all recipients
  * bounced), false otherwise.
+ * @returns true if all recipients bounced
  */
 BounceSchema.methods.isCriticalBounce = function (
   this: IBounceSchema,
@@ -148,6 +150,7 @@ BounceSchema.methods.isCriticalBounce = function (
 /**
  * Returns true if the document indicates that all recipients bounced and
  * all bounces were permanent, false otherwise.
+ * @returns true if all bounecs were permanent
  */
 BounceSchema.methods.areAllPermanentBounces = function (
   this: IBounceSchema,
@@ -160,6 +163,7 @@ BounceSchema.methods.areAllPermanentBounces = function (
 
 /**
  * Returns the list of email recipients for this form
+ * @returns Array of email addresses
  */
 BounceSchema.methods.getEmails = function (this: IBounceSchema): string[] {
   // Return a regular array to prevent unexpected bugs with mongoose
@@ -170,6 +174,7 @@ BounceSchema.methods.getEmails = function (this: IBounceSchema): string[] {
 /**
  * Sets hasAutoEmailed to true if at least one person has been emailed.
  * @param emailRecipients Array of recipients who were emailed.
+ * @returns void. Modifies document in place.
  */
 BounceSchema.methods.setNotificationState = function (
   this: IBounceSchema,
@@ -185,8 +190,9 @@ BounceSchema.methods.setNotificationState = function (
 }
 
 /**
- * Returns true if an automated email has been sent for this form,
+ * Returns true if an automated email or SMS has been sent for this form,
  * false otherwise.
+ * @returns true if at least one admin or collaborator has been notified
  */
 BounceSchema.methods.hasNotified = function (this: IBounceSchema): boolean {
   return this.hasAutoEmailed || this.hasAutoSmsed

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -131,13 +131,19 @@ export const isValidSnsRequest = async (
  * @param hasDeactivated Whether the form was deactivated
  * @returns void
  */
-export const logCriticalBounce = (
-  bounceDoc: IBounceSchema,
-  notification: IEmailNotification,
-  autoEmailRecipients: string[],
-  autoSmsRecipients: UserWithContactNumber[],
-  hasDeactivated: boolean,
-): void => {
+export const logCriticalBounce = ({
+  bounceDoc,
+  notification,
+  autoEmailRecipients,
+  autoSmsRecipients,
+  hasDeactivated,
+}: {
+  bounceDoc: IBounceSchema
+  notification: IEmailNotification
+  autoEmailRecipients: string[]
+  autoSmsRecipients: UserWithContactNumber[]
+  hasDeactivated: boolean
+}): void => {
   const submissionId = extractHeader(notification, EMAIL_HEADERS.submissionId)
   const bounceInfo = isBounceNotification(notification)
     ? notification.bounce

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -14,7 +14,6 @@ import {
   IPopulatedForm,
   ISnsNotification,
 } from '../../../types'
-import getFormModel from '../../models/form.server.model'
 import { EMAIL_HEADERS, EmailType } from '../../services/mail/mail.constants'
 import MailService from '../../services/mail/mail.service'
 
@@ -24,7 +23,6 @@ import { extractHeader, isBounceNotification } from './bounce.util'
 const logger = createLoggerWithLabel(module)
 const shortTermLogger = createCloudWatchLogger('email')
 const Bounce = getBounceModel(mongoose)
-const Form = getFormModel(mongoose)
 
 // Note that these need to be ordered in order to generate
 // the correct string to sign
@@ -161,18 +159,8 @@ const computeValidEmails = (
 
 export const notifyAdminOfBounce = async (
   bounceDoc: IBounceSchema,
+  form: IPopulatedForm,
 ): Promise<string[]> => {
-  const form = await Form.getFullFormById(bounceDoc.formId)
-  if (!form) {
-    logger.error({
-      message: 'Unable to retrieve form',
-      meta: {
-        action: 'notifyAdminOfBounce',
-        formId: bounceDoc.formId,
-      },
-    })
-    return []
-  }
   const emailRecipients = computeValidEmails(form, bounceDoc)
   if (emailRecipients.length > 0) {
     await MailService.sendBounceNotification({

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -169,7 +169,7 @@ const computeValidEmails = (
   return difference(possibleEmails, bounceDoc.getEmails())
 }
 
-export const notifyAdminOfBounce = async (
+export const notifyAdminsOfBounce = async (
   bounceDoc: IBounceSchema,
   form: IPopulatedForm,
   possibleSmsRecipients: UserContactView[],

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../types'
 import { EMAIL_HEADERS, EmailType } from '../../services/mail/mail.constants'
 import MailService from '../../services/mail/mail.service'
+import { getCollabEmailsWithPermission } from '../form/form.utils'
 
 import getBounceModel from './bounce.model'
 import { extractHeader, isBounceNotification } from './bounce.util'
@@ -150,9 +151,9 @@ const computeValidEmails = (
   populatedForm: IPopulatedForm,
   bounceDoc: IBounceSchema,
 ): string[] => {
-  const collabEmails = populatedForm.permissionList
-    ? populatedForm.permissionList.map((collab) => collab.email)
-    : []
+  const collabEmails = getCollabEmailsWithPermission(
+    populatedForm.permissionList,
+  )
   const possibleEmails = collabEmails.concat(populatedForm.admin.email)
   return difference(possibleEmails, bounceDoc.getEmails())
 }

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -13,6 +13,7 @@ import {
   IEmailNotification,
   IPopulatedForm,
   ISnsNotification,
+  UserContactView,
 } from '../../../types'
 import { EMAIL_HEADERS, EmailType } from '../../services/mail/mail.constants'
 import MailService from '../../services/mail/mail.service'
@@ -113,6 +114,7 @@ export const logCriticalBounce = (
   bounceDoc: IBounceSchema,
   notification: IEmailNotification,
   autoEmailRecipients: string[],
+  autoSmsRecipients: UserContactView[],
   hasDeactivated: boolean,
 ): void => {
   const submissionId = extractHeader(notification, EMAIL_HEADERS.submissionId)
@@ -140,6 +142,7 @@ export const logCriticalBounce = (
       // Assume that this function is correctly only called when all recipients bounced
       numPermanent: bounceDoc.bounces.length - numTransient,
       autoEmailRecipients,
+      autoSmsRecipients,
       // We know for sure that critical bounces can only happen because of bounce
       // notifications, so we don't expect this to be undefined
       bounceInfo: bounceInfo,

--- a/src/app/modules/bounce/bounce.types.ts
+++ b/src/app/modules/bounce/bounce.types.ts
@@ -1,0 +1,10 @@
+import { SetRequired } from 'type-fest'
+
+import { UserContactView } from '../../../types'
+
+export type UserWithContactNumber = SetRequired<UserContactView, 'contact'>
+
+export interface AdminNotificationResult {
+  emailRecipients: string[]
+  smsRecipients: UserWithContactNumber[]
+}

--- a/src/app/modules/bounce/bounce.util.ts
+++ b/src/app/modules/bounce/bounce.util.ts
@@ -65,6 +65,14 @@ export const isDeliveryNotification = (
   body: IEmailNotification,
 ): body is IDeliveryNotification => body.notificationType === 'Delivery'
 
+/**
+ * Filters the given SMS recipients to only those which were sent succesfully
+ * @param smsResults Array of Promise.allSettled results
+ * @param smsRecipients Recipients who were SMSed. This array must correspond
+ * exactly to smsResults, i.e. the result at smsResults[i] corresponds
+ * to the result of the attempt to SMS smsRecipients[i]
+ * @returns the contact details of SMSes sent successfully
+ */
 export const extractSuccessfulSmsRecipients = (
   smsResults: PromiseSettledResult<boolean>[],
   smsRecipients: UserWithContactNumber[],
@@ -77,6 +85,11 @@ export const extractSuccessfulSmsRecipients = (
   }, [])
 }
 
+/**
+ * Extracts the errors from results of attempting to send SMSes
+ * @param smsResults Array of Promise.allSettled results
+ * @returns Array of errors
+ */
 export const extractSmsErrors = (
   smsResults: PromiseSettledResult<boolean>[],
 ): PromiseRejectedResult['reason'][] => {

--- a/src/app/modules/bounce/bounce.util.ts
+++ b/src/app/modules/bounce/bounce.util.ts
@@ -3,6 +3,8 @@ import {
   IDeliveryNotification,
   IEmailNotification,
 } from '../../../types'
+
+import { UserWithContactNumber } from './bounce.types'
 /**
  * Extracts custom headers which we send with all emails, such as form ID, submission ID
  * and email type (admin response, email confirmation OTP etc).
@@ -62,3 +64,26 @@ export const isBounceNotification = (
 export const isDeliveryNotification = (
   body: IEmailNotification,
 ): body is IDeliveryNotification => body.notificationType === 'Delivery'
+
+export const extractSuccessfulSmsRecipients = (
+  smsResults: PromiseSettledResult<boolean>[],
+  smsRecipients: UserWithContactNumber[],
+): UserWithContactNumber[] => {
+  return smsResults.reduce<UserWithContactNumber[]>((acc, result, index) => {
+    if (result.status === 'fulfilled') {
+      acc.push(smsRecipients[index])
+    }
+    return acc
+  }, [])
+}
+
+export const extractSmsErrors = (
+  smsResults: PromiseSettledResult<boolean>[],
+): PromiseRejectedResult['reason'][] => {
+  return smsResults.reduce<PromiseRejectedResult['reason'][]>((acc, result) => {
+    if (result.status === 'rejected') {
+      acc.push(result.reason)
+    }
+    return acc
+  }, [])
+}

--- a/src/app/modules/form/__tests__/form.utils.spec.ts
+++ b/src/app/modules/form/__tests__/form.utils.spec.ts
@@ -9,11 +9,18 @@ import {
   IFieldSchema,
   IPopulatedForm,
   IPopulatedUser,
+  Permission,
   ResponseMode,
   Status,
 } from 'src/types'
 
-import { removePrivateDetailsFromForm } from '../form.utils'
+import {
+  getCollabEmailsWithPermission,
+  removePrivateDetailsFromForm,
+} from '../form.utils'
+
+const MOCK_EMAIL_1 = 'a@abc.com'
+const MOCK_EMAIL_2 = 'b@def.com'
 
 const MOCK_POPULATED_FORM = ({
   startPage: {
@@ -75,6 +82,43 @@ const MOCK_POPULATED_FORM = ({
 } as unknown) as IPopulatedForm
 
 describe('form.utils', () => {
+  describe('getCollabEmailsWithPermission', () => {
+    it('should return empty array when no arguments are given', () => {
+      expect(getCollabEmailsWithPermission()).toEqual([])
+    })
+
+    it('should return empty array when permissionList is undefined but writePermission is defined', () => {
+      expect(getCollabEmailsWithPermission(undefined, true)).toEqual([])
+    })
+
+    it('should return all collaborators when writePermission is undefined', () => {
+      const collabs: Permission[] = [
+        { email: MOCK_EMAIL_1, write: true },
+        { email: MOCK_EMAIL_2, write: false },
+      ]
+      const result = getCollabEmailsWithPermission(collabs)
+      expect(result).toEqual([MOCK_EMAIL_1, MOCK_EMAIL_2])
+    })
+
+    it('should return write-only collaborators when writePermission is true', () => {
+      const collabs: Permission[] = [
+        { email: MOCK_EMAIL_1, write: true },
+        { email: MOCK_EMAIL_2, write: false },
+      ]
+      const result = getCollabEmailsWithPermission(collabs, true)
+      expect(result).toEqual([MOCK_EMAIL_1])
+    })
+
+    it('should return read-only collaborators when writePermission is false', () => {
+      const collabs: Permission[] = [
+        { email: MOCK_EMAIL_1, write: true },
+        { email: MOCK_EMAIL_2, write: false },
+      ]
+      const result = getCollabEmailsWithPermission(collabs, false)
+      expect(result).toEqual([MOCK_EMAIL_2])
+    })
+  })
+
   describe('removePrivateDetailsFromForm', () => {
     it('should correctly remove private details', async () => {
       // Act

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -71,9 +71,10 @@ export const getCollabEmailsWithPermission = (
     return []
   }
   return permissionList.reduce<string[]>((acc, collaborator) => {
-    if (writePermission === undefined) {
-      acc.push(collaborator.email)
-    } else if (collaborator.write === writePermission) {
+    if (
+      writePermission === undefined ||
+      writePermission === collaborator.write
+    ) {
       acc.push(collaborator.email)
     }
     return acc

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -61,6 +61,7 @@ export const removePrivateDetailsFromForm = (
  * write permission.
  * @param permissionList List of collaborators
  * @param writePermission Optional write permission to filter on
+ * @returns Array of emails
  */
 export const getCollabEmailsWithPermission = (
   permissionList?: Permission[],

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,7 +1,7 @@
 import { pick } from 'lodash'
 import { Merge } from 'type-fest'
 
-import { IPopulatedForm } from 'src/types'
+import { IPopulatedForm, Permission } from '../../../types'
 
 // Kept in this file instead of form.types.ts so that this can be kept in sync
 // with FORM_PUBLIC_FIELDS more easily.
@@ -54,4 +54,27 @@ export const removePrivateDetailsFromForm = (
     ...(pick(form, FORM_PUBLIC_FIELDS) as PublicFormValues),
     admin: pick(form.admin, 'agency'),
   }
+}
+
+/**
+ * Extracts emails of collaborators, optionally filtering for a specific
+ * write permission.
+ * @param permissionList List of collaborators
+ * @param writePermission Optional write permission to filter on
+ */
+export const getCollabEmailsWithPermission = (
+  permissionList?: Permission[],
+  writePermission?: boolean,
+): string[] => {
+  if (!permissionList) {
+    return []
+  }
+  return permissionList.reduce<string[]>((acc, collaborator) => {
+    if (writePermission === undefined) {
+      acc.push(collaborator.email)
+    } else if (collaborator.write === writePermission) {
+      acc.push(collaborator.email)
+    }
+    return acc
+  }, [])
 }

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -465,3 +465,24 @@ const removeAdminVerificationDoc = (userId: string) => {
     },
   )
 }
+
+export const findContactsForEmails = (
+  emails: string[],
+): ResultAsync<string[], DatabaseError> => {
+  return ResultAsync.fromPromise(
+    UserModel.findContactNumbersByEmails(emails),
+    (error) => {
+      logger.error({
+        message: 'Error while retrieving contacts for email addresses',
+        meta: {
+          action: 'findContactsForEmails',
+          emails,
+        },
+        error,
+      })
+      return new DatabaseError(
+        'Failed to retrieve contacts for email addresses',
+      )
+    },
+  )
+}

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -467,6 +467,11 @@ const removeAdminVerificationDoc = (userId: string) => {
   )
 }
 
+/**
+ * Finds emergency contact numbers for a given list of emails.
+ * @param emails Emails for which contacts should be found
+ * @returns Array of email-contact pairings
+ */
 export const findContactsForEmails = (
   emails: string[],
 ): ResultAsync<UserContactView[], DatabaseError> => {

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -10,6 +10,7 @@ import {
   IPopulatedUser,
   IUserSchema,
   UpsertOtpParams,
+  UserContactView,
 } from '../../../types'
 import getAdminVerificationModel from '../../models/admin_verification.server.model'
 import { AGENCY_SCHEMA_ID } from '../../models/agency.server.model'
@@ -468,7 +469,7 @@ const removeAdminVerificationDoc = (userId: string) => {
 
 export const findContactsForEmails = (
   emails: string[],
-): ResultAsync<string[], DatabaseError> => {
+): ResultAsync<UserContactView[], DatabaseError> => {
   return ResultAsync.fromPromise(
     UserModel.findContactNumbersByEmails(emails),
     (error) => {

--- a/src/app/services/sms/__tests__/sms.factory.spec.ts
+++ b/src/app/services/sms/__tests__/sms.factory.spec.ts
@@ -1,6 +1,9 @@
+import { ObjectId } from 'bson'
 import { okAsync } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
 import Twilio from 'twilio'
 
+import { MissingFeatureError } from 'src/app/modules/core/core.errors'
 import {
   FeatureNames,
   ISms,
@@ -9,7 +12,7 @@ import {
 
 import { createSmsFactory } from '../sms.factory'
 import * as SmsService from '../sms.service'
-import { TwilioConfig } from '../sms.types'
+import { BounceNotificationSmsParams, TwilioConfig } from '../sms.types'
 
 // This is hoisted and thus a const cannot be passed in.
 jest.mock('twilio', () =>
@@ -18,9 +21,21 @@ jest.mock('twilio', () =>
   })),
 )
 
+jest.mock('../sms.service')
+const MockSmsService = mocked(SmsService, true)
+
 const MOCKED_TWILIO = ({
   mocked: 'this is mocked',
 } as unknown) as Twilio.Twilio
+
+const MOCK_BOUNCE_SMS_PARAMS: BounceNotificationSmsParams = {
+  adminEmail: 'admin@email.com',
+  adminId: new ObjectId().toHexString(),
+  formId: new ObjectId().toHexString(),
+  formTitle: 'mock form title',
+  recipient: '+6581234567',
+  recipientEmail: 'recipient@email.com',
+}
 
 describe('sms.factory', () => {
   beforeEach(() => jest.clearAllMocks())
@@ -54,6 +69,18 @@ describe('sms.factory', () => {
         'sendVerificationOtp: SMS feature must be enabled in Feature Manager first',
       )
     })
+
+    it('should reject with MissingFeatureError for sendFormDeactivatedSms', async () => {
+      await expect(
+        SmsFactory.sendFormDeactivatedSms(MOCK_BOUNCE_SMS_PARAMS),
+      ).rejects.toThrowError(new MissingFeatureError(FeatureNames.Sms))
+    })
+
+    it('should reject with MissingFeatureError for sendBouncedSubmissionSms', async () => {
+      await expect(
+        SmsFactory.sendBouncedSubmissionSms(MOCK_BOUNCE_SMS_PARAMS),
+      ).rejects.toThrowError(new MissingFeatureError(FeatureNames.Sms))
+    })
   })
 
   describe('sms feature enabled', () => {
@@ -68,14 +95,15 @@ describe('sms.factory', () => {
         twilioMsgSrvcSid: 'formsg-is-great-pleasehelpme',
       },
     }
-
+    const expectedTwilioConfig: TwilioConfig = {
+      msgSrvcSid: MOCK_ENABLED_SMS_FEATURE.props.twilioMsgSrvcSid,
+      client: MOCKED_TWILIO,
+    }
     const SmsFactory = createSmsFactory(MOCK_ENABLED_SMS_FEATURE)
 
     it('should call SmsService counterpart when invoking sendAdminContactOtp', async () => {
       // Arrange
-      const serviceContactSpy = jest
-        .spyOn(SmsService, 'sendAdminContactOtp')
-        .mockReturnValueOnce(okAsync(true))
+      MockSmsService.sendAdminContactOtp.mockReturnValueOnce(okAsync(true))
 
       const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
         'mockRecipient',
@@ -87,13 +115,8 @@ describe('sms.factory', () => {
       await SmsFactory.sendAdminContactOtp(...mockArguments)
 
       // Assert
-      const expectedTwilioConfig: TwilioConfig = {
-        msgSrvcSid: MOCK_ENABLED_SMS_FEATURE.props.twilioMsgSrvcSid,
-        client: MOCKED_TWILIO,
-      }
-
-      expect(serviceContactSpy).toHaveBeenCalledTimes(1)
-      expect(serviceContactSpy).toHaveBeenCalledWith(
+      expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledTimes(1)
+      expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledWith(
         ...mockArguments,
         expectedTwilioConfig,
       )
@@ -101,9 +124,7 @@ describe('sms.factory', () => {
 
     it('should call SmsService counterpart when invoking sendVerificationOtp', async () => {
       // Arrange
-      const serviceVfnSpy = jest
-        .spyOn(SmsService, 'sendVerificationOtp')
-        .mockResolvedValue(true)
+      MockSmsService.sendVerificationOtp.mockResolvedValue(true)
 
       const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
         'mockRecipient',
@@ -115,14 +136,31 @@ describe('sms.factory', () => {
       await SmsFactory.sendVerificationOtp(...mockArguments)
 
       // Assert
-      const expectedTwilioConfig: TwilioConfig = {
-        msgSrvcSid: MOCK_ENABLED_SMS_FEATURE.props.twilioMsgSrvcSid,
-        client: MOCKED_TWILIO,
-      }
-
-      expect(serviceVfnSpy).toHaveBeenCalledTimes(1)
-      expect(serviceVfnSpy).toHaveBeenCalledWith(
+      expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledTimes(1)
+      expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledWith(
         ...mockArguments,
+        expectedTwilioConfig,
+      )
+    })
+
+    it('should call SmsService when sendFormDeactivatedSms is called', async () => {
+      MockSmsService.sendFormDeactivatedSms.mockResolvedValueOnce(true)
+
+      await SmsFactory.sendFormDeactivatedSms(MOCK_BOUNCE_SMS_PARAMS)
+
+      expect(MockSmsService.sendFormDeactivatedSms).toHaveBeenCalledWith(
+        MOCK_BOUNCE_SMS_PARAMS,
+        expectedTwilioConfig,
+      )
+    })
+
+    it('should call SmsService when sendBouncedSubmissionSms is called', async () => {
+      MockSmsService.sendBouncedSubmissionSms.mockResolvedValueOnce(true)
+
+      await SmsFactory.sendBouncedSubmissionSms(MOCK_BOUNCE_SMS_PARAMS)
+
+      expect(MockSmsService.sendBouncedSubmissionSms).toHaveBeenCalledWith(
+        MOCK_BOUNCE_SMS_PARAMS,
         expectedTwilioConfig,
       )
     })

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -114,7 +114,7 @@ describe('sms.service', () => {
       const expectedLogParams = {
         smsData: mockOtpData,
         msgSrvcSid: MOCK_MSG_SRVC_SID,
-        smsType: SmsType.verification,
+        smsType: SmsType.Verification,
         logType: LogType.success,
       }
       expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)
@@ -141,7 +141,7 @@ describe('sms.service', () => {
       const expectedLogParams = {
         smsData: mockOtpData,
         msgSrvcSid: MOCK_MSG_SRVC_SID,
-        smsType: SmsType.verification,
+        smsType: SmsType.Verification,
         logType: LogType.failure,
       }
       expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)
@@ -168,7 +168,7 @@ describe('sms.service', () => {
           admin: testUser._id,
         },
         msgSrvcSid: MOCK_MSG_SRVC_SID,
-        smsType: SmsType.adminContact,
+        smsType: SmsType.AdminContact,
         logType: LogType.success,
       }
       expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)
@@ -196,7 +196,7 @@ describe('sms.service', () => {
         admin: testUser._id,
       },
       msgSrvcSid: MOCK_MSG_SRVC_SID,
-      smsType: SmsType.adminContact,
+      smsType: SmsType.AdminContact,
       logType: LogType.failure,
     }
     expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -112,7 +112,7 @@ describe('sms.service', () => {
       await expect(actualPromise).resolves.toEqual(true)
       // Logging should also have happened.
       const expectedLogParams = {
-        otpData: mockOtpData,
+        smsData: mockOtpData,
         msgSrvcSid: MOCK_MSG_SRVC_SID,
         smsType: SmsType.verification,
         logType: LogType.success,
@@ -139,7 +139,7 @@ describe('sms.service', () => {
       await expect(actualPromise).rejects.toThrow(expectedError)
       // Logging should also have happened.
       const expectedLogParams = {
-        otpData: mockOtpData,
+        smsData: mockOtpData,
         msgSrvcSid: MOCK_MSG_SRVC_SID,
         smsType: SmsType.verification,
         logType: LogType.failure,
@@ -164,7 +164,7 @@ describe('sms.service', () => {
       expect(actualResult._unsafeUnwrap()).toEqual(true)
       // Logging should also have happened.
       const expectedLogParams = {
-        otpData: {
+        smsData: {
           admin: testUser._id,
         },
         msgSrvcSid: MOCK_MSG_SRVC_SID,
@@ -192,7 +192,7 @@ describe('sms.service', () => {
 
     // Logging should also have happened.
     const expectedLogParams = {
-      otpData: {
+      smsData: {
         admin: testUser._id,
       },
       msgSrvcSid: MOCK_MSG_SRVC_SID,

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'bson'
 import mongoose from 'mongoose'
 
 import getFormModel from 'src/app/models/form.server.model'
@@ -8,6 +9,10 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import * as SmsService from '../sms.service'
 import { LogType, SmsType, TwilioConfig } from '../sms.types'
+import {
+  renderBouncedSubmissionSms,
+  renderFormDeactivatedSms,
+} from '../sms.util'
 import getSmsCountModel from '../sms_count.server.model'
 
 const FormModel = getFormModel(mongoose)
@@ -16,30 +21,38 @@ const SmsCountModel = getSmsCountModel(mongoose)
 // Test numbers provided by Twilio:
 // https://www.twilio.com/docs/iam/test-credentials
 const TWILIO_TEST_NUMBER = '+15005550006'
-
 const MOCK_MSG_SRVC_SID = 'mockMsgSrvcSid'
+const MOCK_RECIPIENT_EMAIL = 'recipientEmail@email.com'
+const MOCK_ADMIN_EMAIL = 'adminEmail@email.com'
+const MOCK_ADMIN_ID = new ObjectId().toHexString()
+const MOCK_FORM_ID = new ObjectId().toHexString()
+const MOCK_FORM_TITLE = 'formTitle'
+
+const twilioSuccessSpy = jest.fn().mockResolvedValue({
+  status: 'testStatus',
+  sid: 'testSid',
+})
 
 const MOCK_VALID_CONFIG = ({
   msgSrvcSid: MOCK_MSG_SRVC_SID,
   client: {
     messages: {
-      create: jest.fn().mockResolvedValue({
-        status: 'testStatus',
-        sid: 'testSid',
-      }),
+      create: twilioSuccessSpy,
     },
   },
 } as unknown) as TwilioConfig
+
+const twilioFailureSpy = jest.fn().mockResolvedValue({
+  status: 'testStatus',
+  sid: undefined,
+  errorCode: 21211,
+})
 
 const MOCK_INVALID_CONFIG = ({
   msgSrvcSid: MOCK_MSG_SRVC_SID,
   client: {
     messages: {
-      create: jest.fn().mockResolvedValue({
-        status: 'testStatus',
-        sid: undefined,
-        errorCode: 21211,
-      }),
+      create: twilioFailureSpy,
     },
   },
 } as unknown) as TwilioConfig
@@ -53,10 +66,168 @@ describe('sms.service', () => {
   beforeEach(async () => {
     const { user } = await dbHandler.insertFormCollectionReqs()
     testUser = user
-    smsCountSpy.mockClear()
+    jest.clearAllMocks()
   })
   afterEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('sendFormDeactivatedSms', () => {
+    it('should send SMS and log success when sending is successful', async () => {
+      const expectedMessage = renderFormDeactivatedSms(MOCK_FORM_TITLE)
+
+      await SmsService.sendFormDeactivatedSms(
+        {
+          recipient: TWILIO_TEST_NUMBER,
+          adminEmail: MOCK_ADMIN_EMAIL,
+          adminId: MOCK_ADMIN_ID,
+          formId: MOCK_FORM_ID,
+          formTitle: MOCK_FORM_TITLE,
+          recipientEmail: MOCK_RECIPIENT_EMAIL,
+        },
+        MOCK_VALID_CONFIG,
+      )
+
+      expect(twilioSuccessSpy).toHaveBeenCalledWith({
+        to: TWILIO_TEST_NUMBER,
+        body: expectedMessage,
+        from: MOCK_VALID_CONFIG.msgSrvcSid,
+        forceDelivery: true,
+      })
+      expect(smsCountSpy).toHaveBeenCalledWith({
+        smsData: {
+          form: MOCK_FORM_ID,
+          collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+          recipientNumber: TWILIO_TEST_NUMBER,
+          formAdmin: {
+            email: MOCK_ADMIN_EMAIL,
+            userId: MOCK_ADMIN_ID,
+          },
+        },
+        smsType: SmsType.DeactivatedForm,
+        msgSrvcSid: MOCK_VALID_CONFIG.msgSrvcSid,
+        logType: LogType.success,
+      })
+    })
+
+    it('should log failure when sending fails', async () => {
+      const expectedMessage = renderFormDeactivatedSms(MOCK_FORM_TITLE)
+      const expectedError = new Error(VfnErrors.InvalidMobileNumber)
+      expectedError.name = VfnErrors.SendOtpFailed
+
+      const resultPromise = SmsService.sendFormDeactivatedSms(
+        {
+          recipient: TWILIO_TEST_NUMBER,
+          adminEmail: MOCK_ADMIN_EMAIL,
+          adminId: MOCK_ADMIN_ID,
+          formId: MOCK_FORM_ID,
+          formTitle: MOCK_FORM_TITLE,
+          recipientEmail: MOCK_RECIPIENT_EMAIL,
+        },
+        MOCK_INVALID_CONFIG,
+      )
+
+      await expect(resultPromise).rejects.toThrowError(expectedError)
+      expect(twilioFailureSpy).toHaveBeenCalledWith({
+        to: TWILIO_TEST_NUMBER,
+        body: expectedMessage,
+        from: MOCK_INVALID_CONFIG.msgSrvcSid,
+        forceDelivery: true,
+      })
+      expect(smsCountSpy).toHaveBeenCalledWith({
+        smsData: {
+          form: MOCK_FORM_ID,
+          collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+          recipientNumber: TWILIO_TEST_NUMBER,
+          formAdmin: {
+            email: MOCK_ADMIN_EMAIL,
+            userId: MOCK_ADMIN_ID,
+          },
+        },
+        smsType: SmsType.DeactivatedForm,
+        msgSrvcSid: MOCK_INVALID_CONFIG.msgSrvcSid,
+        logType: LogType.failure,
+      })
+    })
+  })
+
+  describe('sendBouncedSubmissionSms', () => {
+    it('should send SMS and log success when sending is successful', async () => {
+      const expectedMessage = renderBouncedSubmissionSms(MOCK_FORM_TITLE)
+
+      await SmsService.sendBouncedSubmissionSms(
+        {
+          recipient: TWILIO_TEST_NUMBER,
+          adminEmail: MOCK_ADMIN_EMAIL,
+          adminId: MOCK_ADMIN_ID,
+          formId: MOCK_FORM_ID,
+          formTitle: MOCK_FORM_TITLE,
+          recipientEmail: MOCK_RECIPIENT_EMAIL,
+        },
+        MOCK_VALID_CONFIG,
+      )
+
+      expect(twilioSuccessSpy).toHaveBeenCalledWith({
+        to: TWILIO_TEST_NUMBER,
+        body: expectedMessage,
+        from: MOCK_VALID_CONFIG.msgSrvcSid,
+        forceDelivery: true,
+      })
+      expect(smsCountSpy).toHaveBeenCalledWith({
+        smsData: {
+          form: MOCK_FORM_ID,
+          collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+          recipientNumber: TWILIO_TEST_NUMBER,
+          formAdmin: {
+            email: MOCK_ADMIN_EMAIL,
+            userId: MOCK_ADMIN_ID,
+          },
+        },
+        smsType: SmsType.BouncedSubmission,
+        msgSrvcSid: MOCK_VALID_CONFIG.msgSrvcSid,
+        logType: LogType.success,
+      })
+    })
+
+    it('should log failure when sending fails', async () => {
+      const expectedMessage = renderBouncedSubmissionSms(MOCK_FORM_TITLE)
+      const expectedError = new Error(VfnErrors.InvalidMobileNumber)
+      expectedError.name = VfnErrors.SendOtpFailed
+
+      const resultPromise = SmsService.sendBouncedSubmissionSms(
+        {
+          recipient: TWILIO_TEST_NUMBER,
+          adminEmail: MOCK_ADMIN_EMAIL,
+          adminId: MOCK_ADMIN_ID,
+          formId: MOCK_FORM_ID,
+          formTitle: MOCK_FORM_TITLE,
+          recipientEmail: MOCK_RECIPIENT_EMAIL,
+        },
+        MOCK_INVALID_CONFIG,
+      )
+
+      await expect(resultPromise).rejects.toThrowError(expectedError)
+      expect(twilioFailureSpy).toHaveBeenCalledWith({
+        to: TWILIO_TEST_NUMBER,
+        body: expectedMessage,
+        from: MOCK_INVALID_CONFIG.msgSrvcSid,
+        forceDelivery: true,
+      })
+      expect(smsCountSpy).toHaveBeenCalledWith({
+        smsData: {
+          form: MOCK_FORM_ID,
+          collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+          recipientNumber: TWILIO_TEST_NUMBER,
+          formAdmin: {
+            email: MOCK_ADMIN_EMAIL,
+            userId: MOCK_ADMIN_ID,
+          },
+        },
+        smsType: SmsType.BouncedSubmission,
+        msgSrvcSid: MOCK_INVALID_CONFIG.msgSrvcSid,
+        logType: LogType.failure,
+      })
+    })
+  })
 
   describe('sendVerificationOtp', () => {
     let mockOtpData: FormOtpData

--- a/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
+++ b/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
@@ -18,12 +18,216 @@ const MOCK_SMSCOUNT_PARAMS = {
   },
 }
 
+const MOCK_BOUNCED_SUBMISSION_PARAMS = {
+  form: new ObjectId(),
+  formAdmin: {
+    email: 'a@abc.com',
+    userId: new ObjectId(),
+  },
+  collaboratorEmail: 'b@def.com',
+  recipientNumber: '+6581234567',
+  msgSrvcSid: 'mockMsgSrvcSid',
+  smsType: SmsType.BouncedSubmission,
+  logType: LogType.success,
+}
+
+const MOCK_FORM_DEACTIVATED_PARAMS = {
+  form: new ObjectId(),
+  formAdmin: {
+    email: 'a@abc.com',
+    userId: new ObjectId(),
+  },
+  collaboratorEmail: 'b@def.com',
+  recipientNumber: '+6581234567',
+  msgSrvcSid: 'mockMsgSrvcSid',
+  smsType: SmsType.DeactivatedForm,
+  logType: LogType.success,
+}
+
 const MOCK_MSG_SRVC_SID = 'mockMsgSrvcSid'
 
 describe('SmsCount', () => {
   beforeAll(async () => await dbHandler.connect())
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('FormDeactivatedSmsCountSchema', () => {
+    it('should create and save successfully', async () => {
+      const saved = await SmsCount.create(MOCK_FORM_DEACTIVATED_PARAMS)
+
+      expect(saved._id).toBeDefined()
+      expect(saved.createdAt).toBeInstanceOf(Date)
+      const actualSavedObject = omit(saved.toObject(), [
+        '_id',
+        'createdAt',
+        '__v',
+      ])
+      expect(actualSavedObject).toEqual(MOCK_FORM_DEACTIVATED_PARAMS)
+    })
+
+    it('should reject if form is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_FORM_DEACTIVATED_PARAMS, 'form'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if formAdmin.email is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_FORM_DEACTIVATED_PARAMS, 'formAdmin.email'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if formAdmin.userId is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_FORM_DEACTIVATED_PARAMS, 'formAdmin.userId'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if collaboratorEmail is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_FORM_DEACTIVATED_PARAMS, 'collaboratorEmail'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if collaboratorEmail is invalid', async () => {
+      const invalidSmsCount = new SmsCount(
+        merge({}, MOCK_FORM_DEACTIVATED_PARAMS, {
+          collaboratorEmail: 'invalid',
+        }),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if recipientNumber is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_FORM_DEACTIVATED_PARAMS, 'recipientNumber'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if recipientNumber is invalid', async () => {
+      const invalidSmsCount = new SmsCount(
+        merge({}, MOCK_FORM_DEACTIVATED_PARAMS, {
+          recipientNumber: 'invalid',
+        }),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+  })
+
+  describe('BouncedSubmissionSmsCountSchema', () => {
+    it('should create and save successfully', async () => {
+      const saved = await SmsCount.create(MOCK_BOUNCED_SUBMISSION_PARAMS)
+
+      expect(saved._id).toBeDefined()
+      expect(saved.createdAt).toBeInstanceOf(Date)
+      const actualSavedObject = omit(saved.toObject(), [
+        '_id',
+        'createdAt',
+        '__v',
+      ])
+      expect(actualSavedObject).toEqual(MOCK_BOUNCED_SUBMISSION_PARAMS)
+    })
+
+    it('should reject if form is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_BOUNCED_SUBMISSION_PARAMS, 'form'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if formAdmin.email is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_BOUNCED_SUBMISSION_PARAMS, 'formAdmin.email'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if formAdmin.userId is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_BOUNCED_SUBMISSION_PARAMS, 'formAdmin.userId'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if collaboratorEmail is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_BOUNCED_SUBMISSION_PARAMS, 'collaboratorEmail'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if collaboratorEmail is invalid', async () => {
+      const invalidSmsCount = new SmsCount(
+        merge({}, MOCK_BOUNCED_SUBMISSION_PARAMS, {
+          collaboratorEmail: 'invalid',
+        }),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if recipientNumber is missing', async () => {
+      const invalidSmsCount = new SmsCount(
+        omit(MOCK_BOUNCED_SUBMISSION_PARAMS, 'recipientNumber'),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should reject if recipientNumber is invalid', async () => {
+      const invalidSmsCount = new SmsCount(
+        merge({}, MOCK_BOUNCED_SUBMISSION_PARAMS, {
+          recipientNumber: 'invalid',
+        }),
+      )
+
+      await expect(invalidSmsCount.save()).rejects.toThrowError(
+        mongoose.Error.ValidationError,
+      )
+    })
+  })
 
   describe('VerificationCount Schema', () => {
     it('should create and save successfully', async () => {
@@ -174,6 +378,106 @@ describe('SmsCount', () => {
   describe('Statics', () => {
     describe('logSms', () => {
       const MOCK_FORM_ID = MOCK_SMSCOUNT_PARAMS.form
+
+      it('should correctly log bounced submission SMS successes', async () => {
+        const saved = await SmsCount.logSms({
+          logType: LogType.success,
+          smsType: SmsType.BouncedSubmission,
+          msgSrvcSid: MOCK_BOUNCED_SUBMISSION_PARAMS.msgSrvcSid,
+          smsData: omit(MOCK_BOUNCED_SUBMISSION_PARAMS, [
+            'msgSrvcSid',
+            'smsType',
+            'logType',
+          ]),
+        })
+
+        expect(saved._id).toBeDefined()
+        expect(saved.createdAt).toBeInstanceOf(Date)
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'createdAt',
+          '__v',
+        ])
+        expect(actualSavedObject).toEqual(
+          merge({}, MOCK_BOUNCED_SUBMISSION_PARAMS, {
+            logType: LogType.success,
+          }),
+        )
+      })
+
+      it('should correctly log bounced submission SMS failures', async () => {
+        const saved = await SmsCount.logSms({
+          logType: LogType.failure,
+          smsType: SmsType.BouncedSubmission,
+          msgSrvcSid: MOCK_BOUNCED_SUBMISSION_PARAMS.msgSrvcSid,
+          smsData: omit(MOCK_BOUNCED_SUBMISSION_PARAMS, [
+            'msgSrvcSid',
+            'smsType',
+            'logType',
+          ]),
+        })
+
+        expect(saved._id).toBeDefined()
+        expect(saved.createdAt).toBeInstanceOf(Date)
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'createdAt',
+          '__v',
+        ])
+        expect(actualSavedObject).toEqual(
+          merge({}, MOCK_BOUNCED_SUBMISSION_PARAMS, {
+            logType: LogType.failure,
+          }),
+        )
+      })
+
+      it('should correctly log form deactivated SMS successes', async () => {
+        const saved = await SmsCount.logSms({
+          logType: LogType.success,
+          smsType: SmsType.DeactivatedForm,
+          msgSrvcSid: MOCK_FORM_DEACTIVATED_PARAMS.msgSrvcSid,
+          smsData: omit(MOCK_FORM_DEACTIVATED_PARAMS, [
+            'msgSrvcSid',
+            'smsType',
+            'logType',
+          ]),
+        })
+
+        expect(saved._id).toBeDefined()
+        expect(saved.createdAt).toBeInstanceOf(Date)
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'createdAt',
+          '__v',
+        ])
+        expect(actualSavedObject).toEqual(
+          merge({}, MOCK_FORM_DEACTIVATED_PARAMS, { logType: LogType.success }),
+        )
+      })
+
+      it('should correctly log form deactivated SMS failures', async () => {
+        const saved = await SmsCount.logSms({
+          logType: LogType.failure,
+          smsType: SmsType.DeactivatedForm,
+          msgSrvcSid: MOCK_FORM_DEACTIVATED_PARAMS.msgSrvcSid,
+          smsData: omit(MOCK_FORM_DEACTIVATED_PARAMS, [
+            'msgSrvcSid',
+            'smsType',
+            'logType',
+          ]),
+        })
+
+        expect(saved._id).toBeDefined()
+        expect(saved.createdAt).toBeInstanceOf(Date)
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'createdAt',
+          '__v',
+        ])
+        expect(actualSavedObject).toEqual(
+          merge({}, MOCK_FORM_DEACTIVATED_PARAMS, { logType: LogType.failure }),
+        )
+      })
 
       it('should successfully log verification successes in the collection', async () => {
         // Arrange

--- a/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
+++ b/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
@@ -275,7 +275,7 @@ const logAndReturnExpectedLog = async ({
   smsType: SmsType
 }) => {
   await SmsCount.logSms({
-    otpData: MOCK_SMSCOUNT_PARAMS,
+    smsData: MOCK_SMSCOUNT_PARAMS,
     msgSrvcSid: MOCK_MSG_SRVC_SID,
     smsType,
     logType,

--- a/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
+++ b/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
@@ -181,7 +181,7 @@ describe('SmsCount', () => {
 
         // Act
         const expectedLog = await logAndReturnExpectedLog({
-          smsType: SmsType.verification,
+          smsType: SmsType.Verification,
           logType: LogType.success,
         })
 
@@ -207,7 +207,7 @@ describe('SmsCount', () => {
 
         // Act
         const expectedLog = await logAndReturnExpectedLog({
-          smsType: SmsType.verification,
+          smsType: SmsType.Verification,
           logType: LogType.failure,
         })
 
@@ -240,7 +240,7 @@ describe('SmsCount', () => {
       it('should reject if logType is invalid', async () => {
         await expect(
           logAndReturnExpectedLog({
-            smsType: SmsType.verification,
+            smsType: SmsType.Verification,
             // @ts-ignore
             logType: 'INVALID',
           }),
@@ -252,7 +252,7 @@ describe('SmsCount', () => {
 
 const createVerificationSmsCountParams = ({
   logType = LogType.success,
-  smsType = SmsType.verification,
+  smsType = SmsType.Verification,
 }: {
   logType?: LogType
   smsType?: SmsType

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -4,6 +4,7 @@ import FeatureManager, {
   FeatureNames,
   RegisteredFeature,
 } from '../../../config/feature-manager'
+import { MissingFeatureError } from '../../modules/core/core.errors'
 
 import {
   sendAdminContactOtp,
@@ -47,8 +48,10 @@ export const createSmsFactory = (
       sendVerificationOtp: () => {
         throw new Error(`sendVerificationOtp: ${errorMessage}`)
       },
-      sendFormDeactivatedSms: () => Promise.resolve(true),
-      sendBouncedSubmissionSms: () => Promise.resolve(true),
+      sendFormDeactivatedSms: () =>
+        Promise.reject(new MissingFeatureError(FeatureNames.Sms)),
+      sendBouncedSubmissionSms: () =>
+        Promise.reject(new MissingFeatureError(FeatureNames.Sms)),
     }
   }
 

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -1,3 +1,4 @@
+import { okAsync } from 'neverthrow'
 import Twilio from 'twilio'
 
 import FeatureManager, {
@@ -5,8 +6,13 @@ import FeatureManager, {
   RegisteredFeature,
 } from '../../../config/feature-manager'
 
-import { sendAdminContactOtp, sendVerificationOtp } from './sms.service'
-import { TwilioConfig } from './sms.types'
+import {
+  sendAdminContactOtp,
+  sendBouncedSubmissionSms,
+  sendFormDeactivatedSms,
+  sendVerificationOtp,
+} from './sms.service'
+import { BounceNotificationSmsParams, TwilioConfig } from './sms.types'
 
 interface ISmsFactory {
   sendVerificationOtp: (
@@ -19,6 +25,12 @@ interface ISmsFactory {
     otp: string,
     userId: string,
   ) => ReturnType<typeof sendAdminContactOtp>
+  sendFormDeactivatedSms: (
+    params: BounceNotificationSmsParams,
+  ) => ReturnType<typeof sendFormDeactivatedSms>
+  sendBouncedSubmissionSms: (
+    params: BounceNotificationSmsParams,
+  ) => ReturnType<typeof sendBouncedSubmissionSms>
 }
 
 const smsFeature = FeatureManager.get(FeatureNames.Sms)
@@ -36,6 +48,8 @@ export const createSmsFactory = (
       sendVerificationOtp: () => {
         throw new Error(`sendVerificationOtp: ${errorMessage}`)
       },
+      sendFormDeactivatedSms: () => okAsync(true),
+      sendBouncedSubmissionSms: () => okAsync(true),
     }
   }
 
@@ -59,6 +73,10 @@ export const createSmsFactory = (
       sendVerificationOtp(recipient, otp, formId, twilioConfig),
     sendAdminContactOtp: (recipient, otp, userId) =>
       sendAdminContactOtp(recipient, otp, userId, twilioConfig),
+    sendFormDeactivatedSms: (params) =>
+      sendFormDeactivatedSms(params, twilioConfig),
+    sendBouncedSubmissionSms: (params) =>
+      sendBouncedSubmissionSms(params, twilioConfig),
   }
 }
 

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -48,7 +48,7 @@ export const createSmsFactory = (
       sendVerificationOtp: () => {
         throw new Error(`sendVerificationOtp: ${errorMessage}`)
       },
-      sendFormDeactivatedSms: () => okAsync(true),
+      sendFormDeactivatedSms: () => Promise.resolve(true),
       sendBouncedSubmissionSms: () => okAsync(true),
     }
   }

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -25,9 +25,31 @@ interface ISmsFactory {
     otp: string,
     userId: string,
   ) => ReturnType<typeof sendAdminContactOtp>
+  /**
+   * Informs recipient that the given form was deactivated. Rejects if SMS feature
+   * not activated in app.
+   * @param params Data for SMS to be sent
+   * @param params.recipient Mobile number to be SMSed
+   * @param params.recipientEmail The email address of the recipient being SMSed
+   * @param params.adminId User ID of the admin of the deactivated form
+   * @param params.adminEmail Email of the admin of the deactivated form
+   * @param params.formId Form ID of deactivated form
+   * @param params.formTitle Title of deactivated form
+   */
   sendFormDeactivatedSms: (
     params: BounceNotificationSmsParams,
   ) => ReturnType<typeof sendFormDeactivatedSms>
+  /**
+   * Informs recipient that a response for the given form was lost due to email bounces.
+   * Rejects if SMS feature not activated in app.
+   * @param params Data for SMS to be sent
+   * @param params.recipient Mobile number to be SMSed
+   * @param params.recipientEmail The email address of the recipient being SMSed
+   * @param params.adminId User ID of the admin of the form
+   * @param params.adminEmail Email of the admin of the form
+   * @param params.formId Form ID of form
+   * @param params.formTitle Title of form
+   */
   sendBouncedSubmissionSms: (
     params: BounceNotificationSmsParams,
   ) => ReturnType<typeof sendBouncedSubmissionSms>

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -1,4 +1,3 @@
-import { okAsync } from 'neverthrow'
 import Twilio from 'twilio'
 
 import FeatureManager, {
@@ -49,7 +48,7 @@ export const createSmsFactory = (
         throw new Error(`sendVerificationOtp: ${errorMessage}`)
       },
       sendFormDeactivatedSms: () => Promise.resolve(true),
-      sendBouncedSubmissionSms: () => okAsync(true),
+      sendBouncedSubmissionSms: () => Promise.resolve(true),
     }
   }
 

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -336,7 +336,7 @@ export const sendFormDeactivatedSms = (
     formTitle,
   }: BounceNotificationSmsParams,
   defaultConfig: TwilioConfig,
-): ResultAsync<boolean, SmsSendError> => {
+): Promise<boolean> => {
   logger.info({
     message: `Sending form deactivation notification for ${recipientEmail}`,
     meta: {
@@ -357,23 +357,12 @@ export const sendFormDeactivatedSms = (
     },
   }
 
-  return ResultAsync.fromPromise(
-    send(defaultConfig, smsData, recipient, message, SmsType.DeactivatedForm),
-    (error) => {
-      logger.error({
-        message:
-          'Failed to send SMS notification for automatic form deactivation',
-        meta: {
-          action: 'sendFormDeactivatedSms',
-          recipient,
-        },
-        error,
-      })
-
-      return new SmsSendError(
-        'Failed to send SMS notification for automatic form deactivation',
-      )
-    },
+  return send(
+    defaultConfig,
+    smsData,
+    recipient,
+    message,
+    SmsType.DeactivatedForm,
   )
 }
 

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -269,7 +269,7 @@ export const sendVerificationOtp = async (
 
   const message = `Use the OTP ${otp} to complete your submission on ${config.app.title}.`
 
-  return send(twilioData, otpData, recipient, message, SmsType.verification)
+  return send(twilioData, otpData, recipient, message, SmsType.Verification)
 }
 
 export const sendAdminContactOtp = (
@@ -293,7 +293,7 @@ export const sendAdminContactOtp = (
   }
 
   return ResultAsync.fromPromise(
-    send(defaultConfig, otpData, recipient, message, SmsType.adminContact),
+    send(defaultConfig, otpData, recipient, message, SmsType.AdminContact),
     (error) => {
       logger.error({
         message: 'Failed to send OTP for admin contact verification',

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -376,7 +376,7 @@ export const sendBouncedSubmissionSms = (
     formTitle,
   }: BounceNotificationSmsParams,
   defaultConfig: TwilioConfig,
-): ResultAsync<boolean, SmsSendError> => {
+): Promise<boolean> => {
   logger.info({
     message: `Sending bounced submission notification for ${recipientEmail}`,
     meta: {
@@ -397,21 +397,11 @@ export const sendBouncedSubmissionSms = (
     },
   }
 
-  return ResultAsync.fromPromise(
-    send(defaultConfig, smsData, recipient, message, SmsType.BouncedSubmission),
-    (error) => {
-      logger.error({
-        message: 'Failed to send SMS notification for bounced submission',
-        meta: {
-          action: 'sendBouncedSubmissionSms',
-          recipient,
-        },
-        error,
-      })
-
-      return new SmsSendError(
-        'Failed to send SMS notification for bounced submission',
-      )
-    },
+  return send(
+    defaultConfig,
+    smsData,
+    recipient,
+    message,
+    SmsType.BouncedSubmission,
   )
 }

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -348,6 +348,7 @@ export const sendFormDeactivatedSms = ({
   const smsData: FormDeactivatedSmsData = {
     form: formId,
     collaboratorEmail: recipientEmail,
+    recipientNumber: recipient,
     formAdmin: {
       email: adminEmail,
       userId: adminId,
@@ -396,6 +397,7 @@ export const sendBouncedSubmissionSms = ({
   const smsData: BouncedSubmissionSmsData = {
     form: formId,
     collaboratorEmail: recipientEmail,
+    recipientNumber: recipient,
     formAdmin: {
       email: adminEmail,
       userId: adminId,

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -326,15 +326,17 @@ export const sendAdminContactOtp = (
   )
 }
 
-export const sendFormDeactivatedSms = ({
-  recipient,
-  recipientEmail,
-  adminId,
-  adminEmail,
-  formId,
-  formTitle,
-  defaultConfig,
-}: BounceNotificationSmsParams): ResultAsync<boolean, SmsSendError> => {
+export const sendFormDeactivatedSms = (
+  {
+    recipient,
+    recipientEmail,
+    adminId,
+    adminEmail,
+    formId,
+    formTitle,
+  }: BounceNotificationSmsParams,
+  defaultConfig: TwilioConfig,
+): ResultAsync<boolean, SmsSendError> => {
   logger.info({
     message: `Sending form deactivation notification for ${recipientEmail}`,
     meta: {
@@ -375,15 +377,17 @@ export const sendFormDeactivatedSms = ({
   )
 }
 
-export const sendBouncedSubmissionSms = ({
-  recipient,
-  recipientEmail,
-  adminId,
-  adminEmail,
-  formId,
-  formTitle,
-  defaultConfig,
-}: BounceNotificationSmsParams): ResultAsync<boolean, SmsSendError> => {
+export const sendBouncedSubmissionSms = (
+  {
+    recipient,
+    recipientEmail,
+    adminId,
+    adminEmail,
+    formId,
+    formTitle,
+  }: BounceNotificationSmsParams,
+  defaultConfig: TwilioConfig,
+): ResultAsync<boolean, SmsSendError> => {
   logger.info({
     message: `Sending bounced submission notification for ${recipientEmail}`,
     meta: {

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -132,13 +132,13 @@ const getTwilio = async (
  * @param twilioConfig The configuration used to send OTPs with
  * @param twilioData.client The client to use
  * @param twilioData.msgSrvcSid The message service sid to send from with.
- * @param otpData The data for logging smsCount
+ * @param smsData The data for logging smsCount
  * @param recipient The mobile number of the recipient
  * @param message The message to send
  */
 const send = async (
   twilioConfig: TwilioConfig,
-  otpData: FormOtpData | AdminContactOtpData,
+  smsData: FormOtpData | AdminContactOtpData,
   recipient: string,
   message: string,
   smsType: SmsType,
@@ -165,7 +165,7 @@ const send = async (
 
       // Log success
       const logParams: LogSmsParams = {
-        otpData,
+        smsData,
         smsType,
         msgSrvcSid,
         logType: LogType.success,
@@ -186,7 +186,7 @@ const send = async (
         message: 'Successfully sent sms',
         meta: {
           action: 'send',
-          otpData,
+          smsData,
         },
       })
 
@@ -203,7 +203,7 @@ const send = async (
 
       // Log failure
       const logParams: LogSmsParams = {
-        otpData,
+        smsData,
         smsType,
         msgSrvcSid,
         logType: LogType.failure,

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -326,6 +326,17 @@ export const sendAdminContactOtp = (
   )
 }
 
+/**
+ * Informs recipient that the given form was deactivated.
+ * @param params Data for SMS to be sent
+ * @param params.recipient Mobile number to be SMSed
+ * @param params.recipientEmail The email address of the recipient being SMSed
+ * @param params.adminId User ID of the admin of the deactivated form
+ * @param params.adminEmail Email of the admin of the deactivated form
+ * @param params.formId Form ID of deactivated form
+ * @param params.formTitle Title of deactivated form
+ * @param defaultConfig Twilio configuration
+ */
 export const sendFormDeactivatedSms = (
   {
     recipient,
@@ -366,6 +377,17 @@ export const sendFormDeactivatedSms = (
   )
 }
 
+/**
+ * Informs recipient that a response for the given form was lost due to email bounces.
+ * @param params Data for SMS to be sent
+ * @param params.recipient Mobile number to be SMSed
+ * @param params.recipientEmail The email address of the recipient being SMSed
+ * @param params.adminId User ID of the admin of the form
+ * @param params.adminEmail Email of the admin of the form
+ * @param params.formId Form ID of form
+ * @param params.formTitle Title of form
+ * @param defaultConfig Twilio configuration
+ */
 export const sendBouncedSubmissionSms = (
   {
     recipient,

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -93,5 +93,4 @@ export interface BounceNotificationSmsParams {
   adminEmail: string
   formId: string
   formTitle: string
-  defaultConfig: TwilioConfig
 }

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -6,11 +6,14 @@ import {
   FormOtpData,
   IFormSchema,
   IUserSchema,
+  Permission,
 } from '../../../types'
 
 export enum SmsType {
   Verification = 'VERIFICATION',
   AdminContact = 'ADMIN_CONTACT',
+  DeactivatedForm = 'DEACTIVATED_FORM',
+  BouncedSubmission = 'BOUNCED_SUBMISSION',
 }
 
 export enum LogType {
@@ -18,8 +21,23 @@ export enum LogType {
   success = 'SUCCESS',
 }
 
+export type FormDeactivatedSmsData = {
+  form: IFormSchema['_id']
+  formAdmin: {
+    email: IUserSchema['email']
+    userId: IUserSchema['_id']
+  }
+  collaboratorEmail: Permission['email']
+}
+
+export type BouncedSubmissionSmsData = FormDeactivatedSmsData
+
 export type LogSmsParams = {
-  smsData: FormOtpData | AdminContactOtpData
+  smsData:
+    | FormOtpData
+    | AdminContactOtpData
+    | FormDeactivatedSmsData
+    | BouncedSubmissionSmsData
   msgSrvcSid: string
   smsType: SmsType
   logType: LogType
@@ -65,4 +83,14 @@ export type TwilioCredentials = {
 export type TwilioConfig = {
   client: Twilio
   msgSrvcSid: string
+}
+
+export interface BounceNotificationSmsParams {
+  recipient: string
+  recipientEmail: string
+  adminId: string
+  adminEmail: string
+  formId: string
+  formTitle: string
+  defaultConfig: TwilioConfig
 }

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -70,6 +70,22 @@ export interface IAdminContactSmsCount extends ISmsCount {
 
 export type IAdminContactSmsCountSchema = ISmsCountSchema
 
+export interface IFormDeactivatedSmsCount
+  extends ISmsCount,
+    FormDeactivatedSmsData {}
+
+export interface IFormDeactivatedSmsCountSchema
+  extends ISmsCountSchema,
+    FormDeactivatedSmsData {}
+
+export interface IBouncedSubmissionSmsCount
+  extends ISmsCount,
+    BouncedSubmissionSmsData {}
+
+export interface IBouncedSubmissionSmsCountSchema
+  extends ISmsCountSchema,
+    BouncedSubmissionSmsData {}
+
 export interface ISmsCountModel extends Model<ISmsCountSchema> {
   logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>
 }

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -6,11 +6,11 @@ import {
   FormOtpData,
   IFormSchema,
   IUserSchema,
-} from 'src/types'
+} from '../../../types'
 
 export enum SmsType {
-  verification = 'VERIFICATION',
-  adminContact = 'ADMIN_CONTACT',
+  Verification = 'VERIFICATION',
+  AdminContact = 'ADMIN_CONTACT',
 }
 
 export enum LogType {

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -28,6 +28,7 @@ export type FormDeactivatedSmsData = {
     userId: IUserSchema['_id']
   }
   collaboratorEmail: Permission['email']
+  recipientNumber: string
 }
 
 export type BouncedSubmissionSmsData = FormDeactivatedSmsData

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -19,7 +19,7 @@ export enum LogType {
 }
 
 export type LogSmsParams = {
-  otpData: FormOtpData | AdminContactOtpData
+  smsData: FormOtpData | AdminContactOtpData
   msgSrvcSid: string
   smsType: SmsType
   logType: LogType

--- a/src/app/services/sms/sms.util.ts
+++ b/src/app/services/sms/sms.util.ts
@@ -1,4 +1,6 @@
-export const renderFormDeactivatedSms = (formTitle: string): string => `
+import dedent from 'dedent-js'
+
+export const renderFormDeactivatedSms = (formTitle: string): string => dedent`
   Due to responses bouncing from all recipient inboxes, your form "${formTitle}" has been automatically deactivated to prevent further response loss.
 
   Please ensure your recipient email addresses (Settings tab) have the ability to receive emailed responses from us. Invalid email addresses should be deleted, and full inboxes should be cleared.
@@ -6,6 +8,6 @@ export const renderFormDeactivatedSms = (formTitle: string): string => `
   If a systemic email issue is affecting email delivery, consider temporarily deactivating your form until email delivery is stable, or switching the form to Storage mode to continue receiving responses.
 `
 
-export const renderBouncedSubmissionSms = (formTitle: string): string => `
+export const renderBouncedSubmissionSms = (formTitle: string): string => dedent`
   A response to your form "${formTitle}" has bounced from all recipient inboxes. Bounced responses cannot be recovered. To prevent more bounces, please ensure recipient email addresses are correct, and clear any full inboxes.
 `

--- a/src/app/services/sms/sms.util.ts
+++ b/src/app/services/sms/sms.util.ts
@@ -1,0 +1,11 @@
+export const renderFormDeactivatedSms = (formTitle: string): string => `
+  Due to responses bouncing from all recipient inboxes, your form "${formTitle}" has been automatically deactivated to prevent further response loss.
+
+  Please ensure your recipient email addresses (Settings tab) have the ability to receive emailed responses from us. Invalid email addresses should be deleted, and full inboxes should be cleared.
+
+  If a systemic email issue is affecting email delivery, consider temporarily deactivating your form until email delivery is stable, or switching the form to Storage mode to continue receiving responses.
+`
+
+export const renderBouncedSubmissionSms = (formTitle: string): string => `
+  A response to your form "${formTitle}" has bounced from all recipient inboxes. Bounced responses cannot be recovered. To prevent more bounces, please ensure recipient email addresses are correct, and clear any full inboxes.
+`

--- a/src/app/services/sms/sms_count.server.model.ts
+++ b/src/app/services/sms/sms_count.server.model.ts
@@ -89,8 +89,8 @@ const compileSmsCountModel = (db: Mongoose) => {
   )
 
   // Adding Discriminators
-  SmsCountModel.discriminator(SmsType.verification, VerificationSmsCountSchema)
-  SmsCountModel.discriminator(SmsType.adminContact, AdminContactSmsCountSchema)
+  SmsCountModel.discriminator(SmsType.Verification, VerificationSmsCountSchema)
+  SmsCountModel.discriminator(SmsType.AdminContact, AdminContactSmsCountSchema)
 
   return SmsCountModel
 }

--- a/src/app/services/sms/sms_count.server.model.ts
+++ b/src/app/services/sms/sms_count.server.model.ts
@@ -69,10 +69,10 @@ const compileSmsCountModel = (db: Mongoose) => {
 
   SmsCountSchema.statics.logSms = async function (
     this: ISmsCountModel,
-    { otpData, msgSrvcSid, smsType, logType }: LogSmsParams,
+    { smsData, msgSrvcSid, smsType, logType }: LogSmsParams,
   ) {
     const schemaData: Omit<ISmsCount, '_id'> = {
-      ...otpData,
+      ...smsData,
       msgSrvcSid,
       smsType,
       logType,

--- a/src/types/bounce.ts
+++ b/src/types/bounce.ts
@@ -2,6 +2,7 @@ import { Document } from 'mongoose'
 
 import { IFormSchema } from './form'
 import { BounceType, IEmailNotification } from './sns'
+import { UserContactView } from './user'
 
 // Enforce that bounceType is present if hasBounced is true
 export type ISingleBounce =
@@ -19,6 +20,7 @@ export interface IBounce {
   formId: IFormSchema['_id']
   bounces: ISingleBounce[]
   hasAutoEmailed: boolean
+  hasAutoSmsed: boolean
   expireAt: Date
 }
 
@@ -27,6 +29,9 @@ export interface IBounceSchema extends IBounce, Document {
   isCriticalBounce: () => boolean
   areAllPermanentBounces: () => boolean
   getEmails: () => string[]
-  setNotificationState: (emailRecipients: string[]) => void
+  setNotificationState: (
+    emailRecipients: string[],
+    smsRecipients: UserContactView[],
+  ) => void
   hasNotified: () => boolean
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -30,6 +30,13 @@ export interface IUserModel extends Model<IUserSchema> {
   upsertUser: (
     upsertParams: Pick<IUser, 'email' | 'agency' | 'lastAccessed'>,
   ) => Promise<IPopulatedUser>
+  /**
+   * Finds the contact numbers for all given email addresses which exist in the
+   * User collection.
+   * @param emails List of email addresses for which to find contact numbers
+   * @returns List of contact numbers
+   */
+  findContactNumbersByEmails: (emails: string[]) => Promise<string[]>
 }
 
 export interface IPopulatedUser extends IUserSchema {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -15,6 +15,8 @@ export interface IUser {
   updatedAt?: Date
 }
 
+export type UserContactView = Pick<IUser, 'email' | 'contact'>
+
 export interface IUserSchema extends IUser, Document {
   created?: Date
 }
@@ -36,7 +38,7 @@ export interface IUserModel extends Model<IUserSchema> {
    * @param emails List of email addresses for which to find contact numbers
    * @returns List of contact numbers
    */
-  findContactNumbersByEmails: (emails: string[]) => Promise<string[]>
+  findContactNumbersByEmails: (emails: string[]) => Promise<UserContactView[]>
 }
 
 export interface IPopulatedUser extends IUserSchema {

--- a/tests/unit/backend/models/user.server.model.spec.ts
+++ b/tests/unit/backend/models/user.server.model.spec.ts
@@ -15,6 +15,9 @@ const AGENCY_DOMAIN = 'example.com'
 const VALID_USER_EMAIL = `test@${AGENCY_DOMAIN}`
 const VALID_CONTACT = '+6581234567'
 
+const VALID_USER_EMAIL_2 = `test2@${AGENCY_DOMAIN}`
+const VALID_CONTACT_2 = '+6581234568'
+
 describe('User Model', () => {
   let agency: IAgencySchema
 
@@ -147,6 +150,79 @@ describe('User Model', () => {
   })
 
   describe('Statics', () => {
+    describe('findContactNumbersByEmails', () => {
+      it('should find contact number when a single email is given', async () => {
+        await User.create({
+          email: VALID_USER_EMAIL,
+          agency: agency._id,
+          contact: VALID_CONTACT,
+        })
+
+        const contacts = await User.findContactNumbersByEmails([
+          VALID_USER_EMAIL,
+        ])
+        expect(contacts).toEqual([
+          { email: VALID_USER_EMAIL, contact: VALID_CONTACT },
+        ])
+      })
+
+      it('should find contact numbers when multiple emails are given', async () => {
+        await User.create({
+          email: VALID_USER_EMAIL,
+          agency: agency._id,
+          contact: VALID_CONTACT,
+        })
+        await User.create({
+          email: VALID_USER_EMAIL_2,
+          agency: agency._id,
+          contact: VALID_CONTACT_2,
+        })
+
+        const contacts = await User.findContactNumbersByEmails([
+          VALID_USER_EMAIL,
+          VALID_USER_EMAIL_2,
+        ])
+        expect(contacts.length).toBe(2)
+        expect(contacts).toContainEqual({
+          email: VALID_USER_EMAIL,
+          contact: VALID_CONTACT,
+        })
+        expect(contacts).toContainEqual({
+          email: VALID_USER_EMAIL_2,
+          contact: VALID_CONTACT_2,
+        })
+      })
+
+      it('should ignore email addresses which do not exist in the collection', async () => {
+        await User.create({
+          email: VALID_USER_EMAIL,
+          agency: agency._id,
+          contact: VALID_CONTACT,
+        })
+
+        const contacts = await User.findContactNumbersByEmails([
+          VALID_USER_EMAIL,
+          'invalid@email.com',
+        ])
+        expect(contacts).toEqual([
+          { email: VALID_USER_EMAIL, contact: VALID_CONTACT },
+        ])
+      })
+
+      it('should return empty array when no given email addresses exist in the collection', async () => {
+        await User.create({
+          email: VALID_USER_EMAIL,
+          agency: agency._id,
+          contact: VALID_CONTACT,
+        })
+
+        const contacts = await User.findContactNumbersByEmails([
+          'invalid@email.com',
+        ])
+        expect(contacts).toEqual([])
+      })
+    })
+
     describe('upsertUser', () => {
       it('should create new User document when user does not yet exist in the collection', async () => {
         // Arrange


### PR DESCRIPTION
## Problem

High operational workload due to need to contact email mode form admins when their form responses bounce.

Closes #903 and #949 

## Solution

Text form admins and collaborators at their emergency contact numbers when responses are lost, and when their forms are automatically deactivated due to permanent bounces.

Notifications for lost submissions are limited to one email and one SMS a day via the `hasAutoEmailed` and `hasAutoSmsed` fields in the `Bounce` collection. However, SMSes for form deactivation are sent every time the form is deactivated.

## Tests
- [ ] Create an email mode form and add one valid and one invalid (e.g. non-existent email address) email recipient. Add an editor as well as a read-only collaborator.
- [ ] Submit the form and ensure that you do NOT receive any texts.
- [ ] Replace the valid recipient with another invalid one. Submit the form and check that you AND the collaborator with write permissions receive two texts: one saying that a response has bounced, and another saying that your form was deactivated. ALL collaborators (including the read-only collaborator) should also receive an automated email. Check that each text has a corresponding document in the `smscounts` collection, with smsType as either `BOUNCED_SUBMISSION` or `FORM_DEACTIVATED`.
- [ ] Reactivate the form and submit again. You and the collaborator with write permissions should receive only one text saying that the form was deactivated, and no emails.