### PR TITLE
build(webhook-retries): create SQS queue in dev mode (1)

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -26,9 +26,12 @@ RUN apk update && apk upgrade && \
     ttf-freefont \
     tini \
     # Localstack - these are necessary in order to initialise local S3 buckets
+    # jq is a package for easily parsing Localstack health endpoint's JSON output
+    jq \
     py-pip && \
     npm install --quiet node-gyp -g && \
-    pip install awscli-local
+    # [ver1] ensures that the underlying AWS CLI version is also installed
+    pip install awscli-local[ver1]
 
 # Chinese fonts
 RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
@@ -41,5 +44,5 @@ EXPOSE 5000
 # tini is the init process that will adopt orphaned zombie processes
 # e.g. chromium when launched to create a new PDF
 ENTRYPOINT [ "tini", "--" ]
-# Create local S3 buckets before building the app
-CMD npm run docker-dev
+# Create local AWS resources before building the app
+CMD sh init-localstack.sh && npm run docker-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - MYINFO_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/spcp.crt
       - MYINFO_CLIENT_ID=mockClientId
       - MYINFO_CLIENT_SECRET=mockClientSecret
+      - WEBHOOK_SQS_URL=http://localhost:4566/000000000000/local-webhooks-sqs-queue
       - GA_TRACKING_ID
       - SENTRY_CONFIG_URL
       - TWILIO_ACCOUNT_SID
@@ -105,11 +106,8 @@ services:
     depends_on:
       - formsg
     environment:
-      - SERVICES=s3
+      - SERVICES=s3,sqs
       - DATA_DIR=/tmp/localstack/data
-      - ATTACHMENT_S3_BUCKET=local-attachment-bucket
-      - IMAGE_S3_BUCKET=local-image-bucket
-      - LOGO_S3_BUCKET=local-logo-bucket
     volumes:
       - './.localstack:/tmp/localstack'
       - '/var/run/docker.sock:/var/run/docker.sock'

--- a/docker-entrypoint-initaws.d/init-localstack.sh
+++ b/docker-entrypoint-initaws.d/init-localstack.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -x
-awslocal s3 mb s3://$IMAGE_S3_BUCKET
-awslocal s3 mb s3://$LOGO_S3_BUCKET
-awslocal s3 mb s3://$ATTACHMENT_S3_BUCKET
-set +x

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Wait for all Localstack services to be ready
+while [[ "$(curl -s -f http://localhost:4566/health | jq '[.services[] == "running"] | all')" != "true" ]]; do
+  sleep 5
+done
+set -x
+# Create S3 buckets
+awslocal s3 mb s3://$IMAGE_S3_BUCKET
+awslocal s3 mb s3://$LOGO_S3_BUCKET
+awslocal s3 mb s3://$ATTACHMENT_S3_BUCKET
+
+# Create SQS queue for webhooks
+# Extract queue name, which is the part of the queue URL after the final "/"
+awslocal sqs create-queue --queue-name ${WEBHOOK_SQS_URL##*/} --attributes '{
+    "ReceiveMessageWaitTimeSeconds": "20"
+}'
+
+set +x


### PR DESCRIPTION
First in a series of PRs to enable webhook retries. This PR ensures that the SQS queue is created in the dev environment before the server starts up.

To test, check out this branch and start the dev environment. Note in the `formsg` container logs that the SQS queue is created before the server is initialised.