### PR TITLE
chore(robots): disallow NLB crawler to parse beyond loading the frontend

### DIFF
--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -2,4 +2,6 @@
 
 User-agent: *
 
+Disallow: /public/bundle.js
+
 Sitemap: https://form.gov.sg/public/sitemap.xml

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -5,7 +5,3 @@ User-agent: NLB_archive_bot
 Allow: /
 Allow: /public/
 Disallow: *
-
-User-agent: *
-
-Sitemap: https://form.gov.sg/public/sitemap.xml

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,7 +1,11 @@
 # robotstxt.org/
 
-User-agent: *
+User-agent: NLB_archive_bot
 
-Disallow: /public/bundle.js
+Allow: /
+Allow: /public/
+Disallow: *
+
+User-agent: *
 
 Sitemap: https://form.gov.sg/public/sitemap.xml


### PR DESCRIPTION
## Problem

Crawlers may be overly aggressive and parse bundle.js for possible links.
This results in the crawler trying to request paths from FormSG that do not
actually exist

## Solution

There are no real URLs in bundle.js, so don't let crawlers
read and parse the file lest they start to mistakenly query
for paths that don't exist
