### PR TITLE
refactor(auth.client): (3) extract fetch user service function to Typescript

### DIFF
--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -41,11 +41,17 @@ function avatarDropdownController(
 
   async function retrieveUser() {
     try {
-      const trueUser = await UserService.fetchUser().then((user) => {
-        UserService.saveUserToLocalStorage(user)
-      })
+      const trueUser = await UserService.fetchUser()
+        .then((user) => {
+          UserService.saveUserToLocalStorage(user)
+          return user
+        })
+        .catch(() => {
+          UserService.clearUserFromLocalStorage()
+          return null
+        })
+
       if (!trueUser) {
-        UserService.clearUserFromLocalStorage()
         $state.go('signin')
         return
       }

--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -41,8 +41,11 @@ function avatarDropdownController(
 
   async function retrieveUser() {
     try {
-      const trueUser = await UserService.fetchUser()
+      const trueUser = await UserService.fetchUser().then((user) => {
+        UserService.saveUserToLocalStorage(user)
+      })
       if (!trueUser) {
+        UserService.clearUserFromLocalStorage()
         $state.go('signin')
         return
       }

--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -1,5 +1,7 @@
 const get = require('lodash/get')
 
+const UserService = require('../../../services/UserService')
+
 angular.module('core').component('avatarDropdownComponent', {
   templateUrl: 'modules/core/componentViews/avatar-dropdown.html',
   bindings: {},
@@ -39,7 +41,7 @@ function avatarDropdownController(
 
   async function retrieveUser() {
     try {
-      const trueUser = await Auth.refreshUser()
+      const trueUser = await UserService.fetchUser()
       if (!trueUser) {
         $state.go('signin')
         return

--- a/src/public/modules/users/services/auth.client.service.js
+++ b/src/public/modules/users/services/auth.client.service.js
@@ -23,7 +23,6 @@ function Auth($q, $http, $state, $window) {
   let authService = {
     getUser,
     setUser,
-    refreshUser,
     signOut,
   }
   return authService
@@ -49,19 +48,6 @@ function Auth($q, $http, $state, $window) {
     } catch (error) {
       return null
     }
-  }
-
-  function refreshUser() {
-    return $http
-      .get('/api/v3/user')
-      .then(({ data }) => {
-        setUser(data)
-        return data
-      })
-      .catch(() => {
-        setUser(null)
-        return null
-      })
   }
   function signOut() {
     $http.get('/api/v3/auth/logout').then(

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -18,6 +18,14 @@ export const saveUserToLocalStorage = (user: User): void => {
 }
 
 /**
+ * Clear logged in user from localStorage.
+ * May not even be needed in React depending on implementation.
+ */
+export const clearUserFromLocalStorage = (): void => {
+  localStorage.removeItem(STORAGE_USER_KEY)
+}
+
+/**
  * Fetches the user from the server using the current session cookie.
  *
  * Side effect: Saves the retrieved user to localStorage

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -4,8 +4,8 @@ import { User } from '../../types/api/user'
 
 /** Exported for testing */
 export const STORAGE_USER_KEY = 'user'
-
-const USER_ENDPOINT = '/api/v3/user'
+/** Exported for testing */
+export const USER_ENDPOINT = '/api/v3/user'
 
 /**
  * Save logged in user to localStorage.

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -1,7 +1,11 @@
+import axios from 'axios'
+
 import { User } from '../../types/api/user'
 
 /** Exported for testing */
 export const STORAGE_USER_KEY = 'user'
+
+const USER_ENDPOINT = '/api/v3/user'
 
 /**
  * Save logged in user to localStorage.
@@ -11,4 +15,23 @@ export const STORAGE_USER_KEY = 'user'
  */
 export const saveUserToLocalStorage = (user: User): void => {
   localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(user))
+}
+
+/**
+ * Fetches the user from the server using the current session cookie.
+ *
+ * Side effect: Saves the retrieved user to localStorage
+ * @returns the logged in user if session is valid, `null` otherwise
+ */
+export const fetchUser = async (): Promise<User | null> => {
+  return axios
+    .get<User>(USER_ENDPOINT)
+    .then(({ data: user }) => {
+      saveUserToLocalStorage(user)
+      return user
+    })
+    .catch(() => {
+      saveUserToLocalStorage(null)
+      return null
+    })
 }

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -32,14 +32,5 @@ export const clearUserFromLocalStorage = (): void => {
  * @returns the logged in user if session is valid, `null` otherwise
  */
 export const fetchUser = async (): Promise<User | null> => {
-  return axios
-    .get<User>(USER_ENDPOINT)
-    .then(({ data: user }) => {
-      saveUserToLocalStorage(user)
-      return user
-    })
-    .catch(() => {
-      saveUserToLocalStorage(null)
-      return null
-    })
+  return axios.get<User>(USER_ENDPOINT).then(({ data }) => data)
 }

--- a/src/public/services/__tests__/UserService.test.ts
+++ b/src/public/services/__tests__/UserService.test.ts
@@ -1,33 +1,80 @@
+import axios from 'axios'
+import { mocked } from 'ts-jest/utils'
+
 import { User } from '../../../types/api/user'
-import { saveUserToLocalStorage, STORAGE_USER_KEY } from '../UserService'
+import * as UserService from '../UserService'
+
+const { STORAGE_USER_KEY, USER_ENDPOINT } = UserService
+
+jest.mock('axios')
+
+const MockAxios = mocked(axios, true)
 
 describe('UserService', () => {
+  const MOCK_USER: User = {
+    _id: 'some id' as User['_id'],
+    email: 'mock@example.com',
+    agency: {
+      _id: 'some agency id' as User['agency']['_id'],
+      emailDomain: ['example.com'],
+      fullName: 'Example Agency',
+      logo: 'path/to/agency/logo',
+      shortName: 'e',
+    },
+    created: 'some created date',
+    lastAccessed: 'some last accessed date',
+    updatedAt: 'some last updated at date',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('saveUserToLocalStorage', () => {
     it('should successfully save given user to localStorage', () => {
-      // Arrange
-      const mockUser: User = {
-        _id: 'some id' as User['_id'],
-        email: 'mock@example.com',
-        agency: {
-          _id: 'some agency id' as User['agency']['_id'],
-          emailDomain: ['example.com'],
-          fullName: 'Example Agency',
-          logo: 'path/to/agency/logo',
-          shortName: 'e',
-        },
-        created: 'some created date',
-        lastAccessed: 'some last accessed date',
-        updatedAt: 'some last updated at date',
-      }
-
       // Act
-      saveUserToLocalStorage(mockUser)
+      UserService.saveUserToLocalStorage(MOCK_USER)
 
       // Assert
       expect(localStorage.setItem).toHaveBeenLastCalledWith(
         STORAGE_USER_KEY,
         // Should be stringified.
-        JSON.stringify(mockUser),
+        JSON.stringify(MOCK_USER),
+      )
+    })
+  })
+
+  describe('fetchUser', () => {
+    it('should save returned user to localStorage when successfully fetched', async () => {
+      // Arrange
+      MockAxios.get.mockResolvedValueOnce({ data: MOCK_USER })
+
+      // Act
+      const actual = await UserService.fetchUser()
+
+      // Assert
+      expect(actual).toEqual(MOCK_USER)
+      expect(MockAxios.get).toHaveBeenLastCalledWith(USER_ENDPOINT)
+      expect(localStorage.setItem).toHaveBeenLastCalledWith(
+        STORAGE_USER_KEY,
+        // Should be stringified.
+        JSON.stringify(MOCK_USER),
+      )
+    })
+
+    it('should return null and save null user to localStorage on API rejection', async () => {
+      // Arrange
+      MockAxios.get.mockRejectedValueOnce(new Error('something error'))
+
+      // Act
+      const actual = await UserService.fetchUser()
+
+      // Assert
+      expect(actual).toEqual(null)
+      expect(MockAxios.get).toHaveBeenLastCalledWith(USER_ENDPOINT)
+      expect(localStorage.setItem).toHaveBeenLastCalledWith(
+        STORAGE_USER_KEY,
+        'null',
       )
     })
   })

--- a/src/public/services/__tests__/UserService.test.ts
+++ b/src/public/services/__tests__/UserService.test.ts
@@ -44,6 +44,16 @@ describe('UserService', () => {
     })
   })
 
+  describe('clearUserFromLocalStorage', () => {
+    it('should successfully clear user from localStorage', () => {
+      // Act
+      UserService.clearUserFromLocalStorage()
+
+      // Assert
+      expect(localStorage.removeItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
+    })
+  })
+
   describe('fetchUser', () => {
     it('should save returned user to localStorage when successfully fetched', async () => {
       // Arrange

--- a/src/public/services/__tests__/UserService.test.ts
+++ b/src/public/services/__tests__/UserService.test.ts
@@ -55,7 +55,7 @@ describe('UserService', () => {
   })
 
   describe('fetchUser', () => {
-    it('should save returned user to localStorage when successfully fetched', async () => {
+    it('should return user successfully', async () => {
       // Arrange
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_USER })
 
@@ -65,27 +65,6 @@ describe('UserService', () => {
       // Assert
       expect(actual).toEqual(MOCK_USER)
       expect(MockAxios.get).toHaveBeenLastCalledWith(USER_ENDPOINT)
-      expect(localStorage.setItem).toHaveBeenLastCalledWith(
-        STORAGE_USER_KEY,
-        // Should be stringified.
-        JSON.stringify(MOCK_USER),
-      )
-    })
-
-    it('should return null and save null user to localStorage on API rejection', async () => {
-      // Arrange
-      MockAxios.get.mockRejectedValueOnce(new Error('something error'))
-
-      // Act
-      const actual = await UserService.fetchUser()
-
-      // Assert
-      expect(actual).toEqual(null)
-      expect(MockAxios.get).toHaveBeenLastCalledWith(USER_ENDPOINT)
-      expect(localStorage.setItem).toHaveBeenLastCalledWith(
-        STORAGE_USER_KEY,
-        'null',
-      )
     })
   })
 })


### PR DESCRIPTION
Chain: [`sendOtp`](https://github.com/opengovsg/FormSG/pull/2084) <--- [`verifyOtp`](https://github.com/opengovsg/FormSG/pull/2086) <-- `fetchUser` (you are here)

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR is part 3 of migrating auth.client.js to Typescript. This PR extracts out the fetch user function

Related to #2057

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:

- feat(UserService): add fetchUser function
- use new fetchUser function
- remove old unused refreshUser function

## Tests
<!-- What tests should be run to confirm functionality? -->
Unit tests have been written for `UserService.fetchUser`

### Manual tests
- [ ] Chrome network tab. Open dropdown avatar. The call should succeed and return the current user. Localstorage should also be replaced (or unchanged)

