### PR TITLE
chore: update package and typings for express session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4540,13 +4540,12 @@
       }
     },
     "@types/express-session": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.0.tgz",
-      "integrity": "sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-57DnyxiqClXOIjoCgeKCUYfKxBPOlOY/k+l1TPK+7bSwyiPTrS5FIk1Ycql7twk4wO7P5lfOVy6akDGiaMSLfw==",
       "dev": true,
       "requires": {
-        "@types/express": "*",
-        "@types/node": "*"
+        "@types/express": "*"
       }
     },
     "@types/glob": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@types/express-rate-limit": "^5.1.1",
     "@types/express-request-id": "^1.4.1",
     "@types/express-serve-static-core": "^4.17.18",
-    "@types/express-session": "^1.17.0",
+    "@types/express-session": "^1.17.3",
     "@types/has-ansi": "^3.0.0",
     "@types/helmet": "4.0.0",
     "@types/ip": "^1.1.0",

--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -1,3 +1,4 @@
+import { Session, SessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -51,14 +52,14 @@ export const mapRouteError: MapRouteError = (error, coreErrorMessage) => {
 }
 
 export const isUserInSession = (
-  session?: Express.Session,
-): session is Express.AuthedSession => {
+  session?: Session & Partial<SessionData>,
+): session is Session & SessionData => {
   return !!session?.user?._id
 }
 
 // TODO(#212): Save userId instead of entire user collection in session.
 export const getUserIdFromSession = (
-  session?: Express.Session,
+  session?: Session & Partial<SessionData>,
 ): string | undefined => {
   return session?.user?._id as string | undefined
 }

--- a/src/app/modules/billing/billing.controller.ts
+++ b/src/app/modules/billing/billing.controller.ts
@@ -29,7 +29,8 @@ export const handleGetBillInfo: RequestHandler<
   }
 > = async (req, res) => {
   const { esrvcId, mth, yr } = req.query
-  const authedUser = (req.session as Express.AuthedSession).user
+  // User must be in session.
+  const authedUser = req.session.user!
 
   const startOfMonth = moment
     .tz([parseInt(yr), parseInt(mth)], 'Asia/Singapore')

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -37,7 +37,7 @@ const logger = createLoggerWithLabel(module)
  * @returns 500 when database errors occur
  */
 export const handleListDashboardForms: RequestHandler = async (req, res) => {
-  const authedUserId = (req.session as Express.AuthedSession).user._id
+  const authedUserId = req.session.user!._id
   const dashboardResult = await getDashboardForms(authedUserId)
 
   if (dashboardResult.isErr()) {
@@ -74,7 +74,7 @@ export const handleGetAdminForm: RequestHandler<{ formId: string }> = (
   res,
 ) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -126,7 +126,7 @@ export const handleCreatePresignedPostUrlForImages: RequestHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { fileId, fileMd5Hash, fileType } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -182,7 +182,7 @@ export const handleCreatePresignedPostUrlForLogos: RequestHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { fileId, fileMd5Hash, fileType } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -236,7 +236,7 @@ export const handleCountFormSubmissions: RequestHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { startDate, endDate } = req.query
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   const logMeta = {
     action: 'handleCountFormSubmissions',
@@ -324,7 +324,7 @@ export const handleCountFormFeedback: RequestHandler<{
   formId: string
 }> = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -373,7 +373,7 @@ export const handleStreamFormFeedback: RequestHandler<{
   formId: string
 }> = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   // Step 1: Retrieve currently logged in user.
   const hasReadPermissionResult = await UserService.getPopulatedUserById(
@@ -467,7 +467,7 @@ export const handleGetFormFeedbacks: RequestHandler<{
   formId: string
 }> = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return UserService.getPopulatedUserById(sessionUserId)
     .andThen((user) =>
@@ -511,7 +511,7 @@ export const handleArchiveForm: RequestHandler<{ formId: string }> = async (
   res,
 ) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -564,7 +564,7 @@ export const handleDuplicateAdminForm: RequestHandler<
   DuplicateFormBody
 > = (req, res) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = req.session.user!._id
   const overrideParams = req.body
 
   return (
@@ -609,7 +609,7 @@ export const handleGetTemplateForm: RequestHandler<{ formId: string }> = (
   res,
 ) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = req.session.user!._id
 
   return (
     // Step 1: Retrieve form only if form is currently public.
@@ -667,7 +667,7 @@ export const handleCopyTemplateForm: RequestHandler<
   DuplicateFormBody
 > = (req, res) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = req.session.user!._id
   const overrideParams = req.body
 
   // TODO(#792): Remove when frontend has stopped sending isTemplate.
@@ -738,7 +738,7 @@ export const handleTransferFormOwnership: RequestHandler<
 > = (req, res) => {
   const { formId } = req.params
   const { email: newOwnerEmail } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -792,7 +792,7 @@ export const handleCreateForm: RequestHandler<
   { form: Omit<IForm, 'admin'> }
 > = async (req, res) => {
   const { form: formParams } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = req.session.user!._id
 
   return (
     // Step 1: Retrieve currently logged in user.

--- a/src/types/vendor/express.d.ts
+++ b/src/types/vendor/express.d.ts
@@ -1,17 +1,13 @@
 import { IUserSchema } from 'src/types'
 
-declare global {
-  namespace Express {
-    export interface Request {
-      id?: string
-    }
+declare module 'express' {
+  interface Request {
+    id?: string
+  }
+}
 
-    export interface Session {
-      user?: IUserSchema
-    }
-
-    export interface AuthedSession extends Session {
-      user: IUserSchema
-    }
+declare module 'express-session' {
+  interface SessionData {
+    user: IUserSchema
   }
 }


### PR DESCRIPTION
The types for express-session has finally (??? 3 months ago) been fixed to allow for better session data types.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d1259ee31e6b17c31a5a86e27a0d12f3ec7c5a19#diff-0d13c95494fa97febecd0fbc1fb1b8f6e17bbcaedb8c88d10a0b655046e1c97b

This PR updates the types for session user data stored in our application. I don't really see an alternate path without asserting that session is non-null (due to auth middleware), with the exception of maybe inlining the middleware into the controller... which basically defeats the point of the discussion the team had a couple months ago about using auth as a middleware.