### PR TITLE
fix: agency logos on development environment

### DIFF
--- a/init-mongo.js
+++ b/init-mongo.js
@@ -3,7 +3,7 @@ db.createCollection("agencies")
 db.agencies.insert([{
     "shortName" : "govtech",
     "fullName" : "Government Technology Agency",
-    "logo" : "https://s3-ap-southeast-1.amazonaws.com/agency.form.sg/govtech.jpg",
+    "logo" : "https://s3-ap-southeast-1.amazonaws.com/agency-logo.form.sg/govtech.jpg",
     "emailDomain" : [
         "tech.gov.sg",
         "data.gov.sg",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The MongoDB initialisation script was providing the wrong URL to the `agency.form.sg` S3 bucket, so logos were not working for the longest time.

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

Fixed the URL to `agency-logo.form.sg` S3 bucket instead.

