### PR TITLE
fix: convert form field responses to field class 

### DIFF
--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -41,6 +41,7 @@ angular
     '$translate',
     '$uibModal',
     'FormData',
+    'FormFields',
     'Auth',
     'moment',
     'Toastr',
@@ -56,6 +57,7 @@ function AdminFormController(
   $translate,
   $uibModal,
   FormData,
+  FormFields,
   Auth,
   moment,
   Toastr,
@@ -195,6 +197,7 @@ function AdminFormController(
             const updatedFieldClass = FieldFactory.createFieldFromData(
               updatedFormField,
             )
+            FormFields.injectMyInfoFieldInfo(updatedFieldClass)
 
             // insert created field into form
             $scope.myform.form_fields = [
@@ -219,6 +222,7 @@ function AdminFormController(
             const updatedFieldClass = FieldFactory.createFieldFromData(
               updatedFormField,
             )
+            FormFields.injectMyInfoFieldInfo(updatedFieldClass)
 
             // merge back into the form fields
             const updateIndex = $scope.myform.form_fields.findIndex(
@@ -245,9 +249,11 @@ function AdminFormController(
           )
           .then((updatedFields) => {
             // !!! Convert retrieved form field objects into their class counterparts.
-            const updatedFieldClasses = updatedFields.map((f) =>
-              FieldFactory.createFieldFromData(f),
-            )
+            const updatedFieldClasses = updatedFields.map((f) => {
+              const fieldClass = FieldFactory.createFieldFromData(f)
+              FormFields.injectMyInfoFieldInfo(fieldClass)
+              return fieldClass
+            })
             $scope.myform.form_fields = updatedFieldClasses
           })
           .catch(handleUpdateError)

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -4,6 +4,7 @@ const { StatusCodes } = require('http-status-codes')
 const get = require('lodash/get')
 const { LogicType } = require('../../../../../types')
 const AdminFormService = require('../../../../services/AdminFormService')
+const FieldFactory = require('../../helpers/field-factory')
 const { UPDATE_FORM_TYPES } = require('../constants/update-form-types')
 
 // All viewable tabs. readOnly is true if that tab cannot be used to edit form.
@@ -190,10 +191,15 @@ function AdminFormController(
         return $q
           .when(AdminFormService.createSingleFormField($scope.myform._id, body))
           .then((updatedFormField) => {
+            // !!! Convert retrieved form field objects into their class counterparts.
+            const updatedFieldClass = FieldFactory.createFieldFromData(
+              updatedFormField,
+            )
+
             // insert created field into form
             $scope.myform.form_fields = [
               ...$scope.myform.form_fields,
-              updatedFormField,
+              updatedFieldClass,
             ]
           })
           .catch(handleUpdateError)
@@ -209,12 +215,17 @@ function AdminFormController(
             ),
           )
           .then((updatedFormField) => {
+            // !!! Convert retrieved form field objects into their class counterparts.
+            const updatedFieldClass = FieldFactory.createFieldFromData(
+              updatedFormField,
+            )
+
             // merge back into the form fields
             const updateIndex = $scope.myform.form_fields.findIndex(
               (f) => f._id === fieldId,
             )
             if (updateIndex !== -1) {
-              $scope.myform.form_fields[updateIndex] = updatedFormField
+              $scope.myform.form_fields[updateIndex] = updatedFieldClass
             } else {
               Toastr.error('An error occurred while saving your changes.')
             }
@@ -233,7 +244,11 @@ function AdminFormController(
             ),
           )
           .then((updatedFields) => {
-            $scope.myform.form_fields = updatedFields
+            // !!! Convert retrieved form field objects into their class counterparts.
+            const updatedFieldClasses = updatedFields.map((f) =>
+              FieldFactory.createFieldFromData(f),
+            )
+            $scope.myform.form_fields = updatedFieldClasses
           })
           .catch(handleUpdateError)
       }

--- a/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
@@ -6,6 +6,7 @@ angular
   .module('forms')
   .controller('EditMyInfoFieldController', [
     '$uibModalInstance',
+    'FormFields',
     'externalScope',
     'updateField',
     EditMyInfoFieldController,
@@ -13,6 +14,7 @@ angular
 
 function EditMyInfoFieldController(
   $uibModalInstance,
+  FormFields,
   externalScope,
   updateField,
 ) {
@@ -32,6 +34,10 @@ function EditMyInfoFieldController(
     // No id, creation
     let updateFieldPromise
     const field = externalScope.currField
+
+    // Mutate and remove MyInfo data
+    FormFields.removeMyInfoFieldInfo(field)
+
     // Field creation
     if (!field._id) {
       updateFieldPromise = updateField({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR fixes a bug (not in prod as of this PR) where calling the new form field manipulation APIs created in #1640, #1671, #1726 was
1. Not stripping MyInfo field data before saving it into the database. 
2.  Not converting returned form field JSON objects into their class based implementation.

The PRs above replaced the previous method of updating form fields in `FormApi#update`, where there was an interceptor function to
1. modifying outgoing requests by removing MyInfo field data, and 
2. transforming incoming form responses into an Form class with specific Field classes for the form fields.

However, with the update form field refactors, the interceptor is not invoked (and return shapes are different); thus causing the form field object responses to not be transformed into their Field class representations, causing errors when the Field class methods are being invoked, such as when updating a table field:
![Screenshot 2021-04-27 at 12 55 37 PM](https://user-images.githubusercontent.com/22133008/116187305-df94db00-a757-11eb-94fb-3668a6cbb574.png)

MyInfo field data is also not being stripped when creating them in the backend, causing superfluous data to be stored in the database. 

This PR fixes both of those bugs.

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix: convert form field responses into class counterparts when received from the server
- fix: inject myinfo field info if received form field from server is a myinfo field
- fix: remove myinfo field info before saving myinfo field

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a table field and save it. Without refreshing, edit the table field again. The table should be rendered properly and changes should be saved successfully.
- [ ] Create a Race MyInfo field. When saving it, check the network request. The body should contain the following empty key-values: 
```
fieldName: ""
fieldOptions: []
fieldType: "dropdown"
fieldValue: ""
```
- [ ] Update the same MyInfo field. The network request body should look the same.
