### PR TITLE
feat: upgrade myinfo-gov-client to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4724,9 +4724,9 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "4.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-4.0.0-beta.0.tgz",
-      "integrity": "sha512-OslJubLTMI1SFxzDKYts5elV0jcQoNeWI6gkUTcqBTLX1JJBB23pVVRo1BSTakA1RqNw+0LD3PRrolLHuHHieQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-4.0.0.tgz",
+      "integrity": "sha512-1TmeYY+ZKtlnnlhoc0tjXF3dqMZvdcSoH3HiZqXEk81TVrOlIIeJuHCqecMSd4RdaudBuawuyiTxTKLxsKMKqA==",
       "requires": {
         "axios": "^0.21.1",
         "jsonwebtoken": "^8.5.1",
@@ -4735,9 +4735,12 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "^0.8.4-beta.0",
-    "@opengovsg/myinfo-gov-client": "=4.0.0-beta.0",
+    "@opengovsg/myinfo-gov-client": "^4.0.0",
     "@opengovsg/ng-file-upload": "^12.2.15",
     "@opengovsg/spcp-auth-client": "^1.4.7",
     "@sentry/browser": "^6.4.0",

--- a/src/app/modules/myinfo/myinfo.format.ts
+++ b/src/app/modules/myinfo/myinfo.format.ts
@@ -174,7 +174,7 @@ export const formatVehicleNumbers = (
   const vehicleNumbers: string[] = []
   field.forEach((vehicle) => {
     if (vehicle.unavailable) return
-    if (vehicle.vehicleno.value) {
+    if (vehicle.vehicleno?.value) {
       vehicleNumbers.push(vehicle.vehicleno.value)
     }
   })


### PR DESCRIPTION
Upgrades `@opengovsg/myinfo-gov-client` to the latest version, and makes the necessary update to accommodate the breaking changes.

The latest version includes a breaking change which makes nested scope data optional (see [PR](https://github.com/opengovsg/myinfo-gov-client/pull/30)). This is because there is no way of knowing whether a given `MyInfoPerson` data object contains the given nested scopes without knowing which scopes were requested in advance.

In FormSG's case, `vehicles.vehicleno` is the only nested scope we deal with, and this property is only accessed if the `vehicleno` field is requested, so the property access is safe. Hence the additional `?` optional chain was added purely to accommodate the new types from `myinfo-gov-client`.

## Manual tests
- [ ] Add a Vehicle Number field to a MyInfo form. Test that the form can be submitted for a MyInfo profile with no prefilled vehicle number.
- [ ] Use a profile with a prefilled vehicle number and check that the form can be submitted without editing the field.
- [ ] Use a profile with a prefilled vehicle number and edit the field. Check that the form can still be submitted.