### PR TITLE
feat: add samesite GA cookie property to enable GA in iframe

### DIFF
--- a/src/app/controllers/frontend.server.controller.js
+++ b/src/app/controllers/frontend.server.controller.js
@@ -17,7 +17,8 @@ module.exports.datalayer = function (req, res) {
       gtag('js', new Date());
       gtag('config', '<%= GATrackingID%>', {
         'send_page_view': false,
-        'app_name': '<%= appName%>'
+        'app_name': '<%= appName%>',
+        'cookie_flags': 'samesite=none;secure',
       });
     `
   try {


### PR DESCRIPTION
## Problem
Google analytics currently does not work if a form is embedded on a different site.

## Solution

- Set GA cookies to SameSite=None; Secure to allow iframe tracking
- Browsers have recently tightened cookie rules by ensuring the top-level domain (the domain in your browser navbar) is the same as the domain of the request before sending cookies in that request. In our case, the default SameSite=Lax for GA cookies meant that GA cookies were not being sent as the top-level domain eg. https://ogp-checkfirst-test-staging.netlify.app/ differed from the requests to http://www.google-analytics.com. SameSite=None tells the browser to ignore this same-domain check and attach the cookies on the GA request.
- As far as I can tell, setting SameSite=None has minimal security implications
- Because SameSite=None can only be set when the cookie is also Secure and the site is secure, this means that local testing will only work if using https
- References about SameSite cookies: https://web.dev/samesite-cookies-explained/
- https://medium.com/trabe/cookies-and-iframes-f7cca58b3b9e

## Before & After

**BEFORE**:
[iframe-form-no-GA-har.txt](https://github.com/opengovsg/FormSG/files/6202472/iframe-form-no-GA-har.txt)

**AFTER**:
[iframe-forms-GA-har.txt](https://github.com/opengovsg/FormSG/files/6202473/iframe-forms-GA-har.txt)


![Screenshot 2021-03-25 at 12 25 29 PM](https://user-images.githubusercontent.com/18087283/112427461-97f3eb80-8d74-11eb-87fe-e5c71956fb37.png)

## Tests
Tested by exposing my local formsg and embedding it in a test isomer site