### PR TITLE
feat(api-refactor): implement specific delete form field api

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1151,6 +1151,57 @@ describe('Form Model', () => {
         expect(modifiedForm).toBeNull()
       })
     })
+
+    describe('deleteFormFieldById', () => {
+      it('should return form with deleted field', async () => {
+        // Arrange
+        const fieldToDelete = generateDefaultField(BasicField.Decimal)
+        const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
+          admin: populatedAdmin,
+          form_fields: [fieldToDelete, generateDefaultField(BasicField.Mobile)],
+        })
+        const form = await Form.create(formParams)
+
+        // Act
+        const actual = await Form.deleteFormFieldById(
+          form._id,
+          fieldToDelete._id,
+        )
+
+        // Assert
+        // Only non-deleted form field remains
+        const expectedFormFields = [form.toObject().form_fields![1]]
+        const retrievedForm = await Form.findById(form._id).lean()
+        // Check return shape.
+        expect(actual?.toObject().form_fields).toEqual(expectedFormFields)
+        // Check db state
+        expect(retrievedForm).not.toBeNull()
+        expect(retrievedForm?.form_fields).toEqual(expectedFormFields)
+      })
+
+      it('should return form unchanged when field id is invalid', async () => {
+        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          admin: MOCK_ADMIN_OBJ_ID,
+          form_fields: [
+            generateDefaultField(BasicField.Date),
+            generateDefaultField(BasicField.Mobile),
+          ],
+        })
+        const form = await Form.create(formParams)
+
+        // Act
+        const actual = await Form.deleteFormFieldById(
+          form._id,
+          new ObjectId().toHexString(),
+        )
+
+        // Assert
+        expect(actual?.toObject()).toEqual({
+          ...form.toObject(),
+          lastModified: expect.any(Date),
+        })
+      })
+    })
   })
 
   describe('Methods', () => {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -671,6 +671,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     ).exec()
   }
 
+  // Deletes specified form field by id.
+  FormSchema.statics.deleteFormFieldById = async function (
+    this: IFormModel,
+    formId: string,
+    fieldId: string,
+  ): Promise<IFormSchema | null> {
+    return this.findByIdAndUpdate(
+      formId,
+      { $pull: { form_fields: { _id: fieldId } } },
+      { new: true, runValidators: true },
+    ).exec()
+  }
+
   // Hooks
   FormSchema.pre<IFormSchema>('validate', function (next) {
     // Reject save if form document is too large

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -7818,4 +7818,223 @@ describe('admin-form.controller', () => {
       })
     })
   })
+
+  describe('handleDeleteFormField', () => {
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+    const MOCK_FIELDS = [
+      generateDefaultField(BasicField.Rating),
+      generateDefaultField(BasicField.Table),
+    ]
+    const MOCK_FIELD_ID = String(MOCK_FIELDS[1]._id)
+
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      form_fields: MOCK_FIELDS,
+      title: 'mock title',
+    } as IPopulatedForm
+
+    const MOCK_UPDATED_FORM = {
+      ...MOCK_FORM,
+      form_fields: [MOCK_FIELDS[0]],
+    } as IFormSchema
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID,
+        fieldId: MOCK_FIELD_ID,
+      },
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    beforeEach(() => {
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.deleteFormField.mockReturnValue(
+        okAsync(MOCK_UPDATED_FORM),
+      )
+    })
+
+    it('should return 204 when deletion is successful', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(204)
+      expect(mockRes.json).not.toHaveBeenCalled()
+      expect(MockAdminFormService.deleteFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_FIELD_ID,
+      )
+    })
+
+    it('should return 403 when current user does not have permissions to delete form fields', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const expectedErrorString = 'no write permissions'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.deleteFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when field to delete cannot be found', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      MockAdminFormService.deleteFormField.mockReturnValueOnce(
+        errAsync(new FieldNotFoundError()),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Field to modify not found',
+      })
+      expect(MockAdminFormService.deleteFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_FIELD_ID,
+      )
+    })
+
+    it('should return 404 when form to delete form field for cannot be found', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedErrorString = 'nope'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.deleteFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 410 when form to delete form field for is already archived', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedErrorString = 'already deleted'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.deleteFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedErrorString = 'user not in session??!!'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(MockAdminFormService.deleteFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when generic database error occurs during form field deletion', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      const expectedErrorString = 'some database error bam'
+      MockAdminFormService.deleteFormField.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+
+      // Act
+      await AdminFormController.handleDeleteFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.deleteFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_FIELD_ID,
+      )
+    })
+  })
 })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -47,7 +47,11 @@ import {
 
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
 
-import { LogicNotFoundError, TransferOwnershipError } from '../../form.errors'
+import {
+  FormNotFoundError,
+  LogicNotFoundError,
+  TransferOwnershipError,
+} from '../../form.errors'
 import {
   CreatePresignedUrlError,
   EditFieldError,
@@ -60,6 +64,7 @@ import {
   createFormField,
   createPresignedPostUrlForImages,
   createPresignedPostUrlForLogos,
+  deleteFormField,
   deleteFormLogic,
   duplicateForm,
   editFormFields,
@@ -1540,6 +1545,83 @@ describe('admin-form.service', () => {
       expect(mockForm.reorderFormFieldById).toHaveBeenCalledWith(
         fieldToReorder,
         newPosition,
+      )
+    })
+  })
+
+  describe('deleteFormField', () => {
+    let deleteSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      deleteSpy = jest.spyOn(FormModel, 'deleteFormFieldById')
+    })
+    it('should return updated form when field deletion is successful', async () => {
+      // Arrange
+      const fieldToDelete = generateDefaultField(BasicField.Mobile)
+      const initialFields = [
+        fieldToDelete,
+        generateDefaultField(BasicField.Image),
+      ]
+      const mockUpdatedForm = {
+        title: 'some mock form',
+        // Append created field to end of form_fields.
+        form_fields: [initialFields[1]],
+      } as IFormSchema
+      const mockForm = ({
+        title: 'some mock form',
+        form_fields: initialFields,
+        _id: new ObjectId(),
+      } as unknown) as IPopulatedForm
+      deleteSpy.mockResolvedValueOnce(mockUpdatedForm)
+
+      // Act
+      const actual = await deleteFormField(mockForm, String(fieldToDelete._id))
+
+      // Assert
+      expect(actual._unsafeUnwrap()).toEqual(mockUpdatedForm)
+      expect(deleteSpy).toHaveBeenCalledWith(
+        String(mockForm._id),
+        fieldToDelete._id,
+      )
+    })
+
+    it("should return FieldNotFoundError when the fieldId does not exist in the form's fields", async () => {
+      // Arrange
+      const mockForm = ({
+        title: 'some mock form',
+        form_fields: [generateDefaultField(BasicField.Nric)],
+        _id: new ObjectId(),
+      } as unknown) as IPopulatedForm
+
+      // Act
+      const actual = await deleteFormField(
+        mockForm,
+        new ObjectId().toHexString(),
+      )
+
+      // Assert
+      expect(actual._unsafeUnwrapErr()).toEqual(new FieldNotFoundError())
+      expect(deleteSpy).not.toHaveBeenCalled()
+    })
+
+    it('should return FormNotFoundError when field deletion returns null', async () => {
+      // Arrange
+      const fieldToDelete = generateDefaultField(BasicField.Mobile)
+      const mockForm = ({
+        title: 'some mock form',
+        form_fields: [fieldToDelete],
+        _id: new ObjectId(),
+      } as unknown) as IPopulatedForm
+      deleteSpy.mockResolvedValueOnce(null)
+
+      // Act
+      const actual = await deleteFormField(mockForm, fieldToDelete._id)
+
+      // Assert
+      expect(actual._unsafeUnwrapErr()).toEqual(new FormNotFoundError())
+      expect(deleteSpy).toHaveBeenCalledWith(
+        String(mockForm._id),
+        fieldToDelete._id,
       )
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1767,7 +1767,7 @@ export const handleDeleteFormField: RequestHandler<
         logger.error({
           message: 'Error occurred when deleting form field',
           meta: {
-            action: '_handleDeleteFormField',
+            action: 'handleDeleteFormField',
             ...createReqMeta(req),
             userId: sessionUserId,
             formId,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1729,3 +1729,54 @@ export const handleReorderFormField = [
   }),
   _handleReorderFormField,
 ] as RequestHandler[]
+
+/**
+ * Handler for DELETE /forms/:formId/fields/:fieldId
+ * @security session
+ *
+ * @returns 204 when deletion is successful
+ * @returns 403 when current user does not have permissions to delete form field
+ * @returns 404 when form cannot be found
+ * @returns 404 when form field to delete cannot be found
+ * @returns 410 when deleting form field of an archived form
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs during deletion
+ */
+export const handleDeleteFormField: RequestHandler<
+  { formId: string; fieldId: string },
+  ErrorDto | void
+> = (req, res) => {
+  const { formId, fieldId } = req.params
+  const sessionUserId = (req.session as Express.AuthedSession).user._id
+
+  return (
+    // Step 1: Retrieve currently logged in user.
+    UserService.getPopulatedUserById(sessionUserId)
+      .andThen((user) =>
+        // Step 2: Retrieve form with write permission check.
+        AuthService.getFormAfterPermissionChecks({
+          user,
+          formId,
+          level: PermissionLevel.Write,
+        }),
+      )
+      // Step 3: Delete form field.
+      .andThen((form) => AdminFormService.deleteFormField(form, fieldId))
+      .map(() => res.sendStatus(StatusCodes.NO_CONTENT))
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error occurred when deleting form field',
+          meta: {
+            action: '_handleDeleteFormField',
+            ...createReqMeta(req),
+            userId: sessionUserId,
+            formId,
+            fieldId,
+          },
+          error,
+        })
+        const { errorMessage, statusCode } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
+}

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -92,25 +92,42 @@ AdminFormsFormRouter.post(
 )
 
 /**
- * Update form field according to given new body.
- * @route PUT /admin/forms/:formId/fields/:fieldId
- *
- * @param body the new field to override current field
- * @returns 200 with updated form field
- * @returns 400 when given body fails Joi validation
- * @returns 401 when current user is not logged in
- * @returns 403 when current user does not have permissions to update form field
- * @returns 404 when form cannot be found
- * @returns 404 when field cannot be found
- * @returns 410 when updating form field for archived form
- * @returns 422 when an invalid form field update is attempted on the form
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
+ * Specific form field REST APIs
  */
-AdminFormsFormRouter.put(
+AdminFormsFormRouter.route(
   '/:formId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})',
-  AdminFormController.handleUpdateFormField,
 )
+  /**
+   * Update form field according to given new body.
+   * @route PUT /admin/forms/:formId/fields/:fieldId
+   *
+   * @param body the new field to override current field
+   * @returns 200 with updated form field
+   * @returns 400 when given body fails Joi validation
+   * @returns 401 when current user is not logged in
+   * @returns 403 when current user does not have permissions to update form field
+   * @returns 404 when form cannot be found
+   * @returns 404 when field cannot be found
+   * @returns 410 when updating form field for archived form
+   * @returns 422 when an invalid form field update is attempted on the form
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .put(AdminFormController.handleUpdateFormField)
+  /**
+   * Delete form field by fieldId of form corresponding to formId.
+   * @route DELETE /admin/forms/:formId/fields/:fieldId
+   * @security session
+   *
+   * @returns 204 when deletion is successful
+   * @returns 403 when current user does not have permissions to delete form field
+   * @returns 404 when form cannot be found
+   * @returns 404 when form field to delete cannot be found
+   * @returns 410 when deleting form field of an archived form
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs during deletion
+   */
+  .delete(AdminFormController.handleDeleteFormField)
 
 AdminFormsFormRouter.post(
   '/:formId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})/reorder',

--- a/src/public/modules/forms/admin/constants/update-form-types.ts
+++ b/src/public/modules/forms/admin/constants/update-form-types.ts
@@ -1,5 +1,6 @@
 export const UPDATE_FORM_TYPES = {
   UpdateField: 'update-field',
   CreateField: 'create-field',
+  DeleteField: 'delete-field',
   ReorderField: 'reorder-field',
 }

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -207,6 +207,21 @@ function AdminFormController(
           })
           .catch(handleUpdateError)
       }
+      case UPDATE_FORM_TYPES.DeleteField: {
+        const { fieldId } = update
+        return $q
+          .when(
+            AdminFormService.deleteSingleFormField($scope.myform._id, fieldId),
+          )
+          .then(() => {
+            // Success, remove deleted form field
+            const updatedFormFields = $scope.myform.form_fields.filter(
+              (f) => String(f._id) !== fieldId,
+            )
+            $scope.myform.form_fields = updatedFormFields
+          })
+          .catch(handleUpdateError)
+      }
       case UPDATE_FORM_TYPES.UpdateField: {
         const { fieldId, body } = update
         return $q

--- a/src/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -381,13 +381,10 @@ function editFormController(
     if (field.fieldType === 'attachment') {
       Attachment.attachmentsTotal += parseInt(field.attachmentSize)
     }
+
     return updateField({
-      editFormField: {
-        action: {
-          name: EditFieldActions.Delete,
-        },
-        field: field,
-      },
+      fieldId: field._id,
+      type: UPDATE_FORM_TYPES.DeleteField,
     })
   }
 

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -68,6 +68,19 @@ export const reorderSingleFormField = async (
     .then(({ data }) => data)
 }
 
+/**
+ * Delete a single form field by its id in given form
+ * @param formId the form to delete the field from
+ * @param fieldId the id of the field to delete
+ * @returns void on success
+ */
+export const deleteSingleFormField = async (
+  formId: string,
+  fieldId: string,
+): Promise<void> => {
+  return axios.delete(`${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`)
+}
+
 export const deleteFormLogic = async (
   formId: string,
   logicId: string,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -296,6 +296,16 @@ export interface IFormModel extends Model<IFormSchema> {
     fields?: (keyof IPopulatedForm)[],
   ): Promise<IPopulatedForm | null>
   deleteFormLogic(formId: string, logicId: string): Promise<IFormSchema | null>
+  /**
+   * Deletes specified form field by its id from the form corresponding to given form id.
+   * @param formId the id of the form to delete specific form field for
+   * @param fieldId the id of the form field to delete from the form
+   * @returns updated form after deletion of form field
+   */
+  deleteFormFieldById(
+    formId: string,
+    fieldId: string,
+  ): Promise<IFormSchema | null>
   deactivateById(formId: string): Promise<IFormSchema | null>
   getMetaByUserIdOrEmail(
     userId: IUserSchema['_id'],


### PR DESCRIPTION
Integration tests will be added to a separate PR to prevent PR size from becoming too big

This PR cannot be rolled back after release due to the invocation of the new endpoint on the client side.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a new admin-form server endpoint for form fields deletion, and updates the frontend client to use that endpoint when deleting fields.

Closes #1485

## Solution
<!-- How did you solve the problem? -->

**Server Features**:
- feat(FormModel): add deleteFormFieldById static method
- feat(AdminFormSvc): add deleteFormField service fn
- feat(AdminFormCtl): add handleDeleteFormField controller handler fn
- feat(AdminFormsRoutes): add route for deleting form field

**Client Features**
- feat(AdminFormService): add deleteSingleFormField fn
- feat: use new server endpoint for deleting of fields

## Tests
<!-- What tests should be run to confirm functionality? -->
**To be added**
