### PR TITLE
test: fix flaky form feedback test

### DIFF
--- a/src/app/modules/feedback/__tests__/feedback.service.spec.ts
+++ b/src/app/modules/feedback/__tests__/feedback.service.spec.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'bson-ext'
+import compareAsc from 'date-fns/compareAsc'
 import { times } from 'lodash'
 import moment from 'moment-timezone'
 import mongoose from 'mongoose'
@@ -126,7 +127,8 @@ describe('feedback.service', () => {
       })
       const expectedCreatedFbs = await Promise.all(expectedFbPromises)
       const expectedFeedbackList = expectedCreatedFbs
-        .sort((a, b) => a.created!.getTime() - b.created!.getTime())
+        // Feedback is returned in date order
+        .sort((a, b) => compareAsc(a.created!, b.created!))
         .map((fb, idx) => ({
           index: idx + 1,
           timestamp: moment(fb.created).valueOf(),

--- a/src/app/modules/feedback/__tests__/feedback.service.spec.ts
+++ b/src/app/modules/feedback/__tests__/feedback.service.spec.ts
@@ -125,15 +125,16 @@ describe('feedback.service', () => {
         rating: 1,
       })
       const expectedCreatedFbs = await Promise.all(expectedFbPromises)
-      const expectedFeedbackList = expectedCreatedFbs.map((fb, idx) => ({
-        index: idx + 1,
-        timestamp: moment(fb.created).valueOf(),
-        rating: fb.rating,
-        comment: fb.comment,
-        date: moment(fb.created).tz('Asia/Singapore').format('D MMM YYYY'),
-        dateShort: moment(fb.created).tz('Asia/Singapore').format('D MMM'),
-      }))
-
+      const expectedFeedbackList = expectedCreatedFbs
+        .sort((a, b) => a.created!.getTime() - b.created!.getTime())
+        .map((fb, idx) => ({
+          index: idx + 1,
+          timestamp: moment(fb.created).valueOf(),
+          rating: fb.rating,
+          comment: fb.comment,
+          date: moment(fb.created).tz('Asia/Singapore').format('D MMM YYYY'),
+          dateShort: moment(fb.created).tz('Asia/Singapore').format('D MMM'),
+        }))
       // Act
       const actualResult = await FeedbackService.getFormFeedbacks(mockFormId)
 


### PR DESCRIPTION
## Problem

Form feedback unit tests have been flaking for months because of a non-deterministic `expect` statement. The issue is that form feedback is sorted by creation order when it is retrieved, but the feedback documents in the test are created asynchronously, so sometimes the array of documents is not in the expected order.

## Solution

Sort the array of feedback documents before comparing.