### PR TITLE
feat: add timestamp to form submission end page

### DIFF
--- a/src/public/main.css
+++ b/src/public/main.css
@@ -45,6 +45,7 @@
 @import './modules/forms/base/css/form.css';
 @import './modules/forms/base/css/datepicker.css';
 @import './modules/forms/base/css/verifiable-field.css';
+@import './modules/forms/base/css/end-page.css';
 @import './modules/users/css/sign-in.css';
 @import './modules/users/css/examples-list.css';
 @import './modules/users/css/examples-card.css';

--- a/src/public/modules/forms/base/componentViews/end-page.html
+++ b/src/public/modules/forms/base/componentViews/end-page.html
@@ -4,6 +4,9 @@
   </div>
   <div id="end-page-main-container" class="{{ vm.colorTheme }}-bg">
     <div class="row">
+      <p id="end-page-header">
+        Form submitted <span id="end-page-timestamp"> {{ vm.timestamp }} </span>
+      </p>
       <h2 id="end-page-title">{{ vm.title }}</h2>
       <div id="end-page-follow-up">
         <p ng-bind-html="vm.paragraph | linky:'_blank'"></p>

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -19,7 +19,7 @@ angular.module('forms').component('endPageComponent', {
 function endPageController(SpcpSession, $window, moment) {
   const vm = this
 
-  vm.timestamp = moment().format('DD MM YYYY, HH:mm')
+  vm.timestamp = moment().format('D MMM YYYY, HH:mm')
   vm.userName = SpcpSession.userName
   vm.formLogout = SpcpSession.logout
 

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -12,13 +12,14 @@ angular.module('forms').component('endPageComponent', {
     isAdminPreview: '<',
     colorTheme: '@',
   },
-  controller: ['SpcpSession', '$window', endPageController],
+  controller: ['SpcpSession', '$window', 'moment', endPageController],
   controllerAs: 'vm',
 })
 
-function endPageController(SpcpSession, $window) {
+function endPageController(SpcpSession, $window, moment) {
   const vm = this
 
+  vm.timestamp = moment().format('DD MM YYYY, HH:mm')
   vm.userName = SpcpSession.userName
   vm.formLogout = SpcpSession.logout
 

--- a/src/public/modules/forms/base/css/end-page.css
+++ b/src/public/modules/forms/base/css/end-page.css
@@ -1,7 +1,8 @@
 #end-page-header {
+  margin-top: 68px;
   text-transform: uppercase;
 }
 
-#end-page-header#end-page-timestamp {
+#end-page-header #end-page-timestamp {
   font-weight: bold;
 }

--- a/src/public/modules/forms/base/css/end-page.css
+++ b/src/public/modules/forms/base/css/end-page.css
@@ -1,0 +1,7 @@
+#end-page-header {
+  text-transform: uppercase;
+}
+
+#end-page-header#end-page-timestamp {
+  font-weight: bold;
+}

--- a/src/public/modules/forms/base/css/start-end-page.css
+++ b/src/public/modules/forms/base/css/start-end-page.css
@@ -195,7 +195,6 @@
   font-size: 44px;
   font-weight: 200;
   letter-spacing: -1px;
-  margin-top: 68px;
   margin-bottom: 13px;
 }
 


### PR DESCRIPTION
## Problem

Shows form submission timestamp above "Thank you for..." upon successful form submission.

Closes #1103 

## Things to take note of

The timestamp shown may not be equal to the actual form submission timestamp in the database (difference of at most 1 min unless very poor network conditions after submission), because this rendered timestamp is generated on the fly upon render. Let me know if this is not okay.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-02-09 at 9 55 08 PM](https://user-images.githubusercontent.com/14961285/107373451-838bc480-6b21-11eb-8b55-2e308e4ae16e.png)

**AFTER**:
![Screenshot 2021-02-09 at 9 37 50 PM](https://user-images.githubusercontent.com/14961285/107373088-19731f80-6b21-11eb-8264-6077da5ff6dd.png)