### PR TITLE
fix: fix updating of forms

### DIFF
--- a/src/app/controllers/admin-forms.server.controller.js
+++ b/src/app/controllers/admin-forms.server.controller.js
@@ -233,7 +233,7 @@ function makeModule(connection) {
         }
       }
 
-      _.merge(form, updatedForm)
+      _.extend(form, updatedForm)
 
       // Can't just do updatedForm.save() because updatedForm has some String values
       form.save(function (err, savedForm) {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Logic fields cannot be deleted (and probably other buggy behaviour yet to be uncovered).

## Solution
<!-- How did you solve the problem? -->
In the form updating code on the server, a `_.extend` was changed to a `_.merge` in #1061. However, the two functions behave very differently, as illustrated in this example:

![image](https://user-images.githubusercontent.com/29480346/107467612-5bdc4100-6ba1-11eb-82a4-d36ff33758fb.png)

The fix is to revert to `_.extend`.