### PR TITLE
refactor: migrate GET /submission to new endpt

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -353,14 +353,7 @@ AdminFormsRouter.get(
 AdminFormsRouter.get(
   '/:formId([a-fA-F0-9]{24})/adminform/submissions',
   withUserAuthentication,
-  celebrate({
-    [Segments.QUERY]: {
-      submissionId: Joi.string()
-        .regex(/^[0-9a-fA-F]{24}$/)
-        .required(),
-    },
-  }),
-  EncryptSubmissionController.handleGetEncryptedResponse,
+  EncryptSubmissionController.handleGetEncryptedResponseUsingQueryParams,
 )
 
 /**

--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -336,6 +336,7 @@ AdminFormsRouter.get(
 
 /**
  * Retrieve actual response for a storage mode form
+ * @deprecated in favour of GET api/v3/admin/forms/:formId/submissions/:submissionId
  * @route GET /:formId/adminform/submissions
  * @security session
  *

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -29,7 +29,7 @@ import {
   SubmissionNotFoundError,
 } from '../../submission.errors'
 import {
-  handleGetEncryptedResponse,
+  getEncryptedResponseUsingQueryParams,
   handleGetMetadata,
   streamEncryptedResponses,
 } from '../encrypt-submission.controller'
@@ -45,7 +45,7 @@ const MockAuthService = mocked(AuthService)
 describe('encrypt-submission.controller', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  describe('handleGetEncryptedResponse', () => {
+  describe('getEncryptedResponseUsingQueryParams', () => {
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER_ID = new ObjectId().toHexString()
 
@@ -105,7 +105,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       const expected = {
@@ -144,7 +144,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(400)
@@ -166,7 +166,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(403)
@@ -188,7 +188,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(404)
@@ -209,7 +209,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(404)
@@ -239,7 +239,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(410)
@@ -261,7 +261,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(422)
@@ -285,7 +285,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
@@ -318,7 +318,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -29,8 +29,8 @@ import {
   SubmissionNotFoundError,
 } from '../../submission.errors'
 import {
-  getEncryptedResponse,
   getEncryptedResponseUsingQueryParams,
+  handleGetEncryptedResponse,
   handleGetMetadata,
   streamEncryptedResponses,
 } from '../encrypt-submission.controller'
@@ -340,7 +340,7 @@ describe('encrypt-submission.controller', () => {
     })
   })
 
-  describe('getEncryptedResponse', () => {
+  describe('handleGetEncryptedResponse', () => {
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER_ID = new ObjectId().toHexString()
 
@@ -399,7 +399,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       const expected = {
@@ -438,7 +438,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(400)
@@ -460,7 +460,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(403)
@@ -482,7 +482,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(404)
@@ -503,7 +503,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(404)
@@ -533,7 +533,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(410)
@@ -555,7 +555,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(422)
@@ -579,7 +579,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
@@ -612,7 +612,7 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+      await handleGetEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -29,6 +29,7 @@ import {
   SubmissionNotFoundError,
 } from '../../submission.errors'
 import {
+  getEncryptedResponse,
   getEncryptedResponseUsingQueryParams,
   handleGetMetadata,
   streamEncryptedResponses,
@@ -319,6 +320,299 @@ describe('encrypt-submission.controller', () => {
 
       // Act
       await getEncryptedResponseUsingQueryParams(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID,
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(MockEncryptSubService.checkFormIsEncryptMode).toHaveBeenCalledWith(
+        MOCK_FORM,
+      )
+    })
+  })
+
+  describe('getEncryptedResponse', () => {
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const MOCK_USER_ID = new ObjectId().toHexString()
+
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    } as IPopulatedForm
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: { formId: MOCK_FORM_ID, submissionId: 'mockSubmissionId' },
+      session: {
+        cookie: {
+          maxAge: 20000,
+        },
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    beforeEach(() => {
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValue(
+        ok(MOCK_FORM as IPopulatedEncryptedForm),
+      )
+    })
+
+    it('should return 200 with encrypted response', async () => {
+      // Arrange
+      const mockSubData: SubmissionData = {
+        _id: 'some id',
+        encryptedContent: 'some encrypted content',
+        verifiedContent: 'some verified content',
+        created: new Date('2020-10-10'),
+      } as SubmissionData
+      const mockSignedUrls = {
+        someKey1: 'some-signed-url',
+        someKey2: 'another-signed-url',
+      }
+      const mockRes = expressHandler.mockResponse()
+
+      // Mock service responses.
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        okAsync(mockSubData),
+      )
+      MockEncryptSubService.transformAttachmentMetasToSignedUrls.mockReturnValueOnce(
+        okAsync(mockSignedUrls),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      const expected = {
+        refNo: mockSubData._id,
+        submissionTime: 'Sat, 10 Oct 2020, 08:00:00 AM',
+        content: mockSubData.encryptedContent,
+        verified: mockSubData.verifiedContent,
+        attachmentMetadata: mockSignedUrls,
+      }
+      expect(mockRes.json).toHaveBeenCalledWith(expected)
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID,
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(MockEncryptSubService.checkFormIsEncryptMode).toHaveBeenCalledWith(
+        MOCK_FORM,
+      )
+    })
+
+    it('should return 400 if form is not an encrypt mode form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedError = new ResponseModeError(
+        ResponseMode.Encrypt,
+        ResponseMode.Email,
+      )
+      MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
+        err(expectedError),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedError.message,
+      })
+      expect(
+        MockEncryptSubService.getEncryptedSubmissionData,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 403 when user does not have read permissions for form', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedError = new ForbiddenFormError('no access')
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedError.message,
+      })
+      expect(
+        MockEncryptSubService.getEncryptedSubmissionData,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when form cannot be found in the database', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedError = new FormNotFoundError('not found')
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedError.message,
+      })
+      expect(
+        MockEncryptSubService.getEncryptedSubmissionData,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when submissionId cannot be found in the database', async () => {
+      // Arrange
+      const mockErrorString = 'not found'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        errAsync(new SubmissionNotFoundError(mockErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID,
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(MockEncryptSubService.checkFormIsEncryptMode).toHaveBeenCalledWith(
+        MOCK_FORM,
+      )
+    })
+
+    it('should return 410 when form is already archived', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedError = new FormDeletedError('already archived')
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedError.message,
+      })
+      expect(
+        MockEncryptSubService.getEncryptedSubmissionData,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 422 when user in session cannot be retrieved', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedError = new MissingUserError('user is not found')
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(expectedError),
+      )
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedError.message,
+      })
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(
+        MockEncryptSubService.getEncryptedSubmissionData,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst retrieving submission data', async () => {
+      // Arrange
+      const mockErrorString = 'database error occurred'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: MOCK_FORM_ID,
+          level: PermissionLevel.Read,
+        },
+      )
+      expect(MockEncryptSubService.checkFormIsEncryptMode).toHaveBeenCalledWith(
+        MOCK_FORM,
+      )
+    })
+
+    it('should return 500 when error occurs whilst generating presigned URLs', async () => {
+      // Arrange
+      const mockErrorString = 'presigned url error occured'
+      MockEncryptSubService.getEncryptedSubmissionData.mockReturnValueOnce(
+        okAsync({} as SubmissionData),
+      )
+      MockEncryptSubService.transformAttachmentMetasToSignedUrls.mockReturnValueOnce(
+        errAsync(new CreatePresignedUrlError(mockErrorString)),
+      )
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await getEncryptedResponse(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -604,6 +604,82 @@ export const handleGetEncryptedResponseUsingQueryParams = [
 ] as RequestHandler[]
 
 /**
+ * Handler for GET /:formId/submissions/submissionId
+ * NOTE: This is exported solely for testing
+ * @security session
+ *
+ * @returns 200 with encrypted submission data response
+ * @returns 400 when form is not an encrypt mode form
+ * @returns 403 when user does not have read permissions for form
+ * @returns 404 when submissionId cannot be found in the database
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when any errors occurs in database query or generating signed URL
+ */
+export const getEncryptedResponse: RequestHandler<
+  { formId: string; submissionId: string },
+  EncryptedSubmissionDto | ErrorDto,
+  unknown,
+  Query
+> = async (req, res) => {
+  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const { formId, submissionId } = req.params
+
+  return (
+    // Step 1: Retrieve logged in user.
+    getPopulatedUserById(sessionUserId)
+      // Step 2: Check whether user has read permissions to form.
+      .andThen((user) =>
+        getFormAfterPermissionChecks({
+          user,
+          formId,
+          level: PermissionLevel.Read,
+        }),
+      )
+      // Step 3: Check whether form is encrypt mode.
+      .andThen(checkFormIsEncryptMode)
+      // Step 4: Is encrypt mode form, retrieve submission data.
+      .andThen(() => getEncryptedSubmissionData(formId, submissionId))
+      // Step 5: Retrieve presigned URLs for attachments.
+      .andThen((submissionData) => {
+        // Remaining login duration in seconds.
+        const urlExpiry = (req.session?.cookie.maxAge ?? 0) / 1000
+        return transformAttachmentMetasToSignedUrls(
+          submissionData.attachmentMetadata,
+          urlExpiry,
+        ).map((presignedUrls) =>
+          createEncryptedSubmissionDto(submissionData, presignedUrls),
+        )
+      })
+      .map((responseData) => res.json(responseData))
+      .mapErr((error) => {
+        logger.error({
+          message: 'Failure retrieving encrypted submission response',
+          meta: {
+            action: 'handleGetEncryptedResponse',
+            submissionId,
+            formId,
+            ...createReqMeta(req),
+          },
+          error,
+        })
+
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      })
+  )
+}
+
+// Exported as an array to ensure that the handler always a valid submissionId
+export const handleGetEncryptedResponse = [
+  validateSubmissionId,
+  getEncryptedResponse,
+] as RequestHandler[]
+
+/**
  * Handler for GET /:formId([a-fA-F0-9]{24})/adminform/submissions/metadata
  *
  * @returns 200 with single submission metadata if query.submissionId is provided

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -50,6 +50,8 @@ import {
   mapRouteError,
 } from './encrypt-submission.utils'
 
+const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
+
 const logger = createLoggerWithLabel(module)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 
@@ -516,7 +518,16 @@ export const handleStreamEncryptedResponses = [
   streamEncryptedResponses,
 ] as RequestHandler[]
 
+const validateSubmissionId = celebrate({
+  [Segments.QUERY]: {
+    submissionId: Joi.string()
+      .regex(/^[0-9a-fA-F]{24}$/)
+      .required(),
+  },
+})
+
 /**
+ * Exported solely for testing
  * Handler for GET /:formId/adminform/submissions
  * @security session
  *
@@ -529,7 +540,7 @@ export const handleStreamEncryptedResponses = [
  * @returns 422 when user in session cannot be retrieved from the database
  * @returns 500 when any errors occurs in database query or generating signed URL
  */
-export const handleGetEncryptedResponse: RequestHandler<
+export const getEncryptedResponseUsingQueryParams: RequestHandler<
   { formId: string },
   EncryptedSubmissionDto | ErrorDto,
   unknown,
@@ -585,6 +596,12 @@ export const handleGetEncryptedResponse: RequestHandler<
       })
   )
 }
+
+// Exported as an array to ensure that the handler always a valid submissionId
+export const handleGetEncryptedResponseUsingQueryParams = [
+  validateSubmissionId,
+  getEncryptedResponseUsingQueryParams,
+] as RequestHandler[]
 
 /**
  * Handler for GET /:formId([a-fA-F0-9]{24})/adminform/submissions/metadata

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -602,7 +602,7 @@ export const handleGetEncryptedResponseUsingQueryParams = [
 ] as RequestHandler[]
 
 /**
- * Handler for GET /:formId/submissions/submissionId
+ * Handler for GET /:formId/submissions/:submissionId
  * @security session
  *
  * @returns 200 with encrypted submission data response

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -385,6 +385,7 @@ const validateDateRange = celebrate({
 })
 
 /**
+ * Handler for GET /:formId([a-fA-F0-9]{24})/submissions/download
  * NOTE: This is exported solely for testing
  * Streams and downloads for GET /:formId([a-fA-F0-9]{24})/adminform/submissions/download
  * @security session
@@ -595,7 +596,11 @@ export const getEncryptedResponseUsingQueryParams: RequestHandler<
   )
 }
 
-// Exported as an array to ensure that the handler always a valid submissionId
+/**
+ * Handler for GET /:formId/adminform/submission
+ * @deprecated in favour of GET api/v3/admin/forms/:formId/submissions/:submissionId
+ * Exported as an array to ensure that the handler always a valid submissionId
+ */
 export const handleGetEncryptedResponseUsingQueryParams = [
   validateSubmissionId,
   getEncryptedResponseUsingQueryParams,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -603,7 +603,6 @@ export const handleGetEncryptedResponseUsingQueryParams = [
 
 /**
  * Handler for GET /:formId/submissions/submissionId
- * NOTE: This is exported solely for testing
  * @security session
  *
  * @returns 200 with encrypted submission data response
@@ -615,7 +614,7 @@ export const handleGetEncryptedResponseUsingQueryParams = [
  * @returns 422 when user in session cannot be retrieved from the database
  * @returns 500 when any errors occurs in database query or generating signed URL
  */
-export const getEncryptedResponse: RequestHandler<
+export const handleGetEncryptedResponse: RequestHandler<
   { formId: string; submissionId: string },
   EncryptedSubmissionDto | ErrorDto,
   unknown,
@@ -670,12 +669,6 @@ export const getEncryptedResponse: RequestHandler<
       })
   )
 }
-
-// Exported as an array to ensure that the handler always a valid submissionId
-export const handleGetEncryptedResponse = [
-  validateSubmissionId,
-  getEncryptedResponse,
-] as RequestHandler[]
 
 /**
  * Handler for GET /:formId([a-fA-F0-9]{24})/adminform/submissions/metadata

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -50,8 +50,6 @@ import {
   mapRouteError,
 } from './encrypt-submission.utils'
 
-const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
-
 const logger = createLoggerWithLabel(module)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -598,7 +598,7 @@ export const getEncryptedResponseUsingQueryParams: RequestHandler<
 
 /**
  * Handler for GET /:formId/adminform/submission
- * @deprecated in favour of GET api/v3/admin/forms/:formId/submissions/:submissionId
+ * @deprecated in favour of handleGetEncryptedResponse
  * Exported as an array to ensure that the handler always a valid submissionId
  */
 export const handleGetEncryptedResponseUsingQueryParams = [

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -86,7 +86,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${newForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`,
       )
 
       // Assert
@@ -105,7 +105,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${newForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`,
       )
 
       // Assert
@@ -135,7 +135,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${newForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`,
       )
 
       // Assert
@@ -169,7 +169,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${newForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`,
       )
 
       // Assert
@@ -204,7 +204,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: format(subDays(now, 6), 'yyyy-MM-dd'),
           endDate: format(subDays(now, 3), 'yyyy-MM-dd'),
@@ -242,7 +242,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: format(expectedDate, 'yyyy-MM-dd'),
           endDate: format(expectedDate, 'yyyy-MM-dd'),
@@ -264,7 +264,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           endDate: '2021-04-06',
         })
@@ -293,7 +293,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: '2021-04-06',
         })
@@ -322,7 +322,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: 'not a date',
           endDate: '2021-04-06',
@@ -351,7 +351,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: '2021-04-06',
           // Wrong format
@@ -381,7 +381,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${newForm._id}/submissions/count`)
+        .get(`${ADMIN_FORMS_PREFIX}/${newForm._id}/submissions/count`)
         .query({
           startDate: '2021-04-06',
           endDate: '2020-01-01',
@@ -406,7 +406,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${new ObjectId()}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${new ObjectId()}/submissions/count`,
       )
 
       // Assert
@@ -433,7 +433,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${inaccessibleForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${inaccessibleForm._id}/submissions/count`,
       )
 
       // Assert
@@ -451,7 +451,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${invalidFormId}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${invalidFormId}/submissions/count`,
       )
 
       // Assert
@@ -471,7 +471,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${archivedForm._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${archivedForm._id}/submissions/count`,
       )
 
       // Assert
@@ -486,7 +486,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${new ObjectId()}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${new ObjectId()}/submissions/count`,
       )
 
       // Assert
@@ -510,7 +510,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${form._id}/submissions/count`,
+        `${ADMIN_FORMS_PREFIX}/${form._id}/submissions/count`,
       )
 
       // Assert
@@ -551,7 +551,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${defaultForm._id}/submissions/download`)
+        .get(`${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/download`)
         .query({ downloadAttachments: false })
         .buffer()
         .parse((res, cb) => {
@@ -607,7 +607,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${defaultForm._id}/submissions/download`)
+        .get(`${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/download`)
         .query({ downloadAttachments: true })
         .buffer()
         .parse((res, cb) => {
@@ -682,7 +682,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${defaultForm._id}/submissions/download`)
+        .get(`${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/download`)
         .query({
           startDate: expectedDate,
           endDate: expectedDate,
@@ -754,7 +754,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request
-        .get(`/admin/forms/${defaultForm._id}/submissions/download`)
+        .get(`${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/download`)
         .query({
           startDate: startDateStr,
           endDate: endDateStr,
@@ -807,7 +807,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${emailForm._id}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${emailForm._id}/submissions/download`,
       )
 
       // Assert
@@ -823,7 +823,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${defaultForm._id}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/download`,
       )
 
       // Assert
@@ -850,7 +850,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${inaccessibleForm._id}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${inaccessibleForm._id}/submissions/download`,
       )
 
       // Assert
@@ -868,7 +868,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${invalidFormId}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${invalidFormId}/submissions/download`,
       )
 
       // Assert
@@ -888,7 +888,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${archivedForm._id}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${archivedForm._id}/submissions/download`,
       )
 
       // Assert
@@ -903,7 +903,7 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${new ObjectId()}/submissions/download`,
+        `${ADMIN_FORMS_PREFIX}/${new ObjectId()}/submissions/download`,
       )
 
       // Assert
@@ -937,7 +937,9 @@ describe('admin-form.submissions.routes', () => {
 
       // Act
       const response = await request.get(
-        `/admin/forms/${defaultForm._id}/submissions/${String(submission._id)}`,
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/${String(
+          submission._id,
+        )}`,
       )
 
       // Assert

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -5,11 +5,14 @@ import { times } from 'lodash'
 import mongoose from 'mongoose'
 import supertest, { Session } from 'supertest-session'
 
+import { aws } from 'src/app/config/config'
 import {
   getEmailFormModel,
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
-import getSubmissionModel from 'src/app/models/submission.server.model'
+import getSubmissionModel, {
+  getEncryptSubmissionModel,
+} from 'src/app/models/submission.server.model'
 import getUserModel from 'src/app/models/user.server.model'
 import { saveSubmissionMetadata } from 'src/app/modules/submission/email-submission/email-submission.service'
 import { SubmissionHash } from 'src/app/modules/submission/email-submission/email-submission.types'
@@ -46,8 +49,11 @@ const UserModel = getUserModel(mongoose)
 const EmailFormModel = getEmailFormModel(mongoose)
 const EncryptFormModel = getEncryptedFormModel(mongoose)
 const SubmissionModel = getSubmissionModel(mongoose)
+const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
 
-const app = setupApp('/admin/forms', AdminFormsRouter, {
+const ADMIN_FORMS_PREFIX = '/admin/forms'
+
+const app = setupApp(ADMIN_FORMS_PREFIX, AdminFormsRouter, {
   setupWithAuth: true,
 })
 
@@ -903,6 +909,287 @@ describe('admin-form.submissions.routes', () => {
       // Assert
       expect(response.status).toEqual(422)
       expect(response.body).toEqual({ message: 'User not found' })
+    })
+  })
+
+  describe('GET /:formId/submissions/:submissionId', () => {
+    let defaultForm: IFormDocument
+
+    beforeEach(async () => {
+      defaultForm = (await EncryptFormModel.create({
+        title: 'new form',
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'any public key',
+        admin: defaultUser._id,
+      })) as IFormDocument
+    })
+
+    it('should return 200 with encrypted submission data of queried submissionId (without attachments)', async () => {
+      // Arrange
+      const expectedSubmissionParams = {
+        encryptedContent: 'any encrypted content',
+        verifiedContent: 'any verified content',
+      }
+      const submission = await createSubmission({
+        form: defaultForm,
+        ...expectedSubmissionParams,
+      })
+
+      // Act
+      const response = await request.get(
+        `/admin/forms/${defaultForm._id}/submissions/${String(submission._id)}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({
+        attachmentMetadata: {},
+        content: expectedSubmissionParams.encryptedContent,
+        refNo: String(submission._id),
+        submissionTime: expect.any(String),
+        verified: expectedSubmissionParams.verifiedContent,
+      })
+    })
+
+    it('should return 200 with encrypted submission data of queried submissionId (with attachments)', async () => {
+      // Arrange
+      const expectedSubmissionParams = {
+        encryptedContent: 'any encrypted content',
+        verifiedContent: 'any verified content',
+        attachmentMetadata: new Map([
+          ['fieldId1', 'some.attachment.url'],
+          ['fieldId2', 'some.other.attachment.url'],
+        ]),
+      }
+      const submission = await createSubmission({
+        form: defaultForm,
+        ...expectedSubmissionParams,
+      })
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/${String(
+          submission._id,
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({
+        attachmentMetadata: {
+          fieldId1: expect.stringContaining(
+            expectedSubmissionParams.attachmentMetadata.get('fieldId1') ?? 'no',
+          ),
+          fieldId2: expect.stringContaining(
+            expectedSubmissionParams.attachmentMetadata.get('fieldId2') ?? 'no',
+          ),
+        },
+        content: expectedSubmissionParams.encryptedContent,
+        refNo: String(submission._id),
+        submissionTime: expect.any(String),
+        verified: expectedSubmissionParams.verifiedContent,
+      })
+    })
+
+    it('should return 400 when form of given formId is not an encrypt mode form', async () => {
+      // Arrange
+      const emailForm = await EmailFormModel.create({
+        title: 'new form',
+        responseMode: ResponseMode.Email,
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+      })
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${emailForm._id}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body).toEqual({
+        message: 'Attempted to submit encrypt form to email endpoint',
+      })
+    })
+
+    it('should return 401 when user is not logged in', async () => {
+      // Arrange
+      await logoutSession(request)
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${
+          defaultForm._id
+        }/adminform/submissions/${String(new ObjectId())}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(401)
+      expect(response.body).toEqual({ message: 'User is unauthorized.' })
+    })
+
+    it('should return 403 when user does not have read permissions to form', async () => {
+      // Arrange
+      const anotherUser = (
+        await dbHandler.insertFormCollectionReqs({
+          userId: new ObjectId(),
+          mailName: 'some-user',
+          shortName: 'someUser',
+        })
+      ).user
+
+      // Form that defaultUser has no access to.
+      const inaccessibleForm = await EncryptFormModel.create({
+        title: 'Collab form',
+        publicKey: 'some public key',
+        admin: anotherUser._id,
+        permissionList: [],
+      })
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${inaccessibleForm._id}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(403)
+      expect(response.body).toEqual({
+        message: expect.stringContaining(
+          'not authorized to perform read operation',
+        ),
+      })
+    })
+
+    it('should return 404 when submission cannot be found', async () => {
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(response.body).toEqual({
+        message: 'Unable to find encrypted submission from database',
+      })
+    })
+
+    it('should return 404 when form to retrieve submission for cannot be found', async () => {
+      // Arrange
+      const invalidFormId = new ObjectId().toHexString()
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${invalidFormId}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(response.body).toEqual({ message: 'Form not found' })
+    })
+
+    it('should return 410 when form to retrieve submission for is archived', async () => {
+      // Arrange
+      const archivedForm = await EncryptFormModel.create({
+        title: 'archived form',
+        status: Status.Archived,
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'does not matter',
+        admin: defaultUser._id,
+      })
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${archivedForm._id}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(410)
+      expect(response.body).toEqual({ message: 'Form has been archived' })
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      // Clear user collection
+      await dbHandler.clearCollection(UserModel.collection.name)
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${new ObjectId()}/submissions/${String(
+          new ObjectId(),
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(422)
+      expect(response.body).toEqual({ message: 'User not found' })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving submission', async () => {
+      // Arrange
+      jest
+        .spyOn(EncryptSubmissionModel, 'findEncryptedSubmissionById')
+        .mockRejectedValueOnce(new Error('ohno'))
+      const submission = await createSubmission({
+        form: defaultForm,
+        encryptedContent: 'any encrypted content',
+        verifiedContent: 'any verified content',
+      })
+
+      // Act
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/${String(
+          submission._id,
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(500)
+      expect(response.body).toEqual({
+        message: expect.stringContaining('ohno'),
+      })
+    })
+
+    it('should return 500 when error occurs whilst creating presigned attachment urls', async () => {
+      // Arrange
+      // Mock error.
+      jest
+        .spyOn(aws.s3, 'getSignedUrlPromise')
+        .mockRejectedValueOnce(new Error('something went wrong'))
+
+      const submission = await createSubmission({
+        form: defaultForm,
+        encryptedContent: 'any encrypted content',
+        verifiedContent: 'any verified content',
+        attachmentMetadata: new Map([
+          ['fieldId1', 'some.attachment.url'],
+          ['fieldId2', 'some.other.attachment.url'],
+        ]),
+      })
+
+      // Act
+      const response = await request.get(
+        `${ADMIN_FORMS_PREFIX}/${defaultForm._id}/submissions/${String(
+          submission._id,
+        )}`,
+      )
+
+      // Assert
+      expect(response.status).toEqual(500)
+      expect(response.body).toEqual({
+        message: 'Failed to create attachment URL',
+      })
     })
   })
 })

--- a/src/app/routes/api/v3/admin/forms/admin-forms.submissions.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.submissions.routes.ts
@@ -41,3 +41,23 @@ AdminFormsSubmissionsRouter.route(
 AdminFormsSubmissionsRouter.route(
   '/:formId([a-fA-F0-9]{24})/submissions/download',
 ).get(EncryptSubmissionController.handleStreamEncryptedResponses)
+
+/**
+ * Retrieve actual response for a storage mode form
+ * @route GET /:formId/submissions/:submissionId
+ * @security session
+ *
+ * @returns 200 with encrypted submission data response
+ * @returns 400 when form is not an encrypt mode form
+ * @returns 400 when Joi validation fails
+ * @returns 401 when user does not exist in session
+ * @returns 403 when user does not have read permissions for form
+ * @returns 404 when submissionId cannot be found in the database
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when any errors occurs in database query or generating signed URL
+ */
+AdminFormsSubmissionsRouter.route(
+  '/:formId([a-fA-F0-9]{24})/submissions/:submissionId([a-fA-F0-9]{24})',
+).get(EncryptSubmissionController.handleGetEncryptedResponse)

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -205,9 +205,10 @@ function SubmissionsFactory(
     },
     getEncryptedResponse: function (params) {
       const deferred = $q.defer()
-      const resUrl = `${fixParamsToUrl(params, submitAdminUrl)}?submissionId=${
-        params.submissionId
-      }`
+      const resUrl = `${fixParamsToUrl(
+        params,
+        `${ADMIN_FORMS_PREFIX}/:formId/submissions/:submissionId`,
+      )}`
 
       $http.get(resUrl).then(
         function (response) {


### PR DESCRIPTION
## Problem
This is part 1 of #1520. This PR addresses the fact that URL query parameters should not be used to identify a resource. rather, they should be used to identify _properties_ of a resource. Hence, there is a new controller + endpoint set up so that the api endpoint is restful.

## Solution
1. Remove request parameter from `RequestHandler` and shift it to the url isntead. 
2. Ports over existing controller unit tests and changes it so that the parameter is in the url 
3. Ports over existing integration tests and changes it so that the parameter is in the url

## Manual Tests
1. Create a new storage mode form and make it public. Go to the form and submit a few responses. Go to the admin panel and click on data and click on any response. The panel should be populated with the information of the responses

## Notes 
1. Shifted from `/admin/forms` to`${ADMIN_FORMS_PREFIX}` in tests. Maybe this should have been done in a separate PR? Felt that it was small (and related to the current PR) so i did it here but comments welcome 