### PR TITLE
chore: remove custom logo

### DIFF
--- a/scripts/20200106_remove-custom-logo/delete-custom-logo-key.js
+++ b/scripts/20200106_remove-custom-logo/delete-custom-logo-key.js
@@ -1,0 +1,38 @@
+/* eslint-disable */
+
+/*
+Delete unused customLogo key for all forms
+*/
+
+// Check total forms count
+db.getCollection('forms').count() 
+
+// Check number of forms with customLogo key
+db.getCollection('forms').find({ customLogo: { $exists: true } }).count()
+
+// Check number of forms with startPage.logo key
+db.getCollection('forms').find({ "startPage.logo.state": { $exists: true } }).count()
+
+// !!!! MAIN UPDATE SCRIPT !!!!
+
+// Delete unused customLogo key
+// ~ number updated should match number which had key
+db.getCollection('forms').updateMany({}, {
+  $unset: {
+    'customLogo': 1,
+  }
+})
+
+// !!!! END MAIN UPDATE SCRIPT !!!!
+
+// Check total forms count
+// ~ Should be same as before
+db.getCollection('forms').count()
+
+// Check number of forms with customLogo key
+// ~ Should be zero
+db.getCollection('forms').find({ customLogo: { $exists: true } }).count()
+
+// Check number of forms with startPage.logo key
+// ~ Number should be the same as before
+db.getCollection('forms').find({ "startPage.logo.state": { $exists: true } }).count()

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -31,7 +31,6 @@ const adminPrivateFields = ['email', 'betaFlags']
 const formPublicFields = [
   'admin',
   'authType',
-  'customLogo',
   'endPage',
   'esrvcId',
   'form_fields',

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -235,14 +235,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         },
       },
 
-      customLogo: {
-        type: String,
-        match: [
-          /$^|\.(gif|jpeg|jpg|png|svg)(\?|$|#)/i,
-          'Please fill a valid image URL',
-        ],
-      },
-
       status: {
         type: String,
         enum: Object.values(Status),

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -201,8 +201,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         logo: FormLogoSchema,
       },
 
-      logo: FormLogoSchema,
-
       endPage: {
         title: {
           type: String,

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -33,7 +33,6 @@ export type DuplicateFormBody = {
 )
 
 export type OverrideProps = {
-  customLogo?: undefined
   endPage?: IForm['endPage']
   startPage?: IForm['startPage']
   admin: string

--- a/src/public/modules/forms/admin/constants/covid19.js
+++ b/src/public/modules/forms/admin/constants/covid19.js
@@ -24,7 +24,6 @@ const templates = [
       },
     },
     authType: 'NIL',
-    customLogo: '',
     endPage: {
       title: 'We appreciate your feedback!',
       buttonText: 'Submit another form',
@@ -539,7 +538,6 @@ const templates = [
       },
     },
     authType: 'NIL',
-    customLogo: '',
     endPage: {
       title: 'Thank you for filling out the form.',
       buttonText: 'Submit another form',

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const get = require('lodash/get')
 const {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
@@ -76,39 +75,6 @@ function EditStartPageController(
       enum: FormLogoState.Custom,
     },
   ]
-
-  /**
-   * Pre-fill in radio button selected for logo state if logo is undefined
-   * So that new admin clients can automatically show the logo state, mapped based on customLogo state
-   * TODO: Remove once all forms have logo key and customLogo is removed from schema
-   */
-  vm.setFormLogoIfUndefined = () => {
-    const logo = get(vm.myform, 'startPage.logo', null)
-    const customLogo = get(vm.myform, 'customLogo', null)
-    const defaultLogo = get(vm.myform, 'admin.agency.logo', null)
-    if (!logo) {
-      switch (customLogo) {
-        case undefined:
-        case null:
-        case defaultLogo:
-          vm.myform.startPage.logo = {
-            state: FormLogoState.Default,
-          }
-          break
-        case '':
-          vm.myform.startPage.logo = {
-            state: FormLogoState.None,
-          }
-          break
-        default:
-          // Old custom logo should still be shown
-          vm.myform.startPage.logo = {
-            state: FormLogoState.Custom,
-            oldCustomLogo: customLogo,
-          }
-      }
-    }
-  }
 
   /**
    * Show loading icon before resizing logo

--- a/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
@@ -6,10 +6,7 @@
           <h2 class="modal-title">Edit Welcome</h2>
         </div>
 
-        <div
-          class="row question logo-options"
-          ng-init="vm.setFormLogoIfUndefined()"
-        >
+        <div class="row question logo-options">
           <div class="col-md-12 label-custom label-medium label-bottom">
             Logo
           </div>
@@ -113,23 +110,6 @@
         >
           <i class="bx bx-exclamation bx-md icon-spacing"></i>
           <span class="alert-msg">Please upload a logo</span>
-        </div>
-
-        <div
-          ng-if="vm.myform.startPage.logo.state === vm.FormLogoState.Custom && !vm.myform.startPage.logo.fileId && vm.myform.startPage.logo.oldCustomLogo"
-        >
-          <div class="alert-custom alert-info alert-margin">
-            <i class="bx bx-info-circle bx-md icon-spacing"></i>
-            <span class="alert-msg">
-              Your link is not hosted with us.
-              <a
-                ng-href="{{vm.myform.customLogo}}"
-                target="_blank"
-                rel="noopener noreferrer"
-                >Visit it </a
-              >, save it and upload here!
-            </span>
-          </div>
         </div>
 
         <div class="row"><br /></div>

--- a/src/public/modules/forms/helpers/logo.js
+++ b/src/public/modules/forms/helpers/logo.js
@@ -4,13 +4,10 @@ const { FormLogoState } = require('../../../../types')
 
 /**
  * Function used to decide how to obtain the form logo.
- * TODO: Delete this once we have migrated off customLogo on Feb 14, 2020.
  * @param {Object} myform form object
  * @returns {String} Form logo URL
  */
 function getFormLogo(myform) {
-  // Always check for existence of logo key before checking old keys
-  // hasheader is an older key than customLogo and hence takes precedence
   const logo = get(myform, 'startPage.logo', null)
   if (logo) {
     switch (logo.state) {
@@ -21,10 +18,6 @@ function getFormLogo(myform) {
       case FormLogoState.Custom:
         if (logo.fileId) {
           return `${window.logoBucketUrl}/${logo.fileId}`
-        } else if (logo.oldCustomLogo) {
-          // Account for case where custom radio button is pre-filled based on customLogo, but logo not uploaded yet
-          // logo.oldCustomLogo will not be saved to db, so submit/preview form pages will not be affected
-          return logo.oldCustomLogo
         } else {
           // Occurs when custom radio button is selected, but logo is not uploaded yet
           return ''
@@ -34,12 +27,6 @@ function getFormLogo(myform) {
           `logo is in an invalid state. Only NONE, DEFAULT and CUSTOM are allowed but state is ${logo.state} for form ${myform._id}`,
         )
     }
-  } else if (myform.hasheader === false) {
-    return ''
-  } else if (myform.customLogo !== undefined) {
-    // case A: ''
-    // case B: non-empty url
-    return myform.customLogo
   } else {
     return myform.admin.agency.logo
   }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -98,7 +98,6 @@ export interface IForm {
   hasCaptcha?: boolean
   authType?: AuthType
 
-  customLogo?: string
   status?: Status
 
   inactiveMessage?: string

--- a/tests/unit/backend/controllers/forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/forms.server.controller.spec.js
@@ -80,7 +80,6 @@ describe('Form Controller', () => {
       expectedForm = _.pick(expectedForm, [
         'admin',
         'authType',
-        'customLogo',
         'endPage',
         'esrvcId',
         'form_fields',


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/FormSG/issues/787

## Solution

- Remove `form.customLogo` which was no longer being used
- Remove `form.hasheader` which was no longer being used
- Remove `form.logo` which was no longer being used
- Create script for deletion of `form.customLogo`

_Notes_
- Once `form.customLogo` has been deleted, such forms with either default to the config in `startPage.logo` or if `startPage.logo` is non-existent (i.e. for all new forms), default to the agency logo.

## Tests
- [ ] Create new form on email mode, should have default logo
- [ ] Create new form on storage mode, should have default logo
- [ ] Create new form on duplicate flow, should have default logo
- [ ] Create new form on template flow, should have default logo
- [ ] Edit form to have no logo
- [ ] Edit form to have custom logo

## Deploy Notes
- Script should be run before the code is merged.