### PR TITLE
chore(adminsubmissionsservice): renamed metadata methods

### DIFF
--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -407,11 +407,11 @@ function ViewResponsesController(
         getData: (params) => {
           let { page } = params.url()
           const getMetadataPromise = vm.filterBySubmissionRefId
-            ? AdminSubmissionsService.getFormMetadataById({
+            ? AdminSubmissionsService.getSubmissionMetadataById({
                 formId: vm.myform._id,
                 submissionId: vm.filterBySubmissionRefId,
               })
-            : AdminSubmissionsService.getFormsMetadataByPage({
+            : AdminSubmissionsService.getSubmissionsMetadataByPage({
                 formId: vm.myform._id,
                 pageNum: page,
               })

--- a/src/public/services/AdminSubmissionsService.ts
+++ b/src/public/services/AdminSubmissionsService.ts
@@ -36,7 +36,7 @@ export const countFormSubmissions = async ({
  * @param pageNum The page number of the responses
  * @returns The metadata of the page of forms
  */
-export const getFormsMetadataByPage = async ({
+export const getSubmissionsMetadataByPage = async ({
   formId,
   pageNum,
 }: FormsSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {
@@ -55,7 +55,7 @@ export const getFormsMetadataByPage = async ({
  * @param submissionId The id of the specified submission to retrieve
  * @returns The metadata of the form
  */
-export const getFormMetadataById = async ({
+export const getSubmissionMetadataById = async ({
   formId,
   submissionId,
 }: FormSubmissionMetadataQueryDto): Promise<SubmissionMetadataList> => {

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -7,8 +7,8 @@ import { ADMIN_FORM_ENDPOINT } from '../AdminFormService'
 import {
   countFormSubmissions,
   getEncryptedResponse,
-  getFormMetadataById,
-  getFormsMetadataByPage,
+  getSubmissionMetadataById,
+  getSubmissionsMetadataByPage,
 } from '../AdminSubmissionsService'
 
 jest.mock('axios')
@@ -60,7 +60,7 @@ describe('AdminSubmissionsService', () => {
     })
   })
 
-  describe('getFormsMetadataByPage', () => {
+  describe('getSubmissionsMetadataByPage', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_PAGE_NUM = 1
     const MOCK_RESPONSE: SubmissionMetadataList = {
@@ -79,7 +79,7 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = await getFormsMetadataByPage({
+      const actual = await getSubmissionsMetadataByPage({
         formId: MOCK_FORM_ID,
         pageNum: MOCK_PAGE_NUM,
       })
@@ -97,7 +97,7 @@ describe('AdminSubmissionsService', () => {
     })
   })
 
-  describe('getFormMetadataById', () => {
+  describe('getSubmissionMetadataById', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_SUBMISSION_ID = 'fake'
     const MOCK_RESPONSE: SubmissionMetadataList = {
@@ -116,7 +116,7 @@ describe('AdminSubmissionsService', () => {
       MockAxios.get.mockResolvedValueOnce({ data: MOCK_RESPONSE })
 
       // Act
-      const actual = await getFormMetadataById({
+      const actual = await getSubmissionMetadataById({
         formId: MOCK_FORM_ID,
         submissionId: MOCK_SUBMISSION_ID,
       })


### PR DESCRIPTION
## Problem
renamed metadata related methods to be for submissions because they are related to submissions and not form
