### PR TITLE
fix: use correct argument key when counting form submissions

### DIFF
--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -262,7 +262,7 @@ function ViewResponsesController(
       startDate && endDate
         ? {
             formId: vm.myform._id,
-            date: {
+            dates: {
               startDate: moment(new Date(startDate)).format('YYYY-MM-DD'),
               endDate: moment(new Date(endDate)).format('YYYY-MM-DD'),
             },

--- a/src/public/modules/forms/services/submissions.client.factory.js
+++ b/src/public/modules/forms/services/submissions.client.factory.js
@@ -124,7 +124,7 @@ function SubmissionsFactory($q, $http, $timeout, $window, GTag, FormSgSdk) {
         .when(
           AdminSubmissionsService.countFormSubmissions({
             formId,
-            date: { startDate, endDate },
+            dates: { startDate, endDate },
           }),
         )
         .then((expectedNumResponses) => {


### PR DESCRIPTION
**Discovered on staging, has not hit production yet**

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Wrong param shape was being passed into `AdminSubmissionsService.countFormSubmissions` introduced in #1983, resulting in a failure to retrieve the number of documents in a date range. This prevented the downloading of submissions when a date range is given if the number of responses to download does not equal number of total responses.

This PR fixes the bug.