### PR TITLE
feat(webhooks): streamline webhook response data

### DIFF
--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -3,6 +3,7 @@ import { times } from 'lodash'
 import mongoose from 'mongoose'
 
 import getSubmissionModel, {
+  getEmailSubmissionModel,
   getEncryptSubmissionModel,
 } from 'src/app/models/submission.server.model'
 
@@ -17,6 +18,7 @@ import {
 
 const Submission = getSubmissionModel(mongoose)
 const EncryptedSubmission = getEncryptSubmissionModel(mongoose)
+const EmailSubmission = getEmailSubmissionModel(mongoose)
 
 // TODO: Add more tests for the rest of the submission schema.
 describe('Submission Model', () => {
@@ -107,7 +109,7 @@ describe('Submission Model', () => {
         // Arrange
         const formId = new ObjectID()
 
-        const submission = await Submission.create({
+        const submission = await EncryptedSubmission.create({
           submissionType: SubmissionType.Encrypt,
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
@@ -136,7 +138,7 @@ describe('Submission Model', () => {
       it('should return null view with non-encryptSubmission type', async () => {
         // Arrange
         const formId = new ObjectID()
-        const submission = await Submission.create({
+        const submission = await EmailSubmission.create({
           submissionType: SubmissionType.Email,
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
@@ -182,7 +184,6 @@ describe('Submission Model', () => {
           response: {
             data: '{"result":"test-result"}',
             status: 200,
-            statusText: 'success',
             headers: '{}',
           },
         }) as IWebhookResponse
@@ -223,6 +224,11 @@ describe('Submission Model', () => {
           created: submission.created,
           signature: 'some signature',
           webhookUrl: 'https://form.gov.sg/endpoint',
+          response: {
+            status: 200,
+            headers: '',
+            data: '',
+          },
         } as IWebhookResponse
 
         const invalidSubmissionId = new ObjectID().toHexString()

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -126,14 +126,27 @@ EmailSubmissionSchema.methods.getWebhookView = function (): null {
 
 const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
   {
-    webhookUrl: String,
-    signature: String,
-    errorMessage: String,
+    webhookUrl: {
+      type: String,
+      required: true,
+    },
+    signature: {
+      type: String,
+      required: true,
+    },
     response: {
-      status: Number,
-      statusText: String,
-      headers: String,
-      data: String,
+      status: {
+        type: Number,
+        required: true,
+      },
+      headers: {
+        type: String,
+        required: true,
+      },
+      data: {
+        type: String,
+        required: true,
+      },
     },
   },
   {

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -139,14 +139,8 @@ const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
         type: Number,
         required: true,
       },
-      headers: {
-        type: String,
-        required: true,
-      },
-      data: {
-        type: String,
-        required: true,
-      },
+      headers: String,
+      data: String,
     },
   },
   {

--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -9,7 +9,6 @@ import { getEncryptSubmissionModel } from 'src/app/models/submission.server.mode
 import { WebhookValidationError } from 'src/app/modules/webhook/webhook.errors'
 import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.validation'
 import { transformMongoError } from 'src/app/utils/handle-mongo-error'
-import * as HasPropModule from 'src/app/utils/has-prop'
 import {
   IEncryptedSubmissionSchema,
   IWebhookResponse,
@@ -59,7 +58,6 @@ const MOCK_WEBHOOK_SUCCESS_RESPONSE: Pick<IWebhookResponse, 'response'> = {
   response: {
     data: '{"result":"test-result"}',
     status: 200,
-    statusText: 'success',
     headers: '{}',
   },
 }
@@ -67,7 +65,6 @@ const MOCK_WEBHOOK_FAILURE_RESPONSE: Pick<IWebhookResponse, 'response'> = {
   response: {
     data: '{"result":"test-result"}',
     status: 400,
-    statusText: 'failed',
     headers: '{}',
   },
 }
@@ -78,7 +75,6 @@ const MOCK_WEBHOOK_DEFAULT_FORMAT_RESPONSE: Pick<
   response: {
     data: '',
     status: 0,
-    statusText: '',
     headers: '',
   },
 }
@@ -305,7 +301,6 @@ describe('webhook.service', () => {
 
       // Assert
       const expectedResult = {
-        errorMessage: AXIOS_ERROR_MSG,
         ...MOCK_WEBHOOK_FAILURE_RESPONSE,
         signature: testSignature,
         webhookUrl: MOCK_WEBHOOK_URL,
@@ -334,7 +329,6 @@ describe('webhook.service', () => {
 
       // Assert
       const expectedResult = {
-        errorMessage: DEFAULT_ERROR_MSG,
         ...MOCK_WEBHOOK_DEFAULT_FORMAT_RESPONSE,
         signature: testSignature,
         webhookUrl: MOCK_WEBHOOK_URL,
@@ -359,9 +353,6 @@ describe('webhook.service', () => {
 
       MockAxios.post.mockRejectedValue(mockOriginalError)
       MockAxios.isAxiosError.mockReturnValue(false)
-      const hasPropSpy = jest
-        .spyOn(HasPropModule, 'hasProp')
-        .mockReturnValueOnce(false)
 
       // Act
       const actual = await sendWebhook(
@@ -371,7 +362,6 @@ describe('webhook.service', () => {
 
       // Assert
       const expectedResult = {
-        errorMessage: '',
         ...MOCK_WEBHOOK_DEFAULT_FORMAT_RESPONSE,
         signature: testSignature,
         webhookUrl: MOCK_WEBHOOK_URL,
@@ -380,7 +370,6 @@ describe('webhook.service', () => {
       expect(
         MockWebhookValidationModule.validateWebhookUrl,
       ).toHaveBeenCalledWith(MOCK_WEBHOOK_URL)
-      expect(hasPropSpy).toHaveBeenCalledWith(mockOriginalError, 'message')
       expect(MockAxios.post).toHaveBeenCalledWith(
         MOCK_WEBHOOK_URL,
         testSubmissionWebhookView,

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -12,7 +12,6 @@ import formsgSdk from '../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../config/logger'
 import { getEncryptSubmissionModel } from '../../models/submission.server.model'
 import { transformMongoError } from '../../utils/handle-mongo-error'
-import { hasProp } from '../../utils/has-prop'
 import { PossibleDatabaseError } from '../core/core.errors'
 import { SubmissionNotFoundError } from '../submission/submission.errors'
 
@@ -159,14 +158,9 @@ export const sendWebhook = (
 
       // Webhook was posted but failed
       if (error instanceof WebhookFailedWithUnknownError) {
-        const originalError = error.meta.originalError
-        const errorMessage = hasProp(originalError, 'message')
-          ? originalError.message
-          : ''
         return okAsync({
           signature,
           webhookUrl,
-          errorMessage,
           // Not Axios error so no guarantee of having response.
           // Hence allow formatting function to return default shape.
           response: formatWebhookResponse(),
@@ -177,7 +171,6 @@ export const sendWebhook = (
       return okAsync({
         signature,
         webhookUrl,
-        errorMessage: axiosError.message,
         response: formatWebhookResponse(axiosError.response),
       })
     })

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -11,7 +11,6 @@ export const formatWebhookResponse = (
   response?: AxiosResponse<unknown>,
 ): IWebhookResponse['response'] => ({
   status: response?.status ?? 0,
-  statusText: response?.statusText ?? '',
   headers: stringifySafe(response?.headers) ?? '',
   data: stringifySafe(response?.data) ?? '',
 })

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios'
 import { Document, Model, QueryCursor } from 'mongoose'
 
 import { MyInfoAttribute } from './field'
@@ -105,9 +104,10 @@ export type IEncryptedSubmissionSchema = IEncryptedSubmission &
 export interface IWebhookResponse {
   webhookUrl: string
   signature: string
-  errorMessage?: string
-  response?: Omit<AxiosResponse<string>, 'config' | 'request' | 'headers'> & {
+  response: {
+    status: number
     headers: string
+    data: string
   }
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The webhook response data stored in the database has a couple of superfluous fields:
1. `errorMessage` is useless because it is always a standard `axios` error message, e.g. "Request failed with status code 400".
2. `statusText` is useless because it is just the standard HTTP status text, e.g. `'OK'` for 200

Furthermore, fields that should always be present (webhook URL, signature, status code) are not marked as required in the database schema.

## Solution
<!-- How did you solve the problem? -->

Remove the superfluous fields and mark the rest as `required` where appropriate. `headers` and `data` were not made required as they may be empty strings.