### PR TITLE
chore: remove blocking of SP and RP admin updates

### DIFF
--- a/src/app/modules/auth/auth.middlewares.ts
+++ b/src/app/modules/auth/auth.middlewares.ts
@@ -3,7 +3,6 @@ import { StatusCodes } from 'http-status-codes'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
-import * as UserService from '../user/user.service'
 
 import { isUserInSession } from './auth.utils'
 
@@ -23,39 +22,6 @@ export const withUserAuthentication: ControllerHandler = (req, res, next) => {
   return res
     .status(StatusCodes.UNAUTHORIZED)
     .json({ message: 'User is unauthorized.' })
-}
-
-const DENIED_DOMAINS = ['myrp.edu.sg', 'ichat.sp.edu.sg']
-
-/**
- * If user is from a domain which should not have been whitelisted,
- * do not allow any updates. Only allow GET requests, eg to access
- * submissions.
- * @returns 400 if user in session is from a disallowed domain and
- * HTTP method changes database state; next otherwise
- */
-export const denyRpSpStudentEmails: ControllerHandler = async (
-  req,
-  res,
-  next,
-) => {
-  const userId = (req.session as Express.AuthedSession).user._id
-  return UserService.findUserById(userId)
-    .map((user) => {
-      const emailDomain = user.email.split('@').pop() ?? ''
-      if (
-        DENIED_DOMAINS.includes(emailDomain.toLowerCase()) &&
-        req.method.toLowerCase() !== 'get'
-      ) {
-        return res.sendStatus(StatusCodes.BAD_REQUEST)
-      }
-      return next()
-    })
-    .mapErr(() =>
-      res
-        .status(StatusCodes.UNPROCESSABLE_ENTITY)
-        .json({ message: 'User not found' }),
-    )
 }
 
 /**

--- a/src/app/routes/api/v3/admin/forms/admin-forms.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.routes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
 
 import {
-  denyRpSpStudentEmails,
   logAdminAction,
   withUserAuthentication,
 } from '../../../../../modules/auth/auth.middlewares'
@@ -18,7 +17,6 @@ export const AdminFormsRouter = Router()
 
 // All routes in this handler should be protected by authentication.
 AdminFormsRouter.use(withUserAuthentication)
-AdminFormsRouter.use(denyRpSpStudentEmails)
 
 // Log all non-get admin form actions
 AdminFormsRouter.use('/:formId([a-fA-F0-9]{24})', logAdminAction)


### PR DESCRIPTION
Removes the temporary fix introduced in #2047 to block form updates from admins who had been erroneously onboarded.