### PR TITLE
feat: mask cp uid in autoreply to respondent

### DIFF
--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -268,7 +268,7 @@ export const appendVerifiedSPCPResponses: RequestHandler<
       break
     case AuthType.CP:
       // Note that maskUidOnLastField() relies on the fact that userInfo is pushed in last to parsedResponses
-      // TODO: Remove this after refactor in #1104 (https://github.com/opengovsg/FormSG/issues/1104)
+      // TODO(#1104): Remove this comment after refactoring
       req.body.parsedResponses.push(
         ...createCorppassParsedResponses(uinFin, userInfo),
       )

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -267,6 +267,8 @@ export const appendVerifiedSPCPResponses: RequestHandler<
       req.body.parsedResponses.push(...createSingpassParsedResponses(uinFin))
       break
     case AuthType.CP:
+      // Note that maskUidOnLastField() relies on the fact that userInfo is pushed in last to parsedResponses
+      // TODO: Remove this after refactor in #1104 (https://github.com/opengovsg/FormSG/issues/1104)
       req.body.parsedResponses.push(
         ...createCorppassParsedResponses(uinFin, userInfo),
       )

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -7,7 +7,7 @@ import {
   AuthType,
   BasicField,
   MapRouteError,
-  SPCPValidatedFields,
+  SPCPFieldTitle,
 } from '../../../types'
 import { MissingFeatureError } from '../core/core.errors'
 import { ProcessedSingleAnswerResponse } from '../submission/submission.types'
@@ -171,7 +171,7 @@ export const createSingpassParsedResponses = (
   return [
     {
       _id: '',
-      question: SPCPValidatedFields.SpNric,
+      question: SPCPFieldTitle.SpNric,
       fieldType: BasicField.Nric,
       isVisible: true,
       answer: uinFin,
@@ -191,14 +191,14 @@ export const createCorppassParsedResponses = (
   return [
     {
       _id: '',
-      question: SPCPValidatedFields.CpUen,
+      question: SPCPFieldTitle.CpUen,
       fieldType: BasicField.ShortText,
       isVisible: true,
       answer: uinFin,
     },
     {
       _id: '',
-      question: SPCPValidatedFields.CpUid,
+      question: SPCPFieldTitle.CpUid,
       fieldType: BasicField.Nric,
       isVisible: true,
       answer: userInfo,

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -3,7 +3,12 @@ import crypto from 'crypto'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import { AuthType, BasicField, MapRouteError } from '../../../types'
+import {
+  AuthType,
+  BasicField,
+  MapRouteError,
+  SPCPValidatedFields,
+} from '../../../types'
 import { MissingFeatureError } from '../core/core.errors'
 import { ProcessedSingleAnswerResponse } from '../submission/submission.types'
 
@@ -166,7 +171,7 @@ export const createSingpassParsedResponses = (
   return [
     {
       _id: '',
-      question: 'SingPass Validated NRIC',
+      question: SPCPValidatedFields.SpNric,
       fieldType: BasicField.Nric,
       isVisible: true,
       answer: uinFin,
@@ -186,14 +191,14 @@ export const createCorppassParsedResponses = (
   return [
     {
       _id: '',
-      question: 'CorpPass Validated UEN',
+      question: SPCPValidatedFields.CpUen,
       fieldType: BasicField.ShortText,
       isVisible: true,
       answer: uinFin,
     },
     {
       _id: '',
-      question: 'CorpPass Validated UID',
+      question: SPCPValidatedFields.CpUid,
       fieldType: BasicField.Nric,
       isVisible: true,
       answer: userInfo,

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -4,9 +4,11 @@ import { cloneDeep, merge } from 'lodash'
 
 import {
   BasicField,
+  EmailAutoReplyField,
   FieldResponse,
   IAttachmentResponse,
   ISingleAnswerResponse,
+  SPCPFieldTitle,
 } from 'src/types'
 
 import {
@@ -15,6 +17,7 @@ import {
   getInvalidFileExtensions,
   handleDuplicatesInAttachments,
   mapAttachmentsFromResponses,
+  maskUidOnLastField,
 } from '../email-submission.util'
 
 const validSingleFile = {
@@ -299,6 +302,33 @@ describe('email-submission.util', () => {
         filename: secondAttachment.filename,
         content: secondAttachment.content,
       })
+    })
+  })
+
+  describe('maskUidOnLastField', () => {
+    it('should mask UID on SPCPFieldTitle.CpUid if it is the last field of autoReplyData', () => {
+      const autoReplyData: EmailAutoReplyField[] = [
+        { question: 'question 1', answerTemplate: ['answer1'] },
+        { question: SPCPFieldTitle.CpUid, answerTemplate: ['S1234567A'] },
+      ]
+      const maskedAutoReplyData: EmailAutoReplyField[] = [
+        { question: 'question 1', answerTemplate: ['answer1'] },
+        { question: SPCPFieldTitle.CpUid, answerTemplate: ['*****567A'] },
+      ]
+      expect(maskUidOnLastField(autoReplyData)).toEqual(maskedAutoReplyData)
+    })
+    it('should not mask UID on form field with same name as SPCPFieldTitle.CpUid if it is not the last field of autoReplyData', () => {
+      const autoReplyData: EmailAutoReplyField[] = [
+        { question: 'question 1', answerTemplate: ['answer1'] },
+        { question: 'CorpPass Validated UID', answerTemplate: ['S9999999Z'] },
+        { question: SPCPFieldTitle.CpUid, answerTemplate: ['S1234567A'] },
+      ]
+      const maskedAutoReplyData: EmailAutoReplyField[] = [
+        { question: 'question 1', answerTemplate: ['answer1'] },
+        { question: 'CorpPass Validated UID', answerTemplate: ['S9999999Z'] },
+        { question: SPCPFieldTitle.CpUid, answerTemplate: ['*****567A'] },
+      ]
+      expect(maskUidOnLastField(autoReplyData)).toEqual(maskedAutoReplyData)
     })
   })
 })

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -61,12 +61,20 @@ const zipOnlyValid = {
 
 const MOCK_ANSWER = 'mockAnswer'
 
-const getResponse = (_id: string, answer: string): ISingleAnswerResponse => ({
-  _id,
-  fieldType: BasicField.Attachment,
-  question: 'mockQuestion',
-  answer,
-})
+type WithQuestion<T> = T & {
+  answer: string
+}
+
+const getResponse = (
+  _id: string,
+  answer: string,
+): WithQuestion<ISingleAnswerResponse> =>
+  (({
+    _id,
+    fieldType: BasicField.Attachment,
+    question: 'mockQuestion',
+    answer,
+  } as unknown) as WithQuestion<ISingleAnswerResponse>)
 
 describe('email-submission.util', () => {
   describe('getInvalidFileExtensions', () => {
@@ -171,19 +179,19 @@ describe('email-submission.util', () => {
         [firstAttachment, secondAttachment],
       )
       expect(firstResponse.answer).toBe(firstAttachment.filename)
-      expect((firstResponse as IAttachmentResponse).filename).toBe(
+      expect(((firstResponse as unknown) as IAttachmentResponse).filename).toBe(
         firstAttachment.filename,
       )
-      expect((firstResponse as IAttachmentResponse).content).toEqual(
-        firstAttachment.content,
-      )
+      expect(
+        ((firstResponse as unknown) as IAttachmentResponse).content,
+      ).toEqual(firstAttachment.content)
       expect(secondResponse.answer).toBe(secondAttachment.filename)
-      expect((secondResponse as IAttachmentResponse).filename).toBe(
-        secondAttachment.filename,
-      )
-      expect((secondResponse as IAttachmentResponse).content).toEqual(
-        secondAttachment.content,
-      )
+      expect(
+        ((secondResponse as unknown) as IAttachmentResponse).filename,
+      ).toBe(secondAttachment.filename)
+      expect(
+        ((secondResponse as unknown) as IAttachmentResponse).content,
+      ).toEqual(secondAttachment.content)
     })
 
     it('should overwrite answer with filename when they are different', () => {
@@ -191,10 +199,10 @@ describe('email-submission.util', () => {
       const response = getResponse(attachment.fieldId, MOCK_ANSWER)
       addAttachmentToResponses([response], [attachment])
       expect(response.answer).toBe(attachment.filename)
-      expect((response as IAttachmentResponse).filename).toBe(
+      expect(((response as unknown) as IAttachmentResponse).filename).toBe(
         attachment.filename,
       )
-      expect((response as IAttachmentResponse).content).toEqual(
+      expect(((response as unknown) as IAttachmentResponse).content).toEqual(
         attachment.content,
       )
     })

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -17,6 +17,7 @@ import * as EmailSubmissionService from './email-submission.service'
 import {
   mapAttachmentsFromResponses,
   mapRouteError,
+  maskUidOnLastField,
 } from './email-submission.util'
 
 const logger = createLoggerWithLabel(module)
@@ -227,7 +228,10 @@ export const handleEmailSubmission: RequestHandler<
     parsedResponses,
     submission,
     attachments,
-    autoReplyData: emailData.autoReplyData,
+    autoReplyData:
+      authType === AuthType.CP
+        ? maskUidOnLastField(emailData.autoReplyData)
+        : emailData.autoReplyData,
   }).mapErr((error) => {
     logger.error({
       message: 'Error while sending email confirmations',

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -526,7 +526,7 @@ export const maskUidOnLastField = (
   // Mask corppass UID and show only last 4 chars in autoreply to form filler
   // This does not affect response email to form admin
   // Function assumes corppass UID is last in the autoReplyData array - see appendVerifiedSPCPResponses()
-  // TODO #1104: Refactor to move validation and construction of parsedResponses in class constructor (https://github.com/opengovsg/FormSG/issues/1104)
+  // TODO(#1104): Refactor to move validation and construction of parsedResponses in class constructor
   // This will allow for proper tagging of corppass UID field instead of checking field title and position
 
   const maskedAutoReplyData = autoReplyData.map(

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -11,7 +11,12 @@ import {
   SendAutoReplyEmailsArgs,
 } from 'src/app/services/mail/mail.types'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
-import { BounceType, IPopulatedForm, ISubmissionSchema } from 'src/types'
+import {
+  BounceType,
+  IPopulatedForm,
+  ISubmissionSchema,
+  SPCPValidatedFields,
+} from 'src/types'
 
 const MOCK_VALID_EMAIL = 'to@example.com'
 const MOCK_VALID_EMAIL_2 = 'to2@example.com'
@@ -858,14 +863,14 @@ describe('mail.service', () => {
 
       const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
       customDataParams.responsesData.push({
-        question: 'CorpPass Validated UID',
+        question: SPCPValidatedFields.CpUid,
         answerTemplate: ['S1234567A'],
       })
       customDataParams.autoReplyMailDatas[0].includeFormSummary = true
 
       const expectedRenderDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
       expectedRenderDataParams.responsesData.push({
-        question: 'CorpPass Validated UID',
+        question: SPCPValidatedFields.CpUid,
         answerTemplate: ['*****567A'],
       })
 

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -852,6 +852,63 @@ describe('mail.service', () => {
       expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
     })
 
+    it('should mask CorpPass Validated UID and only display last 4 characters if the field is present', async () => {
+      // Arrange
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
+      customDataParams.responsesData.push({
+        question: 'CorpPass Validated UID',
+        answerTemplate: ['S1234567A'],
+      })
+      customDataParams.autoReplyMailDatas[0].includeFormSummary = true
+
+      const expectedRenderDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
+      expectedRenderDataParams.responsesData.push({
+        question: 'CorpPass Validated UID',
+        answerTemplate: ['*****567A'],
+      })
+
+      const expectedRenderData: AutoreplySummaryRenderData = {
+        formData: expectedRenderDataParams.responsesData,
+        formTitle: expectedRenderDataParams.form.title,
+        formUrl: `${MOCK_APP_URL}/${expectedRenderDataParams.form._id}`,
+        refNo: expectedRenderDataParams.submission.id,
+        submissionTime: moment(expectedRenderDataParams.submission.created)
+          .tz('Asia/Singapore')
+          .format('ddd, DD MMM YYYY hh:mm:ss A'),
+      }
+
+      const expectedMailBody = await MailUtils.generateAutoreplyHtml({
+        autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
+        ...expectedRenderData,
+      })
+
+      const expectedArg = {
+        ...defaultExpectedArg,
+        html: expectedMailBody,
+        // Attachments should be concatted with mock pdf response
+        attachments: [
+          ...(expectedRenderDataParams.attachments ?? []),
+          {
+            content: MOCK_PDF,
+            filename: 'response.pdf',
+          },
+        ],
+      }
+
+      const expectedResponse = await Promise.allSettled([Promise.resolve(true)])
+
+      // Act
+      const pendingSend = mailService.sendAutoReplyEmails(customDataParams)
+
+      // Assert
+      await expect(pendingSend).resolves.toEqual(expectedResponse)
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
+    })
+
     it('should reject with error when autoReplyData.email param is an invalid email', async () => {
       // Arrange
       const invalidDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -11,12 +11,7 @@ import {
   SendAutoReplyEmailsArgs,
 } from 'src/app/services/mail/mail.types'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
-import {
-  BounceType,
-  IPopulatedForm,
-  ISubmissionSchema,
-  SPCPValidatedFields,
-} from 'src/types'
+import { BounceType, IPopulatedForm, ISubmissionSchema } from 'src/types'
 
 const MOCK_VALID_EMAIL = 'to@example.com'
 const MOCK_VALID_EMAIL_2 = 'to2@example.com'
@@ -845,63 +840,6 @@ describe('mail.service', () => {
           },
         ],
       }
-      const expectedResponse = await Promise.allSettled([Promise.resolve(true)])
-
-      // Act
-      const pendingSend = mailService.sendAutoReplyEmails(customDataParams)
-
-      // Assert
-      await expect(pendingSend).resolves.toEqual(expectedResponse)
-      // Check arguments passed to sendNodeMail
-      expect(sendMailSpy).toHaveBeenCalledTimes(1)
-      expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
-    })
-
-    it('should mask CorpPass Validated UID and only display last 4 characters if the field is present', async () => {
-      // Arrange
-      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
-
-      const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
-      customDataParams.responsesData.push({
-        question: SPCPValidatedFields.CpUid,
-        answerTemplate: ['S1234567A'],
-      })
-      customDataParams.autoReplyMailDatas[0].includeFormSummary = true
-
-      const expectedRenderDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
-      expectedRenderDataParams.responsesData.push({
-        question: SPCPValidatedFields.CpUid,
-        answerTemplate: ['*****567A'],
-      })
-
-      const expectedRenderData: AutoreplySummaryRenderData = {
-        formData: expectedRenderDataParams.responsesData,
-        formTitle: expectedRenderDataParams.form.title,
-        formUrl: `${MOCK_APP_URL}/${expectedRenderDataParams.form._id}`,
-        refNo: expectedRenderDataParams.submission.id,
-        submissionTime: moment(expectedRenderDataParams.submission.created)
-          .tz('Asia/Singapore')
-          .format('ddd, DD MMM YYYY hh:mm:ss A'),
-      }
-
-      const expectedMailBody = await MailUtils.generateAutoreplyHtml({
-        autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
-        ...expectedRenderData,
-      })
-
-      const expectedArg = {
-        ...defaultExpectedArg,
-        html: expectedMailBody,
-        // Attachments should be concatted with mock pdf response
-        attachments: [
-          ...(expectedRenderDataParams.attachments ?? []),
-          {
-            content: MOCK_PDF,
-            filename: 'response.pdf',
-          },
-        ],
-      }
-
       const expectedResponse = await Promise.allSettled([Promise.resolve(true)])
 
       // Act

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -13,6 +13,7 @@ import {
   EmailFormField,
   IEmailFormSchema,
   ISubmissionSchema,
+  SPCPValidatedFields,
 } from '../../../types'
 
 import { EMAIL_HEADERS, EmailType } from './mail.constants'
@@ -463,7 +464,7 @@ export class MailService {
     // Mask corppass UID and show only last 4 chars in autoreply to form filler
     // This does not affect response email to form admin
     responsesData.forEach((qaPair) => {
-      if (qaPair.question === 'CorpPass Validated UID') {
+      if (qaPair.question === SPCPValidatedFields.CpUid) {
         qaPair.answerTemplate = qaPair.answerTemplate.map((answer) => {
           return answer.length >= 4 // defensive, in case UID length is less than 4
             ? '*'.repeat(answer.length - 4) + answer.substr(-4)

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -458,7 +458,20 @@ export class MailService {
     autoReplyMailDatas,
     attachments = [],
   }: SendAutoReplyEmailsArgs): Promise<PromiseSettledResult<true>[]> => {
-    // Data to render both the submission details mail HTML body PDF.
+    // Data to render both the submission details mail HTML body and PDF.
+
+    // Mask corppass UID and show only last 4 chars in autoreply to form filler
+    // This does not affect response email to form admin
+    responsesData.forEach((qaPair) => {
+      if (qaPair.question === 'CorpPass Validated UID') {
+        qaPair.answerTemplate = qaPair.answerTemplate.map((answer) => {
+          return answer.length >= 4 // defensive, in case UID length is less than 4
+            ? '*'.repeat(answer.length - 4) + answer.substr(-4)
+            : answer
+        })
+      }
+    })
+
     const renderData: AutoreplySummaryRenderData = {
       refNo: submission.id,
       formTitle: form.title,

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -13,7 +13,6 @@ import {
   EmailFormField,
   IEmailFormSchema,
   ISubmissionSchema,
-  SPCPValidatedFields,
 } from '../../../types'
 
 import { EMAIL_HEADERS, EmailType } from './mail.constants'
@@ -460,18 +459,6 @@ export class MailService {
     attachments = [],
   }: SendAutoReplyEmailsArgs): Promise<PromiseSettledResult<true>[]> => {
     // Data to render both the submission details mail HTML body and PDF.
-
-    // Mask corppass UID and show only last 4 chars in autoreply to form filler
-    // This does not affect response email to form admin
-    responsesData.forEach((qaPair) => {
-      if (qaPair.question === SPCPValidatedFields.CpUid) {
-        qaPair.answerTemplate = qaPair.answerTemplate.map((answer) => {
-          return answer.length >= 4 // defensive, in case UID length is less than 4
-            ? '*'.repeat(answer.length - 4) + answer.substr(-4)
-            : answer
-        })
-      }
-    })
 
     const renderData: AutoreplySummaryRenderData = {
       refNo: submission.id,

--- a/src/public/modules/forms/helpers/process-decrypted-content.js
+++ b/src/public/modules/forms/helpers/process-decrypted-content.js
@@ -1,4 +1,4 @@
-const { SPCPValidatedFields } = require('../../../../types')
+const { SPCPFieldTitle } = require('../../../../types')
 const {
   CURRENT_VERIFIED_FIELDS,
   VerifiedKeys,
@@ -13,25 +13,25 @@ const getResponseFromVerifiedField = (type, value) => {
   switch (type) {
     case VerifiedKeys.SpUinFin:
       return {
-        question: SPCPValidatedFields.SpNric,
+        question: SPCPFieldTitle.SpNric,
         fieldType: 'nric',
         answer: value,
         // Just a unique identifier for CSV header uniqueness
-        _id: SPCPValidatedFields.SpNric,
+        _id: SPCPFieldTitle.SpNric,
       }
     case VerifiedKeys.CpUen:
       return {
-        question: SPCPValidatedFields.CpUen,
+        question: SPCPFieldTitle.CpUen,
         fieldType: 'textfield',
         answer: value,
-        _id: SPCPValidatedFields.CpUen,
+        _id: SPCPFieldTitle.CpUen,
       }
     case VerifiedKeys.CpUid:
       return {
-        question: SPCPValidatedFields.CpUid,
+        question: SPCPFieldTitle.CpUid,
         fieldType: 'nric',
         answer: value,
-        _id: SPCPValidatedFields.CpUid,
+        _id: SPCPFieldTitle.CpUid,
       }
     default:
       return null

--- a/src/public/modules/forms/helpers/process-decrypted-content.js
+++ b/src/public/modules/forms/helpers/process-decrypted-content.js
@@ -1,4 +1,4 @@
-const { SPCPValidatedFields } = require('src/types')
+const { SPCPValidatedFields } = require('../../../../types')
 const {
   CURRENT_VERIFIED_FIELDS,
   VerifiedKeys,

--- a/src/public/modules/forms/helpers/process-decrypted-content.js
+++ b/src/public/modules/forms/helpers/process-decrypted-content.js
@@ -1,3 +1,4 @@
+const { SPCPValidatedFields } = require('src/types')
 const {
   CURRENT_VERIFIED_FIELDS,
   VerifiedKeys,
@@ -12,25 +13,25 @@ const getResponseFromVerifiedField = (type, value) => {
   switch (type) {
     case VerifiedKeys.SpUinFin:
       return {
-        question: 'SingPass Validated NRIC',
+        question: SPCPValidatedFields.SpNric,
         fieldType: 'nric',
         answer: value,
         // Just a unique identifier for CSV header uniqueness
-        _id: 'SingPass Validated NRIC',
+        _id: SPCPValidatedFields.SpNric,
       }
     case VerifiedKeys.CpUen:
       return {
-        question: 'CorpPass Validated UEN',
+        question: SPCPValidatedFields.CpUen,
         fieldType: 'textfield',
         answer: value,
-        _id: 'CorpPass Validated UEN',
+        _id: SPCPValidatedFields.CpUen,
       }
     case VerifiedKeys.CpUid:
       return {
-        question: 'CorpPass Validated UID',
+        question: SPCPValidatedFields.CpUid,
         fieldType: 'nric',
         answer: value,
-        _id: 'CorpPass Validated UID',
+        _id: SPCPValidatedFields.CpUid,
       }
     default:
       return null

--- a/src/types/field/fieldTypes.ts
+++ b/src/types/field/fieldTypes.ts
@@ -53,7 +53,7 @@ export enum MyInfoAttribute {
   GraduationYear = 'gradyear',
 }
 
-export enum SPCPValidatedFields {
+export enum SPCPFieldTitle {
   SpNric = 'SingPass Validated NRIC',
   CpUid = 'CorpPass Validated UID',
   CpUen = 'CorpPass Validated UEN',

--- a/src/types/field/fieldTypes.ts
+++ b/src/types/field/fieldTypes.ts
@@ -52,3 +52,9 @@ export enum MyInfoAttribute {
   WorkpassExpiryDate = 'workpassexpirydate',
   GraduationYear = 'gradyear',
 }
+
+export enum SPCPValidatedFields {
+  SpNric = 'SingPass Validated NRIC',
+  CpUid = 'CorpPass Validated UID',
+  CpUen = 'CorpPass Validated UEN',
+}

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -29,7 +29,7 @@ const {
 const { types } = require('../../../dist/backend/shared/resources/basic')
 
 const {
-  SPCPValidatedFields,
+  SPCPFieldTitle,
 } = require('../../../dist/backend/types/field/fieldTypes')
 
 const NON_SUBMITTED_FIELDS = types
@@ -1162,15 +1162,15 @@ const getAuthFields = (authType, authData) => {
     case 'SP':
       return [
         makeField({
-          title: SPCPValidatedFields.SpNric,
+          title: SPCPFieldTitle.SpNric,
           val: authData.testSpNric,
         }),
       ]
     case 'CP':
       return [
-        { title: SPCPValidatedFields.CpUen, val: authData.testCpUen },
+        { title: SPCPFieldTitle.CpUen, val: authData.testCpUen },
         {
-          title: SPCPValidatedFields.CpUid,
+          title: SPCPFieldTitle.CpUid,
           val: authData.testCpNric,
         },
       ].map(makeField)

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -27,6 +27,11 @@ const {
 } = require('./selectors')
 
 const { types } = require('../../../dist/backend/shared/resources/basic')
+
+const {
+  SPCPValidatedFields,
+} = require('../../../dist/backend/types/field/fieldTypes')
+
 const NON_SUBMITTED_FIELDS = types
   .filter((field) => !field.submitted)
   .map((field) => field.name)
@@ -1157,15 +1162,15 @@ const getAuthFields = (authType, authData) => {
     case 'SP':
       return [
         makeField({
-          title: 'SingPass Validated NRIC',
+          title: SPCPValidatedFields.SpNric,
           val: authData.testSpNric,
         }),
       ]
     case 'CP':
       return [
-        { title: 'CorpPass Validated UEN', val: authData.testCpUen },
+        { title: SPCPValidatedFields.CpUen, val: authData.testCpUen },
         {
-          title: 'CorpPass Validated UID',
+          title: SPCPValidatedFields.CpUid,
           val: authData.testCpNric,
         },
       ].map(makeField)

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -20,6 +20,10 @@ const Verification = dbHandler.makeModel(
 )
 const vfnConstants = require('../../../../dist/backend/shared/util/verification')
 
+const {
+  SPCPValidatedFields,
+} = require('../../../../dist/backend/types/field/fieldTypes')
+
 describe('Email Submissions Controller', () => {
   // Declare global variables
   let sendSubmissionMailSpy
@@ -646,7 +650,7 @@ describe('Email Submissions Controller', () => {
       reqFixtures.form.authType = 'SP'
       const expectedFormData = [
         {
-          question: 'SingPass Validated NRIC',
+          question: SPCPValidatedFields.SpNric,
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
           fieldType: 'nric',
@@ -654,13 +658,13 @@ describe('Email Submissions Controller', () => {
       ]
       const expectedAutoReplyData = [
         {
-          question: 'SingPass Validated NRIC',
+          question: SPCPValidatedFields.SpNric,
           answerTemplate: [resLocalFixtures.uinFin],
         },
       ]
       const expectedJsonData = [
         {
-          question: 'SingPass Validated NRIC',
+          question: SPCPValidatedFields.SpNric,
           answer: resLocalFixtures.uinFin,
         },
       ]
@@ -678,13 +682,13 @@ describe('Email Submissions Controller', () => {
       reqFixtures.form.authType = 'CP'
       const expectedFormData = [
         {
-          question: 'CorpPass Validated UEN',
+          question: SPCPValidatedFields.CpUen,
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
           fieldType: 'textfield',
         },
         {
-          question: 'CorpPass Validated UID',
+          question: SPCPValidatedFields.CpUid,
           answerTemplate: [resLocalFixtures.userInfo],
           answer: resLocalFixtures.userInfo,
           fieldType: 'nric',
@@ -692,21 +696,21 @@ describe('Email Submissions Controller', () => {
       ]
       const expectedAutoReplyData = [
         {
-          question: 'CorpPass Validated UEN',
+          question: SPCPValidatedFields.CpUen,
           answerTemplate: [resLocalFixtures.uinFin],
         },
         {
-          question: 'CorpPass Validated UID',
+          question: SPCPValidatedFields.CpUid,
           answerTemplate: [resLocalFixtures.userInfo],
         },
       ]
       const expectedJsonData = [
         {
-          question: 'CorpPass Validated UEN',
+          question: SPCPValidatedFields.CpUen,
           answer: resLocalFixtures.uinFin,
         },
         {
-          question: 'CorpPass Validated UID',
+          question: SPCPValidatedFields.CpUid,
           answer: resLocalFixtures.userInfo,
         },
       ]

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -21,7 +21,7 @@ const Verification = dbHandler.makeModel(
 const vfnConstants = require('../../../../dist/backend/shared/util/verification')
 
 const {
-  SPCPValidatedFields,
+  SPCPFieldTitle,
 } = require('../../../../dist/backend/types/field/fieldTypes')
 
 describe('Email Submissions Controller', () => {
@@ -650,7 +650,7 @@ describe('Email Submissions Controller', () => {
       reqFixtures.form.authType = 'SP'
       const expectedFormData = [
         {
-          question: SPCPValidatedFields.SpNric,
+          question: SPCPFieldTitle.SpNric,
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
           fieldType: 'nric',
@@ -658,13 +658,13 @@ describe('Email Submissions Controller', () => {
       ]
       const expectedAutoReplyData = [
         {
-          question: SPCPValidatedFields.SpNric,
+          question: SPCPFieldTitle.SpNric,
           answerTemplate: [resLocalFixtures.uinFin],
         },
       ]
       const expectedJsonData = [
         {
-          question: SPCPValidatedFields.SpNric,
+          question: SPCPFieldTitle.SpNric,
           answer: resLocalFixtures.uinFin,
         },
       ]
@@ -682,13 +682,13 @@ describe('Email Submissions Controller', () => {
       reqFixtures.form.authType = 'CP'
       const expectedFormData = [
         {
-          question: SPCPValidatedFields.CpUen,
+          question: SPCPFieldTitle.CpUen,
           answerTemplate: [resLocalFixtures.uinFin],
           answer: resLocalFixtures.uinFin,
           fieldType: 'textfield',
         },
         {
-          question: SPCPValidatedFields.CpUid,
+          question: SPCPFieldTitle.CpUid,
           answerTemplate: [resLocalFixtures.userInfo],
           answer: resLocalFixtures.userInfo,
           fieldType: 'nric',
@@ -696,21 +696,21 @@ describe('Email Submissions Controller', () => {
       ]
       const expectedAutoReplyData = [
         {
-          question: SPCPValidatedFields.CpUen,
+          question: SPCPFieldTitle.CpUen,
           answerTemplate: [resLocalFixtures.uinFin],
         },
         {
-          question: SPCPValidatedFields.CpUid,
+          question: SPCPFieldTitle.CpUid,
           answerTemplate: [resLocalFixtures.userInfo],
         },
       ]
       const expectedJsonData = [
         {
-          question: SPCPValidatedFields.CpUen,
+          question: SPCPFieldTitle.CpUen,
           answer: resLocalFixtures.uinFin,
         },
         {
-          question: SPCPValidatedFields.CpUid,
+          question: SPCPFieldTitle.CpUid,
           answer: resLocalFixtures.userInfo,
         },
       ]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes [#101](https://github.com/datagovsg/formsg-private/issues/101)

## Solution
- Mask UID NRIC before generating autoreply using a function
- To be refactored in #1104 

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![Screenshot 2021-02-02 at 8 59 12 PM](https://user-images.githubusercontent.com/63710093/106603921-e4ebea80-6599-11eb-98e8-a34184ed7b09.png)
![Screenshot 2021-02-02 at 8 59 04 PM](https://user-images.githubusercontent.com/63710093/106603923-e5848100-6599-11eb-9910-455ae11f4d48.png)


**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot 2021-02-02 at 8 58 30 PM](https://user-images.githubusercontent.com/63710093/106603912-e1586380-6599-11eb-9b07-6e62f26a53bc.png)
![Screenshot 2021-02-02 at 8 58 19 PM](https://user-images.githubusercontent.com/63710093/106603915-e1f0fa00-6599-11eb-9320-f40edd1a5d7a.png)

## Tests
- [ ] Create a corppass form with email autoreply and pdf response. Submit form. Check that the autoreply email and pdf response both have a masked UID number with only the last 4 characters shown (e.g. *****123A)
- [ ] Add a text field to the form with the title 'CorpPass Validated UID'. Check that the response on the text field is not masked in autoreply.
- [ ] Check that the email response to the admin still has the full UID number.

