### PR TITLE
refactor: use shared DateSelectedValidation enum instead of DATE_VALIDATION_OPTIONS

### DIFF
--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -266,7 +266,7 @@ function EditFieldsModalController(
 
   vm.dateValidationOptionList = values(DateValidationOptions)
 
-  // Make DATE_VALIDATION_OPTIONS accessible to view
+  // Make date validation option enum accessible to view
   vm.DateValidationOptions = DateValidationOptions
 
   vm.clearDateValidation = function () {

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -204,7 +204,7 @@ function EditFieldsModalController(
       customMaxDate,
     } = dateValidation
 
-    if (selectedDateValidation !== DateValidationOptions.custom) {
+    if (selectedDateValidation !== DateValidationOptions.Custom) {
       return false
     }
     return !customMinDate && !customMaxDate

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -10,14 +10,11 @@ const {
 } = require('shared/constants')
 const { UPDATE_FORM_TYPES } = require('../constants/update-form-types')
 const { uploadImage } = require('../../../../services/FileHandlerService')
+const {
+  DateSelectedValidation: DateValidationOptions,
+} = require('../../../../../shared/constants')
 
 const CancelToken = axios.CancelToken
-
-const DATE_VALIDATION_OPTIONS = {
-  disallowPast: 'Disallow past dates',
-  disallowFuture: 'Disallow future dates',
-  custom: 'Custom date range',
-}
 
 const EMAIL_MODE_ALLOWED_SIZES = ['1', '2', '3', '7']
 
@@ -207,7 +204,7 @@ function EditFieldsModalController(
       customMaxDate,
     } = dateValidation
 
-    if (selectedDateValidation !== DATE_VALIDATION_OPTIONS.custom) {
+    if (selectedDateValidation !== DateValidationOptions.custom) {
       return false
     }
     return !customMinDate && !customMaxDate
@@ -267,10 +264,10 @@ function EditFieldsModalController(
 
   // Controls for date validation
 
-  vm.dateValidationOptions = values(DATE_VALIDATION_OPTIONS)
+  vm.dateValidationOptionList = values(DateValidationOptions)
 
   // Make DATE_VALIDATION_OPTIONS accessible to view
-  vm.DATE_VALIDATION_OPTIONS = DATE_VALIDATION_OPTIONS
+  vm.DateValidationOptions = DateValidationOptions
 
   vm.clearDateValidation = function () {
     const field = vm.field

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -294,7 +294,7 @@
                     >{{$select.selected}}</ui-select-match
                   >
                   <ui-select-choices
-                    repeat="option in vm.dateValidationOptions | filter: $select.search"
+                    repeat="option in vm.dateValidationOptionList | filter: $select.search"
                   >
                     <span ng-bind="option"></span>
                   </ui-select-choices>
@@ -315,7 +315,7 @@
 
           <div
             class="col-xs-12"
-            ng-if="vm.field.dateValidation.selectedDateValidation === vm.DATE_VALIDATION_OPTIONS.custom"
+            ng-if="vm.field.dateValidation.selectedDateValidation === vm.DateValidationOptions.Custom"
             ng-init="vm.reformatDateRange()"
           >
             <div class="col-sm-6 col-xs-12 min-val-input">
@@ -330,7 +330,7 @@
                 ng-model-options="{timezone: 'utc'}"
                 datepicker-options="{}"
                 ng-model="vm.field.dateValidation.customMinDate"
-                ng-disabled="!vm.field.dateValidation.selectedDateValidation || vm.field.dateValidation.selectedDateValidation !== vm.DATE_VALIDATION_OPTIONS.custom"
+                ng-disabled="!vm.field.dateValidation.selectedDateValidation || vm.field.dateValidation.selectedDateValidation !== vm.DateValidationOptions.Custom"
                 datepicker-template-url="modules/forms/base/directiveViews/datepicker.html"
                 datepicker-popup-template-url="modules/forms/base/directiveViews/datepicker-popup.html"
               />
@@ -347,7 +347,7 @@
                 ng-model-options="{timezone: 'utc'}"
                 datepicker-options="{}"
                 ng-model="vm.field.dateValidation.customMaxDate"
-                ng-disabled="!vm.field.dateValidation.selectedDateValidation || vm.field.dateValidation.selectedDateValidation !== vm.DATE_VALIDATION_OPTIONS.custom"
+                ng-disabled="!vm.field.dateValidation.selectedDateValidation || vm.field.dateValidation.selectedDateValidation !== vm.DateValidationOptions.Custom"
                 datepicker-template-url="modules/forms/base/directiveViews/datepicker.html"
                 datepicker-popup-template-url="modules/forms/base/directiveViews/datepicker-popup.html"
               />


### PR DESCRIPTION
## Problem
An enum called `DateSelectedValidation` was introduced during a typescript migration task #749, but the frontend codebase has not been updated to make use of this enum.

Closes #777 

## Solution
Remove the naming conflict between `DateValidationOptions` and `DATE_VALIDATION_OPTIONS`. The former is actually a list of options and the latter is the enum. The former is now called DateValidationOptionList.

Edit usages of the enum from lower-case to title-case to match the new enum. i.e. `DateValidationOptions.custom` to `DateValidationOptions.Custom`

## Reviewers

@tshuli appreciate if you could take a quick look to see if these changes are indeed what you had intended.
