### PR TITLE
test: loosen URL check in e2e test

### DIFF
--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -714,7 +714,7 @@ async function expectStartPage(t, testForm, testFormData, appUrl) {
   await t
     .navigateTo(`${appUrl}/${_id}`)
     .expect(getPageUrl())
-    .eql(`${appUrl}/#!/${_id}`)
+    .contains(_id)
     .expect(formPage.startTitle.textContent)
     .contains(formOptions.title)
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

End-to-end tests are intermittently failing due to the following:
```
AssertionError: expected
      'http://localhost:5000/60c068423668141b03289c84#!/' to deeply equal
      'http://localhost:5000/#!/60c068423668141b03289c84'
      + expected - actual
      -http://localhost:5000/60c068423668141b03289c84#!/
      +http://localhost:5000/#!/60c068423668141b03289c84
```

This is probably because the test checks the URL in the browser before the browser redirects to the form.

## Solution
<!-- How did you solve the problem? -->

Loosen the URL check so it checks for the presence of the form ID in the URL instead of an exact string. If the redirect does not occur correctly then the subsequent assertions will fail anyway.