### PR TITLE
fix: sync email field state between hasAllowedEmailDomains and allowedEmailDomains

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -5,6 +5,7 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { Except, Merge } from 'type-fest'
 
 import {
+  EditFieldActions,
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../shared/constants'
@@ -516,6 +517,22 @@ export const editFormFields = (
   IPopulatedForm,
   EditFieldError | ReturnType<typeof transformMongoError>
 > => {
+  // TODO(#1210): Remove this function when no longer being called.
+  if (
+    [EditFieldActions.Create, EditFieldActions.Update].includes(
+      editFormFieldParams.action.name,
+    )
+  ) {
+    logger.info({
+      message: 'deprecated editFormFields functions are still being used',
+      meta: {
+        action: 'editFormFields',
+        fieldAction: editFormFieldParams.action.name,
+        field: editFormFieldParams.field,
+      },
+    })
+  }
+
   // TODO(#815): Split out this function into their own separate service functions depending on the update type.
   return getUpdatedFormFields(
     originalForm.form_fields,

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -9,6 +9,7 @@ import {
   Status,
 } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
+import { isPossibleEmailFieldSchema } from '../../../utils/field-validation/field-validation.guards'
 import { reorder, replaceAt } from '../../../utils/immutable-array-fns'
 import {
   ApplicationError,
@@ -268,6 +269,20 @@ const updateCurrentField = (
   existingFormFields: IFieldSchema[],
   fieldToUpdate: IFieldSchema,
 ): EditFormFieldResult => {
+  // TODO(#1210): Remove this function when no longer being called.
+  // Sync states for backwards compatibility with old clients send inconsistent
+  // email fields
+  if (isPossibleEmailFieldSchema(fieldToUpdate)) {
+    if (fieldToUpdate.hasAllowedEmailDomains === false) {
+      fieldToUpdate.allowedEmailDomains = []
+    } else {
+      fieldToUpdate.hasAllowedEmailDomains = fieldToUpdate.allowedEmailDomains
+        ?.length
+        ? fieldToUpdate.allowedEmailDomains.length > 0
+        : false
+    }
+  }
+
   const existingFieldPosition = existingFormFields.findIndex(
     (f) => f.globalId === fieldToUpdate.globalId,
   )

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -269,20 +269,6 @@ const updateCurrentField = (
   existingFormFields: IFieldSchema[],
   fieldToUpdate: IFieldSchema,
 ): EditFormFieldResult => {
-  // TODO(#1210): Remove this function when no longer being called.
-  // Sync states for backwards compatibility with old clients send inconsistent
-  // email fields
-  if (isPossibleEmailFieldSchema(fieldToUpdate)) {
-    if (fieldToUpdate.hasAllowedEmailDomains === false) {
-      fieldToUpdate.allowedEmailDomains = []
-    } else {
-      fieldToUpdate.hasAllowedEmailDomains = fieldToUpdate.allowedEmailDomains
-        ?.length
-        ? fieldToUpdate.allowedEmailDomains.length > 0
-        : false
-    }
-  }
-
   const existingFieldPosition = existingFormFields.findIndex(
     (f) => f.globalId === fieldToUpdate.globalId,
   )
@@ -372,6 +358,20 @@ export const getUpdatedFormFields = (
   editFieldParams: EditFormFieldParams,
 ): EditFormFieldResult => {
   const { field: fieldToUpdate, action } = editFieldParams
+
+  // TODO(#1210): Remove this function when no longer being called.
+  // Sync states for backwards compatibility with old clients send inconsistent
+  // email fields
+  if (isPossibleEmailFieldSchema(fieldToUpdate)) {
+    if (fieldToUpdate.hasAllowedEmailDomains === false) {
+      fieldToUpdate.allowedEmailDomains = []
+    } else {
+      fieldToUpdate.hasAllowedEmailDomains = fieldToUpdate.allowedEmailDomains
+        ?.length
+        ? fieldToUpdate.allowedEmailDomains.length > 0
+        : false
+    }
+  }
 
   switch (action.name) {
     // Duplicate is just an alias of create for the use case.

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -1,5 +1,7 @@
+import { get } from 'lodash'
+
 import { types as basicTypes } from '../../../shared/resources/basic'
-import { BasicField, ITableRow } from '../../../types'
+import { BasicField, IEmailFieldSchema, ITableRow } from '../../../types'
 import {
   ColumnResponse,
   ProcessedAttachmentResponse,
@@ -73,4 +75,16 @@ export const isProcessedAttachmentResponse = (
     // No check for response.filename as response.filename is generated only when actual file is uploaded
     // Hence hidden attachment fields - which still return empty response - will not have response.filename property
   )
+}
+
+/**
+ * Utility to check if the given field is a possible IEmailFieldSchema object.
+ * Can be used to assign IEmailFieldSchema variables safely.
+ * @param field the field to check
+ * @returns true if given field's fieldType is BasicField.Email.
+ */
+export const isPossibleEmailFieldSchema = (
+  field: unknown,
+): field is Partial<IEmailFieldSchema> => {
+  return get(field, 'fieldType') === BasicField.Email
 }

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -90,7 +90,7 @@ function EditFieldsModalController(
         '\n',
       )
     }
-    $scope.$watch('vm.field.allowedEmailDomainsFromText', (newValue) => {
+    $scope.$watch('vm.field.isVerifiable', (newValue) => {
       if (newValue) {
         vm.tooltipHtml = 'e.g. @mom.gov.sg, @moe.gov.sg'
       } else {

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -74,8 +74,18 @@ function EditFieldsModalController(
   vm.user = Auth.getUser() || $state.go('signin')
   if (vm.field.fieldType === 'email') {
     const userEmailDomain = '@' + vm.user.email.split('@').pop()
+
+    // Backwards compatibility and inconsistency fix.
+    // Set allowedEmailDomains array to empty if allow domains toggle is off.
+    if (vm.field.hasAllowedEmailDomains === false) {
+      vm.field.allowedEmailDomains = []
+    } else {
+      // hasAllowedEmailDomains is true, set "true" state based on length of allowedEmailDomains.
+      vm.field.hasAllowedEmailDomains = vm.field.allowedEmailDomains.length > 0
+    }
+
     vm.field.allowedEmailDomainsPlaceholder = `${userEmailDomain}\n@agency.gov.sg`
-    if (vm.field.allowedEmailDomains.length > 0) {
+    if (vm.field.hasAllowedEmailDomains) {
       vm.field.allowedEmailDomainsFromText = vm.field.allowedEmailDomains.join(
         '\n',
       )
@@ -142,6 +152,14 @@ function EditFieldsModalController(
       field.fieldOptions = field.fieldOptionsFromText.split('\n')
     } else {
       field.fieldOptions = []
+    }
+  }
+
+  vm.handleRestrictEmailDomainsToggle = function () {
+    const field = vm.field
+    if (field.hasAllowedEmailDomains === false) {
+      // Reset email domains.
+      field.allowedEmailDomainsFromText = ''
     }
   }
 
@@ -475,6 +493,7 @@ function EditFieldsModalController(
           .map((s) => s.trim())
           .filter((s) => s)
       }
+      field.hasAllowedEmailDomains = field.allowedEmailDomains.length > 0
       delete field.allowedEmailDomainsFromText
       delete field.allowedEmailDomainsPlaceholder
     }

--- a/src/public/modules/forms/admin/directives/is-verifiable-save-interceptor.directive.js
+++ b/src/public/modules/forms/admin/directives/is-verifiable-save-interceptor.directive.js
@@ -16,8 +16,9 @@ function isVerifiableSaveInterceptor(Toastr) {
           Toastr.error(
             'Turn on OTP verification again if you wish to restrict email domains.',
           )
+          scope.vm.field.hasAllowedEmailDomains = false
+          scope.vm.field.allowedEmailDomainsFromText = ''
         }
-        scope.vm.field.hasAllowedEmailDomains = false
         return inputValue
       })
     },

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -622,6 +622,7 @@
                 <input
                   type="checkbox"
                   ng-model="vm.field.hasAllowedEmailDomains"
+                  ng-change="vm.handleRestrictEmailDomainsToggle()"
                   ng-disabled="!vm.field.isVerifiable"
                 />
                 <div class="toggle-selector-switch">


### PR DESCRIPTION
> This is the first PR of our journey to remove `emailField.hasAllowedEmailDomains` from the schema. 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, it is somehow possible (and we have some states in the database where this is so) to have the following email field states:

|`hasAllowedEmailDomains`|`allowedEmailDomains`| Remarks|
|---|---|---|
|`true`| `[]`| Not ideal, since the source of truth is muddled, but no real harm since there are sanity checks in the code where isVerifiable && hasAllowedEmailDomains && allowedEmailDomains.length must all be true before restricting domains|
| `false` | `["@someDomain.com", "@anotherDomain.com"]` | Was supposed to be a feature such that admins will be able to toggle restriction on/off and have their previously entered domains. Scrapping this state for cleanliness|
| `true`| `["@someDomain.com", "@anotherDomain.com"]`| consistent and expected shape |
| `false`| `[]`|consistent and expected shape |

This PR removes the first two possible states and syncs all newly created or updated form into the two consistent shapes with both client and server-side validation.

The end goal is to remove `emailField.hasAllowedEmailDOmains` from the email field schema such that the decision of whether or not to restrict email verification to some whitelisted email domains is **determined solely** by the `emailField.allowedEmailDomains` array values.

The PR to fully remove the `hasAllowedEmailDomains` key will come in a later PR when users have stopped using the old client without the frontend sync checks, as it is not safe to migrate now due to possible data inconsistencies whilst running the migration scripts.

As such, a logger is also implemented to keep track of whether any old clients are still calling the deprecated updateField endpoints.

Related to #1312

## Solution
<!-- How did you solve the problem? -->

**Features**:
- feat: add logger to track deprecated updateForm endpoint calls

**Bug Fixes**:

- fix: sync client hasAllowedEmailDomains and allowedEmailDomains states
- fix: watch field.isVerifiable to show relevant tooltip
- fix: sync inconsistent email field states in the backend

## Manual Tests
- [ ] Create an email field with OTP verification toggled on, then toggle on Restrict email domains, then fill in the allowed domains. Save the field. The returned field from the network request should contain 
  - `isVerifiable=true`, 
  - `hasAllowedEmailDomains=true`, 
  - `allowedEmailDomains=[<whatever you filled in>]`
- [ ] For the same field, toggle off OTP verification. Restrict email domains should automatically be toggled off and a toast for restrict email domains should show up. Save the field. The returned field from the network request should contain
  - `isVerifiable=false`,
  - `hasAllowedEmailDomains=false`,
  - `allowedEmailDomains=[]` // empty array
- [ ] For the same field, toggle OTP verification back on and save the field. The returned field should contain
  - `isVerifiable=true`,
  - `hasAllowedEmailDomains=false`,
  - `allowedEmailDomains=[]`

## Manual Tests (Programmatic)
Programatically submit an field creation request to the OLD endpoint (or copy and paste the below body snippet changing the `formId` to a form that you control): 

`POST <baseUrl>/<formId>/adminform`

```
{
  "form": {
    "editFormField": {
      "action": {
        "name": "CREATE"
      },
      "field": {
        "required": true,
        "disabled": false,
        "autoReplyOptions": {
          "hasAutoReply": false,
          "autoReplyMessage": "",
          "includeFormSummary": false
        },
        "isVerifiable": false,
        "hasAllowedEmailDomains": true,
        "allowedEmailDomains": [],
        "fieldName": "Email",
        "title": "Email",
        "fieldType": "email",
      }
    }
  }
}
```

Note the body is mimicking state 1 in the table above, where hasAllowedEmailDomains is true, but the array is empty. 
- [ ] The returned form field should manipulate the created field into state 4, a valid state
- [ ] Change the above body snippet to `hasAllowedEmailDomains=false` with a non-empty `allowedEmailDomains` array value. The returned form field should manipulate the created field also into state 4, since hasAllowedEmailDomains is false.

