### PR TITLE
feat: restore v3 API for retrieving individual admin form

### DIFF
--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -7,7 +7,6 @@ export const AdminFormsFormRouter = Router()
 AdminFormsFormRouter.route('/')
   /**
    * List the forms managed by the user
-   * @route GET /adminform
    * @security session
    *
    * @returns 200 with a list of forms managed by the user
@@ -19,7 +18,6 @@ AdminFormsFormRouter.route('/')
 
   /**
    * Create a new form
-   * @route POST /adminform
    * @security session
    *
    * @returns 200 with newly created form
@@ -33,27 +31,36 @@ AdminFormsFormRouter.route('/')
    */
   .post(AdminFormController.handleCreateForm)
 
-/**
- * Archive the specified form.
- * @route DELETE /:formId/adminform
- * @security session
- *
- * @returns 200 with success message when successfully archived
- * @returns 401 when user does not exist in session
- * @returns 403 when user does not have permissions to archive form
- * @returns 404 when form cannot be found
- * @returns 410 when form is already archived
- * @returns 422 when user in session cannot be retrieved from the database
- * @returns 500 when database error occurs
- */
-AdminFormsFormRouter.delete(
-  '/:formId([a-fA-F0-9]{24})',
-  AdminFormController.handleArchiveForm,
-)
+AdminFormsFormRouter.route('/:formId([a-fA-F0-9]{24})')
+  /**
+   * Return the specified form to the user.
+   * @security session
+   *
+   * @returns 200 with retrieved form with formId if user has read permissions
+   * @returns 401 when user does not exist in session
+   * @returns 403 when user does not have permissions to access form
+   * @returns 404 when form cannot be found
+   * @returns 410 when form is archived
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .get(AdminFormController.handleGetAdminForm)
+  /**
+   * Archive the specified form.
+   * @security session
+   *
+   * @returns 200 with success message when successfully archived
+   * @returns 401 when user does not exist in session
+   * @returns 403 when user does not have permissions to archive form
+   * @returns 404 when form cannot be found
+   * @returns 410 when form is already archived
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .delete(AdminFormController.handleArchiveForm)
 
 /**
  * Duplicate the specified form.
- * @route POST /:formId/adminform
  * @security session
  *
  * @returns 200 with the duplicate form dashboard view
@@ -72,7 +79,6 @@ AdminFormsFormRouter.post(
 
 /**
  * Transfer form ownership to another user
- * @route POST /:formId/adminform/transfer-owner
  * @security session
  *
  * @returns 200 with updated form with transferred owners
@@ -99,7 +105,6 @@ AdminFormsFormRouter.route(
 )
   /**
    * Update form field according to given new body.
-   * @route PUT /admin/forms/:formId/fields/:fieldId
    *
    * @param body the new field to override current field
    * @returns 200 with updated form field
@@ -117,7 +122,6 @@ AdminFormsFormRouter.route(
 
   /**
    * Delete form field by fieldId of form corresponding to formId.
-   * @route DELETE /admin/forms/:formId/fields/:fieldId
    * @security session
    *
    * @returns 204 when deletion is successful
@@ -131,7 +135,6 @@ AdminFormsFormRouter.route(
   .delete(AdminFormController.handleDeleteFormField)
   /**
    * Retrives the form field using the fieldId from the specified form
-   * @route GET /admin/forms/:formId/fields/:fieldId
    * @security session
    *
    * @returns 200 with form field when retrieval is successful
@@ -146,7 +149,6 @@ AdminFormsFormRouter.route(
 
 /**
  * Duplicates the form field with the fieldId from the specified form
- * @route POST /:formId/fields/:fieldId/duplicate
  * @security session
  *
  * @returns 200 with duplicated field

--- a/src/public/services/AdminViewFormService.ts
+++ b/src/public/services/AdminViewFormService.ts
@@ -25,7 +25,9 @@ export const getDashboardView = async (): Promise<FormMetaView[]> => {
 export const getAdminFormView = async (
   formId: string,
 ): Promise<FormViewDto> => {
-  return axios.get<FormViewDto>(`/${formId}/adminform`).then(({ data }) => data)
+  return axios
+    .get<FormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+    .then(({ data }) => data)
 }
 
 /**

--- a/src/public/services/__tests__/AdminViewFormService.test.ts
+++ b/src/public/services/__tests__/AdminViewFormService.test.ts
@@ -82,7 +82,9 @@ describe('AdminViewFormService', () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockAxios.get).toHaveBeenCalledWith(`/${expected._id}/adminform`)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${expected._id}`,
+      )
     })
 
     it('should reject with error message when GET request fails', async () => {
@@ -96,7 +98,9 @@ describe('AdminViewFormService', () => {
 
       // Assert
       await expect(actualPromise).rejects.toEqual(expected)
-      expect(MockAxios.get).toHaveBeenCalledWith(`/${MOCK_FORM._id}/adminform`)
+      expect(MockAxios.get).toHaveBeenCalledWith(
+        `${ADMIN_FORM_ENDPOINT}/${MOCK_FORM._id}`,
+      )
     })
   })
 


### PR DESCRIPTION
Restores changes from #2113, which were reverted in #2169.

- [x] Yes - this PR contains breaking changes
    - New client incompatible with old server due to new API endpoint
- [ ] No - this PR is backwards compatible