### PR TITLE
refactor: encapsulate parsed responses (part 1)

### DIFF
--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -14,6 +14,7 @@ import {
   BasicField,
   IEmailFormSchema,
   IEmailSubmissionSchema,
+  IPopulatedEmailForm,
   MyInfoAttribute,
   SubmissionType,
 } from 'src/types'
@@ -31,6 +32,7 @@ import {
 } from 'tests/unit/backend/helpers/generate-form-data'
 
 import { SendAdminEmailError } from '../../submission.errors'
+import { ProcessedSingleAnswerResponse } from '../../submission.types'
 import {
   ATTACHMENT_PREFIX,
   DIGEST_TYPE,
@@ -46,6 +48,8 @@ import {
   InvalidFileExtensionError,
 } from '../email-submission.errors'
 import * as EmailSubmissionService from '../email-submission.service'
+
+type ResolvedValue<T> = T extends PromiseLike<infer U> ? U | T : never
 
 jest.mock('src/config/config')
 
@@ -96,11 +100,13 @@ describe('email-submission.service', () => {
         new Set(),
       )
 
-      expect(emailData).toEqual({
-        jsonData: [],
-        autoReplyData: [generateSingleAnswerAutoreply(response)],
-        formData: [generateSingleAnswerFormData(response)],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [],
+          autoReplyData: [generateSingleAnswerAutoreply(response)],
+          formData: [generateSingleAnswerFormData(response)],
+        }),
+      )
     })
 
     it('should exclude non-visible fields from autoreply data', () => {
@@ -113,11 +119,13 @@ describe('email-submission.service', () => {
         new Set(),
       )
 
-      expect(emailData).toEqual({
-        jsonData: [generateSingleAnswerJson(response)],
-        autoReplyData: [],
-        formData: [generateSingleAnswerFormData(response)],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [generateSingleAnswerJson(response)],
+          autoReplyData: [],
+          formData: [generateSingleAnswerFormData(response)],
+        }),
+      )
     })
 
     it('should generate table answers with [table] prefix in form and JSON data', () => {
@@ -132,30 +140,32 @@ describe('email-submission.service', () => {
       const firstRow = response.answerArray[0].join(',')
       const secondRow = response.answerArray[1].join(',')
 
-      expect(emailData).toEqual({
-        jsonData: [
-          { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
-          { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
-        ],
-        autoReplyData: [
-          { question, answerTemplate: [firstRow] },
-          { question, answerTemplate: [secondRow] },
-        ],
-        formData: [
-          {
-            question: `${TABLE_PREFIX}${question}`,
-            answer: firstRow,
-            answerTemplate: [firstRow],
-            fieldType: BasicField.Table,
-          },
-          {
-            question: `${TABLE_PREFIX}${question}`,
-            answer: secondRow,
-            answerTemplate: [secondRow],
-            fieldType: BasicField.Table,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [
+            { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
+            { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
+          ],
+          autoReplyData: [
+            { question, answerTemplate: [firstRow] },
+            { question, answerTemplate: [secondRow] },
+          ],
+          formData: [
+            {
+              question: `${TABLE_PREFIX}${question}`,
+              answer: firstRow,
+              answerTemplate: [firstRow],
+              fieldType: BasicField.Table,
+            },
+            {
+              question: `${TABLE_PREFIX}${question}`,
+              answer: secondRow,
+              answerTemplate: [secondRow],
+              fieldType: BasicField.Table,
+            },
+          ],
+        }),
+      )
     })
 
     it('should generate checkbox answers correctly', () => {
@@ -169,18 +179,20 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = response.answerArray.join(', ')
 
-      expect(emailData).toEqual({
-        jsonData: [{ question, answer }],
-        autoReplyData: [{ question, answerTemplate: [answer] }],
-        formData: [
-          {
-            question,
-            answer,
-            answerTemplate: [answer],
-            fieldType: BasicField.Checkbox,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question, answer }],
+          autoReplyData: [{ question, answerTemplate: [answer] }],
+          formData: [
+            {
+              question,
+              answer,
+              answerTemplate: [answer],
+              fieldType: BasicField.Checkbox,
+            },
+          ],
+        }),
+      )
     })
 
     it('should generate attachment answers with [attachment] prefix in form and JSON data', () => {
@@ -194,18 +206,20 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = response.answer
 
-      expect(emailData).toEqual({
-        jsonData: [{ question: `${ATTACHMENT_PREFIX}${question}`, answer }],
-        autoReplyData: [{ question, answerTemplate: [answer] }],
-        formData: [
-          {
-            question: `${ATTACHMENT_PREFIX}${question}`,
-            answer,
-            answerTemplate: [answer],
-            fieldType: BasicField.Attachment,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question: `${ATTACHMENT_PREFIX}${question}`, answer }],
+          autoReplyData: [{ question, answerTemplate: [answer] }],
+          formData: [
+            {
+              question: `${ATTACHMENT_PREFIX}${question}`,
+              answer,
+              answerTemplate: [answer],
+              fieldType: BasicField.Attachment,
+            },
+          ],
+        }),
+      )
     })
 
     it('should split single answer fields by newline', () => {
@@ -221,18 +235,20 @@ describe('email-submission.service', () => {
 
       const question = response.question
 
-      expect(emailData).toEqual({
-        jsonData: [{ question, answer }],
-        autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-        formData: [
-          {
-            question,
-            answer,
-            answerTemplate: answer.split('\n'),
-            fieldType: BasicField.ShortText,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question, answer }],
+          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
+          formData: [
+            {
+              question,
+              answer,
+              answerTemplate: answer.split('\n'),
+              fieldType: BasicField.ShortText,
+            },
+          ],
+        }),
+      )
     })
 
     it('should split table answers by newline', () => {
@@ -247,18 +263,20 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = answerArray[0].join(',')
 
-      expect(emailData).toEqual({
-        jsonData: [{ question: `${TABLE_PREFIX}${question}`, answer }],
-        autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-        formData: [
-          {
-            question: `${TABLE_PREFIX}${question}`,
-            answer,
-            answerTemplate: answer.split('\n'),
-            fieldType: BasicField.Table,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question: `${TABLE_PREFIX}${question}`, answer }],
+          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
+          formData: [
+            {
+              question: `${TABLE_PREFIX}${question}`,
+              answer,
+              answerTemplate: answer.split('\n'),
+              fieldType: BasicField.Table,
+            },
+          ],
+        }),
+      )
     })
 
     it('should split checkbox answers by newline', () => {
@@ -273,18 +291,20 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = answerArray.join(', ')
 
-      expect(emailData).toEqual({
-        jsonData: [{ question, answer }],
-        autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-        formData: [
-          {
-            question,
-            answer,
-            answerTemplate: answer.split('\n'),
-            fieldType: BasicField.Checkbox,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question, answer }],
+          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
+          formData: [
+            {
+              question,
+              answer,
+              answerTemplate: answer.split('\n'),
+              fieldType: BasicField.Checkbox,
+            },
+          ],
+        }),
+      )
     })
 
     it('should prefix verified fields with [verified] only in form data', () => {
@@ -299,19 +319,20 @@ describe('email-submission.service', () => {
 
       const question = response.question
       const answer = response.answer
-
-      expect(emailData).toEqual({
-        jsonData: [{ question, answer }],
-        autoReplyData: [{ question, answerTemplate: [answer] }],
-        formData: [
-          {
-            question: `${VERIFIED_PREFIX}${question}`,
-            answer,
-            answerTemplate: [answer],
-            fieldType: BasicField.Email,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [{ question, answer }],
+          autoReplyData: [{ question, answerTemplate: [answer] }],
+          formData: [
+            {
+              question: `${VERIFIED_PREFIX}${question}`,
+              answer,
+              answerTemplate: [answer],
+              fieldType: BasicField.Email,
+            },
+          ],
+        }),
+      )
     })
 
     it('should prefix MyInfo-verified fields with [MyInfo] only in form data', () => {
@@ -338,41 +359,43 @@ describe('email-submission.service', () => {
         new Set([nameResponse._id]),
       )
 
-      expect(emailData).toEqual({
-        jsonData: [
-          { question: nameResponse.question, answer: nameResponse.answer },
-          {
-            question: vehicleResponse.question,
-            answer: vehicleResponse.answer,
-          },
-        ],
-        autoReplyData: [
-          {
-            question: nameResponse.question,
-            answerTemplate: [nameResponse.answer],
-          },
-          {
-            question: vehicleResponse.question,
-            answerTemplate: [vehicleResponse.answer],
-          },
-        ],
-        formData: [
-          {
-            // Prefixed because its ID was in the Set
-            question: `${MYINFO_PREFIX}${nameResponse.question}`,
-            answer: nameResponse.answer,
-            answerTemplate: [nameResponse.answer],
-            fieldType: BasicField.ShortText,
-          },
-          {
-            // Not prefixed because ID not in Set
-            question: vehicleResponse.question,
-            answer: vehicleResponse.answer,
-            answerTemplate: [vehicleResponse.answer],
-            fieldType: BasicField.ShortText,
-          },
-        ],
-      })
+      expect(emailData).toEqual(
+        expect.objectContaining({
+          jsonData: [
+            { question: nameResponse.question, answer: nameResponse.answer },
+            {
+              question: vehicleResponse.question,
+              answer: vehicleResponse.answer,
+            },
+          ],
+          autoReplyData: [
+            {
+              question: nameResponse.question,
+              answerTemplate: [nameResponse.answer],
+            },
+            {
+              question: vehicleResponse.question,
+              answerTemplate: [vehicleResponse.answer],
+            },
+          ],
+          formData: [
+            {
+              // Prefixed because its ID was in the Set
+              question: `${MYINFO_PREFIX}${nameResponse.question}`,
+              answer: nameResponse.answer,
+              answerTemplate: [nameResponse.answer],
+              fieldType: BasicField.ShortText,
+            },
+            {
+              // Not prefixed because ID not in Set
+              question: vehicleResponse.question,
+              answer: vehicleResponse.answer,
+              answerTemplate: [vehicleResponse.answer],
+              fieldType: BasicField.ShortText,
+            },
+          ],
+        }),
+      )
     })
   })
 
@@ -525,7 +548,9 @@ describe('email-submission.service', () => {
             cb(null, MOCK_HASH),
         )
       const response = generateNewAttachmentResponse()
-      const responseAsEmailField = generateSingleAnswerFormData(response)
+      const responseAsEmailField = generateSingleAnswerFormData(
+        (response as unknown) as ProcessedSingleAnswerResponse,
+      )
       const expectedBaseString = `${response.question} ${response.answer}; ${response.content}`
 
       const result = await EmailSubmissionService.hashSubmission(
@@ -569,7 +594,9 @@ describe('email-submission.service', () => {
         answer: 'answer1',
         content: Buffer.from('content1'),
       })
-      const responseAsEmailField1 = generateSingleAnswerFormData(response1)
+      const responseAsEmailField1 = generateSingleAnswerFormData(
+        (response1 as unknown) as ProcessedSingleAnswerResponse,
+      )
 
       const response2 = generateNewAttachmentResponse({
         question: 'question2',
@@ -577,7 +604,9 @@ describe('email-submission.service', () => {
         content: Buffer.from('content2'),
       })
       const expectedBaseString = `${response1.question} ${response1.answer}; ${response2.question} ${response2.answer}; ${response1.content}${response2.content}`
-      const responseAsEmailField2 = generateSingleAnswerFormData(response2)
+      const responseAsEmailField2 = generateSingleAnswerFormData(
+        (response2 as unknown) as ProcessedSingleAnswerResponse,
+      )
 
       const result = await EmailSubmissionService.hashSubmission(
         [responseAsEmailField1, responseAsEmailField2],
@@ -626,10 +655,10 @@ describe('email-submission.service', () => {
       const createEmailSubmissionSpy = jest
         .spyOn(EmailSubmissionModel, 'create')
         .mockResolvedValueOnce(
-          (mockSubmission as unknown) as IEmailSubmissionSchema,
+          (mockSubmission as unknown) as ResolvedValue<IEmailSubmissionSchema>,
         )
       const result = await EmailSubmissionService.saveSubmissionMetadata(
-        MOCK_EMAIL_FORM,
+        MOCK_EMAIL_FORM as IPopulatedEmailForm,
         { hash: MOCK_HASH.toString(), salt: MOCK_SALT.toString() },
       )
       expect(createEmailSubmissionSpy).toHaveBeenCalledWith({
@@ -649,7 +678,7 @@ describe('email-submission.service', () => {
         .spyOn(EmailSubmissionModel, 'create')
         .mockImplementationOnce(() => Promise.reject(new Error()))
       const result = await EmailSubmissionService.saveSubmissionMetadata(
-        MOCK_EMAIL_FORM,
+        MOCK_EMAIL_FORM as IPopulatedEmailForm,
         { hash: MOCK_HASH.toString(), salt: MOCK_SALT.toString() },
       )
       expect(createEmailSubmissionSpy).toHaveBeenCalledWith({
@@ -685,7 +714,9 @@ describe('email-submission.service', () => {
       MockMailService.sendSubmissionToAdmin.mockResolvedValueOnce(true)
 
       const result = await EmailSubmissionService.sendSubmissionToAdmin(
-        MOCK_PARAMS,
+        (MOCK_PARAMS as unknown) as Parameters<
+          typeof MailService['sendSubmissionToAdmin']
+        >[0],
       )
       expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
         MOCK_PARAMS,
@@ -697,7 +728,9 @@ describe('email-submission.service', () => {
       MockMailService.sendSubmissionToAdmin.mockRejectedValueOnce(true)
 
       const result = await EmailSubmissionService.sendSubmissionToAdmin(
-        MOCK_PARAMS,
+        (MOCK_PARAMS as unknown) as Parameters<
+          typeof MailService['sendSubmissionToAdmin']
+        >[0],
       )
       expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
         MOCK_PARAMS,

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -99,14 +99,13 @@ describe('email-submission.service', () => {
         [response],
         new Set(),
       )
-
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [],
-          autoReplyData: [generateSingleAnswerAutoreply(response)],
-          formData: [generateSingleAnswerFormData(response)],
-        }),
-      )
+      expect(emailData.dataCollationData).toEqual([])
+      expect(emailData.autoReplyData).toEqual([
+        generateSingleAnswerAutoreply(response),
+      ])
+      expect(emailData.formData).toEqual([
+        generateSingleAnswerFormData(response),
+      ])
     })
 
     it('should exclude non-visible fields from autoreply data', () => {
@@ -119,13 +118,13 @@ describe('email-submission.service', () => {
         new Set(),
       )
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [generateSingleAnswerJson(response)],
-          autoReplyData: [],
-          formData: [generateSingleAnswerFormData(response)],
-        }),
-      )
+      expect(emailData.dataCollationData).toEqual([
+        generateSingleAnswerJson(response),
+      ])
+      expect(emailData.autoReplyData).toEqual([])
+      expect(emailData.formData).toEqual([
+        generateSingleAnswerFormData(response),
+      ])
     })
 
     it('should generate table answers with [table] prefix in form and JSON data', () => {
@@ -140,32 +139,34 @@ describe('email-submission.service', () => {
       const firstRow = response.answerArray[0].join(',')
       const secondRow = response.answerArray[1].join(',')
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [
-            { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
-            { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
-          ],
-          autoReplyData: [
-            { question, answerTemplate: [firstRow] },
-            { question, answerTemplate: [secondRow] },
-          ],
-          formData: [
-            {
-              question: `${TABLE_PREFIX}${question}`,
-              answer: firstRow,
-              answerTemplate: [firstRow],
-              fieldType: BasicField.Table,
-            },
-            {
-              question: `${TABLE_PREFIX}${question}`,
-              answer: secondRow,
-              answerTemplate: [secondRow],
-              fieldType: BasicField.Table,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [
+        { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
+        { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
+      ]
+
+      const expectedAutoReplyData = [
+        { question, answerTemplate: [firstRow] },
+        { question, answerTemplate: [secondRow] },
+      ]
+
+      const expectedFormData = [
+        {
+          question: `${TABLE_PREFIX}${question}`,
+          answer: firstRow,
+          answerTemplate: [firstRow],
+          fieldType: BasicField.Table,
+        },
+        {
+          question: `${TABLE_PREFIX}${question}`,
+          answer: secondRow,
+          answerTemplate: [secondRow],
+          fieldType: BasicField.Table,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should generate checkbox answers correctly', () => {
@@ -179,20 +180,20 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = response.answerArray.join(', ')
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [{ question, answer }],
-          autoReplyData: [{ question, answerTemplate: [answer] }],
-          formData: [
-            {
-              question,
-              answer,
-              answerTemplate: [answer],
-              fieldType: BasicField.Checkbox,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [{ question, answer }]
+      const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
+      const expectedFormData = [
+        {
+          question,
+          answer,
+          answerTemplate: [answer],
+          fieldType: BasicField.Checkbox,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should generate attachment answers with [attachment] prefix in form and JSON data', () => {
@@ -206,22 +207,22 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = response.answer
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [
-            { question: `${ATTACHMENT_PREFIX}${question}`, answer },
-          ],
-          autoReplyData: [{ question, answerTemplate: [answer] }],
-          formData: [
-            {
-              question: `${ATTACHMENT_PREFIX}${question}`,
-              answer,
-              answerTemplate: [answer],
-              fieldType: BasicField.Attachment,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [
+        { question: `${ATTACHMENT_PREFIX}${question}`, answer },
+      ]
+      const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
+      const expectedFormData = [
+        {
+          question: `${ATTACHMENT_PREFIX}${question}`,
+          answer,
+          answerTemplate: [answer],
+          fieldType: BasicField.Attachment,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should split single answer fields by newline', () => {
@@ -237,20 +238,22 @@ describe('email-submission.service', () => {
 
       const question = response.question
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [{ question, answer }],
-          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-          formData: [
-            {
-              question,
-              answer,
-              answerTemplate: answer.split('\n'),
-              fieldType: BasicField.ShortText,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [{ question, answer }]
+      const expectedAutoReplyData = [
+        { question, answerTemplate: answer.split('\n') },
+      ]
+      const expectedFormData = [
+        {
+          question,
+          answer,
+          answerTemplate: answer.split('\n'),
+          fieldType: BasicField.ShortText,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should split table answers by newline', () => {
@@ -265,22 +268,24 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = answerArray[0].join(',')
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [
-            { question: `${TABLE_PREFIX}${question}`, answer },
-          ],
-          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-          formData: [
-            {
-              question: `${TABLE_PREFIX}${question}`,
-              answer,
-              answerTemplate: answer.split('\n'),
-              fieldType: BasicField.Table,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [
+        { question: `${TABLE_PREFIX}${question}`, answer },
+      ]
+      const expectedAutoReplyData = [
+        { question, answerTemplate: answer.split('\n') },
+      ]
+      const expectedFormData = [
+        {
+          question: `${TABLE_PREFIX}${question}`,
+          answer,
+          answerTemplate: answer.split('\n'),
+          fieldType: BasicField.Table,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should split checkbox answers by newline', () => {
@@ -295,20 +300,22 @@ describe('email-submission.service', () => {
       const question = response.question
       const answer = answerArray.join(', ')
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [{ question, answer }],
-          autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
-          formData: [
-            {
-              question,
-              answer,
-              answerTemplate: answer.split('\n'),
-              fieldType: BasicField.Checkbox,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [{ question, answer }]
+      const expectedAutoReplyData = [
+        { question, answerTemplate: answer.split('\n') },
+      ]
+      const expectedFormData = [
+        {
+          question,
+          answer,
+          answerTemplate: answer.split('\n'),
+          fieldType: BasicField.Checkbox,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should prefix verified fields with [verified] only in form data', () => {
@@ -323,20 +330,21 @@ describe('email-submission.service', () => {
 
       const question = response.question
       const answer = response.answer
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [{ question, answer }],
-          autoReplyData: [{ question, answerTemplate: [answer] }],
-          formData: [
-            {
-              question: `${VERIFIED_PREFIX}${question}`,
-              answer,
-              answerTemplate: [answer],
-              fieldType: BasicField.Email,
-            },
-          ],
-        }),
-      )
+
+      const expectedDataCollationData = [{ question, answer }]
+      const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
+      const expectedFormData = [
+        {
+          question: `${VERIFIED_PREFIX}${question}`,
+          answer,
+          answerTemplate: [answer],
+          fieldType: BasicField.Email,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
 
     it('should prefix MyInfo-verified fields with [MyInfo] only in form data', () => {
@@ -363,43 +371,43 @@ describe('email-submission.service', () => {
         new Set([nameResponse._id]),
       )
 
-      expect(emailData).toEqual(
-        expect.objectContaining({
-          dataCollationData: [
-            { question: nameResponse.question, answer: nameResponse.answer },
-            {
-              question: vehicleResponse.question,
-              answer: vehicleResponse.answer,
-            },
-          ],
-          autoReplyData: [
-            {
-              question: nameResponse.question,
-              answerTemplate: [nameResponse.answer],
-            },
-            {
-              question: vehicleResponse.question,
-              answerTemplate: [vehicleResponse.answer],
-            },
-          ],
-          formData: [
-            {
-              // Prefixed because its ID was in the Set
-              question: `${MYINFO_PREFIX}${nameResponse.question}`,
-              answer: nameResponse.answer,
-              answerTemplate: [nameResponse.answer],
-              fieldType: BasicField.ShortText,
-            },
-            {
-              // Not prefixed because ID not in Set
-              question: vehicleResponse.question,
-              answer: vehicleResponse.answer,
-              answerTemplate: [vehicleResponse.answer],
-              fieldType: BasicField.ShortText,
-            },
-          ],
-        }),
-      )
+      const expectedDataCollationData = [
+        { question: nameResponse.question, answer: nameResponse.answer },
+        {
+          question: vehicleResponse.question,
+          answer: vehicleResponse.answer,
+        },
+      ]
+      const expectedAutoReplyData = [
+        {
+          question: nameResponse.question,
+          answerTemplate: [nameResponse.answer],
+        },
+        {
+          question: vehicleResponse.question,
+          answerTemplate: [vehicleResponse.answer],
+        },
+      ]
+      const expectedFormData = [
+        {
+          // Prefixed because its ID was in the Set
+          question: `${MYINFO_PREFIX}${nameResponse.question}`,
+          answer: nameResponse.answer,
+          answerTemplate: [nameResponse.answer],
+          fieldType: BasicField.ShortText,
+        },
+        {
+          // Not prefixed because ID not in Set
+          question: vehicleResponse.question,
+          answer: vehicleResponse.answer,
+          answerTemplate: [vehicleResponse.answer],
+          fieldType: BasicField.ShortText,
+        },
+      ]
+
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
+      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
+      expect(emailData.formData).toEqual(expectedFormData)
     })
   })
 

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -81,14 +81,14 @@ describe('email-submission.service', () => {
       const expectedAutoReplyData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerAutoreply,
       )
-      const expectedJsonData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
+      const expectedDataCollationData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerJson,
       )
       const expectedFormData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerFormData,
       )
       expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
-      expect(emailData.jsonData).toEqual(expectedJsonData)
+      expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -102,7 +102,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [],
+          dataCollationData: [],
           autoReplyData: [generateSingleAnswerAutoreply(response)],
           formData: [generateSingleAnswerFormData(response)],
         }),
@@ -121,7 +121,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [generateSingleAnswerJson(response)],
+          dataCollationData: [generateSingleAnswerJson(response)],
           autoReplyData: [],
           formData: [generateSingleAnswerFormData(response)],
         }),
@@ -142,7 +142,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [
+          dataCollationData: [
             { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
             { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
           ],
@@ -181,7 +181,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question, answer }],
+          dataCollationData: [{ question, answer }],
           autoReplyData: [{ question, answerTemplate: [answer] }],
           formData: [
             {
@@ -208,7 +208,9 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question: `${ATTACHMENT_PREFIX}${question}`, answer }],
+          dataCollationData: [
+            { question: `${ATTACHMENT_PREFIX}${question}`, answer },
+          ],
           autoReplyData: [{ question, answerTemplate: [answer] }],
           formData: [
             {
@@ -237,7 +239,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question, answer }],
+          dataCollationData: [{ question, answer }],
           autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
           formData: [
             {
@@ -265,7 +267,9 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question: `${TABLE_PREFIX}${question}`, answer }],
+          dataCollationData: [
+            { question: `${TABLE_PREFIX}${question}`, answer },
+          ],
           autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
           formData: [
             {
@@ -293,7 +297,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question, answer }],
+          dataCollationData: [{ question, answer }],
           autoReplyData: [{ question, answerTemplate: answer.split('\n') }],
           formData: [
             {
@@ -321,7 +325,7 @@ describe('email-submission.service', () => {
       const answer = response.answer
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [{ question, answer }],
+          dataCollationData: [{ question, answer }],
           autoReplyData: [{ question, answerTemplate: [answer] }],
           formData: [
             {
@@ -361,7 +365,7 @@ describe('email-submission.service', () => {
 
       expect(emailData).toEqual(
         expect.objectContaining({
-          jsonData: [
+          dataCollationData: [
             { question: nameResponse.question, answer: nameResponse.answer },
             {
               question: vehicleResponse.question,
@@ -707,7 +711,7 @@ describe('email-submission.service', () => {
           content: Buffer.from('content'),
         },
       ],
-      jsonData: [{ question: 'question', answer: 'answer' }],
+      dataCollationData: [{ question: 'question', answer: 'answer' }],
       formData: [{ question: 'question', answer: 'answer' }],
     }
     it('should call MailService correctly', async () => {

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -4,11 +4,9 @@ import { cloneDeep, merge } from 'lodash'
 
 import {
   BasicField,
-  EmailAutoReplyField,
   FieldResponse,
   IAttachmentResponse,
   ISingleAnswerResponse,
-  SPCPFieldTitle,
 } from 'src/types'
 
 import {
@@ -17,7 +15,6 @@ import {
   getInvalidFileExtensions,
   handleDuplicatesInAttachments,
   mapAttachmentsFromResponses,
-  maskUidOnLastField,
 } from '../email-submission.util'
 
 const validSingleFile = {
@@ -302,33 +299,6 @@ describe('email-submission.util', () => {
         filename: secondAttachment.filename,
         content: secondAttachment.content,
       })
-    })
-  })
-
-  describe('maskUidOnLastField', () => {
-    it('should mask UID on SPCPFieldTitle.CpUid if it is the last field of autoReplyData', () => {
-      const autoReplyData: EmailAutoReplyField[] = [
-        { question: 'question 1', answerTemplate: ['answer1'] },
-        { question: SPCPFieldTitle.CpUid, answerTemplate: ['S1234567A'] },
-      ]
-      const maskedAutoReplyData: EmailAutoReplyField[] = [
-        { question: 'question 1', answerTemplate: ['answer1'] },
-        { question: SPCPFieldTitle.CpUid, answerTemplate: ['*****567A'] },
-      ]
-      expect(maskUidOnLastField(autoReplyData)).toEqual(maskedAutoReplyData)
-    })
-    it('should not mask UID on form field with same name as SPCPFieldTitle.CpUid if it is not the last field of autoReplyData', () => {
-      const autoReplyData: EmailAutoReplyField[] = [
-        { question: 'question 1', answerTemplate: ['answer1'] },
-        { question: 'CorpPass Validated UID', answerTemplate: ['S9999999Z'] },
-        { question: SPCPFieldTitle.CpUid, answerTemplate: ['S1234567A'] },
-      ]
-      const maskedAutoReplyData: EmailAutoReplyField[] = [
-        { question: 'question 1', answerTemplate: ['answer1'] },
-        { question: 'CorpPass Validated UID', answerTemplate: ['S9999999Z'] },
-        { question: SPCPFieldTitle.CpUid, answerTemplate: ['*****567A'] },
-      ]
-      expect(maskUidOnLastField(autoReplyData)).toEqual(maskedAutoReplyData)
     })
   })
 })

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -3,16 +3,23 @@ import { readFileSync } from 'fs'
 import { cloneDeep, merge } from 'lodash'
 
 import {
+  AuthType,
   BasicField,
   FieldResponse,
   IAttachmentResponse,
   ISingleAnswerResponse,
+  SPCPFieldTitle,
 } from 'src/types'
 
+import { ProcessedFieldResponse } from '../../submission.types'
+import { createEmailData } from '../email-submission.service'
+import { ResponseFormattedForEmail } from '../email-submission.types'
 import {
   addAttachmentToResponses,
   areAttachmentsMoreThan7MB,
+  getFormDataPrefixedQuestion,
   getInvalidFileExtensions,
+  getJsonPrefixedQuestion,
   handleDuplicatesInAttachments,
   mapAttachmentsFromResponses,
 } from '../email-submission.util'
@@ -299,6 +306,123 @@ describe('email-submission.util', () => {
         filename: secondAttachment.filename,
         content: secondAttachment.content,
       })
+    })
+  })
+
+  describe('Submission Email Object', () => {
+    const response1 = getResponse(
+      String(new ObjectId()),
+      MOCK_ANSWER,
+    ) as ProcessedFieldResponse
+
+    const response2 = getResponse(
+      String(new ObjectId()),
+      '',
+    ) as ProcessedFieldResponse
+
+    response1.fieldType = BasicField.YesNo
+    response2.fieldType = BasicField.YesNo
+    response1.isVisible = true
+    response2.isVisible = false
+
+    const hashedFields = new Set([
+      new ObjectId().toHexString(),
+      new ObjectId().toHexString(),
+    ])
+    const authType = AuthType.NIL
+    const submissionEmailObj = createEmailData(
+      [response1, response2],
+      hashedFields,
+      authType,
+    )
+
+    it('should return the response in correct json format when dataCollationData() method is called', () => {
+      const correctJson = [
+        {
+          question: getJsonPrefixedQuestion(
+            response1 as ResponseFormattedForEmail,
+          ),
+          answer: (response1 as ResponseFormattedForEmail).answer,
+        },
+        {
+          question: getJsonPrefixedQuestion(
+            response2 as ResponseFormattedForEmail,
+          ),
+          answer: (response2 as ResponseFormattedForEmail).answer,
+        },
+      ]
+      expect(submissionEmailObj.dataCollationData).toEqual(correctJson)
+    })
+
+    it('should return the response in correct admin response format when formData() method is called', () => {
+      const correctFormData = [
+        {
+          question: getFormDataPrefixedQuestion(
+            response1 as ResponseFormattedForEmail,
+            hashedFields,
+          ),
+          answerTemplate: (response1 as ResponseFormattedForEmail).answer.split(
+            '\n',
+          ),
+          answer: (response1 as ResponseFormattedForEmail).answer,
+          fieldType: response1.fieldType,
+        },
+        {
+          question: getFormDataPrefixedQuestion(
+            response2 as ResponseFormattedForEmail,
+            hashedFields,
+          ),
+          answerTemplate: (response2 as ResponseFormattedForEmail).answer.split(
+            '\n',
+          ),
+          answer: (response2 as ResponseFormattedForEmail).answer,
+          fieldType: response2.fieldType,
+        },
+      ]
+      expect(submissionEmailObj.formData).toEqual(correctFormData)
+    })
+
+    it('should return the response in correct email confirmation format when autoReplyData() method is called', () => {
+      const correctConfirmation = [
+        {
+          question: response1.question,
+          answerTemplate: (response1 as ResponseFormattedForEmail).answer.split(
+            '\n',
+          ),
+        },
+        // Note that response2 is not shown in Email Confirmation as isVisible is false
+      ]
+      expect(submissionEmailObj.autoReplyData).toEqual(correctConfirmation)
+    })
+
+    it('should mask corppass UID if AuthType is Corppass and autoReplyData() method is called', () => {
+      const responseCPUID = getResponse(
+        String(new ObjectId()),
+        'S1234567A',
+      ) as ProcessedFieldResponse
+
+      responseCPUID.question = SPCPFieldTitle.CpUid
+      responseCPUID.isVisible = true
+
+      const submissionEmailObjCP = createEmailData(
+        [response1, response2, responseCPUID],
+        hashedFields,
+        AuthType.CP,
+      )
+      const correctConfirmation = [
+        {
+          question: response1.question,
+          answerTemplate: (response1 as ResponseFormattedForEmail).answer.split(
+            '\n',
+          ),
+        },
+        // Note that response2 is not shown in Email Confirmation as isVisible is false
+        {
+          question: responseCPUID.question,
+          answerTemplate: ['*****567A'],
+        },
+      ]
+      expect(submissionEmailObjCP.autoReplyData).toEqual(correctConfirmation)
     })
   })
 })

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -209,7 +209,7 @@ export const handleEmailSubmission: RequestHandler<
       form,
       submission,
       attachments,
-      jsonData: emailData.jsonData,
+      dataCollationData: emailData.dataCollationData,
       formData: emailData.formData,
     },
   )

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -22,7 +22,6 @@ import * as EmailSubmissionService from './email-submission.service'
 import {
   mapAttachmentsFromResponses,
   mapRouteError,
-  maskUidOnLastField,
 } from './email-submission.util'
 
 const logger = createLoggerWithLabel(module)
@@ -172,6 +171,7 @@ export const handleEmailSubmission: RequestHandler<
   const emailData = EmailSubmissionService.createEmailData(
     parsedResponses,
     hashedFields,
+    authType,
   )
 
   // Save submission to database
@@ -242,10 +242,7 @@ export const handleEmailSubmission: RequestHandler<
     parsedResponses,
     submission,
     attachments,
-    autoReplyData:
-      authType === AuthType.CP
-        ? maskUidOnLastField(emailData.autoReplyData)
-        : emailData.autoReplyData,
+    autoReplyData: emailData.autoReplyData,
   }).mapErr((error) => {
     logger.error({
       message: 'Error while sending email confirmations',

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -48,10 +48,12 @@ export const prepareEmailSubmission: RequestHandler<
     (res as ResWithHashedFields<typeof res>).locals.hashedFields || new Set()
   let emailData: EmailData
   // TODO (#847): remove when we are sure of the shape of responses
+  const { form } = req as WithForm<typeof req>
   try {
     emailData = EmailSubmissionService.createEmailData(
       req.body.parsedResponses,
       hashedFields,
+      form.authType,
     )
   } catch (error) {
     logger.error({

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -85,7 +85,8 @@ export const prepareEmailSubmission: RequestHandler<
   }
   // eslint-disable-next-line @typescript-eslint/no-extra-semi
   ;(req as WithEmailData<typeof req>).autoReplyData = emailData.autoReplyData
-  ;(req as WithEmailData<typeof req>).jsonData = emailData.jsonData
+  ;(req as WithEmailData<typeof req>).dataCollationData =
+    emailData.dataCollationData
   ;(req as WithEmailData<typeof req>).formData = emailData.formData
   return next()
 }
@@ -184,7 +185,7 @@ export const validateEmailSubmission: RequestHandler<
  * @param req - Express request object
  * @param req.form - form object from req
  * @param req.formData - the submission for the form
- * @param req.jsonData - data to be included in JSON section of email
+ * @param req.dataCollationData - data to be included in JSON section of email
  * @param req.submission - submission which was saved to database
  * @param req.attachments - submitted attachments, parsed by
  * exports.receiveSubmission
@@ -200,7 +201,7 @@ export const sendAdminEmail: RequestHandler<
   const {
     form,
     formData,
-    jsonData,
+    dataCollationData,
     submission,
     attachments,
   } = req as WithAdminEmailData<typeof req>
@@ -222,7 +223,7 @@ export const sendAdminEmail: RequestHandler<
     form,
     submission,
     attachments,
-    jsonData,
+    dataCollationData,
     formData,
   })
     .map(() => next())

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -6,8 +6,8 @@ import { createLoggerWithLabel } from '../../../../config/logger'
 import {
   AuthType,
   BasicField,
+  EmailAdminDataField,
   EmailData,
-  EmailFormField,
   FieldResponse,
   IAttachmentInfo,
   IEmailSubmissionSchema,
@@ -116,7 +116,7 @@ export const validateAttachments = (
  * @returns errAsync(ConcatSubmissionError) if error occurred while concatenating attachments
  */
 export const hashSubmission = (
-  formData: EmailFormField[],
+  formData: EmailAdminDataField[],
   attachments: IAttachmentInfo[],
 ): ResultAsync<SubmissionHash, SubmissionHashError | ConcatSubmissionError> => {
   // TODO (#847): remove this try-catch when we are sure that the shape of formData is correct

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -40,9 +40,9 @@ import { SubmissionHash } from './email-submission.types'
 import {
   areAttachmentsMoreThan7MB,
   concatAttachmentsAndResponses,
-  EmailDataObj,
   getInvalidFileExtensions,
   mapAttachmentsFromResponses,
+  SubmissionEmailObj,
 } from './email-submission.util'
 
 const EmailSubmissionModel = getEmailSubmissionModel(mongoose)
@@ -59,7 +59,7 @@ export const createEmailData = (
   hashedFields: Set<string>,
   authType: AuthType = AuthType.NIL,
 ): EmailData => {
-  return new EmailDataObj(parsedResponses, hashedFields, authType)
+  return new SubmissionEmailObj(parsedResponses, hashedFields, authType)
 }
 
 /**

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -57,7 +57,7 @@ const logger = createLoggerWithLabel(module)
 export const createEmailData = (
   parsedResponses: ProcessedFieldResponse[],
   hashedFields: Set<string>,
-  authType: AuthType = AuthType.NIL, //default to AuthType.NIL
+  authType: AuthType = AuthType.NIL,
 ): EmailData => {
   return new EmailDataObj(parsedResponses, hashedFields, authType)
 }

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -621,11 +621,10 @@ const getDataCollationFormattedResponse = (
   const { answer, fieldType } = response
   // Headers are excluded from JSON data
   if (fieldType !== BasicField.Section) {
-    const dataCollationData = {
+    return {
       question: getJsonPrefixedQuestion(response),
       answer,
     }
-    return dataCollationData
   }
   return undefined
 }
@@ -640,13 +639,12 @@ const getFormFormattedResponse = (
 ): EmailAdminDataField => {
   const { answer, fieldType } = response
   const answerSplitByNewLine = answer.split('\n')
-  const formData = {
+  return {
     question: getFormDataPrefixedQuestion(response, hashedFields),
     answerTemplate: answerSplitByNewLine,
     answer,
     fieldType,
   }
-  return formData
 }
 
 /**
@@ -660,11 +658,10 @@ const getAutoReplyFormattedResponse = (
   const answerSplitByNewLine = answer.split('\n')
   // Auto reply email will contain only visible fields
   if (isVisible) {
-    const autoReplyData = {
+    return {
       question, // No prefixes for autoreply
       answerTemplate: answerSplitByNewLine,
     }
-    return autoReplyData
   }
   return undefined
 }
@@ -707,22 +704,21 @@ export class EmailDataObj {
    * If AuthType is CP, return a masked version
    */
   get autoReplyData(): EmailRespondentConfirmationField[] {
-    const unmaskedAutoReplyFormattedData = this.parsedResponses.flatMap(
-      (response) =>
-        createFormattedDataForOneField(
-          response,
-          this.hashedFields,
-          getAutoReplyFormattedResponse,
-        ),
-    )
-
     // Compact is necessary because getAutoReplyFormattedResponse
     // will return undefined for non-visible fields
-    const unmaskedAutoReplyData = compact(unmaskedAutoReplyFormattedData)
-    const maskedAutoReplyData = maskUidOnLastField(unmaskedAutoReplyData)
+    const unmaskedAutoReplyData = compact(
+      this.parsedResponses.flatMap(
+        (response) =>
+          createFormattedDataForOneField(
+            response,
+            this.hashedFields,
+            getAutoReplyFormattedResponse,
+          ),
+      )
+    )
 
     return this.authType === AuthType.CP
-      ? maskedAutoReplyData
+      ? maskUidOnLastField(unmaskedAutoReplyData)
       : unmaskedAutoReplyData
   }
   /**

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -608,6 +608,7 @@ const maskField = (field: EmailAutoReplyField): EmailAutoReplyField => {
 
 /**
  * Function to extract information for email json field from response
+ * Json field is used for data collation tool
  */
 const getJsonFormattedResponse = (
   response: ResponseFormattedForEmail,
@@ -626,6 +627,7 @@ const getJsonFormattedResponse = (
 
 /**
  * Function to extract information for email form field from response
+ * Form field is used to send responses to admin
  */
 const getFormFormattedResponse = (
   response: ResponseFormattedForEmail,
@@ -644,6 +646,7 @@ const getFormFormattedResponse = (
 
 /**
  * Function to extract information for email autoreply field from response
+ * Autoreply field is used to send confirmation emails
  */
 const getAutoReplyFormattedResponse = (
   response: ResponseFormattedForEmail,
@@ -674,7 +677,7 @@ export class EmailDataObj {
   }
 
   /**
-   * Getter function to return jsonData
+   * Getter function to return jsonData which is used for data collation tool
    */
   get jsonData(): EmailJsonField[] {
     return this.parsedResponses.flatMap((response) =>
@@ -689,7 +692,7 @@ export class EmailDataObj {
   }
 
   /**
-   * Getter function to return autoReplyData
+   * Getter function to return autoReplyData for confirmation emails to respondent
    */
   get autoReplyData(): EmailAutoReplyField[] {
     return this.parsedResponses.flatMap((response) =>
@@ -716,7 +719,7 @@ export class EmailDataObj {
   }
 
   /**
-   * Getter function to return formData
+   * Getter function to return formData which is used to send responses to admin
    */
   get formData(): EmailFormField[] {
     return this.parsedResponses.flatMap((response) =>

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -24,11 +24,6 @@ import {
   VerifyCaptchaError,
 } from '../../../services/captcha/captcha.errors'
 import {
-  MyInfoHashDidNotMatchError,
-  MyInfoHashingError,
-  MyInfoMissingHashError,
-} from '../../../services/myinfo/myinfo.errors'
-import {
   isProcessedCheckboxResponse,
   isProcessedTableResponse,
 } from '../../../utils/field-validation/field-validation.guards'

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -198,7 +198,7 @@ export const getAnswerForCheckbox = (
 /**
  *  Formats the response for sending to the submitter (autoReplyData),
  *  the table that is sent to the admin (formData),
- *  and the json used by data collation tool (jsonData).
+ *  and the json used by data collation tool (dataCollationData).
  *
  * @param response
  * @param hashedFields Field IDs hashed to verify answers provided by MyInfo
@@ -212,7 +212,7 @@ export const getFormattedResponse = (
   const answerSplitByNewLine = answer.split('\n')
 
   let autoReplyData: EmailRespondentConfirmationField | undefined
-  let jsonData: EmailDataCollationToolField | undefined
+  let dataCollationData: EmailDataCollationToolField | undefined
   // Auto reply email will contain only visible fields
   if (isVisible) {
     autoReplyData = {
@@ -223,7 +223,7 @@ export const getFormattedResponse = (
 
   // Headers are excluded from JSON data
   if (fieldType !== BasicField.Section) {
-    jsonData = {
+    dataCollationData = {
       question: getJsonPrefixedQuestion(response),
       answer,
     }
@@ -238,7 +238,7 @@ export const getFormattedResponse = (
   }
   return {
     autoReplyData,
-    jsonData,
+    dataCollationData,
     formData,
   }
 }
@@ -612,11 +612,11 @@ const getJsonFormattedResponse = (
   const { answer, fieldType } = response
   // Headers are excluded from JSON data
   if (fieldType !== BasicField.Section) {
-    const jsonData = {
+    const dataCollationData = {
       question: getJsonPrefixedQuestion(response),
       answer,
     }
-    return jsonData
+    return dataCollationData
   }
   return undefined
 }
@@ -676,9 +676,9 @@ export class EmailDataObj {
   }
 
   /**
-   * Getter function to return jsonData which is used for data collation tool
+   * Getter function to return dataCollationData which is used for data collation tool
    */
-  get jsonData(): EmailDataCollationToolField[] {
+  get dataCollationData(): EmailDataCollationToolField[] {
     return this.parsedResponses.flatMap((response) =>
       compact(
         createFormattedDataForOneField(

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -666,7 +666,7 @@ const getAutoReplyFormattedResponse = (
   return undefined
 }
 
-export class EmailDataObj {
+export class SubmissionEmailObj {
   parsedResponses: ProcessedFieldResponse[]
   hashedFields: Set<string>
   authType: AuthType

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -568,6 +568,10 @@ const createFormattedDataForOneField = <T>(
  * @param charsToReveal The number of characters at the tail to reveal
  */
 const maskStringHead = (field: string, charsToReveal = 4): string => {
+  // Defensive, in case a negative number is passed in
+  // the entire string is masked
+  if (charsToReveal < 0) return '*'.repeat(field.length)
+
   return field.length >= charsToReveal
     ? '*'.repeat(field.length - charsToReveal) + field.substr(-charsToReveal)
     : field

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import { flattenDeep, sumBy } from 'lodash'
+import { compact, flattenDeep, sumBy } from 'lodash'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
 import { FilePlatforms } from '../../../../shared/constants'
@@ -568,14 +568,6 @@ export const maskUidOnLastField = (
 }
 
 /**
- * Type guard to check that values are not undefined
- * Used in filter in EmailDataObj methods
- */
-const notUndefined = <T>(value: T | undefined): value is T => {
-  return value !== undefined
-}
-
-/**
  * Function to generate email data
  * for a single field
  */
@@ -686,11 +678,13 @@ export class EmailDataObj {
    */
   get jsonData(): EmailJsonField[] {
     return this.parsedResponses.flatMap((response) =>
-      createFormattedDataForOneField(
-        response,
-        this.hashedFields,
-        getJsonFormattedResponse,
-      ).filter(notUndefined),
+      compact(
+        createFormattedDataForOneField(
+          response,
+          this.hashedFields,
+          getJsonFormattedResponse,
+        ),
+      ),
     )
   }
 
@@ -699,11 +693,13 @@ export class EmailDataObj {
    */
   get autoReplyData(): EmailAutoReplyField[] {
     return this.parsedResponses.flatMap((response) =>
-      createFormattedDataForOneField(
-        response,
-        this.hashedFields,
-        getAutoReplyFormattedResponse,
-      ).filter(notUndefined),
+      compact(
+        createFormattedDataForOneField(
+          response,
+          this.hashedFields,
+          getAutoReplyFormattedResponse,
+        ),
+      ),
     )
   }
 
@@ -724,11 +720,13 @@ export class EmailDataObj {
    */
   get formData(): EmailFormField[] {
     return this.parsedResponses.flatMap((response) =>
-      createFormattedDataForOneField(
-        response,
-        this.hashedFields,
-        getFormFormattedResponse,
-      ).filter(notUndefined),
+      compact(
+        createFormattedDataForOneField(
+          response,
+          this.hashedFields,
+          getFormFormattedResponse,
+        ),
+      ),
     )
   }
 }

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -707,14 +707,13 @@ export class EmailDataObj {
     // Compact is necessary because getAutoReplyFormattedResponse
     // will return undefined for non-visible fields
     const unmaskedAutoReplyData = compact(
-      this.parsedResponses.flatMap(
-        (response) =>
-          createFormattedDataForOneField(
-            response,
-            this.hashedFields,
-            getAutoReplyFormattedResponse,
-          ),
-      )
+      this.parsedResponses.flatMap((response) =>
+        createFormattedDataForOneField(
+          response,
+          this.hashedFields,
+          getAutoReplyFormattedResponse,
+        ),
+      ),
     )
 
     return this.authType === AuthType.CP

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -534,8 +534,13 @@ export const concatAttachmentsAndResponses = (
 }
 
 /**
- * Function to generate email data
- * for a single field
+ * Applies a formatting function to generate email data for a single field
+ * @param response
+ * @param hashedFields Used if formatting function is getFormFormattedResponse to provide
+ * [verified] field to admin
+ * @param getFormattedFunction The formatting function to use
+ * @returns EmailRespondentConfirmationField[], EmailDataCollationToolField[] or
+ * EmailAdminDataField[] depending on which formatting function is used
  */
 const createFormattedDataForOneField = <T extends EmailDataFields | undefined>(
   response: ProcessedFieldResponse,

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -591,7 +591,7 @@ const maskUidOnLastField = (
   // TODO(#1104): Refactor to move validation and construction of parsedResponses in class constructor
   // This will allow for proper tagging of corppass UID field instead of checking field title and position
 
-  const maskedAutoReplyData = autoReplyData.map(
+  return autoReplyData.map(
     (autoReplyField: EmailRespondentConfirmationField, index) => {
       if (
         autoReplyField.question === SPCPFieldTitle.CpUid && // Check field title
@@ -609,7 +609,6 @@ const maskUidOnLastField = (
       }
     },
   )
-  return maskedAutoReplyData
 }
 
 /**

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -9,6 +9,7 @@ import {
   BasicField,
   EmailAdminDataField,
   EmailDataCollationToolField,
+  EmailDataFields,
   EmailDataForOneField,
   EmailRespondentConfirmationField,
   FieldResponse,
@@ -541,7 +542,7 @@ export const concatAttachmentsAndResponses = (
  * Function to generate email data
  * for a single field
  */
-const createFormattedDataForOneField = <T>(
+const createFormattedDataForOneField = <T extends EmailDataFields | undefined>(
   response: ProcessedFieldResponse,
   hashedFields: Set<string>,
   getFormattedFunction: (

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -8,7 +8,7 @@ import {
   getVisibleFieldIds,
 } from '../../../shared/util/logic'
 import {
-  EmailAutoReplyField,
+  EmailRespondentConfirmationField,
   FieldResponse,
   IAttachmentInfo,
   IFieldSchema,
@@ -237,7 +237,7 @@ export const sendEmailConfirmations = ({
   form: IPopulatedForm
   submission: ISubmissionSchema
   parsedResponses: ProcessedFieldResponse[]
-  autoReplyData?: EmailAutoReplyField[]
+  autoReplyData?: EmailRespondentConfirmationField[]
   attachments?: IAttachmentInfo[]
 }): ResultAsync<true, SendEmailConfirmationError> => {
   const logMeta = {

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -364,7 +364,7 @@ describe('mail.service', () => {
         created: new Date(),
       },
       attachments: [],
-      jsonData: [
+      dataCollationData: [
         {
           question: 'some question',
           answer: 'some answer',
@@ -389,7 +389,7 @@ describe('mail.service', () => {
         question: 'Timestamp',
         answer: FORMATTED_SUBMISSION_TIME,
       },
-      ...MOCK_VALID_SUBMISSION_PARAMS.jsonData,
+      ...MOCK_VALID_SUBMISSION_PARAMS.dataCollationData,
     ]
 
     const generateExpectedArgWithToField = (toField: string[]) => {
@@ -414,7 +414,7 @@ describe('mail.service', () => {
         appName: MOCK_APP_NAME,
         formData: MOCK_VALID_SUBMISSION_PARAMS.formData,
         formTitle: MOCK_VALID_SUBMISSION_PARAMS.form.title,
-        jsonData: EXPECTED_JSON_DATA,
+        dataCollationData: EXPECTED_JSON_DATA,
         refNo: MOCK_VALID_SUBMISSION_PARAMS.submission.id,
         submissionTime: FORMATTED_SUBMISSION_TIME,
       }

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -10,7 +10,7 @@ import { createLoggerWithLabel } from '../../../config/logger'
 import { HASH_EXPIRE_AFTER_SECONDS } from '../../../shared/util/verification'
 import {
   BounceType,
-  EmailFormField,
+  EmailAdminDataField,
   IEmailFormSchema,
   ISubmissionSchema,
 } from '../../../types'
@@ -379,7 +379,7 @@ export class MailService {
     form: Pick<IEmailFormSchema, '_id' | 'title' | 'emails'>
     submission: Pick<ISubmissionSchema, 'id' | 'created'>
     attachments?: Mail.Attachment[]
-    formData: EmailFormField[]
+    formData: EmailAdminDataField[]
     jsonData: {
       question: string
       answer: string | number

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -364,7 +364,7 @@ export class MailService {
    * @param args.form the form document to retrieve some email data from
    * @param args.submission the submission document to retrieve some email data from
    * @param args.attachments attachments to append to the email, if any
-   * @param args.jsonData the data to use in the data collation tool to be appended to the end of the email
+   * @param args.dataCollationData the data to use in the data collation tool to be appended to the end of the email
    * @param args.formData the form data to display to in the body in table form
    */
   sendSubmissionToAdmin = async ({
@@ -372,7 +372,7 @@ export class MailService {
     form,
     submission,
     attachments,
-    jsonData,
+    dataCollationData,
     formData,
   }: {
     replyToEmails?: string[]
@@ -380,7 +380,7 @@ export class MailService {
     submission: Pick<ISubmissionSchema, 'id' | 'created'>
     attachments?: Mail.Attachment[]
     formData: EmailAdminDataField[]
-    jsonData: {
+    dataCollationData: {
       question: string
       answer: string | number
     }[]
@@ -391,9 +391,9 @@ export class MailService {
       .tz('Asia/Singapore')
       .format('ddd, DD MMM YYYY hh:mm:ss A')
 
-    // Add in additional metadata to jsonData.
+    // Add in additional metadata to dataCollationData.
     // Unshift is not used as it mutates the array.
-    const fullJsonData = [
+    const fullDataCollationData = [
       {
         question: 'Reference Number',
         answer: refNo,
@@ -402,7 +402,7 @@ export class MailService {
         question: 'Timestamp',
         answer: submissionTime,
       },
-      ...jsonData,
+      ...dataCollationData,
     ]
 
     const htmlData = {
@@ -410,7 +410,7 @@ export class MailService {
       formTitle,
       refNo,
       submissionTime,
-      jsonData: fullJsonData,
+      dataCollationData: fullDataCollationData,
       formData,
     }
 

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -64,7 +64,7 @@ export type SubmissionToAdminHtmlData = {
   formTitle: string
   submissionTime: string
   formData: EmailAdminDataField[]
-  jsonData: {
+  dataCollationData: {
     question: string
     answer: string | number
   }[]

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -3,7 +3,7 @@ import { OperationOptions } from 'retry'
 
 import {
   AutoReplyOptions,
-  EmailFormField,
+  EmailAdminDataField,
   IFormSchema,
   IPopulatedForm,
   ISubmissionSchema,
@@ -27,7 +27,7 @@ export type SendAutoReplyEmailsArgs = {
   form: Pick<IPopulatedForm, 'admin' | '_id' | 'title'>
   submission: Pick<ISubmissionSchema, 'id' | 'created'>
   attachments?: Mail.Attachment[]
-  responsesData: Pick<EmailFormField, 'question' | 'answerTemplate'>[]
+  responsesData: Pick<EmailAdminDataField, 'question' | 'answerTemplate'>[]
   autoReplyMailDatas: AutoReplyMailData[]
 }
 
@@ -51,7 +51,7 @@ export type AutoreplySummaryRenderData = {
   refNo: ISubmissionSchema['_id']
   formTitle: IFormSchema['title']
   submissionTime: string
-  formData: Pick<EmailFormField, 'question' | 'answerTemplate'>[]
+  formData: Pick<EmailAdminDataField, 'question' | 'answerTemplate'>[]
   formUrl: string
 }
 
@@ -63,7 +63,7 @@ export type SubmissionToAdminHtmlData = {
   refNo: string
   formTitle: string
   submissionTime: string
-  formData: EmailFormField[]
+  formData: EmailAdminDataField[]
   jsonData: {
     question: string
     answer: string | number

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -8,20 +8,20 @@
     <table
       id="formsg"
       width="100%"
-      style="border-collapse: collapse;"
+      style="border-collapse: collapse"
       cellpadding="5"
     >
       <tbody>
-        <tr style="border-top: 1px solid #eee;">
+        <tr style="border-top: 1px solid #eee">
           <td width="40%"><strong>Reference Number</strong></td>
           <td><%= refNo %></td>
         </tr>
-        <tr style="border-top: 1px solid #eee;">
+        <tr style="border-top: 1px solid #eee">
           <td width="40%"><strong>Timestamp</strong></td>
           <td><%= submissionTime %></td>
         </tr>
         <% formData.forEach(function(fieldTuple) { %>
-        <tr style="border-top: 1px solid #eee;">
+        <tr style="border-top: 1px solid #eee">
           <td width="40%"><strong><%= fieldTuple.question %></strong></td>
           <td>
             <% fieldTuple.answerTemplate.forEach(function(answer) { %> <%=
@@ -41,7 +41,7 @@
       process.
     </p>
     <p>-- Start of JSON --</p>
-    <%= JSON.stringify(jsonData) %>
+    <%= JSON.stringify(dataCollationData) %>
     <p>-- End of JSON --</p>
   </body>
 </html>

--- a/src/types/express.locals.ts
+++ b/src/types/express.locals.ts
@@ -59,13 +59,13 @@ export interface EmailAdminDataField {
 
 export interface EmailData {
   autoReplyData: EmailRespondentConfirmationField[]
-  jsonData: EmailDataCollationToolField[]
+  dataCollationData: EmailDataCollationToolField[]
   formData: EmailAdminDataField[]
 }
 
 export interface EmailDataForOneField {
   autoReplyData?: EmailRespondentConfirmationField
-  jsonData?: EmailDataCollationToolField
+  dataCollationData?: EmailDataCollationToolField
   formData: EmailAdminDataField
 }
 

--- a/src/types/express.locals.ts
+++ b/src/types/express.locals.ts
@@ -40,22 +40,27 @@ export type SpcpLocals =
   | { uinFin: string; userInfo: string }
   | { [key: string]: never } // empty object
 
-export interface EmailRespondentConfirmationField {
+export type EmailRespondentConfirmationField = {
   question: string
   answerTemplate: string[]
 }
 
-export interface EmailDataCollationToolField {
+export type EmailDataCollationToolField = {
   question: string
   answer: string
 }
 
-export interface EmailAdminDataField {
+export type EmailAdminDataField = {
   question: string
   answer: string
   fieldType: BasicField
   answerTemplate: string[]
 }
+
+export type EmailDataFields =
+  | EmailRespondentConfirmationField
+  | EmailDataCollationToolField
+  | EmailAdminDataField
 
 export interface EmailData {
   autoReplyData: EmailRespondentConfirmationField[]

--- a/src/types/express.locals.ts
+++ b/src/types/express.locals.ts
@@ -40,17 +40,17 @@ export type SpcpLocals =
   | { uinFin: string; userInfo: string }
   | { [key: string]: never } // empty object
 
-export interface EmailAutoReplyField {
+export interface EmailRespondentConfirmationField {
   question: string
   answerTemplate: string[]
 }
 
-export interface EmailJsonField {
+export interface EmailDataCollationToolField {
   question: string
   answer: string
 }
 
-export interface EmailFormField {
+export interface EmailAdminDataField {
   question: string
   answer: string
   fieldType: BasicField
@@ -58,15 +58,15 @@ export interface EmailFormField {
 }
 
 export interface EmailData {
-  autoReplyData: EmailAutoReplyField[]
-  jsonData: EmailJsonField[]
-  formData: EmailFormField[]
+  autoReplyData: EmailRespondentConfirmationField[]
+  jsonData: EmailDataCollationToolField[]
+  formData: EmailAdminDataField[]
 }
 
 export interface EmailDataForOneField {
-  autoReplyData?: EmailAutoReplyField
-  jsonData?: EmailJsonField
-  formData: EmailFormField
+  autoReplyData?: EmailRespondentConfirmationField
+  jsonData?: EmailDataCollationToolField
+  formData: EmailAdminDataField
 }
 
 export type WithSubmission<T> = T & { submission: ISubmissionSchema }

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -105,7 +105,7 @@ describe('Email Submissions Controller', () => {
           id: 1,
           created: Date.now(),
         },
-        jsonData: [
+        dataCollationData: [
           {
             question: 'Reference Number',
             answer: '123',
@@ -476,7 +476,7 @@ describe('Email Submissions Controller', () => {
       res.status(200).send({
         formData: req.formData,
         autoReplyData: req.autoReplyData,
-        jsonData: req.jsonData,
+        dataCollationData: req.dataCollationData,
         attachments: req.attachments.map((b) => {
           b.content = b.content.toString('base64')
           return b
@@ -502,12 +502,14 @@ describe('Email Submissions Controller', () => {
       request(app)
         .get(endpointPath)
         .expect(StatusCodes.OK)
-        .then(({ body: { formData, autoReplyData, jsonData } }) => {
+        .then(({ body: { formData, autoReplyData, dataCollationData } }) => {
           expect(formData).withContext('Form Data').toEqual(expected.formData)
           expect(autoReplyData)
             .withContext('autoReplyData')
             .toEqual(expected.autoReplyData)
-          expect(jsonData).withContext('jsonData').toEqual(expected.jsonData)
+          expect(dataCollationData)
+            .withContext('dataCollationData')
+            .toEqual(expected.dataCollationData)
         })
         .then(done)
         .catch(done)
@@ -573,7 +575,7 @@ describe('Email Submissions Controller', () => {
       let expected = {
         autoReplyData: [],
         formData: [],
-        jsonData: [],
+        dataCollationData: [],
       }
       for (let answer of answerArray) {
         answer = String(answer)
@@ -585,7 +587,7 @@ describe('Email Submissions Controller', () => {
             answerTemplate,
           })
         }
-        expected.jsonData.push({
+        expected.dataCollationData.push({
           question,
           answer,
         })
@@ -603,13 +605,13 @@ describe('Email Submissions Controller', () => {
      *  Generate expected output
      * @param {Array} fields
      * @param {Array} responses
-     * @returns {Object} { autoReplyData: Array, formData: Array, jsonData: Array }
+     * @returns {Object} { autoReplyData: Array, formData: Array, dataCollationData: Array }
      */
     const getExpectedOutput = (fields, responses) => {
       let expected = {
         autoReplyData: [],
         formData: [],
-        jsonData: [],
+        dataCollationData: [],
       }
       for (let i = 0; i < fields.length; i++) {
         const answer = String(responses[i].answer)
@@ -617,7 +619,7 @@ describe('Email Submissions Controller', () => {
         if (fields[i].fieldType === 'table') {
           const expectedTable = getExpectedForTable(fields[i], responses[i])
           expected.autoReplyData.push(...expectedTable.autoReplyData)
-          expected.jsonData.push(...expectedTable.jsonData)
+          expected.dataCollationData.push(...expectedTable.dataCollationData)
           expected.formData.push(...expectedTable.formData)
         } else {
           let question = fields[i].title
@@ -629,7 +631,7 @@ describe('Email Submissions Controller', () => {
             })
           }
           if (fields[i].fieldType !== 'section') {
-            expected.jsonData.push({
+            expected.dataCollationData.push({
               question,
               answer,
             })
@@ -662,7 +664,7 @@ describe('Email Submissions Controller', () => {
           answerTemplate: [resLocalFixtures.uinFin],
         },
       ]
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: SPCPFieldTitle.SpNric,
           answer: resLocalFixtures.uinFin,
@@ -671,7 +673,7 @@ describe('Email Submissions Controller', () => {
       const expected = {
         formData: expectedFormData,
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
       }
       prepareSubmissionThenCompare(expected, done)
     })
@@ -705,7 +707,7 @@ describe('Email Submissions Controller', () => {
           answerTemplate: [maskedCpUid],
         },
       ]
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: SPCPFieldTitle.CpUen,
           answer: resLocalFixtures.uinFin,
@@ -718,7 +720,7 @@ describe('Email Submissions Controller', () => {
       const expected = {
         formData: expectedFormData,
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
       }
       prepareSubmissionThenCompare(expected, done)
     })
@@ -744,7 +746,7 @@ describe('Email Submissions Controller', () => {
         required: true,
         myInfo: { attr },
       })
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: 'myinfo',
           answer: 'bar',
@@ -766,7 +768,7 @@ describe('Email Submissions Controller', () => {
       ]
       const expected = {
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
         formData: expectedFormData,
       }
       prepareSubmissionThenCompare(expected, done)
@@ -792,7 +794,7 @@ describe('Email Submissions Controller', () => {
           answerTemplate: ['foo'],
         },
       ]
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: 'regular',
           answer: 'foo',
@@ -809,7 +811,7 @@ describe('Email Submissions Controller', () => {
       const expected = {
         formData: expectedFormData,
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
       }
       prepareSubmissionThenCompare(expected, done)
     })
@@ -858,7 +860,7 @@ describe('Email Submissions Controller', () => {
         _id: '5db00a15af2ffb29487d4eb1',
         logicType: 'showFields',
       })
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: nonVisibleField.title,
           answer: nonVisibleResponse.answer,
@@ -890,7 +892,7 @@ describe('Email Submissions Controller', () => {
       ]
       const expected = {
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
         formData: expectedFormData,
       }
       prepareSubmissionThenCompare(expected, done)
@@ -914,7 +916,7 @@ describe('Email Submissions Controller', () => {
         fieldType: 'attachment',
         attachmentSize: '1',
       })
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: '[attachment] an attachment',
           answer: validAttachmentName,
@@ -936,7 +938,7 @@ describe('Email Submissions Controller', () => {
       ]
       const expected = {
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
         formData: expectedFormData,
       }
       prepareSubmissionThenCompare(expected, done)
@@ -961,7 +963,7 @@ describe('Email Submissions Controller', () => {
         ],
         minimumRows: 1,
       })
-      const expectedJsonData = [
+      const expectedDataCollationData = [
         {
           question: '[table] a table (Name, Age)',
           answer: ',',
@@ -983,7 +985,7 @@ describe('Email Submissions Controller', () => {
       ]
       const expected = {
         autoReplyData: expectedAutoReplyData,
-        jsonData: expectedJsonData,
+        dataCollationData: expectedDataCollationData,
         formData: expectedFormData,
       }
       prepareSubmissionThenCompare(expected, done)
@@ -1210,7 +1212,7 @@ describe('Email Submissions Controller', () => {
       let expected = {
         autoReplyData: [],
         formData: [],
-        jsonData: [],
+        dataCollationData: [],
       }
       for (let i = 0; i < fields.length; i++) {
         let { fieldType, title } = fields[i]
@@ -1221,7 +1223,10 @@ describe('Email Submissions Controller', () => {
             answerTemplate: String(answer).split('\n'),
           })
           if (fieldType !== 'section') {
-            expected.jsonData.push({ question: title, answer: String(answer) })
+            expected.dataCollationData.push({
+              question: title,
+              answer: String(answer),
+            })
           }
           expected.formData.push({
             question: title,

--- a/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
+++ b/tests/unit/backend/controllers/email-submissions.server.controller.spec.js
@@ -679,6 +679,7 @@ describe('Email Submissions Controller', () => {
     it('maps CorpPass attributes', (done) => {
       resLocalFixtures.uinFin = '123456789K'
       resLocalFixtures.userInfo = 'S1234567A'
+      const maskedCpUid = '*****567A'
       reqFixtures.form.authType = 'CP'
       const expectedFormData = [
         {
@@ -701,7 +702,7 @@ describe('Email Submissions Controller', () => {
         },
         {
           question: SPCPFieldTitle.CpUid,
-          answerTemplate: [resLocalFixtures.userInfo],
+          answerTemplate: [maskedCpUid],
         },
       ]
       const expectedJsonData = [

--- a/tests/unit/backend/helpers/generate-email-data.ts
+++ b/tests/unit/backend/helpers/generate-email-data.ts
@@ -1,26 +1,26 @@
 import { pick } from 'lodash'
 
 import {
-  EmailAutoReplyField,
-  EmailFormField,
-  EmailJsonField,
+  EmailAdminDataField,
+  EmailDataCollationToolField,
+  EmailRespondentConfirmationField,
 } from 'src/app/modules/submission/email-submission/email-submission.types'
 import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
 
 export const generateSingleAnswerJson = (
   response: ProcessedSingleAnswerResponse,
-): EmailJsonField => pick(response, ['question', 'answer'])
+): EmailDataCollationToolField => pick(response, ['question', 'answer'])
 
 export const generateSingleAnswerAutoreply = (
   response: ProcessedSingleAnswerResponse,
-): EmailAutoReplyField => ({
+): EmailRespondentConfirmationField => ({
   question: response.question,
   answerTemplate: response.answer.split('\n'),
 })
 
 export const generateSingleAnswerFormData = (
   response: ProcessedSingleAnswerResponse,
-): EmailFormField => ({
+): EmailAdminDataField => ({
   ...pick(response, ['question', 'answer', 'fieldType']),
   answerTemplate: response.answer.split('\n'),
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Part 1 of #1104

## Solution
- This PR addresses the comments made in #1070 and refactors the implementation of #1109 into class methods instead of a standalone masking function

- As per the objectives stated in #1104, subsequent PR will encapsulate the data processing functions in the middlewares`EmailSubmissionsMiddleware.validateEmailSubmission`, `AdminFormController.passThroughSpcp`, 
`SpcpController.appendVerifiedSPCPResponses` into the same class 

## Tests
- [ ] Create a corppass form with email autoreply and pdf response. Submit form. Check that the autoreply email and pdf response both have a masked UID number with only the last 4 characters shown (e.g. *****123A)
- [ ] Add a text field to the form with the title 'CorpPass Validated UID'. Check that the response on the text field is not masked in autoreply.
- [ ] Check that the email response to the admin still has the full UID number.
