### PR TITLE
fix: show correct error message for e-service ID validation

### DIFF
--- a/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
@@ -178,7 +178,7 @@ describe('myinfo.routes', () => {
 
     it('should return 200 with isValid false and errorCode when e-service ID is invalid', async () => {
       MockAxios.get.mockResolvedValueOnce({
-        data: `<title>Error</title>System Code:&nbsp<b>${MOCK_ERROR_CODE}</b>`,
+        data: `<title>Error</title>System Code:&nbsp;<b>${MOCK_ERROR_CODE}</b>`,
       })
       const response = await request.get(ROUTE).query({ formId: MOCK_FORM_ID })
 

--- a/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
@@ -236,7 +236,7 @@ describe('spcp.routes', () => {
 
     it('should return 200 with isValid false and errorCode when Singpass request is invalid', async () => {
       MockAxios.get.mockResolvedValueOnce({
-        data: `<title>Error</title>System Code:&nbsp<b>${MOCK_ERROR_CODE}</b>`,
+        data: `<title>Error</title>System Code:&nbsp;<b>${MOCK_ERROR_CODE}</b>`,
       })
       const response = await request
         .get(ROUTE)
@@ -251,7 +251,7 @@ describe('spcp.routes', () => {
 
     it('should return 200 with isValid false and errorCode when Corppass request is invalid', async () => {
       MockAxios.get.mockResolvedValueOnce({
-        data: `<title>Error</title>System Code:&nbsp<b>${MOCK_ERROR_CODE}</b>`,
+        data: `<title>Error</title>System Code:&nbsp;<b>${MOCK_ERROR_CODE}</b>`,
       })
       const response = await request
         .get(ROUTE)

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -199,7 +199,7 @@ describe('spcp.service', () => {
 
     it('should return error code when there is error in title', () => {
       const spcpService = new SpcpService(MOCK_PARAMS)
-      const mockHtml = `<title>Error</title>System Code:&nbsp<b>${MOCK_ERROR_CODE}</b>`
+      const mockHtml = `<title>Error</title>System Code:&nbsp;<b>${MOCK_ERROR_CODE}</b>`
       const result = spcpService.validateLoginPage(mockHtml)
       expect(result._unsafeUnwrap()).toEqual({
         isValid: false,

--- a/src/app/modules/spcp/__tests__/spcp.test.constants.ts
+++ b/src/app/modules/spcp/__tests__/spcp.test.constants.ts
@@ -48,7 +48,7 @@ export const MOCK_REDIRECT_URL = 'redirectUrl'
 export const MOCK_REMEMBER_ME = true
 export const MOCK_RELAY_STATE = `${MOCK_DESTINATION},${MOCK_REMEMBER_ME}`
 export const MOCK_LOGIN_HTML = 'html'
-export const MOCK_ERROR_CODE = 'errorCode'
+export const MOCK_ERROR_CODE = '138'
 export const MOCK_TITLE = 'title'
 export const MOCK_JWT = 'jwt'
 

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -178,8 +178,8 @@ export class SpcpService {
     } else {
       // The error page should have text like 'System Code:&nbsp<b>138</b>'
       const errorCode = getSubstringBetween(
-        loginHtml,
-        'System Code:&nbsp<b>',
+        loginHtml.toLowerCase(),
+        'System code:&nbsp;<b>'.toLowerCase(),
         '</b>',
       )
       logger.warn({

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -179,7 +179,7 @@ export class SpcpService {
       // The error page should have text like 'System Code:&nbsp<b>138</b>'
       const errorCode = getSubstringBetween(
         loginHtml.toLowerCase(),
-        'System code:&nbsp;<b>'.toLowerCase(),
+        'system code:&nbsp;<b>',
         '</b>',
       )
       logger.warn({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Singpass e-service ID validation relies on parsing the HTML of the login page. The login page recently added a semicolon in the line showing the error code, resulting in the FormSG server returning `null` for the error code. This causes the frontend to show an error message saying "Could not connect SingPass to validate the e-service ID", instead of showing that the e-service ID is invalid.

## Solution
<!-- How did you solve the problem? -->

Add the semicolon to the parsing code, and also make the comparison case-insensitive.

## Screenshots

### Before
![Screenshot 2021-04-26 at 10 47 52 AM](https://user-images.githubusercontent.com/29480346/116022483-dd118300-a67c-11eb-957d-14785a572277.png)


### After
![image](https://user-images.githubusercontent.com/29480346/116022150-3331f680-a67c-11eb-9f71-d8efa69afe0b.png)
