### PR TITLE
fix: set form logo default value when creating form document

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -12,6 +12,7 @@ import {
   BasicField,
   EndPage,
   FormFieldWithId,
+  FormLogoState,
   IEncryptedForm,
   IFieldSchema,
   IFormSchema,
@@ -57,6 +58,9 @@ const FORM_DEFAULTS = {
   isListed: true,
   startPage: {
     colorTheme: 'blue',
+    logo: {
+      state: FormLogoState.Default,
+    },
   },
   endPage: {
     title: 'Thank you for filling out the form.',
@@ -1620,7 +1624,7 @@ describe('Form Model', () => {
           lastModified: expect.any(Date),
           startPage: { ...form.startPage, ...updatedStartPage },
         })
-        expect(actual.lastModified! > prevModifiedDate!).toBe(true)
+        expect((actual?.lastModified ?? 0) > (prevModifiedDate ?? 0)).toBe(true)
       })
 
       it('should update start page with defaults when optional values are not provided', async () => {
@@ -1648,6 +1652,9 @@ describe('Form Model', () => {
             ...updatedStartPage,
             // Defaults should be populated and returned
             colorTheme: 'blue',
+            logo: {
+              state: FormLogoState.Default,
+            },
           },
         })
       })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -261,7 +261,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           enum: Object.values(Colors),
           default: Colors.Blue,
         },
-        logo: FormLogoSchema,
+        logo: {
+          type: FormLogoSchema,
+          default: () => ({}),
+        },
       },
 
       endPage: {


### PR DESCRIPTION
**!! Will probably need a DB migration script to populate old forms (that did not update their start pages) with a default form logo state**

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Creating a new form does not create a default startPage.logo nested document, resulting in a new form not having a default form logo state.

![Screenshot 2021-05-25 at 11 25 52 AM](https://user-images.githubusercontent.com/22133008/119435033-fd9c2e00-bd4b-11eb-8c0a-5dfb3b716f8e.png)

![Screenshot 2021-05-25 at 11 26 30 AM](https://user-images.githubusercontent.com/22133008/119435077-0ee53a80-bd4c-11eb-9e52-94cce55f55e7.png)

This PR populates `startPage.logo` with its default state.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible 
  - If rolled back... just means new documents don't have a default state

**Improvements**:

- fix: set default form logo schema on form document creation


## Tests
<!-- What tests should be run to confirm functionality? -->
- tests have been updated

### Manual tests
- [ ] Create a new email form. Check that the returned form object from the server now has `startPage.logo.state = "DEFAULT"` 
