### PR TITLE
refactor/polyfills: browser detection, other fixes for performance gains

### DIFF
--- a/src/public/main.js
+++ b/src/public/main.js
@@ -1,20 +1,9 @@
 'use strict'
 
-require('core-js/stable')
-require('regenerator-runtime/runtime')
 require('./polyfills')
 
-const textEncoding = require('text-encoding')
 const Sentry = require('@sentry/browser')
 const { Angular: AngularIntegration } = require('@sentry/integrations')
-
-if (!window['TextDecoder']) {
-  window['TextDecoder'] = textEncoding.TextDecoder
-}
-
-if (!window['TextEncoder']) {
-  window['TextEncoder'] = textEncoding.TextEncoder
-}
 
 // Define module dependencies (without ngSentry)
 const moduleDependencies = [

--- a/src/public/modules/forms/helpers/decryption.worker.js
+++ b/src/public/modules/forms/helpers/decryption.worker.js
@@ -1,5 +1,9 @@
-require('core-js/stable')
-require('regenerator-runtime/runtime')
+// Roundabout way to detect IE, since WebWorkers do not run in the
+// same context as the main thread.
+if (!window.Promise) {
+  require('core-js/stable')
+  require('regenerator-runtime/runtime')
+}
 
 const formsgPackage = require('@opengovsg/formsg-sdk')
 const { cloneDeep } = require('lodash')

--- a/src/public/modules/forms/helpers/decryption.worker.js
+++ b/src/public/modules/forms/helpers/decryption.worker.js
@@ -1,9 +1,8 @@
 // Roundabout way to detect IE, since WebWorkers do not run in the
 // same context as the main thread.
-if (!window.Promise) {
-  require('core-js/stable')
-  require('regenerator-runtime/runtime')
-}
+
+require('core-js/stable')
+require('regenerator-runtime/runtime')
 
 const formsgPackage = require('@opengovsg/formsg-sdk')
 const { cloneDeep } = require('lodash')

--- a/src/public/modules/forms/helpers/decryption.worker.js
+++ b/src/public/modules/forms/helpers/decryption.worker.js
@@ -1,6 +1,3 @@
-// Roundabout way to detect IE, since WebWorkers do not run in the
-// same context as the main thread.
-
 require('core-js/stable')
 require('regenerator-runtime/runtime')
 

--- a/src/public/modules/forms/helpers/ndjsonStream.js
+++ b/src/public/modules/forms/helpers/ndjsonStream.js
@@ -1,26 +1,17 @@
 /* eslint-disable camelcase */
 'use strict'
 
-// Polyfills
-const streams = require('web-streams-polyfill')
-const textEncoding = require('text-encoding')
+// Modified fork of https://github.com/canjs/can-ndjson-stream to enqueue
+// the string immediately without a JSON.parse() step, as the stream payload
+// is to be decrypted by the decryption worker.
 
-// Use polyfill if it does not exist
-if (!window['TextDecoder']) {
-  window['TextDecoder'] = textEncoding.TextDecoder
-}
-
-// Modified fork of https://github.com/canjs/can-ndjson-stream to use polyfilled
-// ReadableStream so it works in ie11.
-
-// Also modified to return the string immediately instead of parsing since the
-// string is to be passed into a decryption worker.
+// Note that this code assumes a polyfill of TextDecoder is available to run in IE11.
 
 const ndjsonStream = function (response) {
   // For cancellation
   var is_reader
   var cancellationRequest = false
-  return new streams.ReadableStream({
+  return new ReadableStream({
     start: function (controller) {
       var reader = response.getReader()
       is_reader = reader

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -30,8 +30,11 @@ if (isInternetExplorer()) {
 }
 
 /**
- * Detects if the runtime browser is Internet Explorer. Works for IE5 and upwards.
- * Should be pretty safe since even IE 10 is considered ancient.
+ * Detects if the runtime browser is Internet Explorer. Works for IE5 and upwards, so
+ * should be considered pretty safe since even IE 10 is ancient.
+ *
+ * This function is not safe to call from WebWorkers as those do not have access to the
+ * window object.
  * See https://www.w3schools.com/jsref/prop_doc_documentmode.asp
  */
 function isInternetExplorer() {

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -2,17 +2,20 @@
  * Runtime logic to inject polyfills into the global namespace based on browser detection.
  */
 
+// core-js polyfills crucial, commonly used functions expected to be in the standard library
+// e.g. Promises, Object.values, Array.prototype.includes
+// The stable option includes ES and web standards.
+// See link for more info:
+// https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
+require('core-js/stable')
+
+// Runtime library for async and generator functions. Babel transpilation expects this to be in
+// the target namespace, and it also relies on core-js, so this cannot be optimised away
+// until IE11 support is dropped.
+require('regenerator-runtime/runtime')
+
+// IE-specific polyfills
 if (isInternetExplorer()) {
-  // Polyfills crucial, commonly used functions expected to be in the standard library
-  // e.g. Promises, Object.values, Array.prototype.includes
-  // The stable option includes ES and web standards.
-  // See link for more info:
-  // https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
-  require('core-js/stable')
-
-  // Runtime library for async and generator functions
-  require('regenerator-runtime/runtime')
-
   require('web-streams-polyfill') // Web Streams API
   require('whatwg-fetch') // fetch API
   require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -1,23 +1,39 @@
-// Polyfills crucial, commonly used functions from the standard library.
-// The stable option includes ES and web standards.
-// See link for more info:
-//  https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
-require('core-js/stable')
+/**
+ * Runtime logic to inject polyfills into the global namespace based on browser detection.
+ */
 
-// Runtime library for async and generator functions
-require('regenerator-runtime/runtime')
+if (isInternetExplorer()) {
+  // Polyfills crucial, commonly used functions expected to be in the standard library
+  // e.g. Promises, Object.values, Array.prototype.includes
+  // The stable option includes ES and web standards.
+  // See link for more info:
+  // https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
+  require('core-js/stable')
 
-require('web-streams-polyfill') // Web Streams
-require('whatwg-fetch') // fetch API
-require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController
+  // Runtime library for async and generator functions
+  require('regenerator-runtime/runtime')
 
-// TextEncoder and TextDecoder
-const textEncoding = require('text-encoding')
+  require('web-streams-polyfill') // Web Streams API
+  require('whatwg-fetch') // fetch API
+  require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController
 
-if (!window['TextDecoder']) {
-  window['TextDecoder'] = textEncoding.TextDecoder
+  // TextEncoder and TextDecoder
+  const textEncoding = require('text-encoding')
+
+  if (!window['TextDecoder']) {
+    window['TextDecoder'] = textEncoding.TextDecoder
+  }
+
+  if (!window['TextEncoder']) {
+    window['TextEncoder'] = textEncoding.TextEncoder
+  }
 }
 
-if (!window['TextEncoder']) {
-  window['TextEncoder'] = textEncoding.TextEncoder
+/**
+ * Detects if the runtime browser is Internet Explorer. Works for IE5 and upwards.
+ * Should be pretty safe since even IE 10 is considered ancient.
+ * See https://www.w3schools.com/jsref/prop_doc_documentmode.asp
+ */
+function isInternetExplorer() {
+  return Boolean(window.document.documentMode)
 }

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -1,45 +1,36 @@
 /**
- * Runtime logic to inject polyfills into the global namespace based on browser detection.
+ * Runtime polyfill injection with feature detection to make app work on older browsers.
  */
 
 // core-js polyfills crucial, commonly used functions expected to be in the standard library
-// e.g. Promises, Object.values, Array.prototype.includes
-// The stable option includes ES and web standards.
-// See link for more info:
+// e.g. Promise, Object.values, Array.prototype.includes
+// The stable option includes ES and web standards. See link for more info:
 // https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
 require('core-js/stable')
 
 // Runtime library for async and generator functions. Babel transpilation expects this to be in
-// the target namespace, and it also relies on core-js, so this cannot be optimised away
+// the target namespace, and it also relies on core-js, so this cannot be removed
 // until IE11 support is dropped.
 require('regenerator-runtime/runtime')
 
-// IE-specific polyfills
-if (isInternetExplorer()) {
-  require('web-streams-polyfill') // Web Streams API
-  require('whatwg-fetch') // fetch API
-  require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController
-
-  // TextEncoder and TextDecoder
-  const textEncoding = require('text-encoding')
-
-  if (!window['TextDecoder']) {
-    window['TextDecoder'] = textEncoding.TextDecoder
-  }
-
-  if (!window['TextEncoder']) {
-    window['TextEncoder'] = textEncoding.TextEncoder
-  }
+// Web Streams API has varying levels of support amongst different browsers
+// See https://caniuse.com/streams
+if (!window.ReadableStream || !window.WritableStream) {
+  require('web-streams-polyfill')
 }
 
-/**
- * Detects if the runtime browser is Internet Explorer. Works for IE5 and upwards, so
- * should be considered pretty safe since even IE 10 is ancient.
- *
- * This function is not safe to call from WebWorkers as those do not have access to the
- * window object.
- * See https://www.w3schools.com/jsref/prop_doc_documentmode.asp
- */
-function isInternetExplorer() {
-  return Boolean(window.document.documentMode)
+// For IE11, Opera Mini
+// https://caniuse.com/?search=fetch
+if (!window.fetch) {
+  require('whatwg-fetch') // fetch API
+  require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
+}
+
+// For IE11, Opera Mini
+// https://caniuse.com/?search=TextEncoder
+if (!window.TextDecoder || !window.TextEncoder) {
+  // TextEncoder and TextDecoder
+  const textEncoding = require('text-encoding')
+  window['TextDecoder'] = textEncoding.TextDecoder
+  window['TextEncoder'] = textEncoding.TextEncoder
 }

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -1,4 +1,17 @@
-require('web-streams-polyfill')
-require('text-encoding')
-require('whatwg-fetch')
-require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
+require('core-js/stable')
+require('regenerator-runtime/runtime')
+
+require('web-streams-polyfill') // Web Streams
+require('whatwg-fetch') // fetch
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController
+
+// TextEncoder and TextDecoder
+const textEncoding = require('text-encoding')
+
+if (!window['TextDecoder']) {
+  window['TextDecoder'] = textEncoding.TextDecoder
+}
+
+if (!window['TextEncoder']) {
+  window['TextEncoder'] = textEncoding.TextEncoder
+}

--- a/src/public/polyfills.js
+++ b/src/public/polyfills.js
@@ -1,8 +1,14 @@
+// Polyfills crucial, commonly used functions from the standard library.
+// The stable option includes ES and web standards.
+// See link for more info:
+//  https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md
 require('core-js/stable')
+
+// Runtime library for async and generator functions
 require('regenerator-runtime/runtime')
 
 require('web-streams-polyfill') // Web Streams
-require('whatwg-fetch') // fetch
+require('whatwg-fetch') // fetch API
 require('abortcontroller-polyfill/dist/polyfill-patch-fetch') // AbortController
 
 // TextEncoder and TextDecoder

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -25,6 +25,7 @@ module.exports = [
         },
         {
           test: /\.worker\.js$/,
+          // Don't transpile polyfills
           exclude: /@babel(?:\/|\\{1,2})runtime|core-js/,
           use: [
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -35,7 +35,8 @@ module.exports = [
       rules: [
         {
           test: /\.js$/,
-          exclude: /@babel(?:\/|\\{1,2})runtime|core-js/,
+          // Don't transpile polyfills
+          exclude: /@babel(?:\/|\\{1,2})runtime|core-js|web-streams-polyfill|whatwg-fetch|abortcontroller-polyfill|text-encoding/,
           use: {
             loader: 'babel-loader',
           },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There was user feedback that CSV decryption is taking unusually long.

> For instance, I had to wait for >2 hours for surveys with 179 responses and 32 responses respectively. Both survey forms are of standard 15 mins type.

It is possible that some of the degraded performance is the result of overzealous polyfills in #981.

## Solution
<!-- How did you solve the problem? -->

Instead of polyfilling functionality for all browsers, we detect the runtime browser by testing for the `window.document.documentMode` property, which is unique to Internet Explorer from version 5 onwards. Non-IE browsers will not have the native API replaced, even though `bundle.js` will still contain the polyfill.

The polyfills in question are:

- `web-streams-polyfill`
- `whatwg-fetch`
- `abortcontroller-polyfill`
- `text-encoding`

Chrome, Firefox and Safari all support these APIs.

**Features**
- IE11 browser detection before executing the main app polyfills at runtime

**Improvements**:
- Centralise management of polyfills into a single file

**Fixes**
- Avoid babel transpilation for polyfill libraries

## Remaining issues

Almost all our polyfills are necessary simply to support IE11. Unlike the rest of the codebase however, WebWorker code powering CSV downloads is performance sensitive. The performance will degrade significantly on modern browsers such as Chrome if we do not rely on their native APIs. However, these polyfills remain crucial for IE11 compatibility, especially as code complexity has increased with the introduction of bulk attachments download.

If we're able to drop support for all CSV downloads on IE11, we can remove almost all the polyfills that are degrading performance for Chrome users, while reducing bundle size at the same time for faster loads:

**Decryption worker polyfills (removal should result in significant speed gains on Chrome)**
- `core-js`
- `regenerator-runtime`