### PR TITLE
fix(verification): loosen OTP waiting time by 2 seconds

### DIFF
--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -4,6 +4,7 @@ import {
   HASH_EXPIRE_AFTER_SECONDS,
   VERIFIED_FIELDTYPES,
   WAIT_FOR_OTP_SECONDS,
+  WAIT_FOR_OTP_TOLERANCE_SECONDS,
 } from '../../../shared/util/verification'
 import {
   IFieldSchema,
@@ -108,7 +109,13 @@ export const isOtpWaitTimeElapsed = (hashCreatedAt: Date | null): boolean => {
   // No hash created yet, so no wait time
   if (!hashCreatedAt) return true
 
-  const elapseAt = getExpiryDate(WAIT_FOR_OTP_SECONDS, hashCreatedAt)
+  // Loosen validation by WAIT_FOR_OTP_TOLERANCE_SECONDS. This is because of
+  // potential clock drift between servers, where valid requests may be rejected
+  // because servers are a few seconds in front/behind each other.
+  const elapseAt = getExpiryDate(
+    /*expireAfter=*/ WAIT_FOR_OTP_SECONDS - WAIT_FOR_OTP_TOLERANCE_SECONDS,
+    /*fromDate=*/ hashCreatedAt,
+  )
   const currentDate = new Date()
   return currentDate > elapseAt
 }

--- a/src/shared/util/verification.ts
+++ b/src/shared/util/verification.ts
@@ -5,6 +5,11 @@ export const SALT_ROUNDS = 10
 export const TRANSACTION_EXPIRE_AFTER_SECONDS = 14400 // 4 hours
 export const HASH_EXPIRE_AFTER_SECONDS = 600 // 10 minutes
 export const WAIT_FOR_OTP_SECONDS = 30
+/**
+ * WAIT_FOR_OTP_SECONDS tolerance. Server allows OTPs to be requested every
+ * (WAIT_FOR_OTP_SECONDS - WAIT_FOR_OTP_TOLERANCE_SECONDS) seconds.
+ */
+export const WAIT_FOR_OTP_TOLERANCE_SECONDS = 2
 export const NUM_OTP_RETRIES = 4
 
 export enum VfnErrors {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #1923, see issue for detailed explanation of problem

## Solution
<!-- How did you solve the problem? -->

Add a tolerance of 2 seconds to the OTP waiting time check. This means the server allows OTPs to be requested every 28 seconds.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible, only server-side changes

## Tests
<!-- What tests should be run to confirm functionality? -->
No tests to be updated. Current service tests check that the OTP requests are rejected if made within 25 seconds of each other, which is still true _(pats self on the back)._

## Manual tests
- [ ] Request for an OTP for a verified field. When the 30 second timer on the UI elapses, _immediately_ request a new one. The request should be valid and you should receive the new OTP.