### PR TITLE
feat(feature-manager): hardcode /features API response

### DIFF
--- a/src/app/modules/frontend/frontend.controller.ts
+++ b/src/app/modules/frontend/frontend.controller.ts
@@ -141,12 +141,12 @@ export const showFeaturesStates: ControllerHandler<
   Record<FeatureNames, boolean>
 > = (_req, res) => {
   return res.json({
-    captcha: true,
-    sms: true,
-    'spcp-myinfo': true,
-    'verified-fields': true,
-    'google-analytics': true,
-    'webhook-verified-content': true,
-    sentry: true,
+    [FeatureNames.Captcha]: true,
+    [FeatureNames.Sms]: true,
+    [FeatureNames.SpcpMyInfo]: true,
+    [FeatureNames.VerifiedFields]: true,
+    [FeatureNames.GoogleAnalytics]: true,
+    [FeatureNames.WebhookVerifiedContent]: true,
+    [FeatureNames.Sentry]: true,
   })
 }

--- a/src/app/modules/frontend/frontend.controller.ts
+++ b/src/app/modules/frontend/frontend.controller.ts
@@ -1,7 +1,6 @@
 import ejs from 'ejs'
 import { StatusCodes } from 'http-status-codes'
 
-import featureManager from '../../config/feature-manager'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
@@ -116,15 +115,38 @@ export const generateRedirectUrl: ControllerHandler<
   }
 }
 
+// Duplicated here since the feature manager is being deprecated.
+// TODO (#2147): delete this.
+enum FeatureNames {
+  Captcha = 'captcha',
+  GoogleAnalytics = 'google-analytics',
+  Sentry = 'sentry',
+  Sms = 'sms',
+  SpcpMyInfo = 'spcp-myinfo',
+  VerifiedFields = 'verified-fields',
+  WebhookVerifiedContent = 'webhook-verified-content',
+}
+
 /**
  * Handler for GET /frontend/features endpoint.
  * @param _req - Express request object
  * @param res - Express response object
  * @returns Current featureManager states
+ * @deprecated as the feature manager has been deprecated. This endpoint
+ * now hardcodes the feature states to support old clients.
+ * TODO (#2147): delete this
  */
 export const showFeaturesStates: ControllerHandler<
   unknown,
-  typeof featureManager.states
+  Record<FeatureNames, boolean>
 > = (_req, res) => {
-  return res.json(featureManager.states)
+  return res.json({
+    captcha: true,
+    sms: true,
+    'spcp-myinfo': true,
+    'verified-fields': true,
+    'google-analytics': true,
+    'webhook-verified-content': true,
+    sentry: true,
+  })
 }

--- a/src/app/modules/frontend/frontend.routes.ts
+++ b/src/app/modules/frontend/frontend.routes.ts
@@ -27,6 +27,8 @@ FrontendRouter.get('/environment', FrontendServerController.addEnvVarData)
  * Generate a json of current activated features
  * @route GET /frontend/features
  * @return json with featureManager.states
+ * @deprecated
+ * TODO (#2147): delete this
  */
 FrontendRouter.get('/features', FrontendServerController.showFeaturesStates)
 

--- a/src/app/routes/api/v3/client/client.routes.ts
+++ b/src/app/routes/api/v3/client/client.routes.ts
@@ -30,6 +30,8 @@ ClientRouter.get('/environment', FrontendServerController.addEnvVarData)
  * Generate a json of current activated features
  * @route GET /api/v3/client/features
  * @return json with featureManager.states
+ * @deprecated
+ * TODO (#2147): delete this
  */
 ClientRouter.get('/features', FrontendServerController.showFeaturesStates)
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Old clients make API calls to the /features endpoint in order to retrieve the list of features currently enabled in the application. However, since the feature manager is being deprecated, all features are always enabled. This means the dependence of this API endpoint on the feature manager is blocking the deprecation of the feature manager.

Part of #1842 

## Solution
<!-- How did you solve the problem? -->

Hardcode the API response from the /features endpoint until old clients stop calling it. This allows the rest of feature manager to be safely deprecated.