### PR TITLE
feat: add <sg-govt-banner-component> to top of public forms

### DIFF
--- a/src/public/modules/core/componentViews/sg-govt-banner.html
+++ b/src/public/modules/core/componentViews/sg-govt-banner.html
@@ -1,4 +1,8 @@
-<div ng-show="{{vm.showBanner}}" id="sg-govt-banner">
+<div
+  ng-show="{{vm.showBanner}}"
+  id="sg-govt-banner"
+  class="{{vm.paddingSmall ? 'banner-x-padding-small' : ''}}"
+>
   <div class="sgds-masthead">
     <a href="https://www.gov.sg" target="_blank">
       <span class="sgds-icon sgds-icon-sg-crest"></span>

--- a/src/public/modules/core/components/sg-govt-banner.client.component.js
+++ b/src/public/modules/core/components/sg-govt-banner.client.component.js
@@ -2,14 +2,16 @@
 
 angular.module('core').component('sgGovtBannerComponent', {
   templateUrl: 'modules/core/componentViews/sg-govt-banner.html',
-  controller: ['$location', SgGovtBannerController],
+  controller: ['$location', '$attrs', SgGovtBannerController],
   controllerAs: 'vm',
 })
 
-function SgGovtBannerController($location) {
+function SgGovtBannerController($location, $attrs) {
   const vm = this
 
   // Only show banner if the website is a Singapore Government Website.
   // See https://www.designsystem.gov.sg/docs/masthead/.
   vm.showBanner = $location.host().includes('.gov.sg')
+  // The x-padding-small attribute maps to paddingSmall instead of xPaddingSmall.
+  vm.paddingSmall = Object.prototype.hasOwnProperty.call($attrs, 'paddingSmall')
 }

--- a/src/public/modules/core/css/sg-govt-banner.css
+++ b/src/public/modules/core/css/sg-govt-banner.css
@@ -70,6 +70,12 @@
   background-color: #f0f0f0;
 }
 
+#sg-govt-banner.banner-x-padding-small {
+  padding-left: 4px;
+  padding-right: 4px;
+  background-color: #f0f0f0;
+}
+
 @media screen and (max-width: 992px) {
   #sg-govt-banner {
     padding: 0;

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -14,7 +14,6 @@
   <div id="start-page-container">
     <div id="start-page-main-container" class="{{ vm.colorTheme }}-bg">
       <!-- Header View on all pages -->
-      <sg-govt-banner-component x-padding-small></sg-govt-banner-component>
       <div ng-if="vm.logoUrl" class="form-header">
         <!-- TODO: <center> tag is deprecated in HTML5 -->
         <center><img ng-src="{{ vm.logoUrl }}" /></center>

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -14,7 +14,7 @@
   <div id="start-page-container">
     <div id="start-page-main-container" class="{{ vm.colorTheme }}-bg">
       <!-- Header View on all pages -->
-      <sg-govt-banner-component></sg-govt-banner-component>
+      <sg-govt-banner-component x-padding-small></sg-govt-banner-component>
       <div ng-if="vm.logoUrl" class="form-header">
         <!-- TODO: <center> tag is deprecated in HTML5 -->
         <center><img ng-src="{{ vm.logoUrl }}" /></center>

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -14,6 +14,7 @@
   <div id="start-page-container">
     <div id="start-page-main-container" class="{{ vm.colorTheme }}-bg">
       <!-- Header View on all pages -->
+      <sg-govt-banner-component></sg-govt-banner-component>
       <div ng-if="vm.logoUrl" class="form-header">
         <!-- TODO: <center> tag is deprecated in HTML5 -->
         <center><img ng-src="{{ vm.logoUrl }}" /></center>

--- a/src/public/modules/forms/base/views/submit-form.client.view.html
+++ b/src/public/modules/forms/base/views/submit-form.client.view.html
@@ -1,3 +1,4 @@
+<sg-govt-banner-component x-padding-small></sg-govt-banner-component>
 <!-- Public Banner -->
 <banner-component message="vm.banner.msg | linky"></banner-component>
 


### PR DESCRIPTION
## Problem

Closes #969 

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-03-23 at 7 23 00 PM](https://user-images.githubusercontent.com/14961285/112139465-c1463780-8c0d-11eb-9a82-ae8a16610153.png)

**AFTER**:
**With info banner**
<img width="824" alt="Screenshot 2021-04-28 at 11 40 08 AM" src="https://user-images.githubusercontent.com/22133008/116343262-b0916e80-a816-11eb-8ac9-5a5b723c9a0a.png">
<img width="824" alt="Screenshot 2021-04-28 at 11 40 13 AM" src="https://user-images.githubusercontent.com/22133008/116343271-b424f580-a816-11eb-91c8-719051ae99c8.png">
**Without**
<img width="824" alt="Screenshot 2021-04-28 at 11 40 24 AM" src="https://user-images.githubusercontent.com/22133008/116343322-c868f280-a816-11eb-9f7e-bf0538a1ae54.png">
<img width="824" alt="Screenshot 2021-04-28 at 11 40 27 AM" src="https://user-images.githubusercontent.com/22133008/116343326-cb63e300-a816-11eb-932c-06913979bb48.png">


![Screenshot 2021-04-08 at 6 45 57 PM](https://user-images.githubusercontent.com/14961285/114014776-901b6780-989b-11eb-85e4-3b8f719da8f6.png)
![Screenshot 2021-04-08 at 6 46 04 PM](https://user-images.githubusercontent.com/14961285/114014806-9873a280-989b-11eb-83ae-56fca7989e1d.png)

## Deploy Notes

The indentation of the text `A Singapore Government Agency Website` looks strange on form pages.
