### PR TITLE
fix: trigger digest cycle for delete logic

### DIFF
--- a/src/public/modules/forms/admin/components/edit-logic.client.component.js
+++ b/src/public/modules/forms/admin/components/edit-logic.client.component.js
@@ -84,7 +84,9 @@ function editLogicComponentController($uibModal, FormFields, Toastr, $q) {
     const logicIdToDelete = vm.myform.form_logics[logicIndex]._id
     $q.when(AdminFormService.deleteFormLogic(vm.myform._id, logicIdToDelete))
       .then(() => {
-        vm.myform.form_logics.splice(logicIndex, 1)
+        const updatedLogic = [...vm.myform.form_logics]
+        updatedLogic.splice(logicIndex, 1)
+        vm.myform.form_logics = updatedLogic
       })
       .catch((logicDeleteError) => {
         console.error(logicDeleteError)


### PR DESCRIPTION
## Problem
- The digest cycle wasn't triggered to update the build tab after logic is deleted in #1586. This is because in the previous implementation, the form_logic object is replaced on delete logic, while with the refactor, only the form_logic array is spliced.
- This means that after deleting a logic, user will need to refresh before the build tab will be updated

## Solution
- Trigger digest cycle on delete logic

## Tests 
- [ ] Create a form with showField logic. Delete the logic. Check that the build tab is updated.