### PR TITLE
fix: Release 4.58.1 hotfix - mobile signature validation

### DIFF
--- a/src/app/utils/field-validation/validators/mobileNoValidator.ts
+++ b/src/app/utils/field-validation/validators/mobileNoValidator.ts
@@ -55,7 +55,7 @@ const makeMobileSignatureValidator: MobileNoValidatorConstructor = (
       signatureString: signature,
       submissionCreatedAt: Date.now(),
       fieldId: _id,
-      answer: answer,
+      answer,
     })
 
   return isSigned

--- a/src/app/utils/field-validation/validators/mobileNoValidator.ts
+++ b/src/app/utils/field-validation/validators/mobileNoValidator.ts
@@ -2,9 +2,10 @@ import { chain, left, right } from 'fp-ts/lib/Either'
 import { flow } from 'fp-ts/lib/function'
 
 import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
-import { IMobileField } from 'src/types/field'
+import { IMobileFieldSchema } from 'src/types/field'
 import { ResponseValidator } from 'src/types/field/utils/validation'
 
+import formsgSdk from '../../../../config/formsg-sdk'
 import {
   isMobilePhoneNumber,
   startsWithSgPrefix,
@@ -14,7 +15,7 @@ import { notEmptySingleAnswerResponse } from './common'
 
 type MobileNoValidator = ResponseValidator<ProcessedSingleAnswerResponse>
 type MobileNoValidatorConstructor = (
-  mobileNumberField: IMobileField,
+  mobileNumberField: IMobileFieldSchema,
 ) => MobileNoValidator
 
 const mobilePhoneNumberValidator: MobileNoValidator = (response) => {
@@ -37,11 +38,37 @@ const makePrefixValidator: MobileNoValidatorConstructor = (
   return mobileNumberField.allowIntlNumbers ? right : sgPrefixValidator
 }
 
+const makeMobileSignatureValidator: MobileNoValidatorConstructor = (
+  mobileNumberField,
+) => (response) => {
+  const { isVerifiable, _id } = mobileNumberField
+  if (!isVerifiable) {
+    return right(response) // no validation occurred
+  }
+  const { signature, answer } = response
+  if (!signature) {
+    return left(`MobileNoValidator:\t answer does not have valid signature`)
+  }
+  const isSigned =
+    formsgSdk.verification.authenticate &&
+    formsgSdk.verification.authenticate({
+      signatureString: signature,
+      submissionCreatedAt: Date.now(),
+      fieldId: _id,
+      answer: answer,
+    })
+
+  return isSigned
+    ? right(response)
+    : left(`MobileNoValidator:\t answer does not have valid signature`)
+}
+
 export const constructMobileNoValidator: MobileNoValidatorConstructor = (
   mobileNumberField,
 ) =>
   flow(
     notEmptySingleAnswerResponse,
     chain(mobilePhoneNumberValidator),
+    chain(makeMobileSignatureValidator(mobileNumberField)),
     chain(makePrefixValidator(mobileNumberField)),
   )


### PR DESCRIPTION
## Problem
- Mobile number signature validation was dropped during migration to ts for mobile number validator

## Solution
- Add signature validation to mobile number validator

## Tests
- [ ] Create verified mobile field. Check that submission of verified mobile number works normally
- [ ] Clone network request and modify the signature. Submit programatically. Check that submission fails