### PR TITLE
fix(submissions): remove captcha dependence on feature toggle

### DIFF
--- a/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
+++ b/src/public/modules/forms/base/directiveViews/submit-form.directive.view.html
@@ -128,7 +128,7 @@
         <div
           vc-recaptcha
           key="captchaService.publicKey"
-          ng-if="captchaService.create(feature.captcha) && form.hasCaptcha && !disableSubmitButton"
+          ng-if="form.hasCaptcha && !disableSubmitButton"
           size="invisible"
           on-create="captchaService.setWidget(widgetId)"
           on-success="captchaService.onSuccess(response, submitForm)"

--- a/src/public/modules/forms/services/captcha.client.service.js
+++ b/src/public/modules/forms/services/captcha.client.service.js
@@ -27,22 +27,6 @@ function captchaService($window, vcRecaptchaService, Toastr, GTag) {
   this.widgetId = null
 
   /**
-   * Flag indicating if captcha feature is enabled on app
-   */
-  this.enabled = false
-
-  /**
-   * Set enabled flag
-   * @param {Boolean} enabled
-   */
-  this.create = function (enabled) {
-    // We cannot use setWidget() as an indication that captcha is enabled/disabled because setWidget() will not be called
-    // when captcha is enabled but captcha is blocked
-    this.enabled = enabled
-    return this.enabled
-  }
-
-  /**
    * Set widgetId
    * @param {String} widgetId
    */
@@ -77,20 +61,18 @@ function captchaService($window, vcRecaptchaService, Toastr, GTag) {
   }
 
   /**
-   * Expire captcha if captcha enabled
+   * Expire captcha
    */
   this.expire = function () {
-    if (this.enabled) {
-      vcRecaptchaService.reload(this.widgetId)
-      this.response = null
-    }
+    vcRecaptchaService.reload(this.widgetId)
+    this.response = null
   }
 
   /**
-   * Check if response has been set, assuming captcha is enabled
+   * Check if response has been set
    */
   this.isValid = function () {
-    if (this.response || !this.enabled) {
+    if (this.response) {
       return true
     } else {
       return false


### PR DESCRIPTION
## Problem

#2118 broke the submissions pipeline because of an overlooked dependence of the frontend Captcha service on the feature toggles. This was not caught by end-to-end tests because captcha is always disabled for those tests.

## Solution

Remove the dependence on the feature toggles.

## Tests

Functionality can be verified by submitting a form with captcha enabled.