### PR TITLE
refactor(corppass-ui): make ui changes for corppass

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -258,6 +258,14 @@
                     class="radiomark"
                     ng-class="tempForm.authType === type.val ? 'blue-border' : ''"
                   ></span>
+                  <i
+                    class="glyphicon glyphicon-question-sign"
+                    uib-tooltip="Corppass no longer has its own login page, and now uses 
+                    Singpass to authenticate corporate users. You will still need a 
+                    separate Corppass e-service ID."
+                    tooltip-trigger="'click mouseenter'"
+                    ng-if="type.val === 'CP'"
+                  ></i>
                 </label>
               </div>
               <div

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -171,17 +171,17 @@ function settingsFormDirective(
           },
           {
             val: 'SP',
-            name: 'SingPass',
+            name: 'Singpass',
             isEnabledInStorageMode: true,
           },
           {
             val: 'MyInfo',
-            name: 'SingPass (MyInfo)',
+            name: 'Singpass (MyInfo)',
             isEnabledInStorageMode: false,
           },
           {
             val: 'CP',
-            name: 'CorpPass',
+            name: 'Singpass (Corporate)',
             isEnabledInStorageMode: true,
           },
         ]

--- a/src/public/modules/forms/admin/views/activate-form.client.modal.html
+++ b/src/public/modules/forms/admin/views/activate-form.client.modal.html
@@ -27,13 +27,13 @@
           <div class="field-description">
             <span ng-if="vm.esrvcIdError.errorCode">
               {{ (['SP', 'MyInfo'].includes(vm.esrvcIdError.authType) ?
-              'SingPass' : 'CorpPass') + ' returns the error code ' }}
+              'Singpass' : 'Corppass') + ' returns the error code ' }}
               <b>{{vm.esrvcIdError.errorCode}}</b>
               {{' for the e-service ID ' }} <b>{{vm.esrvcIdError.esrvcId}}</b>
             </span>
             <span ng-if="!vm.esrvcIdError.errorCode">
               {{ 'Could not connect to ' + (vm.esrvcIdError.authType === 'CP' ?
-              'CorpPass' : 'SingPass') + ' to check the e-service id '}}
+              'Corppass' : 'Singpass') + ' to check the e-service id '}}
               <b>{{vm.esrvcIdError.esrvcId}}</b>
             </span>
           </div>
@@ -48,7 +48,7 @@
         </div>
         <!-- Since CorpPass eservice id cannot be validated, remind user to check-->
         <div ng-if="vm.esrvcIdSuccess.authType === 'CP'">
-          <div class="field-title">This form uses CorpPass.</div>
+          <div class="field-title">This form uses Corppass.</div>
           <div class="field-description">
             Please make sure <b>{{vm.esrvcIdSuccess.esrvcId}}</b> is the correct
             e-service ID

--- a/src/public/modules/forms/admin/views/edit-myinfo-field.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-myinfo-field.client.modal.html
@@ -56,7 +56,7 @@
             <a
               translate-attr="{ href: 'LINKS.SINGPASS_ELIGIBILITY_FAQ' }"
               target="_blank"
-              >SingPass</a
+              >Singpass</a
             >
           </div>
         </div>

--- a/src/public/modules/forms/base/componentViews/end-page.html
+++ b/src/public/modules/forms/base/componentViews/end-page.html
@@ -12,7 +12,7 @@
         <p ng-bind-html="vm.paragraph | linky:'_blank'"></p>
       </div>
       <div class="end-page-follow-up" ng-if="vm.authType === 'MyInfo'">
-        <p>You will be automatically logged out of SingPass.</p>
+        <p>You will be automatically logged out of Singpass.</p>
       </div>
 
       <div id="end-page-btn-link">

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -54,20 +54,20 @@
             ng-if="['SP', 'MyInfo'].includes(vm.authType) && !vm.userName && !vm.isTemplate"
             ng-disabled="vm.isAdminPreview"
           >
-            <span>Log in with SingPass</span>
+            <span>Login with Singpass</span>
             <span class="hidden-xs">
               <i class="bx bx-log-in"></i>
             </span>
           </button>
           <button
             type="button"
-            class="start-page-btn {{ vm.colorTheme }}-font"
+            class="start-page-btn {{ vm.colorTheme }}-font start-page-multiline-btn"
             ng-click="vm.formLogin({ authType: 'CP', rememberMe: false })"
             ng-if="vm.authType==='CP' && !vm.userName && !vm.isTemplate"
             ng-disabled="vm.isAdminPreview"
           >
-            <span>Log in with CorpPass</span>
-            <span class="hidden-xs">
+            <span>Login with Singpass (Corporate)</span>
+            <span class="hidden-xs start-page-multiline-btn-decorator">
               <i class="bx bx-log-in"></i>
             </span>
           </button>
@@ -100,13 +100,20 @@
               ng-if="['SP', 'MyInfo'].includes(vm.authType)"
               class="form-locked-msg padded-view"
             >
-              Login with SingPass to access this form. Your SingPass ID will be
+              Login with Singpass to access this form. Your Singpass ID will be
               included with your form submission.
             </div>
             <div ng-if="vm.authType==='CP'" class="form-locked-msg padded-view">
-              Login with CorpPass to access this form. Your Entity ID and
-              CorpPass ID will be included with your form submission.
+              Corporate entity login is required for this form. Your Singpass ID
+              and corporate Entity ID will be included with your form
+              submission.
             </div>
+          </div>
+          <div
+            ng-if="vm.authType==='CP' && (vm.userName || vm.isTemplate)"
+            class="form-locked-msg padded-view"
+          >
+            <div>Logged in as corporate user</div>
           </div>
           <label
             class="remember-me-btn"

--- a/src/public/modules/forms/base/css/start-end-page.css
+++ b/src/public/modules/forms/base/css/start-end-page.css
@@ -255,6 +255,16 @@
   width: 100%;
 }
 
+#start-page-main-container .start-page-multiline-btn {
+  height: auto;
+  max-width: max-content;
+}
+
+#start-page-main-container .start-page-multiline-btn-decorator {
+  display: flex;
+  align-items: center;
+}
+
 #start-page-main-container .start-page-btn {
   margin: 39px auto 0 auto;
 }

--- a/src/public/modules/forms/base/css/start-end-page.css
+++ b/src/public/modules/forms/base/css/start-end-page.css
@@ -258,6 +258,7 @@
 #start-page-main-container .start-page-multiline-btn {
   height: auto;
   max-width: max-content;
+  padding: 17px 30px;
 }
 
 #start-page-main-container .start-page-multiline-btn-decorator {

--- a/src/public/translations/en-SG/landing.json
+++ b/src/public/translations/en-SG/landing.json
@@ -63,16 +63,16 @@
     "SUBSECTION_3": {
       "HEADER": "Integrated with government systems",
       "POINT_1": {
-        "TITLE": "SingPass",
-        "TEXT": "With the push of a button you can authenticate citizens filling in your form with SingPass Login"
+        "TITLE": "Singpass",
+        "TEXT": "With the push of a button you can authenticate citizens filling in your form with Singpass Login"
       },
       "POINT_2": {
-        "TITLE": "CorpPass",
-        "TEXT": "With the push of a button you can enable CorpPass Login on your form to authenticate companies"
+        "TITLE": "Corppass",
+        "TEXT": "With the push of a button you can enable Corppass Login on your form to authenticate companies"
       },
       "POINT_3": {
         "TITLE": "MyInfo",
-        "TEXT": "Select which MyInfo fields you want to collect. These fields will be pre-filled once citizens log in through SingPass"
+        "TEXT": "Select which MyInfo fields you want to collect. These fields will be pre-filled once citizens log in through Singpass"
       }
     }
   },

--- a/tests/end-to-end/helpers/selectors.js
+++ b/tests/end-to-end/helpers/selectors.js
@@ -192,7 +192,7 @@ const formPage = {
   },
   submitBtn: Selector('#form-submit button'),
   spcpLoginBtn: Selector('#start-page-btn-container button span').withText(
-    'LOG IN',
+    'LOGIN',
   ),
   spcpLogoutBtn: Selector('#start-page-btn-container button span').withText(
     'LOG OUT',

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -1131,7 +1131,7 @@ const expectSpcpLogin = async (t, authType, authData) => {
     case 'MyInfo':
       await t
         .expect(formPage.spcpLoginBtn.textContent)
-        .contains(`Log in with SingPass`)
+        .contains(`Login with Singpass`)
         .click(formPage.spcpLoginBtn)
         .click(mockpass.loginBtn)
         .click(mockpass.nricDropdownBtn)
@@ -1143,7 +1143,7 @@ const expectSpcpLogin = async (t, authType, authData) => {
     case 'SP':
       await t
         .expect(formPage.spcpLoginBtn.textContent)
-        .contains(`Log in with SingPass`)
+        .contains(`Login with Singpass`)
         .click(formPage.spcpLoginBtn)
         .click(mockpass.loginBtn)
         .click(mockpass.nricDropdownBtn)
@@ -1154,7 +1154,7 @@ const expectSpcpLogin = async (t, authType, authData) => {
     case 'CP':
       await t
         .expect(formPage.spcpLoginBtn.textContent)
-        .contains(`Log in with CorpPass`)
+        .contains(`Login with Singpass (Corporate)`)
         .click(formPage.spcpLoginBtn)
         .click(mockpass.loginBtn)
         .click(mockpass.nricDropdownBtn)


### PR DESCRIPTION
## Problem

Make appropriate UI updates to FormSG to prepare for Corppass migration.

Closes #1446

## Solution
<!-- How did you solve the problem? -->

**Features**:

- update copy for ui
- update all mentions of singpass and corppass to use new casing
- make necessary frontend changes for corporate singpass button
- add tooltip beside corppass option in settings > enable authentication
- update e2e tests for new changes

## Before & After Screenshots
<details>
<summary> Click here to show screenshots </summary>

**BEFORE**:
<img width="1792" alt="Screenshot 2021-03-31 at 4 08 56 PM" src="https://user-images.githubusercontent.com/21305518/113112465-c6256f80-923b-11eb-9869-59b768c256ee.png">
<img width="1792" alt="Screenshot 2021-03-31 at 4 10 19 PM" src="https://user-images.githubusercontent.com/21305518/113112485-c9b8f680-923b-11eb-9122-b58a55134fc7.png">
<img width="1792" alt="Screenshot 2021-03-31 at 4 09 51 PM" src="https://user-images.githubusercontent.com/21305518/113112489-cb82ba00-923b-11eb-9c6a-ce8c37e86161.png">

**AFTER**:
<img width="1792" alt="Screenshot 2021-03-31 at 3 31 36 PM" src="https://user-images.githubusercontent.com/21305518/113112551-df2e2080-923b-11eb-85ed-958988d8922e.png">
<img width="1792" alt="Screenshot 2021-03-31 at 3 31 51 PM" src="https://user-images.githubusercontent.com/21305518/113112525-d76e7c00-923b-11eb-8d85-cbbb22def783.png">
<img width="1792" alt="Screenshot 2021-03-31 at 3 32 25 PM" src="https://user-images.githubusercontent.com/21305518/113112529-d9383f80-923b-11eb-8760-75b7f1fb70ed.png">
![Screenshot 2021-04-05 at 2 06 30 PM](https://user-images.githubusercontent.com/21305518/113546954-98676e80-961f-11eb-9541-c831059e5fae.png)
<img width="1138" alt="Screenshot 2021-03-31 at 3 24 11 PM" src="https://user-images.githubusercontent.com/21305518/113112546-ddfcf380-923b-11eb-9df7-5d7ed7c90478.png">
<img width="1792" alt="Screenshot 2021-03-31 at 3 22 08 PM" src="https://user-images.githubusercontent.com/21305518/113112540-dc333000-923b-11eb-8d45-c216803bf078.png">
<img width="1792" alt="Screenshot 2021-03-31 at 3 31 01 PM" src="https://user-images.githubusercontent.com/21305518/113112548-de958a00-923b-11eb-81d2-9926d988be56.png">
</details>

## Tests

### Login button for CorpPass-authenticated forms
- [ ] Should now display the text "Login with Singpass (Corporate)"
- [ ] Should resize automatically based on viewport width (e.g: one line on desktop, two or more lines on mobile)
- [ ] Text below button should now read "Login with CorpPass to access this form. Your Entity ID and CorpPass ID will be included with your form submission."
### Login button for SingPass-authenticated forms
- [ ] Should now display the text "Login with Singpass"
### Post-CorpPass-authentication redirect page (Both Admin Preview and normal user views)
- [ ] Text beneath log out button should read "Logged in as corporate user"
### Form > Settings > Authentication
- [ ] Check that tooltip appears next to "Corppass" and displays text "Corppass no longer has its own login page, and now uses Singpass to authenticate corporate users. You will still need a separate Corppass e-service ID." when moused-over.