### PR TITLE
fix: add back home number field icon

### DIFF
--- a/src/public/modules/forms/base/resources/icon-types.js
+++ b/src/public/modules/forms/base/resources/icon-types.js
@@ -47,6 +47,7 @@ const iconTypeMap = {
   marriagedate: 'bx bx-calendar-check',
   divorcedate: 'bx bx-calendar-x',
   workpassexpirydate: 'bx bx-calendar-alt',
+  homeno: 'bx bx-phone',
   mobileno: 'bx bx-mobile-alt',
   marriagecertno: 'bx bx-award',
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Home number field icon was accidentally deleted in #1073 as `'homeno'` is both a MyInfo attribute and a field type.

## Solution
<!-- How did you solve the problem? -->
Add the icon back.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/29480346/108021238-157f5a00-7059-11eb-913e-2faedc82ccc9.png)

### After
![image](https://user-images.githubusercontent.com/29480346/108021247-19ab7780-7059-11eb-8bfb-76323d6cb784.png)
