### PR TITLE
fix(deps): upgrade formsg-sdk to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5837,10 +5837,11 @@
       "integrity": "sha512-MKlviL+Fw3cK56PwlrTmrkLMl2zbeDNcKqyTwZzSZbInsue+DYy6KQOt/SAotKjGG2+bt2ttgv+GoUUEQccr8A=="
     },
     "@opengovsg/formsg-sdk": {
-      "version": "0.8.4-beta.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.8.4-beta.0.tgz",
-      "integrity": "sha512-Hqx1x9QxOIGri8wUHGXeMnNfJ8CeqwI67WaToQJk/jfPA9CzrdOetM66IIQuyUgZpiSC/Jb8tBlsiO8UKqSOEw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.9.0.tgz",
+      "integrity": "sha512-HH42Da6U4/eIuAHi01SKLbWdiiCcYhgOyF3FFayGd3Kp58YG0Il0XVLl+/NH8H3ikbMX52rv0BHLg0UZjxe7OA==",
       "requires": {
+        "axios": "^0.21.1",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@opengovsg/angular-daterangepicker-webpack": "^1.1.5",
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
-    "@opengovsg/formsg-sdk": "^0.8.4-beta.0",
+    "@opengovsg/formsg-sdk": "^0.9.0",
     "@opengovsg/myinfo-gov-client": "^4.0.0",
     "@opengovsg/ng-file-upload": "^12.2.15",
     "@opengovsg/spcp-auth-client": "^1.4.8",


### PR DESCRIPTION
Upgrades `@opengovsg/formsg-sdk` to the latest version to take advantage of the new defaults in the dev environment and remove blockers for #2158 and #2159.