### PR TITLE
fix: remove Learn More link for MyInfo field limit

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/edit-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/edit-form.client.view.html
@@ -235,7 +235,6 @@
         <i class="bx bx-info-circle bx-md icon-spacing"></i>
         Only {{ maxMyInfoFields }} MyInfo fields are allowed in Email mode. You
         currently have {{ numMyInfoFields }} MyInfo field(s).
-        <a href="#">Learn more</a>
       </div>
     </div>
     <!-- Webhook warning -->


### PR DESCRIPTION
Removes the broken link, since there is no section on the MyInfo field limit in the guide.

Closes #1801 