### PR TITLE
fix(collaborator-modal/client/controller): bugfix for spinner ui

### DIFF
--- a/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
@@ -237,7 +237,7 @@ function CollaboratorModalController(
     )
 
     $scope.btnStatus = 2 // pressed; loading
-    $scope.updatePermissionList(permissionList).catch((err) => {
+    $scope.updatePermissionList(permissionList).then((err) => {
       if (err) {
         // Make the alert message correspond to the error code
         if (err.response.status === StatusCodes.BAD_REQUEST) {


### PR DESCRIPTION
## Problem
fixes the infinite spinner on UI when adding collaborators. this was due to an erroneous change (by me) from changing the `then` block into a `catch`. this was made because i thought that it should still be a catch block (as there is an error) but this is not the case because it is an ordinary value now. 

## Solution
changes it back into a `then` block 
