### PR TITLE
fix(client): set default logo option on edit start page modal if missing

### DIFF
--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -42,7 +42,7 @@ function EditStartPageController(
   vm.myform = angular.copy(myform)
 
   // Populate start page with default if it does not exist.
-  if (get(vm.myform, 'startPage.logo')) {
+  if (!get(vm.myform, 'startPage.logo')) {
     vm.myform.startPage = {
       logo: FormLogoState.Default,
     }

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -43,9 +43,7 @@ function EditStartPageController(
 
   // Populate start page with default if it does not exist.
   if (!get(vm.myform, 'startPage.logo')) {
-    vm.myform.startPage = {
-      logo: FormLogoState.Default,
-    }
+    vm.myform.startPage.logo = FormLogoState.Default
   }
 
   vm.colorThemes = Object.values(Colors)

--- a/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-start-page-modal.client.controller.js
@@ -1,6 +1,8 @@
 'use strict'
-const { Colors } = require('../../../../../types/form.ts')
+const get = require('lodash/get')
 const axios = require('axios').default
+
+const { Colors } = require('../../../../../types/form.ts')
 const {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
@@ -38,6 +40,14 @@ function EditStartPageController(
 
   // Make a copy so nothing is changed in the original.
   vm.myform = angular.copy(myform)
+
+  // Populate start page with default if it does not exist.
+  if (get(vm.myform, 'startPage.logo')) {
+    vm.myform.startPage = {
+      logo: FormLogoState.Default,
+    }
+  }
+
   vm.colorThemes = Object.values(Colors)
   vm.hasClickedSave = false
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Yet another PR for not having a default form logo, this time for the client side.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  
  - Purely client side change

**Improvements**:

- fix: set default logo option on edit start page modal if missing
