### PR TITLE
feat(webhook-retries): produce and consume retries (3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22244,6 +22244,32 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sqs-consumer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-5.5.0.tgz",
+      "integrity": "sha512-vzKzOZlZtZarOWbg/nbEoMyNu64XnQ4QB3e74nMBNaIuM/RhelUGNGrvrB83IW6a7/DxKDulM46h2TeQP3/1nA==",
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "sqs-producer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sqs-producer/-/sqs-producer-2.1.0.tgz",
+      "integrity": "sha512-UOlBaVIyCPJ/thAUSFjbB5MTgu3HG9FzFhjN5aiu/Y/QEeqoT4Twc+o7Yappwiz6easqJHz7+kqBq7Oy1GwQ8w==",
+      "requires": {
+        "aws-sdk": "^2.673.0"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -26820,6 +26846,11 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.0.0.tgz",
+      "integrity": "sha512-4DBG6siN02ooPB1yvEEqoe32maHzKEdGgtQ2HEz6FnFtgTjwZtzJ3ScuiDgtssWfDyLnQ3MvtSj6ff5ANL4STw=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,8 @@
     "slick-carousel": "1.8.1",
     "sortablejs": "~1.13.0",
     "spark-md5": "^3.0.1",
+    "sqs-consumer": "^5.5.0",
+    "sqs-producer": "^2.1.0",
     "text-encoding": "^0.7.0",
     "toastr": "^2.1.4",
     "triple-beam": "^1.3.0",
@@ -154,7 +156,8 @@
     "web-streams-polyfill": "^3.0.3",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.3.3",
-    "winston-cloudwatch": "^2.5.2"
+    "winston-cloudwatch": "^2.5.2",
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/app/config/feature-manager/types.ts
+++ b/src/app/config/feature-manager/types.ts
@@ -79,6 +79,7 @@ export interface IVerifiedFields {
 
 export interface IWebhookVerifiedContent {
   signingSecretKey: string
+  webhookQueueUrl: string
 }
 
 export interface IIntranet {

--- a/src/app/config/feature-manager/webhook-verified-content.config.ts
+++ b/src/app/config/feature-manager/webhook-verified-content.config.ts
@@ -10,6 +10,12 @@ const webhookVerifiedContentFeature: RegisterableFeature<FeatureNames.WebhookVer
       default: null,
       env: 'SIGNING_SECRET_KEY',
     },
+    webhookQueueUrl: {
+      doc: 'URL of AWS SQS queue for webhook retries',
+      format: String,
+      default: '',
+      env: 'WEBHOOK_SQS_URL',
+    },
   },
 }
 

--- a/src/app/constants/timezone.ts
+++ b/src/app/constants/timezone.ts
@@ -1,0 +1,1 @@
+export const TIMEZONE = 'Asia/Singapore'

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -217,18 +217,16 @@ EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
   this: IEncryptSubmissionModel,
   submissionId: string,
 ): Promise<SubmissionWebhookInfo | null> {
-  return (this.findById(submissionId)
+  return this.findById(submissionId)
     .populate('form', 'webhook')
-    .exec() as Promise<IPopulatedWebhookSubmission | null>).then(
-    (populatedSubmission) => {
+    .then((populatedSubmission: IPopulatedWebhookSubmission | null) => {
       if (!populatedSubmission) return null
       return {
         webhookUrl: populatedSubmission.form.webhook?.url ?? '',
         isRetryEnabled: !!populatedSubmission.form.webhook?.isRetryEnabled,
         webhookView: populatedSubmission.getWebhookView(),
       }
-    },
-  )
+    })
 }
 
 EncryptSubmissionSchema.statics.findSingleMetadata = function (

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -9,6 +9,7 @@ import {
   IEmailSubmissionSchema,
   IEncryptedSubmissionSchema,
   IEncryptSubmissionModel,
+  IPopulatedWebhookSubmission,
   ISubmissionModel,
   ISubmissionSchema,
   IWebhookResponse,
@@ -17,6 +18,7 @@ import {
   SubmissionCursorData,
   SubmissionMetadata,
   SubmissionType,
+  SubmissionWebhookInfo,
   WebhookData,
   WebhookView,
 } from '../../types'
@@ -182,8 +184,11 @@ const EncryptSubmissionSchema = new Schema<
 EncryptSubmissionSchema.methods.getWebhookView = function (
   this: IEncryptedSubmissionSchema,
 ): WebhookView {
+  const formId = this.populated('form')
+    ? String(this.form._id)
+    : String(this.form)
   const webhookData: WebhookData = {
-    formId: String(this.form),
+    formId,
     submissionId: String(this._id),
     encryptedContent: this.encryptedContent,
     verifiedContent: this.verifiedContent,
@@ -206,6 +211,24 @@ EncryptSubmissionSchema.statics.addWebhookResponse = function (
     { $push: { webhookResponses: webhookResponse } },
     { new: true, setDefaultsOnInsert: true, runValidators: true },
   ).exec()
+}
+
+EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
+  this: IEncryptSubmissionModel,
+  submissionId: string,
+): Promise<SubmissionWebhookInfo | null> {
+  return (this.findById(submissionId)
+    .populate('form', 'webhook')
+    .exec() as Promise<IPopulatedWebhookSubmission | null>).then(
+    (populatedSubmission) => {
+      if (!populatedSubmission) return null
+      return {
+        webhookUrl: populatedSubmission.form.webhook?.url ?? '',
+        isRetryEnabled: !!populatedSubmission.form.webhook?.isRetryEnabled,
+        webhookView: populatedSubmission.getWebhookView(),
+      }
+    },
+  )
 }
 
 EncryptSubmissionSchema.statics.findSingleMetadata = function (

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -182,7 +182,7 @@ const EncryptSubmissionSchema = new Schema<
  * which will be posted to the webhook URL.
  */
 EncryptSubmissionSchema.methods.getWebhookView = function (
-  this: IEncryptedSubmissionSchema,
+  this: IEncryptedSubmissionSchema | IPopulatedWebhookSubmission,
 ): WebhookView {
   const formId = this.populated('form')
     ? String(this.form._id)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -343,16 +343,11 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
   })
 
   // Fire webhooks if available
-  // Note that we push data to webhook endpoints on a best effort basis
-  // As such, we should not await on these post requests
+  // To avoid being coupled to latency of receiving system,
+  // do not await on webhook
   const webhookUrl = form.webhook?.url
   if (webhookUrl) {
-    void WebhookFactory.sendWebhook(
-      submission,
-      webhookUrl,
-    ).andThen((response) =>
-      WebhookFactory.saveWebhookRecord(submission._id, response),
-    )
+    void WebhookFactory.sendInitialWebhook(submission, webhookUrl)
   }
 
   // Send Email Confirmations

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -347,7 +347,11 @@ const submitEncryptModeForm: RequestHandler = async (req, res) => {
   // do not await on webhook
   const webhookUrl = form.webhook?.url
   if (webhookUrl) {
-    void WebhookFactory.sendInitialWebhook(submission, webhookUrl)
+    void WebhookFactory.sendInitialWebhook(
+      submission,
+      webhookUrl,
+      !!form.webhook?.isRetryEnabled,
+    )
   }
 
   // Send Email Confirmations

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -12,7 +12,7 @@ export class ConflictError extends ApplicationError {
 }
 
 export class SubmissionNotFoundError extends ApplicationError {
-  constructor(message: string) {
+  constructor(message = 'Submission not found for given ID') {
     super(message)
   }
 }

--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -238,7 +238,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 
@@ -259,7 +259,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 
@@ -296,7 +296,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 
@@ -324,7 +324,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 
@@ -357,7 +357,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 
@@ -387,7 +387,7 @@ describe('webhook.service', () => {
 
       // Act
       const actual = await sendWebhook(
-        testEncryptedSubmission,
+        testEncryptedSubmission.getWebhookView(),
         MOCK_WEBHOOK_URL,
       )
 

--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -138,6 +138,7 @@ describe('webhook.service', () => {
         'X-FormSG-Signature': `t=${MOCK_EPOCH},s=${testEncryptedSubmission._id},f=${testEncryptedForm._id},v1=${testSignature}`,
       },
       maxRedirects: 0,
+      timeout: 10000,
     }
   })
 

--- a/src/app/modules/webhook/webhook.constants.ts
+++ b/src/app/modules/webhook/webhook.constants.ts
@@ -40,7 +40,7 @@ export const MAX_DELAY_SECONDS = minutes(15)
 
 /**
  * Tolerance allowed for determining if a message is due to be sent.
- * If a message's next attempt is due within this number of seconds
- * from the current time, it will be sent.
+ * If a message's next attempt is scheduled either in the past or this
+ * number of seconds in the future, it will be sent.
  */
 export const DUE_TIME_TOLERANCE_SECONDS = minutes(1)

--- a/src/app/modules/webhook/webhook.constants.ts
+++ b/src/app/modules/webhook/webhook.constants.ts
@@ -1,0 +1,41 @@
+import config from '../../config/config'
+
+import { RetryInterval } from './webhook.types'
+
+/**
+ * Current version of queue message format.
+ */
+export const QUEUE_MESSAGE_VERSION = 0
+
+// Conversion to seconds
+const hours = (h: number) => h * 60 * 60
+const minutes = (m: number) => m * 60
+
+/**
+ * Encodes retry policy.
+ * Element 0 is time to wait + jitter before
+ * retrying the first time, element 1 is time to wait
+ * to wait + jitter before 2nd time, etc.
+ * All units are in seconds.
+ */
+export const RETRY_INTERVALS: RetryInterval[] = config.isDev
+  ? [
+      { base: 10, jitter: 5 },
+      { base: 20, jitter: 5 },
+      { base: 30, jitter: 5 },
+    ]
+  : [
+      { base: minutes(5), jitter: minutes(1) },
+      { base: hours(1), jitter: minutes(30) },
+      { base: hours(2), jitter: minutes(30) },
+      { base: hours(4), jitter: minutes(30) },
+      { base: hours(8), jitter: minutes(30) },
+      { base: hours(24), jitter: minutes(30) },
+    ]
+
+/**
+ * Tolerance allowed for determining if a message is due to be sent.
+ * If a message's next attempt is due within this number of seconds
+ * from the current time, it will be sent.
+ */
+export const DUE_TIME_TOLERANCE_SECONDS = minutes(1)

--- a/src/app/modules/webhook/webhook.constants.ts
+++ b/src/app/modules/webhook/webhook.constants.ts
@@ -34,6 +34,11 @@ export const RETRY_INTERVALS: RetryInterval[] = config.isDev
     ]
 
 /**
+ * Max possible delay for a message, as specified by AWS.
+ */
+export const MAX_DELAY_SECONDS = minutes(15)
+
+/**
  * Tolerance allowed for determining if a message is due to be sent.
  * If a message's next attempt is due within this number of seconds
  * from the current time, it will be sent.

--- a/src/app/modules/webhook/webhook.consumer.ts
+++ b/src/app/modules/webhook/webhook.consumer.ts
@@ -227,8 +227,8 @@ const retrieveWebhookInfo = (
 ): ResultAsync<
   SubmissionWebhookInfo,
   SubmissionNotFoundError | PossibleDatabaseError
-> =>
-  ResultAsync.fromPromise(
+> => {
+  return ResultAsync.fromPromise(
     EncryptSubmission.retrieveWebhookInfoById(submissionId),
     (error) => {
       logger.error({
@@ -245,3 +245,4 @@ const retrieveWebhookInfo = (
     if (!submissionInfo) return errAsync(new SubmissionNotFoundError())
     return okAsync(submissionInfo)
   })
+}

--- a/src/app/modules/webhook/webhook.consumer.ts
+++ b/src/app/modules/webhook/webhook.consumer.ts
@@ -1,0 +1,247 @@
+import aws from 'aws-sdk'
+import https from 'https'
+import mongoose from 'mongoose'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { Consumer } from 'sqs-consumer'
+
+import { SubmissionWebhookInfo } from '../../../types'
+import config from '../../config/config'
+import { createLoggerWithLabel } from '../../config/logger'
+import { getEncryptSubmissionModel } from '../../models/submission.server.model'
+import { transformMongoError } from '../../utils/handle-mongo-error'
+import { PossibleDatabaseError } from '../core/core.errors'
+import { SubmissionNotFoundError } from '../submission/submission.errors'
+
+import {
+  WebhookNoMoreRetriesError,
+  WebhookPushToQueueError,
+  WebhookRetriesNotEnabledError,
+  WebhookValidationError,
+} from './webhook.errors'
+import { WebhookQueueMessage } from './webhook.message'
+import { WebhookProducer } from './webhook.producer'
+import * as WebhookService from './webhook.service'
+import { isSuccessfulResponse } from './webhook.utils'
+
+const logger = createLoggerWithLabel(module)
+const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+
+/**
+ * Starts polling a queue for webhook messages.
+ * @param queueUrl URL of queue from which to consume messages
+ * @param producer Producer which can be used to enqueue messages
+ */
+export const startWebhookConsumer = (
+  queueUrl: string,
+  producer: WebhookProducer,
+): void => {
+  const app = Consumer.create({
+    queueUrl,
+    region: config.aws.region,
+    handleMessage: createWebhookQueueHandler(producer),
+    // By default, the default Node.js HTTP/HTTPS SQS agent
+    // creates a new TCP connection for every new request.
+    // In production, pass an SQS instance to avoid the cost
+    // of establishing new connections.
+    sqs: config.isDev
+      ? undefined
+      : new aws.SQS({
+          region: config.aws.region,
+          httpOptions: {
+            agent: new https.Agent({
+              keepAlive: true,
+            }),
+          },
+        }),
+  })
+
+  app.on('error', (error, message) => {
+    logger.error({
+      message:
+        'Webhook consumer encountered error while interacting with queue',
+      meta: {
+        action: 'startWebhookConsumer',
+        message,
+      },
+      error,
+    })
+  })
+
+  app.start()
+
+  logger.info({
+    message: 'Webhook consumer started',
+    meta: {
+      action: 'startWebhookConsumer',
+    },
+  })
+}
+
+/**
+ * Creates a handler to consume messages from webhook queue.
+ * This handler does the following:
+ * 1) Parses the message
+ * 2) If the webhook is not due, requeues the message
+ * 3) If the webhook is due, attempts the webhook
+ * 4) Records the webhook attempt in the database
+ * 5) If the webhook failed again, requeues the message
+ * @param producer Producer which can write messages to queue
+ * @returns Handler for consumption of queue messages
+ */
+const createWebhookQueueHandler = (producer: WebhookProducer) => async (
+  sqsMessage: aws.SQS.Message,
+): Promise<void> => {
+  logger.info({
+    message: 'Consumed message from webhook queue',
+    meta: {
+      action: 'createWebhookQueueHandler',
+    },
+  })
+  const { Body } = sqsMessage
+  if (!Body) {
+    logger.error({
+      message: 'Webhook queue message contained undefined body',
+      meta: {
+        action: 'createWebhookQueueHandler',
+        sqsMessage,
+      },
+    })
+    // Malformed message will be retried until redrive policy is exceeded,
+    // upon which it will be moved to dead-letter queue
+    return Promise.reject()
+  }
+
+  // Parse message
+  const webhookMessageResult = WebhookQueueMessage.deserialise(Body)
+  if (webhookMessageResult.isErr()) {
+    logger.error({
+      message: 'Webhook queue message could not be parsed',
+      meta: {
+        action: 'createWebhookQueueHandler',
+      },
+      error: webhookMessageResult.error,
+    })
+    return Promise.reject()
+  }
+  const webhookMessage = webhookMessageResult.value
+
+  // If not due, requeue
+  if (!webhookMessage.isDue()) {
+    logger.info({
+      message: 'Webhook not due yet, requeueing',
+      meta: {
+        action: 'createWebhookQueueHandler',
+      },
+    })
+    const requeueResult = await producer.sendMessage(webhookMessage)
+    if (requeueResult.isErr()) {
+      logger.error({
+        message: 'Webhook queue message could not be requeued',
+        meta: {
+          action: 'createWebhookQueueHandler',
+          webhookMessage: webhookMessage.prettify(),
+        },
+        error: requeueResult.error,
+      })
+      // Reject so requeue can be re-attempted
+      return Promise.reject()
+    }
+    // Delete existing message from queue
+    return Promise.resolve()
+  }
+
+  // If due, send webhook
+  // First, retrieve webhook view and URL from database
+  const retryResult = await retrieveWebhookInfo(
+    webhookMessage.submissionId,
+  ).andThen<
+    true,
+    | WebhookRetriesNotEnabledError
+    | WebhookValidationError
+    | WebhookNoMoreRetriesError
+    | WebhookPushToQueueError
+  >((webhookInfo) => {
+    const { webhookUrl, isRetryEnabled } = webhookInfo
+    // Webhook URL was deleted or retries disabled
+    if (!webhookUrl || !isRetryEnabled)
+      return errAsync(
+        new WebhookRetriesNotEnabledError(webhookUrl, isRetryEnabled),
+      )
+
+    // Attempt webhook
+    return WebhookService.sendWebhook(
+      webhookInfo.webhookView,
+      webhookUrl,
+    ).andThen((webhookResponse) => {
+      // Save webhook response to database, but carry on even if it fails
+      void WebhookService.saveWebhookRecord(
+        webhookMessage.submissionId,
+        webhookResponse,
+      )
+
+      // Webhook was successful, no further action required
+      if (isSuccessfulResponse(webhookResponse)) return okAsync(true)
+
+      // Requeue webhook for subsequent retry
+      return webhookMessage
+        .incrementAttempts()
+        .asyncAndThen((newMessage) => producer.sendMessage(newMessage))
+    })
+  })
+
+  if (retryResult.isOk()) return Promise.resolve()
+  // Error cases
+  // Special handling for max retries exceeded - log a separate message
+  // and resolve Promise so that message is removed from queue
+  if (retryResult.error instanceof WebhookNoMoreRetriesError) {
+    logger.warn({
+      message: 'Maximum retries exceeded for webhook',
+      meta: {
+        action: 'createWebhookQueueHandler',
+        webhookMessage: webhookMessage.getRetriesFailedState(),
+      },
+    })
+    return Promise.resolve()
+  }
+  logger.error({
+    message: 'Error while attempting to retry webhook',
+    meta: {
+      action: 'createWebhookQueueHandler',
+      webhookMessage: webhookMessage.prettify(),
+    },
+    error: retryResult.error,
+  })
+  // Reject so retry can be reattempted or moved to dead-letter queue
+  // if redrive policy is exceeded
+  return Promise.reject()
+}
+
+/**
+ * Retrieves all relevant information to send webhook for a given submission.
+ * @param submissionId
+ * @returns ok(webhook information) if database retrieval succeeds
+ * @returns err if submission ID does not exist or database retrieval errors
+ */
+const retrieveWebhookInfo = (
+  submissionId: string,
+): ResultAsync<
+  SubmissionWebhookInfo,
+  SubmissionNotFoundError | PossibleDatabaseError
+> =>
+  ResultAsync.fromPromise(
+    EncryptSubmission.retrieveWebhookInfoById(submissionId),
+    (error) => {
+      logger.error({
+        message: 'Error while retrieving webhook info for submission',
+        meta: {
+          action: 'retrieveWebhookInfo',
+          submissionId,
+        },
+        error,
+      })
+      return transformMongoError(error)
+    },
+  ).andThen((submissionInfo) => {
+    if (!submissionInfo) return errAsync(new SubmissionNotFoundError())
+    return okAsync(submissionInfo)
+  })

--- a/src/app/modules/webhook/webhook.errors.ts
+++ b/src/app/modules/webhook/webhook.errors.ts
@@ -65,3 +65,12 @@ export class WebhookNoMoreRetriesError extends ApplicationError {
     super(message)
   }
 }
+
+/**
+ * Failed to push message to SQS.
+ */
+export class WebhookPushToQueueError extends ApplicationError {
+  constructor(message = 'Failed to push webhook to message queue') {
+    super(message)
+  }
+}

--- a/src/app/modules/webhook/webhook.errors.ts
+++ b/src/app/modules/webhook/webhook.errors.ts
@@ -74,3 +74,26 @@ export class WebhookPushToQueueError extends ApplicationError {
     super(message)
   }
 }
+
+/**
+ * Cannot send webhook retry because form has no webhook URL or does not have
+ * retries enabled.
+ */
+export class WebhookRetriesNotEnabledError extends ApplicationError {
+  meta: {
+    webhookUrl: string
+    isRetryEnabled: boolean
+  }
+
+  constructor(
+    webhookUrl: string,
+    isRetryEnabled: boolean,
+    message = 'Unable to send webhook as form has no webhook URL or does not have retries enabled',
+  ) {
+    super(message)
+    this.meta = {
+      webhookUrl,
+      isRetryEnabled,
+    }
+  }
+}

--- a/src/app/modules/webhook/webhook.errors.ts
+++ b/src/app/modules/webhook/webhook.errors.ts
@@ -39,3 +39,29 @@ export class WebhookFailedWithAxiosError extends ApplicationError {
     this.meta = { originalError: error }
   }
 }
+
+/**
+ * Webhook queue message incorrectly formatted and hence could not be parsed
+ */
+export class WebhookQueueMessageParsingError extends ApplicationError {
+  meta: {
+    originalError: unknown
+  }
+
+  constructor(
+    error: unknown,
+    message = 'Unable to parse body of webhook queue message',
+  ) {
+    super(message)
+    this.meta = { originalError: error }
+  }
+}
+
+/**
+ * Maximum retries exceeded for webhook.
+ */
+export class WebhookNoMoreRetriesError extends ApplicationError {
+  constructor(message = 'Maximum retries exceeded for webhook') {
+    super(message)
+  }
+}

--- a/src/app/modules/webhook/webhook.factory.ts
+++ b/src/app/modules/webhook/webhook.factory.ts
@@ -9,19 +9,23 @@ import { MissingFeatureError } from '../core/core.errors'
 import * as WebhookService from './webhook.service'
 
 interface IWebhookFactory {
-  sendWebhook: typeof WebhookService.sendWebhook
-  saveWebhookRecord: typeof WebhookService.saveWebhookRecord
+  sendInitialWebhook: ReturnType<
+    typeof WebhookService.createInitialWebhookSender
+  >
 }
 
 export const createWebhookFactory = ({
   isEnabled,
   props,
 }: RegisteredFeature<FeatureNames.WebhookVerifiedContent>): IWebhookFactory => {
-  if (isEnabled && props) return WebhookService
+  if (isEnabled && props) {
+    return {
+      sendInitialWebhook: WebhookService.createInitialWebhookSender(),
+    }
+  }
   const error = new MissingFeatureError(FeatureNames.SpcpMyInfo)
   return {
-    sendWebhook: () => errAsync(error),
-    saveWebhookRecord: () => errAsync(error),
+    sendInitialWebhook: () => errAsync(error),
   }
 }
 

--- a/src/app/modules/webhook/webhook.message.ts
+++ b/src/app/modules/webhook/webhook.message.ts
@@ -1,0 +1,174 @@
+import { differenceInSeconds } from 'date-fns'
+import { Result } from 'neverthrow'
+
+import { createLoggerWithLabel } from '../../config/logger'
+
+import {
+  DUE_TIME_TOLERANCE_SECONDS,
+  QUEUE_MESSAGE_VERSION,
+} from './webhook.constants'
+import {
+  WebhookNoMoreRetriesError,
+  WebhookQueueMessageParsingError,
+} from './webhook.errors'
+import {
+  WebhookFailedQueueMessage,
+  webhookMessageSchema,
+  WebhookQueueMessageObject,
+  WebhookQueueMessagePrettified,
+} from './webhook.types'
+import { getNextAttempt, prettifyEpoch } from './webhook.utils'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Encapsulates a queue message for webhook retries.
+ */
+export class WebhookQueueMessage {
+  message: WebhookQueueMessageObject
+
+  constructor(message: WebhookQueueMessageObject) {
+    this.message = message
+  }
+
+  /**
+   * Converts a webhook queue message body into an encapsulated
+   * class instance.
+   * @param body Raw body of webhook queue message
+   * @returns ok(encapsulated message) if message can be parsed successfully
+   * @returns err if message fails to be parsed
+   */
+  static deserialise(
+    body: string,
+  ): Result<WebhookQueueMessage, WebhookQueueMessageParsingError> {
+    return Result.fromThrowable(
+      () => JSON.parse(body) as unknown,
+      (error) => {
+        logger.error({
+          message: 'Unable to parse webhook queue message body',
+          meta: {
+            action: 'deserialise',
+            body,
+          },
+          error,
+        })
+        return new WebhookQueueMessageParsingError(error)
+      },
+    )()
+      .andThen((parsed) =>
+        Result.fromThrowable(
+          () => webhookMessageSchema.parse(parsed),
+          (error) => {
+            logger.error({
+              message: 'Webhook queue message body has wrong shape',
+              meta: {
+                action: 'deserialise',
+                body,
+              },
+              error,
+            })
+            return new WebhookQueueMessageParsingError(error)
+          },
+        )(),
+      )
+      .map((validated) => new WebhookQueueMessage(validated))
+  }
+
+  /**
+   * Initialises a webhook queue message which has not been
+   * retried as yet. This function succeeds as long as
+   * the retry policy allows for at least one retry.
+   * @param submissionId
+   * @returns ok(encapsulated message) if retry policy exists
+   * @returns err if the retry policy does not allow any retries
+   */
+  static fromSubmissionId(
+    submissionId: string,
+  ): Result<WebhookQueueMessage, WebhookNoMoreRetriesError> {
+    return getNextAttempt([]).map(
+      (nextAttempt) =>
+        new WebhookQueueMessage({
+          submissionId,
+          previousAttempts: [],
+          nextAttempt,
+          _v: QUEUE_MESSAGE_VERSION,
+        }),
+    )
+  }
+
+  /**
+   * Serialises for enqueueing.
+   * @returns Serialised message
+   */
+  serialise(): string {
+    return JSON.stringify(this.message)
+  }
+
+  /**
+   * Determines whether the message is currently due to be sent.
+   * @returns true if webhook is currently due to be sent, false otherwise
+   */
+  isDue(): boolean {
+    // Allow tolerance for clock drift
+    return (
+      Math.abs(differenceInSeconds(Date.now(), this.message.nextAttempt)) <=
+      DUE_TIME_TOLERANCE_SECONDS
+    )
+  }
+
+  /**
+   * Updates the message as having just been retried, and adds a new time for the
+   * next attempt.
+   * This function should only be called on a message for which the webhook has just
+   * been attempted and failed.
+   * @returns ok(WebhookQueueMessage) if message can still be retried
+   * @returns err(WebhookNoMoreRetriesError) if max retries have been exceeded
+   */
+  incrementAttempts(): Result<WebhookQueueMessage, WebhookNoMoreRetriesError> {
+    const updatedPreviousAttempts = [
+      ...this.message.previousAttempts,
+      this.message.nextAttempt,
+    ]
+    return getNextAttempt(updatedPreviousAttempts).map(
+      (nextAttempt) =>
+        new WebhookQueueMessage({
+          submissionId: this.message.submissionId,
+          previousAttempts: updatedPreviousAttempts,
+          nextAttempt,
+          _v: QUEUE_MESSAGE_VERSION,
+        }),
+    )
+  }
+
+  /**
+   * Converts a message to reflect that all retries have failed.
+   * @returns Message converted into a failure shape
+   */
+  getRetriesFailedState(): WebhookFailedQueueMessage {
+    return {
+      submissionId: this.submissionId,
+      previousAttempts: [
+        ...this.message.previousAttempts,
+        this.nextAttempt,
+      ].map(prettifyEpoch),
+      _v: this.message._v,
+    }
+  }
+
+  prettify(): WebhookQueueMessagePrettified {
+    return {
+      submissionId: this.submissionId,
+      previousAttempts: this.message.previousAttempts.map(prettifyEpoch),
+      nextAttempt: prettifyEpoch(this.nextAttempt),
+      _v: this.message._v,
+    }
+  }
+
+  get submissionId(): string {
+    return this.message.submissionId
+  }
+
+  get nextAttempt(): number {
+    return this.message.nextAttempt
+  }
+}

--- a/src/app/modules/webhook/webhook.message.ts
+++ b/src/app/modules/webhook/webhook.message.ts
@@ -17,7 +17,7 @@ import {
   WebhookQueueMessageObject,
   WebhookQueueMessagePrettified,
 } from './webhook.types'
-import { getNextAttempt, prettifyEpoch } from './webhook.utils'
+import { getFirstAttempt, getNextAttempt, prettifyEpoch } from './webhook.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -85,7 +85,7 @@ export class WebhookQueueMessage {
   static fromSubmissionId(
     submissionId: string,
   ): Result<WebhookQueueMessage, WebhookNoMoreRetriesError> {
-    return getNextAttempt([]).map(
+    return getFirstAttempt().map(
       (nextAttempt) =>
         new WebhookQueueMessage({
           submissionId,

--- a/src/app/modules/webhook/webhook.message.ts
+++ b/src/app/modules/webhook/webhook.message.ts
@@ -111,7 +111,9 @@ export class WebhookQueueMessage {
   isDue(): boolean {
     // Allow tolerance for clock drift
     return (
-      Math.abs(differenceInSeconds(Date.now(), this.message.nextAttempt)) <=
+      // Argument order is important. If nextAttempt is in the past,
+      // differenceInSeconds will return a negative number.
+      differenceInSeconds(this.message.nextAttempt, Date.now()) <=
       DUE_TIME_TOLERANCE_SECONDS
     )
   }

--- a/src/app/modules/webhook/webhook.producer.ts
+++ b/src/app/modules/webhook/webhook.producer.ts
@@ -1,0 +1,76 @@
+import { ResultAsync } from 'neverthrow'
+import promiseRetry from 'promise-retry'
+import { Producer } from 'sqs-producer'
+
+import config from '../../config/config'
+import { createLoggerWithLabel } from '../../config/logger'
+
+import { WebhookPushToQueueError } from './webhook.errors'
+import { WebhookQueueMessage } from './webhook.message'
+import { calculateDelaySeconds } from './webhook.utils'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Encapsulates a producer which can write webhook retry messages
+ * to a message queue.
+ */
+export class WebhookProducer {
+  producer: Producer
+
+  constructor(queueUrl: string) {
+    this.producer = Producer.create({
+      queueUrl,
+      region: config.aws.region,
+    })
+  }
+
+  /**
+   * Enqueues a message.
+   * @param queueMessage Message to send
+   * @returns ok(true) if sending message suceeds
+   * @returns err if sending message fails
+   */
+  sendMessage(
+    queueMessage: WebhookQueueMessage,
+  ): ResultAsync<true, WebhookPushToQueueError> {
+    const sendMessageRetry = promiseRetry<true>(async (retry, attemptNum) => {
+      try {
+        await this.producer.send({
+          body: queueMessage.serialise(),
+          id: queueMessage.submissionId, // only needs to be unique within request
+          delaySeconds: calculateDelaySeconds(queueMessage.nextAttempt),
+        })
+        logger.info({
+          message: `Pushed webhook to queue`,
+          meta: {
+            action: 'sendMessage',
+            webhookMessage: queueMessage.prettify(),
+            attemptNum,
+          },
+        })
+        return true
+      } catch (error) {
+        logger.error({
+          message: `Failed to push webhook to queue`,
+          meta: {
+            action: 'sendMessage',
+            attemptNum,
+          },
+          error,
+        })
+        return retry(error)
+      }
+    })
+    return ResultAsync.fromPromise(sendMessageRetry, (error) => {
+      logger.error({
+        message: 'All attempts to push webhook to queue failed',
+        meta: {
+          action: 'sendMessage',
+        },
+        error,
+      })
+      return new WebhookPushToQueueError()
+    })
+  }
+}

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -71,12 +71,7 @@ export const saveWebhookRecord = (
 export const sendWebhook = (
   submission: IEncryptedSubmissionSchema,
   webhookUrl: string,
-): ResultAsync<
-  IWebhookResponse,
-  | WebhookValidationError
-  | WebhookFailedWithAxiosError
-  | WebhookFailedWithUnknownError
-> => {
+): ResultAsync<IWebhookResponse, WebhookValidationError> => {
   const now = Date.now()
   const submissionWebhookView = submission.getWebhookView()
   const { submissionId, formId } = submissionWebhookView.data

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -114,6 +114,9 @@ export const sendWebhook = (
             }),
           },
           maxRedirects: 0,
+          // Timeout after 10 seconds to allow for cold starts in receiver,
+          // e.g. Lambdas
+          timeout: 10 * 1000,
         }),
         (error) => {
           logger.error({

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -173,3 +173,23 @@ export const sendWebhook = (
       })
     })
 }
+
+/**
+ * Creates a function which sends a webhook and saves the necessary records.
+ * @returns function which sends webhook and saves a record of it
+ */
+export const createInitialWebhookSender = () => (
+  submission: IEncryptedSubmissionSchema,
+  webhookUrl: string,
+): ResultAsync<
+  true,
+  WebhookValidationError | PossibleDatabaseError | SubmissionNotFoundError
+> => {
+  // Attempt to send webhook
+  return sendWebhook(submission, webhookUrl)
+    .andThen((webhookResponse) =>
+      // Save record of sending to database
+      saveWebhookRecord(submission._id, webhookResponse),
+    )
+    .map(() => true)
+}

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -179,6 +179,9 @@ export const sendWebhook = (
 
 /**
  * Creates a function which sends a webhook and saves the necessary records.
+ * This function sends the INITIAL webhook, which occurs immediately after
+ * a submission. If the initial webhook fails and retries are enabled, the
+ * webhook is queued for retries.
  * @returns function which sends webhook and saves a record of it
  */
 export const createInitialWebhookSender = (producer?: WebhookProducer) => (

--- a/src/app/modules/webhook/webhook.types.ts
+++ b/src/app/modules/webhook/webhook.types.ts
@@ -1,9 +1,6 @@
-import {
-  IEncryptedSubmissionSchema,
-  IFormSchema,
-  ISubmissionSchema,
-  WebhookView,
-} from '../../../types'
+import * as z from 'zod'
+
+import { IFormSchema, ISubmissionSchema, WebhookView } from '../../../types'
 
 export interface WebhookParams {
   webhookUrl: string
@@ -14,7 +11,45 @@ export interface WebhookParams {
   signature: string
 }
 
-export interface WebhookRequestLocals {
-  form: IFormSchema
-  submission: IEncryptedSubmissionSchema
+/**
+ * Schema for webhook queue message, which allows an object to be validated.
+ */
+export const webhookMessageSchema = z.object({
+  submissionId: z.string(),
+  previousAttempts: z.array(z.number()),
+  nextAttempt: z.number(),
+  _v: z.number(),
+})
+
+/**
+ * Shape of webhook queue message object.
+ */
+export type WebhookQueueMessageObject = z.infer<typeof webhookMessageSchema>
+
+/**
+ * Webhook queue message object formatted for readable logs.
+ */
+export type WebhookQueueMessagePrettified = Omit<
+  WebhookQueueMessageObject,
+  'previousAttempts' | 'nextAttempt'
+> & {
+  previousAttempts: string[]
+  nextAttempt: string
+}
+
+/**
+ * Failed webhook queue message formatted for readable logs.
+ * Same as a regular queue message except no next attempt.
+ */
+export type WebhookFailedQueueMessage = Omit<
+  WebhookQueueMessagePrettified,
+  'nextAttempt'
+>
+
+/**
+ * Specification of when a webhook should be retried.
+ */
+export type RetryInterval = {
+  base: number
+  jitter: number
 }

--- a/src/app/modules/webhook/webhook.types.ts
+++ b/src/app/modules/webhook/webhook.types.ts
@@ -15,7 +15,7 @@ export interface WebhookParams {
  * Schema for webhook queue message, which allows an object to be validated.
  */
 export const webhookMessageSchema = z.object({
-  submissionId: z.string(),
+  submissionId: z.string().regex(/^[a-f\d]{24}$/i),
   previousAttempts: z.array(z.number()),
   nextAttempt: z.number(),
   _v: z.number(),

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios'
+import { inRange } from 'lodash'
 import moment from 'moment-timezone'
 import { err, ok, Result } from 'neverthrow'
 
@@ -39,6 +40,16 @@ export const getNextAttempt = (
   )
   return ok(Date.now() + nextAttemptWaitTimeSeconds * 1000)
 }
+
+/**
+ * Encodes success condition of webhook. Webhooks are considered
+ * successful if the status code >= 200 and < 300.
+ * @param webhookResponse Response from receiving server
+ * @returns true if webhook was successful
+ */
+export const isSuccessfulResponse = (
+  webhookResponse: IWebhookResponse,
+): boolean => inRange(webhookResponse.response.status, 200, 300)
 
 /**
  * Calculates the number of seconds to delay a message sent to

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -1,7 +1,13 @@
 import { AxiosResponse } from 'axios'
+import moment from 'moment-timezone'
+import { err, ok, Result } from 'neverthrow'
 
 import { stringifySafe } from '../../../shared/util/stringify-safe'
 import { IWebhookResponse } from '../../../types'
+import { randomUniform } from '../../utils/random-uniform'
+
+import { RETRY_INTERVALS } from './webhook.constants'
+import { WebhookNoMoreRetriesError } from './webhook.errors'
 
 /**
  * Formats a response object for update in the Submissions collection
@@ -14,3 +20,30 @@ export const formatWebhookResponse = (
   headers: stringifySafe(response?.headers) ?? '',
   data: stringifySafe(response?.data) ?? '',
 })
+
+/**
+ * Computes epoch of next webhook attempt based on previous attempts.
+ * @param previousAttempts Array of epochs of previous attempts
+ * @returns ok(epoch of next attempt) if there are valid retries remaining
+ * @returns err(WebhookNoMoreRetriesError) if there are no more retries remaining
+ */
+export const getNextAttempt = (
+  previousAttempts: number[],
+): Result<number, WebhookNoMoreRetriesError> => {
+  if (previousAttempts.length >= RETRY_INTERVALS.length)
+    return err(new WebhookNoMoreRetriesError())
+  const interval = RETRY_INTERVALS[previousAttempts.length]
+  const nextAttemptWaitTimeSeconds = randomUniform(
+    interval.base - interval.jitter,
+    interval.base + interval.jitter,
+  )
+  return ok(Date.now() + nextAttemptWaitTimeSeconds * 1000)
+}
+
+/**
+ * Converts an epoch to a readable format.
+ * @param epoch
+ * @returns the epoch represented as a readable string
+ */
+export const prettifyEpoch = (epoch: number): string =>
+  moment(epoch).tz('Asia/Singapore').format('D MMM YYYY, h:mm:ssa z')

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -24,6 +24,21 @@ export const formatWebhookResponse = (
 })
 
 /**
+ * Computes epoch of first webhook retry.
+ * In practice this should never return an error, but for the sake of code
+ * maintainability, it does not make any assumptions about the retry policy,
+ * i.e. the retry policy can be an empty array.
+ * @returns ok(epoch of next attempt) if there is a retry policy
+ * @returns err(WebhookNoMoreRetriesError) if the retry policy is empty
+ */
+export const getFirstAttempt = (): Result<
+  number,
+  WebhookNoMoreRetriesError
+> => {
+  return getNextAttempt(/* previousAttempts= */ [])
+}
+
+/**
  * Computes epoch of next webhook attempt based on previous attempts.
  * @param previousAttempts Array of epochs of previous attempts
  * @returns ok(epoch of next attempt) if there are valid retries remaining

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -31,8 +31,9 @@ export const formatWebhookResponse = (
 export const getNextAttempt = (
   previousAttempts: number[],
 ): Result<number, WebhookNoMoreRetriesError> => {
-  if (previousAttempts.length >= RETRY_INTERVALS.length)
+  if (previousAttempts.length >= RETRY_INTERVALS.length) {
     return err(new WebhookNoMoreRetriesError())
+  }
   const interval = RETRY_INTERVALS[previousAttempts.length]
   const nextAttemptWaitTimeSeconds = randomUniform(
     interval.base - interval.jitter,

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -6,7 +6,7 @@ import { stringifySafe } from '../../../shared/util/stringify-safe'
 import { IWebhookResponse } from '../../../types'
 import { randomUniform } from '../../utils/random-uniform'
 
-import { RETRY_INTERVALS } from './webhook.constants'
+import { MAX_DELAY_SECONDS, RETRY_INTERVALS } from './webhook.constants'
 import { WebhookNoMoreRetriesError } from './webhook.errors'
 
 /**
@@ -38,6 +38,17 @@ export const getNextAttempt = (
     interval.base + interval.jitter,
   )
   return ok(Date.now() + nextAttemptWaitTimeSeconds * 1000)
+}
+
+/**
+ * Calculates the number of seconds to delay a message sent to
+ * the webhook queue. This is the minimum of (time to next attempt,
+ * max possible delay timeout).
+ * @param nextAttempt Epoch of next attempt
+ */
+export const calculateDelaySeconds = (nextAttempt: number): number => {
+  const secondsToNextAttempt = Math.max(0, (nextAttempt - Date.now()) / 1000)
+  return Math.min(secondsToNextAttempt, MAX_DELAY_SECONDS)
 }
 
 /**

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -5,7 +5,7 @@ import { err, ok, Result } from 'neverthrow'
 
 import { stringifySafe } from '../../../shared/util/stringify-safe'
 import { IWebhookResponse } from '../../../types'
-import { randomUniform } from '../../utils/random-uniform'
+import { randomUniformInt } from '../../utils/random-uniform'
 
 import { MAX_DELAY_SECONDS, RETRY_INTERVALS } from './webhook.constants'
 import { WebhookNoMoreRetriesError } from './webhook.errors'
@@ -35,7 +35,7 @@ export const getNextAttempt = (
     return err(new WebhookNoMoreRetriesError())
   }
   const interval = RETRY_INTERVALS[previousAttempts.length]
-  const nextAttemptWaitTimeSeconds = randomUniform(
+  const nextAttemptWaitTimeSeconds = randomUniformInt(
     interval.base - interval.jitter,
     interval.base + interval.jitter,
   )

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -5,6 +5,7 @@ import { err, ok, Result } from 'neverthrow'
 
 import { stringifySafe } from '../../../shared/util/stringify-safe'
 import { IWebhookResponse } from '../../../types'
+import { TIMEZONE } from '../../constants/timezone'
 import { randomUniformInt } from '../../utils/random-uniform'
 
 import { MAX_DELAY_SECONDS, RETRY_INTERVALS } from './webhook.constants'
@@ -69,4 +70,4 @@ export const calculateDelaySeconds = (nextAttempt: number): number => {
  * @returns the epoch represented as a readable string
  */
 export const prettifyEpoch = (epoch: number): string =>
-  moment(epoch).tz('Asia/Singapore').format('D MMM YYYY, h:mm:ssa z')
+  moment(epoch).tz(TIMEZONE).format('D MMM YYYY, h:mm:ssa z')

--- a/src/app/utils/random-uniform.ts
+++ b/src/app/utils/random-uniform.ts
@@ -5,7 +5,7 @@
  * @param max
  * @returns Integer generated uniformly in interval
  */
-export const randomUniform = (min: number, max: number): number => {
+export const randomUniformInt = (min: number, max: number): number => {
   const roundedMin = Math.ceil(min)
   const roundedMax = Math.floor(max)
   return Math.floor(Math.random() * (roundedMax - roundedMin + 1)) + roundedMin

--- a/src/app/utils/random-uniform.ts
+++ b/src/app/utils/random-uniform.ts
@@ -1,0 +1,12 @@
+/**
+ * Generates a random integer between min and max (both inclusive).
+ * If min/max are not integers, the ceiling and floor are taken respectively.
+ * @param min
+ * @param max
+ * @returns Integer generated uniformly in interval
+ */
+export const randomUniform = (min: number, max: number): number => {
+  const roundedMin = Math.ceil(min)
+  const roundedMax = Math.floor(max)
+  return Math.floor(Math.random() * (roundedMax - roundedMin + 1)) + roundedMin
+}

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -57,6 +57,20 @@ export interface WebhookView {
   data: WebhookData
 }
 
+export type SubmissionWebhookInfo = {
+  webhookUrl: string
+  isRetryEnabled: boolean
+  webhookView: WebhookView
+}
+
+export interface IPopulatedWebhookSubmission
+  extends IEncryptedSubmissionSchema {
+  form: {
+    _id: IFormSchema['_id']
+    webhook: IFormSchema['webhook']
+  }
+}
+
 export interface ISubmissionSchema extends ISubmission, Document {}
 
 export type FindFormsWithSubsAboveResult = {
@@ -187,6 +201,15 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       submissionId: string,
       webhookResponse: IWebhookResponse,
     ): Promise<IEncryptedSubmissionSchema | null>
+
+    /**
+     * Retrieves webhook-related info for a given submission.
+     * @param submissionId
+     * @returns Object containing webhook destination and data
+     */
+    retrieveWebhookInfoById(
+      submissionId: string,
+    ): Promise<SubmissionWebhookInfo | null>
   }
 
 export interface IWebhookResponseSchema extends IWebhookResponse, Document {}


### PR DESCRIPTION
Third in a series of PRs to enable webhook retries. This PR contains the bulk of the application logic for the production and consumption of messages from the queue.

Can be reviewed by commit.