### PR TITLE
refactor: stop replacing spaces in SAML artifact

### DIFF
--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -275,7 +275,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: true,
         cookieDuration: MOCK_PARAMS.spCookieMaxAgePreserved,
-        samlArt: MOCK_SP_SAML,
       })
     })
 
@@ -293,7 +292,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: true,
         cookieDuration: MOCK_PARAMS.cpCookieMaxAge,
-        samlArt: MOCK_CP_SAML,
       })
     })
 
@@ -311,7 +309,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: false,
         cookieDuration: MOCK_PARAMS.spCookieMaxAge,
-        samlArt: MOCK_SP_SAML,
       })
     })
 
@@ -329,7 +326,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: false,
         cookieDuration: MOCK_PARAMS.cpCookieMaxAge,
-        samlArt: MOCK_CP_SAML,
       })
     })
 
@@ -347,7 +343,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: false,
         cookieDuration: MOCK_PARAMS.spCookieMaxAge,
-        samlArt: MOCK_SP_SAML,
       })
     })
 
@@ -365,7 +360,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}`,
         rememberMe: false,
         cookieDuration: MOCK_PARAMS.cpCookieMaxAge,
-        samlArt: MOCK_CP_SAML,
       })
     })
 
@@ -383,7 +377,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}/`,
         rememberMe: true,
         cookieDuration: MOCK_PARAMS.spCookieMaxAgePreserved,
-        samlArt: MOCK_SP_SAML,
       })
     })
 
@@ -401,7 +394,6 @@ describe('spcp.service', () => {
         destination: `/${MOCK_TARGET}/`,
         rememberMe: true,
         cookieDuration: MOCK_PARAMS.cpCookieMaxAge,
-        samlArt: MOCK_CP_SAML,
       })
     })
 

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -183,17 +183,13 @@ export const handleLogin: (
   unknown,
   { SAMLart: string; RelayState: string }
 > = (authType) => async (req, res) => {
-  const { SAMLart: rawSamlArt, RelayState: rawRelayState } = req.query
+  const { SAMLart, RelayState } = req.query
   const logMeta = {
     action: 'handleLogin',
-    samlArt: rawSamlArt,
-    relayState: rawRelayState,
+    samlArt: SAMLart,
+    relayState: RelayState,
   }
-  const parseResult = SpcpFactory.parseOOBParams(
-    rawSamlArt,
-    rawRelayState,
-    authType,
-  )
+  const parseResult = SpcpFactory.parseOOBParams(SAMLart, RelayState, authType)
   if (parseResult.isErr()) {
     logger.error({
       message: 'Invalid SPCP login parameters',
@@ -202,13 +198,7 @@ export const handleLogin: (
     })
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
-  const {
-    formId,
-    destination,
-    rememberMe,
-    cookieDuration,
-    samlArt,
-  } = parseResult.value
+  const { formId, destination, rememberMe, cookieDuration } = parseResult.value
   const formResult = await FormService.retrieveFullFormById(formId)
   if (formResult.isErr()) {
     logger.error({
@@ -232,7 +222,7 @@ export const handleLogin: (
     return res.redirect(destination)
   }
   const jwtResult = await SpcpFactory.getSpcpAttributes(
-    samlArt,
+    SAMLart,
     destination,
     authType,
   )

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -297,8 +297,10 @@ export class SpcpService {
         destination,
         rememberMe,
         cookieDuration,
-        // Resolve known express req.query issue where pluses become spaces
-        samlArt: String(samlArt).replace(/ /g, '+'),
+        // In the past, this function would perform some transformations
+        // on the SAML artifact. This is no longer necessary, so we simply
+        // return the original SAML artifact passed to the function.
+        samlArt,
       })
     } else {
       logger.error({

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -297,10 +297,6 @@ export class SpcpService {
         destination,
         rememberMe,
         cookieDuration,
-        // In the past, this function would perform some transformations
-        // on the SAML artifact. This is no longer necessary, so we simply
-        // return the original SAML artifact passed to the function.
-        samlArt,
       })
     } else {
       logger.error({

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -35,5 +35,4 @@ export interface ParsedSpcpParams {
   destination: string
   rememberMe: boolean
   cookieDuration: number
-  samlArt: string
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In the past, SPCP SAML artifacts were not URL-encoded when we received them at our login endpoints. This means that Express would automatically parse `+` characters as spaces, and we had to manually change them back to `+`.

SAML artifacts are now URL-encoded so this is no longer necessary.

Closes #1322 

## Solution
<!-- How did you solve the problem? -->

Remove the code which replaced spaces with + in the SAML artifact.

Once this change was made, the `parseOOBParams` function was taking in the SAML artifact as a parameter and returning it unchanged. This made little sense, so the function signature was changed to stop returning the SAML artifact.