### PR TITLE
feat(admin-forms): implement retrieval of form settings

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -443,13 +443,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return { ...newForm, ...overrideProps }
   }
 
-  FormSchema.methods.pick = function (
-    this: IFormSchema,
-    fields: (keyof IFormSchema)[],
-  ) {
-    return pick(this, fields)
-  }
-
   FormSchema.methods.getPublicView = function (this: IFormSchema): PublicForm {
     const basePublicView = pick(this, FORM_PUBLIC_FIELDS) as PublicFormValues
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -443,6 +443,13 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return { ...newForm, ...overrideProps }
   }
 
+  FormSchema.methods.pick = function (
+    this: IFormSchema,
+    fields: (keyof IFormSchema)[],
+  ) {
+    return pick(this, fields)
+  }
+
   FormSchema.methods.getPublicView = function (this: IFormSchema): PublicForm {
     const basePublicView = pick(this, FORM_PUBLIC_FIELDS) as PublicFormValues
 
@@ -525,8 +532,9 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   FormSchema.statics.getFullFormById = async function (
     this: IFormModel,
     formId: string,
+    fields?: (keyof IPopulatedForm)[],
   ): Promise<IPopulatedForm | null> {
-    return this.findById(formId).populate({
+    return this.findById(formId, fields).populate({
       path: 'admin',
       populate: {
         path: 'agency',

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -291,8 +291,8 @@ export const getFormAfterPermissionChecks = ({
 }
 
 /**
- * Retrieves the form fields of given formId provided that the given user has the
- * required permissions.
+ * Ensures that the given user has the required pre-specified permissions
+ * for the form.
  *
  * @returns ok(form) if the user has the required permissions
  * @returns err(FormNotFoundError) if form does not exist in the database

--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -142,7 +142,7 @@ describe('FormService', () => {
     })
   })
 
-  describe('retrieveFormFieldsById', () => {
+  describe('retrieveFormKeysById', () => {
     it('should return form successfully', async () => {
       // Arrange
       const formId = new ObjectId().toHexString()
@@ -159,7 +159,7 @@ describe('FormService', () => {
         .mockResolvedValueOnce(expectedForm)
 
       // Act
-      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+      const actualResult = await FormService.retrieveFormKeysById(formId, [
         'title',
         'admin',
       ])
@@ -179,7 +179,7 @@ describe('FormService', () => {
         .mockResolvedValueOnce(null)
 
       // Act
-      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+      const actualResult = await FormService.retrieveFormKeysById(formId, [
         'title',
         'admin',
       ])
@@ -203,7 +203,7 @@ describe('FormService', () => {
         .mockResolvedValueOnce(expectedForm)
 
       // Act
-      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+      const actualResult = await FormService.retrieveFormKeysById(formId, [
         'title',
       ])
 
@@ -222,7 +222,7 @@ describe('FormService', () => {
         .mockRejectedValueOnce(new Error('Some error'))
 
       // Act
-      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+      const actualResult = await FormService.retrieveFormKeysById(formId, [
         'title',
         'admin',
       ])

--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -142,6 +142,98 @@ describe('FormService', () => {
     })
   })
 
+  describe('retrieveFormFieldsById', () => {
+    it('should return form successfully', async () => {
+      // Arrange
+      const formId = new ObjectId().toHexString()
+      const expectedForm = ({
+        _id: formId,
+        title: 'mock title',
+        admin: {
+          _id: new ObjectId(),
+          email: 'mockEmail@example.com',
+        },
+      } as unknown) as IPopulatedForm
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'getFullFormById')
+        .mockResolvedValueOnce(expectedForm)
+
+      // Act
+      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+        'title',
+        'admin',
+      ])
+
+      // Assert
+      expect(retrieveFormSpy).toHaveBeenCalledTimes(1)
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
+    })
+
+    it('should return FormNotFoundError if formId is invalid', async () => {
+      // Arrange
+      const formId = new ObjectId().toHexString()
+      // Resolve query to null.
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'getFullFormById')
+        .mockResolvedValueOnce(null)
+
+      // Act
+      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+        'title',
+        'admin',
+      ])
+
+      // Assert
+      expect(retrieveFormSpy).toHaveBeenCalledTimes(1)
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(FormNotFoundError)
+    })
+
+    it('should still return retrieved form even when it does not contain admin', async () => {
+      // Arrange
+      const formId = new ObjectId().toHexString()
+      const expectedForm = ({
+        _id: formId,
+        title: 'mock title',
+        // Note no admin key-value.
+      } as unknown) as IPopulatedForm
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'getFullFormById')
+        .mockResolvedValueOnce(expectedForm)
+
+      // Act
+      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+        'title',
+      ])
+
+      // Assert
+      expect(retrieveFormSpy).toHaveBeenCalledTimes(1)
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
+    })
+
+    it('should return DatabaseError when error occurs whilst querying database', async () => {
+      // Arrange
+      const formId = new ObjectId().toHexString()
+      // Mock rejection.
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'getFullFormById')
+        .mockRejectedValueOnce(new Error('Some error'))
+
+      // Act
+      const actualResult = await FormService.retrieveFormFieldsById(formId, [
+        'title',
+        'admin',
+      ])
+
+      // Assert
+      expect(retrieveFormSpy).toHaveBeenCalledTimes(1)
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+  })
+
   describe('retrieveFormById', () => {
     it('should return form successfully', async () => {
       // Arrange

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1048,9 +1048,7 @@ export const handleGetSettings: RequestHandler<
       })),
     )
     .andThen(AuthService.checkFormForPermissions(PermissionLevel.Read))
-    .map((form) =>
-      res.status(StatusCodes.OK).json(form.getSettings() as IPopulatedForm),
-    )
+    .map((form) => res.status(StatusCodes.OK).json(form.getSettings()))
     .mapErr((error) => {
       logger.error({
         message: 'Error occurred when retrieving form settings',

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -113,6 +113,39 @@ export const retrieveFullFormById = (
 }
 
 /**
+ * Retrieves the specified form fields of the given formId
+ * @param formId the id of the form
+ * @param fields an array of field names to retrieve
+ * @returns ok(form) if form exists
+ * @returns err(FormNotFoundError) if the form or form admin does not exist
+ * @returns err(DatabaseError) if error occurs whilst querying the database
+ */
+export const retrieveFormFields = (
+  formId: string,
+  fields: (keyof IPopulatedForm)[],
+): ResultAsync<IPopulatedForm, FormNotFoundError | DatabaseError> => {
+  if (!mongoose.Types.ObjectId.isValid(formId)) {
+    return errAsync(new FormNotFoundError())
+  }
+
+  return ResultAsync.fromPromise(
+    FormModel.getFullFormById(formId, fields),
+    (error) => {
+      logger.error({
+        message: 'Error retrieving form from database',
+        meta: {
+          action: 'retrieveFormFields',
+        },
+        error,
+      })
+      return new DatabaseError()
+    },
+  ).andThen((result) =>
+    result ? okAsync(result) : errAsync(new FormNotFoundError()),
+  )
+}
+
+/**
  * Retrieves (non-populated) form document of the given formId.
  * @param formId the id of the form to retrieve
  * @returns ok(form) if form exists

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -120,7 +120,7 @@ export const retrieveFullFormById = (
  * @returns err(FormNotFoundError) if the form or form admin does not exist
  * @returns err(DatabaseError) if error occurs whilst querying the database
  */
-export const retrieveFormFields = (
+export const retrieveFormFieldsById = (
   formId: string,
   fields: (keyof IPopulatedForm)[],
 ): ResultAsync<IPopulatedForm, FormNotFoundError | DatabaseError> => {
@@ -134,7 +134,7 @@ export const retrieveFormFields = (
       logger.error({
         message: 'Error retrieving form from database',
         meta: {
-          action: 'retrieveFormFields',
+          action: 'retrieveFormFieldsById',
         },
         error,
       })

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -120,7 +120,7 @@ export const retrieveFullFormById = (
  * @returns err(FormNotFoundError) if the form or form admin does not exist
  * @returns err(DatabaseError) if error occurs whilst querying the database
  */
-export const retrieveFormFieldsById = (
+export const retrieveFormKeysById = (
   formId: string,
   fields: (keyof IPopulatedForm)[],
 ): ResultAsync<IPopulatedForm, FormNotFoundError | DatabaseError> => {
@@ -134,7 +134,7 @@ export const retrieveFormFieldsById = (
       logger.error({
         message: 'Error retrieving form from database',
         meta: {
-          action: 'retrieveFormFieldsById',
+          action: 'retrieveFormKeysById',
         },
         error,
       })

--- a/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
@@ -32,42 +32,37 @@ const updateSettingsValidator = celebrate({
   }).min(1),
 })
 
-/**
- * Update form settings according to given subset of settings.
- * @route PATCH /admin/forms/:formId/settings
- * @group admin
- * @param body the subset of settings to patch
- * @produces application/json
- * @consumes application/json
- * @returns 200 with latest form settings on successful update
- * @returns 400 when given body fails Joi validation
- * @returns 401 when current user is not logged in
- * @returns 403 when current user does not have permissions to update form settings
- * @returns 404 when form to update settings for cannot be found
- * @returns 409 when saving form settings incurs a conflict in the database
- * @returns 410 when updating settings for archived form
- * @returns 413 when updating settings causes form to be too large to be saved in the database
- * @returns 422 when an invalid settings update is attempted on the form
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
- */
-AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/settings').patch(
-  updateSettingsValidator,
-  handleUpdateSettings,
-)
-
-/**
- * Retrieve the settings of the specified form
- * @route GET /admin/forms/:formId/settings
- * @group admin
- * @produces application/json
- * @returns 200 with latest form settings on successful update
- * @returns 401 when current user is not logged in
- * @returns 403 when current user does not have permissions to obtain form settings
- * @returns 404 when form to retrieve settings for cannot be found
- * @returns 409 when saving form settings incurs a conflict in the database
- * @returns 500 when database error occurs
- */
-AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/settings').get(
-  handleGetSettings,
-)
+AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/settings')
+  /**
+   * Update form settings according to given subset of settings.
+   * @route PATCH /admin/forms/:formId/settings
+   * @group admin
+   * @param body the subset of settings to patch
+   * @produces application/json
+   * @consumes application/json
+   * @returns 200 with latest form settings on successful update
+   * @returns 400 when given body fails Joi validation
+   * @returns 401 when current user is not logged in
+   * @returns 403 when current user does not have permissions to update form settings
+   * @returns 404 when form to update settings for cannot be found
+   * @returns 409 when saving form settings incurs a conflict in the database
+   * @returns 410 when updating settings for archived form
+   * @returns 413 when updating settings causes form to be too large to be saved in the database
+   * @returns 422 when an invalid settings update is attempted on the form
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .patch(updateSettingsValidator, handleUpdateSettings)
+  /**
+   * Retrieve the settings of the specified form
+   * @route GET /admin/forms/:formId/settings
+   * @group admin
+   * @produces application/json
+   * @returns 200 with latest form settings on successful update
+   * @returns 401 when current user is not logged in
+   * @returns 403 when current user does not have permissions to obtain form settings
+   * @returns 404 when form to retrieve settings for cannot be found
+   * @returns 409 when saving form settings incurs a conflict in the database
+   * @returns 500 when database error occurs
+   */
+  .get(handleGetSettings)

--- a/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
@@ -3,7 +3,10 @@ import { Router } from 'express'
 
 import { AuthType, Status } from '../../../../../../types'
 import { SettingsUpdateDto } from '../../../../../../types/api'
-import { handleUpdateSettings } from '../../../../../modules/form/admin-form/admin-form.controller'
+import {
+  handleGetSettings,
+  handleUpdateSettings,
+} from '../../../../../modules/form/admin-form/admin-form.controller'
 
 export const AdminFormsSettingsRouter = Router()
 
@@ -51,4 +54,20 @@ const updateSettingsValidator = celebrate({
 AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/settings').patch(
   updateSettingsValidator,
   handleUpdateSettings,
+)
+
+/**
+ * Retrieve the settings of the specified form
+ * @route GET /admin/forms/:formId/settings
+ * @group admin
+ * @produces application/json
+ * @returns 200 with latest form settings on successful update
+ * @returns 401 when current user is not logged in
+ * @returns 403 when current user does not have permissions to obtain form settings
+ * @returns 404 when form to retrieve settings for cannot be found
+ * @returns 409 when saving form settings incurs a conflict in the database
+ * @returns 500 when database error occurs
+ */
+AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/settings').get(
+  handleGetSettings,
 )

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -196,10 +196,6 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   getDuplicateParams(
     overrideProps: OverrideProps,
   ): PickDuplicateForm & OverrideProps
-  /**
-   *
-   */
-  pick(fields: (keyof IFormSchema)[]): Pick<IFormSchema, keyof IFormSchema>
 }
 
 /**

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -196,6 +196,10 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   getDuplicateParams(
     overrideProps: OverrideProps,
   ): PickDuplicateForm & OverrideProps
+  /**
+   *
+   */
+  pick(fields: (keyof IFormSchema)[]): Pick<IFormSchema, keyof IFormSchema>
 }
 
 /**
@@ -248,7 +252,10 @@ export type IPopulatedEmailForm = IPopulatedForm & IEmailForm
 
 export interface IFormModel extends Model<IFormSchema> {
   getOtpData(formId: string): Promise<FormOtpData | null>
-  getFullFormById(formId: string): Promise<IPopulatedForm | null>
+  getFullFormById(
+    formId: string,
+    fields?: (keyof IPopulatedForm)[],
+  ): Promise<IPopulatedForm | null>
   deactivateById(formId: string): Promise<IFormSchema | null>
   getMetaByUserIdOrEmail(
     userId: IUserSchema['_id'],


### PR DESCRIPTION
## Problem
the retrieval counterpart to #1383 is missing

Fixes #1496 

## Solution
[form]
- augment `FormSchema.getFullFormById()`,
  which will partially populate an IPopulatedForm with specified keys,
  if given
- feed the `fields` argument supplied in the abovementioned fn as
  the projection arg of `Schema.findById()`
- implement `FormSchema.pick()`, allowing one to pick only the fields
  we want out of a given IFormSchema

[auth-service]
- implement `getFormFieldsAfterPermissionChecks()`, exploiting
  type-generic parameters to allow callers to specify the shape
  of the return value
- take care to only return fields specified by the caller

[admin-form]
- declare and implement `handleGetSettings()` in controller and route,
  taking inspiration from `handleUpdateSettings()`
  - import `FORM_SETTING_FIELDS` from form.server.model to specify the
    form setting fields we need

TODO: Unit-testing
