### PR TITLE
refactor: use neverthrow in /transaction/:transactionId (part 2)

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -1,0 +1,121 @@
+import { ObjectId } from 'bson'
+import { Response } from 'express'
+import { StatusCodes } from 'http-status-codes'
+import mongoose from 'mongoose'
+import { errAsync, okAsync } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
+
+import { IVerificationSchema } from 'src/types'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import expressHandler from '../../../../../tests/unit/backend/helpers/jest-express'
+import { DatabaseError } from '../../core/core.errors'
+import * as VerificationController from '../verification.controller'
+import { TransactionNotFoundError } from '../verification.errors'
+import { VerificationFactory } from '../verification.factory'
+import getVerificationModel from '../verification.model'
+
+const VerificationModel = getVerificationModel(mongoose)
+
+jest.mock('../verification.factory')
+const MockVerificationFactory = mocked(VerificationFactory, true)
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {}
+const MOCK_FORM_ID = new ObjectId().toHexString()
+const MOCK_TRANSACTION_ID = new ObjectId().toHexString()
+
+describe('Verification controller', () => {
+  let mockTransaction: IVerificationSchema
+  let mockRes: Response
+
+  beforeAll(async () => {
+    await dbHandler.connect()
+    mockTransaction = await VerificationModel.create({
+      _id: MOCK_TRANSACTION_ID,
+      formId: MOCK_FORM_ID,
+      expireAt: new Date(),
+      fields: [],
+    })
+  })
+
+  beforeEach(() => {
+    mockRes = expressHandler.mockResponse()
+  })
+
+  afterEach(() => jest.resetAllMocks())
+
+  afterAll(async () => {
+    // mockTransaction is reused throughout the tests
+    await dbHandler.clearDatabase()
+    await dbHandler.closeDatabase()
+  })
+
+  describe('handleGetTransactionMetadata', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: { transactionId: MOCK_TRANSACTION_ID },
+    })
+
+    it('should return metadata when parameters are valid', async () => {
+      const transactionPublicView = mockTransaction.getPublicView()
+      MockVerificationFactory.getTransactionMetadata.mockReturnValueOnce(
+        okAsync(transactionPublicView),
+      )
+
+      await VerificationController.handleGetTransactionMetadata(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(
+        MockVerificationFactory.getTransactionMetadata,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(mockRes.json).toHaveBeenCalledWith(transactionPublicView)
+    })
+
+    it('should return 404 when transaction is not found', async () => {
+      MockVerificationFactory.getTransactionMetadata.mockReturnValueOnce(
+        errAsync(new TransactionNotFoundError()),
+      )
+
+      await VerificationController.handleGetTransactionMetadata(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(
+        MockVerificationFactory.getTransactionMetadata,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      MockVerificationFactory.getTransactionMetadata.mockReturnValueOnce(
+        errAsync(new DatabaseError()),
+      )
+
+      await VerificationController.handleGetTransactionMetadata(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(
+        MockVerificationFactory.getTransactionMetadata,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+  })
+})

--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -21,12 +21,9 @@ const VerificationModel = getVerificationModel(mongoose)
 jest.mock('../verification.factory')
 const MockVerificationFactory = mocked(VerificationFactory, true)
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {}
-const MOCK_FORM_ID = new ObjectId().toHexString()
-const MOCK_TRANSACTION_ID = new ObjectId().toHexString()
-
 describe('Verification controller', () => {
+  const MOCK_FORM_ID = new ObjectId().toHexString()
+  const MOCK_TRANSACTION_ID = new ObjectId().toHexString()
   let mockTransaction: IVerificationSchema
   let mockRes: Response
 
@@ -66,7 +63,7 @@ describe('Verification controller', () => {
       await VerificationController.handleGetTransactionMetadata(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(
@@ -84,7 +81,7 @@ describe('Verification controller', () => {
       await VerificationController.handleGetTransactionMetadata(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(
@@ -104,7 +101,7 @@ describe('Verification controller', () => {
       await VerificationController.handleGetTransactionMetadata(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -7,7 +7,6 @@ import expressHandler from 'tests/unit/backend/helpers/jest-express'
 import {
   createTransaction,
   getNewOtp,
-  getTransactionMetadata,
   resetFieldInTransaction,
   verifyOtp,
 } from '../verification.controller'
@@ -62,44 +61,6 @@ describe('Verification controller', () => {
       )
       expect(MOCK_RES.status).toHaveBeenCalledWith(200)
       expect(MOCK_RES.json).toHaveBeenCalledWith({})
-    })
-  })
-
-  describe('getTransactionMetadata', () => {
-    const MOCK_REQ = expressHandler.mockRequest({
-      body: {},
-      params: { transactionId: MOCK_TRANSACTION_ID },
-    })
-    afterEach(() => jest.clearAllMocks())
-
-    it('should correctly return metadata when parameters are valid', async () => {
-      // Coerce type
-      const transaction = ('it' as unknown) as ReturnType<
-        typeof MockVfnService.getTransactionMetadata
-      >
-      MockVfnService.getTransactionMetadata.mockReturnValueOnce(
-        Promise.resolve(transaction),
-      )
-      await getTransactionMetadata(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(200)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(transaction)
-    })
-
-    it('should return 404 when service throws error', async () => {
-      MockVfnService.getTransactionMetadata.mockImplementationOnce(() => {
-        const error = new Error(notFoundError)
-        error.name = notFoundError
-        throw error
-      })
-      await getTransactionMetadata(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransactionMetadata).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
     })
   })
 

--- a/src/app/modules/verification/__tests__/verification.model.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.model.spec.ts
@@ -114,15 +114,14 @@ describe('Verification Model', () => {
   })
 
   describe('Statics', () => {
-    describe('findTransactionMetadata', () => {
+    describe('getPublicViewById', () => {
       it('should only return non-sensitive fields', async () => {
         const verification = new Verification(VFN_PARAMS)
         const verificationSaved = await verification.save()
         expect(verificationSaved._id).toBeDefined()
-        const found = await Verification.findTransactionMetadata(
+        const actual = await Verification.getPublicViewById(
           verificationSaved._id,
         )
-        const actual = found.toObject()
         const expected = pick(verificationSaved, ['formId', 'expireAt', '_id'])
         expect(actual).toEqual(expected)
       })

--- a/src/app/modules/verification/__tests__/verification.service.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.new.spec.ts
@@ -1,0 +1,76 @@
+import { ObjectId } from 'bson'
+import mongoose from 'mongoose'
+
+import { IVerificationSchema, PublicTransaction } from 'src/types'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import { TransactionNotFoundError } from '../verification.errors'
+import getVerificationModel from '../verification.model'
+import * as VerificationService from '../verification.service'
+
+import { generateFieldParams } from './verification.test.helpers'
+
+const VerificationModel = getVerificationModel(mongoose)
+
+describe('Verification service', () => {
+  const mockFieldId = new ObjectId().toHexString()
+  const mockField = { ...generateFieldParams(), _id: mockFieldId }
+  const mockTransactionId = new ObjectId().toHexString()
+  const mockFormId = new ObjectId().toHexString()
+  let mockTransaction: IVerificationSchema
+
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(async () => {
+    mockTransaction = await VerificationModel.create({
+      _id: mockTransactionId,
+      formId: mockFormId,
+      fields: [mockField],
+      // Expire 1 hour in future
+      expireAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.resetAllMocks()
+  })
+
+  describe('getTransactionMetadata', () => {
+    let getPublicViewByIdSpy: jest.SpyInstance<
+      Promise<PublicTransaction | null>,
+      [id: string]
+    >
+    let mockPublicView: PublicTransaction
+
+    beforeEach(() => {
+      mockPublicView = {
+        expireAt: mockTransaction.expireAt,
+        formId: mockTransaction.formId,
+        _id: new ObjectId(),
+      }
+      getPublicViewByIdSpy = jest
+        .spyOn(VerificationModel, 'getPublicViewById')
+        .mockResolvedValueOnce(mockPublicView)
+    })
+
+    it('should call VerificationModel.getPublicViewById and return the result', async () => {
+      const result = await VerificationService.getTransactionMetadata(
+        mockTransactionId,
+      )
+
+      expect(getPublicViewByIdSpy).toHaveBeenCalledWith(mockTransactionId)
+      expect(result._unsafeUnwrap()).toEqual(mockPublicView)
+    })
+
+    it('should call VerificationModel.getPublicViewById and return TransactionNotFoundError when result is null', async () => {
+      getPublicViewByIdSpy.mockReset().mockResolvedValueOnce(null)
+
+      const result = await VerificationService.getTransactionMetadata(
+        mockTransactionId,
+      )
+
+      expect(getPublicViewByIdSpy).toHaveBeenCalledWith(mockTransactionId)
+      expect(result._unsafeUnwrapErr()).toEqual(new TransactionNotFoundError())
+    })
+  })
+})

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -18,7 +18,6 @@ import getVerificationModel from '../verification.model'
 import {
   createTransaction,
   getNewOtp,
-  getTransactionMetadata,
   resetFieldInTransaction,
   verifyOtp,
 } from '../verification.service'
@@ -95,29 +94,6 @@ describe('Verification service', () => {
       expect(returnedTransaction).toEqual({
         transactionId: foundTransaction!._id,
         expireAt: foundTransaction!.expireAt,
-      })
-    })
-  })
-
-  describe('getTransactionMetadata', () => {
-    afterEach(async () => await dbHandler.clearDatabase())
-
-    it('should throw error when transaction does not exist', async () => {
-      return expect(
-        getTransactionMetadata(String(new ObjectId())),
-      ).rejects.toThrowError('TRANSACTION_NOT_FOUND')
-    })
-
-    it('should correctly return metadata when request is valid', async () => {
-      const formId = new ObjectId()
-      const expireAt = new Date()
-      const testVerification = new Verification({ formId, expireAt })
-      await testVerification.save()
-      const actual = await getTransactionMetadata(testVerification._id)
-      expect(actual).toEqual({
-        _id: testVerification._id,
-        formId,
-        expireAt,
       })
     })
   })

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -114,7 +114,7 @@ describe('Verification service', () => {
       const testVerification = new Verification({ formId, expireAt })
       await testVerification.save()
       const actual = await getTransactionMetadata(testVerification._id)
-      expect(actual.toObject()).toEqual({
+      expect(actual).toEqual({
         _id: testVerification._id,
         formId,
         expireAt,

--- a/src/app/modules/verification/verification.errors.ts
+++ b/src/app/modules/verification/verification.errors.ts
@@ -1,0 +1,84 @@
+import { ApplicationError } from '../core/core.errors'
+
+/**
+ * Transaction with given ID not found.
+ */
+export class TransactionNotFoundError extends ApplicationError {
+  constructor(message = 'Transaction with given ID not found') {
+    super(message)
+  }
+}
+
+/**
+ * Field with given ID not found in the transaction.
+ */
+export class FieldNotFoundInTransactionError extends ApplicationError {
+  constructor(message = 'Field with given ID not found in the transaction') {
+    super(message)
+  }
+}
+
+/**
+ * Transaction is expired
+ */
+export class TransactionExpiredError extends ApplicationError {
+  constructor(message = 'Transaction is expired') {
+    super(message)
+  }
+}
+
+/**
+ * OTP is expired
+ */
+export class OtpExpiredError extends ApplicationError {
+  constructor(message = 'OTP is expired') {
+    super(message)
+  }
+}
+
+/**
+ * OTP cannot be verified because hash data is missing.
+ */
+export class MissingHashDataError extends ApplicationError {
+  constructor(message = 'Field is missing information on hashed OTP') {
+    super(message)
+  }
+}
+
+/**
+ * OTP maximum retries exceeded.
+ */
+export class OtpRetryExceededError extends ApplicationError {
+  constructor(message = 'Too many invalid attempts to enter OTP') {
+    super(message)
+  }
+}
+
+/**
+ * Wrong OTP entered.
+ */
+export class WrongOtpError extends ApplicationError {
+  constructor(message = 'Wrong OTP entered') {
+    super(message)
+  }
+}
+
+/**
+ * OTP requested too soon after previous request.
+ */
+export class WaitForOtpError extends ApplicationError {
+  constructor(message = 'OTP requested too soon after previous OTP') {
+    super(message)
+  }
+}
+
+/**
+ * Unsupported field type for OTP verification
+ */
+export class NonVerifiedFieldTypeError extends ApplicationError {
+  constructor(unsupportedFieldType: string) {
+    super(
+      `Unsupported field type for OTP verification: ${unsupportedFieldType}`,
+    )
+  }
+}

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -1,5 +1,3 @@
-import { RequestHandler } from 'express'
-import { StatusCodes } from 'http-status-codes'
 import { errAsync } from 'neverthrow'
 
 import featureManager, {
@@ -8,42 +6,8 @@ import featureManager, {
 } from '../../../config/feature-manager'
 import { MissingFeatureError } from '../core/core.errors'
 
-import * as verification from './verification.controller'
 import * as VerificationService from './verification.service'
 
-interface IVerifiedFieldsMiddleware {
-  createTransaction: RequestHandler
-  resetFieldInTransaction: RequestHandler<{ transactionId: string }>
-  getNewOtp: RequestHandler<{ transactionId: string }>
-  verifyOtp: RequestHandler<{ transactionId: string }>
-}
-
-const verificationMiddlewareFactory = ({
-  isEnabled,
-}: {
-  isEnabled: boolean
-}): IVerifiedFieldsMiddleware => {
-  if (isEnabled) {
-    return {
-      createTransaction: verification.createTransaction,
-      resetFieldInTransaction: verification.resetFieldInTransaction,
-      getNewOtp: verification.getNewOtp,
-      verifyOtp: verification.verifyOtp,
-    }
-  } else {
-    const errMsg = 'Verified fields feature is not enabled'
-    return {
-      createTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
-      resetFieldInTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
-      getNewOtp: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
-      verifyOtp: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
-    }
-  }
-}
 interface IVerifiedFieldsFactory {
   getTransactionMetadata: typeof VerificationService.getTransactionMetadata
 }
@@ -60,10 +24,6 @@ export const createVerificationFactory = ({
     getTransactionMetadata: () => errAsync(error),
   }
 }
-
-export const verificationMiddleware = verificationMiddlewareFactory(
-  featureManager.get(FeatureNames.VerifiedFields),
-)
 
 export const VerificationFactory = createVerificationFactory(
   featureManager.get(FeatureNames.VerifiedFields),

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -1,13 +1,18 @@
 import { RequestHandler } from 'express'
 import { StatusCodes } from 'http-status-codes'
+import { errAsync } from 'neverthrow'
 
-import featureManager, { FeatureNames } from '../../../config/feature-manager'
+import featureManager, {
+  FeatureNames,
+  RegisteredFeature,
+} from '../../../config/feature-manager'
+import { MissingFeatureError } from '../core/core.errors'
 
 import * as verification from './verification.controller'
+import * as VerificationService from './verification.service'
 
-interface IVerifiedFieldsFactory {
+interface IVerifiedFieldsMiddleware {
   createTransaction: RequestHandler
-  getTransactionMetadata: RequestHandler<{ transactionId: string }>
   resetFieldInTransaction: RequestHandler<{ transactionId: string }>
   getNewOtp: RequestHandler<{ transactionId: string }>
   verifyOtp: RequestHandler<{ transactionId: string }>
@@ -17,11 +22,10 @@ const verificationMiddlewareFactory = ({
   isEnabled,
 }: {
   isEnabled: boolean
-}): IVerifiedFieldsFactory => {
+}): IVerifiedFieldsMiddleware => {
   if (isEnabled) {
     return {
       createTransaction: verification.createTransaction,
-      getTransactionMetadata: verification.getTransactionMetadata,
       resetFieldInTransaction: verification.resetFieldInTransaction,
       getNewOtp: verification.getNewOtp,
       verifyOtp: verification.verifyOtp,
@@ -30,8 +34,6 @@ const verificationMiddlewareFactory = ({
     const errMsg = 'Verified fields feature is not enabled'
     return {
       createTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
-      getTransactionMetadata: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       resetFieldInTransaction: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
@@ -42,7 +44,27 @@ const verificationMiddlewareFactory = ({
     }
   }
 }
+interface IVerifiedFieldsFactory {
+  getTransactionMetadata: typeof VerificationService.getTransactionMetadata
+}
+
+export const createVerificationFactory = ({
+  isEnabled,
+  props,
+}: RegisteredFeature<FeatureNames.VerifiedFields>): IVerifiedFieldsFactory => {
+  if (isEnabled && props) {
+    return VerificationService
+  }
+  const error = new MissingFeatureError(FeatureNames.VerifiedFields)
+  return {
+    getTransactionMetadata: () => errAsync(error),
+  }
+}
 
 export const verificationMiddleware = verificationMiddlewareFactory(
+  featureManager.get(FeatureNames.VerifiedFields),
+)
+
+export const VerificationFactory = createVerificationFactory(
   featureManager.get(FeatureNames.VerifiedFields),
 )

--- a/src/app/modules/verification/verification.middleware.ts
+++ b/src/app/modules/verification/verification.middleware.ts
@@ -1,0 +1,43 @@
+import { RequestHandler } from 'express'
+import { StatusCodes } from 'http-status-codes'
+
+import featureManager, { FeatureNames } from '../../../config/feature-manager'
+
+import * as verification from './verification.controller'
+
+interface IVerifiedFieldsMiddleware {
+  createTransaction: RequestHandler
+  resetFieldInTransaction: RequestHandler<{ transactionId: string }>
+  getNewOtp: RequestHandler<{ transactionId: string }>
+  verifyOtp: RequestHandler<{ transactionId: string }>
+}
+
+const verificationMiddlewareFactory = ({
+  isEnabled,
+}: {
+  isEnabled: boolean
+}): IVerifiedFieldsMiddleware => {
+  if (isEnabled) {
+    return {
+      createTransaction: verification.createTransaction,
+      resetFieldInTransaction: verification.resetFieldInTransaction,
+      getNewOtp: verification.getNewOtp,
+      verifyOtp: verification.verifyOtp,
+    }
+  } else {
+    const errMsg = 'Verified fields feature is not enabled'
+    return {
+      createTransaction: (req, res) =>
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
+      resetFieldInTransaction: (req, res) =>
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
+      getNewOtp: (req, res) =>
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
+      verifyOtp: (req, res) =>
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
+    }
+  }
+}
+export const verificationMiddleware = verificationMiddlewareFactory(
+  featureManager.get(FeatureNames.VerifiedFields),
+)

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -70,6 +70,13 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
     return pick(this, VERIFICATION_PUBLIC_FIELDS) as PublicTransaction
   }
 
+  VerificationSchema.methods.getField = function (
+    this: IVerificationSchema,
+    fieldId: string,
+  ): IVerificationFieldSchema | undefined {
+    return this.fields.find((field) => field._id === fieldId)
+  }
+
   // Static methods
   // Method to return non-sensitive fields
   VerificationSchema.statics.getPublicViewById = async function (

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -1,3 +1,4 @@
+import { pick } from 'lodash'
 import { Mongoose, Schema } from 'mongoose'
 
 import * as vfnConstants from '../../../shared/util/verification'
@@ -5,11 +6,14 @@ import {
   IVerificationFieldSchema,
   IVerificationModel,
   IVerificationSchema,
+  PublicTransaction,
 } from '../../../types'
 import { FORM_SCHEMA_ID } from '../../models/form.server.model'
 
 const { getExpiryDate } = vfnConstants
 const VERIFICATION_SCHEMA_ID = 'Verification'
+
+export const VERIFICATION_PUBLIC_FIELDS = ['formId', 'expireAt', '_id']
 
 const VerificationFieldSchema = new Schema<IVerificationFieldSchema>({
   _id: {
@@ -59,13 +63,22 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
     return next()
   })
 
+  // Instance methods
+  VerificationSchema.methods.getPublicView = function (
+    this: IVerificationSchema,
+  ): PublicTransaction {
+    return pick(this, VERIFICATION_PUBLIC_FIELDS) as PublicTransaction
+  }
+
   // Static methods
   // Method to return non-sensitive fields
-  VerificationSchema.statics.findTransactionMetadata = function (
+  VerificationSchema.statics.getPublicViewById = async function (
     this: IVerificationModel,
     id: IVerificationSchema['_id'],
-  ) {
-    return this.findById(id, 'formId expireAt')
+  ): Promise<PublicTransaction | null> {
+    const document = await this.findById(id)
+    if (!document) return null
+    return document.getPublicView()
   }
 
   const VerificationModel = db.model<IVerificationSchema, IVerificationModel>(

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -1,6 +1,7 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { Router } from 'express'
 
+import * as VerificationController from './verification.controller'
 import { verificationMiddleware } from './verification.factory'
 
 export const VfnRouter = Router()
@@ -24,7 +25,7 @@ VfnRouter.get(
       transactionId: formatOfId,
     }),
   }),
-  verificationMiddleware.getTransactionMetadata,
+  VerificationController.handleGetTransactionMetadata,
 )
 
 VfnRouter.post(

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -2,7 +2,7 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { Router } from 'express'
 
 import * as VerificationController from './verification.controller'
-import { verificationMiddleware } from './verification.factory'
+import { verificationMiddleware } from './verification.middleware'
 
 export const VfnRouter = Router()
 

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -13,6 +13,7 @@ import {
   IMobileFieldSchema,
   IVerificationFieldSchema,
   IVerificationSchema,
+  PublicTransaction,
 } from '../../../types'
 import getFormModel from '../../models/form.server.model'
 import { MailSendError } from '../../services/mail/mail.errors'
@@ -66,19 +67,16 @@ export const createTransaction = async (
   return null
 }
 
-type TransactionMetadata = ReturnType<
-  typeof Verification.findTransactionMetadata
->
 /**
  *  Retrieves a transaction's metadata by id
  * @param transactionId
  */
 export const getTransactionMetadata = async (
   transactionId: string,
-): Promise<TransactionMetadata> => {
-  const transaction = await Verification.findTransactionMetadata(transactionId)
+): Promise<PublicTransaction> => {
+  const transaction = await Verification.getPublicViewById(transactionId)
   if (transaction === null) {
-    throwError(VfnErrors.TransactionNotFound)
+    return throwError(VfnErrors.TransactionNotFound)
   }
   return transaction
 }

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -75,10 +75,6 @@ export const mapRouteError: MapRouteError = (
       }
     case FieldNotFoundInTransactionError:
     case TransactionNotFoundError:
-      return {
-        errorMessage: coreErrorMsg,
-        statusCode: StatusCodes.NOT_FOUND,
-      }
     case FormNotFoundError:
       return {
         errorMessage: coreErrorMsg,

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -1,0 +1,107 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import { WAIT_FOR_OTP_SECONDS } from '../../../shared/util/verification'
+import { MapRouteError } from '../../../types'
+import { MailSendError } from '../../services/mail/mail.errors'
+import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
+import { HashingError } from '../../utils/hash'
+import {
+  DatabaseError,
+  MalformedParametersError,
+  MissingFeatureError,
+} from '../core/core.errors'
+import { FormNotFoundError } from '../form/form.errors'
+
+import {
+  FieldNotFoundInTransactionError,
+  MissingHashDataError,
+  NonVerifiedFieldTypeError,
+  OtpExpiredError,
+  OtpRetryExceededError,
+  TransactionExpiredError,
+  TransactionNotFoundError,
+  WaitForOtpError,
+  WrongOtpError,
+} from './verification.errors'
+
+const logger = createLoggerWithLabel(module)
+
+export const mapRouteError: MapRouteError = (
+  error,
+  coreErrorMsg = 'Sorry, something went wrong. Please refresh and try again.',
+) => {
+  switch (error.constructor) {
+    case TransactionExpiredError:
+      return {
+        errorMessage: 'Your session has expired, please refresh and try again.',
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case OtpExpiredError:
+      return {
+        errorMessage: 'Your OTP has expired, please request for a new one.',
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case OtpRetryExceededError:
+      return {
+        errorMessage:
+          'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case WrongOtpError:
+      return {
+        errorMessage: 'Wrong OTP.',
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+      }
+    case WaitForOtpError:
+      return {
+        errorMessage: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case InvalidNumberError:
+      return {
+        errorMessage:
+          'This phone number does not seem to be valid. Please try again with a valid phone number.',
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case MalformedParametersError:
+    case SmsSendError:
+    case MailSendError:
+    case NonVerifiedFieldTypeError:
+    case MissingHashDataError:
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case FieldNotFoundInTransactionError:
+    case TransactionNotFoundError:
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.NOT_FOUND,
+      }
+    case FormNotFoundError:
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.NOT_FOUND,
+      }
+    case HashingError:
+    case DatabaseError:
+    case MissingFeatureError:
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      }
+    default:
+      logger.warn({
+        message: 'Unknown error type encountered',
+        meta: {
+          action: 'mapRouteError',
+        },
+        error,
+      })
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      }
+  }
+}

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -1,5 +1,6 @@
-import { Document, Model, Query } from 'mongoose'
+import { Document, Model } from 'mongoose'
 
+import { PublicView } from './database'
 import { IFormSchema } from './form'
 
 export interface IVerificationField {
@@ -20,14 +21,23 @@ export interface IVerificationFieldSchema
 
 export interface IVerification {
   formId: IFormSchema['_id']
-  expireAt?: Date
+  expireAt: Date
   fields: IVerificationFieldSchema[]
 }
 
-export interface IVerificationSchema extends IVerification, Document {}
+export interface IVerificationSchema
+  extends IVerification,
+    Document,
+    PublicView<PublicTransaction> {}
+
+// Keep in sync with VERIFICATION_PUBLIC_FIELDS
+export type PublicTransaction = Pick<
+  IVerificationSchema,
+  'formId' | 'expireAt' | '_id'
+>
 
 export interface IVerificationModel extends Model<IVerificationSchema> {
-  findTransactionMetadata(
+  getPublicViewById(
     id: IVerificationSchema['_id'],
-  ): Query<Omit<IVerificationSchema, 'fields'>, IVerificationSchema>
+  ): Promise<PublicTransaction | null>
 }

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -29,7 +29,14 @@ export interface IVerificationSchema
   extends IVerification,
     Document,
     PublicView<PublicTransaction> {
+  /**
+   * Retrieves an individual field in a transaction, or undefined if not found
+   * @param fieldId
+   */
   getField(fieldId: string): IVerificationFieldSchema | undefined
+  /**
+   * Extracts non-sensitive fields from a transaction
+   */
   getPublicView(): PublicTransaction
 }
 
@@ -40,6 +47,10 @@ export type PublicTransaction = Pick<
 >
 
 export interface IVerificationModel extends Model<IVerificationSchema> {
+  /**
+   * Retrieves non-sensitive fields of a transaction, given its ID
+   * @param id Transaction ID
+   */
   getPublicViewById(
     id: IVerificationSchema['_id'],
   ): Promise<PublicTransaction | null>

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -28,7 +28,10 @@ export interface IVerification {
 export interface IVerificationSchema
   extends IVerification,
     Document,
-    PublicView<PublicTransaction> {}
+    PublicView<PublicTransaction> {
+  getField(fieldId: string): IVerificationFieldSchema | undefined
+  getPublicView(): PublicTransaction
+}
 
 // Keep in sync with VERIFICATION_PUBLIC_FIELDS
 export type PublicTransaction = Pick<


### PR DESCRIPTION
Builds on #1450

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

See #1450

## Solution
<!-- How did you solve the problem? -->

This is the 2nd part of the solution, which focuses on the `GET /transaction/:transactionId` endpoint. It has the following additional changes:
- Renames the old `verification.factory` to `verification.middleware`, and adds an actual `verification.factory` to export service methods

## Tests
See #1450