### PR TITLE
fix(AuthClientCtl): cancel timeout promise on page change

### DIFF
--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -5,6 +5,7 @@ const HttpStatus = require('http-status-codes')
 angular
   .module('users')
   .controller('AuthenticationController', [
+    '$scope',
     '$state',
     '$timeout',
     '$window',
@@ -13,7 +14,14 @@ angular
     AuthenticationController,
   ])
 
-function AuthenticationController($state, $timeout, $window, Auth, GTag) {
+function AuthenticationController(
+  $scope,
+  $state,
+  $timeout,
+  $window,
+  Auth,
+  GTag,
+) {
   const vm = this
 
   vm.credentials = {}
@@ -195,7 +203,7 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
         },
       )
       .finally(function () {
-        $timeout(function () {
+        vm.notifDelayTimeout = $timeout(function () {
           vm.signInMsg.isMsg = false
           vm.showOtpDelayNotification = true
         }, 20000)
@@ -250,4 +258,10 @@ function AuthenticationController($state, $timeout, $window, Auth, GTag) {
       },
     )
   }
+
+  $scope.$on('$destroy', function () {
+    if (vm.notifDelayTimeout) {
+      $timeout.cancel(vm.notifDelayTimeout)
+    }
+  })
 }

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -24,6 +24,8 @@ function AuthenticationController(
 ) {
   const vm = this
 
+  let notifDelayTimeout
+
   vm.credentials = {}
   vm.buttonClicked = false
   vm.showOtpDelayNotification = false
@@ -172,42 +174,42 @@ function AuthenticationController(
     vm.buttonClicked = true
     vm.showOtpDelayNotification = false
     const { email } = vm.credentials
-    Auth.sendOtp({ email })
-      .then(
-        function (success) {
-          vm.isOtpSending = false
-          vm.buttonClicked = false
-          // Configure message to be show
-          vm.signInMsg = {
-            isMsg: true,
-            isError: false,
-            msg: success,
-          }
-          $timeout(function () {
-            angular.element('#otp-input').focus()
-            angular.element('#otp-input').select()
-          }, 100)
-        },
-        function (error) {
-          vm.isOtpSending = false
-          vm.buttonClicked = false
-          // Configure message to be shown
-          const msg =
-            (error && error.data && error.data.message) ||
-            'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
-          vm.signInMsg = {
-            isMsg: true,
-            isError: true,
-            msg,
-          }
-        },
-      )
-      .finally(function () {
-        vm.notifDelayTimeout = $timeout(function () {
+    Auth.sendOtp({ email }).then(
+      function (success) {
+        vm.isOtpSending = false
+        vm.buttonClicked = false
+        // Configure message to be show
+        vm.signInMsg = {
+          isMsg: true,
+          isError: false,
+          msg: success,
+        }
+        $timeout(function () {
+          angular.element('#otp-input').focus()
+          angular.element('#otp-input').select()
+        }, 100)
+
+        // Cancel existing timeout and set new one.
+        cancelNotifDelayTimeout()
+        notifDelayTimeout = $timeout(function () {
           vm.signInMsg.isMsg = false
           vm.showOtpDelayNotification = true
         }, 20000)
-      })
+      },
+      function (error) {
+        vm.isOtpSending = false
+        vm.buttonClicked = false
+        // Configure message to be shown
+        const msg =
+          (error && error.data && error.data.message) ||
+          'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
+        vm.signInMsg = {
+          isMsg: true,
+          isError: true,
+          msg,
+        }
+      },
+    )
   }
 
   /**
@@ -259,9 +261,13 @@ function AuthenticationController(
     )
   }
 
-  $scope.$on('$destroy', function () {
-    if (vm.notifDelayTimeout) {
-      $timeout.cancel(vm.notifDelayTimeout)
+  const cancelNotifDelayTimeout = () => {
+    if (notifDelayTimeout) {
+      $timeout.cancel(notifDelayTimeout)
     }
+  }
+
+  $scope.$on('$destroy', function () {
+    cancelNotifDelayTimeout()
   })
 }


### PR DESCRIPTION
Small fix for #748, prevents timeout from firing when page has already changed.

Also change the timeout to only be fired when sendOtp succeeds in the `then` clause rather than the `finally` clause