### PR TITLE
ref: collapse middlewares of GET /:formId/adminform/submissions route

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -72,6 +72,16 @@ describe('encrypt-submission.controller', () => {
       },
     })
 
+    beforeEach(() => {
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValue(
+        ok(MOCK_FORM as IPopulatedEncryptedForm),
+      )
+    })
+
     it('should return 200 with encrypted response', async () => {
       // Arrange
       const mockSubData: SubmissionData = {
@@ -87,15 +97,6 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Mock service responses.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
         okAsync(mockSubData),
       )
@@ -134,13 +135,6 @@ describe('encrypt-submission.controller', () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-
       const expectedError = new ResponseModeError(
         ResponseMode.Encrypt,
         ResponseMode.Email,
@@ -166,9 +160,6 @@ describe('encrypt-submission.controller', () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new ForbiddenFormError('no access')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -191,9 +182,6 @@ describe('encrypt-submission.controller', () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new FormNotFoundError('not found')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -214,15 +202,6 @@ describe('encrypt-submission.controller', () => {
 
     it('should return 404 when submissionId cannot be found in the database', async () => {
       // Arrange
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       const mockErrorString = 'not found'
       MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
         errAsync(new SubmissionNotFoundError(mockErrorString)),
@@ -254,9 +233,6 @@ describe('encrypt-submission.controller', () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
 
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
       const expectedError = new FormDeletedError('already archived')
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         errAsync(expectedError),
@@ -302,15 +278,6 @@ describe('encrypt-submission.controller', () => {
 
     it('should return 500 when database error occurs whilst retrieving submission data', async () => {
       // Arrange
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       const mockErrorString = 'database error occurred'
       MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
         errAsync(new DatabaseError(mockErrorString)),
@@ -340,15 +307,6 @@ describe('encrypt-submission.controller', () => {
 
     it('should return 500 when error occurs whilst generating presigned URLs', async () => {
       // Arrange
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
-        ok(MOCK_FORM as IPopulatedEncryptedForm),
-      )
       const mockErrorString = 'presigned url error occured'
       MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
         okAsync({} as SubmissionData),

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
@@ -1,0 +1,41 @@
+import { ObjectId } from 'bson-ext'
+import moment from 'moment-timezone'
+
+import { SubmissionData } from 'src/types'
+
+import { createEncryptedSubmissionDto } from '../encrypt-submission.utils'
+
+describe('encrypt-submission.utils', () => {
+  describe('createEncryptedSubmissionDto', () => {
+    it('should create an encrypted submission DTO sucessfully', () => {
+      // Arrange
+      const createdDate = new Date()
+      const submissionData = {
+        _id: new ObjectId(),
+        created: createdDate,
+        encryptedContent: 'some encrypted content',
+        verifiedContent: 'some verified content',
+      } as SubmissionData
+      const attachmentPresignedUrls = {
+        someSubmissionId: 'some presigned url',
+      }
+
+      // Act
+      const actual = createEncryptedSubmissionDto(
+        submissionData,
+        attachmentPresignedUrls,
+      )
+
+      // Assert
+      expect(actual).toEqual({
+        refNo: submissionData._id,
+        submissionTime: moment(submissionData.created)
+          .tz('Asia/Singapore')
+          .format('ddd, D MMM YYYY, hh:mm:ss A'),
+        content: submissionData.encryptedContent,
+        verified: submissionData.verifiedContent,
+        attachmentMetadata: attachmentPresignedUrls,
+      })
+    })
+  })
+})

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -575,6 +575,7 @@ export const handleGetEncryptedResponse: RequestHandler<
             action: 'handleGetEncryptedResponse',
             submissionId,
             formId,
+            ...createReqMeta(req),
           },
           error,
         })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -521,8 +521,13 @@ export const handleStreamEncryptedResponses: RequestHandler<
  * Handler for GET /:formId/adminform/submissions
  *
  * @returns 200 with encrypted submission data response
- * @returns 404 if submissionId cannot be found in the database
- * @returns 500 if any errors occurs in database query or generating signed URL
+ * @returns 400 when form is not an encrypt mode form
+ * @returns 403 when user does not have read permissions for form
+ * @returns 404 when submissionId cannot be found in the database
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when any errors occurs in database query or generating signed URL
  */
 export const handleGetEncryptedResponse: RequestHandler<
   { formId: string },

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -1,6 +1,8 @@
 import { StatusCodes } from 'http-status-codes'
+import moment from 'moment-timezone'
 
 import { createLoggerWithLabel } from '../../../../config/logger'
+import { EncryptedSubmissionDto, SubmissionData } from '../../../../types'
 import { MapRouteError } from '../../../../types/routing'
 import {
   CaptchaConnectionError,
@@ -167,5 +169,24 @@ export const mapRouteError: MapRouteError = (
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: 'Something went wrong. Please try again.',
       }
+  }
+}
+
+/**
+ * Creates and returns an EncryptedSubmissionDto object from submissionData and
+ * attachment presigned urls.
+ */
+export const createEncryptedSubmissionDto = (
+  submissionData: SubmissionData,
+  attachmentPresignedUrls: Record<string, string>,
+): EncryptedSubmissionDto => {
+  return {
+    refNo: submissionData._id,
+    submissionTime: moment(submissionData.created)
+      .tz('Asia/Singapore')
+      .format('ddd, D MMM YYYY, hh:mm:ss A'),
+    content: submissionData.encryptedContent,
+    verified: submissionData.verifiedContent,
+    attachmentMetadata: attachmentPresignedUrls,
   }
 }

--- a/src/app/routes/admin-forms.server.routes.js
+++ b/src/app/routes/admin-forms.server.routes.js
@@ -523,7 +523,7 @@ module.exports = function (app) {
    * @security OTP
    */
   app.route('/:formId([a-fA-F0-9]{24})/adminform/submissions').get(
-    authEncryptedResponseAccess,
+    withUserAuthentication,
     celebrate({
       [Segments.QUERY]: {
         submissionId: Joi.string()

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -15,6 +15,14 @@ export type SubmissionMetadata = {
   submissionTime: string
 }
 
+export type EncryptedSubmissionDto = {
+  refNo: IEncryptedSubmissionSchema['_id']
+  submissionTime: string
+  content: IEncryptedSubmissionSchema['encryptedContent']
+  verified: IEncryptedSubmissionSchema['verifiedContent']
+  attachmentMetadata: Record<string, string>
+}
+
 export interface ISubmission {
   form: IFormSchema['_id']
   authType?: AuthType


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR cleans up the janky `authEncryptedResponseAccess` middleware used in the `/adminform/submissions` endpoint and collapses the used middlewares in the `handleGetEncryptedResponse` controller handler.

This PR is just one of the few PRs needed to remove total usage of the `authEncryptedResponseAccess` middleware.

Related to #1434

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- feat: inline auth middlewares for `handleGetEncryptedResponse`

## Tests
<!-- What tests should be run to confirm functionality? -->
- unit tests have been added for the refactored controller handler function

### Manual tests
- [ ] Go to view responses for a storage mode form. 
  - [ ] Click into a single response without attachments. The data should decrypt properly and show no attachments to download.
  - [ ] Click into a single response with attachments. The data should decrypt properly and show attachments to download.
