### PR TITLE
Test: publicform integration tests

### DIFF
--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -952,10 +952,11 @@ describe('public-form.controller', () => {
         // Arrange
         // 1. Mock the response
         const mockRes = expressHandler.mockResponse()
+        const MOCK_FORM_TITLE = 'private form'
 
         // 2. Mock the call to retrieve the form
         MockAuthService.getFormIfPublic.mockReturnValueOnce(
-          errAsync(new PrivateFormError(MOCK_ERROR_STRING, 'private form')),
+          errAsync(new PrivateFormError(MOCK_ERROR_STRING, MOCK_FORM_TITLE)),
         )
 
         // Act
@@ -977,6 +978,8 @@ describe('public-form.controller', () => {
         expect(mockRes.status).toHaveBeenCalledWith(404)
         expect(mockRes.json).toHaveBeenCalledWith({
           message: MOCK_ERROR_STRING,
+          formTitle: MOCK_FORM_TITLE,
+          isPageFound: true,
         })
       })
     })

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -1,5 +1,5 @@
 import SPCPAuthClient from '@opengovsg/spcp-auth-client'
-import _ from 'lodash'
+import { ObjectId } from 'bson-ext'
 import { errAsync } from 'neverthrow'
 import supertest, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
@@ -196,7 +196,7 @@ describe('public-form.routes', () => {
         usedCount: 0,
         state: MyInfoCookieState.Success,
       })
-      const MOCK_FORM_ID = _.pad('', 24, '1')
+      const MOCK_FORM_ID = new ObjectId().toHexString()
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
           message: 'Form not found',
@@ -223,8 +223,9 @@ describe('public-form.routes', () => {
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
-          message:
-            'If you think this is a mistake, please contact the agency that gave you the form link.',
+          message: form.inactiveMessage,
+          formTitle: form.title,
+          isPageFound: true,
         }),
       )
 

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -1,0 +1,279 @@
+import SPCPAuthClient from '@opengovsg/spcp-auth-client'
+import _ from 'lodash'
+import { errAsync } from 'neverthrow'
+import supertest, { Session } from 'supertest-session'
+import { mocked } from 'ts-jest/utils'
+
+import { DatabaseError } from 'src/app/modules/core/core.errors'
+import { MYINFO_COOKIE_NAME } from 'src/app/modules/myinfo/myinfo.constants'
+import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
+import { AuthType, Status } from 'src/types'
+
+import { setupApp } from 'tests/integration/helpers/express-setup'
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import * as AuthService from '../../../auth/auth.service'
+import { PublicFormRouter } from '../public-form.routes'
+
+jest.mock('@opengovsg/myinfo-gov-client', () => ({
+  MyInfoGovClient: jest.fn().mockImplementation(() => ({
+    getPerson: jest.fn().mockReturnValue({ uinFin: 'S1234567A' }),
+    extractUinFin: jest.fn().mockReturnValue('S1234567A'),
+  })),
+  MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
+  MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
+  MyInfoAddressType: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAddressType,
+  MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
+    .MyInfoAttribute,
+}))
+
+jest.mock('@opengovsg/spcp-auth-client')
+const MockSpcpAuthClient = mocked(SPCPAuthClient, true)
+
+const app = setupApp('/', PublicFormRouter, {
+  setupWithAuth: false,
+})
+
+describe('public-form.routes', () => {
+  let request: Session
+  const mockSpClient = mocked(MockSpcpAuthClient.mock.instances[0], true)
+  const mockCpClient = mocked(MockSpcpAuthClient.mock.instances[1], true)
+
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(async () => {
+    request = supertest(app)
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.restoreAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('GET /:formId/publicform', () => {
+    const MOCK_COOKIE_PAYLOAD = {
+      userName: 'mock',
+      rememberMe: false,
+    }
+
+    it('should return 200 with public form when form has AuthType.NIL and valid formId', async () => {
+      // Arrange
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: { status: Status.Public },
+      })
+      // NOTE: This is needed to inject admin info into the form
+      const fullForm = await dbHandler.getFullFormById(form._id)
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          form: fullForm.getPublicView(),
+          isIntranetUser: false,
+        }),
+      )
+
+      // Act
+      const actualResponse = await request.get(`/${form._id}/publicform`)
+
+      // Assert
+      expect(actualResponse.status).toEqual(200)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+
+    it('should return 200 with public form when form has AuthType.SP and valid formId', async () => {
+      // Arrange
+      mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
+        cb(null, {
+          userName: MOCK_COOKIE_PAYLOAD.userName,
+        }),
+      )
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          esrvcId: 'mockEsrvcId',
+          authType: AuthType.SP,
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+      const formId = form._id
+      // NOTE: This is needed to inject admin info into the form
+      const fullForm = await dbHandler.getFullFormById(formId)
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          form: fullForm?.getPublicView(),
+          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
+          isIntranetUser: false,
+        }),
+      )
+
+      // Act
+      // Set cookie on request
+      const actualResponse = await request
+        .get(`/${formId}/publicform`)
+        .set('Cookie', ['jwtSp=mockJwt'])
+
+      // Assert
+      expect(actualResponse.status).toEqual(200)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+    it('should return 200 with public form when form has AuthType.CP and valid formId', async () => {
+      // Arrange
+      mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
+        cb(null, {
+          userName: MOCK_COOKIE_PAYLOAD.userName,
+          userInfo: 'MyCorpPassUEN',
+        }),
+      )
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          esrvcId: 'mockEsrvcId',
+          authType: AuthType.CP,
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+      const formId = form._id
+      // NOTE: This is needed to inject admin info into the form
+      const fullForm = await dbHandler.getFullFormById(formId)
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          form: fullForm?.getPublicView(),
+          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
+          isIntranetUser: false,
+        }),
+      )
+
+      // Act
+      // Set cookie on request
+      const actualResponse = await request
+        .get(`/${formId}/publicform`)
+        .set('Cookie', ['jwtCp=mockJwt'])
+
+      // Assert
+      expect(actualResponse.status).toEqual(200)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+    it('should return 200 with public form when form has AuthType.MyInfo and valid formId', async () => {
+      // Arrange
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: {
+          esrvcId: 'mockEsrvcId',
+          authType: AuthType.MyInfo,
+          hasCaptcha: false,
+          status: Status.Public,
+        },
+      })
+      // NOTE: This is needed to inject admin info into the form
+      const fullForm = await dbHandler.getFullFormById(form._id)
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          form: fullForm.getPublicView(),
+          spcpSession: { userName: 'S1234567A' },
+          isIntranetUser: false,
+        }),
+      )
+      const cookie = JSON.stringify({
+        accessToken: 'mockAccessToken',
+        usedCount: 0,
+        state: MyInfoCookieState.Success,
+      })
+
+      // Act
+      const actualResponse = await request
+        .get(`/${form._id}/publicform`)
+        .set('Cookie', [
+          // The j: indicates that the cookie is in JSON
+          `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+        ])
+
+      // Assert
+      expect(actualResponse.status).toEqual(200)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+
+    it('should return 404 if the form does not exist', async () => {
+      // Arrange
+      const cookie = JSON.stringify({
+        accessToken: 'mockAccessToken',
+        usedCount: 0,
+        state: MyInfoCookieState.Success,
+      })
+      const MOCK_FORM_ID = _.pad('', 24, '1')
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          message: 'Form not found',
+        }),
+      )
+
+      // Act
+      const actualResponse = await request
+        .get(`/${MOCK_FORM_ID}/publicform`)
+        .set('Cookie', [
+          // The j: indicates that the cookie is in JSON
+          `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+        ])
+
+      // Assert
+      expect(actualResponse.status).toEqual(404)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+
+    it('should return 404 if the form is private', async () => {
+      // Arrange
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: { status: Status.Private },
+      })
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          message:
+            'If you think this is a mistake, please contact the agency that gave you the form link.',
+        }),
+      )
+
+      // Act
+      const actualResponse = await request.get(`/${form._id}/publicform`)
+
+      // Assert
+      expect(actualResponse.status).toEqual(404)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+
+    it('should return 410 if the form has been archived', async () => {
+      // Arrange
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: { status: Status.Archived },
+      })
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({
+          message: 'Gone',
+        }),
+      )
+
+      // Act
+      const actualResponse = await request.get(`/${form._id}/publicform`)
+
+      // Assert
+      expect(actualResponse.status).toEqual(410)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+
+    it('should return 500 if a database error occurs', async () => {
+      // Arrange
+      const { form } = await dbHandler.insertEmailForm({
+        formOptions: { status: Status.Public },
+      })
+      const expectedError = new DatabaseError('all your base are belong to us')
+      const expectedResponseBody = JSON.parse(
+        JSON.stringify({ message: expectedError.message }),
+      )
+      jest
+        .spyOn(AuthService, 'getFormIfPublic')
+        .mockReturnValueOnce(errAsync(expectedError))
+
+      // Act
+      const actualResponse = await request.get(`/${form._id}/publicform`)
+
+      // Assert
+      expect(actualResponse.status).toEqual(500)
+      expect(actualResponse.body).toEqual(expectedResponseBody)
+    })
+  })
+})

--- a/src/types/api/core.ts
+++ b/src/types/api/core.ts
@@ -1,3 +1,8 @@
-export type ErrorDto = {
+export interface ErrorDto {
   message: string
+}
+
+export interface PrivateFormErrorDto extends ErrorDto {
+  isPageFound: true
+  formTitle: string
 }

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -15,7 +15,6 @@ import {
   IUserSchema,
   ResponseMode,
 } from 'src/types'
-import { SettingsUpdateDto } from 'src/types/api'
 
 import MemoryDatabaseServer from 'tests/database'
 
@@ -220,16 +219,6 @@ const getFullFormById = async (
 ): Promise<IPopulatedForm | null> =>
   await getEmailFormModel(mongoose).getFullFormById(formId)
 
-// 1. Get full form by id
-// 2. Patch in new settings
-const updateForm = async (
-  formId: string,
-  settingsToUpdate: SettingsUpdateDto,
-): Promise<IFormSchema | null> =>
-  await getEmailFormModel(mongoose)
-    .findByIdAndUpdate(formId, settingsToUpdate)
-    .exec()
-
 const dbHandler = {
   connect,
   closeDatabase,
@@ -241,7 +230,6 @@ const dbHandler = {
   insertEmailForm,
   insertEncryptForm,
   getFullFormById,
-  updateForm,
 }
 
 export default dbHandler

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -11,9 +11,11 @@ import {
   IAgencySchema,
   IEmailFormSchema,
   IEncryptedFormSchema,
+  IPopulatedForm,
   IUserSchema,
   ResponseMode,
 } from 'src/types'
+import { SettingsUpdateDto } from 'src/types/api'
 
 import MemoryDatabaseServer from 'tests/database'
 
@@ -153,7 +155,6 @@ const insertEmailForm = async ({
   })
 
   const EmailFormModel = getEmailFormModel(mongoose)
-
   const form = await EmailFormModel.create({
     title: 'example form title',
     admin: user._id,
@@ -214,6 +215,21 @@ const insertEncryptForm = async ({
   }
 }
 
+const getFullFormById = async (
+  formId: string,
+): Promise<IPopulatedForm | null> =>
+  await getEmailFormModel(mongoose).getFullFormById(formId)
+
+// 1. Get full form by id
+// 2. Patch in new settings
+const updateForm = async (
+  formId: string,
+  settingsToUpdate: SettingsUpdateDto,
+): Promise<IFormSchema | null> =>
+  await getEmailFormModel(mongoose)
+    .findByIdAndUpdate(formId, settingsToUpdate)
+    .exec()
+
 const dbHandler = {
   connect,
   closeDatabase,
@@ -224,6 +240,8 @@ const dbHandler = {
   clearCollection,
   insertEmailForm,
   insertEncryptForm,
+  getFullFormById,
+  updateForm,
 }
 
 export default dbHandler


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
current public form end point does not have any integration tests and only has unit tests on the controller. this PR adds integration tests for HTTP errors.

Part of #1513 

## Solution
<!-- How did you solve the problem? -->
Added integration tests for `GET /:formId/publicform` endpoint. 