### PR TITLE
fix: add rows attr to email confirmation email body textarea

### DIFF
--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -779,6 +779,7 @@
                 class="input-custom input-medium"
                 ng-model="vm.field.autoReplyOptions.autoReplyMessage"
                 placeholder="Default email body"
+                rows="11"
               ></textarea>
             </div>
           </div>


### PR DESCRIPTION
added rows attribute to email confirmation body textarea to increase height to something reasonable for an email

## Problem

email confirmation > email body textarea is too short. even if your email is very short, it is difficult to scroll to where you want to edit and there is a tendency to miss it. 

Before:
<img width="1265" alt="Screenshot 2021-03-16 at 2 51 47 AM" src="https://user-images.githubusercontent.com/55272802/111205839-a3237a80-8602-11eb-88a0-4b3d48b0fa8e.png">

After:
<img width="562" alt="Screenshot 2021-03-16 at 2 47 59 AM" src="https://user-images.githubusercontent.com/55272802/111205868-aae31f00-8602-11eb-8e6a-eb70d9adc727.png">


