### PR TITLE
refactor: return custom error from utils when bcrypt fails

### DIFF
--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -2,12 +2,13 @@ import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
 import MailService from 'src/app/services/mail/mail.service'
+import { HashingError } from 'src/app/utils/hash'
 import { IAgencySchema, IUserSchema } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import { MailSendError } from '../../../services/mail/mail.errors'
-import { ApplicationError, DatabaseError } from '../../core/core.errors'
+import { DatabaseError } from '../../core/core.errors'
 import * as UserService from '../../user/user.service'
 import * as AuthController from '../auth.controller'
 import { InvalidDomainError, InvalidOtpError } from '../auth.errors'
@@ -236,7 +237,7 @@ describe('auth.controller', () => {
       )
       // Mock generic error from verifyLoginOtp.
       MockAuthService.verifyLoginOtp.mockReturnValueOnce(
-        errAsync(new ApplicationError('generic error')),
+        errAsync(new HashingError()),
       )
 
       // Act

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -4,6 +4,7 @@ import supertest, { Session } from 'supertest-session'
 import validator from 'validator'
 
 import MailService from 'src/app/services/mail/mail.service'
+import { HashingError } from 'src/app/utils/hash'
 import * as OtpUtils from 'src/app/utils/otp'
 import { IAgencySchema } from 'src/types'
 
@@ -12,7 +13,7 @@ import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { MailSendError } from '../../../services/mail/mail.errors'
-import { ApplicationError, DatabaseError } from '../../core/core.errors'
+import { DatabaseError } from '../../core/core.errors'
 import * as UserService from '../../user/user.service'
 import { AuthRouter } from '../auth.routes'
 import * as AuthService from '../auth.service'
@@ -177,7 +178,7 @@ describe('auth.routes', () => {
       // Arrange
       const createLoginOtpSpy = jest
         .spyOn(AuthService, 'createLoginOtp')
-        .mockReturnValueOnce(errAsync(new ApplicationError()))
+        .mockReturnValueOnce(errAsync(new HashingError()))
 
       // Act
       const response = await request

--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { MapRouteError } from '../../../types/routing'
 import * as MailErrors from '../../services/mail/mail.errors'
+import { HashingError } from '../../utils/hash'
 import * as CoreErrors from '../core/core.errors'
 
 import * as AuthErrors from './auth.errors'
@@ -28,7 +29,7 @@ export const mapRouteError: MapRouteError = (error, coreErrorMessage) => {
         errorMessage: error.message,
       }
     case MailErrors.MailSendError:
-    case CoreErrors.ApplicationError:
+    case HashingError:
     case CoreErrors.DatabaseError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -9,11 +9,12 @@ import {
 import * as UserService from 'src/app/modules/user/user.service'
 import { SmsSendError } from 'src/app/services/sms/sms.errors'
 import { SmsFactory } from 'src/app/services/sms/sms.factory'
+import { HashingError } from 'src/app/utils/hash'
 import { IPopulatedUser, IUser, IUserSchema } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
-import { ApplicationError, DatabaseError } from '../../core/core.errors'
+import { DatabaseError } from '../../core/core.errors'
 
 jest.mock('src/app/modules/user/user.service')
 jest.mock('src/app/services/sms/sms.factory')
@@ -337,10 +338,10 @@ describe('user.controller', () => {
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
     })
 
-    it('should return 500 when verifying contact returns ApplicationError', async () => {
+    it('should return 500 when verifying contact returns HashingError', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
-      const expectedError = new ApplicationError('mock missing user error')
+      const expectedError = new HashingError()
 
       // Mock UserService to return error.
       MockUserService.verifyContactOtp.mockReturnValueOnce(

--- a/src/app/modules/user/user.utils.ts
+++ b/src/app/modules/user/user.utils.ts
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as SmsErrors from '../../services/sms/sms.errors'
+import { HashingError } from '../../utils/hash'
 import * as CoreErrors from '../core/core.errors'
 import { ErrorResponseData } from '../core/core.types'
 
@@ -36,7 +37,7 @@ export const mapRouteError = (
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
         errorMessage: error.message,
       }
-    case CoreErrors.ApplicationError:
+    case HashingError:
     case CoreErrors.DatabaseError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,

--- a/src/app/utils/hash.ts
+++ b/src/app/utils/hash.ts
@@ -8,6 +8,17 @@ const logger = createLoggerWithLabel(module)
 const DEFAULT_SALT_ROUNDS = 10
 
 /**
+ * Error while hashing data
+ */
+export class HashingError extends ApplicationError {
+  constructor(
+    message = 'Error occurred while processing OTP. Please try again.',
+  ) {
+    super(message)
+  }
+}
+
+/**
  * Neverthrown version of bcrypt.hash.
  * @param dataToHash the data to hash
  * @param logMeta additional metadata for logging, if available
@@ -17,9 +28,10 @@ const DEFAULT_SALT_ROUNDS = 10
 export const hashData = (
   dataToHash: unknown,
   logMeta: Record<string, unknown> = {},
-): ResultAsync<string, ApplicationError> => {
+  saltRounds?: number,
+): ResultAsync<string, HashingError> => {
   return ResultAsync.fromPromise(
-    bcrypt.hash(dataToHash, DEFAULT_SALT_ROUNDS),
+    bcrypt.hash(dataToHash, saltRounds ?? DEFAULT_SALT_ROUNDS),
     (error) => {
       logger.error({
         message: 'bcrypt hash error',
@@ -30,7 +42,7 @@ export const hashData = (
         error,
       })
 
-      return new ApplicationError()
+      return new HashingError()
     },
   )
 }
@@ -47,7 +59,7 @@ export const compareHash = (
   data: unknown,
   encrypted: string,
   logMeta: Record<string, unknown> = {},
-): ResultAsync<boolean, ApplicationError> => {
+): ResultAsync<boolean, HashingError> => {
   return ResultAsync.fromPromise(bcrypt.compare(data, encrypted), (error) => {
     logger.error({
       message: 'bcrypt compare error',
@@ -58,6 +70,6 @@ export const compareHash = (
       error,
     })
 
-    return new ApplicationError()
+    return new HashingError()
   })
 }

--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -1,4 +1,9 @@
 import crypto from 'crypto'
+import { ResultAsync } from 'neverthrow'
+
+import { hashData, HashingError } from './hash'
+
+const DEFAULT_SALT_ROUNDS = 10
 
 /**
  * Randomly generates and returns a 6 digit OTP.
@@ -16,4 +21,28 @@ export const generateOtp = (): string => {
     digits[i] = chars[Math.floor(rnd[i] * d)]
   }
   return digits.join('')
+}
+
+/**
+ * Generates a 6-digit OTP together with its hash.
+ * @param logMeta Metadata to be included in logs. Defaults to empty object.
+ * @param saltRounds Number of salt rounds to use when hashing. Defaults to 10.
+ * @returns ok({ otp, hashedOtp }) if OTP generation and hashing are successful
+ * @returns err(HashingError) if error occurs while hashing
+ */
+export const generateOtpWithHash = (
+  logMeta: Record<string, unknown> = {},
+  saltRounds = DEFAULT_SALT_ROUNDS,
+): ResultAsync<
+  {
+    otp: string
+    hashedOtp: string
+  },
+  HashingError
+> => {
+  const otp = generateOtp()
+  return hashData(otp, logMeta, saltRounds).map((hashedOtp) => ({
+    otp,
+    hashedOtp,
+  }))
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. In `src/app/utils/hash`, we have utility functions which wrap calls to `bcrypt.hash` and `bcrypt.compare` in `ResultAsync`. However, we return a generic `ApplicationError` when these functions fail. This means that downstream functionality has to deal with the error as a generic `ApplicationError` without context of where it came from, e.g. when deciding what status code and message to return in `mapRouteError`. Developers have to search through all the service functions called in controllers one by one until they find where the `ApplicationError` was returned.
2. We have a `generateOtp` utility, but all the times when we need to call it, we have to create not just the OTP but a hash of it as well. Since these two bits of functionality always come together, it makes sense to have a utility function which does both.

Part of #941 

## Solution
<!-- How did you solve the problem? -->

1. Return a new `HashingError` when `bcrypt` fails. This makes the origin of the error much clearer.
2. Create a `generateOtpWithHash` utility function, so we can call `generateOtpWithHash().andThen...` instead of `const otp = generateOtp(); hashData(otp).andThen...`. Note that `verification.service` was left out (it still calls `generateOtp` instead of `generateOtpWithHash`) as it will be addressed together with the rest of #941.