### PR TITLE
chore(admin-forms-routes): remove duplicate logic route endpoint

### DIFF
--- a/src/app/routes/api/v3/admin/forms/admin-forms.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.routes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
 
 import { withUserAuthentication } from '../../../../../modules/auth/auth.middlewares'
-import { handleDeleteLogic } from '../../../../../modules/form/admin-form/admin-form.controller'
 
 import { AdminFormsFeedbackRouter } from './admin-forms.feedback.routes'
 import { AdminFormsFormRouter } from './admin-forms.form.routes'
@@ -21,19 +20,3 @@ AdminFormsRouter.use(AdminFormsFormRouter)
 AdminFormsRouter.use(AdminFormsSubmissionsRouter)
 AdminFormsRouter.use(AdminFormsPreviewRouter)
 AdminFormsRouter.use(AdminFormsLogicRouter)
-
-/**
- * Deletes a logic.
- * @route DELETE /admin/forms/:formId/logic/:logicId
- * @group admin
- * @produces application/json
- * @consumes application/json
- * @returns 200 with success message when successfully deleted
- * @returns 403 when user does not have permissions to delete logic
- * @returns 404 when form cannot be found
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
- */
-AdminFormsRouter.route(
-  '/:formId([a-fA-F0-9]{24})/logic/:logicId([a-fA-F0-9]{24})',
-).delete(handleDeleteLogic)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, there is a redundant `DELETE /admin/forms/:formId/logic/:logicId` endpoint defined in the `admin-forms-routes` file. This endpoint already exists in `admin-forms.logic.routes`.

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- Remove redundant endpoint
