### PR TITLE
chore: config babel to ignore node_modules directory

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,11 +1,15 @@
 {
   "presets": [
-    ["@babel/preset-env", {
-      "corejs": 3,
-      "useBuiltIns": "entry",
-      "targets": {
-        "browsers": ["IE 11", "not dead"]
+    [
+      "@babel/preset-env",
+      {
+        "corejs": 3,
+        "useBuiltIns": "entry",
+        "targets": {
+          "browsers": ["IE 11", "not dead"]
+        }
       }
-    }]
-  ]
+    ]
+  ],
+  "ignore": ["node_modules"]
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Babel seems to also be pushing `node_modules` directory into its pipeline, resulting in longer process and possible heap overflow.

![Screenshot 2021-03-01 at 11 00 31 AM](https://user-images.githubusercontent.com/22133008/109446866-73f70000-7a7d-11eb-80a6-c76fb1c74987.png)


## Solution
- config babel to ignore the `node_modules` directory