### PR TITLE
fix: restore typings to some model static methods

### DIFF
--- a/src/app/models/form_feedback.server.model.ts
+++ b/src/app/models/form_feedback.server.model.ts
@@ -1,4 +1,4 @@
-import { Mongoose, Schema } from 'mongoose'
+import { Mongoose, QueryCursor, Schema } from 'mongoose'
 
 import { IFormFeedbackModel, IFormFeedbackSchema } from '../../types'
 
@@ -39,7 +39,9 @@ const FormFeedbackSchema = new Schema<IFormFeedbackSchema, IFormFeedbackModel>(
  * @param formId the form id to return the submissions cursor for
  * @returns a cursor to the feedback retrieved
  */
-FormFeedbackSchema.statics.getFeedbackCursorByFormId = function (formId) {
+FormFeedbackSchema.statics.getFeedbackCursorByFormId = function (
+  formId: string,
+): QueryCursor<IFormFeedbackSchema> {
   return this.find({ formId }).batchSize(2000).read('secondary').lean().cursor()
 }
 

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -15,6 +15,7 @@ import {
   IWebhookResponseSchema,
   MyInfoAttribute,
   SubmissionCursorData,
+  SubmissionData,
   SubmissionMetadata,
   SubmissionType,
   WebhookData,
@@ -314,9 +315,12 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
 }
 
 EncryptSubmissionSchema.statics.getSubmissionCursorByFormId = function (
-  formId,
-  dateRange = {},
-) {
+  formId: string,
+  dateRange: {
+    startDate?: string
+    endDate?: string
+  } = {},
+): QueryCursor<SubmissionCursorData> {
   const streamQuery = {
     form: formId,
     ...createQueryWithDateParam(dateRange?.startDate, dateRange?.endDate),
@@ -341,7 +345,7 @@ EncryptSubmissionSchema.statics.getSubmissionCursorByFormId = function (
 EncryptSubmissionSchema.statics.findEncryptedSubmissionById = function (
   formId: string,
   submissionId: string,
-) {
+): Promise<SubmissionData | null> {
   return this.findOne({
     _id: submissionId,
     form: formId,

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -120,9 +120,13 @@ export type SubmissionCursorData = Pick<
   'encryptedContent' | 'verifiedContent' | 'created' | 'id'
 > & { attachmentMetadata?: Record<string, string> } & Document
 
-export type SubmissionData = Omit<
+export type SubmissionData = Pick<
   IEncryptedSubmissionSchema,
-  'version' | 'webhookResponses'
+  | 'encryptedContent'
+  | 'verifiedContent'
+  | 'attachmentMetadata'
+  | 'created'
+  | '_id'
 >
 
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some typings were accidentally removed in #2046 when replacing some static methods' declaration from assigning a function to inlining their methods. This PR fixes that.


## Solution
<!-- How did you solve the problem? -->
**Bug Fixes**:

- fix: restore typings to some model static methods 
