### PR TITLE
refactor(submissions.client.factory): extract admin form features

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -498,7 +498,7 @@ const validateDateRange = celebrate({
  */
 export const countFormSubmissions: RequestHandler<
   { formId: string },
-  unknown,
+  ErrorDto | number,
   unknown,
   { startDate?: string; endDate?: string }
 > = async (req, res) => {

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -406,14 +406,17 @@ function ViewResponsesController(
       {
         getData: (params) => {
           let { page } = params.url()
-          return $q
-            .when(
-              AdminSubmissionsService.getFormsMetadata({
+          const getMetadataPromise = vm.filterBySubmissionRefId
+            ? AdminSubmissionsService.getFormMetadata({
                 formId: vm.myform._id,
                 submissionId: vm.filterBySubmissionRefId,
+              })
+            : AdminSubmissionsService.getFormsMetadata({
+                formId: vm.myform._id,
                 pageNum: page,
-              }),
-            )
+              })
+          return $q
+            .when(getMetadataPromise)
             .then((data) => {
               params.total(data.count)
               vm.responsesCount = data.count

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -400,11 +400,14 @@ function ViewResponsesController(
       {
         getData: (params) => {
           let { page } = params.url()
-          return Submissions.getMetadata({
-            formId: vm.myform._id,
-            filterBySubmissionRefId: vm.filterBySubmissionRefId,
-            page,
-          })
+          return $q
+            .when(
+              AdminFormService.getFormsMetadata({
+                formId: vm.myform._id,
+                submissionId: vm.filterBySubmissionRefId,
+                pageNum: page,
+              }),
+            )
             .then((data) => {
               params.total(data.count)
               vm.responsesCount = data.count

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -5,7 +5,7 @@ const { triggerFileDownload } = require('../../helpers/util')
 
 const SHOW_PROGRESS_DELAY_MS = 3000
 
-const AdminFormService = require('../../../../services/AdminFormService')
+const AdminSubmissionsService = require('../../../../services/AdminSubmissionsService')
 
 angular
   .module('forms')
@@ -201,7 +201,7 @@ function ViewResponsesController(
     vm.currentView = 3
 
     $q.when(
-      AdminFormService.getEncryptedResponse({
+      AdminSubmissionsService.getEncryptedResponse({
         formId: vm.myform._id,
         submissionId,
       }),
@@ -268,7 +268,7 @@ function ViewResponsesController(
         'YYYY-MM-DD',
       )
     }
-    $q.when(AdminFormService.countFormSubmissions(params)).then(
+    $q.when(AdminSubmissionsService.countFormSubmissions(params)).then(
       (responsesCount) => {
         vm.attachmentsToDownload = responsesCount
         $uibModal
@@ -358,7 +358,9 @@ function ViewResponsesController(
   // When this route is initialized, call the responses count function
   $scope.$parent.$watch('vm.activeResultsTab', (newValue) => {
     if (newValue === 'responses' && vm.loading) {
-      $q.when(AdminFormService.countFormSubmissions({ formId: vm.myform._id }))
+      $q.when(
+        AdminSubmissionsService.countFormSubmissions({ formId: vm.myform._id }),
+      )
         .then((responsesCount) => {
           vm.responsesCount = responsesCount
           $timeout(() => {
@@ -404,7 +406,7 @@ function ViewResponsesController(
           let { page } = params.url()
           return $q
             .when(
-              AdminFormService.getFormsMetadata({
+              AdminSubmissionsService.getFormsMetadata({
                 formId: vm.myform._id,
                 submissionId: vm.filterBySubmissionRefId,
                 pageNum: page,

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -200,10 +200,12 @@ function ViewResponsesController(
     vm.loading = true
     vm.currentView = 3
 
-    Submissions.getEncryptedResponse({
-      formId: vm.myform._id,
-      submissionId,
-    }).then((response) => {
+    $q.when(
+      AdminFormService.getEncryptedResponse({
+        formId: vm.myform._id,
+        submissionId,
+      }),
+    ).then((response) => {
       if (vm.encryptionKey !== null) {
         vm.attachmentDownloadUrls = new Map()
 

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -407,11 +407,11 @@ function ViewResponsesController(
         getData: (params) => {
           let { page } = params.url()
           const getMetadataPromise = vm.filterBySubmissionRefId
-            ? AdminSubmissionsService.getFormMetadata({
+            ? AdminSubmissionsService.getFormMetadataById({
                 formId: vm.myform._id,
                 submissionId: vm.filterBySubmissionRefId,
               })
-            : AdminSubmissionsService.getFormsMetadata({
+            : AdminSubmissionsService.getFormsMetadataByPage({
                 formId: vm.myform._id,
                 pageNum: page,
               })

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -257,17 +257,19 @@ function ViewResponsesController(
   }
 
   vm.confirmSubmissionCountsBeforeDownload = function () {
-    let params = {
-      formId: vm.myform._id,
-    }
-    if (vm.datePicker.date.startDate && vm.datePicker.date.endDate) {
-      params.startDate = moment(new Date(vm.datePicker.date.startDate)).format(
-        'YYYY-MM-DD',
-      )
-      params.endDate = moment(new Date(vm.datePicker.date.endDate)).format(
-        'YYYY-MM-DD',
-      )
-    }
+    const { startDate, endDate } = vm.datePicker.date
+    const params =
+      startDate && endDate
+        ? {
+            formId: vm.myform._id,
+            date: {
+              startDate: moment(new Date(startDate)).format('YYYY-MM-DD'),
+              endDate: moment(new Date(endDate)).format('YYYY-MM-DD'),
+            },
+          }
+        : {
+            formId: vm.myform._id,
+          }
     $q.when(AdminSubmissionsService.countFormSubmissions(params)).then(
       (responsesCount) => {
         vm.attachmentsToDownload = responsesCount

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -76,7 +76,7 @@ function settingsFormDirective(
           })
           .catch((error) => {
             Toastr.error(
-              `Unfortunately, there was an error in displaying the number of responses. Please refresh and try again!`,
+              `There was an error in displaying the number of responses. Please refresh and try again.`,
             )
             console.log(error)
           })

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -1,7 +1,7 @@
 'use strict'
 const dedent = require('dedent-js')
 const { get, set, isEqual } = require('lodash')
-const AdminFormService = require('../../../../services/AdminFormService')
+const AdminSubmissionsService = require('../../../../services/AdminSubmissionsService')
 
 const SETTINGS_PATH = [
   'title',
@@ -67,7 +67,7 @@ function settingsFormDirective(
 
         $scope.currentResponsesCount = 0
         $q.when(
-          AdminFormService.countFormSubmissions({
+          AdminSubmissionsService.countFormSubmissions({
             formId: $scope.myform._id,
           }),
         )

--- a/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
+++ b/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const FormFeedbackService = require('../../../../services/FormFeedbackService')
+const AdminFormService = require('../../../../services/AdminFormService')
 
 angular
   .module('forms')
   .directive('viewFeedbackDirective', [
+    '$q',
     '$timeout',
     '$q',
     'Submissions',
@@ -14,6 +16,7 @@ angular
   ])
 
 function viewFeedbackDirective(
+  $q,
   $timeout,
   $q,
   Submissions,
@@ -67,16 +70,17 @@ function viewFeedbackDirective(
         // When this route is initialized, call the count function
         $scope.$parent.$watch('vm.activeResultsTab', (newValue) => {
           if (newValue === 'feedback' && $scope.loading) {
-            Submissions.count({
-              formId: $scope.myform._id,
-            }).then(
-              function (response) {
-                $scope.createFeedbackTable(response)
-              },
-              function (error) {
-                console.error(error)
-              },
+            $q.when(
+              AdminFormService.countFormSubmissions({
+                formId: $scope.myform._id,
+              }),
             )
+              .then(function (response) {
+                $scope.createFeedbackTable(response)
+              })
+              .catch(function (error) {
+                console.error(error)
+              })
           }
         })
 

--- a/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
+++ b/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const FormFeedbackService = require('../../../../services/FormFeedbackService')
-const AdminFormService = require('../../../../services/AdminFormService')
+const AdminSubmissionsService = require('../../../../services/AdminSubmissionsService')
 
 angular
   .module('forms')
@@ -71,7 +71,7 @@ function viewFeedbackDirective(
         $scope.$parent.$watch('vm.activeResultsTab', (newValue) => {
           if (newValue === 'feedback' && $scope.loading) {
             $q.when(
-              AdminFormService.countFormSubmissions({
+              AdminSubmissionsService.countFormSubmissions({
                 formId: $scope.myform._id,
               }),
             )

--- a/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
+++ b/src/public/modules/forms/admin/directives/view-feedback.client.directive.js
@@ -8,21 +8,12 @@ angular
   .directive('viewFeedbackDirective', [
     '$q',
     '$timeout',
-    '$q',
-    'Submissions',
     'NgTableParams',
     'emoji',
     viewFeedbackDirective,
   ])
 
-function viewFeedbackDirective(
-  $q,
-  $timeout,
-  $q,
-  Submissions,
-  NgTableParams,
-  emoji,
-) {
+function viewFeedbackDirective($q, $timeout, NgTableParams, emoji) {
   return {
     templateUrl:
       'modules/forms/admin/directiveViews/view-feedback.client.view.html',

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -18,7 +18,6 @@ angular
     '$timeout',
     '$window',
     'GTag',
-    'responseModeEnum',
     'FormSgSdk',
     SubmissionsFactory,
   ])
@@ -31,15 +30,7 @@ function killWorkers(pool) {
   pool.forEach((worker) => worker.terminate())
 }
 
-function SubmissionsFactory(
-  $q,
-  $http,
-  $timeout,
-  $window,
-  GTag,
-  responseModeEnum,
-  FormSgSdk,
-) {
+function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
   const ADMIN_FORMS_PREFIX = '/api/v3/admin/forms'
 
   const generateDownloadUrl = (params, downloadAttachments) => {
@@ -78,6 +69,7 @@ function SubmissionsFactory(
       )
       return deferred.promise
     },
+
     getMetadata: function (params) {
       const deferred = $q.defer()
       let resUrl = `${fixParamsToUrl(

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -49,48 +49,6 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
   }
 
   const submissionService = {
-    count: function (params) {
-      const deferred = $q.defer()
-      let resUrl = fixParamsToUrl(
-        params,
-        `${ADMIN_FORMS_PREFIX}/:formId/submissions/count`,
-      )
-      if (params.startDate && params.endDate) {
-        resUrl += `?startDate=${params.startDate}&endDate=${params.endDate}`
-      }
-
-      $http.get(resUrl).then(
-        function (response) {
-          deferred.resolve(response.data)
-        },
-        function () {
-          deferred.reject('Submissions count cannot be obtained.')
-        },
-      )
-      return deferred.promise
-    },
-
-    getMetadata: function (params) {
-      const deferred = $q.defer()
-      let resUrl = `${fixParamsToUrl(
-        params,
-        `${ADMIN_FORMS_PREFIX}/:formId/submissions/metadata`,
-      )}?page=${params.page}`
-
-      if (params.filterBySubmissionRefId) {
-        resUrl += `&submissionId=${params.filterBySubmissionRefId}`
-      }
-
-      $http.get(resUrl).then(
-        function (response) {
-          deferred.resolve(response.data)
-        },
-        function () {
-          deferred.reject('Submissions: Responses cannot be obtained.')
-        },
-      )
-      return deferred.promise
-    },
     getEncryptedResponse: function (params) {
       const deferred = $q.defer()
       const resUrl = `${fixParamsToUrl(
@@ -177,6 +135,7 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
       // Creates a new AbortController for every request
       downloadAbortController = new AbortController()
 
+      // TODO: change this to AdminFormService.countFormSubmissions
       return this.count(params).then((expectedNumResponses) => {
         return new Promise(function (resolve, reject) {
           // No responses expected

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -124,8 +124,7 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
         .when(
           AdminSubmissionsService.countFormSubmissions({
             formId,
-            startDate,
-            endDate,
+            date: { startDate, endDate },
           }),
         )
         .then((expectedNumResponses) => {

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -7,6 +7,7 @@ const ndjsonStream = require('../helpers/ndjsonStream')
 const fetchStream = require('fetch-readablestream')
 const { decode: decodeBase64 } = require('@stablelib/base64')
 const JSZip = require('jszip')
+const AdminFormService = require('../../../services/AdminFormService')
 
 const NUM_OF_METADATA_ROWS = 5
 
@@ -49,23 +50,6 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
   }
 
   const submissionService = {
-    getEncryptedResponse: function (params) {
-      const deferred = $q.defer()
-      const resUrl = `${fixParamsToUrl(
-        params,
-        `${ADMIN_FORMS_PREFIX}/:formId/submissions/:submissionId`,
-      )}`
-
-      $http.get(resUrl).then(
-        function (response) {
-          deferred.resolve(response.data)
-        },
-        function () {
-          deferred.reject('Submissions: Specific response cannot be obtained.')
-        },
-      )
-      return deferred.promise
-    },
     /**
      * Triggers a download of a set of attachments as a zip file when given attachment metadata and a secret key
      * @param {Map} attachmentDownloadUrls Map of question number to individual attachment metadata (object with url and filename properties)
@@ -134,210 +118,221 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
       workerPool = []
       // Creates a new AbortController for every request
       downloadAbortController = new AbortController()
+      const { formId, startDate, endDate } = params
 
-      // TODO: change this to AdminFormService.countFormSubmissions
-      return this.count(params).then((expectedNumResponses) => {
-        return new Promise(function (resolve, reject) {
-          // No responses expected
-          if (expectedNumResponses === 0) {
-            return resolve({
-              expectedCount: 0,
-              successCount: 0,
-              errorCount: 0,
-            })
-          }
-
-          let resUrl = generateDownloadUrl(params, downloadAttachments)
-          let experimentalCsvGenerator = new CsvMHGenerator(
-            expectedNumResponses,
-            NUM_OF_METADATA_ROWS,
-          )
-          let attachmentErrorCount = 0
-          let errorCount = 0
-          let unverifiedCount = 0
-          let receivedRecordCount = 0
-
-          // Create a pool of decryption workers
-          // If we are downloading attachments, we restrict the number of threads
-          // to one to limit resource usage on the client's browser.
-          const numWorkers = downloadAttachments
-            ? 1
-            : $window.navigator.hardwareConcurrency || 4
-
-          // Trigger analytics here before starting decryption worker.
-          GTag.downloadResponseStart(params, expectedNumResponses, numWorkers)
-
-          for (let i = 0; i < numWorkers; i++) {
-            workerPool.push(new DecryptionWorker())
-          }
-
-          // Configure each worker
-          workerPool.forEach((worker) => {
-            // When worker returns a decrypted message
-            worker.onmessage = (event) => {
-              const { data } = event
-              const { csvRecord } = data
-
-              if (csvRecord.status === 'ATTACHMENT_ERROR') {
-                attachmentErrorCount++
-                errorCount++
-              } else if (csvRecord.status === 'ERROR') {
-                errorCount++
-              } else if (csvRecord.status === 'UNVERIFIED') {
-                unverifiedCount++
-              }
-
-              if (csvRecord.submissionData) {
-                // accumulate dataset if it exists, since we may have status columns available
-                experimentalCsvGenerator.addRecord(csvRecord.submissionData)
-              }
-
-              if (downloadAttachments && csvRecord.downloadBlob) {
-                triggerFileDownload(
-                  csvRecord.downloadBlob,
-                  'RefNo ' + csvRecord.id + '.zip',
-                )
-              }
-            }
-            // When worker fails to decrypt a message
-            worker.onerror = (error) => {
-              errorCount++
-              console.error('EncryptionWorker Error', error)
+      return $q
+        .when(
+          AdminFormService.countFormSubmissions({ formId, startDate, endDate }),
+        )
+        .then((expectedNumResponses) => {
+          return new Promise(function (resolve, reject) {
+            // No responses expected
+            if (expectedNumResponses === 0) {
+              return resolve({
+                expectedCount: 0,
+                successCount: 0,
+                errorCount: 0,
+              })
             }
 
-            // Initiate all workers with formsgSdkMode so they can spin up
-            // formsg sdk with the correct keys.
-            worker.postMessage({
-              init: true,
-              formsgSdkMode: $window.formsgSdkMode,
-            })
-          })
+            let resUrl = generateDownloadUrl(params, downloadAttachments)
+            let experimentalCsvGenerator = new CsvMHGenerator(
+              expectedNumResponses,
+              NUM_OF_METADATA_ROWS,
+            )
+            let attachmentErrorCount = 0
+            let errorCount = 0
+            let unverifiedCount = 0
+            let receivedRecordCount = 0
 
-          let downloadStartTime
-          fetchStream(resUrl, { signal: downloadAbortController.signal })
-            .then((response) => ndjsonStream(response.body))
-            .then((stream) => {
-              downloadStartTime = performance.now()
-              const reader = stream.getReader()
-              let read
-              reader
-                .read()
-                .then(
-                  (read = (result) => {
-                    if (result.done) return
-                    try {
-                      // round-robin scheduling
-                      workerPool[receivedRecordCount % numWorkers].postMessage({
-                        line: result.value,
-                        secretKey,
-                        downloadAttachments,
-                      })
-                      receivedRecordCount++
-                    } catch (error) {
-                      console.error('Error parsing JSON', error)
+            // Create a pool of decryption workers
+            // If we are downloading attachments, we restrict the number of threads
+            // to one to limit resource usage on the client's browser.
+            const numWorkers = downloadAttachments
+              ? 1
+              : $window.navigator.hardwareConcurrency || 4
+
+            // Trigger analytics here before starting decryption worker.
+            GTag.downloadResponseStart(params, expectedNumResponses, numWorkers)
+
+            for (let i = 0; i < numWorkers; i++) {
+              workerPool.push(new DecryptionWorker())
+            }
+
+            // Configure each worker
+            workerPool.forEach((worker) => {
+              // When worker returns a decrypted message
+              worker.onmessage = (event) => {
+                const { data } = event
+                const { csvRecord } = data
+
+                if (csvRecord.status === 'ATTACHMENT_ERROR') {
+                  attachmentErrorCount++
+                  errorCount++
+                } else if (csvRecord.status === 'ERROR') {
+                  errorCount++
+                } else if (csvRecord.status === 'UNVERIFIED') {
+                  unverifiedCount++
+                }
+
+                if (csvRecord.submissionData) {
+                  // accumulate dataset if it exists, since we may have status columns available
+                  experimentalCsvGenerator.addRecord(csvRecord.submissionData)
+                }
+
+                if (downloadAttachments && csvRecord.downloadBlob) {
+                  triggerFileDownload(
+                    csvRecord.downloadBlob,
+                    'RefNo ' + csvRecord.id + '.zip',
+                  )
+                }
+              }
+              // When worker fails to decrypt a message
+              worker.onerror = (error) => {
+                errorCount++
+                console.error('EncryptionWorker Error', error)
+              }
+
+              // Initiate all workers with formsgSdkMode so they can spin up
+              // formsg sdk with the correct keys.
+              worker.postMessage({
+                init: true,
+                formsgSdkMode: $window.formsgSdkMode,
+              })
+            })
+
+            let downloadStartTime
+            fetchStream(resUrl, { signal: downloadAbortController.signal })
+              .then((response) => ndjsonStream(response.body))
+              .then((stream) => {
+                downloadStartTime = performance.now()
+                const reader = stream.getReader()
+                let read
+                reader
+                  .read()
+                  .then(
+                    (read = (result) => {
+                      if (result.done) return
+                      try {
+                        // round-robin scheduling
+                        workerPool[
+                          receivedRecordCount % numWorkers
+                        ].postMessage({
+                          line: result.value,
+                          secretKey,
+                          downloadAttachments,
+                        })
+                        receivedRecordCount++
+                      } catch (error) {
+                        console.error('Error parsing JSON', error)
+                      }
+
+                      reader.read().then(read) // recurse through the stream
+                    }),
+                  )
+                  .catch((err) => {
+                    if (!downloadStartTime) {
+                      // No start time, means did not even start http request.
+                      GTag.downloadNetworkFailure(params, err)
+                    } else {
+                      const downloadFailedTime = performance.now()
+                      const timeDifference =
+                        downloadFailedTime - downloadStartTime
+                      // Google analytics tracking for failure.
+                      GTag.downloadResponseFailure(
+                        params,
+                        numWorkers,
+                        expectedNumResponses,
+                        timeDifference,
+                        err,
+                      )
                     }
 
-                    reader.read().then(read) // recurse through the stream
-                  }),
-                )
-                .catch((err) => {
-                  if (!downloadStartTime) {
-                    // No start time, means did not even start http request.
-                    GTag.downloadNetworkFailure(params, err)
-                  } else {
-                    const downloadFailedTime = performance.now()
-                    const timeDifference =
-                      downloadFailedTime - downloadStartTime
-                    // Google analytics tracking for failure.
-                    GTag.downloadResponseFailure(
-                      params,
-                      numWorkers,
-                      expectedNumResponses,
-                      timeDifference,
+                    console.error(
+                      'Failed to download data, is there a network issue?',
                       err,
                     )
-                  }
+                    killWorkers(workerPool)
+                    reject(err)
+                  })
+                  .finally(() => {
+                    function checkComplete() {
+                      // If all the records could not be decrypted
+                      if (
+                        errorCount + unverifiedCount ===
+                        expectedNumResponses
+                      ) {
+                        const failureEndTime = performance.now()
+                        const timeDifference =
+                          failureEndTime - downloadStartTime
+                        // Google analytics tracking for partial decrypt
+                        // failure.
+                        GTag.partialDecryptionFailure(
+                          params,
+                          numWorkers,
+                          experimentalCsvGenerator.length(),
+                          errorCount,
+                          attachmentErrorCount,
+                          timeDifference,
+                        )
+                        killWorkers(workerPool)
+                        reject(
+                          new Error(
+                            JSON.stringify({
+                              expectedCount: expectedNumResponses,
+                              successCount: experimentalCsvGenerator.length(),
+                              errorCount,
+                              unverifiedCount,
+                            }),
+                          ),
+                        )
+                      } else if (
+                        // All results have been decrypted
+                        experimentalCsvGenerator.length() +
+                          errorCount +
+                          unverifiedCount >=
+                        expectedNumResponses
+                      ) {
+                        killWorkers(workerPool)
+                        // Generate first three rows of meta-data before download
+                        experimentalCsvGenerator.addMetaDataFromSubmission(
+                          errorCount,
+                          unverifiedCount,
+                        )
+                        experimentalCsvGenerator.downloadCsv(
+                          `${params.formTitle}-${params.formId}.csv`,
+                        )
 
-                  console.error(
-                    'Failed to download data, is there a network issue?',
-                    err,
-                  )
-                  killWorkers(workerPool)
-                  reject(err)
-                })
-                .finally(() => {
-                  function checkComplete() {
-                    // If all the records could not be decrypted
-                    if (errorCount + unverifiedCount === expectedNumResponses) {
-                      const failureEndTime = performance.now()
-                      const timeDifference = failureEndTime - downloadStartTime
-                      // Google analytics tracking for partial decrypt
-                      // failure.
-                      GTag.partialDecryptionFailure(
-                        params,
-                        numWorkers,
-                        experimentalCsvGenerator.length(),
-                        errorCount,
-                        attachmentErrorCount,
-                        timeDifference,
-                      )
-                      killWorkers(workerPool)
-                      reject(
-                        new Error(
-                          JSON.stringify({
-                            expectedCount: expectedNumResponses,
-                            successCount: experimentalCsvGenerator.length(),
-                            errorCount,
-                            unverifiedCount,
-                          }),
-                        ),
-                      )
-                    } else if (
-                      // All results have been decrypted
-                      experimentalCsvGenerator.length() +
-                        errorCount +
-                        unverifiedCount >=
-                      expectedNumResponses
-                    ) {
-                      killWorkers(workerPool)
-                      // Generate first three rows of meta-data before download
-                      experimentalCsvGenerator.addMetaDataFromSubmission(
-                        errorCount,
-                        unverifiedCount,
-                      )
-                      experimentalCsvGenerator.downloadCsv(
-                        `${params.formTitle}-${params.formId}.csv`,
-                      )
+                        const downloadEndTime = performance.now()
+                        const timeDifference =
+                          downloadEndTime - downloadStartTime
 
-                      const downloadEndTime = performance.now()
-                      const timeDifference = downloadEndTime - downloadStartTime
+                        // Google analytics tracking for success.
+                        GTag.downloadResponseSuccess(
+                          params,
+                          numWorkers,
+                          experimentalCsvGenerator.length(),
+                          timeDifference,
+                        )
 
-                      // Google analytics tracking for success.
-                      GTag.downloadResponseSuccess(
-                        params,
-                        numWorkers,
-                        experimentalCsvGenerator.length(),
-                        timeDifference,
-                      )
-
-                      resolve({
-                        expectedCount: expectedNumResponses,
-                        successCount: experimentalCsvGenerator.length(),
-                        errorCount,
-                        unverifiedCount,
-                      })
-                      // Kill class instance and reclaim the memory.
-                      experimentalCsvGenerator = null
-                    } else {
-                      $timeout(checkComplete, 100)
+                        resolve({
+                          expectedCount: expectedNumResponses,
+                          successCount: experimentalCsvGenerator.length(),
+                          errorCount,
+                          unverifiedCount,
+                        })
+                        // Kill class instance and reclaim the memory.
+                        experimentalCsvGenerator = null
+                      } else {
+                        $timeout(checkComplete, 100)
+                      }
                     }
-                  }
 
-                  checkComplete()
-                })
-            })
+                    checkComplete()
+                  })
+              })
+          })
         })
-      })
     },
   }
   return submissionService

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -7,7 +7,7 @@ const ndjsonStream = require('../helpers/ndjsonStream')
 const fetchStream = require('fetch-readablestream')
 const { decode: decodeBase64 } = require('@stablelib/base64')
 const JSZip = require('jszip')
-const AdminFormService = require('../../../services/AdminFormService')
+const AdminSubmissionsService = require('../../../services/AdminSubmissionsService')
 
 const NUM_OF_METADATA_ROWS = 5
 
@@ -122,7 +122,11 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
 
       return $q
         .when(
-          AdminFormService.countFormSubmissions({ formId, startDate, endDate }),
+          AdminSubmissionsService.countFormSubmissions({
+            formId,
+            startDate,
+            endDate,
+          }),
         )
         .then((expectedNumResponses) => {
           return new Promise(function (resolve, reject) {

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -1,6 +1,11 @@
 import axios from 'axios'
 
-import { FormSettings, LogicDto, SubmissionMetadataList } from '../../types'
+import {
+  EncryptedSubmissionDto,
+  FormSettings,
+  LogicDto,
+  SubmissionMetadataList,
+} from '../../types'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
@@ -11,9 +16,10 @@ import {
   PermissionsUpdateDto,
   SettingsUpdateDto,
   StartPageUpdateDto,
-  SubmissionCountDto,
-  SubmissionMetadataDto,
+  SubmissionCountQueryDto,
+  SubmissionMetadataQueryDto,
   SubmissionResponseDto,
+  SubmissionResponseQueryDto,
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'
 
@@ -267,7 +273,7 @@ export const countFormSubmissions = async ({
   formId,
   startDate,
   endDate,
-}: SubmissionCountDto): Promise<number> => {
+}: SubmissionCountQueryDto): Promise<number> => {
   const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
   if (startDate && endDate) {
     return axios
@@ -290,13 +296,27 @@ export const getFormsMetadata = async ({
   formId,
   submissionId,
   pageNum,
-}: SubmissionMetadataDto): Promise<SubmissionMetadataList> => {
-  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`
+}: SubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
   const params = submissionId ? { submissionId } : { page: pageNum }
 
   return axios
-    .get(queryUrl, {
+    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`, {
       params,
     })
+    .then(({ data }) => data)
+}
+
+/**
+ * Returns the data of a single submission of a given storage mode form
+ * @param formId The id of the form to query
+ * @param submissionId The id of the submission
+ * @returns The data of the submission
+ */
+export const getEncryptedResponse = ({
+  formId,
+  submissionId,
+}: SubmissionResponseQueryDto): Promise<EncryptedSubmissionDto> => {
+  return axios
+    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/${submissionId}`)
     .then(({ data }) => data)
 }

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -11,6 +11,7 @@ import {
   PermissionsUpdateDto,
   SettingsUpdateDto,
   StartPageUpdateDto,
+  SubmissionCountDto,
   SubmissionResponseDto,
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'
@@ -253,4 +254,23 @@ export const submitStorageModeFormPreview = async ({
       },
     )
     .then(({ data }) => data)
+}
+
+/**
+ * Counts the number of submissions for a given form
+ * @param urlParameters Mapping of the url parameters to values
+ * @returns The number of form submissions
+ */
+export const countFormSubmissions = async ({
+  formId,
+  startDate,
+  endDate,
+}: SubmissionCountDto): Promise<number> => {
+  let queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
+
+  if (startDate && endDate) {
+    queryUrl += `?startDate=${startDate}&endDate=${endDate}`
+  }
+
+  return axios.get(queryUrl).then(({ data }) => data)
 }

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { FormSettings, LogicDto } from '../../types'
+import { FormSettings, LogicDto, SubmissionMetadataList } from '../../types'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
@@ -12,6 +12,7 @@ import {
   SettingsUpdateDto,
   StartPageUpdateDto,
   SubmissionCountDto,
+  SubmissionMetadataDto,
   SubmissionResponseDto,
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'
@@ -267,11 +268,35 @@ export const countFormSubmissions = async ({
   startDate,
   endDate,
 }: SubmissionCountDto): Promise<number> => {
-  let queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
-
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
   if (startDate && endDate) {
-    queryUrl += `?startDate=${startDate}&endDate=${endDate}`
+    return axios
+      .get(queryUrl, {
+        params: { startDate, endDate },
+      })
+      .then(({ data }) => data)
   }
-
   return axios.get(queryUrl).then(({ data }) => data)
+}
+
+/**
+ * Retrieves the metadata for either a page of submission or a single submissionId if submissionId is specified
+ * @param formId The id of the form to retrieve submission for
+ * @param submissionId The id of the specified submission to retrieve
+ * @param pageNum The page number of the responses
+ * @returns The metadata of the form
+ */
+export const getFormsMetadata = async ({
+  formId,
+  submissionId,
+  pageNum,
+}: SubmissionMetadataDto): Promise<SubmissionMetadataList> => {
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`
+  const params = submissionId ? { submissionId } : { page: pageNum }
+
+  return axios
+    .get(queryUrl, {
+      params,
+    })
+    .then(({ data }) => data)
 }

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -16,7 +16,8 @@ import {
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'
 
-const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
+// Exported for testing
+export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
 
 export const updateFormSettings = async (
   formId: string,

--- a/src/public/services/AdminFormService.ts
+++ b/src/public/services/AdminFormService.ts
@@ -1,11 +1,6 @@
 import axios from 'axios'
 
-import {
-  EncryptedSubmissionDto,
-  FormSettings,
-  LogicDto,
-  SubmissionMetadataList,
-} from '../../types'
+import { FormSettings, LogicDto } from '../../types'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
@@ -16,10 +11,7 @@ import {
   PermissionsUpdateDto,
   SettingsUpdateDto,
   StartPageUpdateDto,
-  SubmissionCountQueryDto,
-  SubmissionMetadataQueryDto,
   SubmissionResponseDto,
-  SubmissionResponseQueryDto,
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'
 
@@ -261,62 +253,5 @@ export const submitStorageModeFormPreview = async ({
         },
       },
     )
-    .then(({ data }) => data)
-}
-
-/**
- * Counts the number of submissions for a given form
- * @param urlParameters Mapping of the url parameters to values
- * @returns The number of form submissions
- */
-export const countFormSubmissions = async ({
-  formId,
-  startDate,
-  endDate,
-}: SubmissionCountQueryDto): Promise<number> => {
-  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
-  if (startDate && endDate) {
-    return axios
-      .get(queryUrl, {
-        params: { startDate, endDate },
-      })
-      .then(({ data }) => data)
-  }
-  return axios.get(queryUrl).then(({ data }) => data)
-}
-
-/**
- * Retrieves the metadata for either a page of submission or a single submissionId if submissionId is specified
- * @param formId The id of the form to retrieve submission for
- * @param submissionId The id of the specified submission to retrieve
- * @param pageNum The page number of the responses
- * @returns The metadata of the form
- */
-export const getFormsMetadata = async ({
-  formId,
-  submissionId,
-  pageNum,
-}: SubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
-  const params = submissionId ? { submissionId } : { page: pageNum }
-
-  return axios
-    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`, {
-      params,
-    })
-    .then(({ data }) => data)
-}
-
-/**
- * Returns the data of a single submission of a given storage mode form
- * @param formId The id of the form to query
- * @param submissionId The id of the submission
- * @returns The data of the submission
- */
-export const getEncryptedResponse = ({
-  formId,
-  submissionId,
-}: SubmissionResponseQueryDto): Promise<EncryptedSubmissionDto> => {
-  return axios
-    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/${submissionId}`)
     .then(({ data }) => data)
 }

--- a/src/public/services/AdminSubmissionsService.ts
+++ b/src/public/services/AdminSubmissionsService.ts
@@ -1,0 +1,67 @@
+import axios from 'axios'
+
+import { EncryptedSubmissionDto, SubmissionMetadataList } from 'src/types'
+import {
+  SubmissionCountQueryDto,
+  SubmissionMetadataQueryDto,
+  SubmissionResponseQueryDto,
+} from 'src/types/api'
+
+import { ADMIN_FORM_ENDPOINT } from './AdminFormService'
+
+/**
+ * Counts the number of submissions for a given form
+ * @param urlParameters Mapping of the url parameters to values
+ * @returns The number of form submissions
+ */
+export const countFormSubmissions = async ({
+  formId,
+  startDate,
+  endDate,
+}: SubmissionCountQueryDto): Promise<number> => {
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
+  if (startDate && endDate) {
+    return axios
+      .get(queryUrl, {
+        params: { startDate, endDate },
+      })
+      .then(({ data }) => data)
+  }
+  return axios.get(queryUrl).then(({ data }) => data)
+}
+
+/**
+ * Retrieves the metadata for either a page of submission or a single submissionId if submissionId is specified
+ * @param formId The id of the form to retrieve submission for
+ * @param submissionId The id of the specified submission to retrieve
+ * @param pageNum The page number of the responses
+ * @returns The metadata of the form
+ */
+export const getFormsMetadata = async ({
+  formId,
+  submissionId,
+  pageNum,
+}: SubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
+  const params = submissionId ? { submissionId } : { page: pageNum }
+
+  return axios
+    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`, {
+      params,
+    })
+    .then(({ data }) => data)
+}
+
+/**
+ * Returns the data of a single submission of a given storage mode form
+ * @param formId The id of the form to query
+ * @param submissionId The id of the submission
+ * @returns The data of the submission
+ */
+export const getEncryptedResponse = ({
+  formId,
+  submissionId,
+}: SubmissionResponseQueryDto): Promise<EncryptedSubmissionDto> => {
+  return axios
+    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/${submissionId}`)
+    .then(({ data }) => data)
+}

--- a/src/public/services/AdminSubmissionsService.ts
+++ b/src/public/services/AdminSubmissionsService.ts
@@ -2,8 +2,9 @@ import axios from 'axios'
 
 import { EncryptedSubmissionDto, SubmissionMetadataList } from 'src/types'
 import {
+  FormsSubmissionMetadataQueryDto,
+  FormSubmissionMetadataQueryDto,
   SubmissionCountQueryDto,
-  SubmissionMetadataQueryDto,
   SubmissionResponseQueryDto,
 } from 'src/types/api'
 
@@ -30,22 +31,39 @@ export const countFormSubmissions = async ({
 }
 
 /**
- * Retrieves the metadata for either a page of submission or a single submissionId if submissionId is specified
+ * Retrieves the metadata for a page of submissions
  * @param formId The id of the form to retrieve submission for
- * @param submissionId The id of the specified submission to retrieve
  * @param pageNum The page number of the responses
- * @returns The metadata of the form
+ * @returns The metadata of the page of forms
  */
 export const getFormsMetadata = async ({
   formId,
-  submissionId,
   pageNum,
-}: SubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
-  const params = submissionId ? { submissionId } : { page: pageNum }
-
+}: FormsSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
   return axios
     .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`, {
-      params,
+      params: {
+        page: pageNum,
+      },
+    })
+    .then(({ data }) => data)
+}
+
+/**
+ * Retrieves the metadata for a single submissionId if submissionId is specified
+ * @param formId The id of the form to retrieve submission for
+ * @param submissionId The id of the specified submission to retrieve
+ * @returns The metadata of the form
+ */
+export const getFormMetadata = async ({
+  formId,
+  submissionId,
+}: FormSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
+  return axios
+    .get(`${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`, {
+      params: {
+        submissionId,
+      },
     })
     .then(({ data }) => data)
 }
@@ -56,7 +74,7 @@ export const getFormsMetadata = async ({
  * @param submissionId The id of the submission
  * @returns The data of the submission
  */
-export const getEncryptedResponse = ({
+export const getEncryptedResponse = async ({
   formId,
   submissionId,
 }: SubmissionResponseQueryDto): Promise<EncryptedSubmissionDto> => {

--- a/src/public/services/AdminSubmissionsService.ts
+++ b/src/public/services/AdminSubmissionsService.ts
@@ -36,7 +36,7 @@ export const countFormSubmissions = async ({
  * @param pageNum The page number of the responses
  * @returns The metadata of the page of forms
  */
-export const getFormsMetadata = async ({
+export const getFormsMetadataByPage = async ({
   formId,
   pageNum,
 }: FormsSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
@@ -55,7 +55,7 @@ export const getFormsMetadata = async ({
  * @param submissionId The id of the specified submission to retrieve
  * @returns The metadata of the form
  */
-export const getFormMetadata = async ({
+export const getFormMetadataById = async ({
   formId,
   submissionId,
 }: FormSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {

--- a/src/public/services/AdminSubmissionsService.ts
+++ b/src/public/services/AdminSubmissionsService.ts
@@ -16,14 +16,13 @@ import { ADMIN_FORM_ENDPOINT } from './AdminFormService'
  */
 export const countFormSubmissions = async ({
   formId,
-  startDate,
-  endDate,
+  dates,
 }: SubmissionCountQueryDto): Promise<number> => {
   const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
-  if (startDate && endDate) {
+  if (dates) {
     return axios
       .get(queryUrl, {
-        params: { startDate, endDate },
+        params: { ...dates },
       })
       .then(({ data }) => data)
   }

--- a/src/public/services/__tests__/AdminFormService.test.ts
+++ b/src/public/services/__tests__/AdminFormService.test.ts
@@ -12,6 +12,7 @@ import * as SubmissionUtil from '../../utils/submission'
 import {
   ADMIN_FORM_ENDPOINT,
   countFormSubmissions,
+  getEncryptedResponse,
   getFormsMetadata,
   submitEmailModeFormPreview,
   submitStorageModeFormPreview,
@@ -272,6 +273,33 @@ describe('AdminFormService', () => {
             page: MOCK_PAGE_NUM,
           },
         },
+      )
+    })
+  })
+
+  describe('getEncryptedResponse', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_SUBMISSION_ID = 'fake'
+    const MOCK_RESPONSE = {
+      refNo: '1',
+      submissionTime: 'sometime',
+      content: 'jk',
+      verified: 'whups',
+      attachmentMetadata: {},
+    }
+
+    it('should call the api correctly when the parameters are valid', async () => {
+      // Act
+      const actual = getEncryptedResponse({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/${MOCK_SUBMISSION_ID}`,
       )
     })
   })

--- a/src/public/services/__tests__/AdminFormService.test.ts
+++ b/src/public/services/__tests__/AdminFormService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import MockAxios from 'jest-mock-axios'
 
-import { BasicField } from 'src/types'
+import { BasicField, SubmissionMetadataList } from 'src/types'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
@@ -12,6 +12,7 @@ import * as SubmissionUtil from '../../utils/submission'
 import {
   ADMIN_FORM_ENDPOINT,
   countFormSubmissions,
+  getFormsMetadata,
   submitEmailModeFormPreview,
   submitStorageModeFormPreview,
 } from '../AdminFormService'
@@ -179,7 +180,13 @@ describe('AdminFormService', () => {
       // Assert
       await expect(actual).resolves.toEqual(123)
       expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count?startDate=${MOCK_START_DATE}&endDate=${MOCK_END_DATE}`,
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+        {
+          params: {
+            startDate: MOCK_START_DATE,
+            endDate: MOCK_END_DATE,
+          },
+        },
       )
     })
 
@@ -209,6 +216,62 @@ describe('AdminFormService', () => {
       await expect(actual).resolves.toEqual(123)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+      )
+    })
+  })
+
+  describe('getFormsMetadata', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_SUBMISSION_ID = 'fake'
+    const MOCK_PAGE_NUM = 1
+    const MOCK_RESPONSE: SubmissionMetadataList = {
+      count: 1,
+      metadata: [
+        {
+          number: 1,
+          refNo: '1234',
+          submissionTime: 'sometime',
+        },
+      ],
+    }
+    it('should call the api with only submissionId when both parameters are provided', async () => {
+      // Act
+      const actual = getFormsMetadata({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+        pageNum: MOCK_PAGE_NUM,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
+        {
+          params: {
+            submissionId: MOCK_SUBMISSION_ID,
+          },
+        },
+      )
+    })
+
+    it('should call the api correctly when a single parameter is provided', async () => {
+      // Act
+      const actual = getFormsMetadata({
+        formId: MOCK_FORM_ID,
+        pageNum: MOCK_PAGE_NUM,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
+        {
+          params: {
+            page: MOCK_PAGE_NUM,
+          },
+        },
       )
     })
   })

--- a/src/public/services/__tests__/AdminFormService.test.ts
+++ b/src/public/services/__tests__/AdminFormService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import MockAxios from 'jest-mock-axios'
 
-import { BasicField, SubmissionMetadataList } from 'src/types'
+import { BasicField } from 'src/types'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
@@ -10,10 +10,6 @@ import {
 
 import * as SubmissionUtil from '../../utils/submission'
 import {
-  ADMIN_FORM_ENDPOINT,
-  countFormSubmissions,
-  getEncryptedResponse,
-  getFormsMetadata,
   submitEmailModeFormPreview,
   submitStorageModeFormPreview,
 } from '../AdminFormService'
@@ -160,146 +156,6 @@ describe('AdminFormService', () => {
         MOCK_CONTENT,
         // Should default to stringified null
         { params: { captchaResponse: 'null' } },
-      )
-    })
-  })
-
-  describe('countFormSubmissions', () => {
-    const MOCK_FORM_ID = 'mock–form-id'
-    const MOCK_START_DATE = new Date(2020, 11, 17)
-    const MOCK_END_DATE = new Date(2021, 1, 10)
-
-    it('should call api successfully when all parameters are provided', async () => {
-      // Act
-      const actual = countFormSubmissions({
-        formId: MOCK_FORM_ID,
-        startDate: MOCK_START_DATE,
-        endDate: MOCK_END_DATE,
-      })
-      MockAxios.mockResponse({ data: 123 })
-
-      // Assert
-      await expect(actual).resolves.toEqual(123)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
-        {
-          params: {
-            startDate: MOCK_START_DATE,
-            endDate: MOCK_END_DATE,
-          },
-        },
-      )
-    })
-
-    it('should call api successfully when only formId is provided', async () => {
-      // Act
-      const actual = countFormSubmissions({
-        formId: MOCK_FORM_ID,
-      })
-      MockAxios.mockResponse({ data: 123 })
-
-      // Assert
-      await expect(actual).resolves.toEqual(123)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
-      )
-    })
-
-    it('should call api successfully with only formId when startDate or endDate is provided', async () => {
-      // Act
-      const actual = countFormSubmissions({
-        formId: MOCK_FORM_ID,
-        startDate: MOCK_START_DATE,
-      })
-      MockAxios.mockResponse({ data: 123 })
-
-      // Assert
-      await expect(actual).resolves.toEqual(123)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
-      )
-    })
-  })
-
-  describe('getFormsMetadata', () => {
-    const MOCK_FORM_ID = 'mock–form-id'
-    const MOCK_SUBMISSION_ID = 'fake'
-    const MOCK_PAGE_NUM = 1
-    const MOCK_RESPONSE: SubmissionMetadataList = {
-      count: 1,
-      metadata: [
-        {
-          number: 1,
-          refNo: '1234',
-          submissionTime: 'sometime',
-        },
-      ],
-    }
-    it('should call the api with only submissionId when both parameters are provided', async () => {
-      // Act
-      const actual = getFormsMetadata({
-        formId: MOCK_FORM_ID,
-        submissionId: MOCK_SUBMISSION_ID,
-        pageNum: MOCK_PAGE_NUM,
-      })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
-
-      // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
-        {
-          params: {
-            submissionId: MOCK_SUBMISSION_ID,
-          },
-        },
-      )
-    })
-
-    it('should call the api correctly when a single parameter is provided', async () => {
-      // Act
-      const actual = getFormsMetadata({
-        formId: MOCK_FORM_ID,
-        pageNum: MOCK_PAGE_NUM,
-      })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
-
-      // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
-        {
-          params: {
-            page: MOCK_PAGE_NUM,
-          },
-        },
-      )
-    })
-  })
-
-  describe('getEncryptedResponse', () => {
-    const MOCK_FORM_ID = 'mock–form-id'
-    const MOCK_SUBMISSION_ID = 'fake'
-    const MOCK_RESPONSE = {
-      refNo: '1',
-      submissionTime: 'sometime',
-      content: 'jk',
-      verified: 'whups',
-      attachmentMetadata: {},
-    }
-
-    it('should call the api correctly when the parameters are valid', async () => {
-      // Act
-      const actual = getEncryptedResponse({
-        formId: MOCK_FORM_ID,
-        submissionId: MOCK_SUBMISSION_ID,
-      })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
-
-      // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/${MOCK_SUBMISSION_ID}`,
       )
     })
   })

--- a/src/public/services/__tests__/AdminFormService.test.ts
+++ b/src/public/services/__tests__/AdminFormService.test.ts
@@ -10,6 +10,8 @@ import {
 
 import * as SubmissionUtil from '../../utils/submission'
 import {
+  ADMIN_FORM_ENDPOINT,
+  countFormSubmissions,
   submitEmailModeFormPreview,
   submitStorageModeFormPreview,
 } from '../AdminFormService'
@@ -156,6 +158,57 @@ describe('AdminFormService', () => {
         MOCK_CONTENT,
         // Should default to stringified null
         { params: { captchaResponse: 'null' } },
+      )
+    })
+  })
+
+  describe('countFormSubmissions', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_START_DATE = new Date(2020, 11, 17)
+    const MOCK_END_DATE = new Date(2021, 1, 10)
+
+    it('should call api successfully when all parameters are provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+        startDate: MOCK_START_DATE,
+        endDate: MOCK_END_DATE,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count?startDate=${MOCK_START_DATE}&endDate=${MOCK_END_DATE}`,
+      )
+    })
+
+    it('should call api successfully when only formId is provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+      )
+    })
+
+    it('should call api successfully with only formId when startDate or endDate is provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+        startDate: MOCK_START_DATE,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
       )
     })
   })

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import MockAxios from 'jest-mock-axios'
+
+import { SubmissionMetadataList } from 'src/types'
+
+import { ADMIN_FORM_ENDPOINT } from '../AdminFormService'
+import {
+  countFormSubmissions,
+  getEncryptedResponse,
+  getFormsMetadata,
+} from '../AdminSubmissionsService'
+
+jest.mock('axios', () => MockAxios)
+
+describe('AdminSubmissionsService', () => {
+  describe('countFormSubmissions', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_START_DATE = new Date(2020, 11, 17)
+    const MOCK_END_DATE = new Date(2021, 1, 10)
+
+    it('should call api successfully when all parameters are provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+        startDate: MOCK_START_DATE,
+        endDate: MOCK_END_DATE,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+        {
+          params: {
+            startDate: MOCK_START_DATE,
+            endDate: MOCK_END_DATE,
+          },
+        },
+      )
+    })
+
+    it('should call api successfully when only formId is provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+      )
+    })
+
+    it('should call api successfully with only formId when startDate or endDate is provided', async () => {
+      // Act
+      const actual = countFormSubmissions({
+        formId: MOCK_FORM_ID,
+        startDate: MOCK_START_DATE,
+      })
+      MockAxios.mockResponse({ data: 123 })
+
+      // Assert
+      await expect(actual).resolves.toEqual(123)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
+      )
+    })
+  })
+
+  describe('getFormsMetadata', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_SUBMISSION_ID = 'fake'
+    const MOCK_PAGE_NUM = 1
+    const MOCK_RESPONSE: SubmissionMetadataList = {
+      count: 1,
+      metadata: [
+        {
+          number: 1,
+          refNo: '1234',
+          submissionTime: 'sometime',
+        },
+      ],
+    }
+    it('should call the api with only submissionId when both parameters are provided', async () => {
+      // Act
+      const actual = getFormsMetadata({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+        pageNum: MOCK_PAGE_NUM,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
+        {
+          params: {
+            submissionId: MOCK_SUBMISSION_ID,
+          },
+        },
+      )
+    })
+
+    it('should call the api correctly when a single parameter is provided', async () => {
+      // Act
+      const actual = getFormsMetadata({
+        formId: MOCK_FORM_ID,
+        pageNum: MOCK_PAGE_NUM,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
+        {
+          params: {
+            page: MOCK_PAGE_NUM,
+          },
+        },
+      )
+    })
+  })
+
+  describe('getEncryptedResponse', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_SUBMISSION_ID = 'fake'
+    const MOCK_RESPONSE = {
+      refNo: '1',
+      submissionTime: 'sometime',
+      content: 'jk',
+      verified: 'whups',
+      attachmentMetadata: {},
+    }
+
+    it('should call the api correctly when the parameters are valid', async () => {
+      // Act
+      const actual = getEncryptedResponse({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/${MOCK_SUBMISSION_ID}`,
+      )
+    })
+  })
+})

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -22,8 +22,7 @@ describe('AdminSubmissionsService', () => {
       // Act
       const actual = countFormSubmissions({
         formId: MOCK_FORM_ID,
-        startDate: MOCK_START_DATE,
-        endDate: MOCK_END_DATE,
+        dates: { startDate: MOCK_START_DATE, endDate: MOCK_END_DATE },
       })
       MockAxios.mockResponse({ data: 123 })
 
@@ -44,21 +43,6 @@ describe('AdminSubmissionsService', () => {
       // Act
       const actual = countFormSubmissions({
         formId: MOCK_FORM_ID,
-      })
-      MockAxios.mockResponse({ data: 123 })
-
-      // Assert
-      await expect(actual).resolves.toEqual(123)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
-      )
-    })
-
-    it('should call api successfully with only formId when startDate or endDate is provided', async () => {
-      // Act
-      const actual = countFormSubmissions({
-        formId: MOCK_FORM_ID,
-        startDate: MOCK_START_DATE,
       })
       MockAxios.mockResponse({ data: 123 })
 

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -7,8 +7,8 @@ import { ADMIN_FORM_ENDPOINT } from '../AdminFormService'
 import {
   countFormSubmissions,
   getEncryptedResponse,
-  getFormMetadata,
-  getFormsMetadata,
+  getFormMetadataById,
+  getFormsMetadataByPage,
 } from '../AdminSubmissionsService'
 
 jest.mock('axios')
@@ -60,7 +60,7 @@ describe('AdminSubmissionsService', () => {
     })
   })
 
-  describe('getFormsMetadata', () => {
+  describe('getFormsMetadataByPage', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_PAGE_NUM = 1
     const MOCK_RESPONSE: SubmissionMetadataList = {
@@ -79,7 +79,7 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = getFormsMetadata({
+      const actual = getFormsMetadataByPage({
         formId: MOCK_FORM_ID,
         pageNum: MOCK_PAGE_NUM,
       })
@@ -97,7 +97,7 @@ describe('AdminSubmissionsService', () => {
     })
   })
 
-  describe('getFormMetadata', () => {
+  describe('getFormMetadataById', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_SUBMISSION_ID = 'fake'
     const MOCK_RESPONSE: SubmissionMetadataList = {
@@ -116,7 +116,7 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = getFormMetadata({
+      const actual = getFormMetadataById({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import MockAxios from 'jest-mock-axios'
+import axios from 'axios'
+import { mocked } from 'ts-jest/utils'
 
 import { SubmissionMetadataList } from 'src/types'
 
@@ -11,7 +11,8 @@ import {
   getFormsMetadata,
 } from '../AdminSubmissionsService'
 
-jest.mock('axios', () => MockAxios)
+jest.mock('axios')
+const MockAxios = mocked(axios, true)
 
 describe('AdminSubmissionsService', () => {
   describe('countFormSubmissions', () => {
@@ -20,12 +21,14 @@ describe('AdminSubmissionsService', () => {
     const MOCK_END_DATE = new Date(2021, 1, 10)
 
     it('should call api successfully when all parameters are provided', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: 123 })
+
       // Act
       const actual = countFormSubmissions({
         formId: MOCK_FORM_ID,
         dates: { startDate: MOCK_START_DATE, endDate: MOCK_END_DATE },
       })
-      MockAxios.mockResponse({ data: 123 })
 
       // Assert
       await expect(actual).resolves.toEqual(123)
@@ -41,11 +44,13 @@ describe('AdminSubmissionsService', () => {
     })
 
     it('should call api successfully when only formId is provided', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: 123 })
+
       // Act
       const actual = countFormSubmissions({
         formId: MOCK_FORM_ID,
       })
-      MockAxios.mockResponse({ data: 123 })
 
       // Assert
       await expect(actual).resolves.toEqual(123)
@@ -70,12 +75,14 @@ describe('AdminSubmissionsService', () => {
     }
 
     it('should call the api correctly', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
+
       // Act
       const actual = getFormsMetadata({
         formId: MOCK_FORM_ID,
         pageNum: MOCK_PAGE_NUM,
       })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
 
       // Assert
       await expect(actual).resolves.toEqual(MOCK_RESPONSE)
@@ -105,12 +112,14 @@ describe('AdminSubmissionsService', () => {
     }
 
     it('should call the api correctly', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
+
       // Act
       const actual = getFormMetadata({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
 
       // Assert
       await expect(actual).resolves.toEqual(MOCK_RESPONSE)
@@ -137,12 +146,14 @@ describe('AdminSubmissionsService', () => {
     }
 
     it('should call the api correctly when the parameters are valid', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
+
       // Act
       const actual = getEncryptedResponse({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
 
       // Assert
       await expect(actual).resolves.toEqual(MOCK_RESPONSE)

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -7,6 +7,7 @@ import { ADMIN_FORM_ENDPOINT } from '../AdminFormService'
 import {
   countFormSubmissions,
   getEncryptedResponse,
+  getFormMetadata,
   getFormsMetadata,
 } from '../AdminSubmissionsService'
 
@@ -56,7 +57,6 @@ describe('AdminSubmissionsService', () => {
 
   describe('getFormsMetadata', () => {
     const MOCK_FORM_ID = 'mock–form-id'
-    const MOCK_SUBMISSION_ID = 'fake'
     const MOCK_PAGE_NUM = 1
     const MOCK_RESPONSE: SubmissionMetadataList = {
       count: 1,
@@ -68,28 +68,8 @@ describe('AdminSubmissionsService', () => {
         },
       ],
     }
-    it('should call the api with only submissionId when both parameters are provided', async () => {
-      // Act
-      const actual = getFormsMetadata({
-        formId: MOCK_FORM_ID,
-        submissionId: MOCK_SUBMISSION_ID,
-        pageNum: MOCK_PAGE_NUM,
-      })
-      MockAxios.mockResponse({ data: MOCK_RESPONSE })
 
-      // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
-      expect(MockAxios.get).toHaveBeenCalledWith(
-        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
-        {
-          params: {
-            submissionId: MOCK_SUBMISSION_ID,
-          },
-        },
-      )
-    })
-
-    it('should call the api correctly when a single parameter is provided', async () => {
+    it('should call the api correctly', async () => {
       // Act
       const actual = getFormsMetadata({
         formId: MOCK_FORM_ID,
@@ -104,6 +84,41 @@ describe('AdminSubmissionsService', () => {
         {
           params: {
             page: MOCK_PAGE_NUM,
+          },
+        },
+      )
+    })
+  })
+
+  describe('getFormMetadata', () => {
+    const MOCK_FORM_ID = 'mock–form-id'
+    const MOCK_SUBMISSION_ID = 'fake'
+    const MOCK_RESPONSE: SubmissionMetadataList = {
+      count: 1,
+      metadata: [
+        {
+          number: 1,
+          refNo: '1234',
+          submissionTime: 'sometime',
+        },
+      ],
+    }
+
+    it('should call the api correctly', async () => {
+      // Act
+      const actual = getFormMetadata({
+        formId: MOCK_FORM_ID,
+        submissionId: MOCK_SUBMISSION_ID,
+      })
+      MockAxios.mockResponse({ data: MOCK_RESPONSE })
+
+      // Assert
+      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
+        {
+          params: {
+            submissionId: MOCK_SUBMISSION_ID,
           },
         },
       )

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -25,13 +25,13 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: 123 })
 
       // Act
-      const actual = countFormSubmissions({
+      const actual = await countFormSubmissions({
         formId: MOCK_FORM_ID,
         dates: { startDate: MOCK_START_DATE, endDate: MOCK_END_DATE },
       })
 
       // Assert
-      await expect(actual).resolves.toEqual(123)
+      expect(actual).toEqual(123)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
         {
@@ -48,12 +48,12 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: 123 })
 
       // Act
-      const actual = countFormSubmissions({
+      const actual = await countFormSubmissions({
         formId: MOCK_FORM_ID,
       })
 
       // Assert
-      await expect(actual).resolves.toEqual(123)
+      expect(actual).toEqual(123)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/count`,
       )
@@ -79,13 +79,13 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = getFormsMetadataByPage({
+      const actual = await getFormsMetadataByPage({
         formId: MOCK_FORM_ID,
         pageNum: MOCK_PAGE_NUM,
       })
 
       // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(actual).toEqual(MOCK_RESPONSE)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
         {
@@ -116,13 +116,13 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = getFormMetadataById({
+      const actual = await getFormMetadataById({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })
 
       // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(actual).toEqual(MOCK_RESPONSE)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/metadata`,
         {
@@ -150,13 +150,13 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = getEncryptedResponse({
+      const actual = await getEncryptedResponse({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })
 
       // Assert
-      await expect(actual).resolves.toEqual(MOCK_RESPONSE)
+      expect(actual).toEqual(MOCK_RESPONSE)
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM_ID}/submissions/${MOCK_SUBMISSION_ID}`,
       )

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -11,8 +11,10 @@ export type SubmissionErrorDto = ErrorDto & { spcpSubmissionFailure?: true }
 
 export type SubmissionCountQueryDto = {
   formId: string
-  startDate?: Date
-  endDate?: Date
+  dates?: {
+    startDate: Date
+    endDate: Date
+  }
 }
 
 export type SubmissionMetadataQueryDto = {

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -1,5 +1,3 @@
-import { RequireAtLeastOne } from 'type-fest'
-
 import { ErrorDto } from './core'
 
 export type SubmissionResponseDto = {
@@ -17,12 +15,15 @@ export type SubmissionCountQueryDto = {
   }
 }
 
-export type SubmissionMetadataQueryDto = {
+export type FormsSubmissionMetadataQueryDto = {
   formId: string
-} & RequireAtLeastOne<{
-  submissionId: string
   pageNum: number
-}>
+}
+
+export type FormSubmissionMetadataQueryDto = {
+  formId: string
+  submissionId: string
+}
 
 export type SubmissionResponseQueryDto = {
   formId: string

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -6,3 +6,9 @@ export type SubmissionResponseDto = {
 }
 
 export type SubmissionErrorDto = ErrorDto & { spcpSubmissionFailure?: true }
+
+export type SubmissionCountDto = {
+  formId: string
+  startDate?: Date
+  endDate?: Date
+}

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -1,3 +1,5 @@
+import { RequireAtLeastOne } from 'type-fest'
+
 import { ErrorDto } from './core'
 
 export type SubmissionResponseDto = {
@@ -12,3 +14,10 @@ export type SubmissionCountDto = {
   startDate?: Date
   endDate?: Date
 }
+
+export type SubmissionMetadataDto = {
+  formId: string
+} & RequireAtLeastOne<{
+  submissionId: string
+  pageNum: number
+}>

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -9,15 +9,20 @@ export type SubmissionResponseDto = {
 
 export type SubmissionErrorDto = ErrorDto & { spcpSubmissionFailure?: true }
 
-export type SubmissionCountDto = {
+export type SubmissionCountQueryDto = {
   formId: string
   startDate?: Date
   endDate?: Date
 }
 
-export type SubmissionMetadataDto = {
+export type SubmissionMetadataQueryDto = {
   formId: string
 } & RequireAtLeastOne<{
   submissionId: string
   pageNum: number
 }>
+
+export type SubmissionResponseQueryDto = {
+  formId: string
+  submissionId: string
+}


### PR DESCRIPTION
## Problem
`submissions.client.factory` client-side service that determines the performance and safety of many key features, but has two separate areas of concern - the public form facing submissions and the admin form retrieval of submissions. 

Part 1 of #1874 

## Solution
This extracts out all the straight forward client submission methods to `AdminFormService`, and replaces old method calls with the new one.

The download related methods will be in a separate PR for closer scrutiny!

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Tests
This adds unit tests for all new methods added.

## Manual Tests 
This has been already tested on staging
Create a storage mode form with any field and activate it. Submit the form >= 11 times. Go to the data section and unlock responses. 

- [ ] There should be the correct number of responses displayed
- [ ] Click on any page that is not 1. The relevant responses should be displayed
- [ ] Select a time period without responses and attempt to download (both options). This should **not** work
- [ ] Select a time period with responses and attempt to download (both options). This should work
- [ ] Search for a response using a valid `referenceId`. this should work and clicking into the response should display all related data. 
- [ ] Search for a response using an invalid/partial `referenceId`. There should be no responses displayed.
- [ ] Clicking into a single response should work and display all data correctly.