### PR TITLE
ref: collapse middlewares of /adminform/submissions/download

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -114,8 +114,13 @@ export const handleEncryptedSubmission: RequestHandler = async (
  * @security session
  *
  * @returns 200 with stream of encrypted responses
+ * @returns 400 if form is not an encrypt mode form
  * @returns 400 if req.query.startDate or req.query.endDate is malformed
- * @returns 500 if any errors occurs in stream pipeline
+ * @returns 403 when user does not have read permissions for form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 if any errors occurs in stream pipeline or error retrieving form
  */
 export const handleStreamEncryptedResponses: RequestHandler<
   { formId: string },

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -6,6 +6,9 @@ import { Transform } from 'stream'
 import { aws as AwsConfig } from '../../../../config/config'
 import { createLoggerWithLabel } from '../../../../config/logger'
 import {
+  IPopulatedEncryptedForm,
+  IPopulatedForm,
+  ResponseMode,
   SubmissionCursorData,
   SubmissionData,
   SubmissionMetadata,
@@ -15,7 +18,11 @@ import { isMalformedDate } from '../../../utils/date'
 import { getMongoErrorMessage } from '../../../utils/handle-mongo-error'
 import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
 import { CreatePresignedUrlError } from '../../form/admin-form/admin-form.errors'
-import { SubmissionNotFoundError } from '../submission.errors'
+import { isFormEncryptMode } from '../../form/form.utils'
+import {
+  ResponseModeError,
+  SubmissionNotFoundError,
+} from '../submission.errors'
 
 const logger = createLoggerWithLabel(module)
 const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
@@ -259,4 +266,12 @@ export const getSubmissionMetadataList = (
       return new DatabaseError(getMongoErrorMessage(error))
     },
   )
+}
+
+export const checkFormIsEncryptMode = (
+  form: IPopulatedForm,
+): Result<IPopulatedEncryptedForm, ResponseModeError> => {
+  return isFormEncryptMode(form)
+    ? ok(form)
+    : err(new ResponseModeError(ResponseMode.Encrypt, form.responseMode))
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -9,11 +9,18 @@ import {
 } from '../../../services/captcha/captcha.errors'
 import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
 import { CreatePresignedUrlError } from '../../form/admin-form/admin-form.errors'
-import { FormDeletedError, PrivateFormError } from '../../form/form.errors'
+import {
+  ForbiddenFormError,
+  FormDeletedError,
+  FormNotFoundError,
+  PrivateFormError,
+} from '../../form/form.errors'
+import { MissingUserError } from '../../user/user.errors'
 import {
   ConflictError,
   InvalidEncodingError,
   ProcessingError,
+  ResponseModeError,
   SubmissionNotFoundError,
   ValidateFieldError,
 } from '../submission.errors'
@@ -27,6 +34,26 @@ const logger = createLoggerWithLabel(module)
  */
 export const mapRouteError: MapRouteError = (error) => {
   switch (error.constructor) {
+    case MissingUserError:
+      return {
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+        errorMessage: error.message,
+      }
+    case FormNotFoundError:
+      return {
+        statusCode: StatusCodes.NOT_FOUND,
+        errorMessage: error.message,
+      }
+    case ResponseModeError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    case ForbiddenFormError:
+      return {
+        statusCode: StatusCodes.FORBIDDEN,
+        errorMessage: error.message,
+      }
     case FormDeletedError:
       return {
         statusCode: StatusCodes.GONE,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -57,12 +57,12 @@ export const mapRouteError: MapRouteError = (error) => {
     case FormDeletedError:
       return {
         statusCode: StatusCodes.GONE,
-        errorMessage: '',
+        errorMessage: error.message,
       }
     case PrivateFormError:
       return {
         statusCode: StatusCodes.NOT_FOUND,
-        errorMessage: '',
+        errorMessage: error.message,
       }
     case CaptchaConnectionError:
       return {

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -613,6 +613,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions/download').get(
+    withUserAuthentication,
     celebrate({
       [Segments.QUERY]: Joi.object()
         .keys({
@@ -624,7 +625,6 @@ module.exports = function (app) {
         })
         .and('startDate', 'endDate'),
     }),
-    authEncryptedResponseAccess,
     EncryptSubmissionController.handleStreamEncryptedResponses,
   )
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR cleans up the janky `authEncryptedResponseAccess` middleware used in the `/adminform/submissions/download` endpoint and collapses the used middlewares in the `handleStreamEncryptedResponses` controller handler.

This PR is just one of the few PRs needed to remove total usage of the `authEncryptedResponseAccess` middleware.

Related to #1434

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- feat: collapse middlewares for submission download endpoint

## Tests
<!-- What tests should be run to confirm functionality? -->
- unit tests have been added (where possible) for the refactored controller handler function

### Manual tests
- [ ] Downloading of storage mode responses should work as is
- [ ] Downloading of storage mode responses with attachments should work as is
