### PR TITLE
chore: use nproc to limit number of jest workers on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       workspaces:
         use: build
       script:
-        - npm run test-backend
+        - npm run test-backend-ci
       after_success:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
     - name: End-to-end tests

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "test-backend": "env-cmd -f tests/.test-full-env jest --coverage --maxWorkers=4",
+    "test-backend-ci": "env-cmd -f tests/.test-full-env jest --coverage --maxWorkers=$(nproc)",
     "test-backend:watch": "env-cmd -f tests/.test-full-env jest --watch",
     "test-frontend": "jest --config=tests/unit/frontend/jest.config.js",
     "build": "npm run build-backend && npm run build-frontend",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Travis has been causing our tests to fail sporadically for quite some time, mostly due to timeouts where the test could not start in time. This attempts to hopefully fix the issue by limiting the number of workers to the number of cores Travis has, by introducing a new `test-backend-ci` script that uses Linux's `nproc` to retrieve the number of logical cores available to the machine.

If this PR fails.... then I'll go cry quietly in a corner.

See discussion: https://github.com/facebook/jest/issues/5989