### PR TITLE
refactor: use neverthrow in /transaction (part 3)

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -11,6 +11,7 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import expressHandler from '../../../../../tests/unit/backend/helpers/jest-express'
 import { DatabaseError } from '../../core/core.errors'
+import { FormNotFoundError } from '../../form/form.errors'
 import * as VerificationController from '../verification.controller'
 import { TransactionNotFoundError } from '../verification.errors'
 import { VerificationFactory } from '../verification.factory'
@@ -47,6 +48,95 @@ describe('Verification controller', () => {
     // mockTransaction is reused throughout the tests
     await dbHandler.clearDatabase()
     await dbHandler.closeDatabase()
+  })
+
+  describe('handleCreateTransaction', () => {
+    const MOCK_REQ = expressHandler.mockRequest<
+      never,
+      { formId: string },
+      never
+    >({
+      body: { formId: MOCK_FORM_ID },
+    })
+
+    it('should return transaction when parameters are valid', async () => {
+      MockVerificationFactory.createTransaction.mockReturnValueOnce(
+        okAsync(mockTransaction),
+      )
+
+      await VerificationController.handleCreateTransaction(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        transactionId: mockTransaction._id,
+        expireAt: mockTransaction.expireAt,
+      })
+    })
+
+    it('should return 200 with empty object when transaction is not created', async () => {
+      MockVerificationFactory.createTransaction.mockReturnValueOnce(
+        okAsync(null),
+      )
+      await VerificationController.handleCreateTransaction(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+      expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(mockRes.json).toHaveBeenCalledWith({})
+    })
+
+    it('should return 404 when form is not found', async () => {
+      MockVerificationFactory.createTransaction.mockReturnValueOnce(
+        errAsync(new FormNotFoundError()),
+      )
+
+      await VerificationController.handleCreateTransaction(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      MockVerificationFactory.createTransaction.mockReturnValueOnce(
+        errAsync(new DatabaseError()),
+      )
+
+      await VerificationController.handleCreateTransaction(
+        MOCK_REQ,
+        mockRes,
+        noop,
+      )
+
+      expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
   })
 
   describe('handleGetTransactionMetadata', () => {

--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -67,7 +67,7 @@ describe('Verification controller', () => {
       await VerificationController.handleCreateTransaction(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
@@ -87,7 +87,7 @@ describe('Verification controller', () => {
       await VerificationController.handleCreateTransaction(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
       expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
         MOCK_FORM_ID,
@@ -104,7 +104,7 @@ describe('Verification controller', () => {
       await VerificationController.handleCreateTransaction(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(
@@ -124,7 +124,7 @@ describe('Verification controller', () => {
       await VerificationController.handleCreateTransaction(
         MOCK_REQ,
         mockRes,
-        noop,
+        jest.fn(),
       )
 
       expect(MockVerificationFactory.createTransaction).toHaveBeenCalledWith(

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -5,7 +5,6 @@ import { mocked } from 'ts-jest/utils'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import {
-  createTransaction,
   getNewOtp,
   resetFieldInTransaction,
   verifyOtp,
@@ -17,7 +16,6 @@ jest.mock('../verification.service')
 const MockVfnService = mocked(VfnService, true)
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
-const MOCK_FORM_ID = 'formId'
 const MOCK_TRANSACTION_ID = 'transactionId'
 const MOCK_FIELD_ID = 'fieldId'
 const MOCK_ANSWER = 'answer'
@@ -31,39 +29,6 @@ const sendOtpError = 'SEND_OTP_FAILED'
 const invalidOtpError = 'INVALID_OTP'
 
 describe('Verification controller', () => {
-  describe('createTransaction', () => {
-    const MOCK_REQ = expressHandler.mockRequest({
-      body: { formId: MOCK_FORM_ID },
-    })
-    afterEach(() => jest.clearAllMocks())
-
-    it('should correctly return transaction when parameters are valid', async () => {
-      const returnValue = {
-        transactionId: 'Bereft of life, it rests in peace',
-        expireAt: new Date(),
-      }
-      MockVfnService.createTransaction.mockReturnValueOnce(
-        Promise.resolve(returnValue),
-      )
-      await createTransaction(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
-        MOCK_FORM_ID,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(201)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(returnValue)
-    })
-
-    it('should correctly return 200 with empty object when transaction is not created', async () => {
-      MockVfnService.createTransaction.mockResolvedValueOnce(null)
-      await createTransaction(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.createTransaction).toHaveBeenCalledWith(
-        MOCK_FORM_ID,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(200)
-      expect(MOCK_RES.json).toHaveBeenCalledWith({})
-    })
-  })
-
   describe('resetFieldInTransaction', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       body: { fieldId: MOCK_FIELD_ID },

--- a/src/app/modules/verification/__tests__/verification.service.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.new.spec.ts
@@ -1,9 +1,9 @@
 import { ObjectId } from 'bson'
-import { DatabaseError } from 'dist/backend/app/modules/core/core.errors'
 import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
+import { DatabaseError } from 'src/app/modules/core/core.errors'
 import * as FormService from 'src/app/modules/form/form.service'
 import { IFormSchema, IVerificationSchema, PublicTransaction } from 'src/types'
 

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -16,7 +16,6 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import getVerificationModel from '../verification.model'
 import {
-  createTransaction,
   getNewOtp,
   resetFieldInTransaction,
   verifyOtp,
@@ -48,55 +47,6 @@ describe('Verification service', () => {
     user = preloadedDocuments.user
   })
   afterAll(async () => await dbHandler.closeDatabase())
-
-  describe('createTransaction', () => {
-    afterEach(async () => await dbHandler.clearDatabase())
-
-    it('should return null when form_fields does not exist', async () => {
-      const testForm = new Form({
-        admin: user,
-        title: MOCK_FORM_TITLE,
-      })
-      await testForm.save()
-      await expect(createTransaction(testForm._id)).resolves.toBe(null)
-      // Document should not have been created
-      await expect(
-        Verification.findOne({ formId: testForm._id }),
-      ).resolves.toBe(null)
-    })
-
-    it('should return null when there are no verifiable fields', async () => {
-      const testForm = new Form({
-        form_fields: [{ fieldType: BasicField.YesNo }],
-        admin: user,
-        title: MOCK_FORM_TITLE,
-      })
-      await testForm.save()
-      await expect(createTransaction(testForm._id)).resolves.toBe(null)
-      // Document should not have been created
-      await expect(
-        Verification.findOne({ formId: testForm._id }),
-      ).resolves.toBe(null)
-    })
-
-    it('should correctly save and return transaction when it is valid', async () => {
-      const testForm = new Form({
-        form_fields: [{ fieldType: BasicField.Email, isVerifiable: true }],
-        admin: user,
-        title: MOCK_FORM_TITLE,
-      })
-      await testForm.save()
-      const returnedTransaction = await createTransaction(testForm._id)
-      const foundTransaction = await Verification.findOne({
-        formId: testForm._id,
-      })
-      expect(foundTransaction).toBeTruthy()
-      expect(returnedTransaction).toEqual({
-        transactionId: foundTransaction!._id,
-        expireAt: foundTransaction!.expireAt,
-      })
-    })
-  })
 
   describe('resetFieldInTransaction', () => {
     afterEach(async () => await dbHandler.clearDatabase())

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -9,6 +9,7 @@ import { MissingFeatureError } from '../core/core.errors'
 import * as VerificationService from './verification.service'
 
 interface IVerifiedFieldsFactory {
+  createTransaction: typeof VerificationService.createTransaction
   getTransactionMetadata: typeof VerificationService.getTransactionMetadata
 }
 
@@ -21,6 +22,7 @@ export const createVerificationFactory = ({
   }
   const error = new MissingFeatureError(FeatureNames.VerifiedFields)
   return {
+    createTransaction: () => errAsync(error),
     getTransactionMetadata: () => errAsync(error),
   }
 }

--- a/src/app/modules/verification/verification.middleware.ts
+++ b/src/app/modules/verification/verification.middleware.ts
@@ -6,7 +6,6 @@ import featureManager, { FeatureNames } from '../../../config/feature-manager'
 import * as verification from './verification.controller'
 
 interface IVerifiedFieldsMiddleware {
-  createTransaction: RequestHandler
   resetFieldInTransaction: RequestHandler<{ transactionId: string }>
   getNewOtp: RequestHandler<{ transactionId: string }>
   verifyOtp: RequestHandler<{ transactionId: string }>
@@ -19,7 +18,6 @@ const verificationMiddlewareFactory = ({
 }): IVerifiedFieldsMiddleware => {
   if (isEnabled) {
     return {
-      createTransaction: verification.createTransaction,
       resetFieldInTransaction: verification.resetFieldInTransaction,
       getNewOtp: verification.getNewOtp,
       verifyOtp: verification.verifyOtp,
@@ -27,8 +25,6 @@ const verificationMiddlewareFactory = ({
   } else {
     const errMsg = 'Verified fields feature is not enabled'
     return {
-      createTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       resetFieldInTransaction: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       getNewOtp: (req, res) =>

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -3,12 +3,15 @@ import { Mongoose, Schema } from 'mongoose'
 
 import * as vfnConstants from '../../../shared/util/verification'
 import {
+  IFormSchema,
   IVerificationFieldSchema,
   IVerificationModel,
   IVerificationSchema,
   PublicTransaction,
 } from '../../../types'
 import { FORM_SCHEMA_ID } from '../../models/form.server.model'
+
+import { extractTransactionFields } from './verification.util'
 
 const { getExpiryDate } = vfnConstants
 const VERIFICATION_SCHEMA_ID = 'Verification'
@@ -86,6 +89,20 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
     const document = await this.findById(id)
     if (!document) return null
     return document.getPublicView()
+  }
+
+  VerificationSchema.statics.createTransactionFromForm = async function (
+    this: IVerificationModel,
+    form: IFormSchema,
+  ): Promise<IVerificationSchema | null> {
+    const { form_fields } = form
+    if (!form_fields) return null
+    const fields = extractTransactionFields(form_fields)
+    if (fields.length === 0) return null
+    return this.create({
+      formId: form._id,
+      fields,
+    })
   }
 
   const VerificationModel = db.model<IVerificationSchema, IVerificationModel>(

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -15,7 +15,7 @@ VfnRouter.post(
       formId: formatOfId,
     }),
   }),
-  verificationMiddleware.createTransaction,
+  VerificationController.handleCreateTransaction,
 )
 
 VfnRouter.get(

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -1,8 +1,11 @@
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../../config/logger'
-import { WAIT_FOR_OTP_SECONDS } from '../../../shared/util/verification'
-import { MapRouteError } from '../../../types'
+import {
+  VERIFIED_FIELDTYPES,
+  WAIT_FOR_OTP_SECONDS,
+} from '../../../shared/util/verification'
+import { IFieldSchema, MapRouteError } from '../../../types'
 import { MailSendError } from '../../services/mail/mail.errors'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { HashingError } from '../../utils/hash'
@@ -26,6 +29,29 @@ import {
 } from './verification.errors'
 
 const logger = createLoggerWithLabel(module)
+
+/**
+ * Evaluates whether a field is verifiable
+ * @param field
+ */
+const isFieldVerifiable = (field: IFieldSchema): boolean => {
+  return (
+    VERIFIED_FIELDTYPES.includes(field.fieldType) && field.isVerifiable === true
+  )
+}
+
+/**
+ * Gets verifiable fields from form and initializes the values to be stored in a transaction
+ * @param formFields
+ */
+export const extractTransactionFields = (
+  formFields: IFieldSchema[],
+): Pick<IFieldSchema, '_id' | 'fieldType'>[] => {
+  return formFields.filter(isFieldVerifiable).map(({ _id, fieldType }) => ({
+    _id,
+    fieldType,
+  }))
+}
 
 export const mapRouteError: MapRouteError = (
   error,

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -54,6 +54,11 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
   getPublicViewById(
     id: IVerificationSchema['_id'],
   ): Promise<PublicTransaction | null>
+  /**
+   * Creates a transaction given a form document. Returns null if the form
+   * has no verifiable fields.
+   * @param form Form document
+   */
   createTransactionFromForm(
     form: IFormSchema,
   ): Promise<IVerificationSchema | null>

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -54,4 +54,7 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
   getPublicViewById(
     id: IVerificationSchema['_id'],
   ): Promise<PublicTransaction | null>
+  createTransactionFromForm(
+    form: IFormSchema,
+  ): Promise<IVerificationSchema | null>
 }


### PR DESCRIPTION
Builds on #1451

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

See #1450

## Solution
<!-- How did you solve the problem? -->

This is the 3rd part of the solution, which focuses on the `POST /transaction` endpoint.

## Tests
See #1450