### PR TITLE
feat: upgrade to beta version of myinfo-gov-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4421,9 +4421,9 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-3.0.0.tgz",
-      "integrity": "sha512-UEDgVLC7zsNPS9HB3n3j8ky2UBeQ5HauGtVckXbCjzdkYwXYHZ36yfEWHD6/HUnZ0uXkOMtb9X0jKwfG1Y4Zxw==",
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-4.0.0-beta.0.tgz",
+      "integrity": "sha512-OslJubLTMI1SFxzDKYts5elV0jcQoNeWI6gkUTcqBTLX1JJBB23pVVRo1BSTakA1RqNw+0LD3PRrolLHuHHieQ==",
       "requires": {
         "axios": "^0.21.1",
         "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "^0.8.4-beta.0",
-    "@opengovsg/myinfo-gov-client": "=3.0.0",
+    "@opengovsg/myinfo-gov-client": "^4.0.0-beta.0",
     "@opengovsg/ng-file-upload": "^12.2.15",
     "@opengovsg/spcp-auth-client": "^1.4.0",
     "@sentry/browser": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "^0.8.4-beta.0",
-    "@opengovsg/myinfo-gov-client": "^4.0.0-beta.0",
+    "@opengovsg/myinfo-gov-client": "=4.0.0-beta.0",
     "@opengovsg/ng-file-upload": "^12.2.15",
     "@opengovsg/spcp-auth-client": "^1.4.0",
     "@sentry/browser": "^6.2.1",

--- a/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
@@ -42,7 +42,8 @@ jest.mock('@opengovsg/myinfo-gov-client', () => ({
   })),
   MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
   MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
-  AddressType: jest.requireActual('@opengovsg/myinfo-gov-client').AddressType,
+  MyInfoAddressType: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAddressType,
   MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
     .MyInfoAttribute,
 }))

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -1,6 +1,6 @@
 import {
-  AddressType,
   IPerson,
+  MyInfoAddressType,
   MyInfoMode,
   MyInfoSource,
 } from '@opengovsg/myinfo-gov-client'
@@ -28,7 +28,7 @@ export const MOCK_MYINFO_DATA = {
     nbr: { value: '97324992' },
   },
   regadd: {
-    type: AddressType.Singapore,
+    type: MyInfoAddressType.Singapore,
     country: { code: 'SG', desc: 'SINGAPORE' },
     unit: { value: '128' },
     street: { value: 'BEDOK NORTH AVENUE 1' },
@@ -58,7 +58,7 @@ export const MOCK_MYINFO_FORMAT_DATA = {
     nbr: { value: '97324992' },
   },
   regadd: {
-    type: AddressType.Singapore,
+    type: MyInfoAddressType.Singapore,
     country: { code: 'SG', desc: 'SINGAPORE' },
     unit: { value: '128' },
     street: { value: 'BEDOK NORTH AVENUE 1' },

--- a/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/src/app/modules/myinfo/myinfo.adapter.ts
@@ -269,9 +269,8 @@ export class MyInfoData {
         const data = this.#personData[attr]
         return (
           !!data &&
-          data.source !== MyInfoSource.NotApplicable &&
-          !data.unavailable &&
-          data.source === MyInfoSource.GovtVerified
+          data.source === MyInfoSource.GovtVerified &&
+          !data.unavailable
         )
       }
       // Fields required to always be editable according to MyInfo docs

--- a/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/src/app/modules/myinfo/myinfo.adapter.ts
@@ -269,6 +269,7 @@ export class MyInfoData {
         const data = this.#personData[attr]
         return (
           !!data &&
+          data.source !== MyInfoSource.NotApplicable &&
           !data.unavailable &&
           data.source === MyInfoSource.GovtVerified
         )

--- a/src/app/modules/myinfo/myinfo.format.ts
+++ b/src/app/modules/myinfo/myinfo.format.ts
@@ -38,7 +38,6 @@ export const formatAddress = (addr: MyInfoAddress | undefined): string => {
   }
 
   if (addr.type !== MyInfoAddressType.Singapore) {
-    //workaround - MyInfoAddressType.Unformatted should be the string "UNFORMATTED" not "Unformatted"
     let result = ''
     if (addr.line1?.value) {
       result += addr.line1.value

--- a/src/app/modules/myinfo/myinfo.format.ts
+++ b/src/app/modules/myinfo/myinfo.format.ts
@@ -1,10 +1,12 @@
 import {
-  AddressType,
-  BasicField as MyInfoBasicField,
-  FieldWithCodeAndDesc,
   MyInfoAddress,
+  MyInfoAddressType,
+  MyInfoCodeField,
+  MyInfoNotApplicable,
   MyInfoOccupation,
   MyInfoPhoneNumber,
+  MyInfoSource,
+  MyInfoValueField,
   MyInfoVehicle,
 } from '@opengovsg/myinfo-gov-client'
 
@@ -31,12 +33,12 @@ export const formatPhoneNumber = (
  * @returns Formatted address if minimally the `block`, `street`, `country`,and `postal` values are not empty in {@link addr}. Else return empty string.
  */
 export const formatAddress = (addr: MyInfoAddress | undefined): string => {
-  if (!addr || addr.unavailable) {
+  if (!addr || addr.source === MyInfoSource.NotApplicable || addr.unavailable) {
     return ''
   }
 
-  if (addr.type !== AddressType.Singapore) {
-    //workaround - AddressType.Unformatted should be the string "UNFORMATTED" not "Unformatted"
+  if (addr.type !== MyInfoAddressType.Singapore) {
+    //workaround - MyInfoAddressType.Unformatted should be the string "UNFORMATTED" not "Unformatted"
     let result = ''
     if (addr.line1?.value) {
       result += addr.line1.value
@@ -91,9 +93,14 @@ export const formatAddress = (addr: MyInfoAddress | undefined): string => {
  * @param field Field to format
  */
 export const formatDescriptionField = (
-  field: FieldWithCodeAndDesc | undefined,
+  field: MyInfoCodeField | MyInfoNotApplicable | undefined,
 ): string => {
-  if (!field || field.unavailable) return ''
+  if (
+    !field ||
+    field.source === MyInfoSource.NotApplicable ||
+    field.unavailable
+  )
+    return ''
   return field.desc
 }
 
@@ -103,9 +110,14 @@ export const formatDescriptionField = (
  * @param field Field to format
  */
 export const formatBasicField = (
-  field: MyInfoBasicField | undefined,
+  field: MyInfoValueField | MyInfoNotApplicable | undefined,
 ): string => {
-  if (!field || field.unavailable) return ''
+  if (
+    !field ||
+    field.source === MyInfoSource.NotApplicable ||
+    field.unavailable
+  )
+    return ''
   return field.value
 }
 
@@ -148,11 +160,17 @@ export const formatOccupation = (
  * Possible values are 'Live', 'Approved'.
  */
 export const formatWorkpassStatus = (
-  field: MyInfoBasicField | undefined,
+  field: MyInfoValueField | MyInfoNotApplicable | undefined,
 ): string => {
   // Field value should always be a string, but check for type safety since
   // string methods need to be called
-  if (!field || field.unavailable || typeof field.value !== 'string') return ''
+  if (
+    !field ||
+    field.source === MyInfoSource.NotApplicable ||
+    field.unavailable ||
+    typeof field.value !== 'string'
+  )
+    return ''
   // Change to title case
   const originalValue = field.value
   return (


### PR DESCRIPTION
Upgrades to the latest beta release of `@opengovsg/myinfo-gov-client`, which enforces stricter type-checking of the data returned by MyInfo.

The MyInfo adapter layer was updated with the necessary additional type checks.