### PR TITLE
feat: remove MyInfo error_description support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4389,9 +4389,9 @@
       }
     },
     "@opengovsg/mockpass": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@opengovsg/mockpass/-/mockpass-2.6.4.tgz",
-      "integrity": "sha512-MGNXXcr/35KnT47MB2QwEh4Jr/1xAt/11h3sj5bhbr8D8XH95NvY6zyGZJQ51QUS0nLpBge1nv9Nez7SWw5CuA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@opengovsg/mockpass/-/mockpass-2.6.5.tgz",
+      "integrity": "sha512-5/V29lr5mEHSG5A1Tsok3palmHnVzqPHCjvxjjH7ey6/Hf6wsCJ7LUZcTR213cyfH/SLM55nYF5quBpcalQd6w==",
       "dev": true,
       "requires": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@babel/core": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.13.9",
     "@babel/preset-env": "^7.13.9",
-    "@opengovsg/mockpass": "^2.6.4",
+    "@opengovsg/mockpass": "^2.6.5",
     "@types/bcrypt": "^3.0.0",
     "@types/bluebird": "^3.5.33",
     "@types/busboy": "^0.2.3",

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -151,13 +151,12 @@ const validateMyInfoLogin = celebrate({
       .unknown(true),
     Joi.object()
       .keys({
-        // TODO (#1211): determine whether production returns error_description or error-description
-        error_description: Joi.string(),
         'error-description': Joi.string(),
         error: Joi.string().required(),
         state: Joi.string().required(),
       })
-      .xor('error-description', 'error_description'),
+      // Allow other params in case MyInfo adds them in future
+      .unknown(true),
   ),
 })
 
@@ -165,8 +164,6 @@ type MyInfoLoginQueryParams =
   | { code: string; state: string }
   | {
       error: string
-      // TODO (#1211): determine whether production returns error_description or error-description
-      error_description?: string
       'error-description'?: string
       state: string
     }
@@ -235,9 +232,7 @@ export const loginToMyInfo: RequestHandler<
       meta: {
         ...logMeta,
         error: req.query.error,
-        // TODO (#1211): determine whether production returns error_description or error-description
-        errorDescription: req.query.error_description,
-        errorDescription2: req.query['error-description'],
+        errorDescription: req.query['error-description'],
       },
     })
     res.cookie(MYINFO_COOKIE_NAME, errorCookiePayload, MYINFO_COOKIE_OPTIONS)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When the MyInfo consent flow returns an error, we support both `error-description` (note hyphen) and `error_description` (note underscore) in the query parameters. This is because we were previously unsure which one would be returned - the [documentation](https://public.cloud.myinfo.gov.sg/myinfo/api/myinfo-kyc-v3.1.0.html#operation/getauthorise) says that it should be `error_description`, but the sandbox and staging APIs both returned `error-description`. Now that we have confirmed that production returns `error-description` as well, we can drop support for `error_description`.

Part of #1234 

## Solution
<!-- How did you solve the problem? -->

Drop support for `error_description`. For safety, in case MyInfo decides to add other query parameters, also add `unknown(true)` to the Joi validation.

Mockpass previously returned `error_description`, but since [this PR](https://github.com/opengovsg/mockpass/pull/188) which went into v2.6.5, it now returns `error-description`, so I upgraded Mockpass to make the dev environment match production.

## Tests
- [ ] Log in to a MyInfo form but click "Cancel" on the consent page. Ensure that you see the MyInfo error when redirected back to the form, and that there is matching message in the logs (message: `'MyInfo returned error from consent flow'`) which contains an `errorDescription`.