### PR TITLE
feat(design-system): add Checkbox and Radio Components and stories

### DIFF
--- a/frontend/src/components/Checkbox/Checkbox.stories.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,17 +16,18 @@ Default.args = { options: ['Option 1', 'Option 2', 'Option 3'] }
 export const OthersInput = Template.bind({})
 OthersInput.args = {
   options: ['Option 1', 'Option 2', 'Option 3'],
-  otherComponent: <Input placeholder="Please specify"></Input>, // TODO: replace with input component
+  other: true,
 }
 
 export const OthersDropdown = Template.bind({})
 OthersDropdown.args = {
   options: ['Option 1', 'Option 2', 'Option 3'],
+  other: true,
   otherComponent: (
     <Select placeholder="Select option">
       <option value="option1">Option 1</option>
       <option value="option2">Option 2</option>
       <option value="option3">Option 3</option>
     </Select>
-  ), // TODO: replace with dropdown component
+  ), // TODO: replace with custom dropdown component
 }

--- a/frontend/src/components/Checkbox/Checkbox.stories.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,32 @@
+import { Input, Select } from '@chakra-ui/react'
+import { Meta, Story } from '@storybook/react'
+
+import { Checkbox, CheckboxProps } from './Checkbox'
+
+export default {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  decorators: [],
+} as Meta
+
+const Template: Story<CheckboxProps> = (args) => <Checkbox {...args} />
+export const Default = Template.bind({})
+Default.args = { options: ['Option 1', 'Option 2', 'Option 3'] }
+
+export const OthersInput = Template.bind({})
+OthersInput.args = {
+  options: ['Option 1', 'Option 2', 'Option 3'],
+  otherComponent: <Input placeholder="Please specify"></Input>, // TODO: replace with input component
+}
+
+export const OthersDropdown = Template.bind({})
+OthersDropdown.args = {
+  options: ['Option 1', 'Option 2', 'Option 3'],
+  otherComponent: (
+    <Select placeholder="Select option">
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+    </Select>
+  ), // TODO: replace with dropdown component
+}

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,67 @@
+import { cloneElement } from 'react'
+import {
+  Checkbox as ChakraCheckbox,
+  CheckboxGroup,
+  CheckboxGroupProps as ChakraCheckboxProps,
+  Flex,
+  StylesProvider,
+  useMultiStyleConfig,
+  useStyles,
+  VStack,
+} from '@chakra-ui/react'
+
+export interface CheckboxProps extends ChakraCheckboxProps {
+  options?: string[]
+  otherComponent?: JSX.Element // TODO: change type to disjunction of acceptable components
+}
+
+const CheckboxOption = ({ option }: { option: string }): JSX.Element => {
+  const styles = useStyles()
+  return (
+    <ChakraCheckbox value={option} __css={styles.container}>
+      {option}
+    </ChakraCheckbox>
+  )
+}
+
+const OtherOption = ({
+  component,
+}: {
+  component: JSX.Element
+}): JSX.Element => {
+  const styles = useStyles()
+  return (
+    <Flex direction="column">
+      <CheckboxOption option="Other" />
+      <Flex pl="48px" mt="2px">
+        {cloneElement(component, {
+          isRequired: true,
+          __css: styles.others,
+        })}
+      </Flex>
+    </Flex>
+  )
+}
+
+export const Checkbox = ({
+  options,
+  otherComponent,
+  ...props
+}: CheckboxProps): JSX.Element => {
+  const styles = useMultiStyleConfig('Checkbox', {})
+
+  return (
+    <CheckboxGroup {...props}>
+      <StylesProvider value={styles}>
+        <VStack align="left">
+          {options?.map((option) => (
+            <CheckboxOption option={option} />
+          ))}
+          {otherComponent && (
+            <OtherOption component={otherComponent}></OtherOption>
+          )}
+        </VStack>
+      </StylesProvider>
+    </CheckboxGroup>
+  )
+}

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import {
   CheckboxGroup,
   CheckboxGroupProps as ChakraCheckboxProps,
   Flex,
+  Input,
   StylesProvider,
   useMultiStyleConfig,
   useStyles,
@@ -12,8 +13,11 @@ import {
 
 export interface CheckboxProps extends ChakraCheckboxProps {
   options?: string[]
+  other: boolean
   otherComponent?: JSX.Element // TODO: change type to disjunction of acceptable components
 }
+
+const defaultOtherComponent = <Input placeholder="Please specify"></Input> // TODO: replace with custom input component
 
 const CheckboxOption = ({ option }: { option: string }): JSX.Element => {
   const styles = useStyles()
@@ -45,7 +49,8 @@ const OtherOption = ({
 
 export const Checkbox = ({
   options,
-  otherComponent,
+  other = false,
+  otherComponent = defaultOtherComponent,
   ...props
 }: CheckboxProps): JSX.Element => {
   const styles = useMultiStyleConfig('Checkbox', {})
@@ -57,9 +62,7 @@ export const Checkbox = ({
           {options?.map((option) => (
             <CheckboxOption option={option} />
           ))}
-          {otherComponent && (
-            <OtherOption component={otherComponent}></OtherOption>
-          )}
+          {other && <OtherOption component={otherComponent}></OtherOption>}
         </VStack>
       </StylesProvider>
     </CheckboxGroup>

--- a/frontend/src/components/Checkbox/index.ts
+++ b/frontend/src/components/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox as default } from './Checkbox'

--- a/frontend/src/components/Radio/Radio.stories.tsx
+++ b/frontend/src/components/Radio/Radio.stories.tsx
@@ -1,0 +1,20 @@
+import { Input } from '@chakra-ui/react'
+import { Meta, Story } from '@storybook/react'
+
+import { Radio, RadioProps } from './Radio'
+
+export default {
+  title: 'Components/Radio',
+  component: Radio,
+  decorators: [],
+} as Meta
+
+const Template: Story<RadioProps> = (args) => <Radio {...args} />
+export const Default = Template.bind({})
+Default.args = { options: ['Option 1', 'Option 2', 'Option 3'] }
+
+export const Others = Template.bind({})
+Others.args = {
+  options: ['Option 1', 'Option 2', 'Option 3'],
+  otherComponent: <Input placeholder="Please specify"></Input>, // TODO: replace with input component
+}

--- a/frontend/src/components/Radio/Radio.stories.tsx
+++ b/frontend/src/components/Radio/Radio.stories.tsx
@@ -16,5 +16,5 @@ Default.args = { options: ['Option 1', 'Option 2', 'Option 3'] }
 export const Others = Template.bind({})
 Others.args = {
   options: ['Option 1', 'Option 2', 'Option 3'],
-  otherComponent: <Input placeholder="Please specify"></Input>, // TODO: replace with input component
+  other: true,
 }

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -1,0 +1,69 @@
+import { cloneElement } from 'react'
+import {
+  Flex,
+  Radio as ChakraRadio,
+  RadioGroup,
+  RadioGroupProps as ChakraRadioProps,
+  StylesProvider,
+  useMultiStyleConfig,
+  useStyles,
+  VStack,
+} from '@chakra-ui/react'
+
+export interface RadioProps extends Omit<ChakraRadioProps, 'children'> {
+  children?: React.ReactNode // Children should be optional as radio components should be created in here
+  options?: string[]
+  otherComponent?: JSX.Element // TODO: change type to disjunction of acceptable components
+}
+
+const RadioOption = ({ option }: { option: string }): JSX.Element => {
+  const styles = useStyles()
+  return (
+    <ChakraRadio value={option} __css={styles.row}>
+      {option}
+    </ChakraRadio>
+  )
+}
+
+const OtherOption = ({
+  component,
+}: {
+  component: JSX.Element
+}): JSX.Element => {
+  const styles = useStyles()
+  return (
+    <Flex direction="column">
+      <RadioOption option="Other" />
+      <Flex pl="48px" mt="2px">
+        {cloneElement(component, {
+          isRequired: true,
+          __css: styles.others,
+        })}
+      </Flex>
+    </Flex>
+  )
+}
+
+export const Radio = ({
+  children,
+  options,
+  otherComponent,
+  ...props
+}: RadioProps): JSX.Element => {
+  const styles = useMultiStyleConfig('Radio', {})
+
+  return (
+    <RadioGroup {...props}>
+      <StylesProvider value={styles}>
+        <VStack align="left">
+          {options?.map((option) => (
+            <RadioOption option={option} />
+          ))}
+          {otherComponent && (
+            <OtherOption component={otherComponent}></OtherOption>
+          )}
+        </VStack>
+      </StylesProvider>
+    </RadioGroup>
+  )
+}

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -1,6 +1,7 @@
 import { cloneElement } from 'react'
 import {
   Flex,
+  Input,
   Radio as ChakraRadio,
   RadioGroup,
   RadioGroupProps as ChakraRadioProps,
@@ -13,8 +14,11 @@ import {
 export interface RadioProps extends Omit<ChakraRadioProps, 'children'> {
   children?: React.ReactNode // Children should be optional as radio components should be created in here
   options?: string[]
+  other: boolean
   otherComponent?: JSX.Element // TODO: change type to disjunction of acceptable components
 }
+
+const defaultOtherComponent = <Input placeholder="Please specify"></Input> // TODO: replace with custom input component
 
 const RadioOption = ({ option }: { option: string }): JSX.Element => {
   const styles = useStyles()
@@ -47,7 +51,8 @@ const OtherOption = ({
 export const Radio = ({
   children,
   options,
-  otherComponent,
+  other = false,
+  otherComponent = defaultOtherComponent,
   ...props
 }: RadioProps): JSX.Element => {
   const styles = useMultiStyleConfig('Radio', {})
@@ -59,9 +64,7 @@ export const Radio = ({
           {options?.map((option) => (
             <RadioOption option={option} />
           ))}
-          {otherComponent && (
-            <OtherOption component={otherComponent}></OtherOption>
-          )}
+          {other && <OtherOption component={otherComponent}></OtherOption>}
         </VStack>
       </StylesProvider>
     </RadioGroup>

--- a/frontend/src/components/Radio/index.ts
+++ b/frontend/src/components/Radio/index.ts
@@ -1,0 +1,1 @@
+export { Radio as default } from './Radio'

--- a/frontend/src/theme/components/Checkbox.ts
+++ b/frontend/src/theme/components/Checkbox.ts
@@ -1,0 +1,51 @@
+import { ComponentStyleConfig } from '@chakra-ui/react'
+import { getColor } from '@chakra-ui/theme-tools'
+
+export const Checkbox: ComponentStyleConfig = {
+  parts: ['row', 'others'],
+  baseStyle: (props) => ({
+    control: {
+      borderRadius: '0.19rem',
+      border: '2px solid',
+      borderColor: 'primary.500',
+      _checked: {
+        bg: 'primary.500',
+        borderColor: 'primary.500',
+        _hover: {
+          bg: 'primary.500',
+          borderColor: 'primary.500',
+        },
+      },
+      _focus: {
+        boxShadow: 'none',
+      },
+    },
+    label: {
+      textColor: 'secondary.700',
+      mx: '1rem',
+    },
+    container: {
+      h: '44px',
+      px: '0.25rem',
+      py: '0.5rem',
+      _hover: {
+        bg: 'primary.100',
+      },
+      _focusWithin: {
+        borderColor: 'primary.500',
+        boxShadow: `0 0 0 2px ${getColor(props.theme, 'primary.500')}`,
+      },
+    },
+    others: {
+      alignSelf: 'flex-end',
+    },
+  }),
+  sizes: {
+    // override md size, which is the default size
+    md: {
+      control: { w: '1.5rem', h: '1.5rem' },
+      label: { textStyle: 'body-1' },
+      icon: { fontSize: '0.75rem' },
+    },
+  },
+}

--- a/frontend/src/theme/components/Radio.ts
+++ b/frontend/src/theme/components/Radio.ts
@@ -1,0 +1,59 @@
+import { ComponentStyleConfig } from '@chakra-ui/react'
+import { getColor } from '@chakra-ui/theme-tools'
+
+export const Radio: ComponentStyleConfig = {
+  parts: ['row', 'others'],
+  baseStyle: (props) => ({
+    control: {
+      border: '2px solid',
+      borderColor: 'primary.500',
+      _checked: {
+        borderColor: 'primary.500',
+        bg: 'white',
+        color: 'primary.500',
+        _before: {
+          w: '80%',
+          h: '80%',
+        },
+        _hover: {
+          bg: 'white',
+          borderColor: 'primary.500',
+        },
+      },
+      _focus: {
+        boxShadow: 'none',
+        _hover: {
+          bg: 'white',
+          borderColor: 'primary.500',
+        },
+      },
+    },
+    label: {
+      textColor: 'secondary.700',
+      mx: '1rem',
+    },
+    container: {
+      h: '44px',
+      px: '0.25rem',
+      py: '0.5rem',
+      _hover: {
+        bg: 'primary.100',
+      },
+      _focusWithin: {
+        borderColor: 'primary.500',
+        boxShadow: `0 0 0 2px ${getColor(props.theme, 'primary.500')}`,
+      },
+    },
+    others: {
+      alignSelf: 'flex-end',
+    },
+  }),
+  sizes: {
+    // override md size, which is the default size
+    md: {
+      control: { w: '1.5rem', h: '1.5rem' },
+      label: { textStyle: 'body-1' },
+      icon: { fontSize: '0.75rem' },
+    },
+  },
+}

--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -1,5 +1,6 @@
 import { Button } from './Button'
 import { Checkbox } from './Checkbox'
 import { Input } from './Input'
+import { Radio } from './Radio'
 
-export const components = { Button, Input, Checkbox }
+export const components = { Button, Input, Checkbox, Radio }

--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -1,4 +1,5 @@
 import { Button } from './Button'
+import { Checkbox } from './Checkbox'
 import { Input } from './Input'
 
-export const components = { Button, Input }
+export const components = { Button, Input, Checkbox }


### PR DESCRIPTION
## Problem
This PR implements the `Checkbox` and `Radio` components. `ChakraUI`'s original `Checkbox` and `Radio` components's default hover and focus styles are implemented on the `Control` sub-component. However, we want the these styles to be applied on the entire checkbox and radio rows. Hence, these styles are defined in an additional `part` (`Container`) in the theme for `Checkbox` and is applied explicitly on `ChakraCheckbox` instead to achieve the design specified on Figma. The `Radio` component already has a `Container` part and hence the definition of these styles are done there.

As mentioned in the issue, it could be possible to use different types of components apart from input. Hence, the others input component is introduced as prop, which defaults to an input component (now a `ChakraUI` `input` component). This should be replaced with the custom input component when it is completed.

Closes #2008