### PR TITLE
feat: allow .oa attachments

### DIFF
--- a/src/shared/util/file-validation.ts
+++ b/src/shared/util/file-validation.ts
@@ -34,6 +34,7 @@ const validExtensions = [
   '.mpp',
   '.msg',
   '.mso',
+  '.oa',
   '.odb',
   '.odf',
   '.odg',


### PR DESCRIPTION
Allows .oa files in attachments.

## Tests
- [ ] .oa file can be attached and submitted in email mode
- [ ] .oa file can be attached and submitted in storage mode
- [ ] .oa file can be downloaded from Data tab individual response
- [ ] .oa file can be downloaded in ZIP for individual submission
- [ ] .oa file can be downloaded in bulk attachments