### PR TITLE
feat: show error Toastr for intranet users on SPCP forms

### DIFF
--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -12,6 +12,7 @@ const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormModel = require('../models/form.server.model').default
 const { IntranetFactory } = require('../services/intranet/intranet.factory')
 const { getRequestIp } = require('../utils/request')
+const { AuthType } = require('../../types')
 
 const Form = getFormModel(mongoose)
 
@@ -81,6 +82,21 @@ exports.read = (requestType) =>
     let isIntranetUser = false
     if (isIntranetResult.isOk()) {
       isIntranetUser = isIntranetResult.value
+    }
+
+    // SP, CP and MyInfo are not available on intranet
+    if (
+      isIntranetUser &&
+      [AuthType.SP, AuthType.CP, AuthType.MyInfo].includes(form.authType)
+    ) {
+      logger.warn({
+        message:
+          'Attempting to access SingPass, CorpPass or MyInfo form from intranet',
+        meta: {
+          action: 'read',
+          formId: form._id,
+        },
+      })
     }
 
     return res.json({

--- a/src/app/controllers/forms.server.controller.js
+++ b/src/app/controllers/forms.server.controller.js
@@ -10,6 +10,8 @@ const { StatusCodes } = require('http-status-codes')
 const { createReqMeta } = require('../utils/request')
 const logger = require('../../config/logger').createLoggerWithLabel(module)
 const getFormModel = require('../models/form.server.model').default
+const { IntranetFactory } = require('../services/intranet/intranet.factory')
+const { getRequestIp } = require('../utils/request')
 
 const Form = getFormModel(mongoose)
 
@@ -75,10 +77,17 @@ exports.read = (requestType) =>
       form = _.pick(form, formPublicFields)
     }
 
+    const isIntranetResult = IntranetFactory.isIntranetIp(getRequestIp(req))
+    let isIntranetUser = false
+    if (isIntranetResult.isOk()) {
+      isIntranetUser = isIntranetResult.value
+    }
+
     return res.json({
       form,
       spcpSession,
       myInfoError,
+      isIntranetUser,
     })
   }
 

--- a/src/app/services/intranet/__tests__/intranet.factory.spec.ts
+++ b/src/app/services/intranet/__tests__/intranet.factory.spec.ts
@@ -1,0 +1,50 @@
+import { mocked } from 'ts-jest/utils'
+
+import { MissingFeatureError } from 'src/app/modules/core/core.errors'
+import { FeatureNames } from 'src/config/feature-manager'
+
+import { createIntranetFactory } from '../intranet.factory'
+import { IntranetService } from '../intranet.service'
+
+jest.mock('../intranet.service')
+const MockIntranetService = mocked(IntranetService, true)
+
+const MOCK_INTRANET_PROPS = {
+  intranetIpListPath: 'somePath',
+}
+
+describe('intranet.factory', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('should call the IntranetService constructor when Intranet feature is enabled', () => {
+    createIntranetFactory({
+      isEnabled: true,
+      props: MOCK_INTRANET_PROPS,
+    })
+
+    expect(MockIntranetService).toHaveBeenCalledWith(MOCK_INTRANET_PROPS)
+  })
+
+  it('should return error functions when isEnabled is false', () => {
+    const intranetFactory = createIntranetFactory({
+      isEnabled: false,
+      props: MOCK_INTRANET_PROPS,
+    })
+
+    expect(MockIntranetService).not.toHaveBeenCalled()
+    expect(intranetFactory.isIntranetIp('')._unsafeUnwrapErr()).toEqual(
+      new MissingFeatureError(FeatureNames.Intranet),
+    )
+  })
+
+  it('should return error functions when props is undefined', () => {
+    const intranetFactory = createIntranetFactory({
+      isEnabled: true,
+    })
+
+    expect(MockIntranetService).not.toHaveBeenCalled()
+    expect(intranetFactory.isIntranetIp('')._unsafeUnwrapErr()).toEqual(
+      new MissingFeatureError(FeatureNames.Intranet),
+    )
+  })
+})

--- a/src/app/services/intranet/__tests__/intranet.service.spec.ts
+++ b/src/app/services/intranet/__tests__/intranet.service.spec.ts
@@ -1,0 +1,45 @@
+import fs from 'fs'
+
+import { IntranetService } from '../intranet.service'
+
+const MOCK_IP_LIST = ['1.2.3.4', '5.6.7.8']
+const MOCK_IP_LIST_FILE = Buffer.from(MOCK_IP_LIST.join('\n'))
+const MOCK_IP_LIST_PATH = '../some/path'
+
+jest.mock('fs', () => ({
+  ...(jest.requireActual('fs') as typeof fs),
+  readFileSync: jest.fn().mockImplementation(() => MOCK_IP_LIST_FILE),
+}))
+
+describe('IntranetService', () => {
+  const intranetService = new IntranetService({
+    intranetIpListPath: MOCK_IP_LIST_PATH,
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  describe('constructor', () => {
+    it('should instantiate without errors', () => {
+      const intranetService = new IntranetService({
+        intranetIpListPath: MOCK_IP_LIST_PATH,
+      })
+
+      expect(intranetService).toBeTruthy()
+    })
+  })
+
+  describe('isIntranetIp', () => {
+    it('should return true when IP is in intranet IP list', () => {
+      const result = intranetService.isIntranetIp(MOCK_IP_LIST[0])
+
+      expect(result._unsafeUnwrap()).toBe(true)
+    })
+
+    it('should return false when IP is not in intranet IP list', () => {
+      const ipNotInList = '10.20.30.40'
+
+      const result = intranetService.isIntranetIp(ipNotInList)
+
+      expect(result._unsafeUnwrap()).toBe(false)
+    })
+  })
+})

--- a/src/app/services/intranet/intranet.factory.ts
+++ b/src/app/services/intranet/intranet.factory.ts
@@ -1,0 +1,30 @@
+import { err } from 'neverthrow'
+
+import FeatureManager, {
+  FeatureNames,
+  RegisteredFeature,
+} from '../../../config/feature-manager'
+import { MissingFeatureError } from '../../modules/core/core.errors'
+
+import { IntranetService } from './intranet.service'
+
+interface IIntranetFactory {
+  isIntranetIp: IntranetService['isIntranetIp']
+}
+
+export const createIntranetFactory = ({
+  isEnabled,
+  props,
+}: RegisteredFeature<FeatureNames.Intranet>): IIntranetFactory => {
+  if (isEnabled && props?.intranetIpListPath) {
+    return new IntranetService(props)
+  }
+
+  const error = new MissingFeatureError(FeatureNames.Intranet)
+  return {
+    isIntranetIp: () => err(error),
+  }
+}
+
+const intranetFeature = FeatureManager.get(FeatureNames.Intranet)
+export const IntranetFactory = createIntranetFactory(intranetFeature)

--- a/src/app/services/intranet/intranet.middleware.ts
+++ b/src/app/services/intranet/intranet.middleware.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express-serve-static-core'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import { createReqMeta, getRequestIp } from '../../utils/request'
+
+import { IntranetFactory } from './intranet.factory'
+
+const logger = createLoggerWithLabel(module)
+
+export const logIntranetUsage: RequestHandler = (req, _res, next) => {
+  const isIntranetResult = IntranetFactory.isIntranetIp(getRequestIp(req))
+  // Ignore case where result is err, as this means intranet feature is not enabled
+  if (isIntranetResult.isOk() && isIntranetResult.value) {
+    logger.info({
+      message: 'Request originated from SGProxy',
+      meta: {
+        action: 'logIntranetUsage',
+        ...createReqMeta(req),
+      },
+    })
+  }
+  return next()
+}

--- a/src/app/services/intranet/intranet.service.ts
+++ b/src/app/services/intranet/intranet.service.ts
@@ -1,0 +1,48 @@
+import fs from 'fs'
+import { ok, Result } from 'neverthrow'
+
+import { IIntranet } from '../../../config/feature-manager'
+import { createLoggerWithLabel } from '../../../config/logger'
+import { ApplicationError } from '../../modules/core/core.errors'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Handles intranet functionality based on a given list of intranet IPs.
+ */
+export class IntranetService {
+  /**
+   * List of IP addresses associated with intranet
+   */
+  intranetIps: string[]
+
+  constructor(intranetConfig: IIntranet) {
+    // In future if crucial intranet-specific functionality is implemented,
+    // e.g. intranet-only forms, then this try-catch should be removed so that
+    // an error is thrown if the intranet IP list file does not exist.
+    // For now, the functionality is not crucial, so we can default to an empty array.
+    try {
+      this.intranetIps = fs
+        .readFileSync(intranetConfig.intranetIpListPath)
+        .toString()
+        .split('\n')
+    } catch {
+      logger.warn({
+        message: 'Could not read file containing intranet IPs',
+        meta: {
+          action: 'IntranetService',
+        },
+      })
+      this.intranetIps = []
+    }
+  }
+
+  /**
+   * Checks whether the given IP address is an intranet IP.
+   * @param ip IP address to check
+   * @returns Whether the IP address originated from the intranet
+   */
+  isIntranetIp(ip: string): Result<boolean, ApplicationError> {
+    return ok(this.intranetIps.includes(ip))
+  }
+}

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -21,7 +21,8 @@ export const createReqMeta = (req: Request) => {
   return {
     ip: getRequestIp(req),
     trace: getTrace(req), // trace using cloudflare cf-ray header, with x-request-id header as backup
-    url: req.url,
+    url: req.baseUrl + req.path,
+    urlWithQueryParams: req.originalUrl,
     headers: req.headers,
   }
 }

--- a/src/config/feature-manager/index.ts
+++ b/src/config/feature-manager/index.ts
@@ -2,6 +2,7 @@ import FeatureManager from './util/FeatureManager.class'
 import aggregateStats from './aggregate-stats.config'
 import captcha from './captcha.config'
 import googleAnalytics from './google-analytics.config'
+import { intranetFeature } from './intranet.config'
 import sentry from './sentry.config'
 import sms from './sms.config'
 import spcpMyInfo from './spcp-myinfo.config'
@@ -21,5 +22,6 @@ featureManager.register(spcpMyInfo)
 featureManager.register(webhookVerifiedContent)
 featureManager.register(sms)
 featureManager.register(verifiedFields)
+featureManager.register(intranetFeature)
 
 export default featureManager

--- a/src/config/feature-manager/intranet.config.ts
+++ b/src/config/feature-manager/intranet.config.ts
@@ -4,7 +4,8 @@ export const intranetFeature: RegisterableFeature<FeatureNames.Intranet> = {
   name: FeatureNames.Intranet,
   schema: {
     intranetIpListPath: {
-      doc: 'Path to list of intranet IP addresses',
+      doc:
+        'Path to file containing list of intranet IP addresses, separated by newlines',
       format: String,
       default: null,
       env: 'INTRANET_IP_LIST_PATH',

--- a/src/config/feature-manager/intranet.config.ts
+++ b/src/config/feature-manager/intranet.config.ts
@@ -1,0 +1,13 @@
+import { FeatureNames, RegisterableFeature } from './types'
+
+export const intranetFeature: RegisterableFeature<FeatureNames.Intranet> = {
+  name: FeatureNames.Intranet,
+  schema: {
+    intranetIpListPath: {
+      doc: 'Path to list of intranet IP addresses',
+      format: String,
+      default: null,
+      env: 'INTRANET_IP_LIST_PATH',
+    },
+  },
+}

--- a/src/config/feature-manager/types.ts
+++ b/src/config/feature-manager/types.ts
@@ -10,6 +10,7 @@ export enum FeatureNames {
   SpcpMyInfo = 'spcp-myinfo',
   VerifiedFields = 'verified-fields',
   WebhookVerifiedContent = 'webhook-verified-content',
+  Intranet = 'intranet',
 }
 
 export interface IAggregateStats {
@@ -84,6 +85,10 @@ export interface IWebhookVerifiedContent {
   signingSecretKey: string
 }
 
+export interface IIntranet {
+  intranetIpListPath: string
+}
+
 export interface IFeatureManager {
   [FeatureNames.AggregateStats]: IAggregateStats
   [FeatureNames.Captcha]: ICaptcha
@@ -93,6 +98,7 @@ export interface IFeatureManager {
   [FeatureNames.SpcpMyInfo]: ISpcpMyInfo
   [FeatureNames.VerifiedFields]: IVerifiedFields
   [FeatureNames.WebhookVerifiedContent]: IWebhookVerifiedContent
+  [FeatureNames.Intranet]: IIntranet
 }
 
 export interface RegisteredFeature<T extends FeatureNames> {

--- a/src/loaders/express/index.ts
+++ b/src/loaders/express/index.ts
@@ -25,6 +25,7 @@ import { SubmissionRouter } from '../../app/modules/submission/submission.routes
 import UserRouter from '../../app/modules/user/user.routes'
 import { VfnRouter } from '../../app/modules/verification/verification.routes'
 import apiRoutes from '../../app/routes'
+import * as IntranetMiddleware from '../../app/services/intranet/intranet.middleware'
 import config from '../../config/config'
 
 import errorHandlerMiddlewares from './error-handler'
@@ -136,6 +137,9 @@ const loadExpressApp = async (connection: Connection) => {
 
   // setup express-device
   app.use(device.capture({ parseUserAgent: true }))
+
+  // Log intranet usage
+  app.use(IntranetMiddleware.logIntranetUsage)
 
   // Mount all API endpoints
   apiRoutes.forEach(function (routeFunction) {

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -41,7 +41,7 @@ function SubmitFormController(
   vm.myInfoError = Boolean(FormData.myInfoError)
   if (FormData.isIntranetUser && vm.myform.authType !== 'NIL') {
     Toastr.permanentError(
-      'SingPass and CorpPass login is not yet available on intranet.',
+      'SingPass/CorpPass login is not supported from WOG Intranet. Please use an Internet-enabled device to submit this form.',
     )
   }
   vm.logoUrl = getFormLogo(vm.myform)

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -39,7 +39,10 @@ function SubmitFormController(
   vm.myform.isTemplate = Boolean(FormData.isTemplate)
   vm.myform.isPreview = Boolean(FormData.isPreview)
   vm.myInfoError = Boolean(FormData.myInfoError)
-  if (FormData.isIntranetUser && vm.myform.authType !== 'NIL') {
+  if (
+    FormData.isIntranetUser &&
+    ['SP', 'CP', 'MyInfo'].includes(vm.myform.authType)
+  ) {
     Toastr.permanentError(
       'SingPass/CorpPass login is not supported from WOG Intranet. Please use an Internet-enabled device to submit this form.',
     )

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -10,10 +10,18 @@ angular
     '$window',
     '$document',
     'GTag',
+    'Toastr',
     SubmitFormController,
   ])
 
-function SubmitFormController(FormData, SpcpSession, $window, $document, GTag) {
+function SubmitFormController(
+  FormData,
+  SpcpSession,
+  $window,
+  $document,
+  GTag,
+  Toastr,
+) {
   const vm = this
 
   // The form attribute of the FormData object contains the form fields, logic etc
@@ -31,6 +39,11 @@ function SubmitFormController(FormData, SpcpSession, $window, $document, GTag) {
   vm.myform.isTemplate = Boolean(FormData.isTemplate)
   vm.myform.isPreview = Boolean(FormData.isPreview)
   vm.myInfoError = Boolean(FormData.myInfoError)
+  if (FormData.isIntranetUser && vm.myform.authType !== 'NIL') {
+    Toastr.permanentError(
+      'SingPass and CorpPass login is not yet available on intranet.',
+    )
+  }
   vm.logoUrl = getFormLogo(vm.myform)
 
   // Show banner content if available

--- a/tests/unit/backend/controllers/forms.server.controller.spec.js
+++ b/tests/unit/backend/controllers/forms.server.controller.spec.js
@@ -39,6 +39,7 @@ describe('Form Controller', () => {
       },
       headers: {},
       ip: '127.0.0.1',
+      get: () => this.ip,
     }
   })
 
@@ -61,6 +62,7 @@ describe('Form Controller', () => {
         form: expectedForm,
         spcpSession: res.locals.spcpSession,
         myInfoError: res.locals.myInfoError,
+        isIntranetUser: false,
       })
     })
   })
@@ -98,6 +100,7 @@ describe('Form Controller', () => {
         form: expectedForm,
         spcpSession: res.locals.spcpSession,
         myInfoError: res.locals.myInfoError,
+        isIntranetUser: false,
       })
     })
   })


### PR DESCRIPTION
## Problem

SingPass/CorpPass do not work on the intranet due to an issue with SIS cookies, but nothing in the UI alerts users to this. When they attempt to log in to SingPass/CorpPass, everything seems to be successful, but when they are redirected back to the form, they are not logged in.

## Solution

Show a permanent Toastr when users access a SPCP/MyInfo form from the intranet.

Detection of requests from the intranet was implemented by reading in a list of intranet IPs from a static file, which must be transferred into the server.

In addition, the opportunity was taken to log intranet usage for analytics purposes.

## Other changes
In the `createReqMeta` utility function, we use the `req.url` property to log the URL of the request. However, this does not work well with Express Router, as only the path after the router is logged. This is why e.g. for `handleEmailSubmission`, `meta.url` in our logs looks like this:
```
/5e3ebefa5203c3001108b7ba?captchaResponse=...
```
Notice that the `/v2/submissions/email` prefix is missing.

Hence this was changed to use `req.baseUrl + req.path`, and `req.originalUrl` was added to capture any query parameters.

## Screenshots
![image](https://user-images.githubusercontent.com/29480346/111448974-e9372600-8749-11eb-84f3-12871158b56f.png)

## Tests
- [ ] List of intranet IPs has been SFTPed into production, and `INTRANET_IP_LIST_PATH` env var has been added in production
- [ ] SingPass, CorpPass and MyInfo forms on intranet show the error Toastr
- [ ] Non-authenticated forms on intranet do not show the error Toastr
- [ ] SingPass, CorpPass, MyInfo and non-authenticated forms on internet do not show the error Toastr