### PR TITLE
fix(client): clone field to save before removing myinfo field info

### DIFF
--- a/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-myinfo-field-modal.client.controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const cloneDeep = require('lodash/cloneDeep')
 const { UPDATE_FORM_TYPES } = require('../constants/update-form-types')
 
 angular
@@ -33,7 +34,7 @@ function EditMyInfoFieldController(
   vm.saveMyInfoField = function () {
     // No id, creation
     let updateFieldPromise
-    const field = externalScope.currField
+    const field = cloneDeep(externalScope.currField)
 
     // Mutate and remove MyInfo data
     FormFields.removeMyInfoFieldInfo(field)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR fixes a UI bug where the inject MyInfo field values disappears for a split second before modal closes, or disappears fully on field save error. See gif.

![recording (17)](https://user-images.githubusercontent.com/22133008/116198975-322ac300-a769-11eb-9fc0-b4bc7e77b595.gif)
