### PR TITLE
fix(jest): add --ci and --runInBand flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "npm": "~6.4.0"
   },
   "scripts": {
-    "test-backend": "env-cmd -f tests/.test-full-env jest --coverage --maxWorkers=4",
+    "test-backend": "env-cmd -f tests/.test-full-env jest --ci --coverage --runInBand",
     "test-backend:watch": "env-cmd -f tests/.test-full-env jest --watch",
     "test-frontend": "jest --config=tests/unit/frontend/jest.config.js",
     "build": "npm run build-backend && npm run build-frontend",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Out of memory problems when running Jest tests:
![image](https://user-images.githubusercontent.com/5690550/117769754-af286300-b266-11eb-9fa7-0d23c45cbe3c.png)


## Solution
<!-- How did you solve the problem? -->

Enable the `--runInBand` option and remove `--maxWorkers`, so as to run tests within the current process and avoid spawning additional worker processes. This helps to reduce resource hog, and is also recommended by [mongodb-memory-server](https://github.com/nodkz/mongodb-memory-server#ci).

I also enabled the `--ci` flag to signal to the Jest CLI that it is running in a CI environment. This will be useful soon as part of React snapshot testing, [which would simply save the new snapshot](https://jestjs.io/docs/cli#--ci) instead of failing the test.