### PR TITLE
build: automate dependency upgrades using mergify

### DIFF
--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - 'author=dependabot[bot]'
       - '#check-failure=0'
+      - 'title~=bump [^\s]+ from ([\d]+)\..+ to \1\.'
     actions:
       merge:
         method: squash

--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: Merge dependency upgrades when tests pass
+    conditions:
+      - 'author=dependabot[bot]'
+      - '#check-failure=0'
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This project has over 200 dependencies, resulting in around 5-10 dependency upgrades a day. All these upgrades are currently manually approved and merged by engineers, which requires time and effort.

## Solution
<!-- How did you solve the problem? -->

Use [mergify](https://mergify.io/) to merge dependabot PRs which pass tests, except major version changes.

This screenshot from the Mergify [config editor](https://dashboard.mergify.io/github/opengovsg/config-editor) demonstrates that PR #1417 (patch version change, CI passing) would be automatically merged using this config:
![Screenshot 2021-03-22 at 5 03 46 PM](https://user-images.githubusercontent.com/29480346/111965564-d4370a00-8b30-11eb-9793-04ed5282eec8.png)

Whereas this screenshot shows that PR #1422 (patch version change, CI failing) would not be merged:
![image](https://user-images.githubusercontent.com/29480346/111965607-e0bb6280-8b30-11eb-9a03-624d334be20f.png)

And this screenshot shows that PR #1423 (major version change, CI passing) would not be merged:
![image](https://user-images.githubusercontent.com/29480346/111965624-e5801680-8b30-11eb-9cbd-9c38e9312c52.png)
