### PR TITLE
feat: Remove self from collaborator list

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2319,7 +2319,7 @@ export const handleRemoveSelfFromCollaborators: ControllerHandler<
           level: PermissionLevel.Read,
         })
       })
-      // Step 2: Update the form collaborators
+      // Step 3: Update the form collaborators
       .andThen((form) => {
         const updatedPermissionList = form.permissionList.filter(
           (user) => user.email.toLowerCase() !== currentUserEmail.toLowerCase(),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2289,6 +2289,68 @@ export const handleUpdateCollaborators = [
 ] as ControllerHandler[]
 
 /**
+ * Handler for DELETE /api/v3/admin/forms/:formId/collaborators/self
+ * @precondition Must be preceded by request validation
+ * @security session
+ *
+ * @returns 200 with updated collaborators and permissions
+ * @returns 403 when current user does not have permissions to remove themselves from the collaborators list
+ * @returns 404 when form cannot be found
+ * @returns 410 when updating collaborators for an archived form
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+export const handleRemoveSelfFromCollaborators: ControllerHandler<
+  { formId: string },
+  PermissionsUpdateDto | ErrorDto
+> = (req, res) => {
+  const { formId } = req.params
+  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  let currentUserEmail = ''
+  // Step 1: Get the form after permission checks
+  return (
+    UserService.getPopulatedUserById(sessionUserId)
+      .andThen((user) => {
+        // Step 2: Retrieve form with read permission check, since we are only removing the user themselves
+        currentUserEmail = user.email
+        return AuthService.getFormAfterPermissionChecks({
+          user,
+          formId,
+          level: PermissionLevel.Read,
+        })
+      })
+      // Step 2: Update the form collaborators
+      .andThen((form) => {
+        const updatedPermissionList = form.permissionList.filter(
+          (user) => user.email.toLowerCase() !== currentUserEmail.toLowerCase(),
+        )
+        return AdminFormService.updateFormCollaborators(
+          form,
+          updatedPermissionList,
+        )
+      })
+      .map((updatedCollaborators) =>
+        res.status(StatusCodes.OK).json(updatedCollaborators),
+      )
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error occurred when updating collaborators',
+          meta: {
+            action: 'handleRemoveSelfFromCollaborators',
+            ...createReqMeta(req),
+            userId: sessionUserId,
+            formId,
+            formCollaborators: req.body,
+          },
+          error,
+        })
+        const { errorMessage, statusCode } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
+}
+
+/**
  * NOTE: Exported for testing.
  * Private handler for PUT /forms/:formId/start-page
  * @precondition Must be preceded by request validation

--- a/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
@@ -97,3 +97,20 @@ AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/collaborators')
    * @returns 500 when database error occurs
    */
   .get(AdminFormController.handleGetFormCollaborators)
+
+AdminFormsSettingsRouter.route('/:formId([a-fA-F0-9]{24})/collaborators/self')
+  /**
+   * Removes the current user from the collaborator list
+   * @route DELETE /admin/forms/:formId/collaborators/self
+   * @group admin
+   * @precondition Must be preceded by request validation
+   * @security session
+   *
+   * @returns 200 with updated collaborators and permissions
+   * @returns 403 when current user does not have permissions to remove themselves the collaborators list
+   * @returns 404 when form cannot be found
+   * @returns 410 when updating collaborators for an archived form
+   * @returns 422 when user in session cannot be retrieved from the database
+   * @returns 500 when database error occurs
+   */
+  .delete(AdminFormController.handleRemoveSelfFromCollaborators)

--- a/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
@@ -7,12 +7,11 @@ const UpdateFormService = require('../../../../services/UpdateFormService')
 angular
   .module('forms')
   .controller('CollaboratorModalController', [
-    '$location',
     '$q',
     '$scope',
+    '$state',
     '$timeout',
     '$uibModalInstance',
-    '$window',
     'externalScope',
     'Toastr',
     'FormApi',
@@ -32,12 +31,11 @@ const ROLES = {
 }
 
 function CollaboratorModalController(
-  $location,
   $q,
   $scope,
+  $state,
   $timeout,
   $uibModalInstance,
-  $window,
   externalScope,
   Toastr,
   FormApi,
@@ -150,7 +148,9 @@ function CollaboratorModalController(
       .when(UpdateFormService.removeSelfFromCollaborators($scope.myform._id))
       .then(() => {
         // redirects the user back to the home page now that they have lost access to this form
-        $window.location.href = $window.location.origin
+        $scope.toggleRemoveSelfFromCollabModal()
+        $scope.closeModal()
+        $state.go('listForms')
       })
   }
 

--- a/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/collaborator-modal.client.controller.js
@@ -7,10 +7,12 @@ const UpdateFormService = require('../../../../services/UpdateFormService')
 angular
   .module('forms')
   .controller('CollaboratorModalController', [
+    '$location',
     '$q',
     '$scope',
     '$timeout',
     '$uibModalInstance',
+    '$window',
     'externalScope',
     'Toastr',
     'FormApi',
@@ -30,10 +32,12 @@ const ROLES = {
 }
 
 function CollaboratorModalController(
+  $location,
   $q,
   $scope,
   $timeout,
   $uibModalInstance,
+  $window,
   externalScope,
   Toastr,
   FormApi,
@@ -62,6 +66,8 @@ function CollaboratorModalController(
 
   $scope.isDisplayTransferOwnerModal = false
   $scope.transferOwnerEmail = undefined
+
+  $scope.isDisplayRemoveSelfFromCollabModal = false
 
   /**
    * Transfers ownership of the form to the selected user, reset UI messages
@@ -134,6 +140,33 @@ function CollaboratorModalController(
         return err
       })
     }
+  }
+
+  /**
+   * Removes the current user from the collaborator list and bounces the user back to the forms select page
+   */
+  $scope.removeSelfFromCollab = () => {
+    return $q
+      .when(UpdateFormService.removeSelfFromCollaborators($scope.myform._id))
+      .then(() => {
+        // redirects the user back to the home page now that they have lost access to this form
+        $window.location.href = $window.location.origin
+      })
+  }
+
+  /**
+   * Toggles the remove self from collaboration modal
+   */
+  $scope.toggleRemoveSelfFromCollabModal = () => {
+    $scope.isDisplayRemoveSelfFromCollabModal =
+      !$scope.isDisplayRemoveSelfFromCollabModal
+  }
+
+  /**
+   * Remove the current user from the permissionList, prompting the user first before confirming the action.
+   */
+  $scope.handleRemoveSelfFromCollabButtonClick = () => {
+    $scope.isDisplayRemoveSelfFromCollabModal = true
   }
 
   /**

--- a/src/public/modules/forms/admin/views/collaborator.client.modal.html
+++ b/src/public/modules/forms/admin/views/collaborator.client.modal.html
@@ -36,7 +36,36 @@
       </button>
     </div>
 
-    <div ng-if="!isDisplayTransferOwnerModal">
+    <div ng-if="isDisplayRemoveSelfFromCollabModal">
+      <div class="label-custom" id="invite-title">
+        Remove myself as a collaborator from this form
+      </div>
+      <div class="" id="collab-title">
+        You will be removed as a collaborator and will lose access to this form.
+        You cannot undo this.
+      </div>
+      <button
+        type="submit"
+        id="transfer-owner-btn"
+        class="btn-custom red-bg-dark btn-medium"
+        ng-click="removeSelfFromCollab()"
+        ng-class="btnStatus >= 2 ? 'btn-pressed' : ''"
+      >
+        Remove me
+      </button>
+      <button
+        type="submit"
+        id="transfer-owner-cancel-btn"
+        class="btn-medium"
+        ng-click="toggleRemoveSelfFromCollabModal()"
+      >
+        Cancel
+      </button>
+    </div>
+
+    <div
+      ng-if="!isDisplayTransferOwnerModal && !isDisplayRemoveSelfFromCollabModal"
+    >
       <!-- Top section contains the title and functionality to add new collaborators -->
       <div id="top-section" ng-if="userCanEdit">
         <div class="top-section-label">
@@ -296,6 +325,13 @@
                   class="btn-delete"
                   ng-if="user.email !== userObj.email.toLowerCase() && userCanEdit"
                   ng-click="deleteCollabEmail(userObj.email);closeEditCollaboratorDropdowns()"
+                >
+                  <i class="bx bx-trash bx-md"></i>
+                </button>
+                <button
+                  class="btn-delete"
+                  ng-if="user.email === userObj.email.toLowerCase()"
+                  ng-click="handleRemoveSelfFromCollabButtonClick()"
                 >
                   <i class="bx bx-trash bx-md"></i>
                 </button>

--- a/src/public/services/UpdateFormService.ts
+++ b/src/public/services/UpdateFormService.ts
@@ -78,6 +78,16 @@ export const updateCollaborators = async (
     .then(({ data }) => data)
 }
 
+export const removeSelfFromCollaborators = async (
+  formId: string,
+): Promise<PermissionsUpdateDto> => {
+  return axios
+    .delete<PermissionUpdateDto>(
+      `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators/self`,
+    )
+    .then(({ data }) => data)
+}
+
 export const duplicateSingleFormField = async (
   formId: string,
   fieldId: string,

--- a/src/public/services/UpdateFormService.ts
+++ b/src/public/services/UpdateFormService.ts
@@ -82,7 +82,7 @@ export const removeSelfFromCollaborators = async (
   formId: string,
 ): Promise<PermissionsUpdateDto> => {
   return axios
-    .delete<PermissionUpdateDto>(
+    .delete<PermissionsUpdateDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators/self`,
     )
     .then(({ data }) => data)


### PR DESCRIPTION
## Problem
Enables writers and readers to remove themselves from the collaborator list.

Closes #33

## Solution
Added a new `DELETE /:formId([a-fA-F0-9]{24})/collaborators/self` route that removes the current user from the collaborator list, and wired up the appropriate parts of the front-end for this.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Screenshots
![remove-self](https://user-images.githubusercontent.com/691628/122666239-015f7c80-d161-11eb-9331-c8a3cd11ef7b.JPG)

## Tests
Create a new form with collaborators, then login as the collaborators and manually remove themselves. It should succeed.