### PR TITLE
build: upgrade development to use mongo:4.0 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     network_mode: 'service:formsg' # reuse formsg service's network stack so that it can resolve localhost:5156 to mockpass:5156
 
   database:
-    image: 'mongo:3.6'
+    image: 'mongo:4.0'
     container_name: 'formsg-db'
     environment:
       - MONGO_INITDB_DATABASE=formsg


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Upgrades local development to use MongoDB 4.0 as part of https://github.com/datagovsg/formsg-private/issues/27

## Solution
<!-- How did you solve the problem? -->

Change the image used in `docker-compose.yml` to `mongo:4.0`.

Note that the local development Docker volume is not compatible and should be removed via e.g. `docker volume prune`. This will wipe your existing local development database and start your local development environment on a clean slate.
