### PR TITLE
refactor: replace set hook with validator hook in emailField model

### DIFF
--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -29,9 +29,15 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
       includeFormSummary: {
         type: Boolean,
         default: false,
-        set: function (this: IEmailFieldSchema, v: boolean) {
-          // PDF response not allowed for encrypt forms
-          return this.parent().responseMode === ResponseMode.Encrypt ? false : v
+        validate: {
+          validator: function (this: IEmailFieldSchema) {
+            // PDF response not allowed for encrypt forms but ignore if no autoreply
+            return (
+              this.parent().responseMode !== ResponseMode.Encrypt ||
+              !this.autoReplyOptions.hasAutoReply
+            )
+          },
+          message: 'Autoreply PDF is not allowed for storage mode forms',
         },
       },
     },

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -37,7 +37,8 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
               !this.autoReplyOptions.hasAutoReply
             )
           },
-          message: 'Autoreply PDF is not allowed for storage mode forms',
+          message:
+            'PDF response summaries are not allowed for email confirmations in storage mode forms',
         },
       },
     },
@@ -66,21 +67,6 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
         message: 'There are one or more duplicate or invalid email domains.',
       },
     },
-  })
-
-  // PDF response not allowed if autoreply is set in encrypted forms. If
-  // autoreply is not set, then we don't care whether the pdf is set.
-  EmailFieldSchema.pre<IEmailFieldSchema>('validate', function (next) {
-    if (this.parent().responseMode === ResponseMode.Encrypt) {
-      const { hasAutoReply, includeFormSummary } = this.autoReplyOptions || {}
-      if (hasAutoReply && includeFormSummary) {
-        return next(
-          Error('Autoreply PDF is not allowed for storage mode forms'),
-        )
-      }
-    }
-
-    return next()
   })
 
   return EmailFieldSchema

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -30,12 +30,12 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
         type: Boolean,
         default: false,
         validate: {
-          validator: function (this: IEmailFieldSchema) {
+          validator: function (this: IEmailFieldSchema, v: boolean) {
             // PDF response not allowed for encrypt forms but ignore if no autoreply
-            return (
-              this.parent().responseMode !== ResponseMode.Encrypt ||
-              !this.autoReplyOptions.hasAutoReply
-            )
+            return v
+              ? this.parent().responseMode !== ResponseMode.Encrypt ||
+                  !this.autoReplyOptions.hasAutoReply
+              : true
           },
           message:
             'PDF response summaries are not allowed for email confirmations in storage mode forms',

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -31,11 +31,14 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
         default: false,
         validate: {
           validator: function (this: IEmailFieldSchema, v: boolean) {
-            // PDF response not allowed for encrypt forms but ignore if no autoreply
-            return v
-              ? this.parent().responseMode !== ResponseMode.Encrypt ||
-                  !this.autoReplyOptions.hasAutoReply
-              : true
+            // always ok to set to false
+            return (
+              !v ||
+              // either true or false is okay if not in storage mode
+              this.parent().responseMode !== ResponseMode.Encrypt ||
+              // in storage mode, we can ignore this field if email confirmation is not enabled anyway
+              !this.autoReplyOptions.hasAutoReply
+            )
           },
           message:
             'PDF response summaries are not allowed for email confirmations in storage mode forms',


### PR DESCRIPTION
Refer to issue #1222 for details. This PR only replaces the set hook in `emailField`'s `includeFormSummary`. Two set hooks remain in `form.server.model.ts`. Conversion of these hooks is slightly more complicated due to the use of functions such as `findByIdAndUpdate`, `findOneAndUpdate` amongst others, which write directly to the database. The validator is therefore not able to access the object to perform the needed validation.

## Tests
Ensure existing unit tests still pass. 
### Manual Tests
- [ ] Create email field directly in storage mode via API call by **flipping `includePdfSummary` to `true`**. Ensure that new email field is not created upon refresh.
- [ ] Create email field in email mode. Ensure that including PDF summary is allowed.