### PR TITLE
build: mute database container logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
       - ./init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
     ports:
       - '27017:27017'
+    logging:
+      driver: none
 
   localstack:
     image: localstack/localstack:0.11.5


### PR DESCRIPTION
Dev environment logs mostly comprise large chunks of database container logs which are never useful. This mutes the logs from the database container so developers can focus on the important parts of the logs.

## Old logs
![image](https://user-images.githubusercontent.com/29480346/118778309-8afb0080-b8bc-11eb-953f-397039eb56f9.png)

## New logs
<img width="1782" alt="Screenshot 2021-05-19 at 4 09 33 PM" src="https://user-images.githubusercontent.com/29480346/118778371-9b12e000-b8bc-11eb-83df-9c4d505d8ab7.png">
