### PR TITLE
test(webhook-retries): add unit tests for message, producer, consumer (7)

### DIFF
--- a/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
@@ -1,0 +1,285 @@
+import aws from 'aws-sdk'
+import { ObjectId } from 'bson'
+import { addHours } from 'date-fns'
+import mongoose from 'mongoose'
+import { errAsync, okAsync } from 'neverthrow'
+import { mocked } from 'ts-jest/utils'
+
+import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
+import { IWebhookResponse, SubmissionWebhookInfo } from 'src/types'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import { createWebhookQueueHandler } from '../webhook.consumer'
+import { WebhookPushToQueueError } from '../webhook.errors'
+import { WebhookProducer } from '../webhook.producer'
+import * as WebhookService from '../webhook.service'
+import { WebhookQueueMessageObject } from '../webhook.types'
+
+jest.mock('../webhook.service')
+const MockWebhookService = mocked(WebhookService, true)
+
+const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
+
+const MOCK_WEBHOOK_SUCCESS_RESPONSE: IWebhookResponse = {
+  signature: 'mockSignature',
+  webhookUrl: 'mockWebhookUrl',
+  response: {
+    data: 'mockData',
+    headers: 'mockHeaders',
+    status: 200,
+  },
+}
+const MOCK_WEBHOOK_FAILURE_RESPONSE: IWebhookResponse = {
+  signature: 'mockSignature',
+  webhookUrl: 'mockWebhookUrl',
+  response: {
+    data: 'mockData',
+    headers: 'mockHeaders',
+    status: 400,
+  },
+}
+
+const SUCCESS_PRODUCER = ({
+  sendMessage: jest.fn().mockReturnValue(okAsync(true)),
+} as unknown) as WebhookProducer
+
+const FAILURE_PRODUCER = ({
+  sendMessage: jest
+    .fn()
+    .mockReturnValue(errAsync(new WebhookPushToQueueError())),
+} as unknown) as WebhookProducer
+
+const VALID_MESSAGE_BODY: WebhookQueueMessageObject = {
+  submissionId: new ObjectId().toHexString(),
+  previousAttempts: [Date.now()],
+  nextAttempt: Date.now(),
+  _v: 0,
+}
+
+const VALID_SQS_MESSAGE: aws.SQS.Message = {
+  Body: JSON.stringify(VALID_MESSAGE_BODY),
+}
+
+const MOCK_WEBHOOK_INFO = {
+  isRetryEnabled: true,
+  webhookUrl: 'some url',
+  webhookView: {
+    data: {
+      submissionId: VALID_MESSAGE_BODY.submissionId,
+    },
+  },
+} as SubmissionWebhookInfo
+
+describe('webhook.consumer', () => {
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  describe('createWebhookQueueHandler', () => {
+    it('should reject when message body is undefined', async () => {
+      const result = createWebhookQueueHandler(SUCCESS_PRODUCER)({})
+
+      await expect(result).toReject()
+    })
+
+    it('should reject when message body cannot be parsed', async () => {
+      const result = createWebhookQueueHandler(SUCCESS_PRODUCER)({
+        Body: 'yoooooooooooo',
+      })
+
+      await expect(result).toReject()
+    })
+
+    it('should requeue webhook when it is not due', async () => {
+      const message = {
+        Body: JSON.stringify({
+          ...VALID_MESSAGE_BODY,
+          // next attempt in the future
+          nextAttempt: addHours(Date.now(), 1).getTime(),
+        }),
+      }
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(message),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(SUCCESS_PRODUCER.sendMessage).toHaveBeenCalled()
+    })
+
+    it('should reject when it fails to requeue webhook which is not due', async () => {
+      const message = {
+        Body: JSON.stringify({
+          ...VALID_MESSAGE_BODY,
+          // next attempt in the future
+          nextAttempt: addHours(Date.now(), 1).getTime(),
+        }),
+      }
+
+      await expect(
+        createWebhookQueueHandler(FAILURE_PRODUCER)(message),
+      ).toReject()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(FAILURE_PRODUCER.sendMessage).toHaveBeenCalled()
+    })
+
+    it('should reject when submission ID cannot be found', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce(null)
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toReject()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should reject when database error occurs', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockRejectedValueOnce(new Error(''))
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toReject()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should resolve when form has no webhook URL', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce({
+          ...MOCK_WEBHOOK_INFO,
+          webhookUrl: '',
+        })
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should resolve when form does not have retries enabled', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce({
+          ...MOCK_WEBHOOK_INFO,
+          isRetryEnabled: false,
+        })
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+      expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should resolve without requeuing when webhook succeeds', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
+      MockWebhookService.sendWebhook.mockReturnValueOnce(
+        okAsync(MOCK_WEBHOOK_SUCCESS_RESPONSE),
+      )
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).toHaveBeenCalledWith(
+        MOCK_WEBHOOK_INFO.webhookView,
+        MOCK_WEBHOOK_INFO.webhookUrl,
+      )
+      expect(MockWebhookService.saveWebhookRecord).toHaveBeenCalledWith(
+        VALID_MESSAGE_BODY.submissionId,
+        MOCK_WEBHOOK_SUCCESS_RESPONSE,
+      )
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should requeue webhook when retry fails and there are retries remaining', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
+      MockWebhookService.sendWebhook.mockReturnValueOnce(
+        // note failure response instead of success
+        okAsync(MOCK_WEBHOOK_FAILURE_RESPONSE),
+      )
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).toHaveBeenCalledWith(
+        MOCK_WEBHOOK_INFO.webhookView,
+        MOCK_WEBHOOK_INFO.webhookUrl,
+      )
+      expect(MockWebhookService.saveWebhookRecord).toHaveBeenCalledWith(
+        VALID_MESSAGE_BODY.submissionId,
+        MOCK_WEBHOOK_FAILURE_RESPONSE,
+      )
+      expect(SUCCESS_PRODUCER.sendMessage).toHaveBeenCalled()
+    })
+
+    it('should resolve without requeuing when retry fails and there are no retries remaining', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
+      MockWebhookService.sendWebhook.mockReturnValueOnce(
+        okAsync(MOCK_WEBHOOK_SUCCESS_RESPONSE),
+      )
+      const message = {
+        Body: JSON.stringify({
+          ...VALID_MESSAGE_BODY,
+          // length greater than max possible number of retries
+          previousAttempts: Array(10).fill(0),
+        }),
+      }
+
+      await expect(
+        createWebhookQueueHandler(SUCCESS_PRODUCER)(message),
+      ).toResolve()
+      expect(MockWebhookService.sendWebhook).toHaveBeenCalledWith(
+        MOCK_WEBHOOK_INFO.webhookView,
+        MOCK_WEBHOOK_INFO.webhookUrl,
+      )
+      expect(MockWebhookService.saveWebhookRecord).toHaveBeenCalledWith(
+        VALID_MESSAGE_BODY.submissionId,
+        MOCK_WEBHOOK_SUCCESS_RESPONSE,
+      )
+      expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('should reject when retry fails and subsequently fails to be requeued', async () => {
+      jest
+        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
+      MockWebhookService.sendWebhook.mockReturnValueOnce(
+        okAsync(MOCK_WEBHOOK_FAILURE_RESPONSE),
+      )
+
+      await expect(
+        createWebhookQueueHandler(FAILURE_PRODUCER)(VALID_SQS_MESSAGE),
+      ).toReject()
+      expect(MockWebhookService.sendWebhook).toHaveBeenCalledWith(
+        MOCK_WEBHOOK_INFO.webhookView,
+        MOCK_WEBHOOK_INFO.webhookUrl,
+      )
+      expect(MockWebhookService.saveWebhookRecord).toHaveBeenCalledWith(
+        VALID_MESSAGE_BODY.submissionId,
+        MOCK_WEBHOOK_FAILURE_RESPONSE,
+      )
+      expect(FAILURE_PRODUCER.sendMessage).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/modules/webhook/__tests__/webhook.message.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.message.spec.ts
@@ -1,0 +1,185 @@
+import { ObjectId } from 'bson'
+
+import {
+  DUE_TIME_TOLERANCE_SECONDS,
+  QUEUE_MESSAGE_VERSION,
+  RETRY_INTERVALS,
+} from '../webhook.constants'
+import {
+  WebhookNoMoreRetriesError,
+  WebhookQueueMessageParsingError,
+} from '../webhook.errors'
+import { WebhookQueueMessage } from '../webhook.message'
+import { WebhookQueueMessageObject } from '../webhook.types'
+import { prettifyEpoch } from '../webhook.utils'
+
+describe('WebhookQueueMessage', () => {
+  const VALID_MESSAGE: WebhookQueueMessageObject = {
+    submissionId: new ObjectId().toHexString(),
+    previousAttempts: [Date.now()],
+    nextAttempt: Date.now(),
+    _v: 0,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('deserialise', () => {
+    it('should return WebhookQueueMessageParsingError when string is invalid JSON', () => {
+      const result = WebhookQueueMessage.deserialise('tis')
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        WebhookQueueMessageParsingError,
+      )
+    })
+
+    it('should return WebhookQueueMessageParsingError when JSON has invalid shape', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify({ but: 'a' }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        WebhookQueueMessageParsingError,
+      )
+    })
+
+    it('should return WebhookQueueMessageParsingError when submissionId is not an ObjectId', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify({
+          ...VALID_MESSAGE,
+          submissionId: 'flesh wound',
+        }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        WebhookQueueMessageParsingError,
+      )
+    })
+
+    it('should return instance of WebhookQueueMessage when input is valid', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify(VALID_MESSAGE),
+      )
+
+      expect(result._unsafeUnwrap().message).toEqual(VALID_MESSAGE)
+    })
+  })
+
+  describe('fromSubmissionId', () => {
+    it('should correctly create a WebhookQueueMessage without any retry history', () => {
+      const submissionId = new ObjectId().toHexString()
+      const result = WebhookQueueMessage.fromSubmissionId(submissionId)
+
+      expect(result._unsafeUnwrap().message).toEqual({
+        submissionId,
+        previousAttempts: [],
+        nextAttempt: expect.any(Number),
+        _v: QUEUE_MESSAGE_VERSION,
+      })
+    })
+  })
+
+  describe('serialise', () => {
+    it('should return stringified message', () => {
+      const msg = new WebhookQueueMessage(VALID_MESSAGE)
+
+      expect(msg.serialise()).toEqual(JSON.stringify(VALID_MESSAGE))
+    })
+  })
+
+  describe('isDue', () => {
+    const MOCK_NOW = Date.now()
+
+    beforeAll(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(MOCK_NOW)
+    })
+
+    afterAll(() => jest.restoreAllMocks())
+
+    it('should return true if nextAttempt is in the past', () => {
+      const msg = new WebhookQueueMessage({
+        ...VALID_MESSAGE,
+        nextAttempt: MOCK_NOW - 1,
+      })
+
+      expect(msg.isDue()).toBe(true)
+    })
+
+    it('should return true if nextAttempt is in the future but within tolerance', () => {
+      const msg = new WebhookQueueMessage({
+        ...VALID_MESSAGE,
+        nextAttempt: MOCK_NOW + DUE_TIME_TOLERANCE_SECONDS * 1000 - 1,
+      })
+
+      expect(msg.isDue()).toBe(true)
+    })
+
+    it('should return false if nextAttempt is in the future and outside tolerance', () => {
+      const msg = new WebhookQueueMessage({
+        ...VALID_MESSAGE,
+        nextAttempt: MOCK_NOW + DUE_TIME_TOLERANCE_SECONDS * 1000 + 1,
+      })
+
+      expect(msg.isDue()).toBe(true)
+    })
+  })
+
+  describe('incrementAttempts', () => {
+    it('should return incremented attempts when retries have not been exhausted', () => {
+      const msg = new WebhookQueueMessage(VALID_MESSAGE)
+
+      const result = msg.incrementAttempts()._unsafeUnwrap()
+
+      expect(result.message.previousAttempts).toEqual([
+        ...VALID_MESSAGE.previousAttempts,
+        VALID_MESSAGE.nextAttempt,
+      ])
+      expect(result.message.submissionId).toBe(VALID_MESSAGE.submissionId)
+      // nextAttempt should have been incremented
+      expect(result.message.nextAttempt).toBeGreaterThan(
+        VALID_MESSAGE.nextAttempt,
+      )
+    })
+
+    it('should return WebhookNoMoreRetriesError when retries have been exhausted', () => {
+      const msg = new WebhookQueueMessage({
+        ...VALID_MESSAGE,
+        // length greater than allowed number of retries
+        previousAttempts: Array(RETRY_INTERVALS.length).fill(0),
+      })
+
+      const result = msg.incrementAttempts()._unsafeUnwrapErr()
+
+      expect(result).toBeInstanceOf(WebhookNoMoreRetriesError)
+    })
+  })
+
+  describe('getRetriesFailedState', () => {
+    it('should correctly convert message to failed state', () => {
+      const msg = new WebhookQueueMessage(VALID_MESSAGE)
+
+      expect(msg.getRetriesFailedState()).toEqual({
+        submissionId: VALID_MESSAGE.submissionId,
+        previousAttempts: [
+          ...VALID_MESSAGE.previousAttempts,
+          VALID_MESSAGE.nextAttempt,
+        ].map(prettifyEpoch),
+        _v: VALID_MESSAGE._v,
+      })
+    })
+  })
+
+  describe('prettify', () => {
+    it('should return human-readable form of message', () => {
+      const msg = new WebhookQueueMessage(VALID_MESSAGE)
+
+      expect(msg.prettify()).toEqual({
+        submissionId: VALID_MESSAGE.submissionId,
+        previousAttempts: VALID_MESSAGE.previousAttempts.map(prettifyEpoch),
+        nextAttempt: prettifyEpoch(VALID_MESSAGE.nextAttempt),
+        _v: VALID_MESSAGE._v,
+      })
+    })
+  })
+})

--- a/src/app/modules/webhook/__tests__/webhook.producer.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.producer.spec.ts
@@ -1,0 +1,140 @@
+import { ObjectId } from 'bson'
+import { addHours, addMinutes, subMinutes } from 'date-fns'
+import { Producer } from 'sqs-producer'
+import { mocked } from 'ts-jest/utils'
+
+import { MAX_DELAY_SECONDS } from '../webhook.constants'
+import { WebhookPushToQueueError } from '../webhook.errors'
+import { WebhookQueueMessage } from '../webhook.message'
+import { WebhookProducer } from '../webhook.producer'
+
+jest.mock('sqs-producer')
+const MockSqsProducer = mocked(Producer, true)
+
+describe('WebhookProducer', () => {
+  let webhookProducer: WebhookProducer
+  const mockSendMessage = jest.fn()
+
+  const MESSAGE_BODY = {
+    submissionId: new ObjectId().toHexString(),
+    previousAttempts: [Date.now()],
+    nextAttempt: Date.now(),
+    _v: 0,
+  }
+
+  beforeAll(() => {
+    MockSqsProducer.create.mockReturnValue(({
+      send: mockSendMessage,
+    } as unknown) as Producer)
+    webhookProducer = new WebhookProducer('')
+  })
+
+  beforeEach(() => jest.resetAllMocks())
+
+  describe('sendMessage', () => {
+    it('should return true when message is sent on first try', async () => {
+      mockSendMessage.mockResolvedValueOnce([])
+      const webhookMessage = new WebhookQueueMessage(MESSAGE_BODY)
+
+      const result = await webhookProducer.sendMessage(webhookMessage)
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: expect.any(Number),
+      })
+    })
+
+    it('should return true when message fails on first try, but subsequently succeeds', async () => {
+      mockSendMessage
+        .mockRejectedValueOnce(new Error(''))
+        .mockResolvedValueOnce([])
+      const webhookMessage = new WebhookQueueMessage(MESSAGE_BODY)
+
+      const result = await webhookProducer.sendMessage(webhookMessage)
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(mockSendMessage).toHaveBeenCalledTimes(2)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: expect.any(Number),
+      })
+    })
+
+    it('should return WebhookPushToQueueError when message fails all attempts to be sent', async () => {
+      mockSendMessage.mockRejectedValue(new Error(''))
+      const webhookMessage = new WebhookQueueMessage(MESSAGE_BODY)
+
+      const result = await webhookProducer.sendMessage(webhookMessage, {
+        minTimeout: 0,
+      })
+
+      expect(result._unsafeUnwrapErr()).toEqual(new WebhookPushToQueueError())
+      // promise-retry retries 10 times by default, so total is 1 try + 10 retries = 11
+      expect(mockSendMessage).toHaveBeenCalledTimes(11)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: expect.any(Number),
+      })
+    })
+
+    it('should queue message with 0 delay when nextAttempt is in the past', async () => {
+      mockSendMessage.mockResolvedValueOnce([])
+      const webhookMessage = new WebhookQueueMessage({
+        ...MESSAGE_BODY,
+        nextAttempt: subMinutes(Date.now(), 10).getTime(),
+      })
+
+      const result = await webhookProducer.sendMessage(webhookMessage)
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: 0,
+      })
+    })
+
+    it('should queue message with a maximum of 15min delay when nextAttempt is in the future', async () => {
+      mockSendMessage.mockResolvedValueOnce([])
+      const webhookMessage = new WebhookQueueMessage({
+        ...MESSAGE_BODY,
+        nextAttempt: addHours(Date.now(), 10).getTime(),
+      })
+
+      const result = await webhookProducer.sendMessage(webhookMessage)
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: MAX_DELAY_SECONDS,
+      })
+    })
+
+    it('should queue message with exactly the required delay of nextAttempt is less than 15min in the future', async () => {
+      const minutesInFuture = 10
+      mockSendMessage.mockResolvedValueOnce([])
+      const webhookMessage = new WebhookQueueMessage({
+        ...MESSAGE_BODY,
+        nextAttempt: addMinutes(Date.now(), minutesInFuture).getTime(),
+      })
+
+      const result = await webhookProducer.sendMessage(webhookMessage)
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        body: JSON.stringify(webhookMessage.message),
+        id: webhookMessage.submissionId,
+        delaySeconds: minutesInFuture * 60,
+      })
+    })
+  })
+})

--- a/src/app/modules/webhook/__tests__/webhook.utils.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.utils.spec.ts
@@ -1,0 +1,66 @@
+import { addHours, addMinutes } from 'date-fns'
+import { last } from 'lodash'
+import { mocked } from 'ts-jest/utils'
+
+import { randomUniformInt } from 'src/app/utils/random-uniform'
+
+import { MAX_DELAY_SECONDS, RETRY_INTERVALS } from '../webhook.constants'
+import { WebhookNoMoreRetriesError } from '../webhook.errors'
+import { calculateDelaySeconds, getNextAttempt } from '../webhook.utils'
+
+jest.mock('src/app/utils/random-uniform')
+const MockRandomUniformInt = mocked(randomUniformInt, true)
+
+describe('webhook.utils', () => {
+  const MOCK_NOW = Date.now()
+  const MOCK_RANDOM_INT = 37
+
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(MOCK_NOW)
+    MockRandomUniformInt.mockReturnValue(MOCK_RANDOM_INT)
+  })
+  describe('getNextAttempt', () => {
+    it('should return WebhookNoMoreRetriesError when retry limit is exceeded', () => {
+      // array of previous attempts is exactly equal to RETRY_INTERVALS, meaning
+      // all retries are used up
+      const result = getNextAttempt(Array(RETRY_INTERVALS.length).fill(0))
+
+      expect(result._unsafeUnwrapErr()).toEqual(new WebhookNoMoreRetriesError())
+    })
+
+    it('should return time of next attempt correctly when there are retries remaining', () => {
+      // still 1 retry remaining
+      const result = getNextAttempt(Array(RETRY_INTERVALS.length - 1).fill(0))
+
+      const finalRetryInterval = last(RETRY_INTERVALS)!
+      expect(MockRandomUniformInt).toHaveBeenCalledWith(
+        finalRetryInterval.base - finalRetryInterval.jitter,
+        finalRetryInterval.base + finalRetryInterval.jitter,
+      )
+      expect(result._unsafeUnwrap()).toBe(MOCK_NOW + MOCK_RANDOM_INT * 1000)
+    })
+  })
+
+  describe('calculateDelaySeconds', () => {
+    it('should return 0 when nextAttempt is in the past', () => {
+      const result = calculateDelaySeconds(MOCK_NOW - 1000)
+
+      expect(result).toBe(0)
+    })
+
+    it('should return a maximum of 15min regardless of how far nextAttempt is in the future', () => {
+      const result = calculateDelaySeconds(addHours(MOCK_NOW, 12).getTime())
+
+      expect(result).toBe(MAX_DELAY_SECONDS)
+    })
+
+    it('should return exactly the time to nextAttempt if it is less than 15min in the future', () => {
+      const minutesInFuture = 10
+      const result = calculateDelaySeconds(
+        addMinutes(MOCK_NOW, minutesInFuture).getTime(),
+      )
+
+      expect(result).toBe(minutesInFuture * 60)
+    })
+  })
+})

--- a/src/app/modules/webhook/webhook.consumer.ts
+++ b/src/app/modules/webhook/webhook.consumer.ts
@@ -85,10 +85,12 @@ export const startWebhookConsumer = (
  * 3) If the webhook is due, attempts the webhook
  * 4) Records the webhook attempt in the database
  * 5) If the webhook failed again, requeues the message
+ *
+ * Exported for testing.
  * @param producer Producer which can write messages to queue
  * @returns Handler for consumption of queue messages
  */
-const createWebhookQueueHandler = (producer: WebhookProducer) => async (
+export const createWebhookQueueHandler = (producer: WebhookProducer) => async (
   sqsMessage: aws.SQS.Message,
 ): Promise<void> => {
   const { Body, MessageId } = sqsMessage

--- a/src/app/modules/webhook/webhook.producer.ts
+++ b/src/app/modules/webhook/webhook.producer.ts
@@ -1,5 +1,6 @@
 import { ResultAsync } from 'neverthrow'
 import promiseRetry from 'promise-retry'
+import { OperationOptions } from 'retry'
 import { Producer } from 'sqs-producer'
 
 import config from '../../config/config'
@@ -28,11 +29,13 @@ export class WebhookProducer {
   /**
    * Enqueues a message.
    * @param queueMessage Message to send
+   * @param retryOptions optional customisation of retry parameters
    * @returns ok(true) if sending message suceeds
    * @returns err if sending message fails
    */
   sendMessage(
     queueMessage: WebhookQueueMessage,
+    retryOptions?: OperationOptions,
   ): ResultAsync<true, WebhookPushToQueueError> {
     const sendMessageRetry = promiseRetry<true>(async (retry, attemptNum) => {
       try {
@@ -61,7 +64,7 @@ export class WebhookProducer {
         })
         return retry(error)
       }
-    })
+    }, retryOptions)
     return ResultAsync.fromPromise(sendMessageRetry, (error) => {
       logger.error({
         message: 'All attempts to push webhook to queue failed',


### PR DESCRIPTION
Adds unit tests for the following:
- `WebhookQueueMessage` class
- Handler for webhook consumer
- `WebhookProducer` class
- Important utils for calculating time of next retry attempt and queue delay