### PR TITLE
feat: deprecate MyInfo fields for V3 (step 1 - frontend)

### DIFF
--- a/src/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -7,6 +7,16 @@ const newFields = new Set() // Adding a fieldTypes will add a "new" label.
 
 angular.module('forms').directive('editFormDirective', editFormDirective)
 
+// TODO (private #110): remove this variable
+const DEPRECATED_MYINFO_ATTRS = [
+  'homeno',
+  'billadd',
+  'mailadd',
+  'edulevel',
+  'schoolname',
+  'gradyear',
+]
+
 function editFormDirective() {
   return {
     templateUrl:
@@ -453,5 +463,10 @@ function editFormController(
   // Populate AddField with all available form field types
   $scope.addField = {}
   $scope.addField.types = FormFields.basicTypes
-  $scope.addField.myInfoTypes = FormFields.myInfoTypes
+
+  // TODO (private #110): remove this filtering once the deprecated fields
+  // are deleted from shared/resources/myinfo
+  $scope.addField.myInfoTypes = FormFields.myInfoTypes.filter(
+    (type) => !DEPRECATED_MYINFO_ATTRS.includes(type.name),
+  )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The following MyInfo fields are set to return empty strings, and therefore should be deprecated:
- Home number
- Billing address
- Mailing address
- Highest education level
- School name
- Graduation year

## Solution
<!-- How did you solve the problem? -->

The deprecation requires 3 steps:
1. Stop allowing admins to add these fields
2. Database migration to convert these fields to regular (non-MyInfo) fields
3. Drop support for these fields

This PR addresses step 1. We need to hide these fields from the admin panel while still supporting existing fields, so we simply filter out the fields in the form builder.

## Tests
- [ ] Home number, mailing address, billing address, education level, school name and graduation year are missing from MyInfo options in Build tab
- [ ] Existing forms with these fields can still be submitted
- [ ] Existing forms with these fields can still be edited. The deprecated fields can be edited, reordered and deleted.