### PR TITLE
chore(mergify): remove 0 check failure condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,7 +2,6 @@ pull_request_rules:
   - name: Approve and merge non-major dependency upgrades
     conditions:
       - 'author=dependabot[bot]'
-      - '#check-failure=0'
       - 'title~=bump [^\s]+ from ([\d]+)\..+ to \1\.'
     actions:
       review:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The [Mergify documentation](https://docs.mergify.io/conditions/#validating-all-status-checks) states that `#check-failure=0` should not be used as a condition because of a possible race condition where the PR might be merged before any service reports its status check.

Credit to @lamkeewei for pointing this out.

## Solution
<!-- How did you solve the problem? -->

Remove the `#check-failure=0` condition. We can rely on branch protections to ensure that all status checks pass before PRs can be merged (which is what we were implicitly doing in the first place).