### PR TITLE
refactor(auth.client): (4) extract admin logout service function to Typescript 

### DIFF
--- a/src/public/modules/core/componentViews/avatar-dropdown.html
+++ b/src/public/modules/core/componentViews/avatar-dropdown.html
@@ -68,7 +68,7 @@
       <!-- Logout block -->
       <li
         class="navbar__dropdown--clickable navbar__dropdown__logout"
-        ng-click="vm.signOut()"
+        ng-click="vm.logout()"
       >
         <span class="navbar__dropdown__logout--text">Logout</span>
         <i class="bx bx-log-out bx-md"></i>

--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -1,11 +1,13 @@
 const get = require('lodash/get')
 
+const AuthService = require('../../../services/AuthService')
 const UserService = require('../../../services/UserService')
 
 angular.module('core').component('avatarDropdownComponent', {
   templateUrl: 'modules/core/componentViews/avatar-dropdown.html',
   bindings: {},
   controller: [
+    '$q',
     '$scope',
     '$state',
     '$uibModal',
@@ -19,6 +21,7 @@ angular.module('core').component('avatarDropdownComponent', {
 })
 
 function avatarDropdownController(
+  $q,
   $scope,
   $state,
   $uibModal,
@@ -92,7 +95,20 @@ function avatarDropdownController(
     },
   )
 
-  vm.signOut = () => Auth.signOut()
+  vm.logout = () => {
+    return $q
+      .when(AuthService.logout())
+      .then(() => {
+        // Clear user and contact banner on logout
+        UserService.clearUserFromLocalStorage()
+        $window.localStorage.removeItem('contactBannerDismissed')
+        // Redirect to landing page
+        $state.go('landing')
+      })
+      .catch((error) => {
+        console.error('sign out failed:', error)
+      })
+  }
 
   vm.openContactNumberModal = () => {
     $uibModal

--- a/src/public/modules/core/components/avatar-dropdown.client.component.js
+++ b/src/public/modules/core/components/avatar-dropdown.client.component.js
@@ -109,7 +109,7 @@ function avatarDropdownController(
         // Update success, update user.
         if (returnVal) {
           vm.user = returnVal
-          Auth.setUser(returnVal)
+          UserService.saveUserToLocalStorage(returnVal)
           vm.showExclamation = !returnVal.contact
         }
       })

--- a/src/public/modules/users/services/auth.client.service.js
+++ b/src/public/modules/users/services/auth.client.service.js
@@ -22,18 +22,8 @@ function Auth($q, $http, $state, $window) {
 
   let authService = {
     getUser,
-    setUser,
-    signOut,
   }
   return authService
-
-  /**
-   * User setter function
-   * @param {User} user
-   */
-  function setUser(user) {
-    $window.localStorage.setItem('user', JSON.stringify(user))
-  }
 
   /**
    * User getter function
@@ -48,18 +38,5 @@ function Auth($q, $http, $state, $window) {
     } catch (error) {
       return null
     }
-  }
-  function signOut() {
-    $http.get('/api/v3/auth/logout').then(
-      function () {
-        $window.localStorage.removeItem('user')
-        // Clear contact banner on logout
-        $window.localStorage.removeItem('contactBannerDismissed')
-        $state.go('landing')
-      },
-      function (error) {
-        console.error('sign out failed:', error)
-      },
-    )
   }
 }

--- a/src/public/services/AuthService.ts
+++ b/src/public/services/AuthService.ts
@@ -49,3 +49,7 @@ export const verifyLoginOtp = async (params: {
     .post<User>(`${AUTH_ENDPOINT}/otp/verify`, params)
     .then(({ data }) => data)
 }
+
+export const logout = async (): Promise<void> => {
+  return axios.get(`${AUTH_ENDPOINT}/logout`)
+}

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -28,7 +28,8 @@ export const clearUserFromLocalStorage = (): void => {
 /**
  * Fetches the user from the server using the current session cookie.
  *
- * Side effect: Saves the retrieved user to localStorage
+ * Side effect: On success, save the retrieved user to localStorage.
+ * Side effect: On error, clear the user (if any) from localStorage.
  * @returns the logged in user if session is valid, `null` otherwise
  */
 export const fetchUser = async (): Promise<User | null> => {

--- a/src/public/services/__tests__/AuthService.test.ts
+++ b/src/public/services/__tests__/AuthService.test.ts
@@ -5,6 +5,7 @@ import { Opaque } from 'type-fest'
 import {
   AUTH_ENDPOINT,
   checkIsEmailAllowed,
+  logout,
   sendLoginOtp,
   verifyLoginOtp,
 } from '../AuthService'
@@ -81,6 +82,22 @@ describe('AuthService', () => {
         EXPECTED_POST_ENDPOINT,
         expectedParams,
       )
+    })
+  })
+
+  describe('logout', () => {
+    const EXPECTED_ENDPOINT = `${AUTH_ENDPOINT}/logout`
+    it('should call endpoint successfully', async () => {
+      // Arrange
+      const mockReturn = { status: 200 }
+      MockAxios.get.mockResolvedValueOnce(mockReturn)
+
+      // Act
+      const actual = await logout()
+
+      // Assert
+      expect(actual).toEqual(mockReturn)
+      expect(MockAxios.get).toHaveBeenLastCalledWith(EXPECTED_ENDPOINT)
     })
   })
 })


### PR DESCRIPTION
Chain: [`sendOtp`](https://github.com/opengovsg/FormSG/pull/2084) <--- [`verifyOtp`](https://github.com/opengovsg/FormSG/pull/2086) <-- [`fetchUser`](https://github.com/opengovsg/FormSG/pull/2089) <- `logout` (you are here)

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR is part 4 of migrating auth.client.js to Typescript. This PR extracts out the logout admin function

Related to #2057

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:

- feat(AuthService): add and use logout function
- feat(UserService): add clearUserFromLocalStorage fn

## Tests
<!-- What tests should be run to confirm functionality? -->
- test(AuthService): add unit test for logout
- test(UserService): add tests for clearUserFromLocalStorage
- test(UserService): update tests for fetchUser

### Manual tests
- [ ] Logout from the app. The user item from localStorage should be cleared and you should be kicked out to the login page.

