### PR TITLE
test: fix flakiness (again) by hardcoding created dates

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -4719,7 +4719,6 @@ describe('admin-form.routes', () => {
 
     it('should return 200 with stream of encrypted responses between given query.startDate and query.endDate', async () => {
       // Arrange
-      const now = new Date()
       const submissions = await Promise.all(
         times(5, (count) =>
           createSubmission({
@@ -4730,13 +4729,12 @@ describe('admin-form.routes', () => {
               ['fieldId1', `some.attachment.url.${count}`],
               ['fieldId2', `some.other.attachment.url.${count}`],
             ]),
-            created: now,
           }),
         ),
       )
-      // Set 2 submissions to be submitted 3-4 days ago.
-      submissions[2].created = subDays(now, 3)
-      submissions[4].created = subDays(now, 4)
+      // Set 2 submissions to be submitted with specific date
+      submissions[2].created = new Date('2020-02-03')
+      submissions[4].created = new Date('2020-02-04')
       await submissions[2].save()
       await submissions[4].save()
       const expectedSubmissionIds = [
@@ -4748,8 +4746,8 @@ describe('admin-form.routes', () => {
       const response = await request
         .get(`/${defaultForm._id}/adminform/submissions/download`)
         .query({
-          startDate: format(subDays(now, 4), 'yyyy-MM-dd'),
-          endDate: format(subDays(now, 3), 'yyyy-MM-dd'),
+          startDate: '2020-02-03',
+          endDate: '2020-02-04',
         })
         .buffer()
         .parse((res, cb) => {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -4732,9 +4732,12 @@ describe('admin-form.routes', () => {
           }),
         ),
       )
+
+      const startDateStr = '2020-02-03'
+      const endDateStr = '2020-02-04'
       // Set 2 submissions to be submitted with specific date
-      submissions[2].created = new Date('2020-02-03')
-      submissions[4].created = new Date('2020-02-04')
+      submissions[2].created = new Date(startDateStr)
+      submissions[4].created = new Date(endDateStr)
       await submissions[2].save()
       await submissions[4].save()
       const expectedSubmissionIds = [
@@ -4746,8 +4749,8 @@ describe('admin-form.routes', () => {
       const response = await request
         .get(`/${defaultForm._id}/adminform/submissions/download`)
         .query({
-          startDate: '2020-02-03',
-          endDate: '2020-02-04',
+          startDate: startDateStr,
+          endDate: endDateStr,
         })
         .buffer()
         .parse((res, cb) => {


### PR DESCRIPTION
Tests seems to still be failing for a particular test.
This PR (attempts) to fix the flakiness by using hardcoded dates instead of using relative dates for the affected test, which may behave differently in different machines (like CI/CD)