### PR TITLE
feat: Add cancel download attachment feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5170,6 +5170,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "abortcontroller-polyfill": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
+      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@sentry/integrations": "^5.29.2",
     "@stablelib/base64": "^1.0.0",
     "JSONStream": "^1.3.5",
+    "abortcontroller-polyfill": "^1.7.1",
     "angular": "~1.8.2",
     "angular-animate": "^1.8.2",
     "angular-aria": "^1.8.2",

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -461,6 +461,14 @@ function ViewResponsesController(
             'attachmentsToDownload',
             function ($scope, $uibModalInstance, attachmentsToDownload) {
               $scope.attachmentsToDownload = attachmentsToDownload
+              $scope.$on('modal.closing', function (event, reason, closed) {
+                if (!closed) {
+                  // If modal is dismissed, we cancel the current download
+                  Submissions.cancelDownloadEncryptedResponses()
+                  vm.csvDownloading = false
+                  vm.attachmentsToDownload = -1
+                }
+              })
             },
           ],
           templateUrl:

--- a/src/public/modules/forms/admin/views/decrypt-progress.client.modal.html
+++ b/src/public/modules/forms/admin/views/decrypt-progress.client.modal.html
@@ -20,7 +20,7 @@
     <div class="field-description">
       <p>
         Up to {{ attachmentsToDownload }} files are being downloaded into your
-        destination folder. Closing this page will stop the download.
+        destination folder.
       </p>
       <p>
         After download is complete, you can refer to the
@@ -30,5 +30,10 @@
       <p><strong>Estimated time:</strong> 30-50 minutes per 1,000 responses.</p>
     </div>
     <div class="loader"><i class="bx bx-loader bx-spin"></i></div>
+    <div class="action-buttons">
+      <center>
+        <a ng-click="$dismiss()" class="modal-add-btn">Cancel Download</a>
+      </center>
+    </div>
   </div>
 </div>

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -1,3 +1,4 @@
 require('web-streams-polyfill')
 require('text-encoding')
 require('whatwg-fetch')
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch')


### PR DESCRIPTION
## Problem
Users can only cancel attachment downloads by closing the tab right now.

Closes #922

## Solution
Adds a `AbortController` and hooks up the abort controller with the right links in the modal. Also terminates WebWorkers if there are any workers running (since downloads can continue to run even if the main `fetchStream` is cancelled if there are many outstanding download events queued up in the WebWorker queues.

## Screenshots

![image](https://user-images.githubusercontent.com/691628/104858111-cadfb600-58d1-11eb-8a09-efcdf8c11803.png)

## Tests
Make sure downloads are properly canceled, and that future downloads from the same page (both CSV and attachments) are not affected.

## Deploy Notes
**New dependencies**:
- `abortcontroller-polyfill` : Provides AbortController functionality for IE11
