### PR TITLE
fix: loosen validation for sg home numbers

### DIFF
--- a/src/app/utils/field-validation/validators/__tests__/home-num-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/home-num-validation.spec.ts
@@ -55,6 +55,26 @@ describe('Home phone number validation tests', () => {
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
+  it('should allow valid sg home numbers starting with 666 for homeno fieldType', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+6566634424',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow valid sg home numbers starting with 3 for homeno fieldType', () => {
+    const formField = generateDefaultField(BasicField.HomeNo)
+    const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {
+      answer: '+6536634424',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
   it('should disallow home numbers without "+" prefix', () => {
     const formField = generateDefaultField(BasicField.HomeNo)
     const response = generateNewSingleAnswerResponse(BasicField.HomeNo, {

--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -58,6 +58,10 @@ export const isHomePhoneNumber = (phoneNum: string): boolean => {
   if (!parsedNumber) return false
 
   // For SG numbers only check if it starts with 3 or 6 and has 8 digits
+  // Leading number 3 is for IP Telephony (IPT) service and User-Centric Data-Only (UCDO) service
+  // Leading number 6 is for  PSTN service and IP Telephony (IPT) service.
+  // In both cases the length is 8
+  // See IMDA's national numbering plan for specifications: https://www.imda.gov.sg/-/media/imda/files/regulation-licensing-and-consultations/frameworks-and-policies/numbering/national-numbering-plan-and-allocation-process/national-numbering-plan-30-nov-2017.pdf?la=en
   if (parsedNumber.countryCallingCode === '65') {
     return (
       isPhoneNumber(phoneNum) &&

--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -25,7 +25,7 @@ export const isMobilePhoneNumber = (mobileNumber: string): boolean => {
 
   if (!parsedNumber) return false
 
-  if (parsedNumber.countryCallingCode === '65') {
+  if (startsWithSgPrefix(mobileNumber)) {
     return (
       isPhoneNumber(mobileNumber) &&
       // Regex checks if the national number starts with 8 or 9, and is of
@@ -62,7 +62,7 @@ export const isHomePhoneNumber = (phoneNum: string): boolean => {
   // Leading number 6 is for  PSTN service and IP Telephony (IPT) service.
   // In both cases the length is 8
   // See IMDA's national numbering plan for specifications: https://www.imda.gov.sg/-/media/imda/files/regulation-licensing-and-consultations/frameworks-and-policies/numbering/national-numbering-plan-and-allocation-process/national-numbering-plan-30-nov-2017.pdf?la=en
-  if (parsedNumber.countryCallingCode === '65') {
+  if (startsWithSgPrefix(phoneNum)) {
     return (
       isPhoneNumber(phoneNum) &&
       // Regex checks if the national number starts with 3 or 6, and is of
@@ -81,6 +81,6 @@ export const isHomePhoneNumber = (phoneNum: string): boolean => {
   )
 }
 
-export const startsWithSgPrefix = (mobileNumber: string): boolean => {
-  return mobileNumber.startsWith('+65')
+export const startsWithSgPrefix = (phoneNumber: string): boolean => {
+  return phoneNumber.startsWith('+65')
 }

--- a/src/shared/util/phone-num-validation.ts
+++ b/src/shared/util/phone-num-validation.ts
@@ -54,11 +54,21 @@ export const isMobilePhoneNumber = (mobileNumber: string): boolean => {
  */
 export const isHomePhoneNumber = (phoneNum: string): boolean => {
   const parsedNumber = parsePhoneNumberFromString(phoneNum)
+
   if (!parsedNumber) return false
 
+  // For SG numbers only check if it starts with 3 or 6 and has 8 digits
+  if (parsedNumber.countryCallingCode === '65') {
+    return (
+      isPhoneNumber(phoneNum) &&
+      // Regex checks if the national number starts with 3 or 6, and is of
+      // length 8.
+      !!parsedNumber.nationalNumber.match(/^[36][0-9]{7}$/g)
+    )
+  }
+  // For intl numbers check number type as well
   const parsedType = parsedNumber.getType()
   if (!parsedType) return false
-
   return (
     isPhoneNumber(phoneNum) &&
     // Have to include both FIXED_LINE, FIXED_LINE_OR_MOBILE as some countries lump


### PR DESCRIPTION
## Problem

Fixes the problem of sg home numbers starting with '666' being incorrectly rejected.

## Test

- [ ] Create form with home number field. Check that the number `66665555` can be successfully submitted.