### PR TITLE
feat: add and call v3 API for retrieving individual admin form

### DIFF
--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -33,23 +33,35 @@ AdminFormsFormRouter.route('/')
    */
   .post(AdminFormController.handleCreateForm)
 
-/**
- * Archive the specified form.
- * @route DELETE /:formId/adminform
- * @security session
- *
- * @returns 200 with success message when successfully archived
- * @returns 401 when user does not exist in session
- * @returns 403 when user does not have permissions to archive form
- * @returns 404 when form cannot be found
- * @returns 410 when form is already archived
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
- */
-AdminFormsFormRouter.delete(
-  '/:formId([a-fA-F0-9]{24})',
-  AdminFormController.handleArchiveForm,
-)
+AdminFormsFormRouter.route('/:formId([a-fA-F0-9]{24})')
+  /**
+   * Return the specified form to the user.
+   * @route GET /:formId/adminform
+   * @security session
+   *
+   * @returns 200 with retrieved form with formId if user has read permissions
+   * @returns 401 when user does not exist in session
+   * @returns 403 when user does not have permissions to access form
+   * @returns 404 when form cannot be found
+   * @returns 410 when form is archived
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .get(AdminFormController.handleGetAdminForm)
+  /**
+   * Archive the specified form.
+   * @route DELETE /:formId/adminform
+   * @security session
+   *
+   * @returns 200 with success message when successfully archived
+   * @returns 401 when user does not exist in session
+   * @returns 403 when user does not have permissions to archive form
+   * @returns 404 when form cannot be found
+   * @returns 410 when form is already archived
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .delete(AdminFormController.handleArchiveForm)
 
 /**
  * Duplicate the specified form.

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -7,7 +7,6 @@ export const AdminFormsFormRouter = Router()
 AdminFormsFormRouter.route('/')
   /**
    * List the forms managed by the user
-   * @route GET /adminform
    * @security session
    *
    * @returns 200 with a list of forms managed by the user
@@ -19,7 +18,6 @@ AdminFormsFormRouter.route('/')
 
   /**
    * Create a new form
-   * @route POST /adminform
    * @security session
    *
    * @returns 200 with newly created form
@@ -36,7 +34,6 @@ AdminFormsFormRouter.route('/')
 AdminFormsFormRouter.route('/:formId([a-fA-F0-9]{24})')
   /**
    * Return the specified form to the user.
-   * @route GET /:formId/adminform
    * @security session
    *
    * @returns 200 with retrieved form with formId if user has read permissions
@@ -50,7 +47,6 @@ AdminFormsFormRouter.route('/:formId([a-fA-F0-9]{24})')
   .get(AdminFormController.handleGetAdminForm)
   /**
    * Archive the specified form.
-   * @route DELETE /:formId/adminform
    * @security session
    *
    * @returns 200 with success message when successfully archived
@@ -65,7 +61,6 @@ AdminFormsFormRouter.route('/:formId([a-fA-F0-9]{24})')
 
 /**
  * Duplicate the specified form.
- * @route POST /:formId/adminform
  * @security session
  *
  * @returns 200 with the duplicate form dashboard view
@@ -84,7 +79,6 @@ AdminFormsFormRouter.post(
 
 /**
  * Transfer form ownership to another user
- * @route POST /:formId/adminform/transfer-owner
  * @security session
  *
  * @returns 200 with updated form with transferred owners
@@ -111,7 +105,6 @@ AdminFormsFormRouter.route(
 )
   /**
    * Update form field according to given new body.
-   * @route PUT /admin/forms/:formId/fields/:fieldId
    *
    * @param body the new field to override current field
    * @returns 200 with updated form field
@@ -129,7 +122,6 @@ AdminFormsFormRouter.route(
 
   /**
    * Delete form field by fieldId of form corresponding to formId.
-   * @route DELETE /admin/forms/:formId/fields/:fieldId
    * @security session
    *
    * @returns 204 when deletion is successful
@@ -143,7 +135,6 @@ AdminFormsFormRouter.route(
   .delete(AdminFormController.handleDeleteFormField)
   /**
    * Retrives the form field using the fieldId from the specified form
-   * @route GET /admin/forms/:formId/fields/:fieldId
    * @security session
    *
    * @returns 200 with form field when retrieval is successful
@@ -158,7 +149,6 @@ AdminFormsFormRouter.route(
 
 /**
  * Duplicates the form field with the fieldId from the specified form
- * @route POST /:formId/fields/:fieldId/duplicate
  * @security session
  *
  * @returns 200 with duplicated field

--- a/src/public/services/AdminViewFormService.ts
+++ b/src/public/services/AdminViewFormService.ts
@@ -25,7 +25,9 @@ export const getDashboardView = async (): Promise<FormMetaView[]> => {
 export const getAdminFormView = async (
   formId: string,
 ): Promise<FormViewDto> => {
-  return axios.get<FormViewDto>(`/${formId}/adminform`).then(({ data }) => data)
+  return axios
+    .get<FormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+    .then(({ data }) => data)
 }
 
 /**

--- a/src/public/services/__tests__/AdminViewFormService.test.ts
+++ b/src/public/services/__tests__/AdminViewFormService.test.ts
@@ -82,7 +82,9 @@ describe('AdminViewFormService', () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockAxios.get).toHaveBeenCalledWith(`/${expected._id}/adminform`)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${expected._id}`,
+      )
     })
 
     it('should reject with error message when GET request fails', async () => {
@@ -96,7 +98,9 @@ describe('AdminViewFormService', () => {
 
       // Assert
       await expect(actualPromise).rejects.toEqual(expected)
-      expect(MockAxios.get).toHaveBeenCalledWith(`/${MOCK_FORM._id}/adminform`)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM._id}`,
+      )
     })
   })
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Seems to have been missed out when duplicating the current APIs into their `/api/v3` counterparts. This PR adds the new endpoint, calls the new endpoint, and adds missing tests for the endpoint.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - Client calls new endpoint
- [ ] No - this PR is backwards compatible  

**Features**:

- feat: add v3 API for retrieving admin form by id
- feat(AdminViewFormService): call v3 API to retrieve admin form

## Tests
<!-- What tests should be run to confirm functionality? -->
New integration tests have been added for the new endpoint.

### Manual test
- [ ] Access admin form. In chrome network tab, should call new /api/v3 endpoint.
