### PR TITLE
feat: Set SP/CP JWT cookie to HttpOnly

### DIFF
--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -39,7 +39,9 @@ import {
   LoginPageValidationError,
   MissingJwtError,
 } from '../../../spcp/spcp.errors'
+import { SpcpFactory } from '../../../spcp/spcp.factory'
 import { SpcpService } from '../../../spcp/spcp.service'
+import { JwtName } from '../../../spcp/spcp.types'
 import {
   AuthTypeMismatchError,
   FormAuthNoEsrvcIdError,
@@ -1485,6 +1487,71 @@ describe('public-form.controller', () => {
       expect(mockRes.json).toBeCalledWith({
         message: 'Sorry, something went wrong. Please try again.',
       })
+    })
+  })
+
+  describe('handleFormAuthLogout', () => {
+    it('should return 200 if authType is SP and call clearCookie()', async () => {
+      const authType = AuthType.SP
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          authType,
+        },
+      })
+      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
+
+      await PublicFormController._handleFormAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(200)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.json).toBeCalledWith({
+        message: 'Successfully logged out.',
+      })
+    })
+
+    it('should return 200 if authType is CP and call clearCookie()', async () => {
+      const authType = AuthType.CP
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          authType,
+        },
+      })
+      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
+
+      await PublicFormController._handleFormAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(200)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.json).toBeCalledWith({
+        message: 'Successfully logged out.',
+      })
+    })
+
+    it('should return 400 if authType is invalid and not clear cookie', async () => {
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          authType: AuthType.NIL,
+        },
+      })
+      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
+
+      await PublicFormController._handleFormAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(400)
+      expect(mockRes.json).toBeCalledWith({ message: 'Invalid authType.' })
+      expect(mockRes.clearCookie).not.toHaveBeenCalled()
     })
   })
 

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -515,7 +515,12 @@ describe('public-form.controller', () => {
 
       it('should return 200 when client authenticates using SP', async () => {
         // Arrange
-        const MOCK_SPCP_SESSION = { userName: MOCK_JWT_PAYLOAD.userName }
+        const MOCK_SPCP_SESSION = {
+          userName: MOCK_JWT_PAYLOAD.userName,
+          exp: 1000000000,
+          iat: 100000000,
+          rememberMe: false,
+        }
         const MOCK_SP_AUTH_FORM = {
           ...BASE_FORM,
           authType: AuthType.SP,
@@ -543,13 +548,23 @@ describe('public-form.controller', () => {
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_SP_AUTH_FORM.getPublicView(),
           isIntranetUser: false,
-          spcpSession: MOCK_SPCP_SESSION,
+          spcpSession: {
+            userName: MOCK_SPCP_SESSION.userName,
+            iat: MOCK_SPCP_SESSION.iat,
+            rememberMe: MOCK_SPCP_SESSION.rememberMe,
+            msToExpiry: expect.toBeNumber(),
+          },
         })
       })
 
       it('should return 200 when client authenticates using CP', async () => {
         // Arrange
-        const MOCK_SPCP_SESSION = { userName: MOCK_JWT_PAYLOAD.userName }
+        const MOCK_SPCP_SESSION = {
+          userName: MOCK_JWT_PAYLOAD.userName,
+          exp: 1000000000,
+          iat: 100000000,
+          rememberMe: false,
+        }
         const MOCK_CP_AUTH_FORM = {
           ...BASE_FORM,
           authType: AuthType.CP,
@@ -576,7 +591,12 @@ describe('public-form.controller', () => {
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_CP_AUTH_FORM.getPublicView(),
           isIntranetUser: false,
-          spcpSession: MOCK_SPCP_SESSION,
+          spcpSession: {
+            userName: MOCK_SPCP_SESSION.userName,
+            iat: MOCK_SPCP_SESSION.iat,
+            rememberMe: MOCK_SPCP_SESSION.rememberMe,
+            msToExpiry: expect.toBeNumber(),
+          },
         })
       })
 
@@ -989,6 +1009,9 @@ describe('public-form.controller', () => {
     describe('errors in form access', () => {
       const MOCK_SPCP_SESSION = {
         userName: 'mock',
+        exp: 1000000000,
+        iat: 100000000,
+        rememberMe: false,
       }
 
       it('should return 200 with isIntranetUser set to false when a user accesses a form from outside intranet', async () => {
@@ -1051,7 +1074,12 @@ describe('public-form.controller', () => {
         // Assert
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_SP_AUTH_FORM.getPublicView(),
-          spcpSession: MOCK_SPCP_SESSION,
+          spcpSession: {
+            userName: MOCK_SPCP_SESSION.userName,
+            iat: MOCK_SPCP_SESSION.iat,
+            rememberMe: MOCK_SPCP_SESSION.rememberMe,
+            msToExpiry: expect.toBeNumber(),
+          },
           isIntranetUser: true,
         })
       })
@@ -1086,7 +1114,12 @@ describe('public-form.controller', () => {
         // Assert
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_CP_AUTH_FORM.getPublicView(),
-          spcpSession: MOCK_SPCP_SESSION,
+          spcpSession: {
+            userName: MOCK_SPCP_SESSION.userName,
+            iat: MOCK_SPCP_SESSION.iat,
+            rememberMe: MOCK_SPCP_SESSION.rememberMe,
+            msToExpiry: expect.toBeNumber(),
+          },
           isIntranetUser: true,
         })
       })

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1477,7 +1477,9 @@ describe('public-form.controller', () => {
           authType,
         },
       })
-      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
 
       await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 
@@ -1495,7 +1497,9 @@ describe('public-form.controller', () => {
           authType,
         },
       })
-      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
 
       await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -549,12 +549,7 @@ describe('public-form.controller', () => {
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_SP_AUTH_FORM.getPublicView(),
           isIntranetUser: false,
-          spcpSession: {
-            userName: MOCK_SPCP_SESSION.userName,
-            iat: MOCK_SPCP_SESSION.iat,
-            rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            exp: MOCK_SPCP_SESSION.exp,
-          },
+          spcpSession: MOCK_SPCP_SESSION,
         })
       })
 
@@ -592,12 +587,7 @@ describe('public-form.controller', () => {
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_CP_AUTH_FORM.getPublicView(),
           isIntranetUser: false,
-          spcpSession: {
-            userName: MOCK_SPCP_SESSION.userName,
-            iat: MOCK_SPCP_SESSION.iat,
-            rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            exp: MOCK_SPCP_SESSION.exp,
-          },
+          spcpSession: MOCK_SPCP_SESSION,
         })
       })
 
@@ -1075,12 +1065,7 @@ describe('public-form.controller', () => {
         // Assert
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_SP_AUTH_FORM.getPublicView(),
-          spcpSession: {
-            userName: MOCK_SPCP_SESSION.userName,
-            iat: MOCK_SPCP_SESSION.iat,
-            rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            exp: MOCK_SPCP_SESSION.exp,
-          },
+          spcpSession: MOCK_SPCP_SESSION,
           isIntranetUser: true,
         })
       })
@@ -1115,12 +1100,7 @@ describe('public-form.controller', () => {
         // Assert
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_CP_AUTH_FORM.getPublicView(),
-          spcpSession: {
-            userName: MOCK_SPCP_SESSION.userName,
-            iat: MOCK_SPCP_SESSION.iat,
-            rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            exp: MOCK_SPCP_SESSION.exp,
-          },
+          spcpSession: MOCK_SPCP_SESSION,
           isIntranetUser: true,
         })
       })

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1489,7 +1489,7 @@ describe('public-form.controller', () => {
     })
   })
 
-  describe('handleFormAuthLogout', () => {
+  describe('handleSpcpLogout', () => {
     it('should return 200 if authType is SP and call clearCookie()', async () => {
       const authType = AuthType.SP
       const MOCK_REQ = expressHandler.mockRequest({
@@ -1499,11 +1499,7 @@ describe('public-form.controller', () => {
       })
       const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
 
-      await PublicFormController._handleFormAuthLogout(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
@@ -1521,11 +1517,7 @@ describe('public-form.controller', () => {
       })
       const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
 
-      await PublicFormController._handleFormAuthLogout(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -553,7 +553,7 @@ describe('public-form.controller', () => {
             userName: MOCK_SPCP_SESSION.userName,
             iat: MOCK_SPCP_SESSION.iat,
             rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            msToExpiry: expect.toBeNumber(),
+            exp: MOCK_SPCP_SESSION.exp,
           },
         })
       })
@@ -596,7 +596,7 @@ describe('public-form.controller', () => {
             userName: MOCK_SPCP_SESSION.userName,
             iat: MOCK_SPCP_SESSION.iat,
             rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            msToExpiry: expect.toBeNumber(),
+            exp: MOCK_SPCP_SESSION.exp,
           },
         })
       })
@@ -1079,7 +1079,7 @@ describe('public-form.controller', () => {
             userName: MOCK_SPCP_SESSION.userName,
             iat: MOCK_SPCP_SESSION.iat,
             rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            msToExpiry: expect.toBeNumber(),
+            exp: MOCK_SPCP_SESSION.exp,
           },
           isIntranetUser: true,
         })
@@ -1119,7 +1119,7 @@ describe('public-form.controller', () => {
             userName: MOCK_SPCP_SESSION.userName,
             iat: MOCK_SPCP_SESSION.iat,
             rememberMe: MOCK_SPCP_SESSION.rememberMe,
-            msToExpiry: expect.toBeNumber(),
+            exp: MOCK_SPCP_SESSION.exp,
           },
           isIntranetUser: true,
         })

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1533,25 +1533,6 @@ describe('public-form.controller', () => {
         message: 'Successfully logged out.',
       })
     })
-
-    it('should return 400 if authType is invalid and not clear cookie', async () => {
-      const MOCK_REQ = expressHandler.mockRequest({
-        params: {
-          authType: AuthType.NIL,
-        },
-      })
-      const mockRes = expressHandler.mockResponse({ clearCookie: jest.fn() })
-
-      await PublicFormController._handleFormAuthLogout(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      expect(mockRes.status).toBeCalledWith(400)
-      expect(mockRes.json).toBeCalledWith({ message: 'Invalid authType.' })
-      expect(mockRes.clearCookie).not.toHaveBeenCalled()
-    })
   })
 
   describe('handleValidateFormEsrvcId', () => {

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -39,7 +39,6 @@ import {
   LoginPageValidationError,
   MissingJwtError,
 } from '../../../spcp/spcp.errors'
-import { SpcpFactory } from '../../../spcp/spcp.factory'
 import { SpcpService } from '../../../spcp/spcp.service'
 import { JwtName } from '../../../spcp/spcp.types'
 import {

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -83,6 +83,7 @@ describe('public-form.routes', () => {
       mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          exp: 1000000000,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -96,13 +97,13 @@ describe('public-form.routes', () => {
       const formId = form._id
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(formId)
-      const expectedResponseBody = JSON.parse(
-        JSON.stringify({
-          form: fullForm?.getPublicView(),
-          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
-          isIntranetUser: false,
+      const expectedResponseBody = {
+        form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
+        spcpSession: expect.objectContaining({
+          userName: MOCK_COOKIE_PAYLOAD.userName,
         }),
-      )
+        isIntranetUser: false,
+      }
 
       // Act
       // Set cookie on request
@@ -120,6 +121,7 @@ describe('public-form.routes', () => {
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
           userInfo: 'MyCorpPassUEN',
+          exp: 1000000000,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -133,13 +135,13 @@ describe('public-form.routes', () => {
       const formId = form._id
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(formId)
-      const expectedResponseBody = JSON.parse(
-        JSON.stringify({
-          form: fullForm?.getPublicView(),
-          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
-          isIntranetUser: false,
+      const expectedResponseBody = {
+        form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
+        spcpSession: expect.objectContaining({
+          userName: MOCK_COOKIE_PAYLOAD.userName,
         }),
-      )
+        isIntranetUser: false,
+      }
 
       // Act
       // Set cookie on request

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -83,7 +83,9 @@ describe('public-form.routes', () => {
       mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          iat: 100000000,
           exp: 1000000000,
+          rememberMe: false,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -99,9 +101,12 @@ describe('public-form.routes', () => {
       const fullForm = await dbHandler.getFullFormById(formId)
       const expectedResponseBody = {
         form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
-        spcpSession: expect.objectContaining({
+        spcpSession: {
           userName: MOCK_COOKIE_PAYLOAD.userName,
-        }),
+          iat: 100000000,
+          exp: 1000000000,
+          rememberMe: false,
+        },
         isIntranetUser: false,
       }
 
@@ -121,7 +126,9 @@ describe('public-form.routes', () => {
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
           userInfo: 'MyCorpPassUEN',
+          iat: 100000000,
           exp: 1000000000,
+          rememberMe: false,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -137,9 +144,13 @@ describe('public-form.routes', () => {
       const fullForm = await dbHandler.getFullFormById(formId)
       const expectedResponseBody = {
         form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
-        spcpSession: expect.objectContaining({
+        spcpSession: {
           userName: MOCK_COOKIE_PAYLOAD.userName,
-        }),
+          userInfo: 'MyCorpPassUEN',
+          iat: 100000000,
+          exp: 1000000000,
+          rememberMe: false,
+        },
         isIntranetUser: false,
       }
 

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -467,9 +467,10 @@ export const _handleSpcpLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
-  res.clearCookie(JwtName[authType])
-
-  return res.status(200).json({ message: 'Successfully logged out.' })
+  return res
+    .clearCookie(JwtName[authType])
+    .status(200)
+    .json({ message: 'Successfully logged out.' })
 }
 
 /**

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -274,23 +274,14 @@ export const handleGetPublicForm: ControllerHandler<
     case AuthType.CP:
       return SpcpService.extractJwtPayloadFromRequest(authType, req.cookies)
         .map(({ userName, exp, iat, rememberMe }) => {
-          if (!exp) {
-            {
-              logger.error({
-                message: 'Invalid expiry time for cookie',
-                meta: logMeta,
-              })
-            }
-            return res.json({ form: publicForm, isIntranetUser })
-          }
           return res.json({
             form: publicForm,
             isIntranetUser,
             spcpSession: {
               userName,
               iat,
+              exp,
               rememberMe,
-              msToExpiry: exp * 1000 - Date.now(), // Used to tell browser when to refresh page upon cookie expiry
             },
           })
         })

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -274,15 +274,6 @@ export const handleGetPublicForm: ControllerHandler<
     case AuthType.CP:
       return SpcpService.extractJwtPayloadFromRequest(authType, req.cookies)
         .map((spcpSession) => {
-          if (!exp) {
-            {
-              logger.error({
-                message: 'Invalid expiry time for cookie',
-                meta: logMeta,
-              })
-            }
-            return res.json({ form: publicForm, isIntranetUser })
-          }
           return res.json({
             form: publicForm,
             isIntranetUser,

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -32,7 +32,6 @@ import {
   validateMyInfoForm,
 } from '../../myinfo/myinfo.util'
 import { InvalidJwtError, VerifyJwtError } from '../../spcp/spcp.errors'
-import { SpcpFactory } from '../../spcp/spcp.factory'
 import { SpcpService } from '../../spcp/spcp.service'
 import { JwtName } from '../../spcp/spcp.types'
 import { getRedirectTarget, validateSpcpForm } from '../../spcp/spcp.util'
@@ -273,7 +272,7 @@ export const handleGetPublicForm: ControllerHandler<
       return res.json({ form: publicForm, isIntranetUser })
     case AuthType.SP:
     case AuthType.CP:
-      return SpcpFactory.extractJwtPayloadFromRequest(authType, req.cookies)
+      return SpcpService.extractJwtPayloadFromRequest(authType, req.cookies)
         .map(({ userName, exp, iat, rememberMe }) => {
           if (!exp) {
             {

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -491,7 +491,7 @@ export const _handleFormAuthLogout: ControllerHandler<
 }
 
 /**
- * Handler for /forms/:authType/logout
+ * Handler for /forms/auth/:authType/logout
  * Valid AuthTypes are SP or CP
  */
 export const handleFormAuthLogout = [

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -476,14 +476,10 @@ export const handleFormAuthRedirect = [
  * @returns 400 if authType is invalid
  */
 export const _handleFormAuthLogout: ControllerHandler<
-  { authType: AuthType },
+  { authType: AuthType.SP | AuthType.CP },
   PublicFormAuthLogoutDto
 > = (req, res) => {
   const { authType } = req.params
-
-  if (authType !== AuthType.SP && authType !== AuthType.CP) {
-    return res.status(400).json({ message: 'Invalid authType.' })
-  }
 
   res.clearCookie(JwtName[authType])
 

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -274,6 +274,15 @@ export const handleGetPublicForm: ControllerHandler<
     case AuthType.CP:
       return SpcpService.extractJwtPayloadFromRequest(authType, req.cookies)
         .map(({ userName, exp, iat, rememberMe }) => {
+          if (!exp) {
+            {
+              logger.error({
+                message: 'Invalid expiry time for cookie',
+                meta: logMeta,
+              })
+            }
+            return res.json({ form: publicForm, isIntranetUser })
+          }
           return res.json({
             form: publicForm,
             isIntranetUser,

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -273,7 +273,7 @@ export const handleGetPublicForm: ControllerHandler<
     case AuthType.SP:
     case AuthType.CP:
       return SpcpService.extractJwtPayloadFromRequest(authType, req.cookies)
-        .map(({ userName, exp, iat, rememberMe }) => {
+        .map((spcpSession) => {
           if (!exp) {
             {
               logger.error({
@@ -286,12 +286,7 @@ export const handleGetPublicForm: ControllerHandler<
           return res.json({
             form: publicForm,
             isIntranetUser,
-            spcpSession: {
-              userName,
-              iat,
-              exp,
-              rememberMe,
-            },
+            spcpSession,
           })
         })
         .mapErr((error) => {

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -475,7 +475,7 @@ export const handleFormAuthRedirect = [
  * @returns 200 with success message when user logs out successfully
  * @returns 400 if authType is invalid
  */
-export const _handleFormAuthLogout: ControllerHandler<
+export const _handleSpcpLogout: ControllerHandler<
   { authType: AuthType.SP | AuthType.CP },
   PublicFormAuthLogoutDto
 > = (req, res) => {
@@ -490,13 +490,13 @@ export const _handleFormAuthLogout: ControllerHandler<
  * Handler for /forms/auth/:authType/logout
  * Valid AuthTypes are SP or CP
  */
-export const handleFormAuthLogout = [
+export const handleSpcpLogout = [
   celebrate({
     [Segments.PARAMS]: Joi.object({
       authType: Joi.string().valid(AuthType.SP, AuthType.CP).required(),
     }),
   }),
-  _handleFormAuthLogout,
+  _handleSpcpLogout,
 ] as ControllerHandler[]
 
 /**

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -307,7 +307,7 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtSp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
-          httpOnly: true,
+          httpOnly: false,
           sameSite: 'lax',
           secure: !MockConfig.isDev,
           ...MOCK_COOKIE_SETTINGS,
@@ -566,7 +566,7 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtCp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
-          httpOnly: true,
+          httpOnly: false,
           sameSite: 'lax',
           secure: !MockConfig.isDev,
           ...MOCK_COOKIE_SETTINGS,

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -307,7 +307,7 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtSp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
-          httpOnly: false,
+          httpOnly: true,
           sameSite: 'lax',
           secure: !MockConfig.isDev,
           ...MOCK_COOKIE_SETTINGS,
@@ -566,7 +566,7 @@ describe('spcp.controller', () => {
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtCp', MOCK_JWT, {
           maxAge: MOCK_COOKIE_AGE,
-          httpOnly: false,
+          httpOnly: true,
           sameSite: 'lax',
           secure: !MockConfig.isDev,
           ...MOCK_COOKIE_SETTINGS,

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -165,7 +165,7 @@ export const handleLogin: (
     .map(() => {
       res.cookie(JwtName[authType], jwtResult.value, {
         maxAge: cookieDuration,
-        httpOnly: false, // the JWT needs to be read by client-side JS
+        httpOnly: true,
         sameSite: 'lax', // Setting to 'strict' prevents Singpass login on Safari, Firefox
         secure: !config.isDev,
         ...SpcpService.getCookieSettings(),

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -165,7 +165,7 @@ export const handleLogin: (
     .map(() => {
       res.cookie(JwtName[authType], jwtResult.value, {
         maxAge: cookieDuration,
-        httpOnly: true,
+        httpOnly: false, // the JWT needs to be read by client-side JS
         sameSite: 'lax', // Setting to 'strict' prevents Singpass login on Safari, Firefox
         secure: !config.isDev,
         ...SpcpService.getCookieSettings(),

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -26,12 +26,13 @@ import {
 } from './spcp.errors'
 import {
   CorppassAttributes,
-  CorppassJwtPayload,
+  CorppassJwtPayloadFromCookie,
   JwtName,
   JwtPayload,
+  JwtPayloadFromCookie,
   ParsedSpcpParams,
   SingpassAttributes,
-  SingpassJwtPayload,
+  SingpassJwtPayloadFromCookie,
   SpcpCookies,
   SpcpDomainSettings,
 } from './spcp.types'
@@ -221,7 +222,10 @@ export class SpcpServiceClass {
    */
   extractSingpassJwtPayload(
     jwt: string,
-  ): ResultAsync<SingpassJwtPayload, VerifyJwtError | InvalidJwtError> {
+  ): ResultAsync<
+    SingpassJwtPayloadFromCookie,
+    VerifyJwtError | InvalidJwtError
+  > {
     const logMeta = {
       action: 'extractSingpassJwtPayload',
     }
@@ -261,7 +265,10 @@ export class SpcpServiceClass {
    */
   extractCorppassJwtPayload(
     jwt: string,
-  ): ResultAsync<CorppassJwtPayload, VerifyJwtError | InvalidJwtError> {
+  ): ResultAsync<
+    CorppassJwtPayloadFromCookie,
+    VerifyJwtError | InvalidJwtError
+  > {
     const logMeta = {
       action: 'extractCorppassJwtPayload',
     }
@@ -453,7 +460,7 @@ export class SpcpServiceClass {
     authType: AuthType.SP | AuthType.CP,
     cookies: SpcpCookies,
   ): ResultAsync<
-    JwtPayload,
+    JwtPayloadFromCookie,
     VerifyJwtError | InvalidJwtError | MissingJwtError
   > {
     return this.extractJwt(cookies, authType).asyncAndThen((jwtResult) => {

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -10,16 +10,16 @@ export type SpcpCookies = Partial<Record<JwtName, string>>
 export type SingpassJwtPayload = {
   userName: string
   rememberMe: boolean
-  iat?: number
-  exp?: number
+  iat: number
+  exp: number
 }
 
 export type CorppassJwtPayload = {
   userName: string
   userInfo: string
   rememberMe: boolean
-  iat?: number
-  exp?: number
+  iat: number
+  exp: number
 }
 
 export type JwtPayload = SingpassJwtPayload | CorppassJwtPayload

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -10,16 +10,16 @@ export type SpcpCookies = Partial<Record<JwtName, string>>
 export type SingpassJwtPayload = {
   userName: string
   rememberMe: boolean
-  iat: number
-  exp: number
+  iat?: number // iat and exp are present if the payload is received from client, not present when payload is first created by server
+  exp?: number
 }
 
 export type CorppassJwtPayload = {
   userName: string
   userInfo: string
   rememberMe: boolean
-  iat: number
-  exp: number
+  iat?: number // iat and exp are present if the payload is received from client, not present when payload is first created by server
+  exp?: number
 }
 
 export type JwtPayload = SingpassJwtPayload | CorppassJwtPayload

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -20,13 +20,13 @@ export type CorppassJwtPayload = {
 
 export type JwtPayload = SingpassJwtPayload | CorppassJwtPayload
 
-type Timestamp = {
+type CookieTimestamp = {
   iat: number // iat and exp are present after cookie has been set
   exp: number
 }
 
-export type SingpassJwtPayloadFromCookie = SingpassJwtPayload & Timestamp
-export type CorppassJwtPayloadFromCookie = CorppassJwtPayload & Timestamp
+export type SingpassJwtPayloadFromCookie = SingpassJwtPayload & CookieTimestamp
+export type CorppassJwtPayloadFromCookie = CorppassJwtPayload & CookieTimestamp
 
 export type JwtPayloadFromCookie =
   | SingpassJwtPayloadFromCookie

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -10,19 +10,27 @@ export type SpcpCookies = Partial<Record<JwtName, string>>
 export type SingpassJwtPayload = {
   userName: string
   rememberMe: boolean
-  iat?: number // iat and exp are present if the payload is received from client, not present when payload is first created by server
-  exp?: number
 }
 
 export type CorppassJwtPayload = {
   userName: string
   userInfo: string
   rememberMe: boolean
-  iat?: number // iat and exp are present if the payload is received from client, not present when payload is first created by server
-  exp?: number
 }
 
 export type JwtPayload = SingpassJwtPayload | CorppassJwtPayload
+
+type Timestamp = {
+  iat: number // iat and exp are present after cookie has been set
+  exp: number
+}
+
+export type SingpassJwtPayloadFromCookie = SingpassJwtPayload & Timestamp
+export type CorppassJwtPayloadFromCookie = CorppassJwtPayload & Timestamp
+
+export type JwtPayloadFromCookie =
+  | SingpassJwtPayloadFromCookie
+  | CorppassJwtPayloadFromCookie
 
 export interface SingpassAttributes {
   UserName?: string

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -10,12 +10,16 @@ export type SpcpCookies = Partial<Record<JwtName, string>>
 export type SingpassJwtPayload = {
   userName: string
   rememberMe: boolean
+  iat?: number
+  exp?: number
 }
 
 export type CorppassJwtPayload = {
   userName: string
   userInfo: string
   rememberMe: boolean
+  iat?: number
+  exp?: number
 }
 
 export type JwtPayload = SingpassJwtPayload | CorppassJwtPayload

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -26,7 +26,11 @@ import {
   MissingJwtError,
   VerifyJwtError,
 } from './spcp.errors'
-import { CorppassJwtPayload, SingpassJwtPayload, SpcpForm } from './spcp.types'
+import {
+  CorppassJwtPayloadFromCookie,
+  SingpassJwtPayloadFromCookie,
+  SpcpForm,
+} from './spcp.types'
 
 const logger = createLoggerWithLabel(module)
 const DESTINATION_REGEX = /^\/([\w]+)\/?/
@@ -149,7 +153,7 @@ export const verifyJwtPromise = (
  */
 export const isSingpassJwtPayload = (
   payload: unknown,
-): payload is SingpassJwtPayload => {
+): payload is SingpassJwtPayloadFromCookie => {
   return (
     typeof payload === 'object' &&
     !!payload &&
@@ -164,7 +168,7 @@ export const isSingpassJwtPayload = (
  */
 export const isCorppassJwtPayload = (
   payload: unknown,
-): payload is CorppassJwtPayload => {
+): payload is CorppassJwtPayloadFromCookie => {
   return (
     typeof payload === 'object' &&
     !!payload &&

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
@@ -92,6 +92,7 @@ describe('public-form.form.routes', () => {
       mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          exp: 1000000000,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -105,13 +106,13 @@ describe('public-form.form.routes', () => {
       const formId = form._id
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(formId)
-      const expectedResponseBody = JSON.parse(
-        JSON.stringify({
-          form: fullForm?.getPublicView(),
-          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
-          isIntranetUser: false,
+      const expectedResponseBody = {
+        form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
+        spcpSession: expect.objectContaining({
+          userName: MOCK_COOKIE_PAYLOAD.userName,
         }),
-      )
+        isIntranetUser: false,
+      }
 
       // Act
       // Set cookie on request
@@ -129,6 +130,7 @@ describe('public-form.form.routes', () => {
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
           userInfo: 'MyCorpPassUEN',
+          exp: 1000000000,
         }),
       )
       const { form } = await dbHandler.insertEmailForm({
@@ -142,13 +144,13 @@ describe('public-form.form.routes', () => {
       const formId = form._id
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(formId)
-      const expectedResponseBody = JSON.parse(
-        JSON.stringify({
-          form: fullForm?.getPublicView(),
-          spcpSession: { userName: MOCK_COOKIE_PAYLOAD.userName },
-          isIntranetUser: false,
+      const expectedResponseBody = {
+        form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
+        spcpSession: expect.objectContaining({
+          userName: MOCK_COOKIE_PAYLOAD.userName,
         }),
-      )
+        isIntranetUser: false,
+      }
 
       // Act
       // Set cookie on request

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
@@ -92,6 +92,7 @@ describe('public-form.form.routes', () => {
       mockSpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          iat: 100000000,
           exp: 1000000000,
         }),
       )
@@ -110,6 +111,8 @@ describe('public-form.form.routes', () => {
         form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
         spcpSession: expect.objectContaining({
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          iat: 100000000,
+          exp: 1000000000,
         }),
         isIntranetUser: false,
       }
@@ -130,6 +133,7 @@ describe('public-form.form.routes', () => {
         cb(null, {
           userName: MOCK_COOKIE_PAYLOAD.userName,
           userInfo: 'MyCorpPassUEN',
+          iat: 100000000,
           exp: 1000000000,
         }),
       )
@@ -148,6 +152,8 @@ describe('public-form.form.routes', () => {
         form: JSON.parse(JSON.stringify(fullForm?.getPublicView())),
         spcpSession: expect.objectContaining({
           userName: MOCK_COOKIE_PAYLOAD.userName,
+          iat: 100000000,
+          exp: 1000000000,
         }),
         isIntranetUser: false,
       }

--- a/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
@@ -30,7 +30,7 @@ PublicFormsAuthRouter.route('/:formId([a-fA-F0-9]{24})/auth/redirect').get(
  * @returns 400 if authType is invalid
  */
 PublicFormsAuthRouter.route('/auth/:authType/logout').get(
-  PublicFormController.handleFormAuthLogout,
+  PublicFormController.handleSpcpLogout,
 )
 
 /**

--- a/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
@@ -23,6 +23,17 @@ PublicFormsAuthRouter.route('/:formId([a-fA-F0-9]{24})/auth/redirect').get(
 )
 
 /**
+ * Removes SP/CP JWT cookie when called to logout user from SP/CP
+ * @route /:authType/logout
+ *
+ * @returns 200 with success message when user logs out successfully
+ * @returns 400 if authType is invalid
+ */
+PublicFormsAuthRouter.route('/:authType/logout').get(
+  PublicFormController.handleFormAuthLogout,
+)
+
+/**
  * Validates a form's eServiceId through parsing the returned html of the spcp login page
  * @route /:formId/auth/validate
  *

--- a/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
@@ -24,12 +24,12 @@ PublicFormsAuthRouter.route('/:formId([a-fA-F0-9]{24})/auth/redirect').get(
 
 /**
  * Removes SP/CP JWT cookie when called to logout user from SP/CP
- * @route /:authType/logout
+ * @route /auth/:authType/logout
  *
  * @returns 200 with success message when user logs out successfully
  * @returns 400 if authType is invalid
  */
-PublicFormsAuthRouter.route('/:authType/logout').get(
+PublicFormsAuthRouter.route('/auth/:authType/logout').get(
   PublicFormController.handleFormAuthLogout,
 )
 

--- a/src/public/modules/forms/base/componentViews/end-page.html
+++ b/src/public/modules/forms/base/componentViews/end-page.html
@@ -37,7 +37,7 @@
         <button
           type="button"
           class="end-page-btn {{ vm.colorTheme }}-font"
-          ng-click="vm.formLogout()"
+          ng-click="vm.formLogout(vm.authType)"
           ng-disabled="vm.isAdminPreview"
         >
           <span>{{ vm.userName }} - Log out</span

--- a/src/public/modules/forms/base/componentViews/start-page.html
+++ b/src/public/modules/forms/base/componentViews/start-page.html
@@ -5,7 +5,7 @@
       <span
         ng-if="vm.authType!=='NIL' && (vm.isTemplate || vm.userName)"
         class="start-page-header-nav-item"
-        ng-click="!vm.isTemplate? vm.formLogout() : null"
+        ng-click="!vm.isTemplate? vm.formLogout(vm.authType) : null"
       >
         Log out<i class="bx bx-log-out"></i>
       </span>
@@ -74,7 +74,7 @@
           <button
             type="button"
             class="start-page-btn {{ vm.colorTheme }}-font"
-            ng-click="vm.formLogout()"
+            ng-click="vm.formLogout(vm.authType)"
             ng-if="vm.authType!=='NIL' && vm.userName && !vm.isTemplate"
           >
             <span>{{ vm.userName }} - Log out</span>

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -27,6 +27,15 @@ function SubmitFormController(
   // The form attribute of the FormData object contains the form fields, logic etc
   vm.myform = FormData.form
 
+  // For SP / CP forms, also include the spcpSession details
+  // This allows the log out button to be correctly populated with the UID
+  // Also provides time to cookie expiry so that client can refresh page
+  if (['SP', 'CP'].includes(vm.myform.authType)) {
+    if (FormData.spcpSession && FormData.spcpSession.userName) {
+      SpcpSession.setUser(FormData.spcpSession)
+    }
+  }
+
   // Set MyInfo login status
   if (!FormData.isTemplate && vm.myform.authType === 'MyInfo') {
     if (FormData.spcpSession && FormData.spcpSession.userName) {
@@ -70,8 +79,6 @@ function SubmitFormController(
   } else {
     vm.banner = {}
   }
-
-  SpcpSession.setUser(vm.myform.authType)
 
   angular.element($document[0]).on('touchstart', function (e) {
     let activeElement = angular.element($document[0].activeElement)[0]

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -30,10 +30,12 @@ function SubmitFormController(
   // For SP / CP forms, also include the spcpSession details
   // This allows the log out button to be correctly populated with the UID
   // Also provides time to cookie expiry so that client can refresh page
-  if (['SP', 'CP'].includes(vm.myform.authType)) {
-    if (FormData.spcpSession && FormData.spcpSession.userName) {
-      SpcpSession.setUser(FormData.spcpSession)
-    }
+  if (
+    ['SP', 'CP'].includes(vm.myform.authType) &&
+    FormData.spcpSession &&
+    FormData.spcpSession.userName
+  ) {
+    SpcpSession.setUser(FormData.spcpSession)
   }
 
   // Set MyInfo login status

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -423,7 +423,7 @@ function submitFormDirective(
         )
         GTag.submitFormFailure(form, startDate, Date.now(), error)
         if (get(error, 'response.data.spcpSubmissionFailure')) {
-          SpcpSession.logout()
+          SpcpSession.logout(form.authType)
         }
 
         // Expire captcha if form has captcha

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -37,7 +37,7 @@ function SpcpSession($timeout, $window, $cookies) {
       session.userName = undefined
     },
     logout: function (authType) {
-      PublicFormAuthService.spcpLogout(authType)
+      PublicFormAuthService.logoutOfSpcpSession(authType)
       $cookies.put('isJustLogOut', true)
       $window.location.reload()
     },

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const jwtDecode = require('jwt-decode').default
+const PublicFormAuthService = require('../../../services/PublicFormAuthService')
 
 angular
   .module('forms')
@@ -36,11 +37,8 @@ function SpcpSession($window, $cookies) {
     clearUserName: function () {
       session.userName = undefined
     },
-    logout: function () {
-      $cookies.remove(
-        session.cookieName,
-        $window.spcpCookieDomain ? { domain: $window.spcpCookieDomain } : {},
-      )
+    logout: function (authType) {
+      PublicFormAuthService.spcpLogout(authType)
       $cookies.put('isJustLogOut', true)
       $window.location.reload()
     },

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -4,9 +4,16 @@ const PublicFormAuthService = require('../../../services/PublicFormAuthService')
 
 angular
   .module('forms')
-  .factory('SpcpSession', ['$interval', '$window', '$cookies', SpcpSession])
+  .factory('SpcpSession', [
+    '$interval',
+    '$q',
+    'Toastr',
+    '$window',
+    '$cookies',
+    SpcpSession,
+  ])
 
-function SpcpSession($interval, $window, $cookies) {
+function SpcpSession($interval, $q, Toastr, $window, $cookies) {
   let session = {
     userName: null,
     cookieName: null,
@@ -33,9 +40,14 @@ function SpcpSession($interval, $window, $cookies) {
       session.userName = undefined
     },
     logout: function (authType) {
-      PublicFormAuthService.logoutOfSpcpSession(authType)
-      $cookies.put('isJustLogOut', true)
-      $window.location.reload()
+      $q.when(PublicFormAuthService.logoutOfSpcpSession(authType))
+        .then(() => {
+          $cookies.put('isJustLogOut', true)
+          $window.location.reload()
+        })
+        .catch(() => {
+          Toastr.error('Failed to log out, please refresh and try again!')
+        })
     },
     isJustLogOut: function () {
       let val = $cookies.get('isJustLogOut')

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -4,9 +4,9 @@ const PublicFormAuthService = require('../../../services/PublicFormAuthService')
 
 angular
   .module('forms')
-  .factory('SpcpSession', ['$timeout', '$window', '$cookies', SpcpSession])
+  .factory('SpcpSession', ['$interval', '$window', '$cookies', SpcpSession])
 
-function SpcpSession($timeout, $window, $cookies) {
+function SpcpSession($interval, $window, $cookies) {
   let session = {
     userName: null,
     cookieName: null,
@@ -16,19 +16,15 @@ function SpcpSession($timeout, $window, $cookies) {
       SP: 'jwtSp',
       CP: 'jwtCp',
     },
-    setUser: function ({ userName, rememberMe, iat, msToExpiry }) {
+    setUser: function ({ userName, rememberMe, iat, exp }) {
       session.userName = userName
       session.rememberMe = rememberMe
       session.issuedAt = iat
-      if (!rememberMe) {
-        $timeout(function () {
+      $interval(() => {
+        if (Date.now() > exp * 1000) {
           $window.location.reload()
-        }, msToExpiry)
-        // Refresh page after cookie expiry time
-        // Timeout is not set when rememberMe === true because cookie expiry is 30 days
-        // i.e. 2592000000 ms which exceeds the maximum delay value of
-        // 2147483647 ms (see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
-      }
+        }
+      }, 5000) // Every 5s, check cookie expiry time and refresh if necessary
     },
     setUserName: function (userName) {
       session.userName = userName

--- a/src/public/services/PublicFormAuthService.ts
+++ b/src/public/services/PublicFormAuthService.ts
@@ -38,6 +38,8 @@ export const logoutOfSpcpSession = (
   authType: AuthType,
 ): Promise<PublicFormAuthLogoutDto> => {
   return axios
-    .get<PublicFormAuthLogoutDto>(`${PUBLIC_FORMS_ENDPOINT}/${authType}/logout`)
+    .get<PublicFormAuthLogoutDto>(
+      `${PUBLIC_FORMS_ENDPOINT}/auth/${authType}/logout`,
+    )
     .then(({ data }) => data)
 }

--- a/src/public/services/PublicFormAuthService.ts
+++ b/src/public/services/PublicFormAuthService.ts
@@ -34,7 +34,7 @@ export const validateEsrvcId = (
     .then(({ data }) => data)
 }
 
-export const spcpLogout = (
+export const logoutOfSpcpSession = (
   authType: AuthType,
 ): Promise<PublicFormAuthLogoutDto> => {
   return axios

--- a/src/public/services/PublicFormAuthService.ts
+++ b/src/public/services/PublicFormAuthService.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 
+import { AuthType } from '../../types'
 import {
+  PublicFormAuthLogoutDto,
   PublicFormAuthRedirectDto,
   PublicFormAuthValidateEsrvcIdDto,
 } from '../../types/api'
@@ -29,5 +31,13 @@ export const validateEsrvcId = (
     .get<PublicFormAuthValidateEsrvcIdDto>(
       `${PUBLIC_FORMS_ENDPOINT}/${formId}/auth/validate`,
     )
+    .then(({ data }) => data)
+}
+
+export const spcpLogout = (
+  authType: AuthType,
+): Promise<PublicFormAuthLogoutDto> => {
+  return axios
+    .get<PublicFormAuthLogoutDto>(`${PUBLIC_FORMS_ENDPOINT}/${authType}/logout`)
     .then(({ data }) => data)
 }

--- a/src/public/services/__tests__/PublicFormAuthService.test.ts
+++ b/src/public/services/__tests__/PublicFormAuthService.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { ObjectId } from 'bson'
 import { mocked } from 'ts-jest/utils'
 
+import { AuthType } from '../../../types'
 import * as PublicFormAuthService from '../PublicFormAuthService'
 
 jest.mock('axios')
@@ -99,6 +100,36 @@ describe('PublicFormAuthService', () => {
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${MOCK_FORM_ID}/auth/validate`,
       )
+    })
+  })
+
+  describe('spcpLogout', () => {
+    it('should call logout endpoint successfully', async () => {
+      const authType = AuthType.SP
+
+      const mockData = { message: 'Successfully logged out.' }
+      MockAxios.get.mockResolvedValueOnce({ data: mockData })
+
+      const result = await PublicFormAuthService.spcpLogout(authType)
+
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,
+      )
+      expect(result).toEqual(mockData)
+    })
+
+    it('should return error message if logout fails', async () => {
+      const authType = AuthType.NIL
+
+      const mockData = { message: 'Invalid authType.' }
+      MockAxios.get.mockResolvedValueOnce({ data: mockData })
+
+      const result = await PublicFormAuthService.spcpLogout(authType)
+
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,
+      )
+      expect(result).toEqual(mockData)
     })
   })
 })

--- a/src/public/services/__tests__/PublicFormAuthService.test.ts
+++ b/src/public/services/__tests__/PublicFormAuthService.test.ts
@@ -113,7 +113,7 @@ describe('PublicFormAuthService', () => {
       const result = await PublicFormAuthService.logoutOfSpcpSession(authType)
 
       expect(MockAxios.get).toHaveBeenCalledWith(
-        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,
+        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/auth/${authType}/logout`,
       )
       expect(result).toEqual(mockData)
     })
@@ -127,7 +127,7 @@ describe('PublicFormAuthService', () => {
       const result = await PublicFormAuthService.logoutOfSpcpSession(authType)
 
       expect(MockAxios.get).toHaveBeenCalledWith(
-        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,
+        `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/auth/${authType}/logout`,
       )
       expect(result).toEqual(mockData)
     })

--- a/src/public/services/__tests__/PublicFormAuthService.test.ts
+++ b/src/public/services/__tests__/PublicFormAuthService.test.ts
@@ -103,14 +103,14 @@ describe('PublicFormAuthService', () => {
     })
   })
 
-  describe('spcpLogout', () => {
+  describe('logoutOfSpcpSession', () => {
     it('should call logout endpoint successfully', async () => {
       const authType = AuthType.SP
 
       const mockData = { message: 'Successfully logged out.' }
       MockAxios.get.mockResolvedValueOnce({ data: mockData })
 
-      const result = await PublicFormAuthService.spcpLogout(authType)
+      const result = await PublicFormAuthService.logoutOfSpcpSession(authType)
 
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,
@@ -124,7 +124,7 @@ describe('PublicFormAuthService', () => {
       const mockData = { message: 'Invalid authType.' }
       MockAxios.get.mockResolvedValueOnce({ data: mockData })
 
-      const result = await PublicFormAuthService.spcpLogout(authType)
+      const result = await PublicFormAuthService.logoutOfSpcpSession(authType)
 
       expect(MockAxios.get).toHaveBeenCalledWith(
         `${PublicFormAuthService.PUBLIC_FORMS_ENDPOINT}/${authType}/logout`,

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -3,3 +3,5 @@ export type PublicFormAuthRedirectDto = { redirectURL: string }
 export type PublicFormAuthValidateEsrvcIdDto =
   | { isValid: true }
   | { isValid: false; errorCode: string | null }
+
+export type PublicFormAuthLogoutDto = { message: string }

--- a/src/types/spcp.ts
+++ b/src/types/spcp.ts
@@ -1,6 +1,6 @@
 export interface SpcpSession {
   userName: string
-  iat?: number
+  iat?: number // Optional as these are not returned for MyInfo forms
   rememberMe?: boolean
-  msToExpiry?: number
+  exp?: number
 }

--- a/src/types/spcp.ts
+++ b/src/types/spcp.ts
@@ -1,3 +1,6 @@
 export interface SpcpSession {
   userName: string
+  iat?: number
+  rememberMe?: boolean
+  msToExpiry?: number
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2065

## Solution
<!-- How did you solve the problem? -->

- App is updated to use `/logout` endpoint to delete sp/cp jwt cookie.
 
**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - New frontend client expects `/logout` endpoint to be available and will not be able to logout from sp/cp upon rollback
- [ ] No - this PR is backwards compatible  

## Tests
- [ ] Create form with singpass. Log in without selecting 'remember me'. Check that form can be submitted and logout works, with jwtSp cookie deleted upon logout
  - [ ] Repeat the above with 'remember me' checked
- [ ] Create form with corppass. Log in. Check that form can be submitted and logout works, with jwtCp cookie deleted upon logout
- [ ] Create form with myinfo and check that myinfo form submission works normally