### PR TITLE
fix(start-page): remove extra logo props when logo type is not custom

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2218,6 +2218,7 @@ export const handleUpdateStartPage = [
         fileId: Joi.when('state', {
           is: FormLogoState.Custom,
           then: Joi.string().required(),
+          otherwise: Joi.any().forbidden(),
         }),
         fileName: Joi.when('state', {
           is: FormLogoState.Custom,
@@ -2226,10 +2227,12 @@ export const handleUpdateStartPage = [
             // Refer to https://regex101.com/ with the below regex for a full explanation
             .pattern(/\.(gif|png|jpeg|jpg)$/im)
             .required(),
+          otherwise: Joi.any().forbidden(),
         }),
         fileSizeInBytes: Joi.when('state', {
           is: FormLogoState.Custom,
           then: Joi.number().max(MAX_UPLOAD_FILE_SIZE).required(),
+          otherwise: Joi.any().forbidden(),
         }),
       }).required(),
     },

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -43,8 +43,14 @@ function EditStartPageController(
 
   vm.saveStartPage = function (isValid) {
     vm.hasClickedSave = true
+    const logoState = vm.myform.startPage.logo.state
 
     if (isValid) {
+      if (logoState !== FormLogoState.Custom) {
+        vm.myform.startPage.logo = {
+          state: logoState,
+        }
+      }
       $q.when(updateStartPage({ newStartPage: vm.myform.startPage })).then(
         (error) => {
           if (!error) {
@@ -177,12 +183,7 @@ function EditStartPageController(
     $uibModalInstance.close()
   }
 
-  vm.updateLogoUrl = function (logoState) {
-    if (logoState !== FormLogoState.Custom) {
-      vm.myform.startPage.logo = {
-        state: logoState,
-      }
-    }
+  vm.updateLogoUrl = function () {
     vm.logoUrl = getFormLogo(vm.myform)
   }
 }

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -44,14 +44,17 @@ function EditStartPageController(
   vm.saveStartPage = function (isValid) {
     vm.hasClickedSave = true
     const logoState = vm.myform.startPage.logo.state
+    // Clones the start page so that the original one can be used.
+    // This prevents the actual start page from being affected in the event of failure
+    const clonedStartPage = angular.copy(vm.myform.startPage)
 
     if (isValid) {
       if (logoState !== FormLogoState.Custom) {
-        vm.myform.startPage.logo = {
+        clonedStartPage.logo = {
           state: logoState,
         }
       }
-      $q.when(updateStartPage({ newStartPage: vm.myform.startPage })).then(
+      $q.when(updateStartPage({ newStartPage: clonedStartPage })).then(
         (error) => {
           if (!error) {
             vm.hasClickedSave = false

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -177,7 +177,12 @@ function EditStartPageController(
     $uibModalInstance.close()
   }
 
-  vm.updateLogoUrl = function () {
+  vm.updateLogoUrl = function (logoState) {
+    if (logoState !== FormLogoState.Custom) {
+      vm.myform.startPage.logo = {
+        state: logoState,
+      }
+    }
     vm.logoUrl = getFormLogo(vm.myform)
   }
 }

--- a/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
@@ -18,7 +18,7 @@
               <label class="col-xs-12">
                 <input
                   type="radio"
-                  ng-change="vm.updateLogoUrl()"
+                  ng-change="vm.updateLogoUrl(vm.myform.startPage.logo.state)"
                   ng-model="vm.myform.startPage.logo.state"
                   name="logo"
                   ng-value="state.enum"

--- a/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
+++ b/src/public/modules/forms/admin/views/edit-start-page.client.modal.html
@@ -18,7 +18,7 @@
               <label class="col-xs-12">
                 <input
                   type="radio"
-                  ng-change="vm.updateLogoUrl(vm.myform.startPage.logo.state)"
+                  ng-change="vm.updateLogoUrl()"
                   ng-model="vm.myform.startPage.logo.state"
                   name="logo"
                   ng-value="state.enum"


### PR DESCRIPTION
## Problem
See #1885 for a description of the problem

Closes #1885 

## Solution
Added extra functionality to `vm.updateLogoUrl` to remove extra parameters on each button click because each button calls that upon change. 