### PR TITLE
feat: add response ID to thank you page

### DIFF
--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -732,6 +732,7 @@ describe('mail.service', () => {
     beforeAll(async () => {
       defaultHtml = (
         await MailUtils.generateAutoreplyHtml({
+          responseId: MOCK_AUTOREPLY_PARAMS.submission.id,
           autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
         })
       )._unsafeUnwrap()
@@ -911,6 +912,7 @@ describe('mail.service', () => {
       }
       const expectedMailBody = (
         await MailUtils.generateAutoreplyHtml({
+          responseId: MOCK_AUTOREPLY_PARAMS.submission.id,
           autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
           ...expectedRenderData,
         })

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -732,7 +732,7 @@ describe('mail.service', () => {
     beforeAll(async () => {
       defaultHtml = (
         await MailUtils.generateAutoreplyHtml({
-          responseId: MOCK_AUTOREPLY_PARAMS.submission.id,
+          submissionId: MOCK_AUTOREPLY_PARAMS.submission.id,
           autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
         })
       )._unsafeUnwrap()
@@ -912,7 +912,7 @@ describe('mail.service', () => {
       }
       const expectedMailBody = (
         await MailUtils.generateAutoreplyHtml({
-          responseId: MOCK_AUTOREPLY_PARAMS.submission.id,
+          submissionId: MOCK_AUTOREPLY_PARAMS.submission.id,
           autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
           ...expectedRenderData,
         })

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -241,10 +241,12 @@ export class MailService {
       autoReplyMailData.sender || form.admin.agency.fullName
     ).replace('(', '\\(')
 
+    const responseId = submission.id
     const defaultBody = `Dear Sir or Madam,\n\nThank you for submitting this form.\n\nRegards,\n${form.admin.agency.fullName}`
     const autoReplyBody = (autoReplyMailData.body || defaultBody).split('\n')
 
     const templateData = {
+      responseId,
       autoReplyBody,
       // Only destructure formSummaryRenderData if form summary is included.
       ...(autoReplyMailData.includeFormSummary && formSummaryRenderData),

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -241,12 +241,11 @@ export class MailService {
       autoReplyMailData.sender || form.admin.agency.fullName
     ).replace('(', '\\(')
 
-    const responseId = submission.id
     const defaultBody = `Dear Sir or Madam,\n\nThank you for submitting this form.\n\nRegards,\n${form.admin.agency.fullName}`
     const autoReplyBody = (autoReplyMailData.body || defaultBody).split('\n')
 
     const templateData = {
-      responseId,
+      submissionId: submission.id,
       autoReplyBody,
       // Only destructure formSummaryRenderData if form summary is included.
       ...(autoReplyMailData.includeFormSummary && formSummaryRenderData),

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -72,8 +72,11 @@ export type SubmissionToAdminHtmlData = {
 }
 
 export type AutoreplyHtmlData =
-  | ({ autoReplyBody: string[] } & AutoreplySummaryRenderData)
-  | { autoReplyBody: string[] }
+  | ({
+      responseId: string
+      autoReplyBody: string[]
+    } & AutoreplySummaryRenderData)
+  | { responseId: string; autoReplyBody: string[] }
 
 export type BounceNotificationHtmlData = {
   formTitle: string

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -71,7 +71,7 @@ export type SubmissionToAdminHtmlData = {
   appName: string
 }
 
-export type AutoreplyHtmlDefaultBody = {
+type AutoreplyHtmlDefaultBody = {
   submissionId: string
   autoReplyBody: string[]
 }

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -71,12 +71,14 @@ export type SubmissionToAdminHtmlData = {
   appName: string
 }
 
+export type AutoreplyHtmlDefaultBody = {
+  submissionId: string
+  autoReplyBody: string[]
+}
+
 export type AutoreplyHtmlData =
-  | ({
-      responseId: string
-      autoReplyBody: string[]
-    } & AutoreplySummaryRenderData)
-  | { responseId: string; autoReplyBody: string[] }
+  | (AutoreplyHtmlDefaultBody & AutoreplySummaryRenderData)
+  | AutoreplyHtmlDefaultBody
 
 export type BounceNotificationHtmlData = {
   formTitle: string

--- a/src/app/views/templates/submit-form-autoreply.server.view.html
+++ b/src/app/views/templates/submit-form-autoreply.server.view.html
@@ -1,7 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <style type="text/css">
+      hr {
+        margin-top: 20px;
+        margin-bottom: 20px;
+      }
+    </style>
+  </head>
   <body>
-    Response ID: <%= responseId %>
+    Response ID: <%= submissionId %>
     <hr />
     <% autoReplyBody.forEach(function(line) { %> <%= line %><br />
     <% }) %> <% if (locals.refNo) { %>

--- a/src/app/views/templates/submit-form-autoreply.server.view.html
+++ b/src/app/views/templates/submit-form-autoreply.server.view.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <body>
+    Response ID: <%= responseId %>
+    <hr />
     <% autoReplyBody.forEach(function(line) { %> <%= line %><br />
     <% }) %> <% if (locals.refNo) { %>
     <br />

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -916,6 +916,10 @@
   padding: 20px;
 }
 
+.edit-modal-window .preview-field-panel #email-preview #response-id {
+  color: #979797;
+}
+
 .edit-modal-window .preview-field-panel #email-preview .editable-text {
   color: #283d86;
   text-align: justify;

--- a/src/public/modules/forms/admin/views/edit-fields.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-fields.client.modal.html
@@ -1380,6 +1380,8 @@
             >
           </p>
           <div id="email-preview-content">
+            <p id="response-id">Response ID: 123456789</p>
+            <hr />
             <p class="editable-text">
               {{vm.field.autoReplyOptions.autoReplyMessage ?
               vm.field.autoReplyOptions.autoReplyMessage : "Dear Sir or

--- a/src/public/modules/forms/base/componentViews/end-page.html
+++ b/src/public/modules/forms/base/componentViews/end-page.html
@@ -5,8 +5,8 @@
   <div id="end-page-main-container" class="{{ vm.colorTheme }}-bg">
     <div class="row">
       <p id="end-page-header">
-        <span id="end-page-responseid">
-          Response ID: <span id="end-page-id"> {{ vm.responseId }} </span>
+        <span id="end-page-submissionId">
+          Response ID: <span id="end-page-id"> {{ vm.submissionId }} </span>
         </span>
         <br />
         <span>

--- a/src/public/modules/forms/base/componentViews/end-page.html
+++ b/src/public/modules/forms/base/componentViews/end-page.html
@@ -5,7 +5,14 @@
   <div id="end-page-main-container" class="{{ vm.colorTheme }}-bg">
     <div class="row">
       <p id="end-page-header">
-        Form submitted <span id="end-page-timestamp"> {{ vm.timestamp }} </span>
+        <span id="end-page-responseid">
+          Response ID: <span id="end-page-id"> {{ vm.responseId }} </span>
+        </span>
+        <br />
+        <span>
+          Form submitted
+          <span id="end-page-timestamp"> {{ vm.timestamp }} </span>
+        </span>
       </p>
       <h2 id="end-page-title">{{ vm.title }}</h2>
       <div class="end-page-follow-up end-page-instructions">

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -11,6 +11,7 @@ angular.module('forms').component('endPageComponent', {
     authType: '@',
     isAdminPreview: '<',
     colorTheme: '@',
+    responseId: '<',
   },
   controller: ['SpcpSession', '$window', 'moment', endPageController],
   controllerAs: 'vm',

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -11,7 +11,7 @@ angular.module('forms').component('endPageComponent', {
     authType: '@',
     isAdminPreview: '<',
     colorTheme: '@',
-    responseId: '<',
+    responseId: '@',
   },
   controller: ['SpcpSession', '$window', 'moment', endPageController],
   controllerAs: 'vm',

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -11,7 +11,7 @@ angular.module('forms').component('endPageComponent', {
     authType: '@',
     isAdminPreview: '<',
     colorTheme: '@',
-    responseId: '@',
+    submissionId: '@',
   },
   controller: ['SpcpSession', '$window', 'moment', endPageController],
   controllerAs: 'vm',

--- a/src/public/modules/forms/base/css/end-page.css
+++ b/src/public/modules/forms/base/css/end-page.css
@@ -7,10 +7,10 @@
   font-weight: bold;
 }
 
-#end-page-header #end-page-responseid {
+#end-page-header #end-page-submissionId {
   font-size: 12px;
 }
 
-#end-page-header #end-page-responseid #end-page-id {
+#end-page-header #end-page-submissionId #end-page-id {
   text-transform: lowercase;
 }

--- a/src/public/modules/forms/base/css/end-page.css
+++ b/src/public/modules/forms/base/css/end-page.css
@@ -6,3 +6,11 @@
 #end-page-header #end-page-timestamp {
   font-weight: bold;
 }
+
+#end-page-header #end-page-responseid {
+  font-size: 12px;
+}
+
+#end-page-header #end-page-responseid #end-page-id {
+  text-transform: lowercase;
+}

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -91,7 +91,7 @@
       auth-type="{{ form.authType }}"
       is-admin-preview="false"
       color-theme="{{ form.startPage.colorTheme }}"
-      response-id="{{ responseId }}"
+      submission-id="{{ submissionId }}"
     >
     </end-page-component>
   </form>

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -91,6 +91,7 @@
       auth-type="{{ form.authType }}"
       is-admin-preview="false"
       color-theme="{{ form.startPage.colorTheme }}"
+      response-id="{{ responseId }}"
     >
     </end-page-component>
   </form>

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -59,6 +59,7 @@ function submitFormDirective(
       logoUrl: '<',
       myInfoError: '<',
       disableSubmitButton: '<',
+      responseId: '<',
     },
     link: function (scope, _element, _attrs, _ctrl) {
       const startDate = Date.now() // Used to calculate time spent on form
@@ -321,7 +322,7 @@ function submitFormDirective(
             responseMode: form.responseMode,
           },
           submissionContent, // POST body
-        ).then(handleSubmitSuccess, handleSubmitFailure)
+        ).then((response) => handleSubmitSuccess(response), handleSubmitFailure)
       }
 
       /**
@@ -334,7 +335,8 @@ function submitFormDirective(
        * Returns a callback for form submission success, which updates UI
        * state and Google Analytics.
        */
-      const handleSubmitSuccess = () => {
+      const handleSubmitSuccess = (response) => {
+        scope.responseId = response.id
         setFormState(FORM_STATES.SUBMITTED)
         GTag.submitFormSuccess(scope.form, startDate, Date.now())
         if (shouldTrackPersistentLoginUse()) {

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -321,7 +321,10 @@ function submitFormDirective(
             responseMode: form.responseMode,
           },
           submissionContent, // POST body
-        ).then((response) => handleSubmitSuccess(response), handleSubmitFailure)
+        ).then(
+          (response) => handleSubmitSuccess(response),
+          (err, message) => handleSubmitFailure(err, message),
+        )
       }
 
       /**

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -335,7 +335,7 @@ function submitFormDirective(
        * state and Google Analytics.
        */
       const handleSubmitSuccess = (response) => {
-        scope.responseId = response.submissionId
+        scope.submissionId = response.submissionId
         setFormState(FORM_STATES.SUBMITTED)
         GTag.submitFormSuccess(scope.form, startDate, Date.now())
         if (shouldTrackPersistentLoginUse()) {

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -59,7 +59,6 @@ function submitFormDirective(
       logoUrl: '<',
       myInfoError: '<',
       disableSubmitButton: '<',
-      responseId: '<',
     },
     link: function (scope, _element, _attrs, _ctrl) {
       const startDate = Date.now() // Used to calculate time spent on form
@@ -355,6 +354,7 @@ function submitFormDirective(
        * @param {string?} toastMessage The toast message to display, if any.
        */
       const handleSubmitFailure = (error, toastMessage) => {
+        scope.responseId = ''
         const form = scope.form
         console.error('Submission error:\t', error)
         setFormState(FORM_STATES.SUBMISSION_ERROR)

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -321,10 +321,7 @@ function submitFormDirective(
             responseMode: form.responseMode,
           },
           submissionContent, // POST body
-        ).then(
-          (response) => handleSubmitSuccess(response),
-          (err, message) => handleSubmitFailure(err, message),
-        )
+        ).then(handleSubmitSuccess, handleSubmitFailure)
       }
 
       /**
@@ -338,7 +335,7 @@ function submitFormDirective(
        * state and Google Analytics.
        */
       const handleSubmitSuccess = (response) => {
-        scope.responseId = response.id
+        scope.responseId = response.submissionId
         setFormState(FORM_STATES.SUBMITTED)
         GTag.submitFormSuccess(scope.form, startDate, Date.now())
         if (shouldTrackPersistentLoginUse()) {
@@ -357,7 +354,6 @@ function submitFormDirective(
        * @param {string?} toastMessage The toast message to display, if any.
        */
       const handleSubmitFailure = (error, toastMessage) => {
-        scope.responseId = ''
         const form = scope.form
         console.error('Submission error:\t', error)
         setFormState(FORM_STATES.SUBMISSION_ERROR)

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -139,7 +139,7 @@ function SubmissionsFactory(
         function (response) {
           deferred.resolve({
             message: 'Submission has finished.',
-            submissionId: response.submissionId,
+            submissionId: response.data.submissionId,
           })
         },
         function (error) {

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -105,7 +105,10 @@ function SubmissionsFactory(
               submissionId: response.submissionId,
             })
           } else {
-            deferred.reject(`${response.message}`)
+            deferred.reject(
+              `${response.message}` ||
+                "Please refresh and try again. If this doesn't work, try switching devices or networks.",
+            )
           }
         } catch (e) {
           deferred.reject(

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -107,7 +107,6 @@ function SubmissionsFactory(
           } else {
             deferred.reject(`${response.message}`)
           }
-          // eslint-disable-next-line no-empty
         } catch (e) {
           deferred.reject(
             "Please refresh and try again. If this doesn't work, try switching devices or networks.",

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -93,18 +93,20 @@ function SubmissionsFactory(
     xhr.send(fd)
     // On Response
     xhr.onreadystatechange = function () {
-      // 4 DONE  The operation is complete.
       const OPERATION_DONE = 4
       if (xhr.readyState === OPERATION_DONE) {
         // waterfall is successful
+        let response = {}
+        try {
+          response = JSON.parse(xhr.responseText)
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
         if (xhr.status === HttpStatus.OK) {
-          deferred.resolve('Submission has finished.')
+          deferred.resolve({
+            message: 'Submission has finished.',
+            id: response.submissionId || 'Not available',
+          })
         } else {
-          let response = {}
-          try {
-            response = JSON.parse(xhr.responseText)
-            // eslint-disable-next-line no-empty
-          } catch (e) {}
           deferred.reject(
             `${
               response.message ||
@@ -133,8 +135,11 @@ function SubmissionsFactory(
         version: body.version,
       })
       .then(
-        function () {
-          deferred.resolve('Submission has finished.')
+        function (response) {
+          deferred.resolve({
+            message: 'Submission has finished.',
+            id: response.submissionId,
+          })
         },
         function (error) {
           deferred.reject(

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -99,19 +99,18 @@ function SubmissionsFactory(
         let response = {}
         try {
           response = JSON.parse(xhr.responseText)
+          if (xhr.status === HttpStatus.OK) {
+            deferred.resolve({
+              message: 'Submission has finished.',
+              submissionId: response.submissionId,
+            })
+          } else {
+            deferred.reject(`${response.message}`)
+          }
           // eslint-disable-next-line no-empty
-        } catch (e) {}
-        if (xhr.status === HttpStatus.OK) {
-          deferred.resolve({
-            message: 'Submission has finished.',
-            id: response.submissionId || 'Not available',
-          })
-        } else {
+        } catch (e) {
           deferred.reject(
-            `${
-              response.message ||
-              "Please refresh and try again. If this doesn't work, try switching devices or networks."
-            }`,
+            "Please refresh and try again. If this doesn't work, try switching devices or networks.",
           )
         }
       }
@@ -138,7 +137,7 @@ function SubmissionsFactory(
         function (response) {
           deferred.resolve({
             message: 'Submission has finished.',
-            id: response.submissionId,
+            submissionId: response.submissionId,
           })
         },
         function (error) {


### PR DESCRIPTION
## Problem
This PR adds the response ID to the Thank You page. For details, see #1409.

Closes #1409

## Screenshots
<img width="1792" alt="Screenshot 2021-05-12 at 7 12 13 PM" src="https://user-images.githubusercontent.com/54089291/118206030-4de5d700-b494-11eb-92bc-6eb50176a063.png">
<img width="1767" alt="Screenshot 2021-05-17 at 10 00 37 AM" src="https://user-images.githubusercontent.com/54089291/118423046-c350e200-b6f6-11eb-9ab6-d6b525ca2cee.png">
<img width="1443" alt="Screenshot 2021-05-19 at 12 21 06 PM" src="https://user-images.githubusercontent.com/54089291/118760326-2f714880-b8a5-11eb-9c5e-880682c7cda4.png">

## Manual Tests
- [x] Create email field and turn on email confirmation. Check that dummy response ID is present in email confirmation preview in edit field modal
- **Create email field in email mode and submit form**
- [x] Check that correct response ID (submission ID, not form ID) is displayed above time of submission
- [x] Check that response ID is present in email confirmation
- [x] Enter preview mode and repeat above checks
- **Create email field in storage mode and submit form**
- [x] Check that correct response ID (submission ID, not form ID) is displayed above time of submission
- [x] Check that response ID is present in email confirmation
- [x] Enter preview mode and repeat above checks

