### PR TITLE
fix: jest memory leak

### DIFF
--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -80,6 +80,8 @@ describe('Verification service', () => {
     jest.resetAllMocks()
   })
 
+  afterAll(async () => await dbHandler.closeDatabase())
+
   describe('createTransaction', () => {
     const mockForm = ({
       _id: new ObjectId(),

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -37,7 +37,8 @@ const connect = async (): Promise<typeof mongoose> => {
  * Disconnect all mongoose connections.
  */
 const closeDatabase = async (): Promise<void> => {
-  return mongoose.disconnect()
+  await mongoose.disconnect()
+  await MemoryDatabaseServer.stop()
 }
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
For a long time, we had been getting a warning from Jest after our tests:

```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.
```

This was due to our `MongoMemoryServer` instance continuing to run after every test. There was also a missed call to the `dbHandler.closeDatabase` function in one of the test suites.

This has also been more of a problem of late, with many tests failing in TravisCI due to running out of memory, or failing to start a new database instance.

This PR fixes (hopefully?) the memory leak by closing `MongoMemoryServer` when `dbHandler.closeDatabase` is called.

## Solution
<!-- How did you solve the problem? -->
**Bug Fixes**:

- Fix `jest` memory leak.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Leak warning in terminal
![Screenshot 2021-04-16 at 10 51 50 AM](https://user-images.githubusercontent.com/22133008/114964666-c1022a80-9ea1-11eb-9f69-950d5916361e.png)


**AFTER**:
<!-- [insert screenshot here] -->
No leak warning
![Screenshot 2021-04-16 at 10 52 13 AM](https://user-images.githubusercontent.com/22133008/114964703-cf504680-9ea1-11eb-9cd1-cf559011ba02.png)
![Screenshot 2021-04-16 at 10 52 46 AM](https://user-images.githubusercontent.com/22133008/114964742-e3944380-9ea1-11eb-94ec-51fce9c23648.png)


