### PR TITLE
docs(readme): remove active contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,9 @@ FormSG acknowledges the work done by [Arielle Baldwynn](https://github.com/white
 Contributions have also been made by:  
 [@RyanAngJY](https://github.com/RyanAngJY)  
 [@jeantanzy](https://github.com/jeantanzy)  
-[@yong-jie](https://github.com/yong-jie)  
 [@pregnantboy](https://github.com/pregnantboy)  
 [@namnguyen08](https://github.com/namnguyen08)  
 [@zioul123](https://github.com/zioul123)  
 [@JoelWee](https://github.com/JoelWee)  
 [@limli](https://github.com/limli)  
 [@tankevan](https://github.com/tankevan)  
-[@LoneRifle](https://github.com/LoneRifle)


### PR DESCRIPTION
## Context
Remove active contributors from the relevant section in the README, 
since their contributions are now present in the commit log