### PR TITLE
refactor: use neverthrow in /:transactionId/reset (part 4)

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -4,11 +4,7 @@ import { mocked } from 'ts-jest/utils'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
-import {
-  getNewOtp,
-  resetFieldInTransaction,
-  verifyOtp,
-} from '../verification.controller'
+import { getNewOtp, verifyOtp } from '../verification.controller'
 import getVerificationModel from '../verification.model'
 import * as VfnService from '../verification.service'
 
@@ -29,44 +25,6 @@ const sendOtpError = 'SEND_OTP_FAILED'
 const invalidOtpError = 'INVALID_OTP'
 
 describe('Verification controller', () => {
-  describe('resetFieldInTransaction', () => {
-    const MOCK_REQ = expressHandler.mockRequest({
-      body: { fieldId: MOCK_FIELD_ID },
-      params: { transactionId: MOCK_TRANSACTION_ID },
-    })
-    afterEach(() => jest.clearAllMocks())
-
-    it('should correctly call service when params are valid', async () => {
-      const transaction = new Verification({ formId: new ObjectId() })
-      MockVfnService.getTransaction.mockReturnValueOnce(
-        Promise.resolve(transaction),
-      )
-      await resetFieldInTransaction(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MockVfnService.resetFieldInTransaction).toHaveBeenCalledWith(
-        transaction,
-        MOCK_FIELD_ID,
-      )
-      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
-    })
-
-    it('should return 404 when service throws error', async () => {
-      MockVfnService.getTransaction.mockImplementationOnce(() => {
-        const error = new Error(notFoundError)
-        error.name = notFoundError
-        throw error
-      })
-      await resetFieldInTransaction(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
-    })
-  })
-
   describe('getNewOtp', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       body: { fieldId: MOCK_FIELD_ID, answer: MOCK_ANSWER },

--- a/src/app/modules/verification/__tests__/verification.model.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.model.spec.ts
@@ -325,5 +325,78 @@ describe('Verification Model', () => {
         })
       })
     })
+
+    describe('resetField', () => {
+      it('should reset the field and return the new document', async () => {
+        const field = {
+          ...generateFieldParams(),
+          signedData: 'mockSignedData',
+          hashedOtp: 'mockHashedOtp',
+          hashCreatedAt: new Date(),
+        }
+        const transaction = await VerificationModel.create({
+          ...VFN_PARAMS,
+          fields: [field],
+        })
+
+        const result = await VerificationModel.resetField(
+          String(transaction._id),
+          String(field._id),
+        )
+
+        expect(result!.fields[0].hashRetries).toEqual(0)
+        expect(result!.fields[0].signedData).toBeNull()
+        expect(result!.fields[0].hashedOtp).toBeNull()
+        expect(result!.fields[0].hashCreatedAt).toBeNull()
+        expect(result!.formId).toEqual(transaction.formId)
+      })
+
+      it('should reset only the given field ID', async () => {
+        const field1 = {
+          ...generateFieldParams(),
+          signedData: 'mockSignedData',
+          hashedOtp: 'mockHashedOtp',
+          hashCreatedAt: new Date(),
+        }
+        const field2 = {
+          ...generateFieldParams(),
+          signedData: 'mockSignedData2',
+          hashedOtp: 'mockHashedOtp2',
+          hashCreatedAt: new Date(),
+        }
+        const transaction = await VerificationModel.create({
+          ...VFN_PARAMS,
+          fields: [field1, field2],
+        })
+
+        const result = await VerificationModel.resetField(
+          String(transaction._id),
+          String(field1._id),
+        )
+
+        // field1 should be reset
+        expect(result!.fields[0].hashRetries).toEqual(0)
+        expect(result!.fields[0].signedData).toBeNull()
+        expect(result!.fields[0].hashedOtp).toBeNull()
+        expect(result!.fields[0].hashCreatedAt).toBeNull()
+
+        // field2 should be unchanged
+        expect(result!.fields[1].hashRetries).toEqual(field2.hashRetries)
+        expect(result!.fields[1].signedData).toEqual(field2.signedData)
+        expect(result!.fields[1].hashedOtp).toEqual(field2.hashedOtp)
+        expect(result!.fields[1].hashCreatedAt).toEqual(field2.hashCreatedAt)
+
+        expect(result!.formId).toEqual(transaction.formId)
+      })
+
+      it('should return null when the transaction ID is not found', async () => {
+        const result = await VerificationModel.resetField(
+          new ObjectId().toHexString(),
+          new ObjectId().toHexString(),
+        )
+
+        expect(result).toBeNull()
+      })
+    })
   })
 })

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -87,28 +87,31 @@ export const handleGetTransactionMetadata: RequestHandler<
  * @param req
  * @param res
  */
-export const resetFieldInTransaction: RequestHandler<
+export const handleResetField: RequestHandler<
   { transactionId: string },
-  string,
+  { message: string },
   { fieldId: string }
 > = async (req, res) => {
-  try {
-    const { transactionId } = req.params
-    const { fieldId } = req.body
-    const transaction = await VerificationService.getTransaction(transactionId)
-    await VerificationService.resetFieldInTransaction(transaction, fieldId)
-    return res.sendStatus(StatusCodes.OK)
-  } catch (error) {
-    logger.error({
-      message: 'Error resetting field in transaction',
-      meta: {
-        action: 'resetFieldInTransaction',
-      },
-      error,
-    })
-    return handleError(error, res)
+  const { transactionId } = req.params
+  const { fieldId } = req.body
+  const logMeta = {
+    action: 'handleResetField',
+    transactionId,
+    fieldId,
   }
+  return VerificationFactory.resetFieldForTransaction(transactionId, fieldId)
+    .map(() => res.sendStatus(StatusCodes.OK))
+    .mapErr((error) => {
+      logger.error({
+        message: 'Error resetting field in transaction',
+        meta: logMeta,
+        error,
+      })
+      const { errorMessage, statusCode } = mapRouteError(error)
+      return res.status(statusCode).json({ message: errorMessage })
+    })
 }
+
 /**
  * When user requests to verify a field, an otp is generated.
  * The current answer is signed, and the signature is also saved in the transaction, with the field id as the key.

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -11,6 +11,7 @@ import * as VerificationService from './verification.service'
 interface IVerifiedFieldsFactory {
   createTransaction: typeof VerificationService.createTransaction
   getTransactionMetadata: typeof VerificationService.getTransactionMetadata
+  resetFieldForTransaction: typeof VerificationService.resetFieldForTransaction
 }
 
 export const createVerificationFactory = ({
@@ -24,6 +25,7 @@ export const createVerificationFactory = ({
   return {
     createTransaction: () => errAsync(error),
     getTransactionMetadata: () => errAsync(error),
+    resetFieldForTransaction: () => errAsync(error),
   }
 }
 

--- a/src/app/modules/verification/verification.middleware.ts
+++ b/src/app/modules/verification/verification.middleware.ts
@@ -6,7 +6,6 @@ import featureManager, { FeatureNames } from '../../../config/feature-manager'
 import * as verification from './verification.controller'
 
 interface IVerifiedFieldsMiddleware {
-  resetFieldInTransaction: RequestHandler<{ transactionId: string }>
   getNewOtp: RequestHandler<{ transactionId: string }>
   verifyOtp: RequestHandler<{ transactionId: string }>
 }
@@ -18,15 +17,12 @@ const verificationMiddlewareFactory = ({
 }): IVerifiedFieldsMiddleware => {
   if (isEnabled) {
     return {
-      resetFieldInTransaction: verification.resetFieldInTransaction,
       getNewOtp: verification.getNewOtp,
       verifyOtp: verification.verifyOtp,
     }
   } else {
     const errMsg = 'Verified fields feature is not enabled'
     return {
-      resetFieldInTransaction: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       getNewOtp: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       verifyOtp: (req, res) =>

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -105,6 +105,32 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
     })
   }
 
+  VerificationSchema.statics.resetField = async function (
+    this: IVerificationModel,
+    transactionId: string,
+    fieldId: string,
+  ): Promise<IVerificationSchema | null> {
+    return this.findOneAndUpdate(
+      {
+        _id: transactionId,
+        'fields._id': fieldId,
+      },
+      {
+        $set: {
+          'fields.$.hashCreatedAt': null,
+          'fields.$.hashedOtp': null,
+          'fields.$.signedData': null,
+          'fields.$.hashRetries': 0,
+        },
+      },
+      {
+        new: true,
+        runValidators: true,
+        setDefaultsOnInsert: true,
+      },
+    ).exec()
+  }
+
   const VerificationModel = db.model<IVerificationSchema, IVerificationModel>(
     VERIFICATION_SCHEMA_ID,
     VerificationSchema,

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -38,7 +38,7 @@ VfnRouter.post(
       fieldId: formatOfId,
     }),
   }),
-  verificationMiddleware.resetFieldInTransaction,
+  VerificationController.handleResetField,
 )
 
 VfnRouter.post(

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -59,8 +59,7 @@ export const extractTransactionFields = (
 
 /**
  * Checks if expireAt is in the past -- ie transaction has expired
- * @param expireAt
- * @returns boolean
+ * @param transaction the transaction document to
  */
 export const isTransactionExpired = (
   transaction: IVerificationSchema,

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -5,7 +5,11 @@ import {
   VERIFIED_FIELDTYPES,
   WAIT_FOR_OTP_SECONDS,
 } from '../../../shared/util/verification'
-import { IFieldSchema, MapRouteError } from '../../../types'
+import {
+  IFieldSchema,
+  IVerificationSchema,
+  MapRouteError,
+} from '../../../types'
 import { MailSendError } from '../../services/mail/mail.errors'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { HashingError } from '../../utils/hash'
@@ -51,6 +55,18 @@ export const extractTransactionFields = (
     _id,
     fieldType,
   }))
+}
+
+/**
+ * Checks if expireAt is in the past -- ie transaction has expired
+ * @param expireAt
+ * @returns boolean
+ */
+export const isTransactionExpired = (
+  transaction: IVerificationSchema,
+): boolean => {
+  const currentDate = new Date()
+  return transaction.expireAt < currentDate
 }
 
 export const mapRouteError: MapRouteError = (

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -62,6 +62,9 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
   createTransactionFromForm(
     form: IFormSchema,
   ): Promise<IVerificationSchema | null>
+  /**
+   * Resets the hash records of a single field.
+   */
   resetField(
     transactionId: string,
     fieldId: string,

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -62,4 +62,8 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
   createTransactionFromForm(
     form: IFormSchema,
   ): Promise<IVerificationSchema | null>
+  resetField(
+    transactionId: string,
+    fieldId: string,
+  ): Promise<IVerificationSchema | null>
 }


### PR DESCRIPTION
Builds on #1452

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

See #1450

## Solution
<!-- How did you solve the problem? -->

This is the 4th part of the solution, which focuses on the `POST /transaction/:transactionId/reset` endpoint.

## Tests
See #1450