### PR TITLE
chore(pull_request_template): adds breaking changes section to github template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,11 @@ Closes [insert issue #]
 
 **Breaking Changes** 
 <!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
+- [ ] Yes - this PR contains breaking changes
+- [ ] No - this PR is backwards compatible  
 - Details ...
 
 **Features**:
-
-- Details ...
 
 **Improvements**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@ Closes [insert issue #]
 ## Solution
 <!-- How did you solve the problem? -->
 
+**Breaking Changes** 
+<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
+- Details ...
+
 **Features**:
 
 - Details ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,8 @@ Closes [insert issue #]
 
 **Features**:
 
+- Details ...
+
 **Improvements**:
 
 - Details ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,8 @@ Closes [insert issue #]
 **Breaking Changes** 
 <!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
 - [ ] Yes - this PR contains breaking changes
+    - Details ...
 - [ ] No - this PR is backwards compatible  
-- Details ...
 
 **Features**:
 


### PR DESCRIPTION
## Problem
Devs are supposed to indicate breaking changes for easier rollback if hiccups occur on the release day. This makes it prone to human error, where the devs forget. 

## Solution
adds a breaking change section to the PR template 