### PR TITLE
fix/travis: wean off Travis workspaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ jobs:
           name: build
           paths: .
     - stage: Tests
+      install: npm ci
+      cache:
+        - npm
+        - pip
       name: Javascript tests
       workspaces:
         use: build
@@ -43,6 +47,10 @@ jobs:
         - npm run test-backend-jasmine
         - npm run test-frontend
     - name: Typescript tests
+      install: npm ci
+      cache:
+        - npm
+        - pip
       workspaces:
         use: build
       script:
@@ -50,6 +58,10 @@ jobs:
       after_success:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
     - name: End-to-end tests
+      install: npm ci
+      cache:
+        - npm
+        - pip
       workspaces:
         use: build
       addons:
@@ -57,6 +69,10 @@ jobs:
       script:
         - npm run test-e2e-ci
     - stage: Deploy
+      install: npm ci
+      cache:
+        - npm
+        - pip
       services:
         - docker
       workspaces:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,12 @@ jobs:
         - npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
         - npm run lint-ci
         - npm run build
-      workspaces:
-        create:
-          name: build
-          paths: .
     - stage: Tests
       install: npm ci
       cache:
         - npm
         - pip
       name: Javascript tests
-      workspaces:
-        use: build
       script:
         - npm run test-backend-jasmine
         - npm run test-frontend
@@ -51,8 +45,6 @@ jobs:
       cache:
         - npm
         - pip
-      workspaces:
-        use: build
       script:
         - npm run test-backend-jest
       after_success:
@@ -62,8 +54,6 @@ jobs:
       cache:
         - npm
         - pip
-      workspaces:
-        use: build
       addons:
         chrome: stable
       script:
@@ -75,8 +65,6 @@ jobs:
         - pip
       services:
         - docker
-      workspaces:
-        use: build
       script: skip
       before_deploy:
         # Workaround to run before_deploy only once

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 
 jobs:
   include:
-    - stage: Build application
+    - stage: Lint application code
       install: npm ci
       cache:
         - npm
@@ -30,7 +30,6 @@ jobs:
         - set -e
         - npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
         - npm run lint-ci
-        - npm run build
     - stage: Tests
       install: npm ci
       cache:
@@ -38,6 +37,7 @@ jobs:
         - pip
       name: Javascript tests
       script:
+        - npm run build
         - npm run test-backend-jasmine
         - npm run test-frontend
     - name: Typescript tests
@@ -46,6 +46,7 @@ jobs:
         - npm
         - pip
       script:
+        - npm run build
         - npm run test-backend-jest
       after_success:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
@@ -57,15 +58,17 @@ jobs:
       addons:
         chrome: stable
       script:
+        - npm run build
         - npm run test-e2e-ci
-    - stage: Deploy
+    - stage: Build and deploy
       install: npm ci
       cache:
         - npm
         - pip
       services:
         - docker
-      script: skip
+      script:
+        - npm run build
       before_deploy:
         # Workaround to run before_deploy only once
         - >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Builds are failing in Travis.

## Solution
<!-- How did you solve the problem? -->

Remove the reliance on Travis [workspaces](https://docs.travis-ci.com/user/using-workspaces), which allow build stage environments to be shared, but is a beta feature for Travis CI that broke.

The downside is that webpack and Typescript compilation is now duplicated throughout the build stages.

If and when Travis restores workspace functionality, we can simply revert this PR to recover the faster build.
