### PR TITLE
feat: remove MyInfo support from SPCP endpoints

### DIFF
--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -4,7 +4,7 @@ import { mocked } from 'ts-jest/utils'
 import * as FormService from 'src/app/modules/form/form.service'
 import { MOCK_COOKIE_AGE } from 'src/app/modules/myinfo/__tests__/myinfo.test.constants'
 import config from 'src/config/config'
-import { AuthType, IFormSchema } from 'src/types'
+import { AuthType } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -78,22 +78,12 @@ describe('spcp.controller', () => {
   beforeEach(() => jest.clearAllMocks())
 
   describe('handleRedirect', () => {
-    beforeEach(() => {
-      MockFormService.retrieveFormById.mockReturnValueOnce(
-        okAsync(MOCK_SP_FORM as IFormSchema),
-      )
-    })
-
-    it('should return the redirect URL correctly', async () => {
+    it('should return the redirect URL correctly', () => {
       MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
         ok(MOCK_REDIRECT_URL),
       )
 
-      await SpcpController.handleRedirect(
-        MOCK_REDIRECT_REQ,
-        MOCK_RESPONSE,
-        jest.fn(),
-      )
+      SpcpController.handleRedirect(MOCK_REDIRECT_REQ, MOCK_RESPONSE, jest.fn())
 
       expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
         AuthType.SP,
@@ -106,16 +96,12 @@ describe('spcp.controller', () => {
       })
     })
 
-    it('should return 500 if auth client throws an error', async () => {
+    it('should return 500 if auth client throws an error', () => {
       MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
         err(new CreateRedirectUrlError()),
       )
 
-      await SpcpController.handleRedirect(
-        MOCK_REDIRECT_REQ,
-        MOCK_RESPONSE,
-        jest.fn(),
-      )
+      SpcpController.handleRedirect(MOCK_REDIRECT_REQ, MOCK_RESPONSE, jest.fn())
 
       expect(MockSpcpFactory.createRedirectUrl).toHaveBeenCalledWith(
         AuthType.SP,
@@ -130,12 +116,6 @@ describe('spcp.controller', () => {
   })
 
   describe('handleValidate', () => {
-    beforeEach(() => {
-      MockFormService.retrieveFormById.mockReturnValue(
-        okAsync(MOCK_SP_FORM as IFormSchema),
-      )
-    })
-
     it('should return 200 with isValid true if validation passes', async () => {
       MockSpcpFactory.createRedirectUrl.mockReturnValueOnce(
         ok(MOCK_REDIRECT_URL),

--- a/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
@@ -44,10 +44,7 @@ const corppassLoginApp = setupApp('/corppass/login', CorppassLoginRouter)
 
 describe('spcp.routes', () => {
   beforeAll(async () => await dbHandler.connect())
-  beforeEach(async () => {
-    jest.clearAllMocks()
-    await dbHandler.clearDatabase()
-  })
+  beforeEach(async () => jest.clearAllMocks())
   afterAll(async () => await dbHandler.closeDatabase())
 
   describe('GET /spcp/redirect', () => {
@@ -88,7 +85,7 @@ describe('spcp.routes', () => {
         buildCelebrateError({
           query: {
             key: 'authType',
-            message: '"authType" must be one of [SP, CP, MyInfo]',
+            message: '"authType" must be one of [SP, CP]',
           },
         }),
       )
@@ -117,16 +114,6 @@ describe('spcp.routes', () => {
     })
 
     describe('SingPass', () => {
-      beforeEach(async () => {
-        await dbHandler.insertEmailForm({
-          // MOCK_TARGET is the form ID of MOCK_RELAY_STATE
-          formId: new ObjectId(MOCK_TARGET),
-          formOptions: {
-            authType: AuthType.SP,
-          },
-        })
-      })
-
       it('should return 200 with the redirect URL when Singpass request is valid', async () => {
         const response = await request.get(ROUTE).query({
           authType: 'SP',
@@ -142,16 +129,6 @@ describe('spcp.routes', () => {
     })
 
     describe('CorpPass', () => {
-      beforeEach(async () => {
-        await dbHandler.insertEmailForm({
-          // MOCK_TARGET is the form ID of MOCK_RELAY_STATE
-          formId: new ObjectId(MOCK_TARGET),
-          formOptions: {
-            authType: AuthType.CP,
-          },
-        })
-      })
-
       it('should return 200 with the redirect URL when Corppass request is valid', async () => {
         const response = await request.get('/spcp/redirect').query({
           authType: 'CP',
@@ -205,7 +182,7 @@ describe('spcp.routes', () => {
         buildCelebrateError({
           query: {
             key: 'authType',
-            message: '"authType" must be one of [SP, CP, MyInfo]',
+            message: '"authType" must be one of [SP, CP]',
           },
         }),
       )
@@ -361,6 +338,8 @@ describe('spcp.routes', () => {
       })
     })
 
+    afterEach(async () => await dbHandler.clearDatabase())
+
     it('should return 400 when SAMLart is not provided as a query param', async () => {
       const response = await request
         .get(ROUTE)
@@ -483,7 +462,7 @@ describe('spcp.routes', () => {
       })
     })
 
-    afterAll(async () => await dbHandler.clearDatabase())
+    afterEach(async () => await dbHandler.clearDatabase())
 
     it('should return 400 when SAMLart is not provided as a query param', async () => {
       const response = await request

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from 'express'
 import { ParamsDictionary } from 'express-serve-static-core'
 import { StatusCodes } from 'http-status-codes'
-import mongoose from 'mongoose'
 
 import config from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -9,8 +8,6 @@ import { AuthType, WithForm } from '../../../types'
 import { createReqMeta } from '../../utils/request'
 import { BillingFactory } from '../billing/billing.factory'
 import * as FormService from '../form/form.service'
-import { MyInfoNoESrvcIdError } from '../myinfo/myinfo.errors'
-import { MyInfoFactory } from '../myinfo/myinfo.factory'
 import { ProcessedFieldResponse } from '../submission/submission.types'
 
 import { SpcpFactory } from './spcp.factory'
@@ -18,7 +15,6 @@ import { JwtName, LoginPageValidationResult } from './spcp.types'
 import {
   createCorppassParsedResponses,
   createSingpassParsedResponses,
-  extractFormId,
   mapRouteError,
 } from './spcp.util'
 
@@ -34,11 +30,11 @@ export const handleRedirect: RequestHandler<
   { redirectURL: string } | { message: string },
   unknown,
   {
-    authType: AuthType.SP | AuthType.CP | AuthType.MyInfo
+    authType: AuthType.SP | AuthType.CP
     target: string
     esrvcId: string
   }
-> = async (req, res) => {
+> = (req, res) => {
   const { target, authType, esrvcId } = req.query
   const logMeta = {
     action: 'handleRedirect',
@@ -46,54 +42,6 @@ export const handleRedirect: RequestHandler<
     authType,
     target,
     esrvcId,
-  }
-  // TODO (#1116): remove code accommodating AuthType.MyInfo
-  const payloads = target.split(',')
-  const formId = extractFormId(payloads[0])
-  if (!formId || !mongoose.Types.ObjectId.isValid(formId)) {
-    return res.status(StatusCodes.BAD_REQUEST).json({
-      message: 'Something went wrong, please refresh and try again.',
-    })
-  }
-  const formResult = await FormService.retrieveFormById(formId)
-  if (formResult.isErr()) {
-    logger.error({
-      message: 'Error while retrieving form to create login redirect URL',
-      meta: logMeta,
-      error: formResult.error,
-    })
-    const { statusCode, errorMessage } = mapRouteError(formResult.error)
-    return res.status(statusCode).json({ message: errorMessage })
-  }
-  const form = formResult.value
-  if (authType === AuthType.MyInfo || form.authType === AuthType.MyInfo) {
-    if (!form.esrvcId) {
-      logger.error({
-        message: 'Form e-service ID missing',
-        meta: logMeta,
-      })
-      const { statusCode, errorMessage } = mapRouteError(
-        new MyInfoNoESrvcIdError(),
-      )
-      return res.status(statusCode).json({
-        message: errorMessage,
-      })
-    }
-    return MyInfoFactory.createRedirectURL({
-      formEsrvcId: form.esrvcId,
-      formId,
-      requestedAttributes: form.getUniqueMyInfoAttrs(),
-    })
-      .map((redirectURL) => res.json({ redirectURL }))
-      .mapErr((error) => {
-        logger.error({
-          message: 'Error while creating redirect URL',
-          meta: logMeta,
-          error,
-        })
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
-      })
   }
   return SpcpFactory.createRedirectUrl(authType, target, esrvcId)
     .map((redirectURL) => {
@@ -120,15 +68,13 @@ export const handleValidate: RequestHandler<
   LoginPageValidationResult | { message: string },
   unknown,
   {
-    authType: AuthType.SP | AuthType.CP | AuthType.MyInfo
+    authType: AuthType.SP | AuthType.CP
     target: string
     esrvcId: string
   }
 > = (req, res) => {
   const { target, authType, esrvcId } = req.query
-  // TODO (#1116): remove code accommodating AuthType.MyInfo
-  const finalAuthType = authType === AuthType.MyInfo ? AuthType.SP : authType
-  return SpcpFactory.createRedirectUrl(finalAuthType, target, esrvcId)
+  return SpcpFactory.createRedirectUrl(authType, target, esrvcId)
     .asyncAndThen(SpcpFactory.fetchLoginPage)
     .andThen(SpcpFactory.validateLoginPage)
     .map((result) => res.status(StatusCodes.OK).json(result))

--- a/src/app/modules/spcp/spcp.middlewares.ts
+++ b/src/app/modules/spcp/spcp.middlewares.ts
@@ -5,10 +5,7 @@ import { AuthType } from '../../../types'
 export const redirectParamsMiddleware = celebrate({
   [Segments.QUERY]: Joi.object({
     target: Joi.string().required(),
-    // TODO (#1116): stop allowing AuthType.MyInfo
-    authType: Joi.string()
-      .required()
-      .valid(AuthType.SP, AuthType.CP, AuthType.MyInfo),
+    authType: Joi.string().required().valid(AuthType.SP, AuthType.CP),
     esrvcId: Joi.string().required(),
   }),
 })

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -9,9 +9,7 @@ import {
   MapRouteError,
   SPCPFieldTitle,
 } from '../../../types'
-import { DatabaseError, MissingFeatureError } from '../core/core.errors'
-import { FormNotFoundError } from '../form/form.errors'
-import { MyInfoNoESrvcIdError } from '../myinfo/myinfo.errors'
+import { MissingFeatureError } from '../core/core.errors'
 import { ProcessedSingleAnswerResponse } from '../submission/submission.types'
 
 import {
@@ -240,23 +238,6 @@ export const mapRouteError: MapRouteError = (
         statusCode: StatusCodes.UNAUTHORIZED,
         errorMessage:
           'Something went wrong with your login. Please try logging in and submitting again.',
-      }
-    // TODO (#1116): remove the following cases, which accommodate AuthType MyInfo
-    case FormNotFoundError:
-      return {
-        statusCode: StatusCodes.NOT_FOUND,
-        errorMessage: 'This form is no longer available.',
-      }
-    case MyInfoNoESrvcIdError:
-      return {
-        statusCode: StatusCodes.UNAUTHORIZED,
-        errorMessage:
-          'This form is not registered with MyInfo. Please contact the form administrator.',
-      }
-    case DatabaseError:
-      return {
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-        errorMessage: coreErrorMessage,
       }
     default:
       logger.error({


### PR DESCRIPTION
The SingPass and CorpPass /redirect and /validate endpoints currently support MyInfo forms for backwards compatibility. Since clients should all be updated to the version of the frontend post-MyInfo migration, this support can now be removed.

Closes #1116

## Tests
- [ ] Activate and submit a SingPass form
- [ ] Activate and submit a CorpPass form