### PR TITLE
feat(api-refactor): add specific update end page endpoint in server

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1217,6 +1217,7 @@ describe('Form Model', () => {
         const updatedEndPage: EndPage = {
           title: 'some new title',
           paragraph: 'some description paragraph',
+          buttonText: 'custom button text',
         }
 
         // Act
@@ -1227,7 +1228,34 @@ describe('Form Model', () => {
         expect(actual?.toObject()).toEqual({
           ...form,
           lastModified: expect.any(Date),
-          endPage: { ...updatedEndPage, buttonText: 'Submit another form' },
+          endPage: { ...updatedEndPage },
+        })
+      })
+
+      it('should update end page with defaults when optional values are not provided', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
+          admin: MOCK_ADMIN_OBJ_ID,
+        })
+        const form = (await Form.create(formParams)).toObject()
+        const updatedEndPage: EndPage = {
+          paragraph: 'some description paragraph',
+        }
+
+        // Act
+        const actual = await Form.updateEndPageById(form._id, updatedEndPage)
+
+        // Assert
+        // Should have defaults populated but also replace the endpage with the new params
+        expect(actual?.toObject()).toEqual({
+          ...form,
+          lastModified: expect.any(Date),
+          endPage: {
+            ...updatedEndPage,
+            // Defaults should be populated and returned
+            buttonText: 'Submit another form',
+            title: 'Thank you for filling out the form.',
+          },
         })
       })
 

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -10,6 +10,7 @@ import getFormModel, {
 } from 'src/app/models/form.server.model'
 import {
   BasicField,
+  EndPage,
   FormFieldWithId,
   IEncryptedForm,
   IFieldSchema,
@@ -1200,6 +1201,53 @@ describe('Form Model', () => {
           ...form.toObject(),
           lastModified: expect.any(Date),
         })
+      })
+    })
+
+    describe('updateEndPageById', () => {
+      it('should update end page and return updated form when successful', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
+          admin: MOCK_ADMIN_OBJ_ID,
+          endPage: {
+            title: 'old title',
+          },
+        })
+        const form = (await Form.create(formParams)).toObject()
+        const updatedEndPage: EndPage = {
+          title: 'some new title',
+          paragraph: 'some description paragraph',
+        }
+
+        // Act
+        const actual = await Form.updateEndPageById(form._id, updatedEndPage)
+
+        // Assert
+        // Should have defaults populated but also replace the endpage with the new params
+        expect(actual?.toObject()).toEqual({
+          ...form,
+          lastModified: expect.any(Date),
+          endPage: { ...updatedEndPage, buttonText: 'Submit another form' },
+        })
+      })
+
+      it('should return null when formId given is not in the database', async () => {
+        // Arrange
+        await expect(Form.countDocuments()).resolves.toEqual(0)
+        const updatedEndPage: EndPage = {
+          title: 'some new title',
+          paragraph: 'does not really matter',
+        }
+
+        // Act
+        const actual = await Form.updateEndPageById(
+          new ObjectId().toHexString(),
+          updatedEndPage,
+        )
+
+        // Assert
+        expect(actual).toEqual(null)
+        await expect(Form.countDocuments()).resolves.toEqual(0)
       })
     })
   })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -14,6 +14,7 @@ import {
   AuthType,
   BasicField,
   Colors,
+  EndPage,
   FormField,
   FormFieldWithId,
   FormLogoState,
@@ -680,6 +681,18 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return this.findByIdAndUpdate(
       formId,
       { $pull: { form_fields: { _id: fieldId } } },
+      { new: true, runValidators: true },
+    ).exec()
+  }
+
+  FormSchema.statics.updateEndPageById = async function (
+    this: IFormModel,
+    formId: string,
+    newEndPage: EndPage,
+  ) {
+    return this.findByIdAndUpdate(
+      formId,
+      { endPage: newEndPage },
       { new: true, runValidators: true },
     ).exec()
   }

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -48,6 +48,7 @@ import {
   IEncryptedSubmissionSchema,
   IFieldSchema,
   IForm,
+  IFormDocument,
   IFormSchema,
   ILogicSchema,
   IPopulatedEmailForm,
@@ -8034,6 +8035,302 @@ describe('admin-form.controller', () => {
       expect(MockAdminFormService.deleteFormField).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_FIELD_ID,
+      )
+    })
+  })
+
+  describe('_handleUpdateEndPage', () => {
+    const MOCK_USER_ID = new ObjectId().toHexString()
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const MOCK_USER = {
+      _id: MOCK_USER_ID,
+      email: 'somerandom@example.com',
+    } as IPopulatedUser
+
+    const MOCK_FORM = {
+      admin: MOCK_USER,
+      _id: MOCK_FORM_ID,
+      endPage: {
+        title: 'old end page',
+      },
+      title: 'mock end page title',
+    } as IPopulatedForm
+
+    const MOCK_UPDATED_FORM = {
+      ...MOCK_FORM,
+      endPage: {
+        title: 'new mock end page title',
+      },
+    } as IFormDocument
+
+    const MOCK_UPDATED_END_PAGE = MOCK_UPDATED_FORM.endPage
+
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        formId: MOCK_FORM_ID,
+      },
+      body: MOCK_UPDATED_END_PAGE,
+      session: {
+        user: {
+          _id: MOCK_USER_ID,
+        },
+      },
+    })
+
+    beforeEach(() => {
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.updateEndPage.mockReturnValue(
+        okAsync(MOCK_UPDATED_END_PAGE),
+      )
+    })
+
+    it('should return 200 with updated end page', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_UPDATED_END_PAGE)
+      expect(MockAdminFormService.updateEndPage).toHaveBeenCalledWith(
+        MOCK_REQ.params.formId,
+        MOCK_REQ.body,
+      )
+    })
+
+    it('should return 403 when current user does not have permissions to update the end page', async () => {
+      // Arrange
+      const expectedErrorString = 'no permissions pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new ForbiddenFormError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when form cannot be found', async () => {
+      // Arrange
+      const expectedErrorString = 'no form pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormNotFoundError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 410 when attempting to update an archived form', async () => {
+      // Arrange
+      const expectedErrorString = 'form gone pls'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new FormDeletedError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(410)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 413 when updating the end page causes the form to be too large to be saved in the database', async () => {
+      // Arrange
+      const expectedErrorString = 'payload too large'
+      MockAdminFormService.updateEndPage.mockReturnValueOnce(
+        errAsync(new DatabasePayloadSizeError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(413)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).toHaveBeenCalledWith(
+        MOCK_REQ.params.formId,
+        MOCK_REQ.body,
+      )
+    })
+
+    it('should return 422 when DatabaseValidationError occurs', async () => {
+      // Arrange
+      const expectedErrorString = 'invalid thing'
+      MockAdminFormService.updateEndPage.mockReturnValueOnce(
+        errAsync(new DatabaseValidationError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).toHaveBeenCalledWith(
+        MOCK_REQ.params.formId,
+        MOCK_REQ.body,
+      )
+    })
+
+    it('should return 422 when user in session cannot be retrieved from the database', async () => {
+      // Arrange
+      const expectedErrorString = 'user gone'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new MissingUserError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(422)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst retrieving user from database', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(
+        MockAuthService.getFormAfterPermissionChecks,
+      ).not.toHaveBeenCalled()
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst retrieving form from database', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAuthService.getFormAfterPermissionChecks).toHaveBeenCalledWith(
+        {
+          user: MOCK_USER,
+          formId: String(MOCK_FORM_ID),
+          level: PermissionLevel.Write,
+        },
+      )
+      expect(MockAdminFormService.updateEndPage).not.toHaveBeenCalled()
+    })
+
+    it('should return 500 when database error occurs whilst updating end page', async () => {
+      // Arrange
+      const expectedErrorString = 'database error'
+      MockAdminFormService.updateEndPage.mockReturnValueOnce(
+        errAsync(new DatabaseError(expectedErrorString)),
+      )
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateEndPage(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expectedErrorString,
+      })
+      expect(MockAdminFormService.updateEndPage).toHaveBeenCalledWith(
+        MOCK_REQ.params.formId,
+        MOCK_REQ.body,
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -24,6 +24,7 @@ import { EditFieldActions, VALID_UPLOAD_FILE_TYPES } from 'src/shared/constants'
 import {
   AuthType,
   BasicField,
+  EndPage,
   FormLogoState,
   FormMetaView,
   FormSettings,
@@ -71,6 +72,7 @@ import {
   getDashboardForms,
   reorderFormField,
   transferFormOwnership,
+  updateEndPage,
   updateForm,
   updateFormField,
   updateFormSettings,
@@ -1623,6 +1625,59 @@ describe('admin-form.service', () => {
         String(mockForm._id),
         fieldToDelete._id,
       )
+    })
+  })
+
+  describe('updateEndPage', () => {
+    const updateSpy = jest.spyOn(FormModel, 'updateEndPageById')
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const MOCK_NEW_END_PAGE: EndPage = {
+      title: 'expected end page title',
+      buttonLink: 'https://some-button-link.example.com',
+      buttonText: 'expected button text',
+      paragraph: 'some paragraph',
+    }
+
+    it('should return updated end page when update is successful', async () => {
+      // Arrange
+      const mockUpdatedForm = {
+        endPage: MOCK_NEW_END_PAGE,
+      } as IFormDocument
+      updateSpy.mockResolvedValueOnce(mockUpdatedForm)
+
+      // Act
+      const actual = await updateEndPage(MOCK_FORM_ID, MOCK_NEW_END_PAGE)
+
+      // Assert
+      expect(actual._unsafeUnwrap()).toEqual(MOCK_NEW_END_PAGE)
+    })
+
+    it('should return FormNotFoundError when form cannot be found', async () => {
+      // Arrange
+      updateSpy.mockResolvedValueOnce(null)
+
+      // Act
+      const actual = await updateEndPage(MOCK_FORM_ID, MOCK_NEW_END_PAGE)
+
+      // Assert
+      expect(actual._unsafeUnwrapErr()).toEqual(new FormNotFoundError())
+    })
+
+    it('should return DatabaseError when database model update throws an error', async () => {
+      // Arrange
+      const expectedErrorMsg = 'some error'
+      updateSpy.mockRejectedValueOnce(new Error(expectedErrorMsg))
+
+      // Act
+      const actual = await updateEndPage(MOCK_FORM_ID, MOCK_NEW_END_PAGE)
+
+      // Assert
+      const actualError = actual._unsafeUnwrapErr()
+      expect(actualError).toBeInstanceOf(DatabaseError)
+      expect(actualError.message).toIncludeMultiple([
+        expectedErrorMsg,
+        'Please refresh and try again.',
+      ])
     })
   })
 })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1842,7 +1842,7 @@ export const _handleUpdateEndPage: RequestHandler<
 export const handleUpdateEndPage = [
   celebrate({
     [Segments.BODY]: {
-      title: Joi.string().required(),
+      title: Joi.string(),
       paragraph: Joi.string().allow(''),
       buttonLink: Joi.string().uri().allow(''),
       buttonText: Joi.string().allow(''),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -21,6 +21,7 @@ import {
   IUserSchema,
 } from '../../../../types'
 import {
+  EndPageUpdateDto,
   FieldCreateDto,
   FieldUpdateDto,
   SettingsUpdateDto,
@@ -777,5 +778,42 @@ export const deleteFormField = <T extends IFormSchema>(
       return errAsync(new FormNotFoundError())
     }
     return okAsync(updatedForm)
+  })
+}
+
+/**
+ * Update the end page of the given form
+ * @param formId the id of the form to update the end page for
+ * @param newEndPage the new end page object to replace the current one
+ * @returns ok(updated end page object) when update is successful
+ * @returns err(FormNotFoundError) if form cannot be found
+ * @returns err(PossibleDatabaseError) if endpage update fails
+ */
+export const updateEndPage = (
+  formId: string,
+  newEndPage: EndPageUpdateDto,
+): ResultAsync<
+  IFormDocument['endPage'],
+  PossibleDatabaseError | FormNotFoundError
+> => {
+  return ResultAsync.fromPromise(
+    FormModel.updateEndPageById(formId, newEndPage),
+    (error) => {
+      logger.error({
+        message: 'Error occurred when updating form end page',
+        meta: {
+          action: 'updateEndPage',
+          formId,
+          newEndPage,
+        },
+        error,
+      })
+      return transformMongoError(error)
+    },
+  ).andThen((updatedForm) => {
+    if (!updatedForm) {
+      return errAsync(new FormNotFoundError())
+    }
+    return okAsync(updatedForm.endPage)
   })
 }

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -138,3 +138,8 @@ AdminFormsFormRouter.post(
   '/:formId([a-fA-F0-9]{24})/fields',
   AdminFormController.handleCreateFormField,
 )
+
+AdminFormsFormRouter.put(
+  '/:formId([a-fA-F0-9]{24})/end-page',
+  AdminFormController.handleUpdateEndPage,
+)

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -151,6 +151,7 @@ function AdminFormController(
         errorMessage =
           'This page seems outdated, and your changes could not be saved. Please refresh.'
         break
+      case StatusCodes.FORBIDDEN:
       case StatusCodes.UNAUTHORIZED:
         errorMessage =
           'Your changes could not be saved as your account lacks the requisite privileges.'
@@ -282,6 +283,15 @@ function AdminFormController(
           })
           .catch(handleUpdateError)
     }
+  }
+
+  $scope.updateFormEndPage = (newEndPage) => {
+    return $q
+      .when(AdminFormService.updateFormEndPage($scope.myform._id, newEndPage))
+      .then((updatedEndPage) => {
+        $scope.myform.endPage = updatedEndPage
+      })
+      .catch(handleUpdateError)
   }
 
   /**

--- a/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
@@ -7,11 +7,11 @@ angular
   .controller('EditEndPageController', [
     '$uibModalInstance',
     'myform',
-    'updateField',
+    'updateEndPage',
     EditEndPageController,
   ])
 
-function EditEndPageController($uibModalInstance, myform, updateField) {
+function EditEndPageController($uibModalInstance, myform, updateEndPage) {
   const vm = this
 
   vm.logoUrl = getFormLogo(myform)
@@ -29,33 +29,6 @@ function EditEndPageController($uibModalInstance, myform, updateField) {
 
   if (!vm.myform.endPage.buttonText) {
     vm.myform.endPage.buttonText = ''
-  }
-
-  vm.showButtons = false
-  vm.lastButtonID = 0
-
-  // add new Button to the endPage
-  vm.addButton = function () {
-    let newButton = {}
-    newButton.bgColor = '#ddd'
-    newButton.color = '#ffffff'
-    newButton.text = 'Button'
-    newButton._id = Math.floor(100000 * Math.random())
-
-    vm.myform.endPage.buttons.push(newButton)
-  }
-
-  // delete particular Button from endPage
-  vm.deleteButton = function (button) {
-    let currID
-    for (let i = 0; i < vm.myform.endPage.buttons.length; i++) {
-      currID = vm.myform.endPage.buttons[i]._id
-
-      if (currID === button._id) {
-        vm.myform.endPage.buttons.splice(i, 1)
-        break
-      }
-    }
   }
 
   vm.saveEndPage = function (isValid) {
@@ -80,7 +53,7 @@ function EditEndPageController($uibModalInstance, myform, updateField) {
 
       vm.myform.endPage.buttonLink = inputLink
 
-      updateField({ endPage: vm.myform.endPage }).then((error) => {
+      updateEndPage({ newEndPage: vm.myform.endPage }).then((error) => {
         if (!error) {
           $uibModalInstance.close()
         }

--- a/src/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -28,6 +28,7 @@ function editFormDirective() {
     scope: {
       myform: '=',
       updateForm: '&',
+      updateFormEndPage: '&',
     },
     controller: [
       '$scope',
@@ -329,7 +330,7 @@ function editFormController(
       controllerAs: 'vm',
       resolve: {
         myform: () => $scope.myform,
-        updateField: () => updateField,
+        updateEndPage: () => $scope.updateFormEndPage,
       },
     })
   }

--- a/src/public/modules/forms/admin/views/edit-end-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-end-page.client.modal.html
@@ -63,10 +63,20 @@
             </div>
             <input
               type="text"
+              name="buttonLink"
               class="input-custom input-medium"
               ng-model="vm.myform.endPage.buttonLink"
               placeholder="Default to form link"
+              validate-url
+              allow-http="true"
             />
+            <div
+              class="alert-custom alert-error"
+              ng-if="vm.endPageForm.buttonLink.$invalid"
+            >
+              <i class="bx bx-exclamation bx-md icon-spacing"></i>
+              <span class="alert-msg"> Please enter a valid URL</span>
+            </div>
           </div>
         </div>
 

--- a/src/public/modules/forms/base/directives/validate-url.client.directive.js
+++ b/src/public/modules/forms/base/directives/validate-url.client.directive.js
@@ -1,6 +1,9 @@
 'use strict'
 
-const { isValidHttpsUrl } = require('../../../../../shared/util/url-validation')
+const {
+  isValidHttpsUrl,
+  isValidUrl,
+} = require('../../../../../shared/util/url-validation')
 
 angular.module('forms').directive('validateUrl', validateUrl)
 
@@ -8,9 +11,13 @@ function validateUrl() {
   return {
     restrict: 'A',
     require: 'ngModel',
-    link: function (_scope, _elem, _attrs, ctrl) {
-      ctrl.$validators.urlValidator = (modelValue) =>
-        ctrl.$isEmpty(modelValue) || isValidHttpsUrl(modelValue)
+    link: function (_scope, _elem, attrs, ctrl) {
+      ctrl.$validators.urlValidator = (modelValue) => {
+        if (attrs.allowHttp) {
+          return ctrl.$isEmpty(modelValue) || isValidUrl(modelValue)
+        }
+        return ctrl.$isEmpty(modelValue) || isValidHttpsUrl(modelValue)
+      }
     },
   }
 }

--- a/src/public/modules/forms/config/forms.client.routes.js
+++ b/src/public/modules/forms/config/forms.client.routes.js
@@ -133,7 +133,8 @@ angular.module('forms').config([
           'build@viewForm': {
             template: `<edit-form-directive
               myform="myform"
-              update-form="updateForm(update)">
+              update-form="updateForm(update)"
+              update-form-end-page="updateFormEndPage(newEndPage)">
               </edit-form-directive>`,
           },
           'logic@viewForm': {

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import { FormSettings } from '../../types'
 import {
+  EndPageUpdateDto,
   FieldCreateDto,
   FieldUpdateDto,
   FormFieldDto,
@@ -70,7 +71,7 @@ export const reorderSingleFormField = async (
 
 /**
  * Delete a single form field by its id in given form
- * @param formId the form to delete the field from
+ * @param formId the id of the form to delete the field from
  * @param fieldId the id of the field to delete
  * @returns void on success
  */
@@ -79,6 +80,24 @@ export const deleteSingleFormField = async (
   fieldId: string,
 ): Promise<void> => {
   return axios.delete(`${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`)
+}
+
+/**
+ * Updates the end page for the given form referenced by its id
+ * @param formId the id of the form to update end page for
+ * @param newEndPage the new endpage to replace with
+ * @returns the updated end page on success
+ */
+export const updateFormEndPage = async (
+  formId: string,
+  newEndPage: EndPageUpdateDto,
+): Promise<EndPageUpdateDto> => {
+  return axios
+    .put<EndPageUpdateDto>(
+      `${ADMIN_FORM_ENDPOINT}/${formId}/end-page`,
+      newEndPage,
+    )
+    .then(({ data }) => data)
 }
 
 export const deleteFormLogic = async (

--- a/src/shared/util/url-validation.ts
+++ b/src/shared/util/url-validation.ts
@@ -5,11 +5,27 @@ import validator from 'validator'
  * @param url
  */
 export const isValidHttpsUrl = (url: string): boolean => {
+  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
   if (typeof url !== 'string') {
     return false
   }
   return validator.isURL(url, {
     protocols: ['https'],
     require_protocol: true,
+  })
+}
+
+/**
+ * Checks that string is a valid HTTP or HTTPS URL.
+ * @param url the url to check
+ * @returns true if valid, false otherwise
+ */
+export const isValidUrl = (url: string): boolean => {
+  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
+  if (typeof url !== 'string') {
+    return false
+  }
+  return validator.isURL(url, {
+    protocols: ['https', 'http'],
   })
 }

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -2,7 +2,7 @@ import { LeanDocument } from 'mongoose'
 import { ConditionalPick, Primitive } from 'type-fest'
 
 import { FormField, FormFieldSchema, FormFieldWithId } from '../field'
-import { FormSettings } from '../form'
+import { EndPage, FormSettings } from '../form'
 
 export type SettingsUpdateDto = Partial<FormSettings>
 
@@ -17,3 +17,5 @@ export type FormFieldDto = ConditionalPick<
   LeanDocument<FormFieldSchema>,
   Primitive
 >
+
+export type EndPageUpdateDto = EndPage

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -311,6 +311,16 @@ export interface IFormModel extends Model<IFormSchema> {
     userId: IUserSchema['_id'],
     userEmail: IUserSchema['email'],
   ): Promise<FormMetaView[]>
+  /**
+   * Update the end page of form with given endpage object.
+   * @param formId the id of the form to update
+   * @param newEndPage the new EndPage object to replace with
+   * @returns the updated form document if form exists, null otherwise
+   */
+  updateEndPageById(
+    formId: string,
+    newEndPage: EndPage,
+  ): Promise<IFormDocument | null>
 }
 
 export type IEncryptedFormModel = IFormModel & Model<IEncryptedFormSchema>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds a specific endpoint `PUT /api/v3/admin/forms/:formId/end-page` for updating of the form's end page subslice.
The client changes will continue in a separate PR for ease of review.

Note that this new endpoint has stricter Joi validation than before: 
```ts
celebrate({
    [Segments.BODY]: {
      title: Joi.string(),
      paragraph: Joi.string().allow(''),
      buttonLink: Joi.string().uri().allow(''), // model validation did not test for `uri`-ness
      buttonText: Joi.string().allow(''),
    },
})
```

Previously, there was no route level validation, and instead relying on model level validation, which did not test whether a buttonLink was an URI.

Closes #1487

## Solution
<!-- How did you solve the problem? -->

**Features**:
- feat(FormModel): add updateEndPageById form static method
- feat(AdminFormSvc): add updateEndPage fn
- feat(AdminFormCtl): add handler for updating form end page

## Tests
<!-- What tests should be run to confirm functionality? -->
- Unit tests have been added to the model, service and controller layers for the various updateEndPage functions.
