### PR TITLE
feat: Deduplicate Mongodb Error Messages

### DIFF
--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -47,7 +47,7 @@ export const getMongoErrorMessage = (
     const joinedMessage = dedupMessages.join(', ')
 
     return formatErrorRecoveryMessage(
-      joinedMessage ?? err.message ?? defaultErrorMessage,
+      joinedMessage || err.message ?? defaultErrorMessage,
     )
   }
 

--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -47,7 +47,7 @@ export const getMongoErrorMessage = (
     const joinedMessage = dedupMessages.join(', ')
 
     return formatErrorRecoveryMessage(
-      joinedMessage || err.message ?? defaultErrorMessage,
+      (joinedMessage || err.message) ?? defaultErrorMessage,
     )
   }
 

--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -41,10 +41,10 @@ export const getMongoErrorMessage = (
 
   // Handle mongoose errors
   if (err instanceof MongooseError.ValidationError) {
-    // Join all error messages into a single message if available.
-    const joinedMessage = Object.values(err.errors)
-      .map((err) => err.message)
-      .join(', ')
+    // Deduplicate then Join all error messages into a single message if available.
+    const messages = Object.values(err.errors).map((error) => error.message)
+    const dedupMessages = [...new Set(messages)]
+    const joinedMessage = dedupMessages.join(', ')
 
     return formatErrorRecoveryMessage(
       joinedMessage ?? err.message ?? defaultErrorMessage,


### PR DESCRIPTION
## Problem
MongoDB validation error messages may be duplicated in specific cases. This deduplicates those error messages.

Closes #1694 

## Solution
Adds a simple de-duplication to the error messages.