### PR TITLE
feat(sms-limiting): email for disabling sms verification

### DIFF
--- a/src/app/modules/verification/verification.constants.ts
+++ b/src/app/modules/verification/verification.constants.ts
@@ -1,0 +1,1 @@
+export const SMS_VERIFICATION_LIMIT = 10000

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -1,9 +1,13 @@
+import ejs from 'ejs'
 import { cloneDeep } from 'lodash'
 import moment from 'moment-timezone'
 import { err, ok, okAsync } from 'neverthrow'
 import Mail, { Attachment } from 'nodemailer/lib/mailer'
 
-import { MailSendError } from 'src/app/services/mail/mail.errors'
+import {
+  MailGenerationError,
+  MailSendError,
+} from 'src/app/services/mail/mail.errors'
 import { MailService } from 'src/app/services/mail/mail.service'
 import {
   AutoreplySummaryRenderData,
@@ -12,6 +16,8 @@ import {
 } from 'src/app/services/mail/mail.types'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
 import { BounceType, IPopulatedForm, ISubmissionSchema } from 'src/types'
+
+import { SMS_VERIFICATION_LIMIT } from '../../../modules/verification/verification.constants'
 
 const MOCK_VALID_EMAIL = 'to@example.com'
 const MOCK_VALID_EMAIL_2 = 'to2@example.com'
@@ -1240,6 +1246,111 @@ describe('mail.service', () => {
       // non-4xx error.
       expect(sendMailSpy).toHaveBeenCalledTimes(2)
       expect(sendMailSpy).toHaveBeenCalledWith(expectedArgs)
+    })
+  })
+
+  describe('sendSmsVerificationDisabledEmail', () => {
+    const MOCK_FORM_ID = 'mockFormId'
+    const MOCK_FORM_TITLE = 'You are all individuals!'
+    const MOCK_INVALID_EMAIL = 'something wrong@a'
+
+    const MOCK_FORM: IPopulatedForm = {
+      permissionList: [
+        { email: MOCK_VALID_EMAIL },
+        { email: MOCK_VALID_EMAIL_2 },
+      ],
+      admin: {
+        email: MOCK_VALID_EMAIL_3,
+      },
+      title: MOCK_FORM_TITLE,
+      _id: MOCK_FORM_ID,
+    } as unknown as IPopulatedForm
+
+    const MOCK_INVALID_EMAIL_FORM: IPopulatedForm = {
+      permissionList: [],
+      admin: {
+        email: MOCK_INVALID_EMAIL,
+      },
+      title: MOCK_FORM_TITLE,
+      _id: MOCK_FORM_ID,
+    } as unknown as IPopulatedForm
+
+    const generateExpectedMailOptions = async (
+      count: number,
+      emailRecipients: string | string[],
+    ) => {
+      const result = await MailUtils.generateSmsVerificationDisabledHtml({
+        formTitle: MOCK_FORM_TITLE,
+        formLink: `${MOCK_APP_URL}/${MOCK_FORM_ID}`,
+        smsVerificationLimit: SMS_VERIFICATION_LIMIT,
+      }).map((emailHtml) => {
+        return {
+          to: emailRecipients,
+          from: MOCK_SENDER_STRING,
+          html: emailHtml,
+          subject: '[FormSG] SMS Verification - Free Tier Limit Reached',
+          replyTo: MOCK_SENDER_EMAIL,
+          bcc: MOCK_SENDER_EMAIL,
+        }
+      })
+      return result._unsafeUnwrap()
+    }
+
+    it('should send verified sms disabled emails successfully', async () => {
+      // Arrange
+      // sendMail should return mocked success response
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const actualResult = await mailService.sendSmsVerificationDisabledEmail(
+        MOCK_FORM,
+      )
+      const expectedMailOptions = await generateExpectedMailOptions(1000, [
+        MOCK_VALID_EMAIL,
+        MOCK_VALID_EMAIL_2,
+        MOCK_VALID_EMAIL_3,
+      ])
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(expectedMailOptions)
+    })
+
+    it('should return MailSendError when the provided email is invalid', async () => {
+      // Act
+      const actualResult = await mailService.sendSmsVerificationDisabledEmail(
+        MOCK_INVALID_EMAIL_FORM,
+      )
+
+      // Assert
+      expect(actualResult).toEqual(
+        err(new MailSendError('Invalid email error')),
+      )
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(0)
+    })
+
+    it('should return MailGenerationError when the html template could not be created', async () => {
+      // Arrange
+      jest.spyOn(ejs, 'renderFile').mockRejectedValueOnce('no.')
+
+      // Act
+      const actualResult = await mailService.sendSmsVerificationDisabledEmail(
+        MOCK_INVALID_EMAIL_FORM,
+      )
+
+      // Assert
+      expect(actualResult).toEqual(
+        err(
+          new MailGenerationError(
+            'Error occurred whilst rendering mail template',
+          ),
+        ),
+      )
+      // Check arguments passed to sendNodeMail
+      expect(sendMailSpy).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -86,3 +86,9 @@ export type BounceNotificationHtmlData = {
   bouncedRecipients: string
   appName: string
 }
+
+export type SmsVerificationDisabledData = {
+  formLink: string
+  formTitle: string
+  smsVerificationLimit: number
+}

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -14,6 +14,7 @@ import {
   AutoreplyHtmlData,
   AutoreplySummaryRenderData,
   BounceNotificationHtmlData,
+  SmsVerificationDisabledData,
   SubmissionToAdminHtmlData,
 } from './mail.types'
 
@@ -168,4 +169,11 @@ export const isToFieldValid = (addresses: string | string[]): boolean => {
 
   // Every address must be an email to be valid.
   return mails.every((addr) => validator.isEmail(addr))
+}
+
+export const generateSmsVerificationDisabledHtml = (
+  htmlData: SmsVerificationDisabledData,
+): ResultAsync<string, MailGenerationError> => {
+  const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-disabled.server.view.html`
+  return safeRenderFile(pathToTemplate, htmlData)
 }

--- a/src/app/views/templates/sms-verification-disabled.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled.server.view.html
@@ -9,21 +9,23 @@
       <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
     </p>
     <p>
-      SMS OTP verification has been <b>automatically disabled</b>on your form as
-      you have reached the free tier limit of <%= smsVerificationLimit>
+      SMS OTP verification has been <b>automatically disabled</b> on your form
+      as you have reached the free tier limit of <%= smsVerificationLimit %>
       responses.
     </p>
 
     <p>
       We would have previously notified all form admins upon your account
-      reaching 2500, 5000 and 7500 responses, while free SMS OTP verification
-      was enabled.
+      reaching 2500, 5000 and 7500 responses while free SMS OTP verification was
+      enabled.
     </p>
     <p>
-      If you require SMS OTP verification for more than 10,000 responses, please
+      If you require SMS OTP verification for more than <%= smsVerificationLimit
+      %> responses, please
       <a
         href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
-        >arrange advance billing with us.
+      >
+        arrange advance billing with us.
       </a>
     </p>
     <p>

--- a/src/app/views/templates/sms-verification-disabled.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled.server.view.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head> </head>
+  <body>
+    <p>Dear form admin(s),</p>
+    <p>
+      You are receiving this as you have enabled SMS OTP verification on a
+      Mobile Number field of your form:
+      <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
+    </p>
+    <p>
+      SMS OTP verification has been <b>automatically disabled</b>on your form as
+      you have reached the free tier limit of <%= smsVerificationLimit>
+      responses.
+    </p>
+
+    <p>
+      We would have previously notified all form admins upon your account
+      reaching 2500, 5000 and 7500 responses, while free SMS OTP verification
+      was enabled.
+    </p>
+    <p>
+      If you require SMS OTP verification for more than 10,000 responses, please
+      <a
+        href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
+        >arrange advance billing with us.
+      </a>
+    </p>
+    <p>
+      <b>Important: </b> Please refrain from creating multiple forms for the
+      same use case in order to avoid this limit, as such forms risk being
+      flagged for abuse and blacklisted.
+    </p>
+    <p>The FormSG Team</p>
+  </body>
+</html>


### PR DESCRIPTION
## Problem
Admins who have breached their limit of allowable verified SMS should have an eamil sent out to them 

## Solution
1. Adds a method to mail service to send templated disabled emails out to users.

## Screenshots
<img width="1014" alt="Screenshot 2021-06-10 at 3 45 07 PM" src="https://user-images.githubusercontent.com/44049504/121485562-df4c5880-ca02-11eb-9fa3-527bf82a0055.png">
