### PR TITLE
ref: collapse middlewares of GET /adminform/submissions/metadata route

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -158,6 +158,16 @@ describe('encrypt-submission.controller', () => {
       title: 'mock title',
     } as IPopulatedForm
 
+    beforeEach(() => {
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValue(
+        ok(MOCK_FORM as IPopulatedEncryptedForm),
+      )
+    })
+
     it('should return 200 with single submission metadata when query.submissionId is provided and can be found', async () => {
       // Arrange
       const mockSubmissionId = new ObjectId().toHexString()
@@ -180,15 +190,6 @@ describe('encrypt-submission.controller', () => {
         submissionTime: 'some submission time',
       }
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getSubmissionMetadata.mockReturnValueOnce(
         okAsync(expectedMetadata),
       )
@@ -226,15 +227,6 @@ describe('encrypt-submission.controller', () => {
       })
       const mockRes = expressHandler.mockResponse()
       // Mock service result.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getSubmissionMetadata.mockReturnValueOnce(
         okAsync(null),
       )
@@ -281,16 +273,6 @@ describe('encrypt-submission.controller', () => {
         ] as SubmissionMetadata[],
         count: 32,
       }
-
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getSubmissionMetadataList.mockReturnValueOnce(
         okAsync(expectedMetadataList),
       )
@@ -321,13 +303,6 @@ describe('encrypt-submission.controller', () => {
         },
       })
       const mockRes = expressHandler.mockResponse()
-
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
 
       const expectedError = new ResponseModeError(
         ResponseMode.Encrypt,
@@ -367,9 +342,6 @@ describe('encrypt-submission.controller', () => {
       })
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new ForbiddenFormError('no access')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -405,9 +377,6 @@ describe('encrypt-submission.controller', () => {
       })
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new FormNotFoundError('not found')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -443,9 +412,6 @@ describe('encrypt-submission.controller', () => {
       })
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new FormDeletedError('already archived')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -522,15 +488,6 @@ describe('encrypt-submission.controller', () => {
       const mockErrorString = 'error retrieving metadata'
       const mockRes = expressHandler.mockResponse()
       // Mock service result.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getSubmissionMetadata.mockReturnValueOnce(
         errAsync(new DatabaseError(mockErrorString)),
       )
@@ -568,15 +525,6 @@ describe('encrypt-submission.controller', () => {
       const mockErrorString = 'error retrieving metadata list'
       const mockRes = expressHandler.mockResponse()
       // Mock service result.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getSubmissionMetadataList.mockReturnValueOnce(
         errAsync(new DatabaseError(mockErrorString)),
       )

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -6,8 +6,6 @@ import JSONStream from 'JSONStream'
 import mongoose from 'mongoose'
 import { SetOptional } from 'type-fest'
 
-import { ErrorDto } from 'src/types/api'
-
 import { aws as AwsConfig } from '../../../../config/config'
 import { createLoggerWithLabel } from '../../../../config/logger'
 import {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -646,9 +646,10 @@ export const handleGetMetadata: RequestHandler<
         // Step 4a: Retrieve specific submission id.
         if (submissionId) {
           return getSubmissionMetadata(formId, submissionId).map((metadata) => {
-            return metadata
+            const metadataList: SubmissionMetadataList = metadata
               ? { metadata: [metadata], count: 1 }
               : { metadata: [], count: 0 }
+            return metadataList
           })
         }
         // Step 4b: Retrieve all submissions of given form id.

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -23,7 +23,7 @@ import { CaptchaFactory } from '../../../services/captcha/captcha.factory'
 import { checkIsEncryptedEncoding } from '../../../utils/encryption'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { getFormAfterPermissionChecks } from '../../auth/auth.service'
-import { DatabaseError, MissingFeatureError } from '../../core/core.errors'
+import { MissingFeatureError } from '../../core/core.errors'
 import { PermissionLevel } from '../../form/admin-form/admin-form.types'
 import * as FormService from '../../form/form.service'
 import { isFormEncryptMode } from '../../form/form.utils'
@@ -642,7 +642,7 @@ export const handleGetMetadata: RequestHandler<
       // Step 3: Check whether form is encrypt mode.
       .andThen(checkFormIsEncryptMode)
       // Step 4: Retrieve submission metadata.
-      .andThen<SubmissionMetadataList, DatabaseError>(() => {
+      .andThen(() => {
         // Step 4a: Retrieve specific submission id.
         if (submissionId) {
           return getSubmissionMetadata(formId, submissionId).map((metadata) => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -12,6 +12,7 @@ import {
   SubmissionCursorData,
   SubmissionData,
   SubmissionMetadata,
+  SubmissionMetadataList,
 } from '../../../../types'
 import { getEncryptSubmissionModel } from '../../../models/submission.server.model'
 import { isMalformedDate } from '../../../utils/date'
@@ -247,10 +248,7 @@ export const getSubmissionMetadata = (
 export const getSubmissionMetadataList = (
   formId: string,
   page?: number,
-): ResultAsync<
-  { metadata: SubmissionMetadata[]; count: number },
-  DatabaseError
-> => {
+): ResultAsync<SubmissionMetadataList, DatabaseError> => {
   return ResultAsync.fromPromise(
     EncryptSubmissionModel.findAllMetadataByFormId(formId, { page }),
     (error) => {

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -41,15 +41,6 @@ let authActiveForm = (requiredPermission) => [
   auth.verifyPermission(requiredPermission),
 ]
 
-/**
- * Ensures that user has read permissions,form is encrypt-mode and
- * form admin is encrypt beta-enabled.
- */
-const authEncryptedResponseAccess = [
-  authActiveForm(PermissionLevel.Read),
-  adminForms.isFormEncryptMode,
-]
-
 module.exports = function (app) {
   /**
    * @typedef ErrorMessage

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -545,6 +545,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions/count').get(
+    withUserAuthentication,
     celebrate({
       [Segments.QUERY]: Joi.object()
         .keys({
@@ -555,7 +556,6 @@ module.exports = function (app) {
         })
         .and('startDate', 'endDate'),
     }),
-    withUserAuthentication,
     AdminFormController.handleCountFormSubmissions,
   )
 

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -576,7 +576,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata').get(
-    authEncryptedResponseAccess,
+    withUserAuthentication,
     celebrate({
       [Segments.QUERY]: {
         submissionId: Joi.string().optional(),

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -15,6 +15,10 @@ export type SubmissionMetadata = {
   submissionTime: string
 }
 
+export type SubmissionMetadataList = {
+  metadata: SubmissionMetadata[]
+  count: number
+}
 export interface ISubmission {
   form: IFormSchema['_id']
   authType?: AuthType


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR cleans up the janky `authEncryptedResponseAccess` middleware used in the `/adminform/submissions/metadata` endpoint and collapses the used middlewares in the `handleGetMetadata` controller handler.

This PR is just one of the few PRs needed to remove total usage of the `authEncryptedResponseAccess` middleware.

Related to #1434

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- feat: inline auth middlewares for `handleGetMetadata`
- move `withUserAuthentication` middleware of submissions count API route to execute first

## Tests
<!-- What tests should be run to confirm functionality? -->
- unit tests have been added for the refactored controller handler function

### Manual tests
- [ ] Go to view responses for a storage mode form. The list of responses should be shown properly.
