### PR TITLE
fix: fix consecutive storage mode responses downloads from failing

### DIFF
--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -274,6 +274,8 @@ function SubmissionsFactory(
       downloadAttachments,
       secretKey,
     ) {
+      // Clear current worker pool.
+      workerPool = []
       // Creates a new AbortController for every request
       downloadAbortController = new AbortController()
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When storage mode responses are downloaded consecutively, the `workerPool` array is not being cleared properly and thus CSV responses are being piped to workers that have already been killed in a previous run.

This PR fixes the issue by clearing the worker pool on invoking the download function.

Closes #1502

#### Graphical representation:
First run: push 3 workers
[ alive, alive, alive ]
End of first run, all killed
[ dead, dead, dead ]
Start of second run: push 3 more workers without clearing
[ dead, dead, dead, alive, alive, alive ]

posting message to dead workers in round robin fashion means that some csv responses will be piped to dead workers that will never respond, resulting in infinite loop in the final conditional check

```ts
experimentalCsvGenerator.length() + errorCount + unverifiedCount >= expectedNumResponses
```

since some csv records will not be created by dead workers

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- clear current worker pool on download fn invocation

## Manual Tests
- Attempt to download responses consecutively. The modal should not be stuck anymore and downloads should succeed.
