### PR TITLE
fix: add backend email field validation to prevent empty domains when allowing domain whitelist

### DIFF
--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash'
 import { Schema } from 'mongoose'
 
 import { validateEmailDomains } from '../../../shared/util/email-domain-validation'
@@ -8,10 +7,12 @@ const validateAllowDomainsToBeSet = (
   emailDomains: string[],
   hasAllowedEmailDomains: boolean,
 ): boolean => {
+  const areDomainsEmpty = emailDomains.length === 0
+
   // Case 1: hasAllowedEmailDomains is false and emailDomains must be empty.
-  const case1 = !hasAllowedEmailDomains && isEmpty(emailDomains)
+  const case1 = !hasAllowedEmailDomains && areDomainsEmpty
   // Case 2: hasAllowedEmailDomains is true and email domains must not be empty.
-  const case2 = hasAllowedEmailDomains && !isEmpty(emailDomains)
+  const case2 = hasAllowedEmailDomains && !areDomainsEmpty
 
   return case1 || case2
 }
@@ -100,15 +101,6 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
           Error('Autoreply PDF is not allowed for storage mode forms'),
         )
       }
-    }
-
-    return next()
-  })
-
-  // If hasAllowedEmailDomains is false, then clear allowedEmailDomains
-  EmailFieldSchema.pre<IEmailFieldSchema>('validate', function (next) {
-    if (!this.hasAllowedEmailDomains) {
-      this.allowedEmailDomains = []
     }
 
     return next()

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -144,6 +144,14 @@ function EditFieldsModalController(
     }
   }
 
+  vm.handleRestrictEmailDomainsToggle = function () {
+    const field = vm.field
+    if (field.hasAllowedEmailDomains === false) {
+      // Reset email domains.
+      field.allowedEmailDomainsFromText = ''
+    }
+  }
+
   vm.ratingSteps = Rating.steps
   vm.ratingShapes = Rating.shapes
 

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -622,6 +622,7 @@
                 <input
                   type="checkbox"
                   ng-model="vm.field.hasAllowedEmailDomains"
+                  ng-change="vm.handleRestrictEmailDomainsToggle()"
                   ng-disabled="!vm.field.isVerifiable"
                 />
                 <div class="toggle-selector-switch">

--- a/src/shared/util/email-domain-validation.ts
+++ b/src/shared/util/email-domain-validation.ts
@@ -1,15 +1,16 @@
-import { isEmpty } from 'lodash'
 import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
   return (
-    isEmpty(emailDomains) ||
-    (new Set(emailDomains).size === emailDomains.length &&
-      emailDomains.every(
-        (emailDomain) =>
-          // We need to prepend "bob" to the email domain so that it can form an
-          // email address and can be validated by validator.isEmail.
-          emailDomain.startsWith('@') && validator.isEmail('bob' + emailDomain),
-      ))
+    // Email domains to be set must:
+    // 1. Have no duplicates
+    new Set(emailDomains).size === emailDomains.length &&
+    // 2. Be all valid email domains
+    emailDomains.every(
+      (emailDomain) =>
+        // We need to prepend "bob" to the email domain so that it can form an
+        // email address and can be validated by validator.isEmail.
+        emailDomain.startsWith('@') && validator.isEmail('bob' + emailDomain),
+    )
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Somehow even with frontend blocking, some forms are being created with `hasAllowedEmailDomains = true` but with empty `allowedEmailDomains`.

This PR fixes that by adding a backend schema validation on the email field to prevent such occurrences.


## Solution
<!-- How did you solve the problem? -->

**Fixes**:
- add email field validation to prevent empty domains when enabled

## Screenshots
_Note that this will not happen on prod, frontend validation was removed temporarily just to show validation being performed on the backend correctly._
![Screenshot 2021-03-08 at 10 21 32 AM](https://user-images.githubusercontent.com/22133008/110266597-17559100-7ff9-11eb-9a8c-83461405ff19.png)

## Tests
- [ ] Create email field with allowed email domains. Should save properly.
- [ ] For that same field, toggle allow email domains off. Should save properly. Go back into the field; the domains should have been cleared (in both client and network request object)
- [ ] Create email field with allow email domains toggled on. Client should prevent saving
  - [ ] when email domains given are empty
  - [ ] when duplicate email domains are given

