### PR TITLE
fix/updates: bugs and refactors after building payments demo

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -233,7 +233,7 @@ function makeModule(connection) {
         }
       }
 
-      _.extend(form, updatedForm)
+      _.merge(form, updatedForm)
 
       // Can't just do updatedForm.save() because updatedForm has some String values
       form.save(function (err, savedForm) {

--- a/src/public/modules/forms/admin/css/settings-form.css
+++ b/src/public/modules/forms/admin/css/settings-form.css
@@ -7,26 +7,26 @@
 }
 
 #settings-form .settings-input label,
-#settings-form #enable-webhooks label {
+#settings-form .enable-features label {
   margin-bottom: 0;
 }
 
-#settings-form #enable-webhooks .beta-icon {
+#settings-form .enable-features .beta-icon {
   margin: 0;
 }
 
-#settings-form #enable-webhooks .field-optional {
+#settings-form .enable-features .field-optional {
   font-size: 15px;
   font-weight: normal;
   color: #b8b8b8;
   margin-left: 10px;
 }
 
-#settings-form .webhook-divider {
+#settings-form .feature-divider {
   margin-top: 40px;
 }
 
-#settings-form #enable-webhooks .glyphicon {
+#settings-form .enable-features .glyphicon {
   margin-left: 40px !important;
 }
 
@@ -152,20 +152,16 @@
   padding-bottom: 30px;
 }
 
-#settings-form #enable-webhooks {
+#settings-form .enable-features {
   display: flex;
   align-items: center;
   padding-top: 45px;
   padding-bottom: 10px;
 }
 
-#settings-form #url-webhooks {
+#settings-form .feature-container {
   padding-top: 20px;
   padding-bottom: 45px;
-}
-
-#settings-form #url-webhooks input:disabled {
-  opacity: 0.5;
 }
 
 #settings-form #enable-auth {
@@ -207,6 +203,7 @@
   background-color: initial;
   border: solid 1px rgb(184, 184, 184);
   pointer-events: none;
+  opacity: 0.5;
 }
 
 #settings-form .settings-save.input-disabled {

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -281,7 +281,7 @@
         </div>
       </div>
 
-      <div class="settings-divider webhook-divider"></div>
+      <div class="settings-divider feature-divider"></div>
 
       <!-- Webhooks for encrypted forms -->
       <div
@@ -289,7 +289,7 @@
         feature-toggle
         feature-name="webhook-verified-content"
       >
-        <div class="row" id="enable-webhooks">
+        <div class="row enable-features">
           <label
             for="settings-webhook-url"
             class="col-xs-9 label-custom label-large"
@@ -322,7 +322,7 @@
             >Webhook is not available for forms with attachment fields.</span
           >
         </div>
-        <div class="row" id="url-webhooks">
+        <div class="row feature-container">
           <div
             class="settings-save col-xs-12"
             ng-class="(settingsForm.webhookUrl.$invalid) ? 'input-disabled' : ''"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. Form does not save if the schema has more than one nested key. The bug shows up if one were to expand `form.webhooks` beyond the single `url` property.
2. `<input>` elements on the settings panel did not have opacity set
3. Divider elements on the settings panel were not reusable

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- Refactored divider CSS on the Settings page to be re-usable

**Bug Fixes**:

- Nested fields can be extended
- Opacity on input elements
