### PR TITLE
chore: take csv and attachments download out of beta

### DIFF
--- a/src/public/modules/forms/admin/views/decrypt-progress.client.modal.html
+++ b/src/public/modules/forms/admin/views/decrypt-progress.client.modal.html
@@ -15,7 +15,6 @@
   <div ng-if="attachmentsToDownload > 0">
     <div class="field-title">
       Download {{ attachmentsToDownload }} responses and attachments
-      <span class="beta-icon">beta</span>
     </div>
     <div class="field-description">
       <p>

--- a/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
+++ b/src/public/modules/forms/admin/views/download-all-attachments.client.modal.html
@@ -2,7 +2,6 @@
   <div class="modal-body">
     <div class="field-title">
       Download {{ responsesCount }} responses and attachments
-      <span class="beta-icon">beta</span>
     </div>
     <div ng-if="responsesCount > 0" class="field-description">
       <div class="modal-content-spacing">

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -138,7 +138,7 @@
                 <a
                   ng-click="vm.confirmSubmissionCountsBeforeDownload()"
                   style="cursor: pointer"
-                  >CSV and attachments <span class="beta-icon">beta</span></a
+                  >CSV and attachments</a
                 >
               </li>
             </ul>


### PR DESCRIPTION
csv and attachments download has been stable for some time now. we no longer need to communicate that it is a beta feature.

(in comparison, still keeping webhooks as beta due to lack of retries)