### PR TITLE
refactor: convert submission limit service function to ResultAsync

### DIFF
--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -302,7 +302,12 @@ describe('FormService', () => {
       )
 
       // Assert
-      expect(actual._unsafeUnwrapErr()).toEqual(new PrivateFormError())
+      expect(actual._unsafeUnwrapErr()).toEqual(
+        new PrivateFormError(
+          'Submission made after form submission limit was reached',
+          form.title,
+        ),
+      )
       const updated = await Form.findById(form._id)
       expect(updated!.status).toBe('PRIVATE')
     })

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -31,7 +31,13 @@ import {
   isProcessedCheckboxResponse,
   isProcessedTableResponse,
 } from '../../../utils/field-validation/field-validation.guards'
-import { DatabaseError, MissingFeatureError } from '../../core/core.errors'
+import {
+  DatabaseConflictError,
+  DatabaseError,
+  DatabasePayloadSizeError,
+  DatabaseValidationError,
+  MissingFeatureError,
+} from '../../core/core.errors'
 import {
   FormDeletedError,
   FormNotFoundError,
@@ -320,6 +326,12 @@ export const mapRouteError: MapRouteError = (error) => {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
         errorMessage: 'Submission could not be parsed.',
       }
+    case DatabasePayloadSizeError:
+      return {
+        statusCode: StatusCodes.REQUEST_TOO_LONG,
+        errorMessage:
+          'Submission too large to be saved. Please reduce the size of your submission and try again.',
+      }
     case InvalidFileExtensionError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
@@ -330,6 +342,7 @@ export const mapRouteError: MapRouteError = (error) => {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: 'Please keep the size of your attachments under 7MB.',
       }
+    case DatabaseConflictError:
     case ConflictError:
       return {
         statusCode: StatusCodes.CONFLICT,
@@ -339,6 +352,7 @@ export const mapRouteError: MapRouteError = (error) => {
     case ProcessingError:
     case ValidateFieldError:
     case ResponseModeError:
+    case DatabaseValidationError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -10,7 +10,10 @@ import {
   VerifyCaptchaError,
 } from '../../../services/captcha/captcha.errors'
 import {
+  DatabaseConflictError,
   DatabaseError,
+  DatabasePayloadSizeError,
+  DatabaseValidationError,
   MalformedParametersError,
   MissingFeatureError,
 } from '../../core/core.errors'
@@ -137,13 +140,21 @@ export const mapRouteError: MapRouteError = (
         errorMessage:
           'Invalid data was found. Please check your responses and submit again.',
       }
+    case DatabasePayloadSizeError:
+      return {
+        statusCode: StatusCodes.REQUEST_TOO_LONG,
+        errorMessage:
+          'Submission too large to be saved. Please reduce the size of your submission and try again.',
+      }
     case ValidateFieldError:
+    case DatabaseValidationError:
     case ProcessingError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
       }
+    case DatabaseConflictError:
     case ConflictError:
       return {
         statusCode: StatusCodes.CONFLICT,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The `checkFormSubmissionLimitAndDeactivateForm` function returns a `Promise<Result>` instead of `ResultAsync`, making it impossible to chain with other async operations using `andThen`.

## Solution
<!-- How did you solve the problem? -->

Refactor the function to return a `ResultAsync` instead. In the process, the return type was expanded to include `PossibleDatabaseError`. This made it necessary to include all the `PossibleDatabaseError` types in the respective `mapRouteError` functions used by controllers which depend on `checkFormSubmissionLimitAndDeactivateForm`.