### PR TITLE
build: mute Localstack logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,8 @@ services:
       - './.localstack:/tmp/localstack'
       - '/var/run/docker.sock:/var/run/docker.sock'
     network_mode: 'service:formsg' # reuse formsg service's network stack so that it can resolve localhost:4566 to localstack:4566
+    logging:
+      driver: none
 
   maildev:
     image: maildev/maildev


### PR DESCRIPTION
## Problem

Localstack outputs repeated "Waiting for all LocalStack services to be ready" logs for a long time after the dev server starts up, even though the health endpoint reflects that all its services are running. This is annoying.

## Solution

Mute Localstack container logs.