### PR TITLE
fix: align joi validation types to schema

### DIFF
--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -29,8 +29,8 @@ import {
   IFormDocument,
   IFormModel,
   IFormSchema,
-  ILogicWithId,
   IPopulatedForm,
+  LogicDto,
   LogicType,
   Permission,
   PickDuplicateForm,
@@ -690,7 +690,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     this: IFormModel,
     formId: string,
     logicId: string,
-    updatedLogic: ILogicWithId,
+    updatedLogic: LogicDto,
   ): Promise<IFormSchema | null> {
     return this.findByIdAndUpdate(
       formId,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1811,7 +1811,14 @@ export const handleUpdateLogic = [
               state: Joi.string()
                 .valid(...Object.values(LogicConditionState))
                 .required(),
-              value: Joi.any().required(),
+              value: Joi.alternatives()
+                .try(
+                  Joi.number(),
+                  Joi.string(),
+                  Joi.array().items(Joi.string()),
+                  Joi.array().items(Joi.number()),
+                )
+                .required(),
               ifValueType: Joi.valid(...Object.values(LogicIfValue)),
             }).unknown(true),
           )
@@ -1822,7 +1829,7 @@ export const handleUpdateLogic = [
         }),
         preventSubmitMessage: Joi.alternatives().conditional('logicType', {
           is: LogicType.PreventSubmit,
-          then: Joi.string(),
+          then: Joi.string().required(),
         }),
         // Allow other field related key-values to be provided and let the model
         // layer handle the validation.

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1819,7 +1819,9 @@ export const handleUpdateLogic = [
                   Joi.array().items(Joi.number()),
                 )
                 .required(),
-              ifValueType: Joi.valid(...Object.values(LogicIfValue)),
+              ifValueType: Joi.string()
+                .valid(...Object.values(LogicIfValue))
+                .required(),
             }).unknown(true),
           )
           .required(),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -16,7 +16,9 @@ import {
   IForm,
   IFormDocument,
   IPopulatedForm,
+  LogicConditionState,
   LogicDto,
+  LogicIfValue,
   LogicType,
   ResponseMode,
 } from '../../../../types'
@@ -1806,9 +1808,11 @@ export const handleUpdateLogic = [
           .items(
             Joi.object({
               field: Joi.string().required(),
-              state: Joi.string().required(),
-              value: Joi.string().required(),
-              ifValueType: Joi.string(),
+              state: Joi.string()
+                .valid(...Object.values(LogicConditionState))
+                .required(),
+              value: Joi.any().required(),
+              ifValueType: Joi.valid(...Object.values(LogicIfValue)),
             }).unknown(true),
           )
           .required(),
@@ -1818,7 +1822,7 @@ export const handleUpdateLogic = [
         }),
         preventSubmitMessage: Joi.alternatives().conditional('logicType', {
           is: LogicType.PreventSubmit,
-          then: Joi.string().required(),
+          then: Joi.string(),
         }),
         // Allow other field related key-values to be provided and let the model
         // layer handle the validation.

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -1,5 +1,4 @@
-import { Document, LeanDocument } from 'mongoose'
-import { ConditionalPick, Primitive } from 'type-fest'
+import { Document } from 'mongoose'
 
 import { IFieldSchema } from './field/baseField'
 import { BasicField } from './field/fieldTypes'
@@ -39,10 +38,6 @@ export interface ILogic {
 }
 
 export interface ILogicSchema extends ILogic, Document {}
-
-export type ILogicWithId = ILogic & {
-  _id: string
-}
 
 export interface IShowFieldsLogic extends ILogic {
   show: IFieldSchema['_id'][]
@@ -116,4 +111,4 @@ export type LogicCondition =
 /**
  * Logic POJO with functions removed
  */
-export type LogicDto = ConditionalPick<LeanDocument<ILogicSchema>, Primitive>
+export type LogicDto = ILogic & { _id?: IFieldSchema['_id'][] }

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -111,4 +111,4 @@ export type LogicCondition =
 /**
  * Logic POJO with functions removed
  */
-export type LogicDto = ILogic & { _id?: IFieldSchema['_id'][] }
+export type LogicDto = ILogic & { _id?: Document['_id'] }


### PR DESCRIPTION
## Problem

- This PR builds off #1695 and replaces the typings for joi validation for logic endpoint to align to the schema
- Also closes #1810 