### PR TITLE
feat: remove isTemplate validation on duplicate template api

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -741,16 +741,6 @@ export const handleCopyTemplateForm: RequestHandler<
   const userId = (req.session as Express.AuthedSession).user._id
   const overrideParams = req.body
 
-  // TODO(#792): Remove when frontend has stopped sending isTemplate.
-  if ('isTemplate' in req.body) {
-    logger.info({
-      message: 'isTemplate is still being sent by the frontend',
-      meta: {
-        action: 'handleCopyTemplateForm',
-      },
-    })
-  }
-
   return (
     // Step 1: Retrieve currently logged in user.
     UserService.getPopulatedUserById(userId)

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -295,8 +295,6 @@ module.exports = function (app) {
             is: ResponseMode.Encrypt,
             then: Joi.string().required().disallow(''),
           }),
-        // TODO(#792): Remove when frontend has stopped sending isTemplate.
-        isTemplate: Joi.boolean(),
       },
     }),
     AdminFormController.handleCopyTemplateForm,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Remove dangling unused key in Joi validation for `/adminform/copy` endpoint. 
Checked via Cloudwatch logging and no instances of the `isTemplate` key being sent for the past month.

Closes #792 
