### PR TITLE
fix: speed up precommit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged && sh secrets-check.sh
+npm run pre-commit && sh secrets-check.sh

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "lint": "npm run lint-code && npm run lint-style && npm run lint-html",
     "lint-ci": "concurrently \"eslint src/ --quiet\" \"stylelint '*/**/*.css' --quiet\" \"htmlhint\" \"prettier --c './src/public/**/*.html' --ignore-path './dist/**'\"",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We have been installing a fresh version of lint-staged every precommit due to the script in `husky/pre-commit`. This caused every commit to take ~1 second at least and we pretty bad dev-exp.

This PR instead runs an npm script to use the installed lint-staged module, thus greatly(?) speeding up the pre-commit hook.
