### PR TITLE
refactor: migrate submissions metadata

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -381,6 +381,7 @@ AdminFormsRouter.get(
  * Retrieve metadata of responses for a form with encrypted storage
  * @route GET /:formId/adminform/submissions/metadata
  * @security session
+ * @deprecated in favour of GET /api/v3/admin/forms/:formId/submissions/metadata
  *
  * @returns 200 with paginated submission metadata when no submissionId is provided
  * @returns 200 with single submission metadata of submissionId when provided
@@ -394,15 +395,6 @@ AdminFormsRouter.get(
 AdminFormsRouter.get(
   '/:formId([a-fA-F0-9]{24})/adminform/submissions/metadata',
   withUserAuthentication,
-  celebrate({
-    [Segments.QUERY]: {
-      submissionId: Joi.string().optional(),
-      page: Joi.number().min(1).when('submissionId', {
-        not: Joi.exist(),
-        then: Joi.required(),
-      }),
-    },
-  }),
   EncryptSubmissionController.handleGetMetadata,
 )
 

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -30,8 +30,8 @@ import {
 } from '../../submission.errors'
 import {
   getEncryptedResponseUsingQueryParams,
+  getMetadata,
   handleGetEncryptedResponse,
-  handleGetMetadata,
   streamEncryptedResponses,
 } from '../encrypt-submission.controller'
 import * as EncryptSubmissionService from '../encrypt-submission.service'
@@ -633,7 +633,7 @@ describe('encrypt-submission.controller', () => {
     })
   })
 
-  describe('handleGetMetadata', () => {
+  describe('getMetadata', () => {
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER_ID = new ObjectId().toHexString()
 
@@ -684,7 +684,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -721,7 +721,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -767,7 +767,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.json).toHaveBeenCalledWith(expectedMetadataList)
@@ -802,7 +802,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(400)
@@ -837,7 +837,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(403)
@@ -872,7 +872,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(404)
@@ -907,7 +907,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(410)
@@ -941,7 +941,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(422)
@@ -982,7 +982,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -1019,7 +1019,7 @@ describe('encrypt-submission.controller', () => {
       )
 
       // Act
-      await handleGetMetadata(mockReq, mockRes, jest.fn())
+      await getMetadata(mockReq, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.json).toHaveBeenCalledWith({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -681,18 +681,6 @@ export const handleGetEncryptedResponse: RequestHandler<
   )
 }
 
-// NOTE: If submissionId is set, then page is optional.
-// Otherwise, if there is no submissionId, then page >= 1
-const validateSubmissionIdOrPageNum = celebrate({
-  [Segments.QUERY]: {
-    submissionId: Joi.string().optional(),
-    page: Joi.number().min(1).when('submissionId', {
-      not: Joi.exist(),
-      then: Joi.required(),
-    }),
-  },
-})
-
 /**
  * Handler for GET /:formId/submissions/metadata
  * This is exported solely for testing purposes
@@ -718,7 +706,7 @@ export const getMetadata: RequestHandler<
 > = async (req, res) => {
   const sessionUserId = (req.session as Express.AuthedSession).user._id
   const { formId } = req.params
-  const { page = 1, submissionId } = req.query
+  const { page, submissionId } = req.query
 
   const logMeta = {
     action: 'handleGetMetadata',
@@ -773,6 +761,16 @@ export const getMetadata: RequestHandler<
 
 // Handler for GET /:formId/submissions/metadata
 export const handleGetMetadata = [
-  validateSubmissionIdOrPageNum,
+  // NOTE: If submissionId is set, then page is optional.
+  // Otherwise, if there is no submissionId, then page >= 1
+  celebrate({
+    [Segments.QUERY]: {
+      submissionId: Joi.string().optional(),
+      page: Joi.number().min(1).when('submissionId', {
+        not: Joi.exist(),
+        then: Joi.required(),
+      }),
+    },
+  }),
   getMetadata,
 ] as RequestHandler[]

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -1194,6 +1194,274 @@ describe('admin-form.submissions.routes', () => {
       })
     })
   })
+
+  describe('GET /:formId/submissions/metadata', () => {
+    let defaultForm: IFormDocument
+
+    beforeEach(async () => {
+      defaultForm = (await EncryptFormModel.create({
+        title: 'new form',
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'any public key',
+        admin: defaultUser._id,
+      })) as IFormDocument
+    })
+
+    it('should return 200 with empty results if no metadata exists', async () => {
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          page: 1,
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({ count: 0, metadata: [] })
+    })
+
+    it('should return 200 with requested page of metadata when metadata exists', async () => {
+      // Arrange
+      // Create 11 submissions
+      const submissions = await Promise.all(
+        times(11, (count) =>
+          createSubmission({
+            form: defaultForm,
+            encryptedContent: `any encrypted content ${count}`,
+            verifiedContent: `any verified content ${count}`,
+          }),
+        ),
+      )
+      const createdSubmissionIds = submissions.map((s) => String(s._id))
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          page: 1,
+        })
+
+      // Assert
+      const expected = times(10, (index) => ({
+        number: 11 - index,
+        // Loosen refNo checks due to non-deterministic aggregation query.
+        // Just expect refNo is one of the possible ones.
+        refNo: expect.toBeOneOf(createdSubmissionIds),
+        submissionTime: expect.any(String),
+      }))
+      expect(response.status).toEqual(200)
+      // Should be 11, but only return metadata of last 10 submissions due to page size.
+      expect(response.body).toEqual({
+        count: 11,
+        metadata: expected,
+      })
+    })
+
+    it('should return 200 with empty results if query.page does not have metadata', async () => {
+      // Arrange
+      // Create single submission
+      await createSubmission({
+        form: defaultForm,
+        encryptedContent: `any encrypted content`,
+        verifiedContent: `any verified content`,
+      })
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          // Page 2 should have no submissions
+          page: 2,
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Single submission count, but no metadata returned
+      expect(response.body).toEqual({
+        count: 1,
+        metadata: [],
+      })
+    })
+
+    it('should return 200 with metadata of single submissionId when query.submissionId is provided', async () => {
+      // Arrange
+      // Create 3 submissions
+      const submissions = await Promise.all(
+        times(3, (count) =>
+          createSubmission({
+            form: defaultForm,
+            encryptedContent: `any encrypted content ${count}`,
+            verifiedContent: `any verified content ${count}`,
+          }),
+        ),
+      )
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          submissionId: String(submissions[1]._id),
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Only return the single submission id's metadata
+      expect(response.body).toEqual({
+        count: 1,
+        metadata: [
+          {
+            number: 1,
+            refNo: String(submissions[1]._id),
+            submissionTime: expect.any(String),
+          },
+        ],
+      })
+    })
+
+    it('should return 401 when user is not logged in', async () => {
+      // Arrange
+      await logoutSession(request)
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(401)
+      expect(response.body).toEqual({ message: 'User is unauthorized.' })
+    })
+
+    it('should return 403 when user does not have read permissions to form', async () => {
+      // Arrange
+      const anotherUser = (
+        await dbHandler.insertFormCollectionReqs({
+          userId: new ObjectId(),
+          mailName: 'some-user',
+          shortName: 'someUser',
+        })
+      ).user
+      // Form that defaultUser has no access to.
+      const inaccessibleForm = await EncryptFormModel.create({
+        title: 'Collab form',
+        publicKey: 'some public key',
+        admin: anotherUser._id,
+        permissionList: [],
+      })
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${inaccessibleForm._id}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(403)
+      expect(response.body).toEqual({
+        message: expect.stringContaining(
+          'not authorized to perform read operation',
+        ),
+      })
+    })
+
+    it('should return 404 when form to retrieve submission metadata for cannot be found', async () => {
+      // Arrange
+      const invalidFormId = new ObjectId().toHexString()
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${invalidFormId}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(response.body).toEqual({ message: 'Form not found' })
+    })
+
+    it('should return 410 when form to retrieve submission metadata for is archived', async () => {
+      // Arrange
+      const archivedForm = await EncryptFormModel.create({
+        title: 'archived form',
+        status: Status.Archived,
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'does not matter',
+        admin: defaultUser._id,
+      })
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${archivedForm._id}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(410)
+      expect(response.body).toEqual({ message: 'Form has been archived' })
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      // Clear user collection
+      await dbHandler.clearCollection(UserModel.collection.name)
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${new ObjectId()}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(422)
+      expect(response.body).toEqual({ message: 'User not found' })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving submission metadata list', async () => {
+      // Arrange
+      jest
+        .spyOn(EncryptSubmissionModel, 'findAllMetadataByFormId')
+        .mockRejectedValueOnce(new Error('ohno'))
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          page: 10,
+        })
+
+      // Assert
+      expect(response.status).toEqual(500)
+      expect(response.body).toEqual({
+        message: expect.stringContaining('ohno'),
+      })
+    })
+
+    it('should return 500 when database error occurs whilst retrieving single submission metadata', async () => {
+      // Arrange
+      jest
+        .spyOn(EncryptSubmissionModel, 'findSingleMetadata')
+        .mockRejectedValueOnce(new Error('ohno'))
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          submissionId: new ObjectId().toHexString(),
+        })
+
+      // Assert
+      expect(response.status).toEqual(500)
+      expect(response.body).toEqual({
+        message: expect.stringContaining('ohno'),
+      })
+    })
+  })
 })
 
 // Helper utils

--- a/src/app/routes/api/v3/admin/forms/admin-forms.submissions.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.submissions.routes.ts
@@ -61,3 +61,22 @@ AdminFormsSubmissionsRouter.route(
 AdminFormsSubmissionsRouter.route(
   '/:formId([a-fA-F0-9]{24})/submissions/:submissionId([a-fA-F0-9]{24})',
 ).get(EncryptSubmissionController.handleGetEncryptedResponse)
+
+/**
+ * Retrieve metadata of responses for a form with encrypted storage
+ * @route GET /:formId/submissions/metadata
+ * @security session
+ *
+ * @returns 200 with paginated submission metadata when no submissionId is provided
+ * @returns 200 with single submission metadata of submissionId when provided
+ * @returns 401 when user does not exist in session
+ * @returns 403 when user does not have permissions to access form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+AdminFormsSubmissionsRouter.get(
+  '/:formId([a-fA-F0-9]{24})/submissions/metadata',
+  EncryptSubmissionController.handleGetMetadata,
+)

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -42,7 +42,6 @@ function SubmissionsFactory(
   responseModeEnum,
   FormSgSdk,
 ) {
-  const submitAdminUrl = '/:formId/adminform/submissions'
   const publicSubmitUrl = '/api/v3/forms/:formId/submissions/:responseMode'
 
   const previewSubmitUrl = '/v2/submissions/:responseMode/preview/:formId'
@@ -186,9 +185,10 @@ function SubmissionsFactory(
     },
     getMetadata: function (params) {
       const deferred = $q.defer()
-      let resUrl = `${fixParamsToUrl(params, submitAdminUrl)}/metadata?page=${
-        params.page
-      }`
+      let resUrl = `${fixParamsToUrl(
+        params,
+        `${ADMIN_FORMS_PREFIX}/:formId/submissions/metadata`,
+      )}?page=${params.page}`
 
       if (params.filterBySubmissionRefId) {
         resUrl += `&submissionId=${params.filterBySubmissionRefId}`


### PR DESCRIPTION
This is part 2 of #1520. 

## Problem
This PR migrates the old API to the new API rooted at `/api/v3/admin/forms`. The current implementation is ported over as is and something to note is that currently, we are not validating that there is either submission or formId, and that formId should be at least 1. 

This will be rectified in a future PR to avoid scope creep here and this PR should be reviewed as an almost direct port over. 

Closes #1520 

## Solution
1. Adds new endpoint to `AdminFormSubmissions` router for metadata and changed client callsites
2. Ported over integration tests

## Manual Tests

- [ ] Create a storage mode form and activate it. Submit **>10** responses to the form. Go to the admin panel and click on data
    - Verify that clicking on any page returns a list of responses  
    - Verify that searching on any single response id returns exactly that response   
    - Verify that searching on any substring of a response id returns nothing