### PR TITLE
docs(script): add script to remove permissionList.read key from the db

### DIFF
--- a/scripts/20210616_remove-permissionList-read/remove-permissionList-read.js
+++ b/scripts/20210616_remove-permissionList-read/remove-permissionList-read.js
@@ -1,0 +1,54 @@
+/* eslint-disable */
+
+// Number of forms with permissionList.read key - expect 0 after running update
+db.forms.count({
+  permissionList: { $elemMatch: { read: { $exists: true } } }
+})
+
+{
+  // Number of objects in permissionList with read key - expect 0 after running update
+  const permissionListWithReadKey = [
+    {
+      $match: {
+        permissionList: { $elemMatch: { read: { $exists: true } } }
+      },
+    },
+    { $project: { permissionList: 1 } },
+    { $unwind: '$permissionList' },
+    { $match: { 'permissionList.read': { $exists: true } } },
+    { $count: 'numObjs' }
+  ]
+
+  db.getCollection('forms').aggregate(permissionListWithReadKey)
+}
+
+// Update - Remove read key
+db.forms.update(
+  { 'permissionList.read': { $exists: true } },
+  { $unset: { 'permissionList.$[elem].read': 1 } },
+  { arrayFilters: [{ 'elem.read': { $exists: true } }], multi: true }
+)
+
+
+// Check again, should be 0.
+db.forms.count({
+  permissionList: { $elemMatch: { read: { $exists: true } } }
+})
+
+// Check again, should be 0
+{
+  // Number of objects in permissionList with read key - expect 0 after running update
+  const permissionListWithReadKey = [
+    {
+      $match: {
+        permissionList: { $elemMatch: { read: { $exists: true } } }
+      },
+    },
+    { $project: { permissionList: 1 } },
+    { $unwind: '$permissionList' },
+    { $match: { 'permissionList.read': { $exists: true } } },
+    { $count: 'numObjs' }
+  ]
+
+  db.getCollection('forms').aggregate(permissionListWithReadKey)
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Script to remove permissionList.read key from the database.
The key is already removed from the schema, so old/new clients should not matter. 
Any updates by old forms (with the deprecated key already saved in client) will not affect the database.

Related to #2177

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->


**New scripts**:

- add script to remove permissionList.read key from the database.
