### PR TITLE
chore: gitignore intellij metadata directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ dist/
 *.sublime-project
 *.sublime-workspace
 
+# IntelliJ editor
+# ==============
+.idea/
+
 # General
 # =======
 *.log


### PR DESCRIPTION
IntelliJ IDEs generate a .idea directory for metadata.

Would like to add the entry to gitignore so I won't accidentally commit these metadata files.

