### PR TITLE
refactor: move addLogin method to Billing module

### DIFF
--- a/src/app/modules/billing/__tests__/billing.factory.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.factory.spec.ts
@@ -31,7 +31,7 @@ describe('billing.factory', () => {
     const BillingFactory = createBillingFactory(MOCK_DISABLED_FEATURE)
 
     describe('getSpLoginStats', () => {
-      it('should return empty array passthrough', async () => {
+      it('should return empty array passthrough when spcp-myinfo feature is disabled', async () => {
         // Act
         const actualResults = await BillingFactory.getSpLoginStats(
           'anything',
@@ -47,7 +47,8 @@ describe('billing.factory', () => {
     })
 
     describe('recordLoginByForm', () => {
-      it('should return MissingFeatureError', async () => {
+      it('should return MissingFeatureError when spcp-myinfo feature is disabled', async () => {
+        // Argument here does not matter, as the function should always return a MissingFeatureError
         const result = await BillingFactory.recordLoginByForm(
           ({} as unknown) as IPopulatedForm,
         )

--- a/src/app/modules/billing/__tests__/billing.factory.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.factory.spec.ts
@@ -46,12 +46,12 @@ describe('billing.factory', () => {
       })
     })
 
-    describe('addLogin', () => {
+    describe('recordLoginByForm', () => {
       it('should return MissingFeatureError', async () => {
-        const result = await BillingFactory.addLogin(
+        const result = await BillingFactory.recordLoginByForm(
           ({} as unknown) as IPopulatedForm,
         )
-        expect(MockBillingService.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingService.recordLoginByForm).not.toHaveBeenCalled()
         expect(result._unsafeUnwrapErr()).toEqual(
           new MissingFeatureError(FeatureNames.SpcpMyInfo),
         )
@@ -97,20 +97,24 @@ describe('billing.factory', () => {
       })
     })
 
-    describe('addLogin', () => {
-      it('should call BillingService.addLogin', async () => {
+    describe('recordLoginByForm', () => {
+      it('should call BillingService.recordLoginByForm', async () => {
         const mockLoginDoc = ({
           mockKey: 'mockValue',
         } as unknown) as ILoginSchema
         const mockForm = ({
           mockFormKey: 'mockFormvalue',
         } as unknown) as IPopulatedForm
-        MockBillingService.addLogin.mockResolvedValueOnce(okAsync(mockLoginDoc))
+        MockBillingService.recordLoginByForm.mockResolvedValueOnce(
+          okAsync(mockLoginDoc),
+        )
 
-        const result = await BillingFactory.addLogin(mockForm)
+        const result = await BillingFactory.recordLoginByForm(mockForm)
 
         expect(result._unsafeUnwrap()).toEqual(mockLoginDoc)
-        expect(MockBillingService.addLogin).toHaveBeenCalledWith(mockForm)
+        expect(MockBillingService.recordLoginByForm).toHaveBeenCalledWith(
+          mockForm,
+        )
       })
     })
   })

--- a/src/app/modules/billing/__tests__/billing.factory.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.factory.spec.ts
@@ -6,8 +6,14 @@ import {
   ISpcpMyInfo,
   RegisteredFeature,
 } from 'src/config/feature-manager'
-import { AuthType, LoginStatistic } from 'src/types'
+import {
+  AuthType,
+  ILoginSchema,
+  IPopulatedForm,
+  LoginStatistic,
+} from 'src/types'
 
+import { MissingFeatureError } from '../../core/core.errors'
 import { createBillingFactory } from '../billing.factory'
 import * as BillingService from '../billing.service'
 
@@ -37,6 +43,18 @@ describe('billing.factory', () => {
         expect(MockBillingService.getSpLoginStats).not.toHaveBeenCalled()
         expect(actualResults.isOk()).toEqual(true)
         expect(actualResults._unsafeUnwrap()).toEqual([])
+      })
+    })
+
+    describe('addLogin', () => {
+      it('should return MissingFeatureError', async () => {
+        const result = await BillingFactory.addLogin(
+          ({} as unknown) as IPopulatedForm,
+        )
+        expect(MockBillingService.addLogin).not.toHaveBeenCalled()
+        expect(result._unsafeUnwrapErr()).toEqual(
+          new MissingFeatureError(FeatureNames.SpcpMyInfo),
+        )
       })
     })
   })
@@ -76,6 +94,23 @@ describe('billing.factory', () => {
         expect(serviceGetStatsSpy).toHaveBeenCalledTimes(1)
         expect(actualResults.isOk()).toEqual(true)
         expect(actualResults._unsafeUnwrap()).toEqual(mockLoginStats)
+      })
+    })
+
+    describe('addLogin', () => {
+      it('should call BillingService.addLogin', async () => {
+        const mockLoginDoc = ({
+          mockKey: 'mockValue',
+        } as unknown) as ILoginSchema
+        const mockForm = ({
+          mockFormKey: 'mockFormvalue',
+        } as unknown) as IPopulatedForm
+        MockBillingService.addLogin.mockResolvedValueOnce(okAsync(mockLoginDoc))
+
+        const result = await BillingFactory.addLogin(mockForm)
+
+        expect(result._unsafeUnwrap()).toEqual(mockLoginDoc)
+        expect(MockBillingService.addLogin).toHaveBeenCalledWith(mockForm)
       })
     })
   })

--- a/src/app/modules/billing/__tests__/billing.service.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.service.spec.ts
@@ -1,14 +1,57 @@
 import mongoose from 'mongoose'
 
 import getLoginModel from 'src/app/models/login.server.model'
-import { AuthType, LoginStatistic } from 'src/types'
+import { getMongoErrorMessage } from 'src/app/utils/handle-mongo-error'
+import {
+  AuthType,
+  ILoginSchema,
+  IPopulatedForm,
+  LoginStatistic,
+} from 'src/types'
 
 import { DatabaseError } from '../../core/core.errors'
+import { FormHasNoAuthError } from '../billing.errors'
 import * as BillingService from '../billing.service'
 
 const LoginModel = getLoginModel(mongoose)
 
 describe('billing.service', () => {
+  describe('addLogin', () => {
+    beforeEach(() => jest.restoreAllMocks())
+    it('should call LoginModel.addLoginFromForm with the given form', async () => {
+      const mockForm = ({ authType: AuthType.SP } as unknown) as IPopulatedForm
+      const mockLogin = ({ esrvcId: 'esrvcId' } as unknown) as ILoginSchema
+      const addLoginSpy = jest
+        .spyOn(LoginModel, 'addLoginFromForm')
+        .mockResolvedValueOnce(mockLogin)
+      const result = await BillingService.addLogin(mockForm)
+      expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
+      expect(result._unsafeUnwrap()).toEqual(mockLogin)
+    })
+
+    it('should return FormHasNoAuthError when form has authType NIL', async () => {
+      const mockForm = ({ authType: AuthType.NIL } as unknown) as IPopulatedForm
+      const mockLogin = ({ esrvcId: 'esrvcId' } as unknown) as ILoginSchema
+      const addLoginSpy = jest
+        .spyOn(LoginModel, 'addLoginFromForm')
+        .mockResolvedValueOnce(mockLogin)
+      const result = await BillingService.addLogin(mockForm)
+      expect(addLoginSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(new FormHasNoAuthError())
+    })
+
+    it('should return DatabaseError when adding login fails', async () => {
+      const mockForm = ({ authType: AuthType.SP } as unknown) as IPopulatedForm
+      const addLoginSpy = jest
+        .spyOn(LoginModel, 'addLoginFromForm')
+        .mockRejectedValueOnce('')
+      const result = await BillingService.addLogin(mockForm)
+      expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(getMongoErrorMessage('')),
+      )
+    })
+  })
   describe('getSpLoginStats', () => {
     it('should return result of aggregate query successfully', async () => {
       // Arrange

--- a/src/app/modules/billing/__tests__/billing.service.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.service.spec.ts
@@ -16,7 +16,7 @@ import * as BillingService from '../billing.service'
 const LoginModel = getLoginModel(mongoose)
 
 describe('billing.service', () => {
-  describe('addLogin', () => {
+  describe('recordLoginByForm', () => {
     beforeEach(() => jest.restoreAllMocks())
     it('should call LoginModel.addLoginFromForm with the given form', async () => {
       const mockForm = ({ authType: AuthType.SP } as unknown) as IPopulatedForm
@@ -24,7 +24,7 @@ describe('billing.service', () => {
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
         .mockResolvedValueOnce(mockLogin)
-      const result = await BillingService.addLogin(mockForm)
+      const result = await BillingService.recordLoginByForm(mockForm)
       expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
       expect(result._unsafeUnwrap()).toEqual(mockLogin)
     })
@@ -35,7 +35,7 @@ describe('billing.service', () => {
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
         .mockResolvedValueOnce(mockLogin)
-      const result = await BillingService.addLogin(mockForm)
+      const result = await BillingService.recordLoginByForm(mockForm)
       expect(addLoginSpy).not.toHaveBeenCalled()
       expect(result._unsafeUnwrapErr()).toEqual(new FormHasNoAuthError())
     })
@@ -45,7 +45,7 @@ describe('billing.service', () => {
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
         .mockRejectedValueOnce('')
-      const result = await BillingService.addLogin(mockForm)
+      const result = await BillingService.recordLoginByForm(mockForm)
       expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
       expect(result._unsafeUnwrapErr()).toEqual(
         new DatabaseError(getMongoErrorMessage('')),

--- a/src/app/modules/billing/billing.errors.ts
+++ b/src/app/modules/billing/billing.errors.ts
@@ -1,0 +1,12 @@
+import { ApplicationError } from '../core/core.errors'
+
+/**
+ * Attempt to add Login record for form without authentication enabled.
+ */
+export class FormHasNoAuthError extends ApplicationError {
+  constructor(
+    message = 'Attempted to add Login record for form with no authentication',
+  ) {
+    super(message)
+  }
+}

--- a/src/app/modules/billing/billing.factory.ts
+++ b/src/app/modules/billing/billing.factory.ts
@@ -12,7 +12,7 @@ import * as BillingService from './billing.service'
 
 interface IBillingFactory {
   getSpLoginStats: typeof BillingService.getSpLoginStats
-  addLogin: (
+  recordLoginByForm: (
     form: IPopulatedForm,
   ) => ResultAsync<
     ILoginSchema,
@@ -35,7 +35,7 @@ export const createBillingFactory = ({
   const error = new MissingFeatureError(FeatureNames.SpcpMyInfo)
   return {
     getSpLoginStats: () => okAsync([]),
-    addLogin: () => errAsync(error),
+    recordLoginByForm: () => errAsync(error),
   }
 }
 

--- a/src/app/modules/billing/billing.service.ts
+++ b/src/app/modules/billing/billing.service.ts
@@ -61,11 +61,11 @@ export const getSpLoginStats = (
  * @param form Form populated with admin and agency data
  * @return The Login document saved to the database
  */
-export const addLogin = (
+export const recordLoginByForm = (
   form: IPopulatedForm,
 ): ResultAsync<ILoginSchema, FormHasNoAuthError | DatabaseError> => {
   const logMeta = {
-    action: 'addLogin',
+    action: 'recordLoginByForm',
     formId: form._id,
   }
   if (form.authType === AuthType.NIL) {

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -264,7 +264,9 @@ describe('spcp.controller', () => {
         )
         MockSpcpFactory.createJWTPayload.mockReturnValue(ok(MOCK_JWT_PAYLOAD))
         MockSpcpFactory.createJWT.mockReturnValue(ok(MOCK_JWT))
-        MockBillingFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
+        MockBillingFactory.recordLoginByForm.mockReturnValue(
+          okAsync(MOCK_LOGIN_DOC),
+        )
         MockSpcpFactory.getCookieSettings.mockReturnValue(MOCK_COOKIE_SETTINGS)
       })
 
@@ -293,7 +295,9 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.SP,
         )
-        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_SP_FORM)
+        expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+          MOCK_SP_FORM,
+        )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtSp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
           httpOnly: false,
@@ -321,7 +325,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -345,7 +349,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -369,7 +373,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -395,7 +399,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -425,7 +429,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -457,12 +461,12 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
-      it('should set isLoginError cookie and redirect when addLogin errors', async () => {
-        MockBillingFactory.addLogin.mockReturnValue(
+      it('should set isLoginError cookie and redirect when recordLoginByForm errors', async () => {
+        MockBillingFactory.recordLoginByForm.mockReturnValue(
           errAsync(new DatabaseError()),
         )
         await loginHandler(MOCK_SP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
@@ -489,7 +493,9 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.SP,
         )
-        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_SP_FORM)
+        expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+          MOCK_SP_FORM,
+        )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
@@ -517,7 +523,9 @@ describe('spcp.controller', () => {
         )
         MockSpcpFactory.createJWTPayload.mockReturnValue(ok(MOCK_JWT_PAYLOAD))
         MockSpcpFactory.createJWT.mockReturnValue(ok(MOCK_JWT))
-        MockBillingFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
+        MockBillingFactory.recordLoginByForm.mockReturnValue(
+          okAsync(MOCK_LOGIN_DOC),
+        )
         MockSpcpFactory.getCookieSettings.mockReturnValue(MOCK_COOKIE_SETTINGS)
       })
 
@@ -546,7 +554,9 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.CP,
         )
-        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_CP_FORM)
+        expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+          MOCK_CP_FORM,
+        )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtCp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
           httpOnly: false,
@@ -574,7 +584,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -598,7 +608,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -621,7 +631,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -648,7 +658,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -678,7 +688,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -710,12 +720,12 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
-        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
-      it('should set isLoginError cookie and redirect when addLogin errors', async () => {
-        MockBillingFactory.addLogin.mockReturnValue(
+      it('should set isLoginError cookie and redirect when recordLoginByForm errors', async () => {
+        MockBillingFactory.recordLoginByForm.mockReturnValue(
           errAsync(new DatabaseError()),
         )
         await loginHandler(MOCK_CP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
@@ -742,7 +752,9 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.CP,
         )
-        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_CP_FORM)
+        expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+          MOCK_CP_FORM,
+        )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -350,6 +350,29 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
 
+      it('should set isLoginError cookie and redirect when form has wrong auth type', async () => {
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          // Note that this is a CorpPass form
+          okAsync(MOCK_CP_FORM),
+        )
+        await loginHandler(MOCK_SP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
+        expect(MockSpcpFactory.parseOOBParams).toHaveBeenCalledWith(
+          MOCK_SP_SAML,
+          MOCK_RELAY_STATE,
+          AuthType.SP,
+        )
+        expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+          MOCK_TARGET,
+        )
+        expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
+        expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
+        expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
+      })
+
       it('should set isLoginError cookie and redirect when getSpcpAttributes errors', async () => {
         MockSpcpFactory.getSpcpAttributes.mockReturnValue(
           errAsync(new RetrieveAttributesError()),
@@ -554,6 +577,29 @@ describe('spcp.controller', () => {
         expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
+      })
+
+      it('should set isLoginError cookie and redirect when form has wrong auth type', async () => {
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          // Note that this is a SingPass form
+          okAsync(MOCK_SP_FORM),
+        )
+        await loginHandler(MOCK_CP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
+        expect(MockSpcpFactory.parseOOBParams).toHaveBeenCalledWith(
+          MOCK_CP_SAML,
+          MOCK_RELAY_STATE,
+          AuthType.CP,
+        )
+        expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+          MOCK_TARGET,
+        )
+        expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
+        expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
+        expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
       it('should return 404 when form cannot be found', async () => {

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -8,6 +8,7 @@ import { AuthType } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
+import { BillingFactory } from '../../billing/billing.factory'
 import { ApplicationError, DatabaseError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as SpcpController from '../spcp.controller'
@@ -43,6 +44,8 @@ import {
 
 jest.mock('../spcp.factory')
 const MockSpcpFactory = mocked(SpcpFactory, true)
+jest.mock('../../billing/billing.factory')
+const MockBillingFactory = mocked(BillingFactory, true)
 jest.mock('src/app/modules/form/form.service')
 const MockFormService = mocked(FormService, true)
 jest.mock('src/config/config')
@@ -261,7 +264,7 @@ describe('spcp.controller', () => {
         )
         MockSpcpFactory.createJWTPayload.mockReturnValue(ok(MOCK_JWT_PAYLOAD))
         MockSpcpFactory.createJWT.mockReturnValue(ok(MOCK_JWT))
-        MockSpcpFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
+        MockBillingFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
         MockSpcpFactory.getCookieSettings.mockReturnValue(MOCK_COOKIE_SETTINGS)
       })
 
@@ -290,10 +293,7 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.SP,
         )
-        expect(MockSpcpFactory.addLogin).toHaveBeenCalledWith(
-          MOCK_SP_FORM,
-          AuthType.SP,
-        )
+        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_SP_FORM)
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtSp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
           httpOnly: false,
@@ -321,7 +321,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -345,7 +345,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -372,7 +372,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -402,7 +402,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -434,12 +434,14 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
       it('should set isLoginError cookie and redirect when addLogin errors', async () => {
-        MockSpcpFactory.addLogin.mockReturnValue(errAsync(new DatabaseError()))
+        MockBillingFactory.addLogin.mockReturnValue(
+          errAsync(new DatabaseError()),
+        )
         await loginHandler(MOCK_SP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
         expect(MockSpcpFactory.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
@@ -464,10 +466,7 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.SP,
         )
-        expect(MockSpcpFactory.addLogin).toHaveBeenCalledWith(
-          MOCK_SP_FORM,
-          AuthType.SP,
-        )
+        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_SP_FORM)
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
@@ -495,7 +494,7 @@ describe('spcp.controller', () => {
         )
         MockSpcpFactory.createJWTPayload.mockReturnValue(ok(MOCK_JWT_PAYLOAD))
         MockSpcpFactory.createJWT.mockReturnValue(ok(MOCK_JWT))
-        MockSpcpFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
+        MockBillingFactory.addLogin.mockReturnValue(okAsync(MOCK_LOGIN_DOC))
         MockSpcpFactory.getCookieSettings.mockReturnValue(MOCK_COOKIE_SETTINGS)
       })
 
@@ -524,10 +523,7 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.CP,
         )
-        expect(MockSpcpFactory.addLogin).toHaveBeenCalledWith(
-          MOCK_CP_FORM,
-          AuthType.CP,
-        )
+        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_CP_FORM)
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtCp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
           httpOnly: false,
@@ -555,7 +551,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -579,7 +575,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpFactory.getSpcpAttributes).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
       })
@@ -606,7 +602,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWTPayload).not.toHaveBeenCalled()
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -636,7 +632,7 @@ describe('spcp.controller', () => {
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.createJWT).not.toHaveBeenCalled()
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
@@ -668,12 +664,14 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
-        expect(MockSpcpFactory.addLogin).not.toHaveBeenCalled()
+        expect(MockBillingFactory.addLogin).not.toHaveBeenCalled()
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()
       })
 
       it('should set isLoginError cookie and redirect when addLogin errors', async () => {
-        MockSpcpFactory.addLogin.mockReturnValue(errAsync(new DatabaseError()))
+        MockBillingFactory.addLogin.mockReturnValue(
+          errAsync(new DatabaseError()),
+        )
         await loginHandler(MOCK_CP_LOGIN_REQ, MOCK_RESPONSE, jest.fn())
         expect(MockSpcpFactory.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
@@ -698,10 +696,7 @@ describe('spcp.controller', () => {
           MOCK_COOKIE_AGE,
           AuthType.CP,
         )
-        expect(MockSpcpFactory.addLogin).toHaveBeenCalledWith(
-          MOCK_CP_FORM,
-          AuthType.CP,
-        )
+        expect(MockBillingFactory.addLogin).toHaveBeenCalledWith(MOCK_CP_FORM)
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
         expect(MockSpcpFactory.getCookieSettings).not.toHaveBeenCalled()

--- a/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.factory.spec.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils'
 
 import { FeatureNames, ISpcpMyInfo } from 'src/config/feature-manager'
-import { AuthType, IPopulatedForm } from 'src/types'
+import { AuthType } from 'src/types'
 
 import { MissingFeatureError } from '../../core/core.errors'
 import { createSpcpFactory } from '../spcp.factory'
@@ -42,10 +42,6 @@ describe('spcp.factory', () => {
       0,
       AuthType.SP,
     )
-    const addLoginResult = await SpcpFactory.addLogin(
-      ({} as unknown) as IPopulatedForm,
-      AuthType.SP,
-    )
     const createJWTPayloadResult = SpcpFactory.createJWTPayload(
       {},
       true,
@@ -59,7 +55,6 @@ describe('spcp.factory', () => {
     expect(parseOOBParamsResult._unsafeUnwrapErr()).toEqual(error)
     expect(getSpcpAttributesResult._unsafeUnwrapErr()).toEqual(error)
     expect(createJWTResult._unsafeUnwrapErr()).toEqual(error)
-    expect(addLoginResult._unsafeUnwrapErr()).toEqual(error)
     expect(createJWTPayloadResult._unsafeUnwrapErr()).toEqual(error)
     expect(cookieSettings).toEqual({})
   })
@@ -94,10 +89,6 @@ describe('spcp.factory', () => {
       0,
       AuthType.SP,
     )
-    const addLoginResult = await SpcpFactory.addLogin(
-      ({} as unknown) as IPopulatedForm,
-      AuthType.SP,
-    )
     const createJWTPayloadResult = SpcpFactory.createJWTPayload(
       {},
       true,
@@ -111,7 +102,6 @@ describe('spcp.factory', () => {
     expect(parseOOBParamsResult._unsafeUnwrapErr()).toEqual(error)
     expect(getSpcpAttributesResult._unsafeUnwrapErr()).toEqual(error)
     expect(createJWTResult._unsafeUnwrapErr()).toEqual(error)
-    expect(addLoginResult._unsafeUnwrapErr()).toEqual(error)
     expect(createJWTPayloadResult._unsafeUnwrapErr()).toEqual(error)
     expect(cookieSettings).toEqual({})
   })

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -2,19 +2,15 @@ import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import axios from 'axios'
 import fs from 'fs'
 import { omit } from 'lodash'
-import mongoose from 'mongoose'
 import { mocked } from 'ts-jest/utils'
 
-import getLoginModel from 'src/app/models/login.server.model'
 import { MOCK_COOKIE_AGE } from 'src/app/services/myinfo/__tests__/myinfo.test.constants'
 import { ISpcpMyInfo } from 'src/config/feature-manager'
-import { AuthType, ILoginSchema, IPopulatedForm } from 'src/types'
+import { AuthType } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
-import { DatabaseError } from '../../core/core.errors'
 import {
-  AuthTypeMismatchError,
   CreateRedirectUrlError,
   FetchLoginPageError,
   InvalidOOBParamsError,
@@ -56,8 +52,6 @@ jest.mock('fs', () => ({
 }))
 jest.mock('axios')
 const MockAxios = mocked(axios, true)
-
-const LoginModel = getLoginModel(mongoose)
 
 describe('spcp.service', () => {
   beforeAll(async () => await dbHandler.connect())
@@ -669,46 +663,6 @@ describe('spcp.service', () => {
         MOCK_COOKIE_AGE / 1000,
       )
       expect(jwtResult._unsafeUnwrap()).toEqual(MOCK_JWT)
-    })
-  })
-
-  describe('addLogin', () => {
-    beforeEach(() => jest.restoreAllMocks())
-    it('should call LoginModel.addLoginFromForm with the given form', async () => {
-      const spcpService = new SpcpService(MOCK_PARAMS)
-      const mockForm = ({ authType: AuthType.SP } as unknown) as IPopulatedForm
-      const mockLogin = ({ esrvcId: 'esrvcId' } as unknown) as ILoginSchema
-      const addLoginSpy = jest
-        .spyOn(LoginModel, 'addLoginFromForm')
-        .mockResolvedValueOnce(mockLogin)
-      const result = await spcpService.addLogin(mockForm, AuthType.SP)
-      expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
-      expect(result._unsafeUnwrap()).toEqual(mockLogin)
-    })
-
-    it('should return AuthTypeMismatchError when auth types do not match', async () => {
-      const spcpService = new SpcpService(MOCK_PARAMS)
-      const mockForm = ({ authType: AuthType.CP } as unknown) as IPopulatedForm
-      const mockLogin = ({ esrvcId: 'esrvcId' } as unknown) as ILoginSchema
-      const addLoginSpy = jest
-        .spyOn(LoginModel, 'addLoginFromForm')
-        .mockResolvedValueOnce(mockLogin)
-      const result = await spcpService.addLogin(mockForm, AuthType.SP)
-      expect(addLoginSpy).not.toHaveBeenCalled()
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new AuthTypeMismatchError(AuthType.SP, AuthType.CP),
-      )
-    })
-
-    it('should return DatabaseError when adding login fails', async () => {
-      const spcpService = new SpcpService(MOCK_PARAMS)
-      const mockForm = ({ authType: AuthType.SP } as unknown) as IPopulatedForm
-      const addLoginSpy = jest
-        .spyOn(LoginModel, 'addLoginFromForm')
-        .mockRejectedValueOnce('')
-      const result = await spcpService.addLogin(mockForm, AuthType.SP)
-      expect(addLoginSpy).toHaveBeenCalledWith(mockForm)
-      expect(result._unsafeUnwrapErr()).toEqual(new DatabaseError())
     })
   })
 

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -6,6 +6,7 @@ import config from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { AuthType, WithForm } from '../../../types'
 import { createReqMeta } from '../../utils/request'
+import { BillingFactory } from '../billing/billing.factory'
 import * as FormService from '../form/form.service'
 import { ProcessedFieldResponse } from '../submission/submission.types'
 
@@ -241,7 +242,7 @@ export const handleLogin: (
     res.cookie('isLoginError', true)
     return res.redirect(destination)
   }
-  return SpcpFactory.addLogin(form, authType)
+  return BillingFactory.addLogin(form)
     .map(() => {
       res.cookie(JwtName[authType], jwtResult.value, {
         maxAge: cookieDuration,

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -208,6 +208,19 @@ export const handleLogin: (
     })
     return res.sendStatus(StatusCodes.NOT_FOUND)
   }
+  const form = formResult.value
+  if (form.authType !== authType) {
+    logger.error({
+      message: "Log in attempt to wrong endpoint for form's authType",
+      meta: {
+        ...logMeta,
+        formAuthType: form.authType,
+        endpointAuthType: authType,
+      },
+    })
+    res.cookie('isLoginError', true)
+    return res.redirect(destination)
+  }
   const jwtResult = await SpcpFactory.getSpcpAttributes(
     samlArt,
     destination,
@@ -228,7 +241,7 @@ export const handleLogin: (
     res.cookie('isLoginError', true)
     return res.redirect(destination)
   }
-  return SpcpFactory.addLogin(formResult.value, authType)
+  return SpcpFactory.addLogin(form, authType)
     .map(() => {
       res.cookie(JwtName[authType], jwtResult.value, {
         maxAge: cookieDuration,

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -242,7 +242,7 @@ export const handleLogin: (
     res.cookie('isLoginError', true)
     return res.redirect(destination)
   }
-  return BillingFactory.addLogin(form)
+  return BillingFactory.recordLoginByForm(form)
     .map(() => {
       res.cookie(JwtName[authType], jwtResult.value, {
         maxAge: cookieDuration,

--- a/src/app/modules/spcp/spcp.factory.ts
+++ b/src/app/modules/spcp/spcp.factory.ts
@@ -17,7 +17,6 @@ interface ISpcpFactory {
   parseOOBParams: SpcpService['parseOOBParams']
   getSpcpAttributes: SpcpService['getSpcpAttributes']
   createJWT: SpcpService['createJWT']
-  addLogin: SpcpService['addLogin']
   createJWTPayload: SpcpService['createJWTPayload']
   getCookieSettings: SpcpService['getCookieSettings']
 }
@@ -37,7 +36,6 @@ export const createSpcpFactory = ({
       parseOOBParams: () => err(error),
       getSpcpAttributes: () => errAsync(error),
       createJWT: () => err(error),
-      addLogin: () => errAsync(error),
       createJWTPayload: () => err(error),
       getCookieSettings: () => ({}),
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The `addLogin` function is part of the SPCP module, but it really belongs to the Billing module as it relates to tracking logins for e-service IDs. This is blocking #1175 as the MyInfo module needs to share the code for adding logins.

## Solution
<!-- How did you solve the problem? -->
Move the `addLogin` function to the Billing module.