### PR TITLE
feat(webhook-retries): add isRetryEnabled to model (2)

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -68,6 +68,7 @@ const FORM_DEFAULTS = {
   permissionList: [],
   webhook: {
     url: '',
+    isRetryEnabled: false,
   },
   status: 'PRIVATE',
   submissionLimit: null,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -353,6 +353,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
               'Webhook must be a valid URL over HTTPS and point to a public IP.',
           },
         },
+        isRetryEnabled: {
+          type: Boolean,
+          default: false,
+        },
       },
 
       msgSrvcName: {

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'bson-ext'
+import { merge } from 'lodash'
 import mongoose from 'mongoose'
 import { errAsync } from 'neverthrow'
 import supertest, { Session } from 'supertest-session'
@@ -85,11 +86,8 @@ describe('admin-form.settings.routes', () => {
 
       // Assert
       const expectedResponse = JSON.parse(
-        JSON.stringify({
-          ...formToUpdate.getSettings(),
-          // Should get updated with new settings
-          ...settingsToUpdate,
-        }),
+        // Should get updated with new settings
+        JSON.stringify(merge(formToUpdate.getSettings(), settingsToUpdate)),
       )
       expect(response.status).toEqual(200)
       expect(response.body).toEqual(expectedResponse)

--- a/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
@@ -24,8 +24,9 @@ const updateSettingsValidator = celebrate({
     submissionLimit: Joi.number().allow(null),
     title: Joi.string(),
     webhook: Joi.object({
-      url: Joi.string().uri().required().allow(''),
-    }),
+      url: Joi.string().uri().allow(''),
+      isRetryEnabled: Joi.boolean(),
+    }).min(1),
   }).min(1),
 })
 

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -1,10 +1,10 @@
 import { LeanDocument } from 'mongoose'
-import { ConditionalPick, Primitive } from 'type-fest'
+import { ConditionalPick, PartialDeep, Primitive } from 'type-fest'
 
 import { FormField, FormFieldSchema, FormFieldWithId } from '../field'
 import { EndPage, FormSettings, Permission, StartPage } from '../form'
 
-export type SettingsUpdateDto = Partial<FormSettings>
+export type SettingsUpdateDto = PartialDeep<FormSettings>
 
 export type FieldUpdateDto = FormFieldWithId
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -99,6 +99,7 @@ export type Permission = {
 
 export type Webhook = {
   url: string
+  isRetryEnabled: boolean
 }
 
 /**


### PR DESCRIPTION
Second in a series of PRs to enable webhook retries. This PR adds a `webhook.isRetryEnabled` key to the `Form` model, which determines whether retries are enabled for a form. It also makes the necessary changes to ensure that this key can be updated as part of the current form settings update APIs.