### PR TITLE
fix: call correct user update emergency contact endpoint

### DIFF
--- a/src/public/modules/core/controllers/edit-contact-number-modal.client.controller.js
+++ b/src/public/modules/core/controllers/edit-contact-number-modal.client.controller.js
@@ -97,7 +97,7 @@ function EditContactNumberModalController(
     $scope.otpForm.otp.$setPristine()
     $scope.otpForm.otp.$setUntouched()
     $http
-      .post('/api/v3/user/otp/generate', {
+      .post('/api/v3/user/contact/otp/generate', {
         contact: vm.contact.number,
         userId: vm.user._id,
       })
@@ -126,7 +126,7 @@ function EditContactNumberModalController(
     vm.otp.isFetching = true
     // Check with backend if the otp is correct
     $http
-      .post('/api/v3/user/otp/verify', {
+      .post('/api/v3/user/contact/otp/verify', {
         contact: vm.contact.number,
         otp: vm.otp.value,
         userId: vm.user._id,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
updating admin user's contact number would fail since the generation and verification of OTP endpoint is incorrect

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- call correct user update emergency contact endpoints
