### PR TITLE
feat: update editable fields and clear cookie upon submission

### DIFF
--- a/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/src/app/modules/myinfo/myinfo.adapter.ts
@@ -201,8 +201,8 @@ export class MyInfoData {
       case ExternalAttr.DivorceDate:
       case ExternalAttr.PassExpiryDate:
         return formatBasicField(this.#personData[attr])
-      // Above cases should be exhaustive. Fall back to undefined
-      // as data shape is unknown.
+      // Above cases should be exhaustive for all attributes supported by Form.
+      // Fall back to undefined as data shape is unknown.
       default:
         return undefined
     }
@@ -239,24 +239,49 @@ export class MyInfoData {
   ): boolean {
     const data = this.#personData[attr]
     if (!data || !myInfoValue) return false
-    // Edge case: data is in array format
-    if (Array.isArray(data)) {
-      // All array items have source attribute
-      return (data as { source: MyInfoSource }[]).every(
-        (item) => item.source === MyInfoSource.GovtVerified,
-      )
+
+    switch (attr) {
+      case ExternalAttr.Vehicles:
+        // Form always leaves vehicle numbers editable to preserve
+        // behaviour between MyInfo V2 and V3
+        return false
+      case ExternalAttr.MobileNo:
+      case ExternalAttr.RegisteredAddress:
+      case ExternalAttr.Occupation:
+      case ExternalAttr.Sex:
+      case ExternalAttr.Race:
+      case ExternalAttr.Dialect:
+      case ExternalAttr.Nationality:
+      case ExternalAttr.BirthCountry:
+      case ExternalAttr.ResidentialStatus:
+      case ExternalAttr.HousingType:
+      case ExternalAttr.HDBType:
+      case ExternalAttr.Name:
+      case ExternalAttr.PassportNumber:
+      case ExternalAttr.Employment:
+      case ExternalAttr.PassStatus:
+      case ExternalAttr.DateOfBirth:
+      case ExternalAttr.PassportExpiryDate:
+      case ExternalAttr.PassExpiryDate: {
+        const data = this.#personData[attr]
+        return (
+          !!data &&
+          !data.unavailable &&
+          data.source === MyInfoSource.GovtVerified
+        )
+      }
+      // Fields required to always be editable according to MyInfo docs
+      case ExternalAttr.MaritalStatus:
+      case ExternalAttr.MarriageDate:
+      case ExternalAttr.DivorceDate:
+      case ExternalAttr.CountryOfMarriage:
+      case ExternalAttr.MarriageCertNumber:
+        return false
+      // Above cases should be exhaustive for all attributes supported by Form.
+      // Fall back to leaving field editable as data shape is unknown.
+      default:
+        return false
     }
-    return (
-      !data.unavailable &&
-      data.source === MyInfoSource.GovtVerified &&
-      ![
-        ExternalAttr.MaritalStatus,
-        ExternalAttr.MarriageDate,
-        ExternalAttr.DivorceDate,
-        ExternalAttr.CountryOfMarriage,
-        ExternalAttr.MarriageCertNumber,
-      ].includes(attr)
-    )
   }
 
   /**

--- a/src/app/modules/myinfo/myinfo.factory.ts
+++ b/src/app/modules/myinfo/myinfo.factory.ts
@@ -29,7 +29,7 @@ import { MyInfoService } from './myinfo.service'
 import {
   IMyInfoRedirectURLArgs,
   IPossiblyPrefilledField,
-  ParsedRelayState,
+  MyInfoParsedRelayState,
 } from './myinfo.types'
 
 interface IMyInfoFactory {
@@ -50,7 +50,7 @@ interface IMyInfoFactory {
   parseMyInfoRelayState: (
     relayState: string,
   ) => Result<
-    ParsedRelayState,
+    MyInfoParsedRelayState,
     MyInfoParseRelayStateError | MissingFeatureError
   >
   prefillMyInfoFields: (

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -54,9 +54,18 @@ export type MyInfoCookiePayload =
       state: Exclude<MyInfoCookieState, MyInfoCookieState.Success>
     }
 
-export interface ParsedRelayState {
+/**
+ * The stringified properties included in the state sent to MyInfo.
+ */
+export type MyInfoRelayState = {
   uuid: string
   formId: string
+}
+
+/**
+ * RelayState with additional properties derived from parsing it.
+ */
+export type MyInfoParsedRelayState = MyInfoRelayState & {
   cookieDuration: number
 }
 

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -1,8 +1,9 @@
 import bcrypt from 'bcrypt'
 import { StatusCodes } from 'http-status-codes'
 import moment from 'moment'
+import mongoose from 'mongoose'
 import { err, ok, Result } from 'neverthrow'
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4, validate as validateUUID } from 'uuid'
 
 import { createLoggerWithLabel } from '../../../config/logger'
 import { types as myInfoTypes } from '../../../shared/resources/myinfo'
@@ -41,6 +42,7 @@ import {
   MyInfoCookiePayload,
   MyInfoCookieState,
   MyInfoHashPromises,
+  MyInfoRelayState,
   VisibleMyInfoResponse,
 } from './myinfo.types'
 
@@ -369,3 +371,13 @@ export const extractAccessTokenFromCookie = (
   }
   return ok(cookie.accessToken)
 }
+
+export const isMyInfoRelayState = (obj: unknown): obj is MyInfoRelayState =>
+  typeof obj === 'object' &&
+  !!obj &&
+  hasProp(obj, 'formId') &&
+  typeof obj.formId === 'string' &&
+  mongoose.Types.ObjectId.isValid(obj.formId) &&
+  hasProp(obj, 'uuid') &&
+  typeof obj.uuid === 'string' &&
+  validateUUID(obj.uuid)

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -5,6 +5,10 @@ import { AuthType, FieldResponse } from '../../../../types'
 import { CaptchaFactory } from '../../../services/captcha/captcha.factory'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
 import * as FormService from '../../form/form.service'
+import {
+  MYINFO_COOKIE_NAME,
+  MYINFO_COOKIE_OPTIONS,
+} from '../../myinfo/myinfo.constants'
 import { MyInfoFactory } from '../../myinfo/myinfo.factory'
 import * as MyInfoUtil from '../../myinfo/myinfo.util'
 import { SpcpFactory } from '../../spcp/spcp.factory'
@@ -224,6 +228,8 @@ export const handleEmailSubmission: RequestHandler<
     })
   }
 
+  // MyInfo access token is single-use, so clear it
+  res.clearCookie(MYINFO_COOKIE_NAME, MYINFO_COOKIE_OPTIONS)
   // Return the reply early to the submitter
   res.json({
     message: 'Form submission successful.',

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -195,7 +195,7 @@
               </div>
               <div
                 class="col-xs-12"
-                ng-if="(type.val === 'SP' || type.val === 'CP' || type.val === 'MyInfo') && (tempForm.authType === type.val)"
+                ng-if="['SP', 'CP', 'MyInfo'].includes(type.val) && tempForm.authType === type.val"
               >
                 <div
                   class="settings-save esrvcId-input"


### PR DESCRIPTION
Contains the following changes:
1. Makes MyInfo vehicle number always editable to preserve behaviour between MyInfo V2 and V3
2. Clears MyInfo cookie at the point of submission
3. Refactors settings page frontend to use `.includes` instead of an extended series of `||`
4. Extracts type guard for relay state in the backend