### PR TITLE
refactor(verification): reset field verification state when field changes

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -799,4 +799,125 @@ describe('Verification controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
   })
+
+  describe('handleResetFieldVerification', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        transactionId: MOCK_TRANSACTION_ID,
+        fieldId: MOCK_FIELD_ID,
+        formId: MOCK_FORM_ID,
+      },
+    })
+
+    it('should correctly call service when params are valid', async () => {
+      // Arrange
+      MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
+        okAsync(mockTransaction),
+      )
+
+      // Act
+      await VerificationController.handleResetFieldVerification(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(
+        MockVerificationFactory.resetFieldForTransaction,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+
+    it('should return 400 when transaction has expired', async () => {
+      // Arrange
+      MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
+        errAsync(new TransactionExpiredError()),
+      )
+
+      // Act
+      await VerificationController.handleResetFieldVerification(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(
+        MockVerificationFactory.resetFieldForTransaction,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('should return 404 when transaction is not found', async () => {
+      // Arrange
+      MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
+        errAsync(new TransactionNotFoundError()),
+      )
+
+      // Act
+      await VerificationController.handleResetFieldVerification(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(
+        MockVerificationFactory.resetFieldForTransaction,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('should return 404 when field is not found', async () => {
+      // Arrange
+      MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
+        errAsync(new FieldNotFoundInTransactionError()),
+      )
+
+      // Act
+      await VerificationController.handleResetFieldVerification(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(
+        MockVerificationFactory.resetFieldForTransaction,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
+        errAsync(new DatabaseError()),
+      )
+
+      await VerificationController.handleResetFieldVerification(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(
+        MockVerificationFactory.resetFieldForTransaction,
+      ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+  })
 })

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -12,7 +12,7 @@ import {
 } from 'src/app/services/sms/sms.errors'
 import { HashingError } from 'src/app/utils/hash'
 import * as OtpUtils from 'src/app/utils/otp'
-import { IVerificationSchema } from 'src/types'
+import { IFormSchema, IVerificationSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -813,7 +813,9 @@ describe('Verification controller', () => {
     })
 
     beforeEach(() =>
-      MockFormService.retrieveFormById.mockReturnValue(okAsync({})),
+      MockFormService.retrieveFormById.mockReturnValue(
+        okAsync({} as IFormSchema),
+      ),
     )
 
     it('should correctly call service when params are valid', async () => {
@@ -830,6 +832,9 @@ describe('Verification controller', () => {
       )
 
       // Assert
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
@@ -850,6 +855,9 @@ describe('Verification controller', () => {
       )
 
       // Assert
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
@@ -873,6 +881,9 @@ describe('Verification controller', () => {
       )
 
       // Assert
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).not.toHaveBeenCalled()
@@ -896,6 +907,9 @@ describe('Verification controller', () => {
       )
 
       // Assert
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
@@ -919,6 +933,9 @@ describe('Verification controller', () => {
       )
 
       // Assert
+      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
@@ -929,16 +946,19 @@ describe('Verification controller', () => {
     })
 
     it('should return 500 when database error occurs', async () => {
+      // Arrange
       MockVerificationFactory.resetFieldForTransaction.mockReturnValueOnce(
         errAsync(new DatabaseError()),
       )
 
+      // Act
       await VerificationController.handleResetFieldVerification(
         MOCK_REQ,
         mockRes,
         jest.fn(),
       )
 
+      // Assert
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -833,7 +833,7 @@ describe('Verification controller', () => {
       expect(
         MockVerificationFactory.resetFieldForTransaction,
       ).toHaveBeenCalledWith(MOCK_TRANSACTION_ID, MOCK_FIELD_ID)
-      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.NO_CONTENT)
     })
 
     it('should return 400 when transaction has expired', async () => {

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -206,7 +206,7 @@ export const handleVerifyOtp: RequestHandler<
  * @param formId The id of the form to reset the field verification for
  * @param fieldId The id of the field to reset verification for
  * @param transactionId The transaction to reset
- * @returns 200 when reset is successful
+ * @returns 204 when reset is successful
  * @returns 400 when the transaction has expired
  * @returns 404 when the form could not be found
  * @returns 404 when the transaction could not be found
@@ -232,7 +232,7 @@ export const handleResetFieldVerification: RequestHandler<
     .andThen(() =>
       VerificationFactory.resetFieldForTransaction(transactionId, fieldId),
     )
-    .map(() => res.sendStatus(StatusCodes.OK))
+    .map(() => res.sendStatus(StatusCodes.NO_CONTENT))
     .mapErr((error) => {
       logger.error({
         message: 'Error resetting field in transaction',

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -206,6 +206,7 @@ export const handleVerifyOtp: RequestHandler<
  * @param formId The id of the form to reset the field verification for
  * @param fieldId The id of the field to reset verification for
  * @param transactionId The transaction to reset
+ * @returns 200 when reset is successful
  * @returns 400 when the transaction has expired
  * @returns 404 when the form could not be found
  * @returns 404 when the transaction could not be found

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -96,6 +96,7 @@ export const handleCreateVerificationTransaction: RequestHandler<
 /**
  *  When user changes the input value in the verifiable field,
  *  we reset the field in the transaction, removing the previously saved signature.
+ * @deprecated in favour of handleResetFieldVerification
  * @param req
  * @param res
  */
@@ -195,6 +196,44 @@ export const handleVerifyOtp: RequestHandler<
         error,
       })
       const { statusCode, errorMessage } = mapRouteError(error)
+      return res.status(statusCode).json({ message: errorMessage })
+    })
+}
+
+/**
+ * Handler for resetting the verification state of a field.
+ * @param formId The id of the form to reset the field verification for
+ * @param fieldId The id of the field to reset verification for
+ * @param transactionId The transaction to reset
+ * @returns 400 when the transaction has expired
+ * @returns 404 when the transaction could not be found
+ * @returns 404 when the field could not be found
+ * @returns 500 when a database error occurs
+ */
+export const handleResetFieldVerification: RequestHandler<
+  {
+    formId: string
+    fieldId: string
+    transactionId: string
+  },
+  ErrorDto
+> = async (req, res) => {
+  const { transactionId, fieldId } = req.params
+  const logMeta = {
+    action: 'handleResetFieldVerification',
+    transactionId,
+    fieldId,
+    ...createReqMeta(req),
+  }
+  return VerificationFactory.resetFieldForTransaction(transactionId, fieldId)
+    .map(() => res.sendStatus(StatusCodes.OK))
+    .mapErr((error) => {
+      logger.error({
+        message: 'Error resetting field in transaction',
+        meta: logMeta,
+        error,
+      })
+      const { errorMessage, statusCode } = mapRouteError(error)
       return res.status(statusCode).json({ message: errorMessage })
     })
 }

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -140,7 +140,7 @@ describe('public-forms.verification.routes', () => {
   })
 
   describe('POST /forms/:formId/fieldverifications/:transactionId/fields/:fieldId/reset', () => {
-    it('should return 200 when transactionId and fieldId for email field are valid', async () => {
+    it('should return 200 when formId, transactionId and fieldId for email field are valid', async () => {
       // Act
       const response = await request.post(
         `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'bson-ext'
 import { subMinutes } from 'date-fns'
-import { getReasonPhrase, StatusCodes } from 'http-status-codes'
+import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 import session, { Session } from 'supertest-session'
 
@@ -140,26 +140,26 @@ describe('public-forms.verification.routes', () => {
   })
 
   describe('POST /forms/:formId/fieldverifications/:transactionId/fields/:fieldId/reset', () => {
-    it('should return 200 when formId, transactionId and fieldId for email field are valid', async () => {
+    it('should return 204 when formId, transactionId and fieldId for email field are valid', async () => {
       // Act
       const response = await request.post(
         `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
       )
 
       // Assert
-      expect(response.status).toBe(StatusCodes.OK)
-      expect(response.text).toBe(getReasonPhrase(StatusCodes.OK))
+      expect(response.status).toBe(StatusCodes.NO_CONTENT)
+      expect(response.text).toBe('')
     })
 
-    it('should return 200 when transactionId and fieldId for mobile field are valid', async () => {
+    it('should return 204 when transactionId and fieldId for mobile field are valid', async () => {
       // Act
       const response = await request.post(
         `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockMobileFieldId}/reset`,
       )
 
       // Assert
-      expect(response.status).toBe(StatusCodes.OK)
-      expect(response.text).toBe(getReasonPhrase(StatusCodes.OK))
+      expect(response.status).toBe(StatusCodes.NO_CONTENT)
+      expect(response.text).toBe('')
     })
 
     it('should return 400 when the transaction has expired', async () => {

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -139,11 +139,11 @@ describe('public-forms.verification.routes', () => {
     })
   })
 
-  describe('POST /forms/:formId/fieldverification/:transactionId/fields/:fieldId/reset', () => {
+  describe('POST /forms/:formId/fieldverifications/:transactionId/fields/:fieldId/reset', () => {
     it('should return 200 when transactionId and fieldId for email field are valid', async () => {
       // Act
       const response = await request.post(
-        `/forms/${mockVerifiableFormId}/fieldverification/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
+        `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
       )
 
       // Assert
@@ -154,7 +154,7 @@ describe('public-forms.verification.routes', () => {
     it('should return 200 when transactionId and fieldId for mobile field are valid', async () => {
       // Act
       const response = await request.post(
-        `/forms/${mockVerifiableFormId}/fieldverification/${mockTransactionId}/fields/${mockMobileFieldId}/reset`,
+        `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockMobileFieldId}/reset`,
       )
 
       // Assert
@@ -175,7 +175,7 @@ describe('public-forms.verification.routes', () => {
 
       // Act
       const response = await request.post(
-        `/forms/${mockVerifiableFormId}/fieldverification/${mockExpiredTransaction._id}/fields/${mockEmailFieldId}/reset`,
+        `/forms/${mockVerifiableFormId}/fieldverifications/${mockExpiredTransaction._id}/fields/${mockEmailFieldId}/reset`,
       )
 
       // Assert
@@ -184,6 +184,11 @@ describe('public-forms.verification.routes', () => {
     })
 
     it('should return 404 when formId is invalid', async () => {
+      // Arrange
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
       // Act
       const response = await request.post(
         `/forms/${new ObjectId().toHexString()}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
@@ -191,10 +196,15 @@ describe('public-forms.verification.routes', () => {
 
       // Assert
       expect(response.status).toBe(StatusCodes.NOT_FOUND)
-      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
+      expect(response.body).toEqual(expectedResponse)
     })
 
     it('should return 404 when transactionId is invalid', async () => {
+      // Arrange
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
       // Act
       const response = await request.post(
         `/forms/${mockVerifiableFormId}/fieldverifications/${new ObjectId().toHexString()}/fields/${mockEmailFieldId}/reset`,
@@ -202,10 +212,15 @@ describe('public-forms.verification.routes', () => {
 
       // Assert
       expect(response.status).toBe(StatusCodes.NOT_FOUND)
-      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
+      expect(response.body).toEqual(expectedResponse)
     })
 
     it('should return 404 when fieldId is invalid', async () => {
+      // Arrange
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
       // Act
       const response = await request.post(
         `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${new ObjectId().toHexString()}/reset`,
@@ -213,7 +228,7 @@ describe('public-forms.verification.routes', () => {
 
       // Assert
       expect(response.status).toBe(StatusCodes.NOT_FOUND)
-      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
+      expect(response.body).toEqual(expectedResponse)
     })
   })
 })

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -1,7 +1,16 @@
-import { StatusCodes } from 'http-status-codes'
+import { ObjectId } from 'bson-ext'
+import { subMinutes } from 'date-fns'
+import { getReasonPhrase, StatusCodes } from 'http-status-codes'
+import mongoose from 'mongoose'
 import session, { Session } from 'supertest-session'
 
-import { BasicField } from 'src/types'
+import {
+  generateFieldParams,
+  MOCK_HASHED_OTP,
+  MOCK_SIGNED_DATA,
+} from 'src/app/modules/verification/__tests__/verification.test.helpers'
+import getVerificationModel from 'src/app/modules/verification/verification.model'
+import { BasicField, IVerificationSchema } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
@@ -10,6 +19,7 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 import { PublicFormsVerificationRouter } from '../public-forms.verification.routes'
 
 const verificationApp = setupApp('/forms', PublicFormsVerificationRouter)
+const VerificationModel = getVerificationModel(mongoose)
 
 jest.mock('nodemailer', () => ({
   createTransport: jest.fn().mockReturnValue({
@@ -26,8 +36,12 @@ jest.mock('twilio', () => () => ({
 }))
 
 describe('public-forms.verification.routes', () => {
+  let mockTransaction: IVerificationSchema
+  let mockTransactionId: string
   let mockEmptyFormId: string
   let mockVerifiableFormId: string
+  let mockEmailFieldId: string
+  let mockMobileFieldId: string
   let request: Session
 
   beforeAll(async () => await dbHandler.connect())
@@ -48,6 +62,8 @@ describe('public-forms.verification.routes', () => {
     const mobileField = generateDefaultField(BasicField.Mobile, {
       isVerifiable: true,
     })
+    mockEmailFieldId = String(emailField._id)
+    mockMobileFieldId = String(mobileField._id)
     const { form: verifiableForm } = await dbHandler.insertEmailForm({
       // Alternative mail domain so as not to clash with emptyForm
       mailDomain: 'test2.gov.sg',
@@ -56,6 +72,34 @@ describe('public-forms.verification.routes', () => {
       },
     })
     mockVerifiableFormId = String(verifiableForm._id)
+
+    // Mock transaction with both email and mobile fields
+    mockTransaction = await VerificationModel.create({
+      formId: mockVerifiableFormId,
+      fields: [
+        generateFieldParams({
+          _id: mockEmailFieldId,
+          // Hash created 1 minute ago, so we can test requesting for new OTP
+          // without being rejected due to minimum waiting time
+          hashCreatedAt: subMinutes(Date.now(), 1),
+          fieldType: BasicField.Email,
+          hashRetries: 0,
+          hashedOtp: MOCK_HASHED_OTP,
+          signedData: MOCK_SIGNED_DATA,
+        }),
+        generateFieldParams({
+          _id: mockMobileFieldId,
+          // Hash created 1 minute ago, so we can test requesting for new OTP
+          // without being rejected due to minimum waiting time
+          hashCreatedAt: subMinutes(Date.now(), 1),
+          fieldType: BasicField.Mobile,
+          hashRetries: 0,
+          hashedOtp: MOCK_HASHED_OTP,
+          signedData: MOCK_SIGNED_DATA,
+        }),
+      ],
+    })
+    mockTransactionId = String(mockTransaction._id)
   })
 
   afterAll(async () => await dbHandler.closeDatabase())
@@ -92,6 +136,84 @@ describe('public-forms.verification.routes', () => {
         transactionId: expect.any(String),
         expireAt: expect.any(String),
       })
+    })
+  })
+
+  describe('POST /forms/:formId/fieldverification/:transactionId/fields/:fieldId/reset', () => {
+    it('should return 200 when transactionId and fieldId for email field are valid', async () => {
+      // Act
+      const response = await request.post(
+        `/forms/${mockVerifiableFormId}/fieldverification/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.OK)
+      expect(response.text).toBe(getReasonPhrase(StatusCodes.OK))
+    })
+
+    it('should return 200 when transactionId and fieldId for mobile field are valid', async () => {
+      // Act
+      const response = await request.post(
+        `/forms/${mockVerifiableFormId}/fieldverification/${mockTransactionId}/fields/${mockMobileFieldId}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.OK)
+      expect(response.text).toBe(getReasonPhrase(StatusCodes.OK))
+    })
+
+    it('should return 400 when the transaction has expired', async () => {
+      // Arrange
+      // Create an expired transaction
+      const mockExpiredTransaction = await VerificationModel.create({
+        formId: mockVerifiableFormId,
+        expireAt: subMinutes(Date.now(), 1),
+      })
+      const expectedResponse = {
+        message: 'Your session has expired, please refresh and try again.',
+      }
+
+      // Act
+      const response = await request.post(
+        `/forms/${mockVerifiableFormId}/fieldverification/${mockExpiredTransaction._id}/fields/${mockEmailFieldId}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST)
+      expect(response.body).toEqual(expectedResponse)
+    })
+
+    it('should return 404 when formId is invalid', async () => {
+      // Act
+      const response = await request.post(
+        `/forms/${new ObjectId().toHexString()}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.NOT_FOUND)
+      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
+    })
+
+    it('should return 404 when transactionId is invalid', async () => {
+      // Act
+      const response = await request.post(
+        `/forms/${mockVerifiableFormId}/fieldverifications/${new ObjectId().toHexString()}/fields/${mockEmailFieldId}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.NOT_FOUND)
+      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
+    })
+
+    it('should return 404 when fieldId is invalid', async () => {
+      // Act
+      const response = await request.post(
+        `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${new ObjectId().toHexString()}/reset`,
+      )
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.NOT_FOUND)
+      expect(response.text).toBe(getReasonPhrase(StatusCodes.NOT_FOUND))
     })
   })
 })

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -17,5 +17,5 @@ PublicFormsVerificationRouter.route(
  * @returns 500 when a database error occurs
  */
 PublicFormsVerificationRouter.route(
-  '/:formId([a-fA-F0-9]{24})/fieldverification/:transactionId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})/reset',
+  '/:formId([a-fA-F0-9]{24})/fieldverifications/:transactionId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})/reset',
 ).post(VerificationController.handleResetFieldVerification)

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -7,3 +7,14 @@ export const PublicFormsVerificationRouter = Router()
 PublicFormsVerificationRouter.route(
   '/:formId([a-fA-F0-9]{24})/fieldverifications',
 ).post(VerificationController.handleCreateVerificationTransaction)
+
+/**
+ * Route for resetting the verification of a given field
+ * @returns 400 when the transaction has expired
+ * @returns 404 when the transaction could not be found
+ * @returns 404 when the field could not be found
+ * @returns 500 when a database error occurs
+ */
+PublicFormsVerificationRouter.route(
+  '/forms/:formId/fieldverification/:transactionId/fields/:fieldId/reset',
+).post(VerificationController.handleResetFieldVerification)

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -10,6 +10,7 @@ PublicFormsVerificationRouter.route(
 
 /**
  * Route for resetting the verification of a given field
+ * @returns 200 when reset is successful
  * @returns 400 when the transaction has expired
  * @returns 404 when the form could not be found
  * @returns 404 when the transaction could not be found

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -11,10 +11,11 @@ PublicFormsVerificationRouter.route(
 /**
  * Route for resetting the verification of a given field
  * @returns 400 when the transaction has expired
+ * @returns 404 when the form could not be found
  * @returns 404 when the transaction could not be found
  * @returns 404 when the field could not be found
  * @returns 500 when a database error occurs
  */
 PublicFormsVerificationRouter.route(
-  '/forms/:formId/fieldverification/:transactionId/fields/:fieldId/reset',
+  '/:formId([a-fA-F0-9]{24})/fieldverification/:transactionId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})/reset',
 ).post(VerificationController.handleResetFieldVerification)

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -10,7 +10,7 @@ PublicFormsVerificationRouter.route(
 
 /**
  * Route for resetting the verification of a given field
- * @returns 200 when reset is successful
+ * @returns 204 when reset is successful
  * @returns 400 when the transaction has expired
  * @returns 404 when the form could not be found
  * @returns 404 when the transaction could not be found

--- a/src/public/modules/forms/base/componentViews/field-email.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-email.client.view.html
@@ -24,6 +24,7 @@
     transaction-id="vm.transactionId"
     field="vm.field"
     input="vm.forms.myForm[(vm.field._id || 'defaultID')]"
+    form-id="vm.formId"
   >
     <!-- Input -->
     <div class="col-xs-12 field-input">

--- a/src/public/modules/forms/base/componentViews/field-mobile.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-mobile.client.view.html
@@ -23,6 +23,7 @@
     transaction-id="vm.transactionId"
     field="vm.field"
     input="vm.forms.myForm[(vm.field._id || 'defaultID')]"
+    form-id="vm.formId"
   >
     <!-- The field is duplicated as a workaround for intl-tel-input issues -->
     <!-- Verification 

--- a/src/public/modules/forms/base/components/field-email.client.component.js
+++ b/src/public/modules/forms/base/components/field-email.client.component.js
@@ -6,6 +6,7 @@ angular.module('forms').component('emailFieldComponent', {
     field: '<',
     forms: '<',
     transactionId: '<',
+    formId: '<',
   },
   controllerAs: 'vm',
 })

--- a/src/public/modules/forms/base/components/field-mobile.client.component.js
+++ b/src/public/modules/forms/base/components/field-mobile.client.component.js
@@ -7,6 +7,7 @@ angular.module('forms').component('mobileFieldComponent', {
     field: '<',
     forms: '<',
     transactionId: '<',
+    formId: '<',
   },
   controllerAs: 'vm',
 })

--- a/src/public/modules/forms/base/components/verifiable-field.client.component.js
+++ b/src/public/modules/forms/base/components/verifiable-field.client.component.js
@@ -8,6 +8,7 @@ angular.module('forms').component('verifiableFieldComponent', {
     transactionId: '<',
     field: '<', // The model that the input field is based on
     input: '<',
+    formId: '<',
   },
   controller: ['$q', '$timeout', '$interval', verifiableFieldController],
   controllerAs: 'vm',
@@ -99,6 +100,7 @@ function verifiableFieldController($q, $timeout, $interval) {
     if (!vm.field.isVerifiable) {
       return
     }
+
     try {
       // Restores the verified state if input was not changed
       if (
@@ -111,6 +113,7 @@ function verifiableFieldController($q, $timeout, $interval) {
           // We don't await on reset because we don't care if it fails
           // The signature will be wrong anyway if it fails, and submission will be prevented
           FieldVerificationService.resetVerifiedField({
+            formId: vm.formId,
             transactionId: vm.transactionId,
             fieldId: vm.field._id,
           })

--- a/src/public/modules/forms/base/directiveViews/field.client.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/field.client.directive.view.html
@@ -26,6 +26,7 @@
     field="field"
     forms="forms"
     transaction-id="transactionId"
+    form-id="formId"
   >
   </email-field-component>
   <date-field-component
@@ -67,6 +68,7 @@
     field="field"
     forms="forms"
     transaction-id="transactionId"
+    form-id="formId"
   >
   </mobile-field-component>
   <nric-field-component ng-switch-when="nric" field="field" forms="forms">

--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -55,6 +55,7 @@
             colortheme="{{ form.startPage.colorTheme }}"
             is-template="form.isTemplate"
             transaction-id="transactionId"
+            form-id="form._id"
           ></field-directive>
         </div>
       </form>

--- a/src/public/modules/forms/base/directives/field.client.directive.js
+++ b/src/public/modules/forms/base/directives/field.client.directive.js
@@ -21,6 +21,7 @@ function fieldDirective(FormFields) {
       transactionId: '<',
       onDropdownClick: '&',
       isValidateDate: '<',
+      formId: '<',
     },
     link: function (scope) {
       if ((scope.isadminpreview || scope.isTemplate) && scope.field.myInfo) {

--- a/src/public/services/FieldVerificationService.ts
+++ b/src/public/services/FieldVerificationService.ts
@@ -89,18 +89,21 @@ export const verifyOtp = async ({
 /**
  * Reset the field in the transaction, removing the previously saved signature.
  *
+ * @param formId The id of the form to reset the transaction for
  * @param transactionId The generated transaction id for the form
  * @param fieldId The id of the verification field to reset
  * @returns 200 OK status if successfully reset
  */
 export const resetVerifiedField = async ({
+  formId,
   transactionId,
   fieldId,
 }: {
+  formId: string
   transactionId: string
   fieldId: string
 }): Promise<void> => {
-  return axios.post(`${TRANSACTION_ENDPOINT}/${transactionId}/reset`, {
-    fieldId,
-  })
+  return axios.post(
+    `${FORM_API_PREFIX}/${formId}/${VERIFICATION_ENDPOINT}/${transactionId}/fields/${fieldId}/reset`,
+  )
 }

--- a/src/public/services/FieldVerificationService.ts
+++ b/src/public/services/FieldVerificationService.ts
@@ -92,7 +92,7 @@ export const verifyOtp = async ({
  * @param formId The id of the form to reset the transaction for
  * @param transactionId The generated transaction id for the form
  * @param fieldId The id of the verification field to reset
- * @returns 200 OK status if successfully reset
+ * @returns 204 Created if successfully reset
  */
 export const resetVerifiedField = async ({
   formId,

--- a/src/public/services/__tests__/FieldVerificationService.test.ts
+++ b/src/public/services/__tests__/FieldVerificationService.test.ts
@@ -118,9 +118,11 @@ describe('FieldVerificationService', () => {
       // Arrange
       const mockTransactionId = 'mockTransactionIdYetAgain'
       const mockFieldId = 'someFieldIdYetAgain'
+      const mockFormId = 'someFormId'
 
       // Act
       const actualPromise = resetVerifiedField({
+        formId: mockFormId,
         transactionId: mockTransactionId,
         fieldId: mockFieldId,
       })
@@ -129,10 +131,7 @@ describe('FieldVerificationService', () => {
 
       // Assert
       expect(mockAxios.post).toHaveBeenCalledWith(
-        `${TRANSACTION_ENDPOINT}/${mockTransactionId}/reset`,
-        {
-          fieldId: mockFieldId,
-        },
+        `${FORM_API_PREFIX}/${mockFormId}/${VERIFICATION_ENDPOINT}/${mockTransactionId}/fields/${mockFieldId}/reset`,
       )
     })
   })


### PR DESCRIPTION
## Problem
Restructures the endpoints so that the our endpoints follow a RESTful hierarchy because the verification state is part of fields, which is in turn part of the form. 

Part of #1522 

## Manual Tests
tested on staging 
- [ ] Create a new form and set mobile field to require verification. Publish the form and navigate to it. Key in a valid email, then click verify. Click backspace (so that the dropdown to enter the otp disappears) then, reenter the email again. Verify the email with the **previous** otp. This should fail. Next, verify with the **new** otp. This should pass. Attempt to submit the form after verification. This should pass
- [ ] Repeat the above with email field
- [ ] Create a form with >1 fields that require verification. Attempt to submit without 0 verifications. Attempt to submit with less than the required amount of verifications. Both should fail. Submitting with the required amount of verifications should pass 