### PR TITLE
refactor(verified-fields): migrate get transaction

### DIFF
--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -97,6 +97,9 @@ export const handleCreateTransactionWithFieldId: RequestHandler<
  * Returns a transaction's id and expiry time if it exists
  * @param req
  * @param res
+ * @returns 200 with transactionId/formId and expiry time when transaction exists
+ * @returns 404 when the transaction could not be found
+ * @returns 500 when database error occurs
  */
 export const handleGetTransactionMetadata: RequestHandler<
   {

--- a/src/app/modules/verification/verification.routes.ts
+++ b/src/app/modules/verification/verification.routes.ts
@@ -22,6 +22,10 @@ VfnRouter.post(
   VerificationController.handleCreateTransaction,
 )
 
+/**
+ * Route for GET /transaction/:transactionId
+ * @deprecated in favour of GET /forms/:formId/fieldverifications/:id
+ */
 VfnRouter.get(
   '/:transactionId([a-fA-F0-9]{24})',
   celebrate({

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -4,6 +4,24 @@ import * as VerificationController from '../../../../modules/verification/verifi
 
 export const PublicFormsVerificationRouter = Router()
 
+/**
+ * Route for creating a verification transaction instance
+ * @group fieldverifications
+ * @route POST /forms/:formId/fieldverifications
+ */
 PublicFormsVerificationRouter.route(
   '/:formId([a-fA-F0-9]{24})/fieldverifications',
 ).post(VerificationController.handleCreateTransactionWithFieldId)
+
+/**
+ * Route for retrieving a transaction by its id
+ * @group fieldverifications
+import { ObjectId } from 'bson-ext'
+ * @route GET /forms/:formId/fieldverifications/:id
+ * @returns 200 with transactionId/formId and expiry time when transaction exists
+ * @returns 404 when the transaction could not be found
+ * @returns 500 when database error occurs
+ */
+PublicFormsVerificationRouter.route(
+  '/:formId([a-fA-F0-9]{24})/fieldverifications/:transactionId([a-fA-F0-9]{24})',
+).get(VerificationController.handleGetTransactionMetadata)

--- a/src/public/services/FieldVerificationService.ts
+++ b/src/public/services/FieldVerificationService.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import { Opaque } from 'type-fest'
 
+import { PublicTransaction } from 'src/types'
+
 export type JsonDate = Opaque<string, 'JsonDate'>
 
 /**
@@ -101,4 +103,27 @@ export const resetVerifiedField = async ({
   return axios.post(`${TRANSACTION_ENDPOINT}/${transactionId}/reset`, {
     fieldId,
   })
+}
+
+/**
+ * Retrieves the transaction of the form with the given Id.
+ *
+ * @param transactionId The generated transaction id for the form
+ * @param formId The id of form
+ * @returns 200 with transactionId/formId and expiry time when transaction exists
+ * @returns 404 when the transaction could not be found
+ * @returns 500 when internal server occurs
+ */
+export const retrieveTransactionById = ({
+  formId,
+  transactionId,
+}: {
+  formId: string
+  transactionId: string
+}): Promise<PublicTransaction> => {
+  return axios
+    .get<PublicTransaction>(
+      `${FORM_API_PREFIX}/${formId}/${VERIFICATION_ENDPOINT}/${transactionId}`,
+    )
+    .then(({ data }) => data)
 }


### PR DESCRIPTION
## Problem
The verification belongs to a `field`, which is in itself a part of a `form`. Hence, in order for our endpoints to be RESTful, the verification service should belong to `field` and by extension, `form`. 

Part 2 of #1522

## Solution
This PR implements a `/GET transactionMetadata` endpoint (currently unused) as part of a RESTful API hierarchy. 

## Tests
Adds more unit tests to `getTransactionMetadata` for error cases 

## Manual Tests
None here because it's currently unused 