### PR TITLE
fix: convert bigint to string, not number to avoid losing fidelity

### DIFF
--- a/src/shared/util/stringify-safe.ts
+++ b/src/shared/util/stringify-safe.ts
@@ -18,9 +18,7 @@ import stringify from 'json-stringify-safe'
  * @param obj the object to be stringified
  */
 export const stringifySafe = (obj: any): string | undefined => {
-  const bigIntReplacer = (_key: any, value: any): any => {
-    // eslint-disable-next-line valid-typeof
-    return typeof value === 'bigint' ? Number(value) : value
-  }
-  return stringify(obj, bigIntReplacer)
+  return stringify(obj, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value,
+  )
 }

--- a/tests/unit/backend/utils/stringify-safe.spec.ts
+++ b/tests/unit/backend/utils/stringify-safe.spec.ts
@@ -1,14 +1,11 @@
-/* global BigInt */
+import { cloneDeep } from 'lodash'
 
-const {
-  stringifySafe,
-} = require('../../../../dist/backend/shared/util/stringify-safe')
-const { cloneDeep } = require('lodash')
+import { stringifySafe } from 'src/shared/util/stringify-safe'
 
 // Tests that the stringifySafe function works as expected, i.e. correctly
 // deals with circular references and BigInt.
 describe('Safe stringify function', () => {
-  let json, expected
+  let json: Record<string, any>, expected: Record<string, any>
   beforeEach(() => {
     json = {
       complicated: {
@@ -48,9 +45,15 @@ describe('Safe stringify function', () => {
 
     expect(stringifySafe(json)).toEqual(JSON.stringify(expected))
   })
-  it('should convert BigInt to Number', () => {
-    expected.bigInt = 10
+  it('should convert BigInt of < Number.MAX_SAFE_INTEGER to string', () => {
+    expected.bigInt = '10'
     json.bigInt = BigInt(10)
+    expect(stringifySafe(json)).toEqual(JSON.stringify(expected))
+  })
+
+  it('should convert BigInt of > Number.MAX_SAFE_INTEGER to string', () => {
+    expected.bigInt = '9007199254740995'
+    json.bigInt = BigInt('9007199254740995')
     expect(stringifySafe(json)).toEqual(JSON.stringify(expected))
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Fix bug where bigints > MAX_INTEGER would lose fidelity. Convert to string instead.

Also converted the test for stringift-safe.ts to Typescript.

Closes #1552 
