### PR TITLE
chore: disable no-await-without-trycatch in backend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,7 +68,6 @@
       "files": ["*.ts", "*.js"],
       "excludedFiles": ["**/*.spec.ts", "**/.spec.js", "**/__tests__/**/*.ts"],
       "rules": {
-        "typesafe/no-await-without-trycatch": "warn",
         "@typescript-eslint/no-non-null-assertion": "error"
       }
     }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -392,7 +392,6 @@ export const handleStreamEncryptedResponses: RequestHandler<
   const { startDate, endDate } = req.query
 
   // Step 1: Retrieve currently logged in user.
-  // eslint-disable-next-line typesafe/no-await-without-trycatch
   const cursorResult = await getPopulatedUserById(sessionUserId)
     .andThen((user) =>
       // Step 2: Check whether user has read permissions to form


### PR DESCRIPTION
Disables the `no-await-without-trycatch` `eslint` plugin, which is no longer necessary as `neverthrow` is used throughout the backend.