### PR TITLE
feat(email-submission): separate error logging for db and state checks

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -50,8 +50,6 @@ const submitEmailModeForm: RequestHandler<
   return (
     // Retrieve form
     FormService.retrieveFullFormById(formId)
-      .andThen((form) => EmailSubmissionService.checkFormIsEmailMode(form))
-      // NOTE: This is on the top most level because errors are reported together for the first two
       .mapErr((error) => {
         logger.error({
           message: 'Error while retrieving form from database',
@@ -60,6 +58,16 @@ const submitEmailModeForm: RequestHandler<
         })
         return error
       })
+      .andThen((form) =>
+        EmailSubmissionService.checkFormIsEmailMode(form).mapErr((error) => {
+          logger.warn({
+            message: 'Attempt to submit non-email-mode form',
+            meta: logMeta,
+            error,
+          })
+          return error
+        }),
+      )
       .andThen((form) =>
         // Check that form is public
         // If it is, pass through and return the original form


### PR DESCRIPTION
## Problem
Currently, the first two stages of the submission pipeline have their errors logged jointly.

This could be confusing if we have to debug error messages. It is also inconsistent from the rest of the pipeline.

## Solution
Introduce a `mapErr` after the fetching of the form which logs the database errors, and add another `mapErr` during the state checking step with its own error message.

## Reviewers

Would appreciate KR's help in checking if i'm using `neverthrow` properly in this case. 