### PR TITLE
refactor(angularjs): remove angular-moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7306,14 +7306,6 @@
       "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.8.2.tgz",
       "integrity": "sha512-M1qNh/30cLJi4yJJ+3YB8saPonRcavz5Dquqz0T/aUySKJhIkUoeCkmF+BcLH4SJ5PBp04yy4CZUUeNRVi7jZA=="
     },
-    "angular-moment": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.3.0.tgz",
-      "integrity": "sha512-KG8rvO9MoaBLwtGnxTeUveSyNtrL+RNgGl1zqWN36+HDCCVGk2DGWOzqKWB6o+eTTbO3Opn4hupWKIElc8XETA==",
-      "requires": {
-        "moment": ">=2.8.0 <3.0.0"
-      }
-    },
     "angular-permission": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/angular-permission/-/angular-permission-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "angular-cookies": "~1.8.2",
     "angular-drag-scroll": "^0.2.1",
     "angular-messages": "^1.8.2",
-    "angular-moment": "~1.3.0",
     "angular-permission": "~1.1.1",
     "angular-resource": "^1.8.2",
     "angular-sanitize": "^1.8.2",

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -13,7 +13,6 @@ const moduleDependencies = [
   'ngResource',
   'ui.router',
   'ui.bootstrap',
-  'angularMoment',
   'vcRecaptcha',
   'users',
   'ngFileUpload',
@@ -55,7 +54,6 @@ require('angular-permission/dist/angular-permission')
 require('@opengovsg/angular-recaptcha-fallback')
 require('angular-resource')
 require('angular-sanitize')
-require('angular-moment')
 require('angular-messages')
 
 require('angular-ui-bootstrap')
@@ -84,9 +82,6 @@ require('@opengovsg/angular-daterangepicker-webpack')
 const appName = 'FormSG'
 // Add module dependencies
 const app = angular.module(appName, moduleDependencies)
-
-// Override moment using Angular's dependency injection
-app.constant('moment', require('moment-timezone'))
 
 // Setting HTML5 Location Mode
 angular.module(appName).config([

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -2,6 +2,7 @@
 
 const { StatusCodes } = require('http-status-codes')
 const get = require('lodash/get')
+const moment = require('moment-timezone')
 const { LogicType } = require('../../../../../types')
 const UpdateFormService = require('../../../../services/UpdateFormService')
 const UserService = require('../../../../services/UserService')
@@ -43,7 +44,6 @@ angular
     '$uibModal',
     'FormData',
     'FormFields',
-    'moment',
     'Toastr',
     '$state',
     '$window',
@@ -58,7 +58,6 @@ function AdminFormController(
   $uibModal,
   FormData,
   FormFields,
-  moment,
   Toastr,
   $state,
   $window,

--- a/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const get = require('lodash/get')
+const moment = require('moment-timezone')
+
 const BetaService = require('../../../../services/BetaService')
 
 const UserService = require('../../../../services/UserService')
@@ -12,7 +14,6 @@ angular
     '$scope',
     'FormApi',
     '$uibModal',
-    'moment',
     '$state',
     '$timeout',
     '$window',
@@ -25,7 +26,6 @@ function ListFormsController(
   $scope,
   FormApi,
   $uibModal,
-  moment,
   $state,
   $timeout,
   $window,

--- a/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/view-responses.client.controller.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const moment = require('moment-timezone')
+
 const {
   processDecryptedContent,
 } = require('../../helpers/process-decrypted-content')
@@ -24,7 +26,6 @@ angular
     '$timeout',
     '$location',
     '$anchorScroll',
-    'moment',
     ViewResponsesController,
   ])
 
@@ -39,7 +40,6 @@ function ViewResponsesController(
   $timeout,
   $location,
   $anchorScroll,
-  moment,
 ) {
   const vm = this
 

--- a/src/public/modules/forms/base/components/end-page.client.component.js
+++ b/src/public/modules/forms/base/components/end-page.client.component.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const moment = require('moment-timezone')
+
 angular.module('forms').component('endPageComponent', {
   templateUrl: 'modules/forms/base/componentViews/end-page.html',
   bindings: {
@@ -13,11 +15,11 @@ angular.module('forms').component('endPageComponent', {
     colorTheme: '@',
     submissionId: '@',
   },
-  controller: ['SpcpSession', '$window', 'moment', endPageController],
+  controller: ['SpcpSession', '$window', endPageController],
   controllerAs: 'vm',
 })
 
-function endPageController(SpcpSession, $window, moment) {
+function endPageController(SpcpSession, $window) {
   const vm = this
 
   vm.timestamp = moment().format('D MMM YYYY, HH:mm')


### PR DESCRIPTION
## Problem

As we prepare for the React migration, we should minimise the number of 
AngularJS-specific libraries that are currently in use.

## Solution
As we have no need for the AngularJS filters and directives that
angular-moment provides, remove it completely, referencing moment
as a CommonJS module instead.

## Testing
Verify that date formatting remains correct for:
- Admin dashboard form list
- Form builder heading
- Viewing responses in storage mode
- On form submission