### PR TITLE
fix: incorrect mobile number placeholder

### DIFF
--- a/src/public/modules/forms/base/directives/ng-intl-tel-input.js
+++ b/src/public/modules/forms/base/directives/ng-intl-tel-input.js
@@ -176,9 +176,14 @@ function ngIntlTelInput(ngIntlTelInput, $log, $window, $parse) {
         ngIntlTelInput.set({ initialCountry: attr.initialCountry })
       }
 
+      // Set correct placeholder for home number and mobile number
       if (scope.isHomeNumber) {
         ngIntlTelInput.set({
           placeholderNumberType: 'FIXED_LINE',
+        })
+      } else {
+        ngIntlTelInput.set({
+          placeholderNumberType: 'MOBILE',
         })
       }
 


### PR DESCRIPTION
## Problem
Closes #1018

## Solution
<!-- How did you solve the problem? -->

- PlaceholderNumberType property was set to FIXED_LINE if there was a home number field, but this was not reset when the next field is a mobile number field
- This led to placeholderNumberType persisting as FIXED_LINE when there is a home number field created before a mobile number field
- Fixed by setting placeholderNumberType as MOBILE when there is a mobile number field

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-01-16 at 3 15 59 PM](https://user-images.githubusercontent.com/63710093/104805927-99ea7d00-580e-11eb-8a52-bafe386e83de.png)

**AFTER**:
![Screenshot 2021-01-16 at 3 22 50 PM](https://user-images.githubusercontent.com/63710093/104805946-ba1a3c00-580e-11eb-9a3d-5ec37faaab38.png)

## Tests
(tested on IE)

- [ ] Create form with home number field followed by mobile number field
- [ ] Publish form and open in public view. Check that placeholder for both home number and mobile number field are correct
- [ ] Test that form can be submitted