### PR TITLE
fix(auth): make login emails case-insensitive

### DIFF
--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -97,6 +97,23 @@ describe('auth.routes', () => {
       expect(response.text).toEqual('OK')
     })
 
+    it('should return 200 when domain of body.email has a case-insensitive match in Agency collection', async () => {
+      // Arrange
+      // Insert agency
+      const validDomain = 'example.com'
+      const validEmail = `test@${validDomain}`
+      await dbHandler.insertAgency({ mailDomain: validDomain })
+
+      // Act
+      const response = await request
+        .post('/auth/checkuser')
+        .send({ email: validEmail.toUpperCase() })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.text).toEqual('OK')
+    })
+
     it('should return 500 when validating domain returns a database error', async () => {
       // Arrange
       // Insert agency
@@ -245,6 +262,23 @@ describe('auth.routes', () => {
       const response = await request
         .post('/auth/sendotp')
         .send({ email: VALID_EMAIL })
+
+      // Assert
+      expect(sendLoginOtpSpy).toHaveBeenCalled()
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+    })
+
+    it('should return 200 when otp is sent successfully and email is non-lowercase', async () => {
+      // Arrange
+      const sendLoginOtpSpy = jest
+        .spyOn(MailService, 'sendLoginOtp')
+        .mockReturnValueOnce(okAsync(true))
+
+      // Act
+      const response = await request
+        .post('/auth/sendotp')
+        .send({ email: VALID_EMAIL.toUpperCase() })
 
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
@@ -458,6 +492,33 @@ describe('auth.routes', () => {
       const response = await request
         .post('/auth/verifyotp')
         .send({ email: VALID_EMAIL, otp: MOCK_VALID_OTP })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Body should be an user object.
+      expect(response.body).toMatchObject({
+        // Required since that's how the data is sent out from the application.
+        agency: jsonParseStringify(defaultAgency.toObject()),
+        _id: expect.any(String),
+        created: expect.any(String),
+        email: VALID_EMAIL,
+      })
+      // Should have session cookie returned.
+      const sessionCookie = request.cookies.find(
+        (cookie) => cookie.name === 'connect.sid',
+      )
+      expect(sessionCookie).toBeDefined()
+    })
+
+    it('should return 200 with user object when body.otp is a valid OTP and body.email is non-lowercase', async () => {
+      // Arrange
+      // Request for OTP so the hash exists.
+      await requestForOtp(VALID_EMAIL)
+
+      // Act
+      const response = await request
+        .post('/auth/verifyotp')
+        .send({ email: VALID_EMAIL.toUpperCase(), otp: MOCK_VALID_OTP })
 
       // Assert
       expect(response.status).toEqual(200)

--- a/src/app/modules/auth/auth.routes.ts
+++ b/src/app/modules/auth/auth.routes.ts
@@ -23,6 +23,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
     }),
   }),
@@ -49,6 +50,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
     }),
   }),
@@ -75,6 +77,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
       otp: Joi.string()
         .required()

--- a/src/app/modules/auth/auth.routes.ts
+++ b/src/app/modules/auth/auth.routes.ts
@@ -23,8 +23,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
     }),
   }),
   AuthController.handleCheckUser,
@@ -50,8 +50,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
     }),
   }),
   AuthController.handleLoginSendOtp,
@@ -77,8 +77,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
       otp: Joi.string()
         .required()
         .regex(/^\d{6}$/)

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
@@ -301,7 +301,9 @@ describe('admin-form.settings.routes', () => {
       })
       const session = await createAuthedSession(fakeUser.email, request)
       const expectedResponse = jsonParseStringify({
-        message: `User ${fakeUser.email} not authorized to perform write operation on Form ${form._id} with title: ${form.title}.`,
+        message: `User ${fakeUser.email.toLowerCase()} not authorized to perform write operation on Form ${
+          form._id
+        } with title: ${form.title}.`,
       })
 
       // Act
@@ -431,12 +433,14 @@ describe('admin-form.settings.routes', () => {
         },
       })
       const fakeUser = await dbHandler.insertUser({
-        mailName: 'fakeUser',
+        mailName: 'userWithoutReadPermissions',
         agencyId: new ObjectId(),
       })
       const session = await createAuthedSession(fakeUser.email, request)
       const expectedResponse = jsonParseStringify({
-        message: `User ${fakeUser.email} not authorized to perform read operation on Form ${form._id} with title: ${form.title}.`,
+        message: `User ${fakeUser.email.toLowerCase()} not authorized to perform read operation on Form ${
+          form._id
+        } with title: ${form.title}.`,
       })
 
       // Act

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -105,7 +105,7 @@ describe('auth.routes', () => {
 
       // Act
       const response = await request
-        .post('/auth/checkuser')
+        .post('/auth/email/validate')
         .send({ email: validEmail.toUpperCase() })
 
       // Assert
@@ -276,7 +276,7 @@ describe('auth.routes', () => {
 
       // Act
       const response = await request
-        .post('/auth/sendotp')
+        .post('/auth/otp/generate')
         .send({ email: VALID_EMAIL.toUpperCase() })
 
       // Assert

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -96,6 +96,23 @@ describe('auth.routes', () => {
       expect(response.text).toEqual('OK')
     })
 
+    it('should return 200 when domain of body.email has a case-insensitive match in Agency collection', async () => {
+      // Arrange
+      // Insert agency
+      const validDomain = 'example.com'
+      const validEmail = `test@${validDomain}`
+      await dbHandler.insertAgency({ mailDomain: validDomain })
+
+      // Act
+      const response = await request
+        .post('/auth/checkuser')
+        .send({ email: validEmail.toUpperCase() })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.text).toEqual('OK')
+    })
+
     it('should return 500 when validating domain returns a database error', async () => {
       // Arrange
       // Insert agency
@@ -244,6 +261,23 @@ describe('auth.routes', () => {
       const response = await request
         .post('/auth/otp/generate')
         .send({ email: VALID_EMAIL })
+
+      // Assert
+      expect(sendLoginOtpSpy).toHaveBeenCalled()
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+    })
+
+    it('should return 200 when otp is sent successfully and email is non-lowercase', async () => {
+      // Arrange
+      const sendLoginOtpSpy = jest
+        .spyOn(MailService, 'sendLoginOtp')
+        .mockReturnValueOnce(okAsync(true))
+
+      // Act
+      const response = await request
+        .post('/auth/sendotp')
+        .send({ email: VALID_EMAIL.toUpperCase() })
 
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
@@ -457,6 +491,33 @@ describe('auth.routes', () => {
       const response = await request
         .post('/auth/otp/verify')
         .send({ email: VALID_EMAIL, otp: MOCK_VALID_OTP })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Body should be an user object.
+      expect(response.body).toMatchObject({
+        // Required since that's how the data is sent out from the application.
+        agency: JSON.parse(JSON.stringify(defaultAgency.toObject())),
+        _id: expect.any(String),
+        created: expect.any(String),
+        email: VALID_EMAIL,
+      })
+      // Should have session cookie returned.
+      const sessionCookie = request.cookies.find(
+        (cookie) => cookie.name === 'connect.sid',
+      )
+      expect(sessionCookie).toBeDefined()
+    })
+
+    it('should return 200 with user object when body.otp is a valid OTP and body.email is non-lowercase', async () => {
+      // Arrange
+      // Request for OTP so the hash exists.
+      await requestForOtp(VALID_EMAIL)
+
+      // Act
+      const response = await request
+        .post('/auth/otp/verify')
+        .send({ email: VALID_EMAIL.toUpperCase(), otp: MOCK_VALID_OTP })
 
       // Assert
       expect(response.status).toEqual(200)

--- a/src/app/routes/api/v3/auth/auth.routes.ts
+++ b/src/app/routes/api/v3/auth/auth.routes.ts
@@ -21,8 +21,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
     }),
   }),
   AuthController.handleCheckUser,
@@ -48,8 +48,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
     }),
   }),
   AuthController.handleLoginSendOtp,
@@ -75,8 +75,8 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
-        .lowercase()
-        .message('Please enter a valid email'),
+        .message('Please enter a valid email')
+        .lowercase(),
       otp: Joi.string()
         .required()
         .regex(/^\d{6}$/)

--- a/src/app/routes/api/v3/auth/auth.routes.ts
+++ b/src/app/routes/api/v3/auth/auth.routes.ts
@@ -21,6 +21,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
     }),
   }),
@@ -47,6 +48,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
     }),
   }),
@@ -73,6 +75,7 @@ AuthRouter.post(
       email: Joi.string()
         .required()
         .email()
+        .lowercase()
         .message('Please enter a valid email'),
       otp: Joi.string()
         .required()

--- a/tests/integration/helpers/express-auth.ts
+++ b/tests/integration/helpers/express-auth.ts
@@ -35,7 +35,7 @@ export const createAuthedSession = async (
 
   const sendOtpResponse = await request.post('/auth/sendotp').send({ email })
   expect(sendOtpResponse.status).toEqual(200)
-  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email}`)
+  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email.toLowerCase()}`)
 
   // Act
   await request.post('/auth/verifyotp').send({ email, otp: MOCK_VALID_OTP })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

#2084 introduced a bug where non-lowercase emails could not be used to log in to the admin dashboard.

The frontend used to mutate `vm.credentials.email` to lowercase at the point of sending the OTP, then use the lowercased string when subsequently verifying the OTP. This is important because the email domains in the Agencies collection are all in lowercase, so only lowercase email domains are considered to be valid. However, #2084 removed this mutation, resulting in OTP verification breaking for non-lowercase emails.

This exposes a source of bugs in the authorisation flow, namely that the backend implicitly relies on the frontend to send email strings in the correct case.

## Solution
<!-- How did you solve the problem? -->

For all authorisation endpoints, lowercase email addresses at the edge of the application using Joi validation. This ensures that there is no ambiguity about the case of the string at any layer of the backend.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

Login to admin dashboard is now case-insensitive for email addresses.

## Tests
<!-- What tests should be run to confirm functionality? -->

Integration tests were added to test the case-insensitivity of the authorisation endpoints.

## Manual tests
- [ ] Ensure that you can log in successfully to the dashboard when typing your email in uppercase.