### PR TITLE
refactor: check for .message in verification error

### DIFF
--- a/src/public/modules/forms/base/components/verifiable-field.client.component.js
+++ b/src/public/modules/forms/base/components/verifiable-field.client.component.js
@@ -244,6 +244,10 @@ function verifiableFieldController($q, $timeout, $interval) {
   }
 
   const getErrorMessage = (err) => {
+    // TODO (#941): keep only this code, remove switch case for custom strings
+    const serverErrorMsg = get(err, 'response.data.message')
+    if (serverErrorMsg) return serverErrorMsg
+
     // So that switch case works for both axios error objects and string objects.
     const error = get(err, 'response.data', err)
     let errMessage = ''


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Across nearly all APIs in this repo, the server returns a JSON with a `message` key when an error occurs. However, the Verification module is an exception, as it returns one of a set of custom strings (e.g. `'SEND_OTP_FAILED'`, '`INVALID_OTP`'), and the frontend contains a switch statement to determine what error message to display.

We want APIs to behave consistently, so it would be good for the Verification module to return error objects in the form `{ message: 'some error message' }`. However, this would be a backwards-incompatible change as the current frontend would render the entire JSON object instead of just the message string. 

## Solution
<!-- How did you solve the problem? -->

This PR ensures that the API change will be backwards-compatible by checking for a `message` property on the error. #1440 will address the actual API change.