### PR TITLE
feat: switch to CorpPass Cloud for test form

### DIFF
--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -89,6 +89,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
+        false,
       )
       expect(MOCK_RESPONSE.status).toHaveBeenCalledWith(200)
       expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
@@ -107,6 +108,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
+        false,
       )
       expect(MOCK_RESPONSE.status).toHaveBeenCalledWith(500)
       expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
@@ -137,6 +139,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
+        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -171,6 +174,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
+        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -203,6 +207,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
+        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -235,6 +240,7 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
+        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -291,6 +297,7 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -301,6 +308,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
+          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -401,6 +409,7 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
+          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -427,6 +436,7 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -455,6 +465,7 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -465,6 +476,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
+          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -489,6 +501,7 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -499,6 +512,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
+          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -550,6 +564,7 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -560,6 +575,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
+          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,
@@ -660,6 +676,7 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
+          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -686,6 +703,7 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -714,6 +732,7 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -724,6 +743,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
+          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -748,6 +768,7 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
+          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -758,6 +779,7 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
+          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -64,7 +64,7 @@ describe('spcp.service', () => {
     it('should instantiate auth clients with the correct params', () => {
       const spcpService = new SpcpService(MOCK_PARAMS)
       expect(spcpService).toBeTruthy()
-      expect(MockAuthClient).toHaveBeenCalledTimes(2)
+      expect(MockAuthClient).toHaveBeenCalledTimes(3)
       expect(MockAuthClient).toHaveBeenCalledWith({
         partnerEntityId: MOCK_PARAMS.spPartnerEntityId,
         idpLoginURL: MOCK_PARAMS.spIdpLoginUrl,

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -3,6 +3,7 @@ import { ParamsDictionary } from 'express-serve-static-core'
 import { StatusCodes } from 'http-status-codes'
 
 import config from '../../../config/config'
+import FeatureManager, { FeatureNames } from '../../../config/feature-manager'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { AuthType, WithForm } from '../../../types'
 import { createReqMeta } from '../../utils/request'
@@ -15,10 +16,14 @@ import { JwtName, LoginPageValidationResult } from './spcp.types'
 import {
   createCorppassParsedResponses,
   createSingpassParsedResponses,
+  extractFormId,
   mapRouteError,
 } from './spcp.util'
 
 const logger = createLoggerWithLabel(module)
+
+// TODO (private #123): remove checking of form ID against CorpPass cloud test form
+const spcpFeature = FeatureManager.get(FeatureNames.SpcpMyInfo)
 
 /**
  * Generates redirect URL to Official SingPass/CorpPass log in page
@@ -43,7 +48,12 @@ export const handleRedirect: RequestHandler<
     target,
     esrvcId,
   }
-  return SpcpFactory.createRedirectUrl(authType, target, esrvcId)
+  // TODO (private #123): remove checking of form ID against CorpPass cloud test form
+  const payloads = target.split(',')
+  const formId = extractFormId(payloads[0])
+  const useCpCloud =
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === formId
+  return SpcpFactory.createRedirectUrl(authType, target, esrvcId, useCpCloud)
     .map((redirectURL) => {
       return res.status(StatusCodes.OK).json({ redirectURL })
     })
@@ -74,7 +84,9 @@ export const handleValidate: RequestHandler<
   }
 > = (req, res) => {
   const { target, authType, esrvcId } = req.query
-  return SpcpFactory.createRedirectUrl(authType, target, esrvcId)
+  const useCpCloud =
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === target
+  return SpcpFactory.createRedirectUrl(authType, target, esrvcId, useCpCloud)
     .asyncAndThen(SpcpFactory.fetchLoginPage)
     .andThen(SpcpFactory.validateLoginPage)
     .map((result) => res.status(StatusCodes.OK).json(result))
@@ -106,14 +118,16 @@ export const addSpcpSessionInfo: RequestHandler<ParamsDictionary> = async (
   res,
   next,
 ) => {
-  const { authType } = (req as WithForm<typeof req>).form
+  const { authType, _id } = (req as WithForm<typeof req>).form
   if (authType !== AuthType.SP && authType !== AuthType.CP) return next()
 
   const jwtResult = SpcpFactory.extractJwt(req.cookies, authType)
   // No action needed if JWT is missing, just means user is not logged in
   if (jwtResult.isErr()) return next()
 
-  return SpcpFactory.extractJwtPayload(jwtResult.value, authType)
+  const useCpCloud =
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === _id
+  return SpcpFactory.extractJwtPayload(jwtResult.value, authType, useCpCloud)
     .map(({ userName }) => {
       res.locals.spcpSession = { userName }
       return next()
@@ -142,11 +156,15 @@ export const isSpcpAuthenticated: RequestHandler<ParamsDictionary> = (
   res,
   next,
 ) => {
-  const { authType } = (req as WithForm<typeof req>).form
+  const { authType, _id } = (req as WithForm<typeof req>).form
   if (authType !== AuthType.SP && authType !== AuthType.CP) return next()
 
+  const useCpCloud =
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === _id
   return SpcpFactory.extractJwt(req.cookies, authType)
-    .asyncAndThen((jwt) => SpcpFactory.extractJwtPayload(jwt, authType))
+    .asyncAndThen((jwt) =>
+      SpcpFactory.extractJwtPayload(jwt, authType, useCpCloud),
+    )
     .map(({ userName, userInfo }) => {
       res.locals.uinFin = userName
       res.locals.userInfo = userInfo
@@ -221,16 +239,19 @@ export const handleLogin: (
     res.cookie('isLoginError', true)
     return res.redirect(destination)
   }
+  const useCpCloud =
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === form._id
   const jwtResult = await SpcpFactory.getSpcpAttributes(
     SAMLart,
     destination,
     authType,
+    useCpCloud,
   )
     .andThen((attributes) =>
       SpcpFactory.createJWTPayload(attributes, rememberMe, authType),
     )
     .andThen((jwtPayload) =>
-      SpcpFactory.createJWT(jwtPayload, cookieDuration, authType),
+      SpcpFactory.createJWT(jwtPayload, cookieDuration, authType, useCpCloud),
     )
   if (jwtResult.isErr()) {
     logger.error({

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -126,7 +126,7 @@ export const addSpcpSessionInfo: RequestHandler<ParamsDictionary> = async (
   if (jwtResult.isErr()) return next()
 
   const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === _id
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === String(_id)
   return SpcpFactory.extractJwtPayload(jwtResult.value, authType, useCpCloud)
     .map(({ userName }) => {
       res.locals.spcpSession = { userName }
@@ -160,7 +160,7 @@ export const isSpcpAuthenticated: RequestHandler<ParamsDictionary> = (
   if (authType !== AuthType.SP && authType !== AuthType.CP) return next()
 
   const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === _id
+    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === String(_id)
   return SpcpFactory.extractJwt(req.cookies, authType)
     .asyncAndThen((jwt) =>
       SpcpFactory.extractJwtPayload(jwt, authType, useCpCloud),
@@ -240,7 +240,8 @@ export const handleLogin: (
     return res.redirect(destination)
   }
   const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === form._id
+    spcpFeature.isEnabled &&
+    spcpFeature.props?.cpCloudFormId === String(form._id)
   const jwtResult = await SpcpFactory.getSpcpAttributes(
     SAMLart,
     destination,

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -51,8 +51,7 @@ export const handleRedirect: RequestHandler<
   // TODO (private #123): remove checking of form ID against CorpPass cloud test form
   const payloads = target.split(',')
   const formId = extractFormId(payloads[0])
-  const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === formId
+  const useCpCloud = spcpFeature.props?.cpCloudFormId === formId
   return SpcpFactory.createRedirectUrl(authType, target, esrvcId, useCpCloud)
     .map((redirectURL) => {
       return res.status(StatusCodes.OK).json({ redirectURL })
@@ -84,8 +83,7 @@ export const handleValidate: RequestHandler<
   }
 > = (req, res) => {
   const { target, authType, esrvcId } = req.query
-  const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === target
+  const useCpCloud = spcpFeature.props?.cpCloudFormId === target
   return SpcpFactory.createRedirectUrl(authType, target, esrvcId, useCpCloud)
     .asyncAndThen(SpcpFactory.fetchLoginPage)
     .andThen(SpcpFactory.validateLoginPage)
@@ -125,8 +123,7 @@ export const addSpcpSessionInfo: RequestHandler<ParamsDictionary> = async (
   // No action needed if JWT is missing, just means user is not logged in
   if (jwtResult.isErr()) return next()
 
-  const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === String(_id)
+  const useCpCloud = spcpFeature.props?.cpCloudFormId === String(_id)
   return SpcpFactory.extractJwtPayload(jwtResult.value, authType, useCpCloud)
     .map(({ userName }) => {
       res.locals.spcpSession = { userName }
@@ -159,8 +156,7 @@ export const isSpcpAuthenticated: RequestHandler<ParamsDictionary> = (
   const { authType, _id } = (req as WithForm<typeof req>).form
   if (authType !== AuthType.SP && authType !== AuthType.CP) return next()
 
-  const useCpCloud =
-    spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === String(_id)
+  const useCpCloud = spcpFeature.props?.cpCloudFormId === String(_id)
   return SpcpFactory.extractJwt(req.cookies, authType)
     .asyncAndThen((jwt) =>
       SpcpFactory.extractJwtPayload(jwt, authType, useCpCloud),
@@ -239,9 +235,7 @@ export const handleLogin: (
     res.cookie('isLoginError', true)
     return res.redirect(destination)
   }
-  const useCpCloud =
-    spcpFeature.isEnabled &&
-    spcpFeature.props?.cpCloudFormId === String(form._id)
+  const useCpCloud = spcpFeature.props?.cpCloudFormId === String(form._id)
   const jwtResult = await SpcpFactory.getSpcpAttributes(
     SAMLart,
     destination,

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -75,6 +75,14 @@ export class SpcpService {
     })
     // TODO (private #123): remove #corppassCloudAuthClient
     try {
+      logger.info({
+        message: 'Initialising CorpPass Cloud client',
+        meta: {
+          action: 'SpcpService',
+          idpEndpoint: props.cpCloudEndpoint,
+          spcpCertPath: props.cpCloudCertPath,
+        },
+      })
       this.#corppassCloudAuthClient = new SPCPAuthClient({
         partnerEntityId: props.cpPartnerEntityId,
         idpLoginURL: props.cpIdpLoginUrl,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -132,8 +132,7 @@ export const handleEmailSubmission: RequestHandler<
   // Handle SingPass, CorpPass and MyInfo authentication and validation
   const { authType } = form
   if (authType === AuthType.SP || authType === AuthType.CP) {
-    const useCpCloud =
-      spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === formId
+    const useCpCloud = spcpFeature.props?.cpCloudFormId === formId
     // Verify NRIC and/or UEN
     const jwtPayloadResult = await SpcpFactory.extractJwt(
       req.cookies,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -1,5 +1,8 @@
 import { Request, RequestHandler } from 'express'
 
+import FeatureManager, {
+  FeatureNames,
+} from '../../../../config/feature-manager'
 import { createLoggerWithLabel } from '../../../../config/logger'
 import { AuthType, FieldResponse } from '../../../../types'
 import { CaptchaFactory } from '../../../services/captcha/captcha.factory'
@@ -26,6 +29,9 @@ import {
 } from './email-submission.util'
 
 const logger = createLoggerWithLabel(module)
+
+// TODO (private #123): remove checking of form ID against CorpPass cloud test form
+const spcpFeature = FeatureManager.get(FeatureNames.SpcpMyInfo)
 
 export const handleEmailSubmission: RequestHandler<
   { formId: string },
@@ -126,11 +132,15 @@ export const handleEmailSubmission: RequestHandler<
   // Handle SingPass, CorpPass and MyInfo authentication and validation
   const { authType } = form
   if (authType === AuthType.SP || authType === AuthType.CP) {
+    const useCpCloud =
+      spcpFeature.isEnabled && spcpFeature.props?.cpCloudFormId === formId
     // Verify NRIC and/or UEN
     const jwtPayloadResult = await SpcpFactory.extractJwt(
       req.cookies,
       authType,
-    ).asyncAndThen((jwt) => SpcpFactory.extractJwtPayload(jwt, authType))
+    ).asyncAndThen((jwt) =>
+      SpcpFactory.extractJwtPayload(jwt, authType, useCpCloud),
+    )
     if (jwtPayloadResult.isErr()) {
       logger.error({
         message: 'Failed to verify JWT with auth client',

--- a/src/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/config/feature-manager/spcp-myinfo.config.ts
@@ -186,6 +186,25 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
       default: null,
       env: 'MYINFO_CLIENT_SECRET',
     },
+    // TODO (private #123): remove these env vars
+    cpCloudFormId: {
+      doc: 'Temporary test form ID for CorpPass Cloud',
+      format: String,
+      default: '60506aff15c0760011f0b14a',
+      env: 'CP_CLOUD_FORM_ID',
+    },
+    cpCloudCertPath: {
+      doc: 'Temporary certificate path for CorpPass Cloud',
+      format: String,
+      default: '/certs/corppass/prod-spcp-cert-cloud.pem',
+      env: 'CP_CLOUD_CERT_PATH',
+    },
+    cpCloudEndpoint: {
+      doc: 'Temporary certificate path for CorpPass Cloud',
+      format: String,
+      default: 'https://oob.corppass.gov.sg/FIM/sps/CorpIDPFed/saml20/soap',
+      env: 'CP_CLOUD_ENDPOINT',
+    },
   },
 }
 

--- a/src/config/feature-manager/types.ts
+++ b/src/config/feature-manager/types.ts
@@ -68,6 +68,10 @@ export interface IMyInfoConfig {
   myInfoCertPath: string
   myInfoClientId: string
   myInfoClientSecret: string
+  // TODO (private #123): remove these keys
+  cpCloudFormId: string
+  cpCloudEndpoint: string
+  cpCloudCertPath: string
 }
 
 export type ISpcpMyInfo = ISpcpConfig & IMyInfoConfig


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

CorpPass is cutting over to its new cloud infrastructure, and part of the migration process involves a rehearsal on production. While this rehearsal is happening, we don't want any public users to be able to log in to CorpPass, but we still need to be able to test the new cloud infrastructure with our own test form.

## Solution
<!-- How did you solve the problem? -->

Switch to CorpPass Cloud only for a specific test form ID.

The cloud migration involves two changes:
- Changing to a new OOB verification endpoint (`CORPPASS_IDP_ENDPOINT` env var)
- Changing to a new CorpPass public key (`CP_IDP_CERT_PATH` env var)

The approach is to get all forms to use the old env vars, while using the new env vars _only_ for a specific form that we choose.

Why does this work? **Outside of the rehearsal hours**, the _old_ CorpPass infrastructure will be up. Hence the _old_ env vars will work, and all public users will be able to use CorpPass normally. However, the _new_ CorpPass infrastructure will be down, so our test form (which is linked to the new env vars) will not work.

Conversely, **during rehearsal hours**, the old CorpPass infrastructure will be down. The old env vars will direct public users to the old CorpPass login endpoint, so their login will fail. On the other hand, the new CorpPass infrastructure will be up, so our test form will work (assuming the migration succeeds).

This implementation creates new env vars which default to the production Cloud values, as well as the form ID of a test form which I created. The defaults allow us to deploy the code without worrying about environment variables, while still allowing us to adjust the variables if needed.

## Screenshots

When public users attempt to log in to CorpPass during the rehearsal hours, they will see the following Toastr when they are redirected back to the form after logging in:
![image](https://user-images.githubusercontent.com/29480346/111405381-4fe91f00-870b-11eb-9258-005cadd3b873.png)

## Tests
- [ ] Create, activate and submit a new CorpPass form. Should be able to log in and submit successfully.
- [ ] Log out of this new CorpPass form and deactivate it. Change the `CP_CLOUD_FORM_ID` env var to the ID of the new CorpPass form. Should still be able to activate the form, but should see "There was an unexpected error with your log in" after attempting to log in using CorpPass.
- [ ] Delete the `CP_CLOUD_CERT_PATH`, `CP_CLOUD_ENDPOINT` and `CP_CLOUD_FORM_ID` env vars from staging. You should now be able to log in and submit the new CorpPass form again.