### PR TITLE
test: mock DNS in webhooks tests

### DIFF
--- a/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
+++ b/tests/unit/backend/modules/webhook/webhook.utils.spec.ts
@@ -1,49 +1,57 @@
+import { promises as dns } from 'dns'
+import { mocked } from 'ts-jest/utils'
+
 import { WebhookValidationError } from 'src/app/modules/webhook/webhook.errors'
 import { validateWebhookUrl } from 'src/app/modules/webhook/webhook.utils'
 
+jest.mock('dns', () => ({
+  promises: {
+    resolve: jest.fn(),
+  },
+}))
+const MockDns = mocked(dns, true)
+
+const MOCK_WEBHOOK_URL = 'https://mock.webhook.url'
+
 describe('Webhook URL validation', () => {
   it('should accept valid HTTPS URLs', async () => {
-    await expect(
-      validateWebhookUrl('https://staging.form.gov.sg'),
-    ).resolves.toEqual(undefined)
+    MockDns.resolve.mockResolvedValueOnce(['1.1.1.1'])
+    await expect(validateWebhookUrl(MOCK_WEBHOOK_URL)).resolves.toEqual(
+      undefined,
+    )
   })
 
   it('should reject non-HTTPS URLs', async () => {
-    await expect(
-      validateWebhookUrl('http://some.website'),
-    ).rejects.toStrictEqual(
-      new WebhookValidationError(
-        'http://some.website is not a valid HTTPS URL.',
-      ),
+    const httpUrl = 'http://website.com'
+    await expect(validateWebhookUrl(httpUrl)).rejects.toStrictEqual(
+      new WebhookValidationError(`${httpUrl} is not a valid HTTPS URL.`),
     )
   })
 
   it('should reject URLs which do not resolve to any IP', async () => {
-    await expect(
-      validateWebhookUrl('https://some.nonsense.website'),
-    ).rejects.toStrictEqual(
+    MockDns.resolve.mockRejectedValueOnce([])
+    await expect(validateWebhookUrl(MOCK_WEBHOOK_URL)).rejects.toStrictEqual(
       new WebhookValidationError(
-        'Error encountered during DNS resolution for https://some.nonsense.website. Check that the URL is correct.',
+        `Error encountered during DNS resolution for ${MOCK_WEBHOOK_URL}. Check that the URL is correct.`,
       ),
     )
   })
 
   it('should reject URLs which resolve to private IPs', async () => {
-    await expect(
-      validateWebhookUrl('https://localtest.me'),
-    ).rejects.toStrictEqual(
+    MockDns.resolve.mockResolvedValueOnce(['127.0.0.1'])
+    await expect(validateWebhookUrl(MOCK_WEBHOOK_URL)).rejects.toStrictEqual(
       new WebhookValidationError(
-        'https://localtest.me resolves to the following private IPs: 127.0.0.1',
+        `${MOCK_WEBHOOK_URL} resolves to the following private IPs: 127.0.0.1`,
       ),
     )
   })
 
   it('should reject URLs in the same domain as the app URL', async () => {
     await expect(
-      validateWebhookUrl('https://example.com/test'),
+      validateWebhookUrl(`${process.env.APP_URL}/test`),
     ).rejects.toStrictEqual(
       new WebhookValidationError(
-        'You cannot send responses back to https://example.com.',
+        `You cannot send responses back to ${process.env.APP_URL}.`,
       ),
     )
   })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Jest tests are failing due to the following error:
![Screenshot 2021-02-01 at 12 57 39 PM](https://user-images.githubusercontent.com/29480346/106416732-12973d80-648d-11eb-9163-1517a3c0ef17.png)

The test uses `https://some.nonsense.website` to cover the case where the URL does not resolve to any valid IP, but apparently now that URL does actually exist.

## Solution
<!-- How did you solve the problem? -->

Mock the DNS module in webhook tests so this issue does not crop up again.