### PR TITLE
fix(auth.client.controller): add missing undefinedness check

### DIFF
--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -136,7 +136,7 @@ function AuthenticationController($q, $scope, $state, $timeout, $window, GTag) {
     vm.buttonClicked = true
 
     const email = vm.credentials.email
-    if (!validator.isEmail(email)) {
+    if (!email || !validator.isEmail(email)) {
       setEmailSignInError('Please enter a valid email address')
       return
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Missing undefinedness check for email resulted in `validator` throwing an error.  This PR fixes that.


## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix(auth.client.controller): add missing undefinedness check
