### PR TITLE
test: fix flaky form feedback test

### DIFF
--- a/src/app/modules/feedback/__tests__/feedback.service.spec.ts
+++ b/src/app/modules/feedback/__tests__/feedback.service.spec.ts
@@ -150,13 +150,14 @@ describe('feedback.service', () => {
       expect(actual).toEqual({
         average: expectedAverage,
         count: expectedCount,
-        // Feedback may not be returned in same order, so perform unordered check
+        // Feedback may not be returned in same order, so perform unordered check.
+        // We cannot simply sort the arrays and expect them to be equal, as the order
+        // is non-deterministic if the timestamps are identical.
         feedback: expect.arrayContaining(expectedFeedbackList),
       })
       // Check that there are no extra elements
       expect(actual.feedback.length).toBe(expectedFeedbackList.length)
-      // Check that feedback is returned in date order. We cannot simply sort the arrays
-      // as the order is non-deterministic if the timestamps are identical.
+      // Check that feedback is returned in date order.
       expect(expectedFeedbackList.map((f) => f.timestamp)).toEqual(
         actual.feedback.map((f) => f.timestamp),
       )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2213 

## Solution
<!-- How did you solve the problem? -->

Instead of mucking around with array sorting again, just perform an unordered check by using `arrayContaining` to check that the expected array is a subset of the received array, and then check that their lengths are identical to ensure that the arrays contain identical contents. Since this loses the check on the ordering of the elements, perform an additional check that the timestamps are sorted. This works even if the array elements are different, as long as the timestamps are identical.