### PR TITLE
feat: display different e-service placeholder text for singpass and corpass

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -283,7 +283,7 @@
                     type="text"
                     name="esrvcId"
                     ng-model="tempForm.esrvcId"
-                    placeholder="Enter your e-service ID here"
+                    placeholder="{{ ['SP', 'MyInfo'].includes(type.val) && 'Enter Singpass e-service ID' || 'Enter Corppass e-service ID' }}"
                     ng-pattern="/^([a-zA-Z0-9\-]){1,25}$/i"
                     ng-keyup="($event.keyCode === 13 && settingsForm.esrvcId.$valid) && saveForm()"
                     ng-blur="(settingsForm.esrvcId.$valid) && saveForm()"

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -283,7 +283,7 @@
                     type="text"
                     name="esrvcId"
                     ng-model="tempForm.esrvcId"
-                    placeholder="{{ ['SP', 'MyInfo'].includes(type.val) && 'Enter Singpass e-service ID' || 'Enter Corppass e-service ID' }}"
+                    placeholder="{{ ['SP', 'MyInfo'].includes(type.val) ? 'Enter Singpass e-service ID' : 'Enter Corppass e-service ID' }}"
                     ng-pattern="/^([a-zA-Z0-9\-]){1,25}$/i"
                     ng-keyup="($event.keyCode === 13 && settingsForm.esrvcId.$valid) && saveForm()"
                     ng-blur="(settingsForm.esrvcId.$valid) && saveForm()"


### PR DESCRIPTION
This PR changes the placeholder text for entering e-service IDs. 

Closes #1675

## Screenshots
<img width="800" alt="Screenshot 2021-05-25 at 5 33 40 PM" src="https://user-images.githubusercontent.com/54089291/119475646-e7a86080-bd7f-11eb-9180-a4690173dde0.png">
<img width="794" alt="Screenshot 2021-05-25 at 5 33 26 PM" src="https://user-images.githubusercontent.com/54089291/119475657-ea0aba80-bd7f-11eb-9928-901e68ca286e.png">
<img width="815" alt="Screenshot 2021-05-25 at 5 33 15 PM" src="https://user-images.githubusercontent.com/54089291/119475662-eb3be780-bd7f-11eb-85f0-a0fc230d52f3.png">


## Tests
- [ ] Change authentication method to Singpass and Singpass(MyInfo). Placeholder text should show "Enter Singpass e-service ID".
- [ ] Change authentication method to Singpass(Corporate). Placeholder text should show "Enter Corppass e-service ID"

