### PR TITLE
refactor(auth.client): (1) extract email validation and send login otp flow to Typescript

### DIFF
--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const HttpStatus = require('http-status-codes')
-const AdminAuthService = require('../../../services/AdminAuthService')
+const AuthService = require('../../../services/AuthService')
 
 angular
   .module('users')
@@ -130,7 +130,7 @@ function AuthenticationController(
    */
   vm.login = function () {
     vm.buttonClicked = true
-    $q.when(AdminAuthService.checkIsEmailAllowed(vm.credentials.email))
+    $q.when(AuthService.checkIsEmailAllowed(vm.credentials.email))
       .then(() => vm.sendOtp())
       .catch((error) => {
         // Invalid agency
@@ -155,7 +155,7 @@ function AuthenticationController(
     vm.buttonClicked = true
     vm.showOtpDelayNotification = false
 
-    $q.when(AdminAuthService.sendLoginOtp(vm.credentials.email))
+    $q.when(AuthService.sendLoginOtp(vm.credentials.email))
       .then((success) => {
         vm.isOtpSending = false
         vm.buttonClicked = false

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -197,7 +197,7 @@ function AuthenticationController(
       .catch((error) => {
         const errorMsg = get(
           error,
-          'response.data',
+          'response.data.message',
           'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
         )
         vm.isOtpSending = false

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -154,9 +154,9 @@ function AuthenticationController(
     vm.isOtpSending = true
     vm.buttonClicked = true
     vm.showOtpDelayNotification = false
-    const { email } = vm.credentials
-    Auth.sendOtp({ email }).then(
-      function (success) {
+
+    $q.when(AdminAuthService.sendLoginOtp(vm.credentials.email))
+      .then((success) => {
         vm.isOtpSending = false
         vm.buttonClicked = false
         // Configure message to be show
@@ -176,21 +176,17 @@ function AuthenticationController(
           vm.signInMsg.isMsg = false
           vm.showOtpDelayNotification = true
         }, 20000)
-      },
-      function (error) {
+      })
+      .catch((error) => {
         vm.isOtpSending = false
         vm.buttonClicked = false
         // Configure message to be shown
-        const msg =
-          (error && error.data && error.data.message) ||
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.'
         vm.signInMsg = {
           isMsg: true,
           isError: true,
-          msg,
+          msg: error.message,
         }
-      },
-    )
+      })
   }
 
   /**

--- a/src/public/modules/users/services/auth.client.service.js
+++ b/src/public/modules/users/services/auth.client.service.js
@@ -21,8 +21,6 @@ function Auth($q, $http, $state, $window) {
    */
 
   let authService = {
-    checkUser,
-    sendOtp,
     verifyOtp,
     getUser,
     setUser,
@@ -66,33 +64,6 @@ function Auth($q, $http, $state, $window) {
         return null
       })
   }
-
-  function checkUser(credentials) {
-    let deferred = $q.defer()
-    $http.post('/api/v3/auth/email/validate', credentials).then(
-      function (response) {
-        deferred.resolve(response.data)
-      },
-      function (error) {
-        deferred.reject(error.data)
-      },
-    )
-    return deferred.promise
-  }
-
-  function sendOtp(credentials) {
-    let deferred = $q.defer()
-    $http.post('/api/v3/auth/otp/generate', credentials).then(
-      function (response) {
-        deferred.resolve(response.data)
-      },
-      function (error) {
-        deferred.reject(error)
-      },
-    )
-    return deferred.promise
-  }
-
   function verifyOtp(credentials) {
     let deferred = $q.defer()
     $http.post('/api/v3/auth/otp/verify', credentials).then(

--- a/src/public/modules/users/views/authentication/signin.client.view.html
+++ b/src/public/modules/users/views/authentication/signin.client.view.html
@@ -40,7 +40,7 @@
         <div class="btn-grp">
           <button
             class="btn-custom btn-medium"
-            ng-click="vm.checkEmail()"
+            ng-click="vm.login()"
             ng-disabled="vm.buttonClicked || vm.isSubmitEmailDisabled"
           >
             Get Started

--- a/src/public/services/AdminAuthService.ts
+++ b/src/public/services/AdminAuthService.ts
@@ -16,7 +16,9 @@ export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
   }
 
   return axios
-    .post(`${ADMIN_AUTH_ENDPOINT}/email/validate`, { email })
+    .post(`${ADMIN_AUTH_ENDPOINT}/email/validate`, {
+      email: email.toLowerCase(),
+    })
     .then(() => email)
     .catch((error) => {
       if (axios.isAxiosError(error) && error.response?.data) {
@@ -24,6 +26,33 @@ export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
       }
       throw new Error(
         'Something went wrong while validating your email. Please refresh and try again',
+      )
+    })
+}
+
+/**
+ * Sends login OTP to given email
+ * @param email email to send login OTP to
+ * @returns success string if login OTP is sent successfully
+ * @throws Error on invalid email
+ * @throws Error on non 2xx response
+ */
+export const sendLoginOtp = async (email = ''): Promise<string> => {
+  if (!validator.isEmail(email)) {
+    throw new Error('Please enter a valid email address')
+  }
+
+  return axios
+    .post<string>(`${ADMIN_AUTH_ENDPOINT}/otp/generate`, {
+      email: email.toLowerCase(),
+    })
+    .then(({ data }) => data)
+    .catch((error) => {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        throw new Error(error.response.data)
+      }
+      throw new Error(
+        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
       )
     })
 }

--- a/src/public/services/AdminAuthService.ts
+++ b/src/public/services/AdminAuthService.ts
@@ -1,0 +1,29 @@
+import axios from 'axios'
+import validator from 'validator'
+
+const ADMIN_AUTH_ENDPOINT = '/api/v3/auth'
+
+/**
+ * Check whether the given email string is from an email domain.
+ * @param email the email to check
+ * @returns original email if email is valid
+ * @throws Error on invalid email
+ * @throws Error on non 2xx response
+ */
+export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
+  if (!validator.isEmail(email)) {
+    throw new Error('Please enter a valid email address')
+  }
+
+  return axios
+    .post(`${ADMIN_AUTH_ENDPOINT}/email/validate`, { email })
+    .then(() => email)
+    .catch((error) => {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        throw new Error(error.response.data)
+      }
+      throw new Error(
+        'Something went wrong while validating your email. Please refresh and try again',
+      )
+    })
+}

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -7,7 +7,7 @@ export const AUTH_ENDPOINT = '/api/v3/auth'
 type Email = Opaque<string, 'Email'>
 
 /**
- * Check whether the given email string is from an email domain.
+ * Check whether the given email string is from a whitelisted email domain.
  * @param email the email to check
  * @returns original email if email is valid
  */

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import { Opaque } from 'type-fest'
 
-const AUTH_ENDPOINT = '/api/v3/auth'
+// Exported for testing.
+export const AUTH_ENDPOINT = '/api/v3/auth'
 
 type Email = Opaque<string, 'Email'>
 

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -1,33 +1,21 @@
 import axios from 'axios'
-import validator from 'validator'
+import { Opaque } from 'type-fest'
 
 const AUTH_ENDPOINT = '/api/v3/auth'
+
+type Email = Opaque<string, 'Email'>
 
 /**
  * Check whether the given email string is from an email domain.
  * @param email the email to check
  * @returns original email if email is valid
- * @throws Error on invalid email
- * @throws Error on non 2xx response
  */
-export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
-  if (!validator.isEmail(email)) {
-    throw new Error('Please enter a valid email address')
-  }
-
+export const checkIsEmailAllowed = async (email: string): Promise<Email> => {
   return axios
     .post(`${AUTH_ENDPOINT}/email/validate`, {
       email: email.toLowerCase(),
     })
-    .then(() => email)
-    .catch((error) => {
-      if (axios.isAxiosError(error) && error.response?.data) {
-        throw new Error(error.response.data)
-      }
-      throw new Error(
-        'Something went wrong while validating your email. Please refresh and try again',
-      )
-    })
+    .then(() => email as Email)
 }
 
 /**
@@ -37,22 +25,10 @@ export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
  * @throws Error on invalid email
  * @throws Error on non 2xx response
  */
-export const sendLoginOtp = async (email = ''): Promise<string> => {
-  if (!validator.isEmail(email)) {
-    throw new Error('Please enter a valid email address')
-  }
-
+export const sendLoginOtp = async (email: Email): Promise<string> => {
   return axios
     .post<string>(`${AUTH_ENDPOINT}/otp/generate`, {
       email: email.toLowerCase(),
     })
     .then(({ data }) => data)
-    .catch((error) => {
-      if (axios.isAxiosError(error) && error.response?.data) {
-        throw new Error(error.response.data)
-      }
-      throw new Error(
-        'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-      )
-    })
 }

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -23,8 +23,6 @@ export const checkIsEmailAllowed = async (email: string): Promise<Email> => {
  * Sends login OTP to given email
  * @param email email to send login OTP to
  * @returns success string if login OTP is sent successfully
- * @throws Error on invalid email
- * @throws Error on non 2xx response
  */
 export const sendLoginOtp = async (email: Email): Promise<string> => {
   return axios

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import validator from 'validator'
 
-const ADMIN_AUTH_ENDPOINT = '/api/v3/auth'
+const AUTH_ENDPOINT = '/api/v3/auth'
 
 /**
  * Check whether the given email string is from an email domain.
@@ -16,7 +16,7 @@ export const checkIsEmailAllowed = async (email = ''): Promise<string> => {
   }
 
   return axios
-    .post(`${ADMIN_AUTH_ENDPOINT}/email/validate`, {
+    .post(`${AUTH_ENDPOINT}/email/validate`, {
       email: email.toLowerCase(),
     })
     .then(() => email)
@@ -43,7 +43,7 @@ export const sendLoginOtp = async (email = ''): Promise<string> => {
   }
 
   return axios
-    .post<string>(`${ADMIN_AUTH_ENDPOINT}/otp/generate`, {
+    .post<string>(`${AUTH_ENDPOINT}/otp/generate`, {
       email: email.toLowerCase(),
     })
     .then(({ data }) => data)

--- a/src/public/services/__tests__/AuthService.test.ts
+++ b/src/public/services/__tests__/AuthService.test.ts
@@ -1,0 +1,60 @@
+import axios from 'axios'
+import { mocked } from 'ts-jest/utils'
+import { Opaque } from 'type-fest'
+
+import {
+  AUTH_ENDPOINT,
+  checkIsEmailAllowed,
+  sendLoginOtp,
+} from '../AuthService'
+
+jest.mock('axios')
+
+const MockAxios = mocked(axios, true)
+
+// Duplicated here instead of exporting from AuthService to prevent production
+// code from casting to Email type without going through a type guard/validator.
+type TestEmail = Opaque<string, 'Email'>
+
+describe('AuthService', () => {
+  describe('checkIsEmailAllowed', () => {
+    const EXPECTED_POST_ENDPOINT = `${AUTH_ENDPOINT}/email/validate`
+
+    it('should return given email argument when email is allowed', async () => {
+      // Arrange
+      const mockEmail = 'this.should.RETURN@example.com'
+      MockAxios.post.mockResolvedValueOnce({ status: 200 })
+
+      // Act
+      const actual = await checkIsEmailAllowed(mockEmail)
+
+      // Assert
+      expect(actual).toEqual(mockEmail)
+      expect(MockAxios.post).toHaveBeenCalledWith(EXPECTED_POST_ENDPOINT, {
+        email: mockEmail.toLowerCase(),
+      })
+    })
+  })
+
+  describe('sendLoginOtp', () => {
+    const EXPECTED_POST_ENDPOINT = `${AUTH_ENDPOINT}/otp/generate`
+
+    it('should return success string when OTP is successfully generated', async () => {
+      // Arrange
+      const mockEmail = 'otp-email@example.com'
+      const mockSuccessStr = 'yippee ki yay'
+      MockAxios.post.mockResolvedValueOnce({
+        data: mockSuccessStr,
+      })
+
+      // Act
+      const actual = await sendLoginOtp(mockEmail as TestEmail)
+
+      // Assert
+      expect(actual).toEqual(mockSuccessStr)
+      expect(MockAxios.post).toHaveBeenCalledWith(EXPECTED_POST_ENDPOINT, {
+        email: mockEmail.toLowerCase(),
+      })
+    })
+  })
+})


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR is part 1 of migrating auth.client.js to Typescript. This PR extracts out the first two functions
- `checkIsEmailAllowed` for verifying whether email domain is whitelisted, and
- `sendLoginOtp` for sending the login OTP

Related to #2057

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:
- add `AuthService` file containing the first two service functions for admin login flow
- replace old `auth.client.service.js` function calls with new `AuthService` functions.

## Tests
<!-- What tests should be run to confirm functionality? -->
Unit tests have been added for the new `AuthService` functions.

### Manual Tests
- [ ] Login with invalid email. Should return and display not-whitelisted error message below the input
- [ ] Login with disconnected internet (chrome console > network > offline). Should display error message below the input
- [ ] Login with valid email. Should proceed to verify OTP page
- [ ] Enter invalid OTP. Should reject.
- [ ] Click resend OTP, then use previous valid OTP. Should reject. Should receive new OTP.

(Verification of OTP not tested because not in this PR)

