### PR TITLE
feat: remove status key in ApplicationError class, update meta key to unknown type

### DIFF
--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -47,7 +47,7 @@ describe('auth.controller', () => {
       expect(mockRes.sendStatus).toBeCalledWith(200)
     })
 
-    it('should return with ApplicationError status and message when retrieving agency returns an ApplicationError', async () => {
+    it('should return 401 when retrieving agency returns an InvalidDomainError', async () => {
       // Arrange
       const expectedError = new InvalidDomainError()
       const mockRes = expressHandler.mockResponse()
@@ -59,7 +59,7 @@ describe('auth.controller', () => {
       await AuthController.handleCheckUser(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
-      expect(mockRes.status).toBeCalledWith(expectedError.status)
+      expect(mockRes.status).toBeCalledWith(401)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
   })
@@ -91,7 +91,7 @@ describe('auth.controller', () => {
       expect(MockMailService.sendLoginOtp).toHaveBeenCalledTimes(1)
     })
 
-    it('should return with ApplicationError status and message when retrieving agency returns an ApplicationError', async () => {
+    it('should return 401 when retrieving agency returns InvalidDomainError', async () => {
       // Arrange
       const expectedError = new InvalidDomainError()
       const mockRes = expressHandler.mockResponse()
@@ -103,7 +103,7 @@ describe('auth.controller', () => {
       await AuthController.handleLoginSendOtp(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
-      expect(mockRes.status).toBeCalledWith(expectedError.status)
+      expect(mockRes.status).toBeCalledWith(401)
       expect(mockRes.json).toBeCalledWith({ message: expectedError.message })
     })
 
@@ -189,7 +189,7 @@ describe('auth.controller', () => {
       expect(mockRes.json).toBeCalledWith(mockUser.toObject())
     })
 
-    it('should return with ApplicationError status and message when retrieving agency returns an ApplicationError', async () => {
+    it('should return 401 when retrieving agency returns InvalidDomainError', async () => {
       // Arrange
       const expectedError = new InvalidDomainError()
       const mockRes = expressHandler.mockResponse()
@@ -201,7 +201,7 @@ describe('auth.controller', () => {
       await AuthController.handleLoginVerifyOtp(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
-      expect(mockRes.status).toBeCalledWith(expectedError.status)
+      expect(mockRes.status).toBeCalledWith(401)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
 

--- a/src/app/modules/auth/auth.errors.ts
+++ b/src/app/modules/auth/auth.errors.ts
@@ -1,17 +1,15 @@
-import { StatusCodes } from 'http-status-codes'
-
 import { ApplicationError } from '../core/core.errors'
 
 export class InvalidDomainError extends ApplicationError {
   constructor(
     message = 'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
   ) {
-    super(message, StatusCodes.UNAUTHORIZED)
+    super(message)
   }
 }
 
 export class InvalidOtpError extends ApplicationError {
   constructor(message = 'OTP has expired. Please request for a new OTP.') {
-    super(message, StatusCodes.UNPROCESSABLE_ENTITY)
+    super(message)
   }
 }

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -6,15 +6,11 @@ import { FeatureNames } from 'src/config/feature-manager'
  */
 export class ApplicationError extends Error {
   /**
-   * Http status code for the error to be returned in the response.
+   * Meta object to be logged by the application logger, if any.
    */
-  status: number
-  /**
-   * Meta string to be logged by the application logger, if any.
-   */
-  meta?: string
+  meta?: unknown
 
-  constructor(message?: string, status?: number, meta?: string) {
+  constructor(message?: string, meta?: unknown) {
     super()
 
     Error.captureStackTrace(this, this.constructor)
@@ -22,8 +18,6 @@ export class ApplicationError extends Error {
     this.name = this.constructor.name
 
     this.message = message || 'Something went wrong. Please try again.'
-
-    this.status = status || 500
 
     this.meta = meta
   }

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from 'http-status-codes'
-
 import { ResponseMode } from '../../../types'
 import { ApplicationError } from '../core/core.errors'
 
@@ -8,8 +6,8 @@ import { ApplicationError } from '../core/core.errors'
  * when some form fields are missing from the submission
  */
 export class ConflictError extends ApplicationError {
-  constructor(message: string, meta?: string) {
-    super(message, StatusCodes.CONFLICT, meta)
+  constructor(message: string, meta?: unknown) {
+    super(message, meta)
   }
 }
 

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -65,10 +65,10 @@ const getFilteredResponses = (
       ({ _id }) => _id,
     )
     return err(
-      new ConflictError(
-        'Some form fields are missing',
-        `formId="${form._id}" onlyInForm="${onlyInForm}"`,
-      ),
+      new ConflictError('Some form fields are missing', {
+        formId: form._id,
+        onlyInForm,
+      }),
     )
   }
   return ok(results)

--- a/src/app/modules/user/user.errors.ts
+++ b/src/app/modules/user/user.errors.ts
@@ -1,15 +1,13 @@
-import { StatusCodes } from 'http-status-codes'
-
 import { ApplicationError } from '../core/core.errors'
 
 export class InvalidOtpError extends ApplicationError {
-  constructor(message: string, meta?: string) {
-    super(message, StatusCodes.UNPROCESSABLE_ENTITY, meta)
+  constructor(message: string) {
+    super(message)
   }
 }
 
 export class MissingUserError extends ApplicationError {
   constructor(message = 'User not found') {
-    super(message, StatusCodes.BAD_REQUEST)
+    super(message)
   }
 }

--- a/src/app/modules/webhook/webhook.errors.ts
+++ b/src/app/modules/webhook/webhook.errors.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from 'http-status-codes'
-
 import { ApplicationError } from '../core/core.errors'
 
 /**
@@ -7,7 +5,7 @@ import { ApplicationError } from '../core/core.errors'
  * if the submissionWebhookView is null or the webhookUrl is an invalid URL
  */
 export class WebhookValidationError extends ApplicationError {
-  constructor(message: string, meta?: string) {
-    super(message, StatusCodes.UNPROCESSABLE_ENTITY, meta)
+  constructor(message: string) {
+    super(message)
   }
 }

--- a/src/app/services/sms/sms.errors.ts
+++ b/src/app/services/sms/sms.errors.ts
@@ -1,16 +1,10 @@
 import { ApplicationError } from '../../modules/core/core.errors'
 
 export class SmsSendError extends ApplicationError {
-  code?: number
-  sendStatus: unknown
-
   constructor(
     message = 'Error sending OTP. Please try again later and if the problem persists, contact us.',
-    code?: number,
-    sendStatus?: unknown,
+    meta?: unknown,
   ) {
-    super(message)
-    this.code = code
-    this.sendStatus = sendStatus
+    super(message, meta)
   }
 }

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -1,5 +1,6 @@
 import { SecretsManager } from 'aws-sdk'
 import dedent from 'dedent-js'
+import { get } from 'lodash'
 import mongoose from 'mongoose'
 import { ResultAsync } from 'neverthrow'
 import NodeCache from 'node-cache'
@@ -230,7 +231,8 @@ const send = async (
       // Invalid number error code, throw a more reasonable error for error
       // handling.
       // See https://www.twilio.com/docs/api/errors/21211
-      if (err?.code === 21211) {
+      // err.meta.errorCode may exist if SmsSendError is thrown inside the `then` block.
+      if (err?.code === 21211 || get(err, 'meta.errorCode') === 21211) {
         const invalidOtpError = new Error(VfnErrors.InvalidMobileNumber)
         invalidOtpError.name = VfnErrors.SendOtpFailed
         throw invalidOtpError

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -168,7 +168,7 @@ const send = async (
       // Sent but with error code.
       // Throw error to be caught in catch block.
       if (!sid || errorCode) {
-        throw new SmsSendError(errorMessage, errorCode, status)
+        throw new SmsSendError(errorMessage, { errorCode, status })
       }
 
       // Log success


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR removes the unused `status` class variable in `ApplicationError` class that may sometimes cause confusion when poring through logs for issues, since the default value is `500`.

Also updates the `meta` key in `ApplicationError` to accept anything, since we may want to store more info from the creation of the error; e.g. storing original error that resulted in an `ApplicationError` being created for logging purposes.


## Solution
<!-- How did you solve the problem? -->

**Features**:

- remove `status` key in `ApplicationError` class and all its usages
- update `meta` key in `ApplicationError` to unknown type
