### PR TITLE
feat: revert custom code for CorpPass cloud migration

### DIFF
--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -89,7 +89,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
-        false,
       )
       expect(MOCK_RESPONSE.status).toHaveBeenCalledWith(200)
       expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
@@ -108,7 +107,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
-        false,
       )
       expect(MOCK_RESPONSE.status).toHaveBeenCalledWith(500)
       expect(MOCK_RESPONSE.json).toHaveBeenCalledWith({
@@ -139,7 +137,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
-        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -174,7 +171,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
-        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -207,7 +203,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
-        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -240,7 +235,6 @@ describe('spcp.controller', () => {
         AuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
-        false,
       )
       expect(MockSpcpFactory.fetchLoginPage).toHaveBeenCalledWith(
         MOCK_REDIRECT_URL,
@@ -297,7 +291,6 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -308,7 +301,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
-          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -409,7 +401,6 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
-          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -436,7 +427,6 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -465,7 +455,6 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -476,7 +465,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
-          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -501,7 +489,6 @@ describe('spcp.controller', () => {
           MOCK_SP_SAML,
           MOCK_DESTINATION,
           AuthType.SP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -512,7 +499,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.SP,
-          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -564,7 +550,6 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -575,7 +560,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
-          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,
@@ -676,7 +660,6 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
-          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -703,7 +686,6 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -732,7 +714,6 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -743,7 +724,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
-          false,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -768,7 +748,6 @@ describe('spcp.controller', () => {
           MOCK_CP_SAML,
           MOCK_DESTINATION,
           AuthType.CP,
-          false,
         )
         expect(MockSpcpFactory.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
@@ -779,7 +758,6 @@ describe('spcp.controller', () => {
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
           AuthType.CP,
-          false,
         )
         expect(MockBillingFactory.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -64,7 +64,7 @@ describe('spcp.service', () => {
     it('should instantiate auth clients with the correct params', () => {
       const spcpService = new SpcpService(MOCK_PARAMS)
       expect(spcpService).toBeTruthy()
-      expect(MockAuthClient).toHaveBeenCalledTimes(3)
+      expect(MockAuthClient).toHaveBeenCalledTimes(2)
       expect(MockAuthClient).toHaveBeenCalledWith({
         partnerEntityId: MOCK_PARAMS.spPartnerEntityId,
         idpLoginURL: MOCK_PARAMS.spIdpLoginUrl,

--- a/src/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/config/feature-manager/spcp-myinfo.config.ts
@@ -186,25 +186,6 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
       default: null,
       env: 'MYINFO_CLIENT_SECRET',
     },
-    // TODO (private #123): remove these env vars
-    cpCloudFormId: {
-      doc: 'Temporary test form ID for CorpPass Cloud',
-      format: String,
-      default: '60506aff15c0760011f0b14a',
-      env: 'CP_CLOUD_FORM_ID',
-    },
-    cpCloudCertPath: {
-      doc: 'Temporary certificate path for CorpPass Cloud',
-      format: String,
-      default: '/certs/corppass/prod-spcp-cert-cloud.pem',
-      env: 'CP_CLOUD_CERT_PATH',
-    },
-    cpCloudEndpoint: {
-      doc: 'Temporary certificate path for CorpPass Cloud',
-      format: String,
-      default: 'https://oob.corppass.gov.sg/FIM/sps/CorpIDPFed/saml20/soap',
-      env: 'CP_CLOUD_ENDPOINT',
-    },
   },
 }
 

--- a/src/config/feature-manager/types.ts
+++ b/src/config/feature-manager/types.ts
@@ -69,10 +69,6 @@ export interface IMyInfoConfig {
   myInfoCertPath: string
   myInfoClientId: string
   myInfoClientSecret: string
-  // TODO (private #123): remove these keys
-  cpCloudFormId: string
-  cpCloudEndpoint: string
-  cpCloudCertPath: string
 }
 
 export type ISpcpMyInfo = ISpcpConfig & IMyInfoConfig


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

#1392 added custom handling code for a CorpPass test form specifically to accommodate the CorpPass Cloud migration rehearsal. This code is no longer necessary as the rehearsal went successfully.

## Solution
<!-- How did you solve the problem? -->

Delete the custom handling code.