### PR TITLE
test: add tests for new MyInfo functionality

### DIFF
--- a/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
@@ -1,54 +1,75 @@
-import { IPerson, IPersonResponse } from '@opengovsg/myinfo-gov-client'
+import {
+  IPerson,
+  IPersonResponse,
+  MyInfoVehicleFull,
+} from '@opengovsg/myinfo-gov-client'
+import { SetRequired } from 'type-fest'
 
 import { MyInfoAttribute } from 'src/types'
 
 import { MyInfoData } from '../myinfo.adapter'
 
-import { MOCK_MYINFO_FORMAT_DATA } from './myinfo.test.constants'
-
-const MOCK_UIN_FIN = 'S9912370B'
+import { MOCK_UINFIN } from './myinfo.test.constants'
+import {
+  MYINFO_BASIC_AVAILABLE,
+  MYINFO_BASIC_NA,
+  MYINFO_BASIC_UNAVAILABLE,
+  MYINFO_DESCRIPTION_AVAILABLE,
+  MYINFO_DESCRIPTION_NA,
+  MYINFO_DESCRIPTION_UNAVAILABLE,
+  MYINFO_MOBILENO_AVAILABLE,
+  MYINFO_MOBILENO_UNAVAILABLE,
+  MYINFO_OCCUPATION_CODE,
+  MYINFO_OCCUPATION_UNAVAILABLE,
+  MYINFO_OCCUPATION_VALUE,
+  MYINFO_PASSSTATUS_AVAILABLE,
+  MYINFO_PASSSTATUS_NA,
+  MYINFO_PASSSTATUS_UNAVAILABLE,
+  MYINFO_REGADD_AVAILABLE,
+  MYINFO_REGADD_NA,
+  MYINFO_REGADD_UNAVAILABLE,
+  MYINFO_VEHNO_AVAILABLE,
+  MYINFO_VEHNO_UNAVAILABLE,
+} from './myinfo.test.data'
 
 describe('myinfo.adapter', () => {
   describe('MyInfoData', () => {
     describe('getFieldValueForAttr', () => {
-      it('should return empty string and readonly as false if valid myInfoAttr does not exist in valid myInfoData', () => {
-        // Arrange
-        const response: IPersonResponse = {
-          uinFin: MOCK_UIN_FIN,
-          data: {},
-        }
-        const myInfoData = new MyInfoData(response)
-
-        // Act
-        const actual = myInfoData.getFieldValueForAttr(
-          MyInfoAttribute.WorkpassExpiryDate,
-        )
-
-        // Assert
-        expect(actual).toEqual({
-          fieldValue: '',
-          isReadOnly: false,
-        })
-      })
-
-      it('should correctly return attr.value', () => {
-        const response: IPersonResponse = {
-          uinFin: MOCK_UIN_FIN,
-          data: MOCK_MYINFO_FORMAT_DATA as IPerson,
-        }
-        const myInfoData = new MyInfoData(response)
-        // Act
-        const actual = myInfoData.getFieldValueForAttr(
-          MyInfoAttribute.WorkpassExpiryDate,
-        )
-
-        // Assert
-        expect(actual.fieldValue).toEqual(
-          MOCK_MYINFO_FORMAT_DATA.passexpirydate.value,
-        )
-      })
-
       describe('Phone numbers', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.MobileNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_MOBILENO_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.MobileNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
         it('should correctly return formatted mobile phone numbers if valid', () => {
           // Arrange
           // code: '65',
@@ -56,8 +77,8 @@ describe('myinfo.adapter', () => {
           // nbr: '97324992',
           const expected = '+65 97324992'
           const response: IPersonResponse = {
-            uinFin: MOCK_UIN_FIN,
-            data: MOCK_MYINFO_FORMAT_DATA as IPerson,
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_MOBILENO_AVAILABLE,
           }
           const myInfoData = new MyInfoData(response)
           // Act
@@ -67,10 +88,62 @@ describe('myinfo.adapter', () => {
 
           // Assert
           expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
         })
       })
 
       describe('Addresses', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.RegisteredAddress,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is not applicable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_REGADD_NA,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.RegisteredAddress,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_REGADD_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.RegisteredAddress,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
         it('should correctly return formatted registered addresses', () => {
           // Arrange
           // unit: '128',
@@ -81,8 +154,8 @@ describe('myinfo.adapter', () => {
           // building: '',
           const expected = '548 BEDOK NORTH AVENUE 1, #09-128, SINGAPORE 460548'
           const response: IPersonResponse = {
-            uinFin: MOCK_UIN_FIN,
-            data: MOCK_MYINFO_FORMAT_DATA as IPerson,
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_REGADD_AVAILABLE,
           }
           const myInfoData = new MyInfoData(response)
           // Act
@@ -92,6 +165,379 @@ describe('myinfo.adapter', () => {
 
           // Assert
           expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
+        })
+      })
+
+      describe('Vehicle numbers', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.VehicleNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_VEHNO_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.VehicleNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return single vehicle numbers', () => {
+          // Grab first vehicle number
+          const expected = (MYINFO_VEHNO_AVAILABLE.vehicles![0] as SetRequired<
+            MyInfoVehicleFull,
+            'vehicleno'
+          >).vehicleno.value
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {
+              vehicles: [MYINFO_VEHNO_AVAILABLE.vehicles![0]],
+            },
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.VehicleNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return multiple vehicle numbers', () => {
+          // Join all vehicle numbers
+          const expected = MYINFO_VEHNO_AVAILABLE.vehicles!.map(
+            (vehicle) =>
+              (vehicle as SetRequired<MyInfoVehicleFull, 'vehicleno'>).vehicleno
+                .value,
+          ).join(', ')
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_VEHNO_AVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.VehicleNo,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(false)
+        })
+      })
+
+      describe('Occupation', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.Occupation,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_OCCUPATION_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.Occupation,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return value and readonly as true when occupation is given as code', () => {
+          const expected = (MYINFO_OCCUPATION_CODE.occupation as any).desc
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_OCCUPATION_CODE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.Occupation,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
+        })
+
+        it('should correctly return value and readonly as false when occupation is user-provided', () => {
+          const expected = (MYINFO_OCCUPATION_VALUE as any).occupation.value
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_OCCUPATION_VALUE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.Occupation,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(false)
+        })
+      })
+
+      describe('Code/description fields', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.ResidentialStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_DESCRIPTION_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(MyInfoAttribute.Sex)
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is not applicable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_DESCRIPTION_NA,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.ResidentialStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return value and readonly as true when data is present and verified', () => {
+          const expected = (MYINFO_DESCRIPTION_AVAILABLE as any).sex.desc
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_DESCRIPTION_AVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(MyInfoAttribute.Sex)
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
+        })
+      })
+
+      describe('Workpass status', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.WorkpassStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_PASSSTATUS_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.WorkpassStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is not applicable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_PASSSTATUS_NA,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.WorkpassStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return value and readonly as true when data is present and verified', () => {
+          const expected = (MYINFO_PASSSTATUS_AVAILABLE as any).passstatus.value
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_PASSSTATUS_AVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.WorkpassStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
+        })
+
+        it('should correctly convert value to TitleCase', () => {
+          const expected = (MYINFO_PASSSTATUS_AVAILABLE as any).passstatus
+            .value as string
+          const uppercasedData = {
+            passstatus: {
+              ...MYINFO_PASSSTATUS_AVAILABLE.passstatus!,
+              value: expected.toUpperCase(),
+            },
+          } as IPerson
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: uppercasedData,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.WorkpassStatus,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
+        })
+      })
+
+      describe('Basic value fields', () => {
+        it('should return empty string and readonly as false when key is not present', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: {},
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(MyInfoAttribute.Name)
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is unavailable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_BASIC_UNAVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(MyInfoAttribute.Name)
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should return empty string and readonly as false when data is not applicable', () => {
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_BASIC_NA,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(
+            MyInfoAttribute.DivorceDate,
+          )
+
+          // Assert
+          expect(actual.fieldValue).toEqual('')
+          expect(actual.isReadOnly).toEqual(false)
+        })
+
+        it('should correctly return value and readonly as true when data is present and verified', () => {
+          const expected = (MYINFO_BASIC_AVAILABLE as any).name.value
+          const response: IPersonResponse = {
+            uinFin: MOCK_UINFIN,
+            data: MYINFO_BASIC_AVAILABLE,
+          }
+          const myInfoData = new MyInfoData(response)
+          // Act
+          const actual = myInfoData.getFieldValueForAttr(MyInfoAttribute.Name)
+
+          // Assert
+          expect(actual.fieldValue).toEqual(expected)
+          expect(actual.isReadOnly).toEqual(true)
         })
       })
     })

--- a/src/app/modules/myinfo/__tests__/myinfo.controller.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.controller.spec.ts
@@ -1,0 +1,443 @@
+import { MyInfoFetchError } from 'dist/backend/app/modules/myinfo/myinfo.errors'
+import { StatusCodes } from 'http-status-codes'
+import { err, errAsync, ok, okAsync } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
+
+import { AuthType, IFormSchema, ILoginSchema, IPopulatedForm } from 'src/types'
+
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+
+import { BillingFactory } from '../../billing/billing.factory'
+import { DatabaseError } from '../../core/core.errors'
+import { FormNotFoundError } from '../../form/form.errors'
+import * as FormService from '../../form/form.service'
+import {
+  MOCK_ERROR_CODE,
+  MOCK_LOGIN_HTML,
+} from '../../spcp/__tests__/spcp.test.constants'
+import {
+  FetchLoginPageError,
+  LoginPageValidationError,
+} from '../../spcp/spcp.errors'
+import { SpcpFactory } from '../../spcp/spcp.factory'
+import { MYINFO_COOKIE_NAME, MYINFO_COOKIE_OPTIONS } from '../myinfo.constants'
+import * as MyInfoController from '../myinfo.controller'
+import { MyInfoFactory } from '../myinfo.factory'
+import { MyInfoCookieState } from '../myinfo.types'
+
+import {
+  MOCK_ACCESS_TOKEN,
+  MOCK_AUTH_CODE,
+  MOCK_COOKIE_AGE,
+  MOCK_FORM_ID,
+  MOCK_MYINFO_FORM,
+  MOCK_REDIRECT_URL,
+} from './myinfo.test.constants'
+
+jest.mock('../myinfo.factory')
+const MockMyInfoFactory = mocked(MyInfoFactory, true)
+
+jest.mock('../../form/form.service')
+const MockFormService = mocked(FormService, true)
+
+jest.mock('../../spcp/spcp.factory')
+const MockSpcpFactory = mocked(SpcpFactory, true)
+
+jest.mock('../../billing/billing.factory')
+const MockBillingFactory = mocked(BillingFactory, true)
+
+describe('MyInfoController', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  describe('handleRedirectURLRequest', () => {
+    const mockReq = expressHandler.mockRequest({
+      query: {
+        formId: MOCK_FORM_ID,
+      },
+    })
+    const mockRes = expressHandler.mockResponse()
+
+    it('should respond with redirect URL when form is valid MyInfo form', async () => {
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        okAsync(MOCK_MYINFO_FORM),
+      )
+      MockMyInfoFactory.createRedirectURL.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+
+      await MyInfoController.respondWithRedirectURL(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.createRedirectURL).toHaveBeenCalledWith({
+        formEsrvcId: MOCK_MYINFO_FORM.esrvcId,
+        formId: MOCK_MYINFO_FORM._id,
+        requestedAttributes: MOCK_MYINFO_FORM.getUniqueMyInfoAttrs(),
+      })
+      expect(mockRes.json).toHaveBeenCalledWith({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+
+    it('should return 404 when form is not found', async () => {
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        errAsync(new FormNotFoundError()),
+      )
+
+      await MyInfoController.respondWithRedirectURL(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.createRedirectURL).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+    })
+
+    it('should return 400 when form is not a MyInfo form', async () => {
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        okAsync({ ...MOCK_MYINFO_FORM, authType: 'SP' } as IFormSchema),
+      )
+
+      await MyInfoController.respondWithRedirectURL(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.createRedirectURL).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        errAsync(new DatabaseError()),
+      )
+
+      await MyInfoController.respondWithRedirectURL(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.createRedirectURL).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+    })
+  })
+
+  describe('checkMyInfoEServiceId', () => {
+    const mockReq = expressHandler.mockRequest({
+      query: {
+        formId: MOCK_FORM_ID,
+      },
+    })
+    const mockRes = expressHandler.mockResponse()
+
+    beforeEach(() => {
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        okAsync(MOCK_MYINFO_FORM),
+      )
+    })
+
+    it('should return 200 with isValid true if validation passes', async () => {
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+      MockSpcpFactory.fetchLoginPage.mockReturnValueOnce(
+        okAsync(MOCK_LOGIN_HTML),
+      )
+      MockSpcpFactory.validateLoginPage.mockReturnValueOnce(
+        ok({ isValid: true }),
+      )
+
+      await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
+
+      expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
+        AuthType.SP,
+        MOCK_MYINFO_FORM._id,
+        MOCK_MYINFO_FORM.esrvcId,
+      )
+      expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
+        MOCK_REDIRECT_URL,
+      )
+      expect(MockSpcpFactory.validateLoginPage).toHaveBeenCalledWith(
+        MOCK_LOGIN_HTML,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        isValid: true,
+      })
+    })
+
+    it('should return 200 with isValid false if validation fails', async () => {
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+      MockSpcpFactory.fetchLoginPage.mockReturnValueOnce(
+        okAsync(MOCK_LOGIN_HTML),
+      )
+      MockSpcpFactory.validateLoginPage.mockReturnValueOnce(
+        ok({ isValid: false, errorCode: MOCK_ERROR_CODE }),
+      )
+
+      await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
+
+      expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
+        AuthType.SP,
+        MOCK_MYINFO_FORM._id,
+        MOCK_MYINFO_FORM.esrvcId,
+      )
+      expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
+        MOCK_REDIRECT_URL,
+      )
+      expect(MockSpcpFactory.validateLoginPage).toHaveBeenCalledWith(
+        MOCK_LOGIN_HTML,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        isValid: false,
+        errorCode: MOCK_ERROR_CODE,
+      })
+    })
+
+    it('should return 503 when FetchLoginPageError occurs', async () => {
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+      MockSpcpFactory.fetchLoginPage.mockReturnValueOnce(
+        errAsync(new FetchLoginPageError()),
+      )
+
+      await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
+
+      expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
+        AuthType.SP,
+        MOCK_MYINFO_FORM._id,
+        MOCK_MYINFO_FORM.esrvcId,
+      )
+      expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
+        MOCK_REDIRECT_URL,
+      )
+      expect(MockSpcpFactory.validateLoginPage).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.SERVICE_UNAVAILABLE,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Failed to contact SingPass. Please try again.',
+      })
+    })
+
+    it('should return 503 when LoginPageValidationError occurs', async () => {
+      MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
+        ok(MOCK_REDIRECT_URL),
+      )
+      MockSpcpFactory.fetchLoginPage.mockReturnValueOnce(
+        okAsync(MOCK_LOGIN_HTML),
+      )
+      MockSpcpFactory.validateLoginPage.mockReturnValueOnce(
+        err(new LoginPageValidationError()),
+      )
+
+      await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
+
+      expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
+        AuthType.SP,
+        MOCK_MYINFO_FORM._id,
+        MOCK_MYINFO_FORM.esrvcId,
+      )
+      expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
+        MOCK_REDIRECT_URL,
+      )
+      expect(MockSpcpFactory.validateLoginPage).toHaveBeenCalledWith(
+        MOCK_LOGIN_HTML,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.SERVICE_UNAVAILABLE,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Failed to contact SingPass. Please try again.',
+      })
+    })
+  })
+
+  describe('loginToMyInfo', () => {
+    const mockState = {
+      formId: MOCK_MYINFO_FORM._id,
+      uuid: 'uuid',
+      cookieDuration: MOCK_COOKIE_AGE,
+    }
+    const expectedCookieOptions = MYINFO_COOKIE_OPTIONS
+    const mockReq = expressHandler.mockRequest({
+      query: {
+        code: MOCK_AUTH_CODE,
+        state: JSON.stringify(mockState),
+      },
+    })
+    const mockRes = expressHandler.mockResponse()
+
+    beforeEach(() => {
+      MockFormService.retrieveFullFormById.mockReturnValue(
+        okAsync(MOCK_MYINFO_FORM as IPopulatedForm),
+      )
+      MockMyInfoFactory.parseMyInfoRelayState.mockReturnValue(ok(mockState))
+      MockMyInfoFactory.retrieveAccessToken.mockReturnValue(
+        okAsync(MOCK_ACCESS_TOKEN),
+      )
+      // Return value is ignored
+      MockBillingFactory.recordLoginByForm.mockReturnValue(
+        okAsync(({} as unknown) as ILoginSchema),
+      )
+    })
+
+    it('should set cookie and redirect to correct destination when login is valid', async () => {
+      await MyInfoController.loginToMyInfo(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).toHaveBeenCalledWith(
+        MOCK_AUTH_CODE,
+      )
+      expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM,
+      )
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_COOKIE_NAME,
+        {
+          accessToken: MOCK_ACCESS_TOKEN,
+          usedCount: 0,
+          state: MyInfoCookieState.Success,
+        },
+        { ...expectedCookieOptions, maxAge: MOCK_COOKIE_AGE },
+      )
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/${MOCK_MYINFO_FORM._id}`)
+    })
+
+    it('should redirect to home page when destination is not valid', async () => {
+      MockFormService.retrieveFullFormById.mockReturnValue(
+        errAsync(new FormNotFoundError()),
+      )
+
+      await MyInfoController.loginToMyInfo(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).not.toHaveBeenCalled()
+      expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
+      expect(mockRes.cookie).not.toHaveBeenCalled()
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/`)
+    })
+
+    it('should set error cookie and redirect to form when form is not MyInfo-authenticated', async () => {
+      MockFormService.retrieveFullFormById.mockReturnValue(
+        okAsync({
+          ...MOCK_MYINFO_FORM,
+          // Modify authType to SingPass
+          authType: AuthType.SP,
+        } as IPopulatedForm),
+      )
+
+      await MyInfoController.loginToMyInfo(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).not.toHaveBeenCalled()
+      expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_COOKIE_NAME,
+        {
+          state: MyInfoCookieState.Error,
+        },
+        expectedCookieOptions,
+      )
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/${MOCK_MYINFO_FORM._id}`)
+    })
+
+    it('should set error cookie and redirect to form when consent flow is not successful', async () => {
+      const mockErrorReq = expressHandler.mockRequest({
+        query: {
+          error: 'error',
+          'error-description': 'error-description',
+          state: JSON.stringify(mockState),
+        },
+      })
+
+      await MyInfoController.loginToMyInfo(mockErrorReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).not.toHaveBeenCalled()
+      expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_COOKIE_NAME,
+        {
+          state: MyInfoCookieState.Error,
+        },
+        expectedCookieOptions,
+      )
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/${MOCK_MYINFO_FORM._id}`)
+    })
+
+    it('should set error cookie and redirect to form when access token is invalid', async () => {
+      MockMyInfoFactory.retrieveAccessToken.mockReturnValue(
+        errAsync(new MyInfoFetchError()),
+      )
+
+      await MyInfoController.loginToMyInfo(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).toHaveBeenCalledWith(
+        MOCK_AUTH_CODE,
+      )
+      expect(MockBillingFactory.recordLoginByForm).not.toHaveBeenCalled()
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_COOKIE_NAME,
+        {
+          state: MyInfoCookieState.Error,
+        },
+        expectedCookieOptions,
+      )
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/${MOCK_MYINFO_FORM._id}`)
+    })
+
+    it('should set error cookie and redirect to form when recording login is unsuccessful', async () => {
+      MockBillingFactory.recordLoginByForm.mockReturnValue(
+        errAsync(new DatabaseError()),
+      )
+
+      await MyInfoController.loginToMyInfo(mockReq, mockRes, jest.fn())
+
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM._id,
+      )
+      expect(MockMyInfoFactory.retrieveAccessToken).toHaveBeenCalledWith(
+        MOCK_AUTH_CODE,
+      )
+      expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM,
+      )
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_COOKIE_NAME,
+        {
+          state: MyInfoCookieState.Error,
+        },
+        expectedCookieOptions,
+      )
+      expect(mockRes.redirect).toHaveBeenCalledWith(`/${MOCK_MYINFO_FORM._id}`)
+    })
+  })
+})

--- a/src/app/modules/myinfo/__tests__/myinfo.factory.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.factory.spec.ts
@@ -7,6 +7,7 @@ import { Environment } from 'src/types'
 import { MyInfoData } from '../myinfo.adapter'
 import { createMyInfoFactory } from '../myinfo.factory'
 import * as MyInfoServiceModule from '../myinfo.service'
+import { IMyInfoRedirectURLArgs } from '../myinfo.types'
 
 import { MOCK_APP_URL, MOCK_NODE_ENV } from './myinfo.test.constants'
 
@@ -36,6 +37,14 @@ describe('myinfo.factory', () => {
     const error = new Error(
       'spcp-myinfo is not activated, but a feature-specific function was called.',
     )
+    const retrieveAccessTokenResult = await MyInfoFactory.retrieveAccessToken(
+      '',
+    )
+    const createRedirectURLResult = MyInfoFactory.createRedirectURL(
+      {} as IMyInfoRedirectURLArgs,
+    )
+    const parseMyInfoRelayStateResult = MyInfoFactory.parseMyInfoRelayState('')
+    const extractUinFinResult = MyInfoFactory.extractUinFin('')
     const fetchMyInfoPersonDataResult = await MyInfoFactory.fetchMyInfoPersonData(
       '',
       [],
@@ -58,6 +67,10 @@ describe('myinfo.factory', () => {
       [],
       {},
     )
+    expect(retrieveAccessTokenResult._unsafeUnwrapErr()).toEqual(error)
+    expect(parseMyInfoRelayStateResult._unsafeUnwrapErr()).toEqual(error)
+    expect(createRedirectURLResult._unsafeUnwrapErr()).toEqual(error)
+    expect(extractUinFinResult._unsafeUnwrapErr()).toEqual(error)
     expect(fetchMyInfoPersonDataResult._unsafeUnwrapErr()).toEqual(error)
     expect(prefillMyInfoFieldsResult._unsafeUnwrapErr()).toEqual(error)
     expect(saveMyInfoHashesResult._unsafeUnwrapErr()).toEqual(error)
@@ -73,6 +86,14 @@ describe('myinfo.factory', () => {
     const error = new Error(
       'spcp-myinfo is not activated, but a feature-specific function was called.',
     )
+    const retrieveAccessTokenResult = await MyInfoFactory.retrieveAccessToken(
+      '',
+    )
+    const createRedirectURLResult = MyInfoFactory.createRedirectURL(
+      {} as IMyInfoRedirectURLArgs,
+    )
+    const parseMyInfoRelayStateResult = MyInfoFactory.parseMyInfoRelayState('')
+    const extractUinFinResult = MyInfoFactory.extractUinFin('')
     const fetchMyInfoPersonDataResult = await MyInfoFactory.fetchMyInfoPersonData(
       '',
       [],
@@ -95,6 +116,10 @@ describe('myinfo.factory', () => {
       [],
       {},
     )
+    expect(retrieveAccessTokenResult._unsafeUnwrapErr()).toEqual(error)
+    expect(parseMyInfoRelayStateResult._unsafeUnwrapErr()).toEqual(error)
+    expect(createRedirectURLResult._unsafeUnwrapErr()).toEqual(error)
+    expect(extractUinFinResult._unsafeUnwrapErr()).toEqual(error)
     expect(fetchMyInfoPersonDataResult._unsafeUnwrapErr()).toEqual(error)
     expect(prefillMyInfoFieldsResult._unsafeUnwrapErr()).toEqual(error)
     expect(saveMyInfoHashesResult._unsafeUnwrapErr()).toEqual(error)

--- a/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
@@ -33,7 +33,8 @@ jest.mock('@opengovsg/myinfo-gov-client', () => ({
   MyInfoGovClient: jest.fn(),
   MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
   MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
-  AddressType: jest.requireActual('@opengovsg/myinfo-gov-client').AddressType,
+  MyInfoAddressType: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAddressType,
   MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
     .MyInfoAttribute,
 }))

--- a/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
@@ -1,0 +1,364 @@
+import { MyInfoGovClient } from '@opengovsg/myinfo-gov-client'
+import SPCPAuthClient from '@opengovsg/spcp-auth-client'
+import axios from 'axios'
+import { ObjectId } from 'bson'
+import session, { Session } from 'supertest-session'
+import { mocked } from 'ts-jest/utils'
+import { v4 as uuidv4 } from 'uuid'
+
+import { AuthType } from 'src/types'
+
+import { setupApp } from 'tests/integration/helpers/express-setup'
+import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import { MOCK_ERROR_CODE } from '../../spcp/__tests__/spcp.test.constants'
+import { MyInfoCookieState } from '../myinfo.types'
+
+import {
+  MOCK_ACCESS_TOKEN,
+  MOCK_AUTH_CODE,
+  MOCK_ESRVC_ID,
+  MOCK_FORM_ID,
+  MOCK_REDIRECT_URL,
+} from './myinfo.test.constants'
+
+jest.mock('axios')
+const MockAxios = mocked(axios, true)
+
+jest.mock('@opengovsg/spcp-auth-client')
+const MockAuthClient = mocked(SPCPAuthClient, true)
+
+jest.mock('@opengovsg/myinfo-gov-client', () => ({
+  MyInfoGovClient: jest.fn(),
+  MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
+  MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
+  AddressType: jest.requireActual('@opengovsg/myinfo-gov-client').AddressType,
+  MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAttribute,
+}))
+const MockMyInfoGovClient = mocked(MyInfoGovClient, true)
+const mockCreateRedirectURL = jest.fn()
+const mockGetAccessToken = jest.fn()
+MockMyInfoGovClient.mockImplementation(
+  () =>
+    (({
+      createRedirectURL: mockCreateRedirectURL,
+      getAccessToken: mockGetAccessToken,
+    } as unknown) as MyInfoGovClient),
+)
+
+// Import last so that mocks are imported correctly
+// eslint-disable-next-line import/first
+import { MyInfoRouter } from '../myinfo.routes'
+
+const myInfoApp = setupApp('/myinfo', MyInfoRouter)
+
+describe('myinfo.routes', () => {
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    await dbHandler.clearDatabase()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('GET /myinfo/redirect', () => {
+    const ROUTE = '/myinfo/redirect'
+    let request: Session
+
+    beforeAll(() => {
+      mockCreateRedirectURL.mockReturnValue(MOCK_REDIRECT_URL)
+    })
+
+    beforeEach(async () => {
+      request = session(myInfoApp)
+      await dbHandler.insertEmailForm({
+        formId: new ObjectId(MOCK_FORM_ID),
+        formOptions: {
+          authType: AuthType.MyInfo,
+          esrvcId: MOCK_ESRVC_ID,
+        },
+      })
+    })
+
+    it('should return 400 when formId is not provided as a query param', async () => {
+      const response = await request.get(ROUTE)
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({ query: { key: 'formId' } }),
+      )
+    })
+
+    it('should return 400 when formId is malformed', async () => {
+      const malformedFormId = 'malformed'
+      const response = await request.get(ROUTE).query({
+        formId: malformedFormId,
+      })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          query: {
+            key: 'formId',
+            message: `"formId" with value "${malformedFormId}" fails to match the required pattern: /^[0-9a-fA-F]{24}$/`,
+          },
+        }),
+      )
+    })
+
+    it('should return 200 with the redirect URL when Singpass request is valid', async () => {
+      const response = await request.get(ROUTE).query({
+        formId: MOCK_FORM_ID,
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+  })
+
+  describe('GET /myinfo/validate', () => {
+    const ROUTE = '/myinfo/validate'
+    let request: Session
+    const mockSpClient = mocked(MockAuthClient.mock.instances[0], true)
+
+    beforeAll(() => {
+      mockSpClient.createRedirectURL.mockReturnValue(MOCK_REDIRECT_URL)
+    })
+
+    beforeEach(async () => {
+      request = session(myInfoApp)
+      await dbHandler.insertEmailForm({
+        formId: new ObjectId(MOCK_FORM_ID),
+        formOptions: {
+          authType: AuthType.MyInfo,
+          esrvcId: MOCK_ESRVC_ID,
+        },
+      })
+    })
+
+    it('should return 400 when formId is not provided as a query param', async () => {
+      const response = await request.get(ROUTE)
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({ query: { key: 'formId' } }),
+      )
+    })
+
+    it('should return 400 when formId is malformed', async () => {
+      const malformedFormId = 'malformed'
+      const response = await request.get(ROUTE).query({
+        formId: malformedFormId,
+      })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          query: {
+            key: 'formId',
+            message: `"formId" with value "${malformedFormId}" fails to match the required pattern: /^[0-9a-fA-F]{24}$/`,
+          },
+        }),
+      )
+    })
+
+    it('should return 200 with isValid true when e-service ID is valid', async () => {
+      MockAxios.get.mockResolvedValueOnce({ data: '<title>Title</title>' })
+      const response = await request.get(ROUTE).query({ formId: MOCK_FORM_ID })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        isValid: true,
+      })
+    })
+
+    it('should return 200 with isValid false and errorCode when e-service ID is invalid', async () => {
+      MockAxios.get.mockResolvedValueOnce({
+        data: `<title>Error</title>System Code:&nbsp<b>${MOCK_ERROR_CODE}</b>`,
+      })
+      const response = await request.get(ROUTE).query({ formId: MOCK_FORM_ID })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        isValid: false,
+        errorCode: MOCK_ERROR_CODE,
+      })
+    })
+
+    it('should return 503 with error message when Singpass server request errors', async () => {
+      MockAxios.get.mockRejectedValueOnce('')
+      const response = await request.get(ROUTE).query({ formId: MOCK_FORM_ID })
+
+      expect(response.status).toBe(503)
+      expect(response.body).toEqual({
+        message: 'Failed to contact SingPass. Please try again.',
+      })
+    })
+  })
+
+  describe('GET /myinfo/login', () => {
+    const ROUTE = '/myinfo/login'
+    const mockState = {
+      formId: MOCK_FORM_ID,
+      uuid: uuidv4(),
+    }
+    const expectedSuccessCookie = {
+      accessToken: MOCK_ACCESS_TOKEN,
+      usedCount: 0,
+      state: MyInfoCookieState.Success,
+    }
+    const expectedErrorCookie = {
+      state: MyInfoCookieState.Error,
+    }
+    let request: Session
+
+    beforeEach(async () => {
+      request = session(myInfoApp)
+      mockGetAccessToken.mockResolvedValueOnce(MOCK_ACCESS_TOKEN)
+      await dbHandler.insertEmailForm({
+        formId: new ObjectId(MOCK_FORM_ID),
+        formOptions: {
+          authType: AuthType.MyInfo,
+          esrvcId: MOCK_ESRVC_ID,
+        },
+      })
+    })
+
+    it('should return 400 when state is not provided as a query param', async () => {
+      const response = await request.get(ROUTE)
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          query: {
+            key: '',
+            message: '"value" does not match any of the allowed types',
+          },
+        }),
+      )
+    })
+
+    it('should return 400 when neither code nor error are provided as query params', async () => {
+      const response = await request.get(ROUTE).query({
+        state: 'someState',
+      })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          query: {
+            key: '',
+            message: '"value" does not match any of the allowed types',
+          },
+        }),
+      )
+    })
+
+    it('should return 400 when state is malformed', async () => {
+      const response = await request.get(ROUTE).query({
+        state: 'someState',
+        code: MOCK_AUTH_CODE,
+      })
+
+      expect(response.status).toBe(400)
+    })
+
+    it('should redirect to destination with cookie when params are valid', async () => {
+      const response = await request
+        .get(ROUTE)
+        .query({ state: JSON.stringify(mockState), code: MOCK_AUTH_CODE })
+
+      expect(response.status).toBe(302)
+      expect(response.headers['set-cookie']).toEqual([
+        expect.stringContaining(
+          encodeURIComponent(JSON.stringify(expectedSuccessCookie)),
+        ),
+      ])
+      expect(response.headers['location']).toEqual(`/${MOCK_FORM_ID}`)
+    })
+
+    it('should redirect to home when form ID does not exist', async () => {
+      const invalidFormIdState = {
+        ...mockState,
+        formId: new ObjectId().toHexString(),
+      }
+      const response = await request.get(ROUTE).query({
+        state: JSON.stringify(invalidFormIdState),
+        code: MOCK_AUTH_CODE,
+      })
+
+      expect(response.status).toBe(302)
+      expect(response.headers['location']).toEqual(`/`)
+    })
+
+    it('should redirect to form with error cookie when form auth type is not MyInfo', async () => {
+      const singpassFormId = new ObjectId()
+      await dbHandler.insertEmailForm({
+        formId: singpassFormId,
+        // Set custom mail domain so as to not conflict with mock MyInfo form
+        // inserted in the beforeEach block
+        mailDomain: 'test2.gov.sg',
+        formOptions: {
+          authType: AuthType.SP,
+          esrvcId: MOCK_ESRVC_ID,
+        },
+      })
+      const state = JSON.stringify({
+        ...mockState,
+        formId: singpassFormId.toHexString(),
+      })
+
+      const response = await request.get(ROUTE).query({
+        state,
+        code: MOCK_AUTH_CODE,
+      })
+
+      expect(response.status).toBe(302)
+      expect(response.headers['set-cookie']).toEqual([
+        expect.stringContaining(
+          encodeURIComponent(JSON.stringify(expectedErrorCookie)),
+        ),
+      ])
+      expect(response.headers['location']).toEqual(
+        `/${singpassFormId.toHexString()}`,
+      )
+    })
+
+    it('should redirect to form with error cookie when consent flow is unsuccessful', async () => {
+      const response = await request.get(ROUTE).query({
+        state: JSON.stringify(mockState),
+        error: 'error',
+        'error-description': 'error-description',
+      })
+
+      expect(response.status).toBe(302)
+      expect(response.headers['set-cookie']).toEqual([
+        expect.stringContaining(
+          encodeURIComponent(JSON.stringify(expectedErrorCookie)),
+        ),
+      ])
+      expect(response.headers['location']).toEqual(`/${MOCK_FORM_ID}`)
+    })
+
+    it('should redirect to form with error cookie when access token cannot be retrieved', async () => {
+      // Clear default mock implementation from beforeEach
+      mockGetAccessToken.mockReset()
+      mockGetAccessToken.mockRejectedValueOnce('rejected')
+
+      const response = await request
+        .get(ROUTE)
+        .query({ state: JSON.stringify(mockState), code: MOCK_AUTH_CODE })
+
+      expect(response.status).toBe(302)
+      expect(response.headers['set-cookie']).toEqual([
+        expect.stringContaining(
+          encodeURIComponent(JSON.stringify(expectedErrorCookie)),
+        ),
+      ])
+      expect(response.headers['location']).toEqual(`/${MOCK_FORM_ID}`)
+    })
+  })
+})

--- a/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcrypt'
 import mongoose from 'mongoose'
 import { mocked } from 'ts-jest/utils'
+import { v4 as uuidv4 } from 'uuid'
 
 import { MyInfoService } from 'src/app/modules/myinfo/myinfo.service'
 import getMyInfoHashModel from 'src/app/modules/myinfo/myinfo_hash.model'
@@ -15,10 +16,18 @@ import {
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { MyInfoData } from '../myinfo.adapter'
-import { IPossiblyPrefilledField } from '../myinfo.types'
+import { MYINFO_CONSENT_PAGE_PURPOSE } from '../myinfo.constants'
+import {
+  MyInfoCircuitBreakerError,
+  MyInfoFetchError,
+  MyInfoInvalidAccessTokenError,
+  MyInfoParseRelayStateError,
+} from '../myinfo.errors'
+import { IPossiblyPrefilledField, MyInfoRelayState } from '../myinfo.types'
 
 import {
   MOCK_ACCESS_TOKEN,
+  MOCK_AUTH_CODE,
   MOCK_COOKIE_AGE,
   MOCK_ESRVC_ID,
   MOCK_FORM_FIELDS,
@@ -27,6 +36,7 @@ import {
   MOCK_HASHES,
   MOCK_MYINFO_DATA,
   MOCK_POPULATED_FORM_FIELDS,
+  MOCK_REDIRECT_URL,
   MOCK_REQUESTED_ATTRS,
   MOCK_RESPONSES,
   MOCK_SERVICE_PARAMS,
@@ -36,9 +46,16 @@ import {
 const MyInfoHash = getMyInfoHashModel(mongoose)
 
 const mockGetPerson = jest.fn()
+const mockCreateRedirectURL = jest.fn()
+const mockGetAccessToken = jest.fn()
+const mockExtractUinFin = jest.fn()
+
 jest.mock('@opengovsg/myinfo-gov-client', () => ({
   MyInfoGovClient: jest.fn().mockImplementation(() => ({
     getPerson: mockGetPerson,
+    createRedirectURL: mockCreateRedirectURL,
+    getAccessToken: mockGetAccessToken,
+    extractUinFin: mockExtractUinFin,
   })),
   MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
   MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
@@ -65,12 +82,113 @@ describe('MyInfoService', () => {
     })
   })
 
+  describe('createRedirectURL', () => {
+    it('should call MyInfoGovClient.createRedirectURL with the correct arguments', () => {
+      mockCreateRedirectURL.mockReturnValueOnce(MOCK_REDIRECT_URL)
+
+      const result = myInfoService.createRedirectURL({
+        formEsrvcId: MOCK_ESRVC_ID,
+        formId: MOCK_FORM_ID,
+        requestedAttributes: MOCK_REQUESTED_ATTRS,
+      })
+
+      const actualArgs = mockCreateRedirectURL.mock.calls[0][0]
+      const actualParsedRelayState = JSON.parse(actualArgs.relayState)
+
+      expect(actualArgs.purpose).toBe(MYINFO_CONSENT_PAGE_PURPOSE)
+      expect(actualParsedRelayState.formId).toBe(MOCK_FORM_ID)
+      expect(actualArgs.requestedAttributes).toEqual(
+        expect.arrayContaining(MOCK_REQUESTED_ATTRS),
+      )
+      expect(actualArgs.singpassEserviceId).toEqual(MOCK_ESRVC_ID)
+      expect(result._unsafeUnwrap()).toBe(MOCK_REDIRECT_URL)
+    })
+  })
+
+  describe('parseMyInfoRelayState', () => {
+    it('should parse valid relay states correctly', () => {
+      const validState: MyInfoRelayState = {
+        uuid: uuidv4(),
+        formId: MOCK_FORM_ID,
+      }
+
+      const result = myInfoService
+        .parseMyInfoRelayState(JSON.stringify(validState))
+        ._unsafeUnwrap()
+
+      expect(result.uuid).toBe(validState.uuid)
+      expect(result.formId).toBe(validState.formId)
+      expect(result.cookieDuration).toBe(
+        MOCK_SERVICE_PARAMS.spcpMyInfoConfig.spCookieMaxAge,
+      )
+    })
+
+    it('should return MyInfoParseRelayStateError when relay state cannot be parsed', () => {
+      const invalidJson = 'abc'
+
+      const result = myInfoService.parseMyInfoRelayState(invalidJson)
+
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new MyInfoParseRelayStateError(),
+      )
+    })
+
+    it('should return MyInfoParseRelayStateError when relay state has incorrect shape', () => {
+      const stateMissingFormId = {
+        uuid: uuidv4(),
+      }
+
+      const result = myInfoService.parseMyInfoRelayState(
+        JSON.stringify(stateMissingFormId),
+      )
+
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new MyInfoParseRelayStateError(),
+      )
+    })
+  })
+
+  describe('retrieveAccessToken', () => {
+    beforeEach(() => {
+      myInfoService = new MyInfoService(MOCK_SERVICE_PARAMS)
+    })
+
+    it('should call MyInfoGovClient.getAccessToken with the correct parameters', async () => {
+      mockGetAccessToken.mockResolvedValueOnce(MOCK_ACCESS_TOKEN)
+
+      const result = await myInfoService.retrieveAccessToken(MOCK_AUTH_CODE)
+
+      expect(mockGetAccessToken).toHaveBeenCalledWith(MOCK_AUTH_CODE)
+      expect(result._unsafeUnwrap()).toEqual(MOCK_ACCESS_TOKEN)
+    })
+
+    it('should throw MyInfoFetchError when getAccessToken fails once', async () => {
+      mockGetAccessToken.mockRejectedValueOnce(new Error())
+      const result = await myInfoService.retrieveAccessToken(MOCK_AUTH_CODE)
+
+      expect(mockGetAccessToken).toHaveBeenCalledWith(MOCK_AUTH_CODE)
+      expect(result._unsafeUnwrapErr()).toEqual(new MyInfoFetchError())
+    })
+
+    it('should throw MyInfoCircuitBreakerError when getAccessToken fails 5 times', async () => {
+      mockGetAccessToken.mockRejectedValue(new Error())
+      for (let i = 0; i < 5; i++) {
+        await myInfoService.retrieveAccessToken(MOCK_AUTH_CODE)
+      }
+      const result = await myInfoService.retrieveAccessToken(MOCK_AUTH_CODE)
+
+      // Last function call doesn't count as breaker is open, so expect 5 calls
+      expect(mockGetAccessToken).toHaveBeenCalledTimes(5)
+      expect(result._unsafeUnwrapErr()).toEqual(new MyInfoCircuitBreakerError())
+    })
+  })
+
   describe('fetchMyInfoPersonData', () => {
     beforeEach(() => {
       myInfoService = new MyInfoService(MOCK_SERVICE_PARAMS)
     })
 
-    it('should call MyInfoGovClient.getPersonBasic with the correct parameters', async () => {
+    it('should call MyInfoGovClient.getPerson with the correct parameters', async () => {
       const mockReturnedParams = {
         uinFin: MOCK_UINFIN,
         data: MOCK_MYINFO_DATA,
@@ -90,7 +208,7 @@ describe('MyInfoService', () => {
       expect(result._unsafeUnwrap()).toEqual(new MyInfoData(mockReturnedParams))
     })
 
-    it('should throw FetchMyInfoError when getPersonBasic fails once', async () => {
+    it('should throw MyInfoFetchError when getPerson fails once', async () => {
       mockGetPerson.mockRejectedValueOnce(new Error())
       const result = await myInfoService.fetchMyInfoPersonData(
         MOCK_ACCESS_TOKEN,
@@ -103,12 +221,10 @@ describe('MyInfoService', () => {
         MOCK_REQUESTED_ATTRS.concat('uinfin' as MyInfoAttribute),
         MOCK_ESRVC_ID,
       )
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new Error('Error while requesting MyInfo data'),
-      )
+      expect(result._unsafeUnwrapErr()).toEqual(new MyInfoFetchError())
     })
 
-    it('should throw CircuitBreakerError when getPersonBasic fails 5 times', async () => {
+    it('should throw MyInfoCircuitBreakerError when getPerson fails 5 times', async () => {
       mockGetPerson.mockRejectedValue(new Error())
       for (let i = 0; i < 5; i++) {
         await myInfoService.fetchMyInfoPersonData(
@@ -125,9 +241,7 @@ describe('MyInfoService', () => {
 
       // Last function call doesn't count as breaker is open, so expect 5 calls
       expect(mockGetPerson).toHaveBeenCalledTimes(5)
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new Error('Circuit breaker tripped'),
-      )
+      expect(result._unsafeUnwrapErr()).toEqual(new MyInfoCircuitBreakerError())
     })
   })
 
@@ -294,6 +408,30 @@ describe('MyInfoService', () => {
 
       expect(result._unsafeUnwrapErr()).toEqual(
         new Error('Responses did not match hashed values'),
+      )
+    })
+  })
+
+  describe('extractUinFin', () => {
+    it('should call MyInfoGovClient.extractUinFin and return the UIN/FIN when token is valid', async () => {
+      mockExtractUinFin.mockReturnValueOnce(MOCK_UINFIN)
+
+      const result = myInfoService.extractUinFin(MOCK_ACCESS_TOKEN)
+
+      expect(mockExtractUinFin).toHaveBeenCalledWith(MOCK_ACCESS_TOKEN)
+      expect(result._unsafeUnwrap()).toBe(MOCK_UINFIN)
+    })
+
+    it('should return MyInfoInvalidAccessTokenError when token is invalid', async () => {
+      mockExtractUinFin.mockImplementationOnce(() => {
+        throw new Error()
+      })
+
+      const result = myInfoService.extractUinFin(MOCK_ACCESS_TOKEN)
+
+      expect(mockExtractUinFin).toHaveBeenCalledWith(MOCK_ACCESS_TOKEN)
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new MyInfoInvalidAccessTokenError(),
       )
     })
   })

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -48,36 +48,6 @@ export const MOCK_MYINFO_DATA = {
   },
 } as IPerson
 
-export const MOCK_MYINFO_FORMAT_DATA = {
-  mobileno: {
-    areacode: { value: '65' },
-    prefix: { value: '+' },
-    lastupdated: '2017-12-13',
-    source: MyInfoSource.GovtVerified,
-    classification: 'C',
-    nbr: { value: '97324992' },
-  },
-  regadd: {
-    type: MyInfoAddressType.Singapore,
-    country: { code: 'SG', desc: 'SINGAPORE' },
-    unit: { value: '128' },
-    street: { value: 'BEDOK NORTH AVENUE 1' },
-    lastupdated: '2016-03-11',
-    block: { value: '548' },
-    source: MyInfoSource.GovtVerified,
-    postal: { value: '460548' },
-    classification: 'C',
-    floor: { value: '09' },
-    building: { value: '' },
-  },
-  passexpirydate: {
-    lastupdated: '2018-03-02',
-    source: MyInfoSource.GovtVerified,
-    classification: 'C',
-    value: '2018-12-31',
-  },
-}
-
 export const MOCK_FORM_FIELDS = [
   // Some MyInfo fields
   {
@@ -147,7 +117,7 @@ export const MOCK_KEY_PATH =
 export const MOCK_CERT_PATH =
   './node_modules/@opengovsg/mockpass/static/certs/server.crt'
 export const MOCK_ESRVC_ID = 'mockEsrvcId'
-export const MOCK_UINFIN = 'mockUinFin'
+export const MOCK_UINFIN = 'S1234567A'
 export const MOCK_REQUESTED_ATTRS = [MyInfoAttribute.Name]
 export const MOCK_FORM_ID = new ObjectId().toHexString()
 export const MOCK_NODE_ENV = Environment.Test

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -8,7 +8,7 @@ import { ObjectId } from 'bson'
 import { merge, zipWith } from 'lodash'
 
 import { ISpcpMyInfo } from 'src/config/feature-manager'
-import { Environment, MyInfoAttribute } from 'src/types'
+import { Environment, IFormSchema, MyInfoAttribute } from 'src/types'
 
 import { IMyInfoServiceConfig } from '../myinfo.types'
 
@@ -170,3 +170,10 @@ export const MOCK_SERVICE_PARAMS: IMyInfoServiceConfig = {
     myInfoClientMode: MyInfoMode.Dev,
   } as ISpcpMyInfo,
 }
+
+export const MOCK_MYINFO_FORM = ({
+  _id: MOCK_FORM_ID,
+  esrvcId: MOCK_ESRVC_ID,
+  authType: 'MyInfo',
+  getUniqueMyInfoAttrs: () => MOCK_REQUESTED_ATTRS,
+} as unknown) as IFormSchema

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -147,14 +147,14 @@ export const MOCK_KEY_PATH =
 export const MOCK_CERT_PATH =
   './node_modules/@opengovsg/mockpass/static/certs/server.crt'
 export const MOCK_ESRVC_ID = 'mockEsrvcId'
-export const MOCK_UINFIN = 'uinFin'
+export const MOCK_UINFIN = 'mockUinFin'
 export const MOCK_REQUESTED_ATTRS = [MyInfoAttribute.Name]
 export const MOCK_FORM_ID = new ObjectId().toHexString()
 export const MOCK_NODE_ENV = Environment.Test
-export const MOCK_APP_URL = 'appUrl'
-export const MOCK_ACCESS_TOKEN = 'accessToken'
+export const MOCK_APP_URL = 'mockAppUrl'
+export const MOCK_ACCESS_TOKEN = 'mockAccessToken'
 export const MOCK_REDIRECT_URL = 'mockRedirectURL'
-export const MOCK_AUTH_CODE = 'authCode'
+export const MOCK_AUTH_CODE = 'mockAuthCode'
 
 export const MOCK_SERVICE_PARAMS: IMyInfoServiceConfig = {
   appUrl: 'http://localhost:5000',

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -153,6 +153,8 @@ export const MOCK_FORM_ID = new ObjectId().toHexString()
 export const MOCK_NODE_ENV = Environment.Test
 export const MOCK_APP_URL = 'appUrl'
 export const MOCK_ACCESS_TOKEN = 'accessToken'
+export const MOCK_REDIRECT_URL = 'mockRedirectURL'
+export const MOCK_AUTH_CODE = 'authCode'
 
 export const MOCK_SERVICE_PARAMS: IMyInfoServiceConfig = {
   appUrl: 'http://localhost:5000',

--- a/src/app/modules/myinfo/__tests__/myinfo.test.data.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.data.ts
@@ -1,0 +1,187 @@
+import {
+  IPerson,
+  MyInfoAddressType,
+  MyInfoDataClassification,
+  MyInfoSource,
+  MyInfoVehicle,
+} from '@opengovsg/myinfo-gov-client'
+
+export const MYINFO_MOBILENO_AVAILABLE: IPerson = {
+  mobileno: {
+    areacode: { value: '65' },
+    prefix: { value: '+' },
+    lastupdated: '2017-12-13',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    nbr: { value: '97324992' },
+  },
+}
+
+export const MYINFO_MOBILENO_UNAVAILABLE: IPerson = {
+  mobileno: {
+    lastupdated: '2017-12-13',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}
+
+export const MYINFO_REGADD_AVAILABLE: IPerson = {
+  regadd: {
+    type: MyInfoAddressType.Singapore,
+    country: { code: 'SG', desc: 'SINGAPORE' },
+    unit: { value: '128' },
+    street: { value: 'BEDOK NORTH AVENUE 1' },
+    lastupdated: '2016-03-11',
+    block: { value: '548' },
+    source: MyInfoSource.GovtVerified,
+    postal: { value: '460548' },
+    classification: MyInfoDataClassification.Confidential,
+    floor: { value: '09' },
+    building: { value: '' },
+  },
+}
+
+export const MYINFO_REGADD_NA: IPerson = {
+  regadd: {
+    source: MyInfoSource.NotApplicable,
+  },
+}
+
+export const MYINFO_REGADD_UNAVAILABLE: IPerson = {
+  regadd: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}
+
+export const MYINFO_VEHNO_AVAILABLE: IPerson = {
+  vehicles: [
+    {
+      lastupdated: '2016-03-11',
+      source: MyInfoSource.GovtVerified,
+      classification: MyInfoDataClassification.Confidential,
+      vehicleno: { value: 'mockVehicleNo1' },
+    } as MyInfoVehicle,
+    {
+      lastupdated: '2016-03-11',
+      source: MyInfoSource.GovtVerified,
+      classification: MyInfoDataClassification.Confidential,
+      vehicleno: { value: 'mockVehicleNo2' },
+    } as MyInfoVehicle,
+  ],
+}
+
+export const MYINFO_VEHNO_UNAVAILABLE: IPerson = {
+  vehicles: [
+    {
+      lastupdated: '2016-03-11',
+      source: MyInfoSource.GovtVerified,
+      classification: MyInfoDataClassification.Confidential,
+      unavailable: true,
+    },
+  ],
+}
+
+export const MYINFO_OCCUPATION_CODE: IPerson = {
+  occupation: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    code: 'occupationCode',
+    desc: 'occupationDesc',
+  },
+}
+
+export const MYINFO_OCCUPATION_VALUE: IPerson = {
+  occupation: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.UserProvided,
+    classification: MyInfoDataClassification.Confidential,
+    value: 'occupationValue',
+  },
+}
+
+export const MYINFO_OCCUPATION_UNAVAILABLE: IPerson = {
+  occupation: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}
+
+export const MYINFO_DESCRIPTION_NA: IPerson = {
+  residentialstatus: {
+    source: MyInfoSource.NotApplicable,
+  },
+}
+
+export const MYINFO_DESCRIPTION_AVAILABLE: IPerson = {
+  sex: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    code: 'sexCode',
+    desc: 'sexDesc',
+  },
+}
+
+export const MYINFO_DESCRIPTION_UNAVAILABLE: IPerson = {
+  sex: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}
+
+export const MYINFO_PASSSTATUS_AVAILABLE: IPerson = {
+  passstatus: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    value: 'Live',
+  },
+}
+
+export const MYINFO_PASSSTATUS_NA: IPerson = {
+  passstatus: {
+    source: MyInfoSource.NotApplicable,
+  },
+}
+
+export const MYINFO_PASSSTATUS_UNAVAILABLE: IPerson = {
+  passstatus: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}
+
+export const MYINFO_BASIC_AVAILABLE: IPerson = {
+  name: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    value: 'name',
+  },
+}
+
+export const MYINFO_BASIC_NA: IPerson = {
+  divorcedate: {
+    source: MyInfoSource.NotApplicable,
+  },
+}
+
+export const MYINFO_BASIC_UNAVAILABLE: IPerson = {
+  name: {
+    lastupdated: '2016-03-11',
+    source: MyInfoSource.GovtVerified,
+    classification: MyInfoDataClassification.Confidential,
+    unavailable: true,
+  },
+}

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -40,7 +40,7 @@ const validateRedirectURLRequest = celebrate({
  * @param req Express Request
  * @param res Express Response
  */
-const respondWithRedirectURL: RequestHandler<
+export const respondWithRedirectURL: RequestHandler<
   unknown,
   { redirectURL: string } | { message: string },
   unknown,
@@ -97,7 +97,7 @@ const validateEServiceIdCheck = celebrate({
  * @param req Express request
  * @param res Express response
  */
-const checkMyInfoEServiceId: RequestHandler<
+export const checkMyInfoEServiceId: RequestHandler<
   unknown,
   LoginPageValidationResult | { message: string },
   unknown,
@@ -177,7 +177,7 @@ type MyInfoLoginQueryParams =
  * @param req Express request
  * @param res Express response
  */
-const loginToMyInfo: RequestHandler<
+export const loginToMyInfo: RequestHandler<
   unknown,
   unknown,
   unknown,

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
@@ -36,8 +36,6 @@ const MyInfoHashModel = getMyInfoHashModel(mongoose)
 
 jest.mock('@opengovsg/spcp-auth-client')
 const MockAuthClient = mocked(SPCPAuthClient, true)
-const mockSpClient = mocked(MockAuthClient.mock.instances[0], true)
-const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
 
 jest.mock('nodemailer', () => ({
   createTransport: jest.fn().mockReturnValue({
@@ -49,7 +47,8 @@ jest.mock('@opengovsg/myinfo-gov-client', () => ({
   MyInfoGovClient: jest.fn(),
   MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
   MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
-  AddressType: jest.requireActual('@opengovsg/myinfo-gov-client').AddressType,
+  MyInfoAddressType: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAddressType,
   MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
     .MyInfoAttribute,
 }))
@@ -75,6 +74,8 @@ const EmailSubmissionsApp = setupApp(
 
 describe('email-submission.routes', () => {
   let request: Session
+  const mockSpClient = mocked(MockAuthClient.mock.instances[0], true)
+  const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
 
   beforeAll(async () => await dbHandler.connect())
   beforeEach(() => {

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
@@ -1,14 +1,22 @@
+import { MyInfoGovClient } from '@opengovsg/myinfo-gov-client'
 import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import { omit } from 'lodash'
+import mongoose from 'mongoose'
 import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 
+import {
+  MOCK_COOKIE_AGE,
+  MOCK_UINFIN,
+} from 'src/app/modules/myinfo/__tests__/myinfo.test.constants'
+import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
+import getMyInfoHashModel from 'src/app/modules/myinfo/myinfo_hash.model'
 import { AuthType, IFieldSchema, Status } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
-import { EmailSubmissionRouter } from '../email-submission.routes'
+import { MYINFO_COOKIE_NAME } from '../../../myinfo/myinfo.constants'
 
 import {
   MOCK_ATTACHMENT_FIELD,
@@ -24,6 +32,8 @@ import {
   MOCK_TEXTFIELD_RESPONSE,
 } from './email-submission.test.constants'
 
+const MyInfoHashModel = getMyInfoHashModel(mongoose)
+
 jest.mock('@opengovsg/spcp-auth-client')
 const MockAuthClient = mocked(SPCPAuthClient, true)
 const mockSpClient = mocked(MockAuthClient.mock.instances[0], true)
@@ -35,7 +45,28 @@ jest.mock('nodemailer', () => ({
   }),
 }))
 
+jest.mock('@opengovsg/myinfo-gov-client', () => ({
+  MyInfoGovClient: jest.fn(),
+  MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
+  MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
+  AddressType: jest.requireActual('@opengovsg/myinfo-gov-client').AddressType,
+  MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAttribute,
+}))
+const MockMyInfoGovClient = mocked(MyInfoGovClient, true)
+const mockExtractUinFin = jest.fn()
+MockMyInfoGovClient.mockImplementation(
+  () =>
+    (({
+      extractUinFin: mockExtractUinFin,
+    } as unknown) as MyInfoGovClient),
+)
+
 const SUBMISSIONS_ENDPT_BASE = '/v2/submissions/email'
+
+// Import last so mocks are imported correctly
+// eslint-disable-next-line import/first
+import { EmailSubmissionRouter } from '../email-submission.routes'
 
 const EmailSubmissionsApp = setupApp(
   SUBMISSIONS_ENDPT_BASE,
@@ -444,7 +475,7 @@ describe('email-submission.routes', () => {
     })
   })
 
-  describe('SPCP authentication', () => {
+  describe('SP, CP and MyInfo authentication', () => {
     describe('SingPass', () => {
       it('should return 200 when submission is valid', async () => {
         mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
@@ -572,6 +603,164 @@ describe('email-submission.routes', () => {
           .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtSp=mockJwt'])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+    })
+
+    describe('MyInfo', () => {
+      it('should return 200 when submission is valid', async () => {
+        mockExtractUinFin.mockReturnValueOnce(MOCK_UINFIN)
+        const { form } = await dbHandler.insertEmailForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: AuthType.MyInfo,
+            hasCaptcha: false,
+            status: Status.Public,
+          },
+        })
+        await MyInfoHashModel.updateHashes(
+          MOCK_UINFIN,
+          form._id,
+          {},
+          MOCK_COOKIE_AGE,
+        )
+        const cookie = JSON.stringify({
+          accessToken: 'mockAccessToken',
+          usedCount: 0,
+          state: MyInfoCookieState.Success,
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [
+            // The j: indicates that the cookie is in JSON
+            `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+          ])
+
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+          message: 'Form submission successful.',
+          submissionId: expect.any(String),
+        })
+      })
+
+      it('should return 401 when submission is missing MyInfo cookie', async () => {
+        const { form } = await dbHandler.insertEmailForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: AuthType.MyInfo,
+            hasCaptcha: false,
+            status: Status.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
+          .query({ captchaResponse: 'null' })
+        // Note cookie is not set
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+
+      it('should return 401 when submission has the wrong cookie type', async () => {
+        const { form } = await dbHandler.insertEmailForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: AuthType.MyInfo,
+            hasCaptcha: false,
+            status: Status.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
+          .query({ captchaResponse: 'null' })
+          // Note cookie is for SingPass, not MyInfo
+          .set('Cookie', ['jwtSp=mockJwt'])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+
+      it('should return 401 when submission has invalid cookie', async () => {
+        // Mock MyInfoGovClient to return error when decoding JWT
+        mockExtractUinFin.mockImplementationOnce(() => {
+          throw new Error()
+        })
+        const { form } = await dbHandler.insertEmailForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: AuthType.MyInfo,
+            hasCaptcha: false,
+            status: Status.Public,
+          },
+        })
+        const cookie = JSON.stringify({
+          accessToken: 'mockAccessToken',
+          usedCount: 0,
+          state: MyInfoCookieState.Success,
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [
+            // The j: indicates that the cookie is in JSON
+            `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+          ])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+
+      it('should return 401 when submission has cookie with the wrong shape', async () => {
+        const { form } = await dbHandler.insertEmailForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: AuthType.SP,
+            hasCaptcha: false,
+            status: Status.Public,
+          },
+        })
+        const cookie = JSON.stringify({
+          accessToken: 'mockAccessToken',
+          usedCount: 0,
+          // Note that state is set to Error instead of Success
+          state: MyInfoCookieState.Error,
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [
+            // The j: indicates that the cookie is in JSON
+            `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+          ])
 
         expect(response.status).toBe(401)
         expect(response.body).toEqual({


### PR DESCRIPTION
Adds unit tests for new code introduced during MyInfo V3 migration, as well as integration tests for MyInfo routes as well as on the email submissions endpoint for MyInfo forms.

Part of #1234 