### PR TITLE
[WIP] Encapsulate construction and representation of parsed responses into a class

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -5120,6 +5120,7 @@ describe('admin-form.controller', () => {
       MockEmailSubmissionService.validateAttachments.mockReturnValue(
         okAsync(true),
       )
+      // TODO: Remove after mocking ParsedResponsesObj
       MockSubmissionService.getProcessedResponses.mockReturnValue(
         ok(MOCK_PARSED_RESPONSES),
       )

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1413,7 +1413,7 @@ export const handleEncryptPreviewSubmission = [
 ] as RequestHandler[]
 
 /**
- * Handler for POST /v2/submissions/encrypt/preview/:formId.
+ * Handler for POST /v2/submissions/email/preview/:formId.
  * @security session
  *
  * @returns 200 with a mock submission ID

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -53,6 +53,7 @@ import * as EmailSubmissionService from '../../submission/email-submission/email
 import {
   mapAttachmentsFromResponses,
   mapRouteError as mapEmailSubmissionError,
+  ParsedResponsesObject,
   SubmissionEmailObj,
 } from '../../submission/email-submission/email-submission.util'
 import * as EncryptSubmissionMiddleware from '../../submission/encrypt-submission/encrypt-submission.middleware'
@@ -1357,12 +1358,7 @@ export const submitEncryptPreview: RequestHandler<
     )
     .andThen((form) =>
       checkIsEncryptedEncoding(encryptedContent)
-        .andThen(() =>
-          SubmissionService.ParsedResponsesObject.parseResponses(
-            form,
-            responses,
-          ),
-        )
+        .andThen(() => ParsedResponsesObject.parseResponses(form, responses))
         .map((parsedResponses) => ({ parsedResponses, form }))
         .mapErr((error) => {
           logger.error({
@@ -1468,9 +1464,7 @@ export const submitEmailPreview: RequestHandler<
 
   const parsedResponsesResult = await EmailSubmissionService.validateAttachments(
     responses,
-  ).andThen(() =>
-    SubmissionService.ParsedResponsesObject.parseResponses(form, responses),
-  )
+  ).andThen(() => ParsedResponsesObject.parseResponses(form, responses))
   if (parsedResponsesResult.isErr()) {
     logger.error({
       message: 'Error while parsing responses for preview submission',

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -26,6 +26,7 @@ import { IPopulatedEmailFormWithResponsesAndHash } from './email-submission.type
 import {
   mapAttachmentsFromResponses,
   mapRouteError,
+  ParsedResponsesObject,
   SubmissionEmailObj,
 } from './email-submission.util'
 
@@ -119,10 +120,7 @@ const submitEmailModeForm: RequestHandler<
         // Validate responses
         EmailSubmissionService.validateAttachments(req.body.responses)
           .andThen(() =>
-            SubmissionService.ParsedResponsesObject.parseResponses(
-              form,
-              req.body.responses,
-            ),
+            ParsedResponsesObject.parseResponses(form, req.body.responses),
           )
           .map((parsedResponses) => ({ parsedResponses, form }))
           .mapErr((error) => {

--- a/src/app/modules/submission/email-submission/email-submission.types.ts
+++ b/src/app/modules/submission/email-submission/email-submission.types.ts
@@ -4,7 +4,8 @@ import {
   IBaseResponse,
   IPopulatedEmailForm,
 } from '../../../../types'
-import { ProcessedFieldResponse, ProcessedResponse } from '../submission.types'
+import { ParsedResponsesObject } from '../submission.service'
+import { ProcessedResponse } from '../submission.types'
 
 // When a response has been formatted for email, all answerArray
 // should have been converted to answer
@@ -28,6 +29,6 @@ export interface SubmissionHash {
 
 export interface IPopulatedEmailFormWithResponsesAndHash {
   form: IPopulatedEmailForm
-  parsedResponses: ProcessedFieldResponse[]
+  parsedResponses: ParsedResponsesObject
   hashedFields?: Set<string>
 }

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import _, { compact, flattenDeep, sumBy } from 'lodash'
+import { compact, flattenDeep, sumBy } from 'lodash'
 import { err, ok, Result } from 'neverthrow'
 
 import { FilePlatforms } from '../../../../shared/constants'
@@ -78,7 +78,7 @@ import {
   ProcessedFieldResponse,
   ProcessedTableResponse,
 } from '../submission.types'
-import { getModeFilter } from '../submission.utils'
+import { getFilteredResponses } from '../submission.utils'
 
 import {
   ATTACHMENT_PREFIX,
@@ -774,46 +774,6 @@ export class SubmissionEmailObj {
       ),
     )
   }
-}
-
-/**
- * Filter allowed form field responses from given responses and return the
- * array of responses with duplicates removed.
- *
- * @param form The form document
- * @param responses the responses that corresponds to the given form
- * @returns neverthrow ok() filtered list of allowed responses with duplicates (if any) removed
- * @returns neverthrow err(ConflictError) if the given form's form field ids count do not match given responses'
- */
-// TODO: wont need to export this after removing `getProcessedResponses` from submission.service.ts
-export const getFilteredResponses = (
-  form: IFormDocument,
-  responses: FieldResponse[],
-): Result<FieldResponse[], ConflictError> => {
-  const modeFilter = getModeFilter(form.responseMode)
-
-  if (!form.form_fields) {
-    return err(new ConflictError('Form fields are missing'))
-  }
-  // _id must be transformed to string as form response is jsonified.
-  const fieldIds = modeFilter(form.form_fields).map((field) => ({
-    _id: String(field._id),
-  }))
-  const uniqueResponses = _.uniqBy(modeFilter(responses), '_id')
-  const results = _.intersectionBy(uniqueResponses, fieldIds, '_id')
-
-  if (results.length < fieldIds.length) {
-    const onlyInForm = _.differenceBy(fieldIds, results, '_id').map(
-      ({ _id }) => _id,
-    )
-    return err(
-      new ConflictError('Some form fields are missing', {
-        formId: form._id,
-        onlyInForm,
-      }),
-    )
-  }
-  return ok(results)
 }
 
 export class ParsedResponsesObject {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -30,11 +30,9 @@ import { SpcpFactory } from '../../spcp/spcp.factory'
 import { getPopulatedUserById } from '../../user/user.service'
 import { VerifiedContentFactory } from '../../verified-content/verified-content.factory'
 import { WebhookFactory } from '../../webhook/webhook.factory'
+import { ParsedResponsesObject } from '../email-submission/email-submission.util'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
-import {
-  ParsedResponsesObject,
-  sendEmailConfirmations,
-} from '../submission.service'
+import { sendEmailConfirmations } from '../submission.service'
 
 import {
   checkFormIsEncryptMode,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -32,7 +32,7 @@ import { VerifiedContentFactory } from '../../verified-content/verified-content.
 import { WebhookFactory } from '../../webhook/webhook.factory'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
 import {
-  getProcessedResponses,
+  ParsedResponsesObject,
   sendEmailConfirmations,
 } from '../submission.service'
 
@@ -154,7 +154,10 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
   }
 
   // Process encrypted submission
-  const processedResponsesResult = await getProcessedResponses(form, responses)
+  const processedResponsesResult = await ParsedResponsesObject.parseResponses(
+    form,
+    responses,
+  )
   if (processedResponsesResult.isErr()) {
     logger.error({
       message: 'Error processing encrypted submission.',
@@ -361,7 +364,11 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
 
   return sendEmailConfirmations({
     form,
-    parsedResponses: processedResponses,
+    /** TODO: NDI responses not appended to storage-mode version of sendEmailConfirmation.
+     *  Figure out a way to project responses differently depending on what context
+     *  it is used in.
+     */
+    parsedResponses: processedResponses.responses,
     submission: savedSubmission,
   }).mapErr((error) => {
     logger.error({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -364,11 +364,16 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
 
   return sendEmailConfirmations({
     form,
-    /** TODO: NDI responses not appended to storage-mode version of sendEmailConfirmation.
-     *  Figure out a way to project responses differently depending on what context
-     *  it is used in.
+    /**
+     * TODO: parsedResponses here can either just be parsedResponses.responses, or a concat with
+     * parsedResponses.ndiResponses which is always blank in this case.
+     * Leaning towards concatenating with ndiResponses because that is how parsedResponses is
+     * used in the email-submissions controller's sendEmailConfirmation function call.
      */
-    parsedResponses: processedResponses.responses,
+    parsedResponses: [
+      ...processedResponses.responses,
+      ...processedResponses.ndiResponses,
+    ],
     submission: savedSubmission,
   }).mapErr((error) => {
     logger.error({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -42,7 +42,6 @@ import {
   VerifyJwtError,
 } from '../../spcp/spcp.errors'
 import { MissingUserError } from '../../user/user.errors'
-import { getFilteredResponses } from '../email-submission/email-submission.util'
 import {
   ConflictError,
   InvalidEncodingError,
@@ -51,7 +50,7 @@ import {
   SubmissionNotFoundError,
   ValidateFieldError,
 } from '../submission.errors'
-import { IncomingSubmission } from '../submission.utils'
+import { getFilteredResponses, IncomingSubmission } from '../submission.utils'
 
 const logger = createLoggerWithLabel(module)
 

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -170,11 +170,22 @@ export class ParsedResponsesObject {
   public ndiResponses: ProcessedFieldResponse[] = []
   constructor(public responses: ProcessedFieldResponse[]) {}
 
-  addNdiResponses(ndiResponses: ProcessedFieldResponse[]) {
+  addNdiResponses(
+    ndiResponses: ProcessedFieldResponse[],
+  ): ParsedResponsesObject {
     this.ndiResponses = ndiResponses
     return this
   }
 
+  /**
+   * Injects response metadata such as the question, visibility state. In
+   * addition, validation such as input validation or signature validation on
+   * verified fields are also performed on the response.
+   * @param form The form document corresponding to the responses
+   * @param responses The responses to process and validate
+   * @returns neverthrow ok() with field responses with additional metadata injected.
+   * @returns neverthrow err() if response validation fails
+   */
   static parseResponses(
     form: IFormDocument,
     responses: FieldResponse[],

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -168,7 +168,7 @@ export const getProcessedResponses = (
 
 export class ParsedResponsesObject {
   public ndiResponses: ProcessedFieldResponse[] = []
-  constructor(public responses: FieldResponse[]) {}
+  constructor(public responses: ProcessedFieldResponse[]) {}
 
   addNdiResponses(ndiResponses: ProcessedFieldResponse[]) {
     this.ndiResponses = ndiResponses

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
@@ -23,6 +22,7 @@ import { createQueryWithDateParam, isMalformedDate } from '../../utils/date'
 import { validateField } from '../../utils/field-validation'
 import { DatabaseError, MalformedParametersError } from '../core/core.errors'
 
+import { getFilteredResponses } from './email-submission/email-submission.util'
 import {
   ConflictError,
   ProcessingError,
@@ -30,49 +30,10 @@ import {
   ValidateFieldError,
 } from './submission.errors'
 import { ProcessedFieldResponse } from './submission.types'
-import { extractEmailConfirmationData, getModeFilter } from './submission.utils'
+import { extractEmailConfirmationData } from './submission.utils'
 
 const logger = createLoggerWithLabel(module)
 const SubmissionModel = getSubmissionModel(mongoose)
-
-/**
- * Filter allowed form field responses from given responses and return the
- * array of responses with duplicates removed.
- *
- * @param form The form document
- * @param responses the responses that corresponds to the given form
- * @returns neverthrow ok() filtered list of allowed responses with duplicates (if any) removed
- * @returns neverthrow err(ConflictError) if the given form's form field ids count do not match given responses'
- */
-const getFilteredResponses = (
-  form: IFormDocument,
-  responses: FieldResponse[],
-): Result<FieldResponse[], ConflictError> => {
-  const modeFilter = getModeFilter(form.responseMode)
-
-  if (!form.form_fields) {
-    return err(new ConflictError('Form fields are missing'))
-  }
-  // _id must be transformed to string as form response is jsonified.
-  const fieldIds = modeFilter(form.form_fields).map((field) => ({
-    _id: String(field._id),
-  }))
-  const uniqueResponses = _.uniqBy(modeFilter(responses), '_id')
-  const results = _.intersectionBy(uniqueResponses, fieldIds, '_id')
-
-  if (results.length < fieldIds.length) {
-    const onlyInForm = _.differenceBy(fieldIds, results, '_id').map(
-      ({ _id }) => _id,
-    )
-    return err(
-      new ConflictError('Some form fields are missing', {
-        formId: form._id,
-        onlyInForm,
-      }),
-    )
-  }
-  return ok(results)
-}
 
 /**
  * Injects response metadata such as the question, visibility state. In
@@ -164,112 +125,6 @@ export const getProcessedResponses = (
   }
 
   return ok(processedResponses)
-}
-
-export class ParsedResponsesObject {
-  public ndiResponses: ProcessedFieldResponse[] = []
-  constructor(public responses: ProcessedFieldResponse[]) {}
-
-  addNdiResponses(
-    ndiResponses: ProcessedFieldResponse[],
-  ): ParsedResponsesObject {
-    this.ndiResponses = ndiResponses
-    return this
-  }
-
-  /**
-   * Injects response metadata such as the question, visibility state. In
-   * addition, validation such as input validation or signature validation on
-   * verified fields are also performed on the response.
-   * @param form The form document corresponding to the responses
-   * @param responses The responses to process and validate
-   * @returns neverthrow ok() with field responses with additional metadata injected.
-   * @returns neverthrow err() if response validation fails
-   */
-  static parseResponses(
-    form: IFormDocument,
-    responses: FieldResponse[],
-  ): Result<
-    ParsedResponsesObject,
-    ProcessingError | ConflictError | ValidateFieldError
-  > {
-    const filteredResponsesResult = getFilteredResponses(form, responses)
-    if (filteredResponsesResult.isErr()) {
-      return err(filteredResponsesResult.error)
-    }
-
-    const filteredResponses = filteredResponsesResult.value
-
-    // Set of all visible fields
-    const visibleFieldIds = getVisibleFieldIds(filteredResponses, form)
-
-    // Guard against invalid form submissions that should have been prevented by
-    // logic.
-    if (
-      getLogicUnitPreventingSubmit(filteredResponses, form, visibleFieldIds)
-    ) {
-      return err(new ProcessingError('Submission prevented by form logic'))
-    }
-
-    // Create a map keyed by field._id for easier access
-
-    if (!form.form_fields) {
-      return err(new ProcessingError('Form fields are undefined'))
-    }
-
-    const fieldMap = form.form_fields.reduce<{
-      [fieldId: string]: IFieldSchema
-    }>((acc, field) => {
-      acc[field._id] = field
-      return acc
-    }, {})
-
-    // Validate each field in the form and inject metadata into the responses.
-    const processedResponses = []
-    for (const response of filteredResponses) {
-      const responseId = response._id
-      const formField = fieldMap[responseId]
-      if (!formField) {
-        return err(
-          new ProcessingError('Response ID does not match form field IDs'),
-        )
-      }
-
-      const processingResponse: ProcessedFieldResponse = {
-        ...response,
-        isVisible:
-          // Set isVisible as true for Encrypt mode if there is a response for mobile and email field
-          // Because we cannot tell if the field is unhidden by logic
-          // This prevents downstream validateField from incorrectly preventing
-          // encrypt mode submissions with responses on unhidden fields
-          // TODO(#780): Remove this once submission service is separated into
-          // Email and Encrypted services
-          form.responseMode === ResponseMode.Encrypt
-            ? 'answer' in response &&
-              typeof response.answer === 'string' &&
-              response.answer.trim() !== ''
-            : visibleFieldIds.has(responseId),
-        question: formField.getQuestion(),
-      }
-
-      if (formField.isVerifiable) {
-        processingResponse.isUserVerified = formField.isVerifiable
-      }
-
-      // Error will be returned if the processed response is not valid.
-      const validateFieldResult = validateField(
-        form._id,
-        formField,
-        processingResponse,
-      )
-      if (validateFieldResult.isErr()) {
-        return err(validateFieldResult.error)
-      }
-      processedResponses.push(processingResponse)
-    }
-
-    return ok(new ParsedResponsesObject(processedResponses))
-  }
 }
 
 /**

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -22,7 +22,6 @@ import { createQueryWithDateParam, isMalformedDate } from '../../utils/date'
 import { validateField } from '../../utils/field-validation'
 import { DatabaseError, MalformedParametersError } from '../core/core.errors'
 
-import { getFilteredResponses } from './email-submission/email-submission.util'
 import {
   ConflictError,
   ProcessingError,
@@ -30,7 +29,10 @@ import {
   ValidateFieldError,
 } from './submission.errors'
 import { ProcessedFieldResponse } from './submission.types'
-import { extractEmailConfirmationData } from './submission.utils'
+import {
+  extractEmailConfirmationData,
+  getFilteredResponses,
+} from './submission.utils'
 
 const logger = createLoggerWithLabel(module)
 const SubmissionModel = getSubmissionModel(mongoose)

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -166,6 +166,101 @@ export const getProcessedResponses = (
   return ok(processedResponses)
 }
 
+export class ParsedResponsesObject {
+  public ndiResponses: ProcessedFieldResponse[] = []
+  constructor(public responses: FieldResponse[]) {}
+
+  addNdiResponses(ndiResponses: ProcessedFieldResponse[]) {
+    this.ndiResponses = ndiResponses
+    return this
+  }
+
+  static parseResponses(
+    form: IFormDocument,
+    responses: FieldResponse[],
+  ): Result<
+    ParsedResponsesObject,
+    ProcessingError | ConflictError | ValidateFieldError
+  > {
+    const filteredResponsesResult = getFilteredResponses(form, responses)
+    if (filteredResponsesResult.isErr()) {
+      return err(filteredResponsesResult.error)
+    }
+
+    const filteredResponses = filteredResponsesResult.value
+
+    // Set of all visible fields
+    const visibleFieldIds = getVisibleFieldIds(filteredResponses, form)
+
+    // Guard against invalid form submissions that should have been prevented by
+    // logic.
+    if (
+      getLogicUnitPreventingSubmit(filteredResponses, form, visibleFieldIds)
+    ) {
+      return err(new ProcessingError('Submission prevented by form logic'))
+    }
+
+    // Create a map keyed by field._id for easier access
+
+    if (!form.form_fields) {
+      return err(new ProcessingError('Form fields are undefined'))
+    }
+
+    const fieldMap = form.form_fields.reduce<{
+      [fieldId: string]: IFieldSchema
+    }>((acc, field) => {
+      acc[field._id] = field
+      return acc
+    }, {})
+
+    // Validate each field in the form and inject metadata into the responses.
+    const processedResponses = []
+    for (const response of filteredResponses) {
+      const responseId = response._id
+      const formField = fieldMap[responseId]
+      if (!formField) {
+        return err(
+          new ProcessingError('Response ID does not match form field IDs'),
+        )
+      }
+
+      const processingResponse: ProcessedFieldResponse = {
+        ...response,
+        isVisible:
+          // Set isVisible as true for Encrypt mode if there is a response for mobile and email field
+          // Because we cannot tell if the field is unhidden by logic
+          // This prevents downstream validateField from incorrectly preventing
+          // encrypt mode submissions with responses on unhidden fields
+          // TODO(#780): Remove this once submission service is separated into
+          // Email and Encrypted services
+          form.responseMode === ResponseMode.Encrypt
+            ? 'answer' in response &&
+              typeof response.answer === 'string' &&
+              response.answer.trim() !== ''
+            : visibleFieldIds.has(responseId),
+        question: formField.getQuestion(),
+      }
+
+      if (formField.isVerifiable) {
+        processingResponse.isUserVerified = formField.isVerifiable
+      }
+
+      // Error will be returned if the processed response is not valid.
+      const validateFieldResult = validateField(
+        form._id,
+        formField,
+        processingResponse,
+      )
+      if (validateFieldResult.isErr()) {
+        return err(validateFieldResult.error)
+      }
+      processedResponses.push(processingResponse)
+    }
+
+    return ok(new ParsedResponsesObject(processedResponses))
+  }
+}
+
 /**
  * Returns number of form submissions of given form id in the given date range.
  *

--- a/src/app/modules/submission/submission.types.ts
+++ b/src/app/modules/submission/submission.types.ts
@@ -1,3 +1,5 @@
+import { Opaque } from 'type-fest'
+
 import {
   IAttachmentResponse,
   ICheckboxResponse,
@@ -5,13 +7,30 @@ import {
   ITableResponse,
 } from 'src/types/response'
 
-import { BasicField } from '../../../types/field'
+import { FieldIdSet } from '../../../shared/util/logic'
+import { BasicField, IFieldSchema } from '../../../types/field'
 
 export type ProcessedResponse = {
   question: string
   isVisible?: boolean
   isUserVerified?: boolean
 }
+
+/**
+ * Represents a field map that is guaranteed to contain the id of
+ * ALL responses in an incoming response.
+ */
+export type ValidatedFieldMap = Opaque<
+  { [p: string]: IFieldSchema },
+  'ValidatedFieldMap'
+>
+
+export type VisibleResponseIdSet = Opaque<FieldIdSet, 'VisibleResponseIdSet'>
+
+export type VerifiableResponseIdSet = Opaque<
+  FieldIdSet,
+  'VerifiableResponseIdSet'
+>
 
 export type ColumnResponse = {
   fieldType: BasicField

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -1,11 +1,29 @@
 import { keyBy } from 'lodash'
+import { combine, err, ok, Result } from 'neverthrow'
 
 import { FIELDS_TO_REJECT } from '../../../shared/resources/basic'
-import { BasicField, IFieldSchema, ResponseMode } from '../../../types'
+import {
+  FieldIdSet,
+  getLogicUnitPreventingSubmit,
+} from '../../../shared/util/logic'
+import {
+  BasicField,
+  FieldResponse,
+  IFieldSchema,
+  IFormDocument,
+  ResponseMode,
+} from '../../../types'
 import { isEmailField } from '../../../types/field/utils/guards'
 import { AutoReplyMailData } from '../../services/mail/mail.types'
+import { validateField } from '../../utils/field-validation'
 
-import { ProcessedFieldResponse } from './submission.types'
+import { ProcessingError, ValidateFieldError } from './submission.errors'
+import {
+  ProcessedFieldResponse,
+  ValidatedFieldMap,
+  VerifiableResponseIdSet,
+  VisibleResponseIdSet,
+} from './submission.types'
 
 type ModeFilterParam = {
   fieldType: BasicField
@@ -67,4 +85,191 @@ export const extractEmailConfirmationData = (
     }
     return acc
   }, [])
+}
+
+export class IncomingSubmission {
+  constructor(public responses: FieldResponse[]) {}
+
+  /**
+   * Generate a look-up table that maps an object ID to form field.
+   * Additionally, guarantees that every response's ID can be found.
+   * @param form - The form to generate the lookup table for.
+   * @param responses - List of responses. Used for validation to achieve
+   * said guarantee.
+   * @returns neverthrow ok() with look-up table.
+   * @returns neverthrow err() if form object does not have `form_fields`,
+   * or if there exists a response whose ID is not a key in the lookup
+   * table.
+   * @protected
+   */
+  protected static getFieldMap(
+    form: IFormDocument,
+    responses: FieldResponse[],
+  ): Result<ValidatedFieldMap, ProcessingError> {
+    if (!form.form_fields) {
+      return err(new ProcessingError('Form fields are undefined'))
+    }
+
+    const fieldMap = form.form_fields.reduce<{
+      [fieldId: string]: IFieldSchema
+    }>((acc, field) => {
+      acc[field._id] = field
+      return acc
+    }, {})
+
+    const validationResultList = responses.map((r) => {
+      const responseId = r._id
+      const formField = fieldMap[responseId]
+      if (!formField) {
+        return err(
+          new ProcessingError('Response ID does not match form field IDs'),
+        )
+      }
+      return ok(r)
+    })
+
+    const validationResultCombined = combine(validationResultList)
+    if (validationResultCombined.isErr()) {
+      return err(
+        new ProcessingError('Response ID does not match form field IDs'),
+      )
+    }
+
+    return ok(fieldMap as ValidatedFieldMap)
+  }
+
+  /**
+   * Generates a set of response IDs that are visible.
+   * @param responses
+   * @param fieldMap
+   * @param visibilityPredicate - Predicate that determines if a response
+   * is visible.
+   * @returns visibleResponseIds - Generated set of response IDs.
+   * @protected
+   */
+  protected static getVisibleResponseIds(
+    responses: FieldResponse[],
+    fieldMap: ValidatedFieldMap,
+    visibilityPredicate: (r: FieldResponse) => boolean,
+  ): VisibleResponseIdSet {
+    return responses.reduce<FieldIdSet>((acc, response) => {
+      const responseId = response._id
+      if (!visibilityPredicate(response)) {
+        return acc
+      }
+      acc.add(responseId)
+      return acc
+    }, new Set()) as VisibleResponseIdSet
+  }
+
+  /**
+   * Generates a set of response IDs that are verifiable. A response is
+   * said to be verifiable if its corresponding form field has the
+   * isVerifiable property set to `true`.
+   * @param responses
+   * @param fieldMap
+   * @returns verifiableResponseIds - Generated set of response IDs.
+   * @protected
+   */
+  protected static getVerifiableResponseIds(
+    responses: FieldResponse[],
+    fieldMap: ValidatedFieldMap,
+  ): VerifiableResponseIdSet {
+    return responses.reduce<FieldIdSet>((acc, response) => {
+      const responseId = response._id
+      const formField = fieldMap[responseId]
+      if (formField.isVerifiable) {
+        acc.add(responseId)
+      }
+      return acc
+    }, new Set()) as VerifiableResponseIdSet
+  }
+
+  /**
+   * Prior to the introduction of IncomingResponse, responses were
+   * stored in a ProcessedFieldResponse[]. This method helps to
+   * create a ProcessedFieldResponse object that can be used in
+   * functions that have not been refactored to take in the new
+   * IncomingResponse object.
+   *
+   * A ProcessedResponse is just a regular FieldResponse with some
+   * metadata inserted into them. This function takes in several
+   * data sets that help determine what each metadata field should
+   * contain.
+   * @param response
+   * @param fieldMap
+   * @param visibleResponseIds
+   * @param verifiableResponseIds
+   * @returns processedFieldResponse - The ProcessedFieldResponse
+   * @protected
+   */
+  protected static getLegacyProcessedFieldResponse(
+    response: FieldResponse,
+    fieldMap: ValidatedFieldMap,
+    visibleResponseIds: VisibleResponseIdSet,
+    verifiableResponseIds: VerifiableResponseIdSet,
+  ): ProcessedFieldResponse {
+    const responseId = response._id
+    const formField = fieldMap[responseId]
+    const processedResponse: ProcessedFieldResponse = {
+      ...response,
+      isVisible: visibleResponseIds.has(responseId),
+      question: formField.getQuestion(),
+    }
+
+    /**
+     * This pattern of mutating processedResponse is copied from the original
+     * getProcessedResponse function. TODO: Check if can just move this into
+     * the object instantiation stage, preserving the possible undefined value.
+     */
+    if (verifiableResponseIds.has(responseId)) {
+      processedResponse.isUserVerified = true
+    }
+
+    return processedResponse
+  }
+
+  protected static validateResponses(
+    responses: FieldResponse[],
+    form: IFormDocument,
+    fieldMap: ValidatedFieldMap,
+    visibleFieldIds: FieldIdSet,
+    visibleResponseIds: VisibleResponseIdSet,
+    verifiableResponseIds: VerifiableResponseIdSet,
+  ): Result<true, ProcessingError | ValidateFieldError> {
+    // Guard against invalid form submissions that should have been prevented by
+    // logic.
+    if (getLogicUnitPreventingSubmit(responses, form, visibleFieldIds)) {
+      return err(new ProcessingError('Submission prevented by form logic'))
+    }
+
+    const validationResultList = responses.map((response) => {
+      const responseId = response._id
+      const formField = fieldMap[responseId]
+      return validateField(
+        form._id,
+        formField,
+        this.getLegacyProcessedFieldResponse(
+          response,
+          fieldMap,
+          visibleResponseIds,
+          verifiableResponseIds,
+        ),
+      )
+    })
+
+    const validationResultCombined = combine(validationResultList)
+    if (validationResultCombined.isErr()) {
+      return err(validationResultCombined.error)
+    }
+
+    return ok(true)
+  }
+
+  /**
+   * TODO: Consider the need for a set of _id: question pairs.
+   * Because this can easily be obtained from fieldMap, this might
+   * not be necessary.
+   */
+  // TODO: Consider the need to store the form object for data lookup.
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -197,10 +197,9 @@ export class IncomingSubmission {
   ): VisibleResponseIdSet {
     return responses.reduce<FieldIdSet>((acc, response) => {
       const responseId = response._id
-      if (!visibilityPredicate(response)) {
-        return acc
+      if (visibilityPredicate(response)) {
+        acc.add(responseId)
       }
-      acc.add(responseId)
       return acc
     }, new Set()) as VisibleResponseIdSet
   }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -1,4 +1,4 @@
-import { keyBy } from 'lodash'
+import _, { keyBy } from 'lodash'
 import { combine, err, ok, Result } from 'neverthrow'
 
 import { FIELDS_TO_REJECT } from '../../../shared/resources/basic'
@@ -17,7 +17,11 @@ import { isEmailField } from '../../../types/field/utils/guards'
 import { AutoReplyMailData } from '../../services/mail/mail.types'
 import { validateField } from '../../utils/field-validation'
 
-import { ProcessingError, ValidateFieldError } from './submission.errors'
+import {
+  ConflictError,
+  ProcessingError,
+  ValidateFieldError,
+} from './submission.errors'
 import {
   ProcessedFieldResponse,
   ValidatedFieldMap,
@@ -85,6 +89,45 @@ export const extractEmailConfirmationData = (
     }
     return acc
   }, [])
+}
+
+/**
+ * Filter allowed form field responses from given responses and return the
+ * array of responses with duplicates removed.
+ *
+ * @param form The form document
+ * @param responses the responses that corresponds to the given form
+ * @returns neverthrow ok() filtered list of allowed responses with duplicates (if any) removed
+ * @returns neverthrow err(ConflictError) if the given form's form field ids count do not match given responses'
+ */
+export const getFilteredResponses = (
+  form: IFormDocument,
+  responses: FieldResponse[],
+): Result<FieldResponse[], ConflictError> => {
+  const modeFilter = getModeFilter(form.responseMode)
+
+  if (!form.form_fields) {
+    return err(new ConflictError('Form fields are missing'))
+  }
+  // _id must be transformed to string as form response is jsonified.
+  const fieldIds = modeFilter(form.form_fields).map((field) => ({
+    _id: String(field._id),
+  }))
+  const uniqueResponses = _.uniqBy(modeFilter(responses), '_id')
+  const results = _.intersectionBy(uniqueResponses, fieldIds, '_id')
+
+  if (results.length < fieldIds.length) {
+    const onlyInForm = _.differenceBy(fieldIds, results, '_id').map(
+      ({ _id }) => _id,
+    )
+    return err(
+      new ConflictError('Some form fields are missing', {
+        formId: form._id,
+        onlyInForm,
+      }),
+    )
+  }
+  return ok(results)
 }
 
 export class IncomingSubmission {

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -11,7 +11,7 @@ import {
 } from '../../types'
 
 type GroupedLogic = Record<string, IConditionSchema[][]>
-type FieldIdSet = Set<IClientFieldSchema['_id']>
+export type FieldIdSet = Set<IClientFieldSchema['_id']>
 // This module handles logic on both the client side (IFieldSchema[])
 // and server side (FieldResponse[])
 type LogicFieldSchemaOrResponse = IClientFieldSchema | FieldResponse


### PR DESCRIPTION
## Problem
Closes #1104 

# Solution
ParsedResponsesObject to be made as a dataclass, meaning its primary job is to store data with minimal business logic to handle the presentation of its data.

More complex projections of its data (like for example, emails to admins, autoreply, data collation tool) will be carried out using double dispatch; it will be the responsibility of other classes/functions to implement logic of building these projections.

## This is a work in progress
### What's done
- [x] Encapsulate parsed responses into a class, with regular responses and NDI responses in separate fields
- [x] Static init method that constructs ParsedResponseObj after validation
- [x] Email submissions endpoint refactored to use ParsedResponseObj
- [x] Encrypt submissions endpoint refactored to use ParsedResponseObj
- [x] Admin-form endpoint refactored to use ParsedResponseObj

### TODO
- [ ] Think of a name that's better than `ParsedResponseObject`
- [ ] Consider the need to separate SP/CP/MyInfo responses into separate fields rather than one lumped up `ndiResponses` field
- [ ] Figure out a good way to present responses in function calls
- [ ] Figure out a way to integrate with SubmissionEmailObj
- [ ] Change existing tests on getProcessedResponses to target the new static init method
- [ ] Delete getProcessedResponses
- [ ] Fix Admin form controller tests
- [ ] Additional tests on new functionality added to ParsedResponseObj



## Solution
<!-- How did you solve the problem? -->

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Tests
<!-- What tests should be run to confirm functionality? -->

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
