### PR TITLE
fix(webhook): change type from any to void, re-order imports

### DIFF
--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -12,7 +12,7 @@ import { WebhookValidationError } from './webhook.errors'
  * @returns Resolves if URL is valid, otherwise rejects.
  * @throws {WebhookValidationError} If URL is invalid so webhook should not be attempted.
  */
-export const validateWebhookUrl = (webhookUrl: string): Promise<any> => {
+export const validateWebhookUrl = (webhookUrl: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     if (!isValidHttpsUrl(webhookUrl)) {
       return reject(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Blocks TypeScript upgrade in #1009

## Solution
<!-- How did you solve the problem? -->

Change the return type to `Promise<void>` from `Promise<any>`.

