### PR TITLE
feat(api-refactor): implement specific create field api

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1411,5 +1411,41 @@ describe('Form Model', () => {
         expect(actual).toBeInstanceOf(mongoose.Error.ValidationError)
       })
     })
+
+    describe('insertFormField', () => {
+      it('should return updated document with inserted form field', async () => {
+        // Arrange
+        const newField = generateDefaultField(BasicField.Checkbox)
+        expect(validForm.form_fields).toBeEmpty()
+
+        // Act
+        const actual = await validForm.insertFormField(newField)
+
+        // Assert
+        const expectedField = {
+          ...omit(newField, 'getQuestion'),
+          _id: new ObjectId(newField._id),
+        }
+        // @ts-ignore
+        expect(actual?.form_fields.toObject()).toEqual([expectedField])
+      })
+
+      it('should return validation error if model validation fails whilst creating field', async () => {
+        // Arrange
+        const newField = {
+          ...generateDefaultField(BasicField.Email),
+          // Invalid value for email field.
+          isVerifiable: 'some string, but this should be boolean',
+        }
+
+        // Act
+        const actual = await validForm
+          .insertFormField(newField)
+          .catch((err) => err)
+
+        // Assert
+        expect(actual).toBeInstanceOf(mongoose.Error.ValidationError)
+      })
+    })
   })
 })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1,12 +1,19 @@
 import BSON from 'bson-ext'
 import { compact, pick, uniq } from 'lodash'
-import mongoose, { Mongoose, Query, Schema, SchemaOptions } from 'mongoose'
+import mongoose, {
+  Mongoose,
+  Query,
+  Schema,
+  SchemaOptions,
+  Types,
+} from 'mongoose'
 import validator from 'validator'
 
 import {
   AuthType,
   BasicField,
   Colors,
+  FormField,
   FormFieldWithId,
   FormLogoState,
   FormMetaView,
@@ -16,6 +23,7 @@ import {
   IEmailFormSchema,
   IEncryptedFormModel,
   IEncryptedFormSchema,
+  IFieldSchema,
   IFormDocument,
   IFormModel,
   IFormSchema,
@@ -510,6 +518,15 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       fieldToUpdate.set(newField)
     }
 
+    return this.save()
+  }
+
+  FormDocumentSchema.methods.insertFormField = function (
+    this: IFormDocument,
+    newField: FormField,
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;(this.form_fields as Types.DocumentArray<IFieldSchema>).push(newField)
     return this.save()
   }
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -1,6 +1,6 @@
 import { PresignedPost } from 'aws-sdk/clients/s3'
 import { ObjectId } from 'bson-ext'
-import { assignIn, cloneDeep, merge } from 'lodash'
+import { assignIn, cloneDeep, merge, pick } from 'lodash'
 import { err, errAsync, ok, okAsync, Result } from 'neverthrow'
 import { PassThrough } from 'stream'
 import { MockedObject } from 'ts-jest/dist/utils/testing'
@@ -58,7 +58,11 @@ import {
   ResponseMode,
   Status,
 } from 'src/types'
-import { EncryptSubmissionDto, FieldUpdateDto } from 'src/types/api'
+import {
+  EncryptSubmissionDto,
+  FieldCreateDto,
+  FieldUpdateDto,
+} from 'src/types/api'
 
 import {
   generateDefaultField,
@@ -7066,6 +7070,293 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         String(MOCK_FIELD._id),
         MOCK_REQ.body,
+      )
+    })
+  })
+
+  describe('_handleCreateFormField', () => {
+    const MOCK_FORM_ID = new ObjectId()
+    const MOCK_USER_ID = new ObjectId()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      title: 'mock title',
+    } as IPopulatedForm
+
+    const MOCK_RETURNED_FIELD = generateDefaultField(BasicField.Nric)
+    const MOCK_CREATE_FIELD_BODY = pick(MOCK_RETURNED_FIELD, [
+      'fieldType',
+      'title',
+    ]) as FieldCreateDto
+    const MOCK_REQ = expressHandler.mockRequest({
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+      params: {
+        formId: String(MOCK_FORM_ID),
+      },
+      body: MOCK_CREATE_FIELD_BODY,
+    })
+
+    beforeEach(() => {
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.createFormField.mockReturnValue(
+        okAsync(MOCK_RETURNED_FIELD),
+      )
+    })
+
+    it('should return 200 with created form field', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_RETURNED_FIELD)
+      expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_CREATE_FIELD_BODY,
+      )
+    })
+
+    it('should return 403 when current user does not have permissions to create a form field', async () => {
+      // Arrange
+      const expectedErrorString = 'no permissions pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when form cannot be found', async () => {
+      // Arrange
+      const expectedErrorString = 'no form pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 410 when attempting to create a form field for an archived form', async () => {
+      // Arrange
+      const expectedErrorString = 'form gone pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 413 when creating a form field causes the form to be too large to be saved in the database', async () => {
+      // Arrange
+      const expectedErrorString = 'payload too large'
+      MockAdminFormService.createFormField.mockReturnValueOnce(
+        errAsync(new DatabasePayloadSizeError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(413)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_CREATE_FIELD_BODY,
+      )
+    })
+
+    it('should return 422 when DatabaseValidationError occurs', async () => {
+      // Arrange
+      const expectedErrorString = 'invalid thing'
+      MockAdminFormService.createFormField.mockReturnValueOnce(
+        errAsync(new DatabaseValidationError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_CREATE_FIELD_BODY,
+      )
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      const expectedErrorString = 'user gone'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst retrieving user from database', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst retrieving form from database', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: String(MOCK_FORM_ID),
+          level: PermissionLevel.Write,
+        },
+      )
+      expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst creating form field', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockAdminFormService.createFormField.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_CREATE_FIELD_BODY,
       )
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1566,10 +1566,10 @@ export const handleCreateFormField = [
       fieldType: Joi.string()
         .valid(...Object.values(BasicField))
         .required(),
-      description: Joi.string().allow('').required(),
-      required: Joi.boolean().required(),
       title: Joi.string().required(),
-      disabled: Joi.boolean().required(),
+      description: Joi.string().allow(''),
+      required: Joi.boolean(),
+      disabled: Joi.boolean(),
       // Allow other field related key-values to be provided and let the model
       // layer handle the validation.
     }).unknown(true),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1562,6 +1562,7 @@ export const handleCreateFormField = [
     [Segments.BODY]: Joi.object({
       // Ensures id is not provided.
       _id: Joi.any().forbidden(),
+      globalId: Joi.any().forbidden(),
       fieldType: Joi.string()
         .valid(...Object.values(BasicField))
         .required(),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1500,13 +1500,23 @@ export const handleUpdateFormField = [
  * NOTE: Exported for testing.
  * Private handler for POST /forms/:formId/fields
  * @precondition Must be preceded by request validation
+ * @security session
+ *
+ * @returns 200 with created form field
+ * @returns 403 when current user does not have permissions to create a form field
+ * @returns 404 when form cannot be found
+ * @returns 410 when creating form field for an archived form
+ * @returns 413 when creating form field causes form to be too large to be saved in the database
+ * @returns 422 when an invalid form field creation is attempted on the form
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
  */
 export const _handleCreateFormField: RequestHandler<
-  { formId: string; fieldId: string },
+  { formId: string },
   FormFieldDto | ErrorDto,
   FieldCreateDto
 > = (req, res) => {
-  const { formId, fieldId } = req.params
+  const { formId } = req.params
   const sessionUserId = (req.session as Express.AuthedSession).user._id
 
   // Step 1: Retrieve currently logged in user.
@@ -1533,7 +1543,6 @@ export const _handleCreateFormField: RequestHandler<
             ...createReqMeta(req),
             userId: sessionUserId,
             formId,
-            fieldId,
             createFieldBody: req.body,
           },
           error,
@@ -1546,16 +1555,6 @@ export const _handleCreateFormField: RequestHandler<
 
 /**
  * Handler for POST /forms/:formId/fields
- * @security session
- *
- * @returns 200 with created form field
- * @returns 403 when current user does not have permissions to create a form field
- * @returns 404 when form cannot be found
- * @returns 410 when creating form field for an archived form
- * @returns 413 when creating form field causes form to be too large to be saved in the database
- * @returns 422 when an invalid form field creation is attempted on the form
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
  */
 export const handleCreateFormField = [
   celebrate({

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1520,10 +1520,10 @@ export const _handleCreateFormField: RequestHandler<
           level: PermissionLevel.Write,
         }),
       )
-      // Step 3: User has permissions, update form field of retrieved form.
+      // Step 3: User has permissions, proceed to create form field with provided body.
       .andThen((form) => AdminFormService.createFormField(form, req.body))
-      .map((updatedFormField) =>
-        res.status(StatusCodes.OK).json(updatedFormField),
+      .map((createdFormField) =>
+        res.status(StatusCodes.OK).json(createdFormField),
       )
       .mapErr((error) => {
         logger.error({

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -459,6 +459,13 @@ export const updateFormField = (
   })
 }
 
+/**
+ * Inserts a new form field into given form's fields with the field provided
+ * @param form the form to insert the new field into
+ * @param newField the new field to insert
+ * @returns ok(created form field)
+ * @returns err(PossibleDatabaseError) when database errors arise
+ */
 export const createFormField = (
   form: IPopulatedForm,
   newField: FieldCreateDto,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -9,6 +9,7 @@ import {
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../shared/constants'
 import {
+  FormFieldWithId,
   FormLogoState,
   FormMetaView,
   FormSettings,
@@ -19,7 +20,11 @@ import {
   IPopulatedForm,
   IUserSchema,
 } from '../../../../types'
-import { FieldUpdateDto, SettingsUpdateDto } from '../../../../types/api'
+import {
+  FieldCreateDto,
+  FieldUpdateDto,
+  SettingsUpdateDto,
+} from '../../../../types/api'
 import { aws as AwsConfig } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import getFormModel from '../../../models/form.server.model'
@@ -453,6 +458,16 @@ export const updateFormField = (
       ? okAsync(updatedFormField)
       : errAsync(new FieldNotFoundError())
   })
+}
+
+export const createFormField = (
+  form: IPopulatedForm,
+  newField: FieldCreateDto,
+): ResultAsync<FormFieldWithId, PossibleDatabaseError> => {
+  console.log('form', form)
+  console.log('newField', newField)
+
+  return okAsync({ ...newField, _id: 'some id' })
 }
 
 /**

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -111,3 +111,8 @@ AdminFormsFormRouter.put(
   '/:formId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})',
   AdminFormController.handleUpdateFormField,
 )
+
+AdminFormsFormRouter.post(
+  '/:formId([a-fA-F0-9]{24})/fields',
+  AdminFormController.handleCreateFormField,
+)

--- a/src/public/modules/forms/admin/constants/update-form-types.ts
+++ b/src/public/modules/forms/admin/constants/update-form-types.ts
@@ -1,3 +1,4 @@
 export const UPDATE_FORM_TYPES = {
   UpdateField: 'update-field',
+  CreateField: 'create-field',
 }

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -184,6 +184,16 @@ function AdminFormController(
     const updateType = get(update, 'type')
 
     switch (updateType) {
+      case UPDATE_FORM_TYPES.CreateField: {
+        const { body } = update
+        return $q
+          .when(AdminFormService.createSingleFormField($scope.myform._id, body))
+          .then((updatedFormField) => {
+            // insert created field into form
+            $scope.myform.form_fields.push(updatedFormField)
+          })
+          .catch(handleUpdateError)
+      }
       case UPDATE_FORM_TYPES.UpdateField: {
         const { fieldId, body } = update
         return $q

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -5,7 +5,6 @@ const values = require('lodash/values')
 const cloneDeep = require('lodash/cloneDeep')
 
 const {
-  EditFieldActions,
   VALID_UPLOAD_FILE_TYPES,
   MAX_UPLOAD_FILE_SIZE,
 } = require('shared/constants')
@@ -493,12 +492,8 @@ function EditFieldsModalController(
     let updateFieldPromise
     if (!field._id) {
       updateFieldPromise = externalScope.updateField({
-        editFormField: {
-          action: {
-            name: EditFieldActions.Create,
-          },
-          field,
-        },
+        body: field,
+        type: UPDATE_FORM_TYPES.CreateField,
       })
     } else {
       // Update field

--- a/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { EditFieldActions } = require('shared/constants')
 const { UPDATE_FORM_TYPES } = require('../constants/update-form-types')
 
 angular
@@ -36,12 +35,8 @@ function EditMyInfoFieldController(
     // Field creation
     if (!field._id) {
       updateFieldPromise = updateField({
-        editFormField: {
-          action: {
-            name: EditFieldActions.Create,
-          },
-          field,
-        },
+        body: field,
+        type: UPDATE_FORM_TYPES.CreateField,
       })
     } else {
       // Update field

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -1,7 +1,12 @@
 import axios from 'axios'
 
 import { FormSettings } from '../../types'
-import { FieldUpdateDto, SettingsUpdateDto } from '../../types/api'
+import {
+  FieldCreateDto,
+  FieldUpdateDto,
+  FormFieldDto,
+  SettingsUpdateDto,
+} from '../../types/api'
 
 const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
 
@@ -26,6 +31,18 @@ export const updateSingleFormField = async (
     .put<FieldUpdateDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`,
       updateFieldBody,
+    )
+    .then(({ data }) => data)
+}
+
+export const createSingleFormField = async (
+  formId: string,
+  createFieldBody: FieldCreateDto,
+): Promise<FormFieldDto> => {
+  return axios
+    .post<FormFieldDto>(
+      `${ADMIN_FORM_ENDPOINT}/${formId}/fields`,
+      createFieldBody,
     )
     .then(({ data }) => data)
 }

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -1,12 +1,14 @@
 import { LeanDocument } from 'mongoose'
 import { ConditionalPick, Primitive } from 'type-fest'
 
-import { FormFieldSchema, FormFieldWithId } from '../field'
+import { FormField, FormFieldSchema, FormFieldWithId } from '../field'
 import { FormSettings } from '../form'
 
 export type SettingsUpdateDto = Partial<FormSettings>
 
 export type FieldUpdateDto = FormFieldWithId
+
+export type FieldCreateDto = FormField
 
 /**
  * Form field POJO with functions removed

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -4,7 +4,12 @@ import { Merge, SetRequired } from 'type-fest'
 import { OverrideProps } from '../app/modules/form/admin-form/admin-form.types'
 
 import { PublicView } from './database'
-import { FormFieldWithId, IFieldSchema, MyInfoAttribute } from './field'
+import {
+  FormField,
+  FormFieldWithId,
+  IFieldSchema,
+  MyInfoAttribute,
+} from './field'
 import { ILogicSchema } from './form_logic'
 import { FormLogoState, IFormLogo } from './form_logo'
 import { IPopulatedUser, IUserSchema, PublicUser } from './user'
@@ -177,6 +182,14 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
     fieldId: string,
     newField: FormFieldWithId,
   ): Promise<T | null>
+
+  /**
+   * Inserts a form field into the form
+   * @param newField the new field to insert
+   * @returns updated form after the insertion if field insertion is successful
+   * @throws validation error on invalid updates
+   */
+  insertFormField<T>(this: T, newField: FormField): Promise<T | null>
 
   /**
    * Returns the dashboard form view of the form.


### PR DESCRIPTION
Integration tests will be added to a separate PR to prevent PR size from becoming too big

This PR cannot be rolled back after release due to the invocation of the new endpoint on the client side.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a specific endpoint to create a single form field, and updates the frontend client to use that endpoint when creating fields.

Closes #1484

## Solution
<!-- How did you solve the problem? -->

**Features**:
- feat(AdminFormCtl): add handleCreateFormField controller and router fn
- feat(FormModel): add insertFormField model instance method
  - Unable to use model static function due to usage of `this.getParent()` method in some field validators which is not available when using MongoDB's `update` methods.
  - NOTE: This is a change from using the globalId to do field comparisons, and we are doing comparisons with _id instead.
- feat(client): impl createSingleFormField service fn for field creation

## Tests
- test(AdminFormCtl): add unit tests for _handleCreateFormField fn
- test(AdminFormSvc): add unit tests for createFormField fn
- test(FormModel): add unit tests for insertFormField instance method

## Manual tests
- [ ] Create a new field. Should be created successfully. Network tab should show a call to the new endpoint.
- [ ] Create a new MyInfo field. Should be created successfully. Network tab should show a call to the new endpoint.