### PR TITLE
feat(webhook-retries): enable toggling retries on frontend (4)

### DIFF
--- a/src/public/modules/forms/admin/css/settings-form.css
+++ b/src/public/modules/forms/admin/css/settings-form.css
@@ -164,6 +164,10 @@
   padding-bottom: 45px;
 }
 
+#settings-form .feature-container.webhook-feature-container {
+  padding-bottom: 30px;
+}
+
 #settings-form #enable-auth {
   padding-top: 45px;
   padding-bottom: 30px;

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -430,16 +430,23 @@
           </div>
         </div>
         <div class="settings-input">
+          <div class="alert-custom alert-info alert-margin">
+            <i class="bx bx-error-circle bx-md icon-spacing"></i>
+            <span class="alert-msg">
+              Your system must meet certain requirements before retries can be
+              safely enabled.
+              <a
+                translate-attr="{ href: 'LINKS.WEBHOOK_RETRIES' }"
+                target="_blank"
+                >Learn more</a
+              >
+            </span>
+          </div>
           <div class="row">
             <div class="col-xs-9">
               <span class="label-custom label-medium label-bottom"
                 >Enable retries</span
               >
-              (<a
-                translate-attr="{ href: 'LINKS.WEBHOOK_RETRIES' }"
-                target="_blank"
-                >What are retries?</a
-              >)
             </div>
             <div class="col-xs-3">
               <label

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -380,16 +380,6 @@
           </label>
         </div>
         <div
-          ng-if="isFormPublic()"
-          class="alert-custom alert-info spcp-warning"
-        >
-          <i class="bx bx-info-circle bx-md icon-spacing"></i>
-          <span class="alert-msg"
-            >Webhook settings cannot be changed unless your form is
-            deactivated.</span
-          >
-        </div>
-        <div
           ng-if="doesFormContainAttachments()"
           class="alert-custom alert-info spcp-warning"
         >
@@ -418,6 +408,13 @@
               ng-class="settingsForm.webhookUrl.$valid ? '' : 'input-error'"
               validate-url
             />
+            <div ng-if="isFormPublic()" class="alert-custom alert-info">
+              <i class="bx bx-info-circle bx-md icon-spacing"></i>
+              <span class="alert-msg"
+                >Webhook URL cannot be changed unless your form is
+                deactivated.</span
+              >
+            </div>
             <div
               class="alert-custom alert-error"
               ng-if="settingsForm.webhookUrl.$invalid"

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -385,7 +385,8 @@
         >
           <i class="bx bx-info-circle bx-md icon-spacing"></i>
           <span class="alert-msg"
-            >Webhook cannot be changed unless your form is deactivated.</span
+            >Webhook settings cannot be changed unless your form is
+            deactivated.</span
           >
         </div>
         <div
@@ -397,7 +398,7 @@
             >Webhook is not available for forms with attachment fields.</span
           >
         </div>
-        <div class="row feature-container">
+        <div class="row feature-container webhook-feature-container">
           <div
             class="settings-save col-xs-12"
             ng-class="(settingsForm.webhookUrl.$invalid) ? 'input-disabled' : ''"
@@ -412,8 +413,8 @@
               ng-required="false"
               ng-disabled="isFormPublic() || doesFormContainAttachments()"
               autocomplete="off"
-              ng-keyup="$event.keyCode === 13 && settingsForm.webhookUrl.$valid && saveForm()"
-              ng-blur="saveForm()"
+              ng-keyup="$event.keyCode === 13 && settingsForm.webhookUrl.$valid && saveWebhookUrl()"
+              ng-blur="saveWebhookUrl()"
               ng-class="settingsForm.webhookUrl.$valid ? '' : 'input-error'"
               validate-url
             />
@@ -425,6 +426,39 @@
               <span class="alert-msg">
                 Please enter a valid URL (starting with https://)
               </span>
+            </div>
+          </div>
+        </div>
+        <div class="settings-input">
+          <div class="row">
+            <div class="col-xs-9">
+              <span class="label-custom label-medium label-bottom"
+                >Enable retries</span
+              >
+              (<a
+                translate-attr="{ href: 'LINKS.WEBHOOK_RETRIES' }"
+                target="_blank"
+                >What are retries?</a
+              >)
+            </div>
+            <div class="col-xs-3">
+              <label
+                class="toggle-selector pull-right"
+                ng-class="tempForm.webhook.isRetryEnabled ? 'toggle-selector-on' : ''"
+                ng-style="isWebhookRetryToggleDisabled() ? { 'cursor': 'not-allowed' } : ''"
+              >
+                <input
+                  type="checkbox"
+                  ng-model="tempForm.webhook.isRetryEnabled"
+                  ng-change="saveForm()"
+                  ng-disabled="isWebhookRetryToggleDisabled()"
+                />
+                <div class="toggle-selector-switch">
+                  <i
+                    ng-class="tempForm.webhook.isRetryEnabled ? 'bx bx-check' : 'bx bx-x'"
+                  ></i>
+                </div>
+              </label>
             </div>
           </div>
         </div>

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -426,7 +426,7 @@
             </div>
           </div>
         </div>
-        <div class="settings-input">
+        <div class="settings-input" ng-if="myform.webhook.url">
           <div class="row">
             <div class="col-xs-9">
               <span class="label-custom label-medium label-bottom"

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -427,18 +427,6 @@
           </div>
         </div>
         <div class="settings-input">
-          <div class="alert-custom alert-info alert-margin">
-            <i class="bx bx-error-circle bx-md icon-spacing"></i>
-            <span class="alert-msg">
-              Your system must meet certain requirements before retries can be
-              safely enabled.
-              <a
-                translate-attr="{ href: 'LINKS.WEBHOOK_RETRIES' }"
-                target="_blank"
-                >Learn more</a
-              >
-            </span>
-          </div>
           <div class="row">
             <div class="col-xs-9">
               <span class="label-custom label-medium label-bottom"
@@ -464,6 +452,18 @@
                 </div>
               </label>
             </div>
+          </div>
+          <div class="alert-custom alert-info alert-margin spcp-warning">
+            <i class="bx bx-error-circle bx-md icon-spacing"></i>
+            <span class="alert-msg">
+              Your system must meet certain requirements before retries can be
+              safely enabled.
+              <a
+                translate-attr="{ href: 'LINKS.WEBHOOK_RETRIES' }"
+                target="_blank"
+                >Learn more</a
+              >
+            </span>
           </div>
         </div>
       </div>

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -13,6 +13,7 @@ const SETTINGS_PATH = [
   'inactiveMessage',
   'submissionLimit',
   'webhook.url',
+  'webhook.isRetryEnabled',
 ]
 
 const createTempSettings = (myform) => {
@@ -353,6 +354,16 @@ function settingsFormDirective(
               updateFormStatusAndSave('Form deactivated!')
             }
           }
+        }
+
+        $scope.isWebhookRetryToggleDisabled = () =>
+          $scope.isFormPublic() || !$scope.tempForm.webhook.url
+
+        $scope.saveWebhookUrl = () => {
+          if (!get($scope, 'tempForm.webhook.url')) {
+            set($scope, 'tempForm.webhook.isRetryEnabled', false)
+          }
+          return $scope.saveForm()
         }
       },
     ],

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -356,7 +356,10 @@ function settingsFormDirective(
           }
         }
 
-        $scope.isWebhookRetryToggleDisabled = () => !$scope.tempForm.webhook.url
+        $scope.isWebhookRetryToggleDisabled = () => {
+          // disable if there is no valid saved webhook URL
+          return !get($scope.myform, 'webhook.url')
+        }
 
         $scope.saveWebhookUrl = () => {
           if (!get($scope, 'tempForm.webhook.url')) {

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -356,8 +356,7 @@ function settingsFormDirective(
           }
         }
 
-        $scope.isWebhookRetryToggleDisabled = () =>
-          $scope.isFormPublic() || !$scope.tempForm.webhook.url
+        $scope.isWebhookRetryToggleDisabled = () => !$scope.tempForm.webhook.url
 
         $scope.saveWebhookUrl = () => {
           if (!get($scope, 'tempForm.webhook.url')) {

--- a/src/public/translations/en-SG/main.json
+++ b/src/public/translations/en-SG/main.json
@@ -21,6 +21,7 @@
     "WHITELISTED_ATTACHMENT_TYPES": "https://go.gov.sg/formsg-cwl",
     "SINGPASS_ELIGIBILITY_FAQ": "https://www.ifaq.gov.sg/SINGPASS/apps/Fcd_faqmain.aspx#FAQ_2101385",
     "ESERVICE_ID_FAQ": "https://go.gov.sg/formsg-spcp",
-    "TERMS_THIRD_PARTY_LIST": "https://s3-ap-southeast-1.amazonaws.com/misc.form.gov.sg/OSS-Legal.pdf"
+    "TERMS_THIRD_PARTY_LIST": "https://s3-ap-southeast-1.amazonaws.com/misc.form.gov.sg/OSS-Legal.pdf",
+    "WEBHOOK_RETRIES": "https://go.gov.sg/form-webhook-retries"
   }
 }


### PR DESCRIPTION
Last in a series of PRs to enable webhook retries. This PR adds a toggle on the frontend to enable or disable retries.

## Screenshots
### Webhooks disabled (toggle hidden)
![Screenshot 2021-06-07 at 12 42 17 PM](https://user-images.githubusercontent.com/29480346/120960171-dbfc6700-c78d-11eb-8484-0206bf56655d.png)

### Webhooks enabled, retries disabled
![Screenshot 2021-06-07 at 12 46 47 PM](https://user-images.githubusercontent.com/29480346/120960445-6e046f80-c78e-11eb-8234-f26f12113b12.png)

### Webhooks and retries both enabled
![Screenshot 2021-06-07 at 12 46 57 PM](https://user-images.githubusercontent.com/29480346/120960456-73fa5080-c78e-11eb-8a03-e8cb30c1920c.png)

### Process of adding URL, enabling retries, disabling retries, removing URL
![webhook-retries-frontend](https://user-images.githubusercontent.com/29480346/120961089-b2443f80-c78f-11eb-9058-002d7f9de473.gif)
