### PR TITLE
feat: use textarea for providing checkbox options

### DIFF
--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -57,9 +57,12 @@ function EditFieldsModalController(
   vm.myform = externalScope.myform
   vm.attachmentsMax = externalScope.attachmentsMax
 
-  if (vm.field.fieldType === 'dropdown' && vm.field.fieldOptions.length > 0) {
+  if (
+    ['dropdown', 'checkbox'].includes(vm.field.fieldType) &&
+    vm.field.fieldOptions.length > 0
+  ) {
     vm.field.fieldOptionsFromText = vm.field.fieldOptions.join('\n')
-  } else if (['radiobutton', 'checkbox'].includes(vm.field.fieldType)) {
+  } else if (['checkbox'].includes(vm.field.fieldType)) {
     vm.field.manualOptions = vm.field.fieldOptions
   }
 

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -133,7 +133,7 @@ function EditFieldsModalController(
 
   // Updates field.fieldOptions array for dropdown fields when the
   // admin user types into the <textarea>
-  vm.reloadDropdownField = function (field) {
+  vm.reloadFieldOptions = function (field) {
     if (field.fieldOptionsFromText) {
       field.fieldOptions = field.fieldOptionsFromText.split('\n')
     } else {
@@ -363,7 +363,7 @@ function EditFieldsModalController(
   // dropdown options based on what is typed in the textarea, as well as to update
   // the admin preview.
   vm.updateColumnOptions = function (index) {
-    vm.reloadDropdownField(vm.field.columns[index])
+    vm.reloadFieldOptions(vm.field.columns[index])
     vm.field.updateColumnOptions(index)
   }
 

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -62,7 +62,7 @@ function EditFieldsModalController(
     vm.field.fieldOptions.length > 0
   ) {
     vm.field.fieldOptionsFromText = vm.field.fieldOptions.join('\n')
-  } else if (['checkbox'].includes(vm.field.fieldType)) {
+  } else if (['radiobutton'].includes(vm.field.fieldType)) {
     vm.field.manualOptions = vm.field.fieldOptions
   }
 

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -905,7 +905,10 @@
             Options
           </div>
           <div class="col-xs-12 field-input dropdown-options">
-            <div ng-if="vm.field.fieldType === 'dropdown'" class="optionFrom">
+            <div
+              ng-if="vm.field.fieldType === 'dropdown' || vm.field.fieldType === 'checkbox'"
+              class="optionFrom"
+            >
               <textarea
                 class="input-custom input-medium"
                 rows="4"
@@ -917,7 +920,7 @@
             </div>
           </div>
           <div
-            ng-if="vm.field.fieldType === 'checkbox' || vm.field.fieldType === 'radiobutton'"
+            ng-if="vm.field.fieldType === 'radiobutton'"
             class="option-panel col-md-12 col-xs-12"
           >
             <div

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -913,7 +913,7 @@
                 class="input-custom input-medium"
                 rows="4"
                 ng-model="vm.field.fieldOptionsFromText"
-                ng-change="vm.reloadDropdownField(vm.field)"
+                ng-change="vm.reloadFieldOptions(vm.field)"
                 ng-model-options="{ debounce: 300 }"
                 placeholder="Please enter one option per line."
               ></textarea>

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -485,7 +485,7 @@ async function createBasicField(t, field) {
     case 'checkbox':
     case 'dropdown':
       await t.selectText(editFieldModal.optionTextArea).pressKey('delete')
-      // The wait(500) is necessary because of the debounce time in reloadDropdownField
+      // The wait(500) is necessary because of the debounce time in reloadFieldOptions
       await t
         .typeText(editFieldModal.optionTextArea, field.fieldOptions.join('\n'))
         .wait(500)

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -483,9 +483,18 @@ async function createBasicField(t, field) {
       }
       break
     case 'checkbox':
+      await t.selectText(editFieldModal.optionTextArea).pressKey('delete')
+      // The wait(500) is necessary because of the debounce time in reloadDropdownField
+      await t
+        .typeText(editFieldModal.optionTextArea, field.fieldOptions.join('\n'))
+        .wait(500)
+      if (field.othersRadioButton) {
+        await t.click(editFieldModal.getToggle('Others option'))
+      }
+      break
     case 'dropdown':
       await t.selectText(editFieldModal.optionTextArea).pressKey('delete')
-      // The wait(500) is necessary because of the debounce time in reloadFieldOptions
+      // The wait(500) is necessary because of the debounce time in reloadDropdownField
       await t
         .typeText(editFieldModal.optionTextArea, field.fieldOptions.join('\n'))
         .wait(500)

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -473,7 +473,6 @@ async function createBasicField(t, field) {
       }
       break
     case 'radiobutton':
-    case 'checkbox':
       await setRatingCheckboxOptions(t, 0, field.fieldOptions[0])
       for (let i = 1; i < field.fieldOptions.length; i++) {
         await t.click(editFieldModal.addOption)
@@ -483,6 +482,7 @@ async function createBasicField(t, field) {
         await t.click(editFieldModal.getToggle('Others option'))
       }
       break
+    case 'checkbox':
     case 'dropdown':
       await t.selectText(editFieldModal.optionTextArea).pressKey('delete')
       // The wait(500) is necessary because of the debounce time in reloadDropdownField


### PR DESCRIPTION
## Problem

We may expect users to have many Checkbox options and adding them one-by-one to FormSG is troublesome. As such, we want Checkbox options to follow Dropdown options so that Checkbox options can be edited by a `textarea` with each option in each line in the `textarea`.

Closes #743

## Solution

Only frontend changes. Edit the conditional rendering (i.e. `ng-if`) such that Dropdown and Checkbox show the same `textarea` for Options and Radio button will show its usual one-by-one options.

In the controller, edit the `if` clauses so that we now transform `fieldOptions` into `fieldOptionsFromText` when rendering Options and we check for `fieldOptionsFromText` instead of `manualOptions` when saving `fieldOptions`.

## Before & After Screenshots

**BEFORE**:

![Screenshot 2020-12-29 at 8 08 43 PM](https://user-images.githubusercontent.com/14961285/103283031-70f67980-4a12-11eb-9629-97dd4d658d5a.png)

**AFTER**:

![Screenshot 2020-12-29 at 8 08 59 PM](https://user-images.githubusercontent.com/14961285/103283044-7784f100-4a12-11eb-8637-f41d02f9cbcf.png)

Note: I have not checked for test breakages yet.