### PR TITLE
feat: prefill mainstream launch

### DIFF
--- a/src/public/modules/core/css/core.css
+++ b/src/public/modules/core/css/core.css
@@ -259,6 +259,11 @@ textarea.input-custom {
   color: #23489b;
 }
 
+.alert-prefill {
+  background-color: #fef8e3;
+  color: #4b411f;
+}
+
 .alert-success,
 .alert-success a {
   background-color: #e5f6f2;

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -622,7 +622,13 @@ function EditFieldsModalController(
    * Inform user that field id has been copied to clipboard
    */
 
-  vm.fieldIdCopied = () => {
+  vm.toastSuccessfulFieldIdCopy = () => {
     Toastr.success('Field ID copied to clipboard!')
+  }
+  /**
+   * Inform user that field id was not copied to clipboard
+   */
+  vm.toastFailedFieldIdCopy = () => {
+    Toastr.error('Failed to copy to clipboard')
   }
 }

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -35,6 +35,7 @@ angular
     'Betas',
     'Auth',
     '$state',
+    'Toastr',
     EditFieldsModalController,
   ])
 
@@ -50,6 +51,7 @@ function EditFieldsModalController(
   Betas,
   Auth,
   $state,
+  Toastr,
 ) {
   let source
   const vm = this
@@ -614,5 +616,13 @@ function EditFieldsModalController(
     // This is a reference to the ng-model of the upload button, which points to the uploaded file
     // On error, we explicitly clear the files stored in the model, as the library does not always automatically do this
     field.uploadedFile = ''
+  }
+
+  /**
+   * Inform user that field id has been copied to clipboard
+   */
+
+  vm.fieldIdCopied = () => {
+    Toastr.success('Field ID copied to clipboard!')
   }
 }

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -1418,3 +1418,7 @@ a.modal-cancel-btn:hover {
   border: 1px solid #ccc;
   color: #979797;
 }
+
+.pull-right {
+  cursor: pointer;
+}

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -1409,4 +1409,5 @@ a.modal-cancel-btn:hover {
   position: absolute;
   top: 10px;
   right: 25px;
+  cursor: grab;
 }

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -1404,3 +1404,9 @@ a.modal-cancel-btn:hover {
   height: 2px;
   margin: 30px 0;
 }
+
+.prefill-copy-icon {
+  position: absolute;
+  top: 10px;
+  right: 25px;
+}

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -1410,4 +1410,11 @@ a.modal-cancel-btn:hover {
   top: 10px;
   right: 25px;
   cursor: grab;
+  color: #b8b8b8;
+}
+
+.prefill-input {
+  background: #f0f0f0;
+  border: 1px solid #ccc;
+  color: #979797;
 }

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1110,7 +1110,6 @@
               <label
                 class="toggle-selector pull-right"
                 ng-class="vm.field.allowPrefill ? 'toggle-selector-on' : ''"
-                onclick=""
               >
                 <input type="checkbox" ng-model="vm.field.allowPrefill" />
                 <div class="toggle-selector-switch">

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1134,16 +1134,20 @@
           <div class="col-md-12">
             <input
               type="text"
-              ng-disabled="true"
+              ng-readonly="true"
               class="input-custom input-medium"
               value="{{vm.field._id || 'Field ID will be generated after field is saved'}}"
+              id="prefill-id"
             />
             <i
               class="bx bx-copy bx-md copy-icon-overlay prefill-copy-icon"
               ng-if="vm.field._id"
               ngclipboard
-              ng-click="vm.fieldIdCopied()"
-              data-clipboard-text="{{vm.field._id}}"
+              ng-click=""
+              data-clipboard-action="copy"
+              data-clipboard-target="#prefill-id"
+              ngclipboard-success="vm.toastSuccessfulFieldIdCopy()"
+              ngclipboard-error="vm.toastFailedFieldIdCopy()"
             ></i>
           </div>
           <div class="col-md-12">

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1087,6 +1087,44 @@
         </div>
         <!-- End custom validation field -->
 
+        <!-- Short Text -->
+
+        <div
+          ng-show="vm.field.fieldType === 'textfield'"
+          class="edit-fields-line"
+        ></div>
+
+        <div ng-if="vm.field.fieldType === 'textfield'" class="row">
+          <div class="row"><br /></div>
+          <div class="toggle-option">
+            <div class="col-xs-8 label-custom label-medium">
+              Enable pre-fill
+              <i
+                class="glyphicon glyphicon-question-sign"
+                uib-tooltip="Allow this field to be pre-populated via URL"
+                tooltip-trigger="'click mouseenter'"
+              >
+              </i>
+            </div>
+            <div class="col-xs-4 field-input">
+              <label
+                class="toggle-selector pull-right"
+                ng-class="vm.field.allowPrefill ? 'toggle-selector-on' : ''"
+                onclick=""
+              >
+                <input type="checkbox" ng-model="vm.field.allowPrefill" />
+                <div class="toggle-selector-switch">
+                  <i
+                    ng-class="vm.field.allowPrefill ? 'bx bx-check' : 'bx bx-x' "
+                  ></i>
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <!-- End Short Text -->
+
         <!-- Decimal -->
         <div ng-if="vm.field.fieldType === 'decimal'">
           <div class="row">

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1123,6 +1123,37 @@
           </div>
         </div>
 
+        <div ng-if="vm.field.fieldType === 'textfield'" class="row">
+          <div class="row"><br /></div>
+          <div class="col-md-12 label-custom label-medium label-bottom">
+            Field ID
+          </div>
+          <div class="col-md-12">
+            <input
+              type="text"
+              ng-disabled="true"
+              class="input-custom input-medium"
+              value="{{vm.field._id}}"
+            />
+          </div>
+          <div class="col-md-12">
+            <div>
+              <div class="alert-custom alert-info">
+                <i class="bx bx-exclamation bx-md icon-spacing"></i>
+                <span class="alert-msg"
+                  >Use Field ID to pre-populate this field for your users.
+                  <a
+                    href="https://guide.form.gov.sg/AdvancedGuide.html#prefill"
+                    target="_blank"
+                  >
+                    Learn how to pre-populate via URL.
+                  </a></span
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- End Short Text -->
 
         <!-- Decimal -->

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1136,10 +1136,11 @@
               type="text"
               ng-disabled="true"
               class="input-custom input-medium"
-              value="{{vm.field._id}}"
+              value="{{vm.field._id || 'Field ID will be generated after field is saved'}}"
             />
             <i
               class="bx bx-copy bx-md copy-icon-overlay prefill-copy-icon"
+              ng-if="vm.field._id"
               ngclipboard
               ng-click="vm.fieldIdCopied()"
               data-clipboard-text="{{vm.field._id}}"

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1143,7 +1143,6 @@
               class="bx bx-copy bx-md copy-icon-overlay prefill-copy-icon"
               ng-if="vm.field._id"
               ngclipboard
-              ng-click=""
               data-clipboard-action="copy"
               data-clipboard-target="#prefill-id"
               ngclipboard-success="vm.toastSuccessfulFieldIdCopy()"

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1135,11 +1135,17 @@
               class="input-custom input-medium"
               value="{{vm.field._id}}"
             />
+            <i
+              class="bx bx-copy bx-md copy-icon-overlay prefill-copy-icon"
+              ngclipboard
+              ng-click="vm.fieldIdCopied()"
+              data-clipboard-text="{{vm.field._id}}"
+            ></i>
           </div>
           <div class="col-md-12">
             <div>
               <div class="alert-custom alert-info">
-                <i class="bx bx-exclamation bx-md icon-spacing"></i>
+                <i class="bx bx-info-circle bx-md icon-spacing"></i>
                 <span class="alert-msg"
                   >Use Field ID to pre-populate this field for your users.
                   <a

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1135,7 +1135,7 @@
             <input
               type="text"
               ng-readonly="true"
-              class="input-custom input-medium"
+              class="input-custom input-medium prefill-input"
               value="{{vm.field._id || 'Field ID will be generated after field is saved'}}"
               id="prefill-id"
             />

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1123,7 +1123,10 @@
           </div>
         </div>
 
-        <div ng-if="vm.field.fieldType === 'textfield'" class="row">
+        <div
+          ng-if="vm.field.fieldType === 'textfield' && vm.field.allowPrefill"
+          class="row"
+        >
           <div class="row"><br /></div>
           <div class="col-md-12 label-custom label-medium label-bottom">
             Field ID

--- a/src/public/modules/forms/base/componentViews/field-textfield.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-textfield.client.view.html
@@ -29,6 +29,7 @@
       ng-required="vm.field.required"
       ng-disabled="vm.field.disabled"
       ng-pattern="vm.pattern"
+      ng-style="vm.field.allowPrefill && {'background-color': '#FEF8E3'}"
       ng-maxlength="{{vm.field.ValidationOptions ? vm.field.ValidationOptions.customMax : ''}}"
       ng-minlength="{{vm.field.ValidationOptions ? vm.field.ValidationOptions.customMin : ''}}"
       ng-model-options="{ allowInvalid: true }"

--- a/src/public/modules/forms/base/componentViews/field-textfield.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-textfield.client.view.html
@@ -29,7 +29,7 @@
       ng-required="vm.field.required"
       ng-disabled="vm.field.disabled"
       ng-pattern="vm.pattern"
-      ng-style="vm.field.allowPrefill && {'background-color': '#FEF8E3'}"
+      ng-class="vm.field.allowPrefill && 'prefill-highlight'"
       ng-maxlength="{{vm.field.ValidationOptions ? vm.field.ValidationOptions.customMax : ''}}"
       ng-minlength="{{vm.field.ValidationOptions ? vm.field.ValidationOptions.customMin : ''}}"
       ng-model-options="{ allowInvalid: true }"

--- a/src/public/modules/forms/base/css/form-field.css
+++ b/src/public/modules/forms/base/css/form-field.css
@@ -86,6 +86,10 @@
   color: #484848;
 }
 
+.field-group.text-field .prefill-highlight {
+  background-color: #fef8e3;
+}
+
 /* ====================================================== */
 
 /* Mobile Number */

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -23,6 +23,21 @@
   >
     <!-- Form Fields View -->
     <div class="form-fields">
+      <!-- Warning label for prefill -->
+      <div class="col-md-12" ng-if="hasPrefill">
+        <div>
+          <div class="alert-custom alert-prefill standard-padding">
+            <i class="bx bx-info-circle bx-md icon-spacing"></i>
+            <span class="alert-msg"
+              >The highlighted fields in this form have been pre-filled
+              according to the link that you clicked. Please check that these
+              values are what you intend to submit, and edit if necessary.
+            </span>
+          </div>
+        </div>
+      </div>
+      <!-- End Warning label for prefill -->
+
       <!-- Form fields -->
       <form name="forms.myForm" novalidate class="standard-padding">
         <div

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -429,9 +429,13 @@ function submitFormDirective(
           }
         })
       }
+
       // Variable to indicate if there are prefill fields
-      scope.hasPrefill = scope.form.form_fields.some((field) => {
-        return field.allowPrefill
+      // Use scope.$watch to monitor logic changes
+      scope.$watch(() => {
+        scope.hasPrefill = scope.form.form_fields.some((field) => {
+          return field.allowPrefill && field.isVisible
+        })
       })
     },
   }

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -429,6 +429,10 @@ function submitFormDirective(
           }
         })
       }
+      // Variable to indicate if there are prefill fields
+      scope.hasPrefill = scope.form.form_fields.some((field) => {
+        return field.allowPrefill
+      })
     },
   }
 }


### PR DESCRIPTION
## Problem

Closes #1593

Forms guide PR [here](https://github.com/opendocsg/opendoc-formsg-faq/pull/78) 

## Solution
- Add prefill toggle for short text field and highlight prefills for public user
- Note that fieldId is generated only upon field create

## Screenshots

**Admin page - Create Field**
![Screenshot 2021-04-27 at 9 21 30 AM](https://user-images.githubusercontent.com/63710093/116173098-88ced780-a73e-11eb-9532-d2131f33ea54.png)
![Screenshot 2021-04-27 at 9 21 24 AM](https://user-images.githubusercontent.com/63710093/116173102-8a989b00-a73e-11eb-9914-a5a0d77f0055.png)


**Admin Page - Edit Field**
![Screenshot 2021-04-27 at 9 21 44 AM](https://user-images.githubusercontent.com/63710093/116173108-8d938b80-a73e-11eb-8a14-4e232659ac36.png)
![Screenshot 2021-04-27 at 9 21 38 AM](https://user-images.githubusercontent.com/63710093/116173109-8e2c2200-a73e-11eb-8248-3fad8e936080.png)


**Public Form View**
![Screenshot 2021-04-22 at 12 21 02 PM](https://user-images.githubusercontent.com/63710093/115656196-52bcdc80-a367-11eb-970d-211184df49e3.png)
![Screenshot 2021-04-22 at 12 21 09 PM](https://user-images.githubusercontent.com/63710093/115656190-518baf80-a367-11eb-8522-c819024f9bbb.png)


## Tests
- [ ] Create two short text fields and set prefill toggle to true. Open form in public view. Check that the fields are prefillable by adding the query params to URL
- [ ] Check that prefill fields are highlighted in yellow
- [ ] Check that warning label appears if there are prefillable fields on form, and does not appear if there are no prefillable fields on form
- [ ] Hide prefill field with logic. Check that warning label only appears when field is visible.