### PR TITLE
refactor: use neverthrow in /:transactionId/otp (part 5)

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -5,31 +5,46 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
+import { MailSendError } from 'src/app/services/mail/mail.errors'
+import {
+  InvalidNumberError,
+  SmsSendError,
+} from 'src/app/services/sms/sms.errors'
+import { HashingError } from 'src/app/utils/hash'
+import * as OtpUtils from 'src/app/utils/otp'
 import { IVerificationSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import expressHandler from '../../../../../tests/unit/backend/helpers/jest-express'
-import { DatabaseError } from '../../core/core.errors'
+import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as VerificationController from '../verification.controller'
 import {
   FieldNotFoundInTransactionError,
+  NonVerifiedFieldTypeError,
   TransactionExpiredError,
   TransactionNotFoundError,
+  WaitForOtpError,
 } from '../verification.errors'
 import { VerificationFactory } from '../verification.factory'
 import getVerificationModel from '../verification.model'
+
+import { MOCK_HASHED_OTP } from './verification.test.helpers'
 
 const VerificationModel = getVerificationModel(mongoose)
 
 jest.mock('../verification.factory')
 const MockVerificationFactory = mocked(VerificationFactory, true)
+jest.mock('src/app/utils/otp')
+const MockOtpUtils = mocked(OtpUtils, true)
 
 describe('Verification controller', () => {
   const MOCK_FORM_ID = new ObjectId().toHexString()
   const MOCK_TRANSACTION_ID = new ObjectId().toHexString()
   const MOCK_FIELD_ID = new ObjectId().toHexString()
+  const MOCK_ANSWER = 'answer'
+  const MOCK_OTP = 'otp'
   let mockTransaction: IVerificationSchema
   let mockRes: Response
 
@@ -314,6 +329,246 @@ describe('Verification controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith({
         message: expect.any(String),
       })
+    })
+  })
+
+  describe('handleGetOtp', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      body: { fieldId: MOCK_FIELD_ID, answer: MOCK_ANSWER },
+      params: { transactionId: MOCK_TRANSACTION_ID },
+    })
+
+    beforeEach(() => {
+      MockOtpUtils.generateOtpWithHash.mockReturnValueOnce(
+        okAsync({
+          otp: MOCK_OTP,
+          hashedOtp: MOCK_HASHED_OTP,
+        }),
+      )
+      MockVerificationFactory.sendNewOtp.mockReturnValueOnce(
+        okAsync(mockTransaction),
+      )
+    })
+
+    it('should call service correctly when params are valid', async () => {
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+    })
+
+    it('should return 404 when transaction is not found', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new TransactionNotFoundError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when transaction has expired', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new TransactionExpiredError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 404 when field ID is not found', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new FieldNotFoundInTransactionError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 500 when error occurs while hashing', async () => {
+      MockOtpUtils.generateOtpWithHash
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new HashingError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when OTP waiting time has not elapsed', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new WaitForOtpError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when form SMS parameters are malformed', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new MalformedParametersError('')))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when SMS sending errors', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new SmsSendError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when phone number is invalid', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new InvalidNumberError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when email sending errors', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new MailSendError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 400 when field type is not verifiable', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new NonVerifiedFieldTypeError('')))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      MockVerificationFactory.sendNewOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(new DatabaseError()))
+
+      await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
+
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationFactory.sendNewOtp).toHaveBeenCalledWith({
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        otp: MOCK_OTP,
+        hashedOtp: MOCK_HASHED_OTP,
+        recipient: MOCK_ANSWER,
+      })
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
   })
 })

--- a/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.new.spec.ts
@@ -436,7 +436,7 @@ describe('Verification controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
 
-    it('should return 400 when OTP waiting time has not elapsed', async () => {
+    it('should return 422 when OTP waiting time has not elapsed', async () => {
       MockVerificationFactory.sendNewOtp
         .mockReset()
         .mockReturnValueOnce(errAsync(new WaitForOtpError()))
@@ -451,7 +451,9 @@ describe('Verification controller', () => {
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
       })
-      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      )
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
 

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -4,7 +4,7 @@ import { mocked } from 'ts-jest/utils'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
-import { getNewOtp, verifyOtp } from '../verification.controller'
+import { verifyOtp } from '../verification.controller'
 import getVerificationModel from '../verification.model'
 import * as VfnService from '../verification.service'
 
@@ -14,101 +14,13 @@ const MockVfnService = mocked(VfnService, true)
 const noop = () => {}
 const MOCK_TRANSACTION_ID = 'transactionId'
 const MOCK_FIELD_ID = 'fieldId'
-const MOCK_ANSWER = 'answer'
 const MOCK_OTP = 'otp'
 const MOCK_DATA = 'data'
 const MOCK_RES = expressHandler.mockResponse()
 const Verification = getVerificationModel(mongoose)
-const notFoundError = 'TRANSACTION_NOT_FOUND'
-const waitOtpError = 'WAIT_FOR_OTP'
-const sendOtpError = 'SEND_OTP_FAILED'
 const invalidOtpError = 'INVALID_OTP'
 
 describe('Verification controller', () => {
-  describe('getNewOtp', () => {
-    const MOCK_REQ = expressHandler.mockRequest({
-      body: { fieldId: MOCK_FIELD_ID, answer: MOCK_ANSWER },
-      params: { transactionId: MOCK_TRANSACTION_ID },
-    })
-
-    const MOCK_TRANSACTION = new Verification({ formId: new ObjectId() })
-    MockVfnService.getTransaction.mockReturnValue(
-      Promise.resolve(MOCK_TRANSACTION),
-    )
-
-    afterEach(() => jest.clearAllMocks())
-
-    it('should call service correctly when params are valid', async () => {
-      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        MOCK_TRANSACTION,
-        MOCK_FIELD_ID,
-        MOCK_ANSWER,
-      )
-      expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(201)
-    })
-
-    it('should return 404 when service throws not found error', async () => {
-      MockVfnService.getNewOtp.mockImplementationOnce(() => {
-        const error = new Error(notFoundError)
-        error.name = notFoundError
-        throw error
-      })
-      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        MOCK_TRANSACTION,
-        MOCK_FIELD_ID,
-        MOCK_ANSWER,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(404)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(notFoundError)
-    })
-
-    it('should return 202 when service throws WaitForOtp error', async () => {
-      MockVfnService.getNewOtp.mockImplementationOnce(() => {
-        const error = new Error(waitOtpError)
-        error.name = waitOtpError
-        throw error
-      })
-      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        MOCK_TRANSACTION,
-        MOCK_FIELD_ID,
-        MOCK_ANSWER,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(202)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(waitOtpError)
-    })
-
-    it('should return 400 when services throws OTP failed error', async () => {
-      MockVfnService.getNewOtp.mockImplementationOnce(() => {
-        const error = new Error(sendOtpError)
-        error.name = sendOtpError
-        throw error
-      })
-      await getNewOtp(MOCK_REQ, MOCK_RES, noop)
-      expect(MockVfnService.getTransaction).toHaveBeenCalledWith(
-        MOCK_TRANSACTION_ID,
-      )
-      expect(MockVfnService.getNewOtp).toHaveBeenCalledWith(
-        MOCK_TRANSACTION,
-        MOCK_FIELD_ID,
-        MOCK_ANSWER,
-      )
-      expect(MOCK_RES.status).toHaveBeenCalledWith(400)
-      expect(MOCK_RES.json).toHaveBeenCalledWith(sendOtpError)
-    })
-  })
-
   describe('verifyOtp', () => {
     const MOCK_REQ = expressHandler.mockRequest({
       body: { fieldId: MOCK_FIELD_ID, otp: MOCK_OTP },

--- a/src/app/modules/verification/__tests__/verification.service.new.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.new.spec.ts
@@ -3,25 +3,50 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { DatabaseError } from 'src/app/modules/core/core.errors'
 import * as FormService from 'src/app/modules/form/form.service'
-import { IFormSchema, IVerificationSchema, PublicTransaction } from 'src/types'
+import { MailSendError } from 'src/app/services/mail/mail.errors'
+import MailService from 'src/app/services/mail/mail.service'
+import { SmsSendError } from 'src/app/services/sms/sms.errors'
+import { SmsFactory } from 'src/app/services/sms/sms.factory'
+import formsgSdk from 'src/config/formsg-sdk'
+import {
+  BasicField,
+  IFormSchema,
+  IVerificationSchema,
+  PublicTransaction,
+  UpdateFieldData,
+} from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
+import { DatabaseError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
 import {
   FieldNotFoundInTransactionError,
   TransactionExpiredError,
   TransactionNotFoundError,
+  WaitForOtpError,
 } from '../verification.errors'
 import getVerificationModel from '../verification.model'
 import * as VerificationService from '../verification.service'
 
-import { generateFieldParams } from './verification.test.helpers'
+import {
+  generateFieldParams,
+  MOCK_HASHED_OTP,
+  MOCK_OTP,
+  MOCK_RECIPIENT,
+  MOCK_SIGNED_DATA,
+} from './verification.test.helpers'
 
 const VerificationModel = getVerificationModel(mongoose)
 
+// Set up mocks
+jest.mock('src/config/formsg-sdk')
+const MockFormsgSdk = mocked(formsgSdk, true)
+jest.mock('src/app/services/sms/sms.factory')
+const MockSmsFactory = mocked(SmsFactory, true)
+jest.mock('src/app/services/mail/mail.service')
+const MockMailService = mocked(MailService, true)
 jest.mock('src/app/modules/form/form.service')
 const MockFormService = mocked(FormService, true)
 
@@ -227,6 +252,248 @@ describe('Verification service', () => {
 
       expect(resetFieldSpy).toHaveBeenCalledWith(mockTransactionId, mockFieldId)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+  })
+
+  describe('sendNewOtp', () => {
+    let updateHashSpy: jest.SpyInstance<
+      Promise<IVerificationSchema | null>,
+      [updateData: UpdateFieldData]
+    >
+
+    beforeEach(() => {
+      updateHashSpy = jest
+        .spyOn(VerificationModel, 'updateHashForField')
+        .mockResolvedValueOnce(mockTransaction)
+      MockSmsFactory.sendVerificationOtp.mockReturnValueOnce(okAsync(true))
+      MockMailService.sendVerificationOtp.mockReturnValueOnce(okAsync(true))
+      MockFormsgSdk.verification.generateSignature.mockReturnValueOnce(
+        MOCK_SIGNED_DATA,
+      )
+    })
+
+    it('should send OTP and update hashes when parameters are valid', async () => {
+      const result = await VerificationService.sendNewOtp({
+        transactionId: mockTransactionId,
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      // Default mock params has fieldType: 'mobile'
+      expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
+        MOCK_RECIPIENT,
+        MOCK_OTP,
+        mockTransaction.formId,
+      )
+      expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
+        {
+          transactionId: mockTransactionId,
+          formId: mockTransaction.formId,
+          fieldId: mockFieldId,
+          answer: MOCK_RECIPIENT,
+        },
+      )
+      expect(updateHashSpy).toHaveBeenCalledWith({
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        signedData: MOCK_SIGNED_DATA,
+        transactionId: mockTransactionId,
+      })
+      expect(result._unsafeUnwrap()).toEqual(mockTransaction)
+    })
+
+    it('should return TransactionNotFoundError when transaction ID does not exist', async () => {
+      const result = await VerificationService.sendNewOtp({
+        // non-existent transaction ID
+        transactionId: new ObjectId().toHexString(),
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(MockSmsFactory.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(new TransactionNotFoundError())
+    })
+
+    it('should return TransactionExpiredError when transaction has expired', async () => {
+      const expiredTransaction = await VerificationModel.create({
+        formId: mockFormId,
+        // Expire 25 hours ago
+        expireAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+      })
+
+      const result = await VerificationService.sendNewOtp({
+        transactionId: expiredTransaction._id,
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(MockSmsFactory.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(new TransactionExpiredError())
+    })
+
+    it('should return FieldNotFoundInTransactionError when field ID does not exist', async () => {
+      const result = await VerificationService.sendNewOtp({
+        transactionId: mockTransactionId,
+        // ObjectId which does not exist in mockTransaction
+        fieldId: new ObjectId().toHexString(),
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(MockSmsFactory.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new FieldNotFoundInTransactionError(),
+      )
+    })
+
+    it('should return WaitForOtpError when OTP waiting time has not elapsed', async () => {
+      const expiredOtpField = generateFieldParams({
+        // Hash created 5 seconds ago
+        hashCreatedAt: new Date(Date.now() - 5 * 1000),
+      })
+      const expiredOtpTransaction = await VerificationModel.create({
+        formId: mockFormId,
+        // Expire 1 hour in future
+        expireAt: new Date(Date.now() + 60 * 60 * 1000),
+        fields: [expiredOtpField],
+      })
+
+      const result = await VerificationService.sendNewOtp({
+        transactionId: expiredOtpTransaction._id,
+        fieldId: expiredOtpField._id,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(MockSmsFactory.sendVerificationOtp).not.toHaveBeenCalled()
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(new WaitForOtpError())
+    })
+
+    it('should forward errors returned by MailService.sendVerificationOtp', async () => {
+      const error = new MailSendError()
+      MockMailService.sendVerificationOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(error))
+      const field = generateFieldParams({
+        fieldType: BasicField.Email,
+      })
+      const transaction = await VerificationModel.create({
+        formId: mockFormId,
+        fields: [field],
+      })
+
+      const result = await VerificationService.sendNewOtp({
+        transactionId: transaction._id,
+        fieldId: field._id,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockMailService.sendVerificationOtp).toHaveBeenCalledWith(
+        MOCK_RECIPIENT,
+        MOCK_OTP,
+      )
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(error)
+    })
+
+    it('should forward errors returned by SmsFactory.sendVerificationOtp', async () => {
+      const error = new SmsSendError()
+      MockSmsFactory.sendVerificationOtp
+        .mockReset()
+        .mockReturnValueOnce(errAsync(error))
+      const field = generateFieldParams({
+        fieldType: BasicField.Mobile,
+      })
+      const transaction = await VerificationModel.create({
+        formId: mockFormId,
+        fields: [field],
+      })
+
+      const result = await VerificationService.sendNewOtp({
+        transactionId: transaction._id,
+        fieldId: field._id,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
+        MOCK_RECIPIENT,
+        MOCK_OTP,
+        new ObjectId(mockFormId),
+      )
+      expect(
+        MockFormsgSdk.verification.generateSignature,
+      ).not.toHaveBeenCalled()
+      expect(updateHashSpy).not.toHaveBeenCalled()
+      expect(result._unsafeUnwrapErr()).toEqual(error)
+    })
+
+    it('should return TransactionNotFoundError when database update returns null', async () => {
+      updateHashSpy.mockReset().mockResolvedValueOnce(null)
+
+      const result = await VerificationService.sendNewOtp({
+        transactionId: mockTransactionId,
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        otp: MOCK_OTP,
+        recipient: MOCK_RECIPIENT,
+      })
+
+      // Mock params default to mobile
+      expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
+        MOCK_RECIPIENT,
+        MOCK_OTP,
+        new ObjectId(mockFormId),
+      )
+      expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
+        {
+          transactionId: mockTransactionId,
+          formId: new ObjectId(mockFormId),
+          fieldId: mockFieldId,
+          answer: MOCK_RECIPIENT,
+        },
+      )
+      expect(updateHashSpy).toHaveBeenCalledWith({
+        fieldId: mockFieldId,
+        hashedOtp: MOCK_HASHED_OTP,
+        signedData: MOCK_SIGNED_DATA,
+        transactionId: mockTransactionId,
+      })
+      expect(result._unsafeUnwrapErr()).toEqual(new TransactionNotFoundError())
     })
   })
 })

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -1,32 +1,18 @@
 import bcrypt from 'bcrypt'
 import { ObjectId } from 'bson'
 import mongoose from 'mongoose'
-import { okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import MailService from 'src/app/services/mail/mail.service'
-import { SmsFactory } from 'src/app/services/sms/sms.factory'
-import { generateOtp } from 'src/app/utils/otp'
-import formsgSdk from 'src/config/formsg-sdk'
-import { SALT_ROUNDS } from 'src/shared/util/verification'
 import { BasicField, IVerificationSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import getVerificationModel from '../verification.model'
-import { getNewOtp, verifyOtp } from '../verification.service'
+import { verifyOtp } from '../verification.service'
 
 const Verification = getVerificationModel(mongoose)
 
 // Set up mocks
-jest.mock('src/app/utils/otp')
-const MockGenerateOtp = mocked(generateOtp, true)
-jest.mock('src/config/formsg-sdk')
-const MockFormsgSdk = mocked(formsgSdk, true)
-jest.mock('src/app/services/sms/sms.factory')
-const MockSmsFactory = mocked(SmsFactory, true)
-jest.mock('src/app/services/mail/mail.service')
-const MockMailService = mocked(MailService, true)
 jest.mock('bcrypt')
 const MockBcrypt = mocked(bcrypt, true)
 
@@ -36,192 +22,6 @@ describe('Verification service', () => {
   })
 
   afterAll(async () => await dbHandler.closeDatabase())
-
-  describe('getNewOtp', () => {
-    let transaction: IVerificationSchema, mockAnswer: string, mockOtp: string
-    let hashedOtp: string, signedData: string, hashRetries: number
-    let hashCreatedAt: Date
-    beforeEach(() => {
-      jest.clearAllMocks()
-      mockAnswer = 'answer'
-      mockOtp = '123456'
-      hashedOtp = 'hash'
-      signedData = 'signedData'
-      hashRetries = 1
-      hashCreatedAt = new Date()
-      const defaultParams = {
-        hashCreatedAt,
-        hashedOtp,
-        signedData,
-        hashRetries,
-        isVerifiable: true,
-      }
-      transaction = new Verification({
-        formId: new ObjectId(),
-        fields: [
-          {
-            fieldType: BasicField.Email,
-            ...defaultParams,
-            _id: new ObjectId(),
-          },
-          {
-            fieldType: BasicField.Mobile,
-            ...defaultParams,
-            _id: new ObjectId(),
-          },
-        ],
-        expireAt: new Date(Date.now() + 6e5), // so it won't expire in tests
-      })
-      MockGenerateOtp.mockReturnValue(mockOtp)
-      MockBcrypt.hash.mockReturnValue(Promise.resolve(hashedOtp))
-      MockFormsgSdk.verification.generateSignature!.mockReturnValue(signedData)
-    })
-
-    afterEach(async () => await dbHandler.clearDatabase())
-
-    it('should throw error when transaction is expired', async () => {
-      transaction.expireAt = new Date(1)
-      await transaction.save()
-      return expect(
-        getNewOtp(transaction, transaction.fields[0]._id!, mockAnswer),
-      ).rejects.toThrowError('TRANSACTION_NOT_FOUND')
-    })
-
-    it('should throw error when field ID is invalid', async () => {
-      return expect(
-        getNewOtp(transaction, String(new ObjectId()), mockAnswer),
-      ).rejects.toThrowError('Field not found in transaction')
-    })
-
-    it('should throw error when OTP is requested too soon', async () => {
-      // 1min in the future
-      transaction.fields[0].hashCreatedAt = new Date(Date.now() + 6e4)
-      // Actual error is 'Wait for _ seconds before requesting'
-      return expect(
-        getNewOtp(transaction, transaction.fields[0]._id!, mockAnswer),
-      ).rejects.toThrowError('seconds before requesting for a new otp')
-    })
-
-    it('should send OTP when params are valid for email field', async () => {
-      // Arrange
-      // Reset field so we can it update later on
-      transaction.fields[0].hashedOtp = null
-      transaction.fields[0].signedData = null
-      transaction.fields[0].hashCreatedAt = null
-      transaction.fields[0].hashRetries = 1
-      await transaction.save()
-      // Mock success of mail sending.
-      MockMailService.sendVerificationOtp.mockReturnValueOnce(okAsync(true))
-
-      // Act
-      await getNewOtp(transaction, transaction.fields[0]._id!, mockAnswer)
-
-      // Assert
-      expect(MockGenerateOtp).toHaveBeenCalled()
-      expect(MockBcrypt.hash).toHaveBeenCalledWith(mockOtp, SALT_ROUNDS)
-      expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
-        {
-          transactionId: transaction._id,
-          formId: transaction.formId,
-          fieldId: transaction.fields[0]._id!,
-          answer: mockAnswer,
-        },
-      )
-      expect(MockMailService.sendVerificationOtp).toHaveBeenCalledWith(
-        mockAnswer,
-        mockOtp,
-      )
-      // Verification document should have been updated.
-      const foundTransaction = await Verification.findOne({
-        _id: transaction._id,
-      })
-
-      expect(foundTransaction!.fields[0]).toEqual(
-        expect.objectContaining({
-          hashCreatedAt: expect.any(Date),
-          hashedOtp,
-          signedData,
-          hashRetries: 0,
-        }),
-      )
-    })
-
-    it('should send OTP when params are valid for mobile field', async () => {
-      // Arrange
-      // Reset field so we can test update later on
-      transaction.fields[1].hashedOtp = null
-      transaction.fields[1].signedData = null
-      transaction.fields[1].hashCreatedAt = null
-      transaction.fields[1].hashRetries = 1
-      await transaction.save()
-      // Mock success of sms sending.
-      MockSmsFactory.sendVerificationOtp.mockReturnValueOnce(okAsync(true))
-
-      // Act
-      await getNewOtp(transaction, transaction.fields[1]._id!, mockAnswer)
-
-      // Assert
-      expect(MockGenerateOtp).toHaveBeenCalled()
-      expect(MockBcrypt.hash).toHaveBeenCalledWith(mockOtp, SALT_ROUNDS)
-      expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
-        {
-          transactionId: transaction._id,
-          formId: transaction.formId,
-          fieldId: transaction.fields[1]._id,
-          answer: mockAnswer,
-        },
-      )
-      expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
-        mockAnswer,
-        mockOtp,
-        transaction.formId,
-      )
-      // Verification document should have been updated.
-      const foundTransaction = await Verification.findOne({
-        _id: transaction._id,
-      })
-      expect(foundTransaction!.fields[1]).toEqual(
-        expect.objectContaining({
-          hashCreatedAt: expect.any(Date),
-          hashedOtp,
-          signedData,
-          hashRetries: 0,
-        }),
-      )
-    })
-
-    it('should catch and re-throw errors thrown when sending email', async () => {
-      // So we don't trigger WAIT_FOR_SECONDS error
-      transaction.fields[0].hashCreatedAt = null
-      transaction.fields[0].signedData = null
-      transaction.fields[0].hashCreatedAt = null
-      transaction.fields[0].hashRetries = 1
-      await transaction.save()
-      const myErrorMsg = "I'd like to have an argument please"
-      MockMailService.sendVerificationOtp.mockImplementationOnce(() => {
-        throw new Error(myErrorMsg)
-      })
-      return expect(
-        getNewOtp(transaction, transaction.fields[0]._id!, mockAnswer),
-      ).rejects.toThrowError(myErrorMsg)
-    })
-
-    it('should catch and re-throw errors thrown when sending sms', async () => {
-      // So we don't trigger WAIT_FOR_SECONDS error
-      transaction.fields[1].hashCreatedAt = null
-      transaction.fields[1].signedData = null
-      transaction.fields[1].hashCreatedAt = null
-      transaction.fields[1].hashRetries = 1
-      await transaction.save()
-      const myErrorMsg = 'Tis but a scratch!'
-      MockSmsFactory.sendVerificationOtp.mockImplementationOnce(() => {
-        throw new Error(myErrorMsg)
-      })
-      return expect(
-        getNewOtp(transaction, transaction.fields[1]._id!, mockAnswer),
-      ).rejects.toThrowError(myErrorMsg)
-    })
-  })
 
   describe('verifyOtp', () => {
     let mockOtp: string, transaction: IVerificationSchema, hashRetries: number

--- a/src/app/modules/verification/verification.factory.ts
+++ b/src/app/modules/verification/verification.factory.ts
@@ -12,6 +12,7 @@ interface IVerifiedFieldsFactory {
   createTransaction: typeof VerificationService.createTransaction
   getTransactionMetadata: typeof VerificationService.getTransactionMetadata
   resetFieldForTransaction: typeof VerificationService.resetFieldForTransaction
+  sendNewOtp: typeof VerificationService.sendNewOtp
 }
 
 export const createVerificationFactory = ({
@@ -26,6 +27,7 @@ export const createVerificationFactory = ({
     createTransaction: () => errAsync(error),
     getTransactionMetadata: () => errAsync(error),
     resetFieldForTransaction: () => errAsync(error),
+    sendNewOtp: () => errAsync(error),
   }
 }
 

--- a/src/app/modules/verification/verification.middleware.ts
+++ b/src/app/modules/verification/verification.middleware.ts
@@ -6,7 +6,6 @@ import featureManager, { FeatureNames } from '../../../config/feature-manager'
 import * as verification from './verification.controller'
 
 interface IVerifiedFieldsMiddleware {
-  getNewOtp: RequestHandler<{ transactionId: string }>
   verifyOtp: RequestHandler<{ transactionId: string }>
 }
 
@@ -17,14 +16,11 @@ const verificationMiddlewareFactory = ({
 }): IVerifiedFieldsMiddleware => {
   if (isEnabled) {
     return {
-      getNewOtp: verification.getNewOtp,
       verifyOtp: verification.verifyOtp,
     }
   } else {
     const errMsg = 'Verified fields feature is not enabled'
     return {
-      getNewOtp: (req, res) =>
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
       verifyOtp: (req, res) =>
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: errMsg }),
     }

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -8,6 +8,7 @@ import {
   IVerificationModel,
   IVerificationSchema,
   PublicTransaction,
+  UpdateFieldData,
 } from '../../../types'
 import { FORM_SCHEMA_ID } from '../../models/form.server.model'
 
@@ -120,6 +121,31 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
           'fields.$.hashCreatedAt': null,
           'fields.$.hashedOtp': null,
           'fields.$.signedData': null,
+          'fields.$.hashRetries': 0,
+        },
+      },
+      {
+        new: true,
+        runValidators: true,
+        setDefaultsOnInsert: true,
+      },
+    ).exec()
+  }
+
+  VerificationSchema.statics.updateHashForField = async function (
+    this: IVerificationModel,
+    updateData: UpdateFieldData,
+  ): Promise<IVerificationSchema | null> {
+    return this.findOneAndUpdate(
+      {
+        _id: updateData.transactionId,
+        'fields._id': updateData.fieldId,
+      },
+      {
+        $set: {
+          'fields.$.hashCreatedAt': new Date(),
+          'fields.$.hashedOtp': updateData.hashedOtp,
+          'fields.$.signedData': updateData.signedData,
           'fields.$.hashRetries': 0,
         },
       },

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -52,7 +52,7 @@ VfnRouter.post(
       answer: Joi.string().required(),
     }),
   }),
-  verificationMiddleware.getNewOtp,
+  VerificationController.handleGetOtp,
 )
 
 VfnRouter.post(

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -15,7 +15,6 @@ import MailService from '../../services/mail/mail.service'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { SmsFactory } from '../../services/sms/sms.factory'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
-import { generateOtp } from '../../utils/otp'
 import {
   ApplicationError,
   DatabaseError,
@@ -26,23 +25,20 @@ import * as FormService from '../form/form.service'
 
 import {
   FieldNotFoundInTransactionError,
+  NonVerifiedFieldTypeError,
   TransactionExpiredError,
   TransactionNotFoundError,
+  WaitForOtpError,
 } from './verification.errors'
 import getVerificationModel from './verification.model'
-import { isTransactionExpired } from './verification.util'
+import { SendOtpParams } from './verification.types'
+import { isOtpWaitTimeElapsed, isTransactionExpired } from './verification.util'
 
 const logger = createLoggerWithLabel(module)
 
 const VerificationModel = getVerificationModel(mongoose)
 
-const {
-  HASH_EXPIRE_AFTER_SECONDS,
-  NUM_OTP_RETRIES,
-  SALT_ROUNDS,
-  VfnErrors,
-  WAIT_FOR_OTP_SECONDS,
-} = VfnUtils
+const { HASH_EXPIRE_AFTER_SECONDS, NUM_OTP_RETRIES, VfnErrors } = VfnUtils
 
 /**
  *  Creates a transaction for a form that has verifiable fields
@@ -256,80 +252,98 @@ export const resetFieldForTransaction = (
 }
 
 /**
- *  Generates hashed otp and signed data for the given transaction, fieldId, and answer
- * @param transaction
+ * Sends OTP and updates database record for the given transaction, fieldId, and answer
+ * @param transactionId
  * @param fieldId
- * @param answer
+ * @param recipient Phone number for verified mobile field, or email address for verified email
+ * @param otp Input OTP to be sent
+ * @param hashedOtp Hash of input OTP to be saved
+ * @returns ok(updated transaction document)
+ * @returns err(TransactionNotFoundError) when transaction ID does not exist
+ * @returns err(TransactionExpiredError) when transaction is expired
+ * @returns err(FieldNotFoundInTransactionError) when field does not exist
+ * @returns err(WaitForOtpError) when waiting time for new OTP has not elapsed
+ * @returns err(MalformedParametersError) when form data to send SMS OTP cannot be retrieved
+ * @returns err(SmsSendError) when attempt to send OTP SMS fails
+ * @returns err(InvalidNumberError) when SMS recipient is invalid
+ * @returns err(MailSendError) when attempt to send OTP email fails
+ * @returns err(NonVerifiedFieldTypeError) when field's fieldType is not verified
+ * @returns err(DatabaseError) when database read/write errors
  */
-export const getNewOtp = async (
-  transaction: IVerificationSchema,
-  fieldId: string,
-  answer: string,
-): Promise<void> => {
-  // TODO (#317): remove usage of non-null assertion
-  if (isDateExpired(transaction.expireAt!)) {
-    throwError(VfnErrors.TransactionNotFound)
+export const sendNewOtp = ({
+  transactionId,
+  fieldId,
+  recipient,
+  otp,
+  hashedOtp,
+}: SendOtpParams): ResultAsync<
+  IVerificationSchema,
+  | TransactionNotFoundError
+  | DatabaseError
+  | FieldNotFoundInTransactionError
+  | TransactionExpiredError
+  | WaitForOtpError
+  | MalformedParametersError
+  | SmsSendError
+  | InvalidNumberError
+  | MailSendError
+  | NonVerifiedFieldTypeError
+> => {
+  const logMeta = {
+    action: 'sendNewOtp',
+    transactionId,
+    fieldId,
   }
-  const field = getFieldOrUndefined(transaction, fieldId)
-  if (!field) {
-    return throwError('Field not found in transaction', VfnErrors.FieldNotFound)
-  }
-  const { _id: transactionId, formId } = transaction
-  // TODO (#317): remove usage of non-null assertion
-  const waitForSeconds = waitToResendOtpSeconds(field.hashCreatedAt!)
-  if (waitForSeconds > 0) {
-    return throwError(
-      `Wait for ${waitForSeconds} seconds before requesting for a new otp`,
-      VfnErrors.WaitForOtp,
-    )
-  } else {
-    const hashCreatedAt = new Date()
-    const otp = generateOtp()
-    const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS)
+  return getValidTransaction(transactionId).andThen((transaction) =>
+    getFieldFromTransaction(transaction, fieldId)
+      .asyncAndThen((field) => {
+        if (!isOtpWaitTimeElapsed(field.hashCreatedAt)) {
+          logger.warn({
+            message: 'OTP requested before waiting time elapsed',
+            meta: logMeta,
+          })
+          return errAsync(new WaitForOtpError())
+        }
 
-    const signedData = formsgSdk.verification.generateSignature!({
-      transactionId,
-      formId,
-      fieldId,
-      answer,
-    })
-
-    await sendOtpForField(formId, field, answer, otp)
+        return sendOtpForField(transaction.formId, field, recipient, otp)
+      })
       .andThen(() => {
+        const signedData = formsgSdk.verification.generateSignature({
+          transactionId,
+          formId: transaction.formId,
+          fieldId,
+          answer: recipient,
+        })
         return ResultAsync.fromPromise(
-          VerificationModel.updateOne(
-            { _id: transactionId, 'fields._id': fieldId },
-            {
-              $set: {
-                'fields.$.hashCreatedAt': hashCreatedAt,
-                'fields.$.hashedOtp': hashedOtp,
-                'fields.$.signedData': signedData,
-                'fields.$.hashRetries': 0,
-              },
-            },
-          ).exec(),
+          VerificationModel.updateHashForField({
+            fieldId,
+            hashedOtp,
+            signedData,
+            transactionId,
+          }),
           (error) => {
             logger.error({
               message:
-                'Database error occurred whilst updating verification document',
-              meta: {
-                action: 'getNewOtp',
-                formId,
-                fieldId,
-                transactionId,
-              },
+                'Error while updating transaction data after sending OTP',
+              meta: logMeta,
               error,
             })
             return new DatabaseError(getMongoErrorMessage(error))
           },
         )
-        // TODO(#941): Properly handle error in controller instead of throwing.
-        // Throwing is currently done to keep old behaviour consistent
       })
-      .mapErr((err) => {
-        throwError(err.message, VfnErrors.SendOtpFailed)
-      })
-  }
+      .andThen((newTransaction) => {
+        // Transaction deleted before update could be applied
+        if (!newTransaction) {
+          logger.warn({
+            message: 'Transaction with given ID not found',
+            meta: logMeta,
+          })
+          return errAsync(new TransactionNotFoundError())
+        }
+        return okAsync(newTransaction)
+      }),
+  )
 }
 
 /**
@@ -434,23 +448,6 @@ const isHashedOtpExpired = (hashCreatedAt: Date): boolean => {
     hashCreatedAt,
   )
   return expireAt < currentDate
-}
-
-/**
- * Checks how many seconds remain before a new otp can be generated
- * @param hashCreatedAt
- */
-const waitToResendOtpSeconds = (hashCreatedAt: Date): number => {
-  if (!hashCreatedAt) {
-    // Hash has not been created
-    return 0
-  }
-  const expireAtMs = VfnUtils.getExpiryDate(
-    WAIT_FOR_OTP_SECONDS,
-    hashCreatedAt,
-  ).getTime()
-  const currentMs = Date.now()
-  return Math.ceil((expireAtMs - currentMs) / 1000)
 }
 
 /**

--- a/src/app/modules/verification/verification.types.ts
+++ b/src/app/modules/verification/verification.types.ts
@@ -6,3 +6,11 @@ export type Transaction =
       expireAt: IVerificationSchema['expireAt']
     }
   | Record<string, never>
+
+export type SendOtpParams = {
+  transactionId: string
+  fieldId: string
+  recipient: string
+  otp: string
+  hashedOtp: string
+}

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -57,6 +57,15 @@ export const extractTransactionFields = (
   }))
 }
 
+export const getExpiryDate = (
+  expireAfterSeconds: number,
+  fromDate?: Date,
+): Date => {
+  const expireAt = fromDate ? new Date(fromDate) : new Date()
+  expireAt.setTime(expireAt.getTime() + expireAfterSeconds * 1000)
+  return expireAt
+}
+
 /**
  * Checks if expireAt is in the past -- ie transaction has expired
  * @param transaction the transaction document to
@@ -66,6 +75,15 @@ export const isTransactionExpired = (
 ): boolean => {
   const currentDate = new Date()
   return transaction.expireAt < currentDate
+}
+
+export const isOtpWaitTimeElapsed = (hashCreatedAt: Date | null): boolean => {
+  // No hash created yet, so no wait time
+  if (!hashCreatedAt) return true
+
+  const elapseAt = getExpiryDate(WAIT_FOR_OTP_SECONDS, hashCreatedAt)
+  const currentDate = new Date()
+  return currentDate > elapseAt
 }
 
 export const mapRouteError: MapRouteError = (

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -128,7 +128,7 @@ export const mapRouteError: MapRouteError = (
     case WaitForOtpError:
       return {
         errorMessage: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
-        statusCode: StatusCodes.BAD_REQUEST,
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       }
     case InvalidNumberError:
       return {

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -57,6 +57,12 @@ export const extractTransactionFields = (
   }))
 }
 
+/**
+ * Computes an expiry date a given number of seconds after the original date.
+ * @param expireAfterSeconds Seconds to add to date
+ * @param fromDate Original date. Defaults to current date.
+ * @returns Date of expiry
+ */
 export const getExpiryDate = (
   expireAfterSeconds: number,
   fromDate?: Date,
@@ -77,6 +83,13 @@ export const isTransactionExpired = (
   return transaction.expireAt < currentDate
 }
 
+/**
+ * Computes whether the minimum waiting time for an OTP has elapsed. If this
+ * returns true, then a new OTP can be requested.
+ * @param hashCreatedAt When field hash was created
+ * @returns True if wait time has elapsed and hence a new OTP can be requested,
+ * false  otherwise
+ */
 export const isOtpWaitTimeElapsed = (hashCreatedAt: Date | null): boolean => {
   // No hash created yet, so no wait time
   if (!hashCreatedAt) return true

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -5,10 +5,10 @@ import { IFormSchema } from './form'
 
 export interface IVerificationField {
   fieldType: string
-  signedData?: string | null
-  hashedOtp?: string | null
-  hashCreatedAt?: Date | null
-  hashRetries?: number
+  signedData: string | null
+  hashedOtp: string | null
+  hashCreatedAt: Date | null
+  hashRetries: number
 }
 
 export interface IVerificationFieldSchema

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -76,6 +76,10 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
     transactionId: string,
     fieldId: string,
   ): Promise<IVerificationSchema | null>
+  /**
+   * Updates the hash records for a single field
+   * @param updateData Data with which to update field
+   */
   updateHashForField(
     updateData: UpdateFieldData,
   ): Promise<IVerificationSchema | null>

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -25,6 +25,13 @@ export interface IVerification {
   fields: IVerificationFieldSchema[]
 }
 
+export type UpdateFieldData = {
+  transactionId: string
+  fieldId: string
+  hashedOtp: string
+  signedData: string
+}
+
 export interface IVerificationSchema
   extends IVerification,
     Document,
@@ -68,5 +75,8 @@ export interface IVerificationModel extends Model<IVerificationSchema> {
   resetField(
     transactionId: string,
     fieldId: string,
+  ): Promise<IVerificationSchema | null>
+  updateHashForField(
+    updateData: UpdateFieldData,
   ): Promise<IVerificationSchema | null>
 }


### PR DESCRIPTION
Builds on #1453

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

See #1450

## Solution
<!-- How did you solve the problem? -->

This is the 5th part of the solution, which focuses on the `POST /transaction/:transactionId/otp` endpoint.

## Tests
See #1450