### PR TITLE
feat(spcp): raise sp cookie max age to 3 hrs

### DIFF
--- a/src/app/config/feature-manager/spcp-myinfo.config.ts
+++ b/src/app/config/feature-manager/spcp-myinfo.config.ts
@@ -24,7 +24,7 @@ const spcpMyInfoFeature: RegisterableFeature<FeatureNames.SpcpMyInfo> = {
     spCookieMaxAge: {
       doc: 'Max SingPass cookie age with remember me unchecked',
       format: 'int',
-      default: 1 * HOUR_IN_MILLIS,
+      default: 3 * HOUR_IN_MILLIS,
       env: 'SP_COOKIE_MAX_AGE',
     },
     spCookieMaxAgePreserved: {


### PR DESCRIPTION
## Problem
Past feedback that 1h was too short for some long forms

Closes #1674 

## Solution
Modify the config's default for SP session age to 3 hours, up from the original 1 hour. Corp pass already has their session age to be 6 hours, so no change required on that front.

