### PR TITLE
feat(sms limit): sms warning for different limits

### DIFF
--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -1353,4 +1353,113 @@ describe('mail.service', () => {
       expect(sendMailSpy).toHaveBeenCalledTimes(0)
     })
   })
+
+  describe('sendSmsVerificationWarningEmail', () => {
+    const MOCK_FORM_ID = 'mockFormId'
+    const MOCK_FORM_TITLE = 'You are all individuals!'
+    const MOCK_INVALID_EMAIL = 'something wrong@a'
+
+    const MOCK_FORM: IPopulatedForm = {
+      permissionList: [
+        { email: MOCK_VALID_EMAIL },
+        { email: MOCK_VALID_EMAIL_2 },
+      ],
+      admin: {
+        email: MOCK_VALID_EMAIL_3,
+      },
+      title: MOCK_FORM_TITLE,
+      _id: MOCK_FORM_ID,
+    } as unknown as IPopulatedForm
+
+    const MOCK_INVALID_EMAIL_FORM: IPopulatedForm = {
+      permissionList: [],
+      admin: {
+        email: MOCK_INVALID_EMAIL,
+      },
+      title: MOCK_FORM_TITLE,
+      _id: MOCK_FORM_ID,
+    } as unknown as IPopulatedForm
+
+    const generateExpectedMailOptions = async (
+      count: number,
+      emailRecipients: string | string[],
+    ) => {
+      const result = await MailUtils.generateSmsVerificationWarningHtml({
+        formTitle: MOCK_FORM_TITLE,
+        formLink: `${MOCK_APP_URL}/${MOCK_FORM_ID}`,
+        numAvailable: SMS_VERIFICATION_LIMIT - count,
+        smsVerificationLimit: SMS_VERIFICATION_LIMIT,
+      }).map((emailHtml) => {
+        return {
+          to: emailRecipients,
+          from: MOCK_SENDER_STRING,
+          html: emailHtml,
+          subject: '[FormSG] SMS Verification - Free Tier Limit Alert',
+          replyTo: MOCK_SENDER_EMAIL,
+          bcc: MOCK_SENDER_EMAIL,
+        }
+      })
+      return result._unsafeUnwrap()
+    }
+
+    it('should send verified sms warning emails successfully', async () => {
+      // Arrange
+      // sendMail should return mocked success response
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const actualResult = await mailService.sendSmsVerificationWarningEmail(
+        MOCK_FORM,
+        1000,
+      )
+      const expectedMailOptions = await generateExpectedMailOptions(1000, [
+        MOCK_VALID_EMAIL,
+        MOCK_VALID_EMAIL_2,
+        MOCK_VALID_EMAIL_3,
+      ])
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(expectedMailOptions)
+    })
+
+    it('should return MailSendError when the provided email is invalid', async () => {
+      // Act
+      const actualResult = await mailService.sendSmsVerificationWarningEmail(
+        MOCK_INVALID_EMAIL_FORM,
+        1000,
+      )
+
+      // Assert
+      expect(actualResult).toEqual(
+        err(new MailSendError('Invalid email error')),
+      )
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(0)
+    })
+
+    it('should return MailGenerationError when the html template could not be created', async () => {
+      // Arrange
+      jest.spyOn(ejs, 'renderFile').mockRejectedValueOnce('no.')
+
+      // Act
+      const actualResult = await mailService.sendSmsVerificationWarningEmail(
+        MOCK_INVALID_EMAIL_FORM,
+        1000,
+      )
+
+      // Assert
+      expect(actualResult).toEqual(
+        err(
+          new MailGenerationError(
+            'Error occurred whilst rendering mail template',
+          ),
+        ),
+      )
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(0)
+    })
+  })
 })

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -97,4 +97,5 @@ export type SmsVerificationWarningData = {
   formTitle: string
   formLink: string
   numAvailable: number
+  smsVerificationLimit: number
 }

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -92,3 +92,9 @@ export type SmsVerificationDisabledData = {
   formTitle: string
   smsVerificationLimit: number
 }
+
+export type SmsVerificationWarningData = {
+  formTitle: string
+  formLink: string
+  numAvailable: number
+}

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -15,6 +15,7 @@ import {
   AutoreplySummaryRenderData,
   BounceNotificationHtmlData,
   SmsVerificationDisabledData,
+  SmsVerificationWarningData,
   SubmissionToAdminHtmlData,
 } from './mail.types'
 
@@ -175,5 +176,12 @@ export const generateSmsVerificationDisabledHtml = (
   htmlData: SmsVerificationDisabledData,
 ): ResultAsync<string, MailGenerationError> => {
   const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-disabled.server.view.html`
+  return safeRenderFile(pathToTemplate, htmlData)
+}
+
+export const generateSmsVerificationWarningHtml = (
+  htmlData: SmsVerificationWarningData,
+): ResultAsync<string, MailGenerationError> => {
+  const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-warning.view.html`
   return safeRenderFile(pathToTemplate, htmlData)
 }

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -5,7 +5,7 @@
     <p>Dear form admin(s),</p>
     <p>
       You are receiving this as you have enabled SMS OTP verification on a
-      Mobile Number field of your form
+      Mobile Number field of your form:
       <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
     </p>
     <p>

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -9,8 +9,8 @@
       <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
     </p>
     <p>
-      Your form can receive <b><%= numAvailable %></b> more responses until free
-      SMS OTP verification is automatically disabled.
+      You can receive <b><%= numAvailable %></b> more responses until free SMS
+      OTP verification is automatically disabled.
     </p>
     <p>
       If you require SMS OTP verification for more than 10,000 responses, please

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head> </head>
+  <body>
+    <p>Dear form admin(s),</p>
+    <p>
+      You are receiving this as you have enabled SMS OTP verification on a
+      Mobile Number field of your form
+      <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
+    </p>
+    <p>
+      Your form can receive <b><%= numAvailable %></b> more responses until free
+      SMS OTP verification is automatically disabled.
+    </p>
+    <p>
+      If you require SMS OTP verification for more than 10,000 responses, please
+      <a
+        href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
+        >arrange advance billing with us.
+      </a>
+    </p>
+    <p>
+      <b>Important: </b> Please refrain from creating multiple forms for the
+      same use case in order to avoid this limit, as such forms risk being
+      flagged for abuse and blacklisted.
+    </p>
+    <p>The FormSG Team</p>
+  </body>
+</html>


### PR DESCRIPTION
## Problem
This PR is part 1 of #1935 - warning emails should be sent out at certain pre-defined threshold

## Solution
1. Adds a method to mail service to send templated warning emails out to users. 
    - the method **does not** care about the current count - that part will be done by verification service in an upcoming PR
   
## Screenshots
<img width="988" alt="Screenshot 2021-06-08 at 5 49 27 PM" src="https://user-images.githubusercontent.com/44049504/121164179-fca5e900-c881-11eb-97ff-c2646973ce64.png">
