### PR TITLE
feat/github - Landing page links to this repository

### DIFF
--- a/src/public/modules/core/views/landing.client.view.html
+++ b/src/public/modules/core/views/landing.client.view.html
@@ -23,6 +23,12 @@
         translate-attr="{ href: 'USER_GUIDE.HREF' }"
         translate="USER_GUIDE.TEXT"
       ></a>
+      <a
+        id="landing-help"
+        target="_blank"
+        translate-attr="{ href: 'GITHUB.HREF' }"
+        translate="GITHUB.TEXT"
+      ></a>
     </div>
     <div id="landing-header-m">
       <img src="/public/modules/core/img/logo-logomark-color.svg" />

--- a/src/public/modules/core/views/landing.client.view.html
+++ b/src/public/modules/core/views/landing.client.view.html
@@ -18,13 +18,11 @@
         translate="SIGN_IN"
       ></button>
       <a
-        id="landing-help"
         target="_blank"
         translate-attr="{ href: 'USER_GUIDE.HREF' }"
         translate="USER_GUIDE.TEXT"
       ></a>
       <a
-        id="landing-help"
         target="_blank"
         translate-attr="{ href: 'GITHUB.HREF' }"
         translate="GITHUB.TEXT"
@@ -34,13 +32,11 @@
       <img src="/public/modules/core/img/logo-logomark-color.svg" />
       <div id="sign-in-m" ng-click="vm.signIn()" translate="SIGN_IN"></div>
       <a
-        id="landing-help"
         target="_blank"
         translate-attr="{ href: 'USER_GUIDE.HREF' }"
         translate="USER_GUIDE.TEXT"
       ></a>
       <a
-        id="landing-help"
         target="_blank"
         translate-attr="{ href: 'GITHUB.HREF' }"
         translate="GITHUB.TEXT"

--- a/src/public/modules/core/views/landing.client.view.html
+++ b/src/public/modules/core/views/landing.client.view.html
@@ -39,6 +39,12 @@
         translate-attr="{ href: 'USER_GUIDE.HREF' }"
         translate="USER_GUIDE.TEXT"
       ></a>
+      <a
+        id="landing-help"
+        target="_blank"
+        translate-attr="{ href: 'GITHUB.HREF' }"
+        translate="GITHUB.TEXT"
+      ></a>
     </div>
 
     <!-- Banner -->

--- a/src/public/translations/en-SG/landing.json
+++ b/src/public/translations/en-SG/landing.json
@@ -4,6 +4,10 @@
     "TEXT": "User Guide",
     "HREF": "@:LINKS.GUIDE.ROOT"
   },
+  "GITHUB": {
+    "TEXT": "GitHub",
+    "HREF": "@:LINKS.GITHUB"
+  },
   "HERO": {
     "TAG_LINE": {
       "LINE_1": "Build government",

--- a/src/public/translations/en-SG/main.json
+++ b/src/public/translations/en-SG/main.json
@@ -7,6 +7,7 @@
       "STORAGE_MODE": "https://guide.form.gov.sg/AdvancedGuide.html#storage-mode",
       "SECRET_KEY_SAFEKEEPING": "https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-make-sure-i-dont-lose-my-secret-key"
     },
+    "GITHUB": "https://github.com/opengovsg/FormSG",
     "APP": {
       "ROOT": "https://form.gov.sg"
     },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #995

## Solution
<!-- How did you solve the problem? -->

Added an additional link to the landing page.

A future improvement could be to use the github icon instead of text, but that would necessitate a design change for the user guide button as well.

**Features**:

- Links to encourage greater awareness to our GitHub repository

**Improvements**:

- Refactored duplicate and unused `id` attribute


## Before & After Screenshots

**BEFORE**:
See [form.gov.sg](https://form.gov.sg)

**AFTER**:
<!-- [insert screenshot here] -->

Desktop
![image](https://user-images.githubusercontent.com/5690550/104443096-ee081e00-55d0-11eb-83ef-ff0307fd6e92.png)

Mobile
![image](https://user-images.githubusercontent.com/5690550/104443125-fa8c7680-55d0-11eb-96d3-4f1606464c2d.png)
