### PR TITLE
fix: interrupt submission if field is blank

### DIFF
--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -302,7 +302,7 @@ function submitFormDirective(
         } catch (err) {
           return handleSubmitFailure(
             err,
-            'Could not prepare your submission. Please contact the form administrator.',
+            'There was an error while processing your submission. Please refresh and try again.',
           )
         }
 

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -315,7 +315,8 @@ function submitFormDirective(
         } catch (err) {
           return handleSubmitFailure(
             err,
-            'There was an error while processing your submission. Please refresh and try again.',
+            'There was an error while processing your submission. Please refresh and try again. ' +
+              'If the problem persists, try using a different browser.',
           )
         }
 

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -138,8 +138,18 @@ function submitFormDirective(
         }
       }
 
+      const isAnyFieldInvalid = () => {
+        return (
+          scope.forms.myForm.$invalid ||
+          scope.form.form_fields.some(
+            ({ _id }) =>
+              scope.forms.myForm[_id] && scope.forms.myForm[_id].$invalid,
+          )
+        )
+      }
+
       scope.checkCaptchaAndSubmit = () => {
-        if (scope.forms.myForm.$invalid) {
+        if (isAnyFieldInvalid()) {
           displayInvalidSubmit()
           return
         }

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -139,6 +139,9 @@ function submitFormDirective(
       }
 
       const isAnyFieldInvalid = () => {
+        // Check the validity of each individual field. We do this due to
+        // a possible bug in WebKit where form submission may not be correctly
+        // prevented when the form is invalid.
         return (
           scope.forms.myForm.$invalid ||
           scope.form.form_fields.some(

--- a/src/public/modules/forms/viewmodels/Fields/CheckboxField.class.js
+++ b/src/public/modules/forms/viewmodels/Fields/CheckboxField.class.js
@@ -17,6 +17,12 @@ class CheckboxField extends MixIns.RangeValidation(ArrayAnswerField) {
 
   getResponse() {
     const response = super.getResponse()
+    // Throw error if field value is missing
+    if (this.isVisible && this.required && this.fieldValue.every((v) => !v)) {
+      throw new Error(
+        `Missing answer for required field, fieldType ${this.fieldType}.`,
+      )
+    }
     // The backend will look for answerArray instead of answer for checkbox
     response.answerArray = this.fieldOptions.filter(
       (_, i) => this.fieldValue[i],

--- a/src/public/modules/forms/viewmodels/Fields/CheckboxField.class.js
+++ b/src/public/modules/forms/viewmodels/Fields/CheckboxField.class.js
@@ -19,6 +19,11 @@ class CheckboxField extends MixIns.RangeValidation(ArrayAnswerField) {
     const response = super.getResponse()
     // Throw error if field value is missing
     if (this.isVisible && this.required && this.fieldValue.every((v) => !v)) {
+      console.error(
+        `Attempt to getResponse on required field with no answer:\tfieldType=${
+          this.fieldType
+        }, fieldId=${this._id}, typeof fieldValue=${typeof this.fieldValue}`,
+      )
       throw new Error(
         `Missing answer for required field, fieldType ${this.fieldType}.`,
       )

--- a/src/public/modules/forms/viewmodels/Fields/SingleAnswerField.class.js
+++ b/src/public/modules/forms/viewmodels/Fields/SingleAnswerField.class.js
@@ -26,6 +26,11 @@ class SingleAnswerField extends AnswerField {
       this.fieldType !== 'section' &&
       !this.fieldValue
     ) {
+      console.error(
+        `Attempt to getResponse on required field with no answer:\tfieldType=${
+          this.fieldType
+        }, fieldId=${this._id}, typeof fieldValue=${typeof this.fieldValue}`,
+      )
       throw new Error(
         `Missing answer for required field, fieldType ${this.fieldType}.`,
       )

--- a/src/public/modules/forms/viewmodels/Fields/SingleAnswerField.class.js
+++ b/src/public/modules/forms/viewmodels/Fields/SingleAnswerField.class.js
@@ -19,6 +19,17 @@ class SingleAnswerField extends AnswerField {
    */
   getResponse() {
     const response = super.getResponse()
+    // Throw error if field value is missing
+    if (
+      this.isVisible &&
+      this.required &&
+      this.fieldType !== 'section' &&
+      !this.fieldValue
+    ) {
+      throw new Error(
+        `Missing answer for required field, fieldType ${this.fieldType}.`,
+      )
+    }
     response.answer =
       this.fieldValue === undefined || this.fieldValue === null
         ? ''


### PR DESCRIPTION
## Problem

Blank submissions in storage mode, likely due to a bug arising due to the interaction of the Safari browser with AngularJS.

## Solution

The existing form validation is clearly not working with Safari, otherwise blank submissions would be prevented. Hence add the following additional layers of checks:
1. Throw an error when attempting to get a response from a field which is visible and required but empty.
2. Check for the `$invalid` property of individual fields in addition to the form as a whole.

Closes #1044 