### PR TITLE
fix: remove verified prefix on blank verified fields

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -110,7 +110,9 @@ const getMyInfoPrefix = (
  * @returns the prefix
  */
 const getVerifiedPrefix = (response: ResponseFormattedForEmail): string => {
-  return response.isUserVerified ? VERIFIED_PREFIX : ''
+  const { answer, isUserVerified } = response
+  const isAnswerBlank = answer === ''
+  return isUserVerified && !isAnswerBlank ? VERIFIED_PREFIX : ''
 }
 
 /**

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -106,6 +106,8 @@ const getMyInfoPrefix = (
 /**
  * Determines the prefix for a question based on whether it was verified
  * by a user during form submission.
+ *
+ * Verified prefixes are not added for optional fields that are left blank.
  * @param response
  * @returns the prefix
  */


### PR DESCRIPTION
## Problem
In the submission emails sent to form admins, verified fields have the [verified] prefix. However, this prefix is also present for optional verified fields that were left blank.

Closes #844

## Solution
Include an extra check to ensure that the field is not blank before adding the [verified] prefix.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/16982839/115652164-46cd1c80-a35f-11eb-8918-520442144e15.png)


**AFTER**:
![image](https://user-images.githubusercontent.com/16982839/115652111-2dc46b80-a35f-11eb-8dae-c91d2402abad.png)
