### PR TITLE
fix: format workpass status correctly, preview submissions, copy changes

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -360,7 +360,7 @@ export const handleCountFormSubmissions: RequestHandler<
  */
 export const passThroughSpcp: RequestHandler = (req, res, next) => {
   const { authType } = (req as WithForm<typeof req>).form
-  if (authType === AuthType.SP || authType === AuthType.CP) {
+  if ([AuthType.SP, AuthType.CP, AuthType.MyInfo].includes(authType)) {
     res.locals = {
       ...res.locals,
       ...getMockSpcpLocals(

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -212,10 +212,14 @@ export const getMockSpcpLocals = (
         .map((field) => field._id.toString())
     : []
   switch (authType) {
-    case AuthType.SP:
+    case AuthType.MyInfo:
       return {
         uinFin: 'S1234567A',
         hashedFields: new Set(myInfoFieldIds),
+      }
+    case AuthType.SP:
+      return {
+        uinFin: 'S1234567A',
       }
     case AuthType.CP:
       return {

--- a/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/src/app/modules/myinfo/myinfo.adapter.ts
@@ -15,6 +15,7 @@ import {
   formatOccupation,
   formatPhoneNumber,
   formatVehicleNumbers,
+  formatWorkpassStatus,
 } from './myinfo.format'
 
 /**
@@ -189,12 +190,14 @@ export class MyInfoData {
       case ExternalAttr.MaritalStatus:
       case ExternalAttr.CountryOfMarriage:
         return formatDescriptionField(this.#personData[attr])
+      // Deal with workpass status bug where value is returned in uppercase
+      case ExternalAttr.PassStatus:
+        return formatWorkpassStatus(this.#personData[attr])
       // Remaining fields should only have 'value' key
       case ExternalAttr.Name:
       case ExternalAttr.PassportNumber:
       case ExternalAttr.Employment:
       case ExternalAttr.MarriageCertNumber:
-      case ExternalAttr.PassStatus:
       case ExternalAttr.DateOfBirth:
       case ExternalAttr.PassportExpiryDate:
       case ExternalAttr.MarriageDate:

--- a/src/app/modules/myinfo/myinfo.format.ts
+++ b/src/app/modules/myinfo/myinfo.format.ts
@@ -134,3 +134,22 @@ export const formatOccupation = (
   if ('value' in field) return field.value
   return field.desc
 }
+
+/**
+ * Formats a MyInfo workpass status value
+ * by ensuring that it is in title case.
+ * Possible values are 'Live', 'Approved'.
+ */
+export const formatWorkpassStatus = (
+  field: MyInfoBasicField | undefined,
+): string => {
+  // Field value should always be a string, but check for type safety since
+  // string methods need to be called
+  if (!field || field.unavailable || typeof field.value !== 'string') return ''
+  // Change to title case
+  const originalValue = field.value
+  return (
+    originalValue.slice(0, 1).toUpperCase() +
+    originalValue.slice(1).toLowerCase()
+  )
+}

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -340,6 +340,7 @@ export const appendVerifiedSPCPResponses: RequestHandler<
   const { form } = req as WithForm<typeof req>
   const { uinFin, userInfo } = res.locals
   switch (form.authType) {
+    case AuthType.MyInfo:
     case AuthType.SP:
       req.body.parsedResponses.push(...createSingpassParsedResponses(uinFin))
       break

--- a/src/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/config/feature-manager/spcp-myinfo.config.ts
@@ -175,13 +175,13 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
       env: 'MYINFO_CERT_PATH',
     },
     myInfoClientId: {
-      doc: 'Client ID registered with MyInfo.',
+      doc: 'OAuth2 client ID registered with MyInfo.',
       format: String,
       default: null,
       env: 'MYINFO_CLIENT_ID',
     },
     myInfoClientSecret: {
-      doc: 'Client secret registered with MyInfo.',
+      doc: 'OAuth2 client secret registered with MyInfo.',
       format: String,
       default: null,
       env: 'MYINFO_CLIENT_SECRET',

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -177,9 +177,9 @@
                 ng-class="isDisableAuthType() ? 'radio-disabled' : ''"
                 ng-if="!isFormEncrypt() || type.isEnabledInStorageMode"
               >
-                <label for="auth-type-{{type.name}}" class="col-xs-12">
+                <label for="auth-type-{{type.val}}" class="col-xs-12">
                   <input
-                    id="auth-type-{{type.name}}"
+                    id="auth-type-{{type.val}}"
                     type="radio"
                     ng-model="tempForm.authType"
                     value="{{ type.val }}"

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -163,7 +163,7 @@ function settingsFormDirective(
           },
           {
             val: 'MyInfo',
-            name: 'MyInfo',
+            name: 'SingPass (MyInfo)',
             isEnabledInStorageMode: false,
           },
           {

--- a/src/public/modules/users/controllers/billing.client.controller.js
+++ b/src/public/modules/users/controllers/billing.client.controller.js
@@ -35,9 +35,22 @@ function BillingController(
       case 'SP':
         return 'SingPass'
       case 'MyInfo':
-        return 'MyInfo'
+        return 'SingPass (MyInfo)'
       case 'CP':
         return 'CorpPass'
+      default:
+        return 'NIL'
+    }
+  }
+
+  vm.authTypeToShortName = (authType) => {
+    switch (authType) {
+      case 'SP':
+        return 'SP'
+      case 'MyInfo':
+        return 'SP (MI)'
+      case 'CP':
+        return 'CP'
       default:
         return 'NIL'
     }

--- a/src/public/modules/users/views/billing.client.view.html
+++ b/src/public/modules/users/views/billing.client.view.html
@@ -121,7 +121,7 @@
                   class="auth-col auth-col-mobile"
                   header-class="'auth-col auth-col-mobile'"
                 >
-                  {{row.authType}}
+                  {{vm.authTypeToShortName(row.authType)}}
                 </td>
                 <td
                   title="'#'"

--- a/src/types/express.locals.ts
+++ b/src/types/express.locals.ts
@@ -35,7 +35,7 @@ export type ResWithHashedFields<T> = T & {
 export type SpcpLocals =
   | {
       uinFin: string
-      hashedFields: Set<string>
+      hashedFields?: Set<string>
     }
   | { uinFin: string; userInfo: string }
   | { [key: string]: never } // empty object

--- a/tests/end-to-end/helpers/selectors.js
+++ b/tests/end-to-end/helpers/selectors.js
@@ -77,19 +77,12 @@ const buildTab = {
 const logicTab = {
   addLogicBtn: Selector('#add-new-logic'),
 }
-const AUTH_TYPE_TO_VALUE = {
-  SP: 'SingPass',
-  CP: 'CorpPass',
-  NIL: 'None',
-  MyInfo: 'MyInfo',
-}
+
 const settingsTab = {
   formStatus: Selector('#golive-option'),
   activateBtn: Selector('#btn-live'),
-  getAuthRadioInput: (authType) =>
-    Selector(`#auth-type-${AUTH_TYPE_TO_VALUE[authType]}`),
-  getAuthRadioLabel: (authType) =>
-    Selector(`#auth-type-${AUTH_TYPE_TO_VALUE[authType]}`).parent(),
+  getAuthRadioInput: (authType) => Selector(`#auth-type-${authType}`),
+  getAuthRadioLabel: (authType) => Selector(`#auth-type-${authType}`).parent(),
   esrvcIdInput: Selector('#enable-auth-options input[type="text"]'),
   captchaToggleInput: Selector('#enable-captcha input'),
   captchaToggleLabel: Selector('#enable-captcha input').parent(),


### PR DESCRIPTION
## Bug fixes
### Workpass status
Workpass status returned by MyInfo is now converted to TitleCase before setting it as the field value. This is because MyInfo staging returns the value in uppercase, whereas the documentation says that it should be in TitleCase, and the allowed values in the dropdown field are in TitleCase.

### Preview submissions
Preview submission emails were previously not including the NRIC for MyInfo forms. This was fixed by adding the relevant cases in the preview submissions pipeline.

## Copy changes
### Settings tab
Label of the MyInfo auth type on the Settings tab was changed to "SingPass (MyInfo)". However, this broke e2e tests as spaces are not allowed in CSS selectors, so some adjustments to the CSS classes had to be made.

### Billing page
Label of the MyInfo auth type in the Billing panel was changed to "SingPass (MyInfo)" in desktop view and "SP(MI)" in mobile view.