### PR TITLE
fix: add _id key in permissionList object for updateForm validator

### DIFF
--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -113,10 +113,14 @@ const updateFormValidator = celebrate({
       ),
       hasCaptcha: Joi.boolean(),
       inactiveMessage: Joi.string(),
-      permissionList: Joi.array().items({
-        email: Joi.string().email().required(),
-        write: Joi.boolean(),
-      }),
+      permissionList: Joi.array().items(
+        Joi.object().keys({
+          email: Joi.string().email().required(),
+          write: Joi.boolean(),
+          // Optional _id as previous saved permissionList objects have an id.
+          _id: Joi.string(),
+        }),
+      ),
       status: Joi.string().valid(...Object.values(Status)),
       title: Joi.string(),
       webhook: Joi.object({


### PR DESCRIPTION
> Note that this PR merges into release candidate branch `release-v4.59.0`.

## Info
This PR fixes a bug (on staging, not on prod yet) where only a single collaborator can be added to a form. This arises due to the Joi validator for the updateform endpoint not accounting for current collaborator objects in `form.permissionList` having an `_id` key due to the database schema.

## Fix
- add `_id` key in permissionList object for updateForm validator