### PR TITLE
feat: sort responses for csv download according to creation date

### DIFF
--- a/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.js
+++ b/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.js
@@ -165,8 +165,9 @@ class CsvMergedHeadersGenerator extends CsvGenerator {
    * @param string secondDate
    */
   _dateComparator(firstDate, secondDate) {
-    const first = moment(firstDate)
-    const second = moment(secondDate)
+    // cast to Asia/Singapore to ensure both dates are of the same timezone
+    const first = moment(firstDate).tz('Asia/Singapore')
+    const second = moment(secondDate).tz('Asia/Singapore')
     if (first.isBefore(second)) {
       return -1
     } else if (first.isAfter(second)) {


### PR DESCRIPTION
## Problem
Currently, when a CSV of responses are downloaded (in storage mode), the responses are not sorted according to date. Refer to issue #1721

Closes #1721

## Solution
The naive approach was adopted to solve this problem. Specifically `Array.prototype.sort()` was used to sort the responses. This solution seems satisfactory even for a large number of responses. When tested with 100,000 responses, the sorting duration ranged from 1 to 2 seconds. With approximately 500,000 responses, the sorting duration ranged from 9 to 10 seconds, which is not significant compared to the decryption duration of approximately 3 minutes. Throughout the download, the following modal is displayed and no obvious freezes or slowdowns in the spinner were observed. The short clip below shows the condition of the spinner before and during sorting. 

https://user-images.githubusercontent.com/54089291/120165348-1023d500-c22e-11eb-8dec-acd5e62a2633.mov

## Tests
- [ ] Submit responses to storage mode form and download CSV. Ensure downloaded CSV is sorted (oldest to newest)
