### PR TITLE
refactor: remove SPCP_COOKIE_MAX_AGE

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -84,7 +84,6 @@ FORMSG_SDK_MODE=
 # purposes. 
 # MYINFO_CLIENT_CONFIG=stg
 # MYINFO_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
-# SPCP_COOKIE_MAX_AGE=7200000
 
 # SP_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
 # SP_FORMSG_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/server.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - DB_HOST=mongodb://database:27017/formsg
       - APP_NAME=FormSG
       - MYINFO_CLIENT_CONFIG=stg
-      - SPCP_COOKIE_MAX_AGE=7200000
       - ATTACHMENT_S3_BUCKET=local-attachment-bucket
       - IMAGE_S3_BUCKET=local-image-bucket
       - LOGO_S3_BUCKET=local-logo-bucket

--- a/tests/.test-full-env
+++ b/tests/.test-full-env
@@ -24,7 +24,6 @@ CORPPASS_PARTNER_ENTITY_ID=https://staging.form.gov.sg/corppass
 CORPPASS_ESRVC_ID=FORMSG-CP-TEST
 CORPPASS_IDP_ID=https://saml.corppass.gov.sg/FIM/sps/CorpIDPFed/saml20
 
-SPCP_COOKIE_MAX_AGE=7200000 
 SHOW_LOGIN_PAGE=true
 IS_SP_MAINTENANCE=Date/Time-SP
 IS_CP_MAINTENANCE=Date/Time-CP


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The `SPCP_COOKIE_MAX_AGE` environment variable is unused, but still remains in the development and test environment.

Addresses https://github.com/datagovsg/formsg-private/issues/112

## Solution
<!-- How did you solve the problem? -->
Remove it from the codebase.
