### PR TITLE
fix: restore link for email reliability

### DIFF
--- a/src/public/translations/en-SG/main.json
+++ b/src/public/translations/en-SG/main.json
@@ -6,7 +6,8 @@
       "GUARD_EMAIL_BOUNCE": "https://go.gov.sg/form-prevent-bounces",
       "STORAGE_MODE": "https://guide.form.gov.sg/AdvancedGuide.html#storage-mode",
       "SECRET_KEY_LOSS": "https://go.gov.sg/secretkeyloss",
-      "SECRET_KEY_SAFEKEEPING": "https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-make-sure-i-dont-lose-my-secret-key"
+      "SECRET_KEY_SAFEKEEPING": "https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-make-sure-i-dont-lose-my-secret-key",
+      "EMAIL_RELIABILITY": "http://go.gov.sg/form-email-reliability"
     },
     "GITHUB": "https://github.com/opengovsg/FormSG",
     "APP": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Link in frontend was accidentally deleted in https://github.com/opengovsg/FormSG/pull/825/files

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- Restore missing email reliability link by pointing it to http://go.gov.sg/form-email-reliability

