### PR TITLE
feat(client): use update endpage api in client, add button link url validation

### DIFF
--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -151,6 +151,7 @@ function AdminFormController(
         errorMessage =
           'This page seems outdated, and your changes could not be saved. Please refresh.'
         break
+      case StatusCodes.FORBIDDEN:
       case StatusCodes.UNAUTHORIZED:
         errorMessage =
           'Your changes could not be saved as your account lacks the requisite privileges.'
@@ -282,6 +283,15 @@ function AdminFormController(
           })
           .catch(handleUpdateError)
     }
+  }
+
+  $scope.updateFormEndPage = (newEndPage) => {
+    return $q
+      .when(AdminFormService.updateFormEndPage($scope.myform._id, newEndPage))
+      .then((updatedEndPage) => {
+        $scope.myform.endPage = updatedEndPage
+      })
+      .catch(handleUpdateError)
   }
 
   /**

--- a/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
@@ -31,33 +31,6 @@ function EditEndPageController($uibModalInstance, myform, updateField) {
     vm.myform.endPage.buttonText = ''
   }
 
-  vm.showButtons = false
-  vm.lastButtonID = 0
-
-  // add new Button to the endPage
-  vm.addButton = function () {
-    let newButton = {}
-    newButton.bgColor = '#ddd'
-    newButton.color = '#ffffff'
-    newButton.text = 'Button'
-    newButton._id = Math.floor(100000 * Math.random())
-
-    vm.myform.endPage.buttons.push(newButton)
-  }
-
-  // delete particular Button from endPage
-  vm.deleteButton = function (button) {
-    let currID
-    for (let i = 0; i < vm.myform.endPage.buttons.length; i++) {
-      currID = vm.myform.endPage.buttons[i]._id
-
-      if (currID === button._id) {
-        vm.myform.endPage.buttons.splice(i, 1)
-        break
-      }
-    }
-  }
-
   vm.saveEndPage = function (isValid) {
     if (isValid) {
       // Check if http(s):// is appended, if not append it

--- a/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-end-page-modal.client.controller.js
@@ -7,11 +7,11 @@ angular
   .controller('EditEndPageController', [
     '$uibModalInstance',
     'myform',
-    'updateField',
+    'updateEndPage',
     EditEndPageController,
   ])
 
-function EditEndPageController($uibModalInstance, myform, updateField) {
+function EditEndPageController($uibModalInstance, myform, updateEndPage) {
   const vm = this
 
   vm.logoUrl = getFormLogo(myform)
@@ -53,7 +53,7 @@ function EditEndPageController($uibModalInstance, myform, updateField) {
 
       vm.myform.endPage.buttonLink = inputLink
 
-      updateField({ endPage: vm.myform.endPage }).then((error) => {
+      updateEndPage({ newEndPage: vm.myform.endPage }).then((error) => {
         if (!error) {
           $uibModalInstance.close()
         }

--- a/src/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -28,6 +28,7 @@ function editFormDirective() {
     scope: {
       myform: '=',
       updateForm: '&',
+      updateFormEndPage: '&',
     },
     controller: [
       '$scope',
@@ -329,7 +330,7 @@ function editFormController(
       controllerAs: 'vm',
       resolve: {
         myform: () => $scope.myform,
-        updateField: () => updateField,
+        updateEndPage: () => $scope.updateFormEndPage,
       },
     })
   }

--- a/src/public/modules/forms/admin/views/edit-end-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-end-page.client.modal.html
@@ -63,10 +63,20 @@
             </div>
             <input
               type="text"
+              name="buttonLink"
               class="input-custom input-medium"
               ng-model="vm.myform.endPage.buttonLink"
               placeholder="Default to form link"
+              validate-url
+              allow-http="true"
             />
+            <div
+              class="alert-custom alert-error"
+              ng-if="vm.endPageForm.buttonLink.$invalid"
+            >
+              <i class="bx bx-exclamation bx-md icon-spacing"></i>
+              <span class="alert-msg"> Please enter a valid URL</span>
+            </div>
           </div>
         </div>
 

--- a/src/public/modules/forms/base/directives/validate-url.client.directive.js
+++ b/src/public/modules/forms/base/directives/validate-url.client.directive.js
@@ -1,6 +1,9 @@
 'use strict'
 
-const { isValidHttpsUrl } = require('../../../../../shared/util/url-validation')
+const {
+  isValidHttpsUrl,
+  isValidUrl,
+} = require('../../../../../shared/util/url-validation')
 
 angular.module('forms').directive('validateUrl', validateUrl)
 
@@ -8,9 +11,13 @@ function validateUrl() {
   return {
     restrict: 'A',
     require: 'ngModel',
-    link: function (_scope, _elem, _attrs, ctrl) {
-      ctrl.$validators.urlValidator = (modelValue) =>
-        ctrl.$isEmpty(modelValue) || isValidHttpsUrl(modelValue)
+    link: function (_scope, _elem, attrs, ctrl) {
+      ctrl.$validators.urlValidator = (modelValue) => {
+        if (attrs.allowHttp) {
+          return ctrl.$isEmpty(modelValue) || isValidUrl(modelValue)
+        }
+        return ctrl.$isEmpty(modelValue) || isValidHttpsUrl(modelValue)
+      }
     },
   }
 }

--- a/src/public/modules/forms/config/forms.client.routes.js
+++ b/src/public/modules/forms/config/forms.client.routes.js
@@ -133,7 +133,8 @@ angular.module('forms').config([
           'build@viewForm': {
             template: `<edit-form-directive
               myform="myform"
-              update-form="updateForm(update)">
+              update-form="updateForm(update)"
+              update-form-end-page="updateFormEndPage(newEndPage)">
               </edit-form-directive>`,
           },
           'logic@viewForm': {

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import { FormSettings } from '../../types'
 import {
+  EndPageUpdateDto,
   FieldCreateDto,
   FieldUpdateDto,
   FormFieldDto,
@@ -70,7 +71,7 @@ export const reorderSingleFormField = async (
 
 /**
  * Delete a single form field by its id in given form
- * @param formId the form to delete the field from
+ * @param formId the id of the form to delete the field from
  * @param fieldId the id of the field to delete
  * @returns void on success
  */
@@ -79,6 +80,24 @@ export const deleteSingleFormField = async (
   fieldId: string,
 ): Promise<void> => {
   return axios.delete(`${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`)
+}
+
+/**
+ * Updates the end page for the given form referenced by its id
+ * @param formId the id of the form to update end page for
+ * @param newEndPage the new endpage to replace with
+ * @returns the updated end page on success
+ */
+export const updateFormEndPage = async (
+  formId: string,
+  newEndPage: EndPageUpdateDto,
+): Promise<EndPageUpdateDto> => {
+  return axios
+    .put<EndPageUpdateDto>(
+      `${ADMIN_FORM_ENDPOINT}/${formId}/end-page`,
+      newEndPage,
+    )
+    .then(({ data }) => data)
 }
 
 export const deleteFormLogic = async (

--- a/src/shared/util/url-validation.ts
+++ b/src/shared/util/url-validation.ts
@@ -5,6 +5,7 @@ import validator from 'validator'
  * @param url
  */
 export const isValidHttpsUrl = (url: string): boolean => {
+  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
   if (typeof url !== 'string') {
     return false
   }
@@ -20,6 +21,7 @@ export const isValidHttpsUrl = (url: string): boolean => {
  * @returns true if valid, false otherwise
  */
 export const isValidUrl = (url: string): boolean => {
+  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
   if (typeof url !== 'string') {
     return false
   }

--- a/src/shared/util/url-validation.ts
+++ b/src/shared/util/url-validation.ts
@@ -13,3 +13,17 @@ export const isValidHttpsUrl = (url: string): boolean => {
     require_protocol: true,
   })
 }
+
+/**
+ * Checks that string is a valid HTTP or HTTPS URL.
+ * @param url the url to check
+ * @returns true if valid, false otherwise
+ */
+export const isValidUrl = (url: string): boolean => {
+  if (typeof url !== 'string') {
+    return false
+  }
+  return validator.isURL(url, {
+    protocols: ['https', 'http'],
+  })
+}


### PR DESCRIPTION
Note that this PR is building on #1760

This PR **cannot be rolled back** due to new endpoints being called on the client.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This is the second PR to use the new endpoint in the frontend. Also added URL validation to the client due to the new endpoint having stricter Joi validation on whether the button link is a valid URL or not.

Also also remove unused functions in the controller left behind when `endPage.buttons` was removed from the schema a long time ago.

See #1487

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(client): add updateFormEndPage to call API
- feat(client): add scoped function to call update end-page API
- feat(client/validate-url): add non-https mode validation
- feat(client): add url validation to end page button link

**Improvements**:

- feat(client/edit-end-page-modal): remove unused functions 
 
## Screenshots
**AFTER**:
<!-- [insert screenshot here] -->
<img width="1310" alt="Screenshot 2021-04-29 at 4 26 44 PM" src="https://user-images.githubusercontent.com/22133008/116522855-37724400-a908-11eb-9692-18203dce5b54.png">
<img width="1310" alt="Screenshot 2021-04-29 at 4 26 50 PM" src="https://user-images.githubusercontent.com/22133008/116522881-3c36f800-a908-11eb-93c8-7537657a9693.png">

## Manual Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Update end page for a form. Should update successfully.
- [ ] Add invalid URL to button link field. Should show error message below the field and prevent submission