### PR TITLE
fix(deps): downgrade typescript to 4.2.4 and pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25259,9 +25259,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "type-fest": "^1.2.0",
-    "typescript": "^4.3.2",
+    "typescript": "=4.2.4",
     "url-loader": "^1.1.2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",


### PR DESCRIPTION
#2092 did not pin the TypeScript version, resulting in dependabot automatically upgrading it again. Oops.