### PR TITLE
feat(client): log client form reCAPTCHA failure to GA

### DIFF
--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -500,5 +500,15 @@ function GTag(Auth, $rootScope, $window) {
     })
   }
 
+  /**
+   * Logs client form reCAPTCHA onError.
+   */
+  gtagService.reCaptchaOnError = () => {
+    _gtagEvents('recaptcha', {
+      event_category: 'Client Form reCAPTCHA',
+      event_action: 'reCAPTCHA connection failure',
+    })
+  }
+
   return gtagService
 }

--- a/src/public/modules/core/services/gtag.client.service.js
+++ b/src/public/modules/core/services/gtag.client.service.js
@@ -503,11 +503,8 @@ function GTag(Auth, $rootScope, $window) {
   /**
    * Logs client form reCAPTCHA onError.
    */
-  gtagService.reCaptchaOnError = () => {
-    _gtagEvents('recaptcha', {
-      event_category: 'Client Form reCAPTCHA',
-      event_action: 'reCAPTCHA connection failure',
-    })
+  gtagService.reCaptchaOnError = (form) => {
+    _gtagPublicFormEvents(form, 'reCAPTCHA connection failure')
   }
 
   return gtagService

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -115,7 +115,7 @@
           size="invisible"
           on-create="captchaService.setWidget(widgetId)"
           on-success="captchaService.onSuccess(response, submitForm)"
-          on-error="captchaService.onError()"
+          on-error="captchaService.onError(form)"
           on-expire="captchaService.expire()"
           data-badge="inline"
         ></div>

--- a/src/public/modules/forms/services/captcha.client.service.js
+++ b/src/public/modules/forms/services/captcha.client.service.js
@@ -65,11 +65,15 @@ function captchaService($window, vcRecaptchaService, Toastr, GTag) {
     cb()
   }
 
-  this.onError = function () {
+  /**
+   * Show error toast and log error with Google Analytics
+   * @param {*} form the form this error occurred for
+   */
+  this.onError = function (form) {
     Toastr.error(
       'Error: Cannot connect to reCAPTCHA. Please check your internet connectivity or try submitting on another device.',
     )
-    GTag.reCaptchaOnError()
+    GTag.reCaptchaOnError(form)
   }
 
   /**

--- a/src/public/modules/forms/services/captcha.client.service.js
+++ b/src/public/modules/forms/services/captcha.client.service.js
@@ -6,10 +6,11 @@ angular
     '$window',
     'vcRecaptchaService',
     'Toastr',
+    'GTag',
     captchaService,
   ])
 
-function captchaService($window, vcRecaptchaService, Toastr) {
+function captchaService($window, vcRecaptchaService, Toastr, GTag) {
   /**
    * Captcha public key associated with app
    */
@@ -68,6 +69,7 @@ function captchaService($window, vcRecaptchaService, Toastr) {
     Toastr.error(
       'Error: Cannot connect to reCAPTCHA. Please check your internet connectivity or try submitting on another device.',
     )
+    GTag.reCaptchaOnError()
   }
 
   /**


### PR DESCRIPTION
## Problem
This PR adds a Google Analytics logging invocation on any recaptcha instantiation failure

Closes #1306 

## Solution
<!-- How did you solve the problem? -->
- feat: log client form reCAPTCHA failure to GA

## Screenshots
**GA Logging screenshot**
![Screenshot 2021-04-26 at 3 28 27 PM](https://user-images.githubusercontent.com/22133008/116044938-18737800-a6a4-11eb-9fba-62a80b46121c.png)
![Screenshot 2021-04-26 at 3 28 19 PM](https://user-images.githubusercontent.com/22133008/116044942-19a4a500-a6a4-11eb-8677-c906bc2c7cef.png)

