### PR TITLE
refactor: migrate field validator tests to typescript

### DIFF
--- a/src/types/field/numberField.ts
+++ b/src/types/field/numberField.ts
@@ -8,9 +8,9 @@ export enum NumberSelectedValidation {
 }
 
 export type NumberValidationOptions = {
-  customMax: number
-  customMin: number
-  customVal: number
+  customMax: number | null
+  customMin: number | null
+  customVal: number | null
   selectedValidation: NumberSelectedValidation | null
 }
 

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -26,6 +26,7 @@ import {
   IImageFieldSchema,
   IMobileField,
   IMobileFieldSchema,
+  INumberField,
   IShortTextField,
   IShortTextFieldSchema,
   ISingleAnswerResponse,
@@ -42,6 +43,7 @@ export const generateDefaultField = (
     | IMobileField
     | ITableField
     | IDateField
+    | INumberField
   >,
 ): IFieldSchema => {
   const defaultParams = {

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -27,6 +27,7 @@ import {
   IMobileField,
   IMobileFieldSchema,
   INumberField,
+  IRatingField,
   IShortTextField,
   IShortTextFieldSchema,
   ISingleAnswerResponse,
@@ -44,6 +45,7 @@ export const generateDefaultField = (
     | ITableField
     | IDateField
     | INumberField
+    | IRatingField
   >,
 ): IFieldSchema => {
   const defaultParams = {

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -34,7 +34,12 @@ import {
 export const generateDefaultField = (
   fieldType: BasicField,
   customParams?: Partial<
-    IField | IAttachmentField | ICheckboxField | IMobileField | ITableField
+    | IField
+    | IAttachmentField
+    | ICheckboxField
+    | IMobileField
+    | ITableField
+    | IDateField
   >,
 ): IFieldSchema => {
   const defaultParams = {

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -24,6 +24,7 @@ import {
   IField,
   IFieldSchema,
   IImageFieldSchema,
+  ILongTextField,
   IMobileField,
   IMobileFieldSchema,
   INumberField,
@@ -46,6 +47,8 @@ export const generateDefaultField = (
     | IDateField
     | INumberField
     | IRatingField
+    | IShortTextField
+    | ILongTextField
   >,
 ): IFieldSchema => {
   const defaultParams = {

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -17,8 +17,10 @@ import {
   ICheckboxFieldSchema,
   ICheckboxResponse,
   IColumn,
+  IDateField,
   IDecimalFieldSchema,
   IDropdownField,
+  IDropdownFieldSchema,
   IField,
   IFieldSchema,
   IImageFieldSchema,
@@ -111,6 +113,13 @@ export const generateDefaultField = (
         getQuestion: () => defaultParams.title,
         ...customParams,
       } as IShortTextFieldSchema
+    case BasicField.Dropdown:
+      return {
+        ...defaultParams,
+        fieldOptions: ['Option 1', 'Option 2'],
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as IDropdownFieldSchema
     case BasicField.Decimal:
       return {
         ...defaultParams,

--- a/tests/unit/backend/utils/field-validation/date-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/date-validation.spec.ts
@@ -1,0 +1,314 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Date field validation', () => {
+  beforeAll(() => {
+    Date.now = jest.fn(() => new Date('2020-01-01').valueOf())
+  })
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+  it('should allow valid date <DD MMM YYYY>', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty string when not required', () => {
+    const formField = generateDefaultField(BasicField.Date, { required: false })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow valid leap year date', () => {
+    const formField = generateDefaultField(BasicField.Date, { required: false })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '29 Feb 2016',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow 00 date', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '00 Jan 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow date less than 2 char', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '9 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow date more than 2 char', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '009 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow date not in month', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '39 Jan 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow invalid month', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jon 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow month less then 3 chars', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jn 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow month more then 3 chars', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 June 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow text year', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jan hello',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow year less than 4 chars', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jan 201',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow year more than 4 chars', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jan 02019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow empty string when required', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow invalid leap year date', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '29 Feb 2019',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow past dates for normal date fields', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '09 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow past dates if disallow past dates is not set', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '01 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow past dates if disallow past dates is set', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: { selectedDateValidation: 'Disallow past dates' },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '9 Jan 2019',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow future dates if disallow future dates is not set', () => {
+    const formField = generateDefaultField(BasicField.Date)
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '01 Jan 2022',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow future dates if disallow future dates is set', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: { selectedDateValidation: 'Disallow future dates' },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '01 Jan 2022',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow dates inside of Custom Date Range if set', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: 'Custom date range',
+        customMinDate: '2020-06-25',
+        customMaxDate: '2020-06-28',
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '26 Jun 2020',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow dates outside of Custom Date Range if set', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: 'Custom date range',
+        customMinDate: '2020-06-25',
+        customMaxDate: '2020-06-28',
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '22 Jun 2020',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: 'Custom date range',
+        customMinDate: '2020-06-25',
+        customMaxDate: '2020-06-28',
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '26 Jun 2020',
+      isVisible: false,
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/decimal-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/decimal-validation.spec.ts
@@ -1,0 +1,277 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Decimal Validation', () => {
+  it('should allow decimal with valid maximum', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: 5,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '4',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow decimal with valid maximum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: 5,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '5',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow decimal with invalid maximum', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: 5,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '6',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow decimal with valid minimum', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: 2,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '5',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow decimal with valid minimum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: 2,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '2',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow decimal with invalid minimum', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: 2,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '1',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow decimal with no custom validation', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty answer with optional field', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow answer to be zero', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '0',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow negative answers', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '-5.0',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow leading zeroes', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '001.3',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow decimal points with no leading numbers', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '.3',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow negative answers with no leading number', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '-.3',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow floats (<16 decimal places) that are out of range (min)', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: 2,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '1.999999999999999',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow floats (<16 decimal places) that are out of range (max)', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: 2,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '2.000000000000001',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow floats less than 0 when customMin is 0', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: 0,
+        customMax: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '-0.2',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+  it('should disallow floats more than 0 when customMax is 0', () => {
+    const formField = generateDefaultField(BasicField.Decimal, {
+      ValidationOptions: {
+        customMin: null,
+        customMax: 0,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '0.1',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Decimal)
+    const response = generateNewSingleAnswerResponse(BasicField.Decimal, {
+      answer: '3',
+      isVisible: false,
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/dropdown-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/dropdown-validation.spec.ts
@@ -1,0 +1,119 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Dropdown validation', () => {
+  it('should allow valid option', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: 'KISS',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow invalid option', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: 'invalid',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow empty answer when required', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty answer when not required', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty answer when it is required but not visible', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: '',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow empty answer when it is required and visible', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow multiple answers', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: (['KISS', 'DRY'] as unknown) as string,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Response has invalid shape'),
+    )
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {
+      fieldOptions: ['KISS', 'DRY', 'YAGNI'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: 'KISS',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/home-num-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/home-num-validation.spec.ts
@@ -1,0 +1,120 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Home phone number validation tests', () => {
+  it('should allow empty answer for required logic field that is not visible', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '',
+      isVisible: false,
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty answer for optional field', () => {
+    const formField = generateDefaultField(BasicField.HomeNo, {
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should not allow empty answer for required field', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow valid home numbers for homeno fieldType', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+6563334444',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow home numbers without "+" prefix', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '6563334444',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow mobile numbers on homeno fieldType', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+6598765432',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow international numbers when field does not allow for it', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+441285291028',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow international numbers when field allows for it', () => {
+    const formField = generateDefaultField(BasicField.HomeNo, {
+      allowIntlNumbers: true,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+441285291028',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+6565656565',
+      isVisible: false,
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/nric-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/nric-validation.spec.ts
@@ -1,0 +1,141 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('NRIC field validation', () => {
+  it('should allow valid NRIC with S prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'S9912345A',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow valid NRIC with T prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'T1394524H',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow valid NRIC with F prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'F0477844T',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow valid NRIC with G prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'G9592927W',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow invalid NRIC with S prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'S9912345B',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow invalid NRIC with T prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'T1394524I',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow invalid NRIC with F prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'F0477844U',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow invalid NRIC with G prefix', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'G9592927X',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty string for optional NRIC', () => {
+    const formField = generateDefaultField(BasicField.Nric, {
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow empty string for required NRIC', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Nric)
+    const response = generateNewSingleAnswerResponse(BasicField.Nric, {
+      answer: 'S9912345A',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/number-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/number-validation.spec.ts
@@ -1,0 +1,292 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField, NumberSelectedValidation } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Number field validation', () => {
+  it('should allow number with valid maximum', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Max,
+        customMin: null,
+        customMax: 2,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '5',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with valid maximum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Max,
+        customMin: null,
+        customMax: 2,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow number with invalid maximum', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Max,
+        customMin: null,
+        customMax: 2,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '555',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow number with valid minimum', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Min,
+        customMin: 2,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '555',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with valid minimum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Min,
+        customMin: 2,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with valid exact', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Exact,
+        customMin: null,
+        customMax: null,
+        customVal: 2,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow number with invalid exact', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Exact,
+        customMin: null,
+        customMax: null,
+        customVal: 2,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '5',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow number with maximum left undefined', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Max,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with minimum left undefined', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Min,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with exact undefined', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: NumberSelectedValidation.Exact,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with no custom validation', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with optional answer', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow answer to be zero', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '0',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow negative answers', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '-55',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow leading zeroes in answer', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '05',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Number, {
+      ValidationOptions: {
+        selectedValidation: null,
+        customMin: null,
+        customMax: null,
+        customVal: null,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Number, {
+      answer: '2',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/radio-button-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/radio-button-validation.spec.ts
@@ -1,0 +1,160 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Radio button validation', () => {
+  it('should allow valid option', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'a',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow invalid option', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'invalid',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow empty option when it is required', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty option when not required', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty option when required and that logic field is not visible', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: '',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow empty option when required and that it is visible', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty option when not required and that it is visible', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'a',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it(`should allow answer that starts with 'Others: ' when others option is selected`, () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+      othersRadioButton: true,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'Others: hi i am others',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it(`should disallow answer that starts with 'Others: ' when others option is not selected`, () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'Others: hi i am others',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it(`should disallow empty answer when others option is selected`, () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+      othersRadioButton: true,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Radio, {
+      fieldOptions: ['a', 'b', 'c'],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Radio, {
+      answer: 'a',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/rating-validation.spec.ts
+++ b/tests/unit/backend/utils/field-validation/rating-validation.spec.ts
@@ -1,0 +1,174 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField } from 'src/types'
+import { RatingShape } from 'src/types/field/ratingField'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Rating field validation', () => {
+  it('should allow answer within range', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '4',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with valid maximum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '5',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow number with invalid maximum', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '6',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow number with valid minimum (inclusive)', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '1',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow number with optional answer', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      required: false,
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '4',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow negative answers', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '-1',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow leading zeroes in answer', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '04',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty answer if optional', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      required: false,
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow empty answer if required', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Rating, {
+      ratingOptions: {
+        steps: 5,
+        shape: RatingShape.Heart,
+      },
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Rating, {
+      answer: '5',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/tests/unit/backend/utils/field-validation/text-validator.spec.ts
+++ b/tests/unit/backend/utils/field-validation/text-validator.spec.ts
@@ -1,0 +1,406 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+import { BasicField, TextSelectedValidation } from 'src/types'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from '../../helpers/generate-form-data'
+
+describe('Text validation', () => {
+  describe('Short text', () => {
+    it('should disallow empty submissions if field is required', () => {
+      const formField = generateDefaultField(BasicField.ShortText)
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: '',
+      })
+
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should allow empty submissions if field is optional', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        required: false,
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: '',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should allow any number of characters in submission if selectedValidation is not set', () => {
+      const formField = generateDefaultField(BasicField.ShortText)
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'hello world',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should disallow whitespace answer if field is required', () => {
+      const formField = generateDefaultField(BasicField.ShortText)
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: ' ',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMin if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'fewer',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMin if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'more than 10 chars',
+      })
+
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMax if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'fewer',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMax if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'more than 10 chars',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMin if selectedValidation is Minimum', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Minimum,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'fewer',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMax if selectedValidation is Maximum', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Maximum,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'more than 10 chars',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+    it('should disallow responses submitted for hidden fields', () => {
+      const formField = generateDefaultField(BasicField.ShortText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        answer: 'fewer',
+        isVisible: false,
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError(
+          'Attempted to submit response on a hidden field',
+        ),
+      )
+    })
+  })
+
+  describe('Long text', () => {
+    it('should disallow empty submissions if field is required', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: '',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should allow empty submissions if field is optional', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+        required: false,
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: '',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should allow a valid submission if selectedValidation is not set', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'valid',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should disallow whitespace answer if field is required', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: ' ',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMin if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'less',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMin if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'more than 10 chars',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMax if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'less',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMax if selectedValidation is Exact', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Exact,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'more than 10 chars',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow fewer characters than customMin if selectedValidation is Minimum', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Minimum,
+          customMin: 10,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'fewer',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should disallow more characters than customMax if selectedValidation is Maximum', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: TextSelectedValidation.Maximum,
+          customMin: null,
+          customMax: 10,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'more than 10 chars',
+      })
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+    it('should disallow responses submitted for hidden fields', () => {
+      const formField = generateDefaultField(BasicField.LongText, {
+        ValidationOptions: {
+          selectedValidation: null,
+          customMin: null,
+          customMax: null,
+          customVal: null,
+        },
+      })
+      const response = generateNewSingleAnswerResponse(BasicField.LongText, {
+        answer: 'some answer',
+        isVisible: false,
+      })
+      response.isVisible = false
+      const validateResult = validateField('formId', formField, response)
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError(
+          'Attempted to submit response on a hidden field',
+        ),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Part of #7

## Solution
- Migrates all the field validator tests from jasmine to jest / typescript
- Jasmine tests to be deleted after 12 Apr 2021