### PR TITLE
build: migrate unit tests to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Load Node.js modules
         uses: actions/cache@v2
         with:
@@ -42,6 +47,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Load Node.js modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,5 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run test-backend
-      - name: Produce coverage
-        run: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,19 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
   test-frontend:
     needs: install
     runs-on: ubuntu-latest
 
     steps:
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run test-frontend
 
   test-backend:
@@ -36,4 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run test-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,7 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run test-backend
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v1.1.2
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,5 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run test-backend
+      - name: Produce coverage
+        run: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   install:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
-      - name: Install dependencies
-        run: npm install
+      - run: npm ci
 
   test-frontend:
     needs: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  install:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,16 +22,18 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - name: Install dependencies
-        run: |
-          npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
-          npm ci
-      - name: Lint
-        run: npm run lint-ci
-      - name: Build application
-        run: npm run build
-      - name: Frontend tests
-        run: npm run test-frontend
-      - name: Backend tests
-        run: npm run test-backend
-      - name: End-to-end tests
-        run: npm run test-e2e-ci
+        run: npm ci
+
+  test-frontend:
+    needs: install
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: npm run test-frontend
+
+  test-backend:
+    needs: install
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: npm run test-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - name: Install dependencies
+        run: |
+          npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
+          npm ci
+      - name: Lint
+        run: npm run lint-ci
+      - name: Build application
+        run: npm run build
+      - name: Frontend tests
+        run: npm run test-frontend
+      - name: Backend tests
+        run: npm run test-backend
+      - name: End-to-end tests
+        run: npm run test-e2e-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
       - run: npm run test-frontend
 
   test-backend:
@@ -58,4 +59,5 @@ jobs:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
       - run: npm run test-backend

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,6 @@ jobs:
         create:
           name: build
           paths: .
-    - stage: Tests
-      name: Frontend tests
-      workspaces:
-        use: build
-      script:
-        - npm run test-frontend
-    - name: Backend tests
-      workspaces:
-        use: build
-      script:
-        - npm run test-backend
-      after_success:
-        - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
     - name: End-to-end tests
       workspaces:
         use: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ jobs:
         create:
           name: build
           paths: .
-    - name: End-to-end tests
+    - stage: Tests
+      name: End-to-end tests
       workspaces:
         use: build
       addons:


### PR DESCRIPTION
## Problem

Unit tests on Travis CI have been intermittently failing due to memory issues with Jest. It does not seem like the issue is with the tests themselves, since running `jest --logHeapUsage` shows that the memory usage does not increase consistently as more tests pass. This suggests that the memory limitation is with Travis.

Part of #1864 

## Solution

This PR migrates only the frontend and backend unit tests to GitHub Actions (GA) to test whether the tests pass consistently. If they do, we can consider migrating the entire CI pipeline to GA.