### PR TITLE
fix(encrypt-submission): shift encrypt mode form guard higher up the pipeline

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -156,12 +156,12 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
   if (!isFormEncryptMode(form)) {
     logger.error({
       message:
-        'Trying to encrypt verified SpCp fields on non-encrypt mode form',
+        'Trying to submit non-encrypt mode submission on encrypt-form submission endpoint',
       meta: logMeta,
     })
     return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
       message:
-        'Unable to encrypt verified SPCP fields on non storage mode forms',
+        'Unable to process non-encrypt mode submission on encrypt-form submission endpoint',
     })
   }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -153,6 +153,18 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
     })
   }
 
+  if (!isFormEncryptMode(form)) {
+    logger.error({
+      message:
+        'Trying to encrypt verified SpCp fields on non-encrypt mode form',
+      meta: logMeta,
+    })
+    return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
+      message:
+        'Unable to encrypt verified SPCP fields on non storage mode forms',
+    })
+  }
+
   // Process encrypted submission
   const processedResponsesResult = await getProcessedResponses(form, responses)
   if (processedResponsesResult.isErr()) {
@@ -237,18 +249,6 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
   }
 
   // Encrypt Verified SPCP Fields
-  if (!isFormEncryptMode(form)) {
-    logger.error({
-      message:
-        'Trying to encrypt verified SpCp fields on non-encrypt mode form',
-      meta: logMeta,
-    })
-    return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
-      message:
-        'Unable to encrypt verified SPCP fields on non storage mode forms',
-    })
-  }
-
   let verified
   if (form.authType === AuthType.SP || form.authType === AuthType.CP) {
     const encryptVerifiedContentResult = VerifiedContentFactory.getVerifiedContent(


### PR DESCRIPTION
## Problem
The guard to prevent submisison of non-storage mode forms in storage mode submission endpoint is located very low in the pipeline, when it should have been one of the first checks made.

Reordering this above will also help reflect the typing of the `form` object accurately, earlier in the pipeline.

## Solution
Copy paste, with changes in wording of the log messaging

