### PR TITLE
fix: shortened sms otp copy for accessibility

### DIFF
--- a/src/app/services/sms/sms.util.ts
+++ b/src/app/services/sms/sms.util.ts
@@ -15,6 +15,6 @@ export const renderBouncedSubmissionSms = (formTitle: string): string => dedent`
 export const renderVerificationSms = (
   otp: string,
   appHost: string,
-): string => dedent`Use the OTP ${otp} to complete your submission on ${appHost}.
+): string => dedent`Use the OTP ${otp} to submit on ${appHost}.
 
-  If you did not request this OTP, do not share the OTP with anyone else. You can safely ignore this message.`
+  Never share your OTP with anyone else. If you did not request this OTP, you can safely ignore this SMS.`


### PR DESCRIPTION
a user reported that an OTP SMS cut off at 153 characters. after investigation, it appears that SMSes longer than 153 chars are sent in 153-char chunks and rebuilt by the recipient's device. 

to avoid future device-specific errors, have shortened the otp sms copy to below 153 chars. 

https://www.twilio.com/docs/glossary/what-sms-character-limit