### PR TITLE
refactor: rename type to AnalyticStatsDto

### DIFF
--- a/src/app/modules/analytics/analytics.controller.ts
+++ b/src/app/modules/analytics/analytics.controller.ts
@@ -4,7 +4,7 @@ import * as F from 'fp-ts/lib/function'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { StatusCodes } from 'http-status-codes'
 
-import { AnalyticStatsDTO } from 'src/types/analytics'
+import { AnalyticStatsDto } from 'src/types/analytics'
 
 import { createLoggerWithLabel } from '../../../config/logger'
 import { createReqMeta } from '../../utils/request'
@@ -132,7 +132,7 @@ export const handleGetStatistics: RequestHandler = async (req, res) => {
           .json('Unable to retrieve statistics from the database')
       },
       ([userCount, formCount, submissionCount]) => {
-        const stats: AnalyticStatsDTO = {
+        const stats: AnalyticStatsDto = {
           userCount,
           formCount,
           submissionCount,

--- a/src/app/modules/analytics/analytics.controller.ts
+++ b/src/app/modules/analytics/analytics.controller.ts
@@ -4,7 +4,7 @@ import * as F from 'fp-ts/lib/function'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { StatusCodes } from 'http-status-codes'
 
-import { AnalyticStats } from 'src/types/analytics'
+import { AnalyticStatsDTO } from 'src/types/analytics'
 
 import { createLoggerWithLabel } from '../../../config/logger'
 import { createReqMeta } from '../../utils/request'
@@ -132,7 +132,7 @@ export const handleGetStatistics: RequestHandler = async (req, res) => {
           .json('Unable to retrieve statistics from the database')
       },
       ([userCount, formCount, submissionCount]) => {
-        const stats: AnalyticStats = {
+        const stats: AnalyticStatsDTO = {
           userCount,
           formCount,
           submissionCount,

--- a/src/public/services/AnalyticsService.ts
+++ b/src/public/services/AnalyticsService.ts
@@ -1,11 +1,11 @@
 import axios from 'axios'
 
-import { AnalyticStatsDTO } from 'src/types/analytics'
+import { AnalyticStatsDto } from 'src/types/analytics'
 
 /**
  * Retrieves landing page statistics - user, form and submission count.
  */
-export const getLandingPageStatistics = async (): Promise<AnalyticStatsDTO> =>
+export const getLandingPageStatistics = async (): Promise<AnalyticStatsDto> =>
   axios
-    .get<AnalyticStatsDTO>('/analytics/statistics')
+    .get<AnalyticStatsDto>('/analytics/statistics')
     .then((response) => response.data)

--- a/src/public/services/AnalyticsService.ts
+++ b/src/public/services/AnalyticsService.ts
@@ -1,11 +1,11 @@
 import axios from 'axios'
 
-import { AnalyticStats } from 'src/types/analytics'
+import { AnalyticStatsDTO } from 'src/types/analytics'
 
 /**
  * Retrieves landing page statistics - user, form and submission count.
  */
-export const getLandingPageStatistics = async (): Promise<AnalyticStats> =>
+export const getLandingPageStatistics = async (): Promise<AnalyticStatsDTO> =>
   axios
-    .get<AnalyticStats>('/analytics/statistics')
+    .get<AnalyticStatsDTO>('/analytics/statistics')
     .then((response) => response.data)

--- a/src/public/services/AnalyticsService.ts
+++ b/src/public/services/AnalyticsService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { AnalyticStatsDto } from 'src/types/analytics'
+import { AnalyticStatsDto } from '../../types/analytics'
 
 /**
  * Retrieves landing page statistics - user, form and submission count.

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,4 +1,4 @@
-export type AnalyticStats = {
+export type AnalyticStatsDTO = {
   userCount: number
   formCount: number
   submissionCount: number

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,4 +1,4 @@
-export type AnalyticStatsDTO = {
+export type AnalyticStatsDto = {
   userCount: number
   formCount: number
   submissionCount: number


### PR DESCRIPTION
It just occurred to me that `AnalyticStats` was in fact a _data transfer object_ that presents a specific data format to the client, so I renamed it. I'm leaving the file in `/types/analytics` instead of `/shared` so that the cleanup can happen all in one go in a future PR.