### PR TITLE
refactor/submit-form: reduce possibility of race conditions in submission flow

### DIFF
--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -83,9 +83,11 @@ function submitFormDirective(
         progressModal: null,
         submitPrevented: false,
       }
+
       // Also used to store a backup of the form state during submission, the state
       // of the progress modal
-      const controllerState = {}
+      scope.controllerState = {}
+
       scope.hasMyInfoFields = FormFields.containsMyInfoFields(scope.form)
       scope.formLogin = function (authType, rememberMe) {
         // Fire GA tracking event
@@ -211,7 +213,7 @@ function submitFormDirective(
             }
             break
           case FORM_STATES.SUBMITTING:
-            controllerState.savedForm = cloneDeep(scope.form)
+            scope.controllerState.savedForm = cloneDeep(scope.form)
             scope.form.lockFields()
             scope.uiState.submitButtonClicked = true
             if (scope.form.hasAttachments()) {
@@ -231,7 +233,7 @@ function submitFormDirective(
             }
             break
           case FORM_STATES.SUBMISSION_ERROR:
-            scope.form = controllerState.savedForm
+            scope.form = scope.controllerState.savedForm
             setFormState(FORM_STATES.DEFAULT)
             break
           case FORM_STATES.SUBMIT_PREVENTED:
@@ -251,7 +253,7 @@ function submitFormDirective(
        * Opens the submission progress modal.
        */
       const openProgressModal = function () {
-        controllerState.progressModal = $uibModal.open({
+        scope.controllerState.progressModal = $uibModal.open({
           animation: true,
           backdrop: 'static',
           keyboard: false,
@@ -265,9 +267,9 @@ function submitFormDirective(
        * Closes the submission progress modal if it is currently open.
        */
       const closeProgressModal = () => {
-        if (controllerState.progressModal) {
-          controllerState.progressModal.close()
-          controllerState.progressModal = null
+        if (scope.controllerState.progressModal) {
+          scope.controllerState.progressModal.close()
+          scope.controllerState.progressModal = null
         }
       }
 

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -314,10 +314,7 @@ function submitFormDirective(
         }
         if (form.responseMode === responseModeEnum.ENCRYPT && form.publicKey) {
           try {
-            submissionContent.encryptedContent = FormSgSdk.crypto.encrypt(
-              submissionContent.responses,
-              form.publicKey,
-            )
+            submissionContent.encryptedContent = form.getEncryptedContent()
 
             // Edge case: We still send mobile and email fields in the plaintext for
             // end-to-end encryption because of SMS and email autoreplies

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -278,9 +278,8 @@ function submitFormDirective(
        * and handle any errors.
        */
       scope.submitForm = () => {
-        let form = cloneDeep(scope.form)
         try {
-          submitFormMain(form)
+          submitFormMain(scope.form)
         } catch (error) {
           handleSubmitFailure(error, 'Please try again later.')
         }
@@ -294,8 +293,9 @@ function submitFormDirective(
         // Disable UI and optionally open progress modal while processing
         setFormState(FORM_STATES.SUBMITTING)
 
+        let attachments
         try {
-          form.attachments = await form.getAttachments()
+          attachments = await form.getAttachments()
         } catch (err) {
           return handleSubmitFailure(
             err,
@@ -307,7 +307,7 @@ function submitFormDirective(
 
         // submissionContent is the POST body to backend when we submit the form
         let submissionContent = {
-          attachments: form.attachments,
+          attachments,
           captchaResponse: captchaService.response,
           isPreview: form.isPreview,
           responses,

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -303,29 +303,17 @@ function submitFormDirective(
           )
         }
 
-        const responses = form.getResponses()
-
         // submissionContent is the POST body to backend when we submit the form
         let submissionContent = {
           attachments,
           captchaResponse: captchaService.response,
           isPreview: form.isPreview,
-          responses,
+          responses: form.getResponsesForSubmission(),
         }
+
         if (form.responseMode === responseModeEnum.ENCRYPT && form.publicKey) {
           try {
             submissionContent.encryptedContent = form.getEncryptedContent()
-
-            // Edge case: We still send mobile and email fields in the plaintext for
-            // end-to-end encryption because of SMS and email autoreplies
-            submissionContent.responses = submissionContent.responses
-              .filter((item) => ['mobile', 'email'].includes(item.fieldType))
-              .map((item) => {
-                return _(item)
-                  .pick(['fieldType', '_id', 'answer', 'signature'])
-                  .omitBy(_.isNull)
-                  .value()
-              })
             // Version the data in case of any backwards incompatibility
             submissionContent.version = ENCRYPT_VERSION
           } catch (err) {

--- a/src/public/modules/forms/viewmodels/Form.class.js
+++ b/src/public/modules/forms/viewmodels/Form.class.js
@@ -47,6 +47,8 @@ class Form {
 
   /**
    * Creates a map of field ID to attachment file.
+   * The values of the map are encrypted for Storage Mode
+   * forms.
    * @returns {Object} Map of { id: file }
    */
   getAttachments() {

--- a/src/public/modules/forms/viewmodels/Form.class.js
+++ b/src/public/modules/forms/viewmodels/Form.class.js
@@ -55,12 +55,12 @@ class Form {
   }
 
   /**
-   * Creates a map of field ID to attachment file.
-   * The values of the map are encrypted for Storage Mode
+   * Internal helper function that creates a map of field ID to attachment file.
+   * The values of the map are encrypted for Storage Mode.
    * forms.
    * @returns {Object} Map of { id: file }
    */
-  getAttachments() {
+  _getAttachments() {
     const attachmentsMap = getAttachmentsMap(this.form_fields)
     if (this.responseMode === 'encrypt') {
       return getEncryptedAttachmentsMap(attachmentsMap, this.publicKey)
@@ -78,9 +78,10 @@ class Form {
   }
 
   /**
-   * Gets the encrypted responses
+   * Gets the encrypted values of the responses. Only applicable to
+   * Storage Mode forms.
    */
-  getEncryptedContent() {
+  _getEncryptedContent() {
     if (this.responseMode === 'encrypt') {
       return formsg.crypto.encrypt(this._getResponses(), this.publicKey)
     }
@@ -90,7 +91,7 @@ class Form {
   /**
    * Method to abstract away edge cases for submission responses in email vs encrypt mode
    */
-  getResponsesForSubmission() {
+  _getResponsesForSubmission() {
     if (this.responseMode === 'encrypt') {
       // Edge case: We still send mobile and email fields to the server in plaintext
       // even with end-to-end encryption in order to support SMS and email autoreplies
@@ -111,12 +112,12 @@ class Form {
    */
   async getSubmissionContent() {
     const submissionContent = {
-      attachments: await this.getAttachments(),
+      attachments: await this._getAttachments(),
       isPreview: this.isPreview,
-      responses: this.getResponsesForSubmission(),
+      responses: this._getResponsesForSubmission(),
     }
     if (this.responseMode === 'encrypt') {
-      submissionContent.encryptedContent = this.getEncryptedContent()
+      submissionContent.encryptedContent = this._getEncryptedContent()
       submissionContent.version = ENCRYPT_VERSION
     }
     return submissionContent

--- a/src/public/modules/forms/viewmodels/Form.class.js
+++ b/src/public/modules/forms/viewmodels/Form.class.js
@@ -9,6 +9,11 @@ const {
 } = require('../helpers/attachments-map')
 const { NoAnswerField } = require('./Fields')
 
+// The current encrypt version to assign to the encrypted submission.
+// This is needed if we ever break backwards compatibility with
+// end-to-end encryption
+const ENCRYPT_VERSION = 1
+
 /**
  * Deserialises raw form object returned by backend and
  * manages form-wide operations.
@@ -98,6 +103,23 @@ class Form {
             .value()
         })
     } else return this._getResponses()
+  }
+
+  /**
+   * Method to determine what to POST to the backend submission endpoint.
+   * Does not include captcha verification.
+   */
+  async getSubmissionContent() {
+    const submissionContent = {
+      attachments: await this.getAttachments(),
+      isPreview: this.isPreview,
+      responses: this.getResponsesForSubmission(),
+    }
+    if (this.responseMode === 'encrypt') {
+      submissionContent.encryptedContent = this.getEncryptedContent()
+      submissionContent.version = ENCRYPT_VERSION
+    }
+    return submissionContent
   }
 }
 

--- a/src/public/modules/forms/viewmodels/Form.class.js
+++ b/src/public/modules/forms/viewmodels/Form.class.js
@@ -1,3 +1,5 @@
+const formsg = require('@opengovsg/formsg-sdk')()
+
 const FieldFactory = require('../helpers/field-factory')
 const {
   getEncryptedAttachmentsMap,
@@ -66,6 +68,16 @@ class Form {
    */
   hasAttachments() {
     return this.form_fields.some(fieldHasAttachment)
+  }
+
+  /**
+   * Gets the encrypted responses
+   */
+  getEncryptedContent() {
+    if (this.responseMode === 'encrypt') {
+      return formsg.crypto.encrypt(this.getResponses(), this.publicKey)
+    }
+    return null
   }
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Addresses #1044 

## Solution
<!-- How did you solve the problem? -->

I did not manage to reproduce the bug in question. This is not a surprise as concurrency bugs are indeterministic by definition. However, based on the symptom and rarity of the bug, it is possible that the behavior is a result of edge cases caused by poor integration with AngularJS. Multiple code paths were thoroughly examined, and the appropriate refactor performed to improve code clarity and reduce the likelihood of bugs.

1. **controllerState variable refactor**

The `controllerState` variable is used to store the cloned form object in the `savedForm` property before fields were locked/disabled. It was previously not attached to the directive scope, but simply as a `const` which makes it a possible candidate to resolve the concurrency bug as AngularJS would not be tracking changes to this variable during the digest cycle.

2. **submitFormMain function refactor**

The need to clone the form object before calling this function was removed by refactoring to avoid assigning to the `form.attachment` property (it is a very bad practice to mutate function arguments). This not only removed the need for an expensive clone operation, but also guarantees that there can be no divergence between the form object in the controller scope vs the one used in the `submitForm` function, since the call to `submitForm(scope.form)` is a reference to the same form object.

Almost all the logic necessary to generate the POST body has also been moved into the `Form` class as instance methods, with the exception of captcha. Internal methods have also been prefixed with an underscore to discourage external use.

**Improvements**:

- Improved code cleanliness and efficiency

**Bug Fixes**:

- Possibly resolves #1044


## Tests
<!-- What tests should be run to confirm functionality? -->

Manually tested with storage mode submissions with and without attachment fields. As this is sensitive code with low test coverage, the reviewer is invited to step through the commits to verify that the new implementation is sound.