### PR TITLE
fix: allow commas in email confirmation sender

### DIFF
--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -738,7 +738,7 @@ describe('mail.service', () => {
 
       defaultExpectedArg = {
         to: MOCK_AUTOREPLY_PARAMS.autoReplyMailDatas[0].email,
-        from: `${MOCK_AUTOREPLY_PARAMS.form.admin.agency.fullName} <${MOCK_SENDER_EMAIL}>`,
+        from: `"${MOCK_AUTOREPLY_PARAMS.form.admin.agency.fullName}" <${MOCK_SENDER_EMAIL}>`,
         subject: `Thank you for submitting ${MOCK_AUTOREPLY_PARAMS.form.title}`,
         html: defaultHtml,
         headers: {
@@ -877,7 +877,7 @@ describe('mail.service', () => {
 
       const expectedArg = {
         ...defaultExpectedArg,
-        from: `${customSender} <${MOCK_SENDER_EMAIL}>`,
+        from: `"${customSender}" <${MOCK_SENDER_EMAIL}>`,
       }
       const expectedResponse = await Promise.allSettled([ok(true)])
 

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -253,7 +253,8 @@ export class MailService {
     return generateAutoreplyHtml(templateData).andThen((mailHtml) => {
       const mail: MailOptions = {
         to: autoReplyMailData.email,
-        from: `${emailSender} <${this.#senderMail}>`,
+        // Quotes necessary to allow for special characters in emailSender, e.g. comma
+        from: `"${emailSender}" <${this.#senderMail}>`,
         subject: emailSubject,
         // Only send attachments if the admin has the box checked for email
         // fields.

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -253,7 +253,8 @@ export class MailService {
     return generateAutoreplyHtml(templateData).andThen((mailHtml) => {
       const mail: MailOptions = {
         to: autoReplyMailData.email,
-        // Quotes necessary to allow for special characters in emailSender, e.g. comma
+        // Quotes necessary to allow for special characters in emailSender, e.g. comma.
+        // See https://github.com/nodemailer/nodemailer/issues/377
         from: `"${emailSender}" <${this.#senderMail}>`,
         subject: emailSubject,
         // Only send attachments if the admin has the box checked for email


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We allow admins to specify the email sender for email confirmations. However, when the sender contains a comma, the text before the comma gets cut off.

### Example from production

**Specifying an email sender with a comma**
![image](https://user-images.githubusercontent.com/29480346/116957688-107e8e00-accb-11eb-9d8f-72fdd9f67828.png)

**Actual email sender**
![Screenshot 2021-05-04 at 11 21 44 AM](https://user-images.githubusercontent.com/29480346/116957634-ea58ee00-acca-11eb-97e3-de4d7c2f303f.png)


## Solution
<!-- How did you solve the problem? -->

According to [this issue](https://github.com/nodemailer/nodemailer/issues/377), sender names containing commas must be wrapped in quotes. This fixed the problem.

### Example from staging

**Specifying an email sender with a comma**
![image](https://user-images.githubusercontent.com/29480346/116957688-107e8e00-accb-11eb-9d8f-72fdd9f67828.png)

**Actual email sender**
![Screenshot 2021-05-04 at 11 24 43 AM](https://user-images.githubusercontent.com/29480346/116957794-55a2c000-accb-11eb-9746-27ca40fbfe4d.png)

### Backwards compatibility

Note that for senders without special characters, the email headers actually remain unchanged, so this change is backwards compatible even for receivers which are manually parsing email headers. For senders with special characters, the email headers get fixed by the inclusion of quotes.

**Without comma, before (production)**
![Screenshot 2021-05-04 at 11 28 28 AM](https://user-images.githubusercontent.com/29480346/116958007-db267000-accb-11eb-89ee-3c71eba17ae8.png)

**Without comma, after (staging)**
![Screenshot 2021-05-04 at 11 27 19 AM](https://user-images.githubusercontent.com/29480346/116957938-b3cfa300-accb-11eb-8191-805bf57ec8fc.png)

**With comma, before (production)**
![Screenshot 2021-05-04 at 11 28 50 AM](https://user-images.githubusercontent.com/29480346/116958031-ea0d2280-accb-11eb-948f-dd0a55f880ad.png)

**With comma, after (staging)**
![Screenshot 2021-05-04 at 11 29 19 AM](https://user-images.githubusercontent.com/29480346/116958061-fa250200-accb-11eb-8e61-6fd04b8a1b0a.png)

