### PR TITLE
fix: apply dropdown padding on whole table

### DIFF
--- a/src/public/modules/forms/base/componentViews/field-table.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-table.client.view.html
@@ -16,9 +16,10 @@
 
   <!-- Input -->
   <div>
-    <!-- View for screen width >= 768px. Either this or the next div is shown. -->
-    <div class="table-scrollable table-desktop">
-      <!-- Labels to be shown in desktop mode but not mobile mode -->
+    <div
+      class="table-scrollable table-desktop"
+      ng-class="{ 'dropdownPadding': vm.hasEndPadding }"
+    >
       <div class="table-row table-labels-desktop">
         <!-- ng-class in ng-repeat below sets whether the column is col-xs-6, col-xs-12 or max-width -->
         <div
@@ -38,10 +39,7 @@
         ng-repeat="n in vm.generateTableRowIndexes()"
         ng-init="$evenRow = $even; $oddRow = $odd"
       >
-        <div
-          class="table-row"
-          ng-class="{ 'dropdownPadding': vm.hasEndPadding && vm.isLastRow(n) }"
-        >
+        <div class="table-row">
           <!-- ng-class in ng-repeat below sets a couple of things:
 							=> whether a row is blue or white
 							=> whether the column is col-xs-6, col-xs-12 or max-width


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In table fields, whenever dropdown fields are opened in the last 2 rows, we add padding to the bottom of the field so the dropdown options do not get hidden. This is broken in mobile view, likely since #894, resulting in dropdown options being hidden for the last row.

## Solution
<!-- How did you solve the problem? -->

The problem is that table rows in mobile are `display: block;` as opposed to `display: flex;` like in desktop, resulting in the padding being applied incorrectly. The fix was to apply the padding on the table field as a whole instead of just the last row, which has the same effect but works properly in mobile.

## Screenshots
### Before (mobile)
![image](https://user-images.githubusercontent.com/29480346/106834046-a22c2e80-66cf-11eb-82b7-077c66eb840b.png)

### After (mobile)
![image](https://user-images.githubusercontent.com/29480346/106834029-99d3f380-66cf-11eb-8802-2704eeeb5d55.png)

### Before and after (desktop)
![image](https://user-images.githubusercontent.com/29480346/106834055-a5bfb580-66cf-11eb-8768-da5e2d8d156e.png)


## Tests
- [ ] Create a table field with multiple text and dropdown columns, where additional rows can be added. In the mobile view, check that opening a dropdown in either of the last 2 rows results in additional padding appearing at the bottom of the table, such that the dropdown options are visible.
- [ ] Add rows to the table field and check that the padding still only applies to the newly created last 2 rows.
- [ ] Delete the rows which were added and check that the behaviour is consistent.
- [ ] Repeat the above 3 checks for the desktop view.