### PR TITLE
fix: update MyInfo field count correctly, show correct error

### DIFF
--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -141,7 +141,8 @@ function AdminFormController(
       return
     }
     let errorMessage
-    switch (error.status) {
+    const status = get(error, 'response.status') || get(error, 'status')
+    switch (status) {
       case StatusCodes.CONFLICT:
       case StatusCodes.BAD_REQUEST:
         errorMessage =
@@ -155,7 +156,7 @@ function AdminFormController(
         // Validation can fail for many reasons, so return more specific message
         errorMessage = get(
           error,
-          'data.message',
+          'response.data.message',
           'Your changes contain invalid input.',
         )
         break

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -191,7 +191,10 @@ function AdminFormController(
           .when(AdminFormService.createSingleFormField($scope.myform._id, body))
           .then((updatedFormField) => {
             // insert created field into form
-            $scope.myform.form_fields.push(updatedFormField)
+            $scope.myform.form_fields = [
+              ...$scope.myform.form_fields,
+              updatedFormField,
+            ]
           })
           .catch(handleUpdateError)
       }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. When user attempts to save more MyInfo fields than is allowed, a generic error message shows in the Toastr, rather than the specific one returned by the backend.
2. On the build tab, MyInfo field count does not update upon creation of MyInfo field.

## Solution
<!-- How did you solve the problem? -->

### Fixing error message
The initial error message was:
![image](https://user-images.githubusercontent.com/29480346/116178315-e74c8380-a747-11eb-894a-3b822161c6ef.png)

This was fixed by accessing `error.response.status` rather than `error.status`, since `error` is now an `AxiosError`.

The error message then changed to this:
![Screenshot 2021-04-27 at 10 54 16 AM](https://user-images.githubusercontent.com/29480346/116178353-fcc1ad80-a747-11eb-87b5-495952abff3d.png)

This was because we return a 422 when an error occurs while editing fields, and the `switch` case handles 422s by attempting to access `error.data.message`. This was fixed by accessing `error.response.data.message` instead.

This finally fixed the error message:
![Screenshot 2021-04-27 at 10 54 55 AM](https://user-images.githubusercontent.com/29480346/116178440-2bd81f00-a748-11eb-874b-8632402f0cc3.png)

### Updating MyInfo field count
This was fixed by assigning to `$scope.myform.form_fields` instead of pushing to the array, which triggers the AngularJS digest cycle correctly.