### PR TITLE
chore: remove endPage.buttons key from database 

### DIFF
--- a/scripts/20210706_remove-endpage-buttons/delete-endpage-buttons.js
+++ b/scripts/20210706_remove-endpage-buttons/delete-endpage-buttons.js
@@ -6,12 +6,8 @@ Delete endPage.buttons key from old form documents in the database
 
 // == PRE-UPDATE CHECKS ==
 
-// Count total number of forms
-db.getCollection('forms').count() 
-
 // Count number of forms with endPage buttons key
-db.getCollection('forms').find({ "endPage.buttons": { $exists: true } }).count()
-
+db.getCollection('forms').count({ "endPage.buttons": { $exists: true } })
 
 // == UPDATE ==
 // Delete endPage buttons key
@@ -24,10 +20,6 @@ db.getCollection('forms').updateMany({}, {
 
 // == POST-UPDATE CHECKS ==
 
-// Check total forms count
-// ~ Should be same as before
-db.getCollection('forms').count()
-
 // Check number of forms with endPage buttons key
 // ~ Should be zero
-db.getCollection('forms').find({ "endPage.buttons": { $exists: true } }).count()
+db.getCollection('forms').count({ "endPage.buttons": { $exists: true } })

--- a/scripts/20210706_remove-endpage-buttons/delete-endpage-buttons.js
+++ b/scripts/20210706_remove-endpage-buttons/delete-endpage-buttons.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+
+/*
+Delete endPage.buttons key from old form documents in the database
+*/
+
+// == PRE-UPDATE CHECKS ==
+
+// Count total number of forms
+db.getCollection('forms').count() 
+
+// Count number of forms with endPage buttons key
+db.getCollection('forms').find({ "endPage.buttons": { $exists: true } }).count()
+
+
+// == UPDATE ==
+// Delete endPage buttons key
+// ~ Number of forms updated should match number which had endPage buttons key
+db.getCollection('forms').updateMany({}, {
+  $unset: {
+    'endPage.buttons': "",
+  }
+})
+
+// == POST-UPDATE CHECKS ==
+
+// Check total forms count
+// ~ Should be same as before
+db.getCollection('forms').count()
+
+// Check number of forms with endPage buttons key
+// ~ Should be zero
+db.getCollection('forms').find({ "endPage.buttons": { $exists: true } }).count()

--- a/src/public/modules/forms/admin/constants/covid19.js
+++ b/src/public/modules/forms/admin/constants/covid19.js
@@ -26,7 +26,6 @@ const templates = [
     endPage: {
       title: 'We appreciate your feedback!',
       buttonText: 'Submit another form',
-      buttons: [],
       buttonLink: '',
     },
     form_fields: [
@@ -171,7 +170,6 @@ const templates = [
     endPage: {
       title: 'Thank you for submitting your declaration.',
       buttonText: 'Submit another form',
-      buttons: [],
       buttonLink: '',
     },
     form_fields: [
@@ -538,7 +536,6 @@ const templates = [
     endPage: {
       title: 'Thank you for filling out the form.',
       buttonText: 'Submit another form',
-      buttons: [],
       buttonLink: '',
       paragraph:
         'Please be reminded that you are to submit your daily temperature taken via this form.',
@@ -679,7 +676,6 @@ const templates = [
     endPage: {
       title: 'Thank you for registering your interest.',
       buttonText: 'Submit another form',
-      buttons: [],
       buttonLink: '',
       paragraph:
         'Our volunteer management team will be in touch with you shortly.',


### PR DESCRIPTION
## Problem
This PR contains a db script to remove the deprecated `endPage.buttons` key in forms. `buttons` are also removed from the covid templates.

Closes #1895