### PR TITLE
feat(feature-manager): remove sms from feature manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,11 @@ services:
       # Keep in sync with the development key in
       # https://github.com/opengovsg/formsg-javascript-sdk/blob/develop/src/resource/signing-keys.ts
       - SIGNING_SECRET_KEY=HDBXpu+2/gu10bLHpy8HjpN89xbA6boH9GwibPGJA8BOXmB+zOUpxCP33/S5p8vBWlPokC7gLR0ca8urVwfMUQ==
-      - TWILIO_ACCOUNT_SID
-      - TWILIO_API_KEY
-      - TWILIO_API_SECRET
-      - TWILIO_MESSAGING_SERVICE_SID
+      # Mock Twilio credentials. SMSes do not work in dev environment.
+      - TWILIO_ACCOUNT_SID=ACmockTwilioAccountSid
+      - TWILIO_API_KEY=mockTwilioApiKey
+      - TWILIO_API_SECRET=mockTwilioApiSecret
+      - TWILIO_MESSAGING_SERVICE_SID=mockTwilioMsgSrvcSid
       - SES_PASS
       - SES_USER
       - OTP_LIFE_SPAN

--- a/src/app/config/feature-manager/index.ts
+++ b/src/app/config/feature-manager/index.ts
@@ -1,5 +1,4 @@
 import FeatureManager from './util/FeatureManager.class'
-import sms from './sms.config'
 import spcpMyInfo from './spcp-myinfo.config'
 
 export * from './types'
@@ -8,6 +7,5 @@ const featureManager = new FeatureManager()
 
 // Register features and associated middleware/fallbacks
 featureManager.register(spcpMyInfo)
-featureManager.register(sms)
 
 export default featureManager

--- a/src/app/config/feature-manager/sms.config.ts
+++ b/src/app/config/feature-manager/sms.config.ts
@@ -1,33 +1,39 @@
-import { FeatureNames, RegisterableFeature } from './types'
+import convict, { Schema } from 'convict'
 
-const smsFeature: RegisterableFeature<FeatureNames.Sms> = {
-  name: FeatureNames.Sms,
-  schema: {
-    twilioAccountSid: {
-      doc: 'Twilio messaging ID',
-      format: String,
-      default: null,
-      env: 'TWILIO_ACCOUNT_SID',
-    },
-    twilioApiKey: {
-      doc: 'Twilio standard API Key',
-      format: String,
-      default: null,
-      env: 'TWILIO_API_KEY',
-    },
-    twilioApiSecret: {
-      doc: 'Twilio API Secret',
-      format: String,
-      default: null,
-      env: 'TWILIO_API_SECRET',
-    },
-    twilioMsgSrvcSid: {
-      doc: 'Messaging service ID',
-      format: String,
-      default: null,
-      env: 'TWILIO_MESSAGING_SERVICE_SID',
-    },
+export interface ISms {
+  twilioAccountSid: string
+  twilioApiKey: string
+  twilioApiSecret: string
+  twilioMsgSrvcSid: string
+}
+
+const smsSchema: Schema<ISms> = {
+  twilioAccountSid: {
+    doc: 'Twilio messaging ID',
+    format: String,
+    default: null,
+    env: 'TWILIO_ACCOUNT_SID',
+  },
+  twilioApiKey: {
+    doc: 'Twilio standard API Key',
+    format: String,
+    default: null,
+    env: 'TWILIO_API_KEY',
+  },
+  twilioApiSecret: {
+    doc: 'Twilio API Secret',
+    format: String,
+    default: null,
+    env: 'TWILIO_API_SECRET',
+  },
+  twilioMsgSrvcSid: {
+    doc: 'Messaging service ID',
+    format: String,
+    default: null,
+    env: 'TWILIO_MESSAGING_SERVICE_SID',
   },
 }
 
-export default smsFeature
+export const smsConfig = convict(smsSchema)
+  .validate({ allowed: 'strict' })
+  .getProperties()

--- a/src/app/config/feature-manager/types.ts
+++ b/src/app/config/feature-manager/types.ts
@@ -2,15 +2,7 @@ import { MyInfoMode } from '@opengovsg/myinfo-gov-client'
 import { Schema } from 'convict'
 
 export enum FeatureNames {
-  Sms = 'sms',
   SpcpMyInfo = 'spcp-myinfo',
-}
-
-export interface ISms {
-  twilioAccountSid: string
-  twilioApiKey: string
-  twilioApiSecret: string
-  twilioMsgSrvcSid: string
 }
 
 export interface ISpcpConfig {
@@ -49,7 +41,6 @@ export interface IMyInfoConfig {
 export type ISpcpMyInfo = ISpcpConfig & IMyInfoConfig
 
 export interface IFeatureManager {
-  [FeatureNames.Sms]: ISms
   [FeatureNames.SpcpMyInfo]: ISpcpMyInfo
 }
 

--- a/src/app/services/sms/__tests__/sms.factory.spec.ts
+++ b/src/app/services/sms/__tests__/sms.factory.spec.ts
@@ -3,12 +3,7 @@ import { okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 import Twilio from 'twilio'
 
-import {
-  FeatureNames,
-  ISms,
-  RegisteredFeature,
-} from 'src/app/config/feature-manager'
-import { MissingFeatureError } from 'src/app/modules/core/core.errors'
+import { ISms } from 'src/app/config/feature-manager/sms.config'
 
 import { createSmsFactory } from '../sms.factory'
 import * as SmsService from '../sms.service'
@@ -40,147 +35,79 @@ const MOCK_BOUNCE_SMS_PARAMS: BounceNotificationSmsParams = {
 describe('sms.factory', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  describe('sms feature disabled', () => {
-    const MOCK_DISABLED_SMS_FEATURE: RegisteredFeature<FeatureNames.Sms> = {
-      isEnabled: false,
-      props: {} as ISms,
-    }
+  const MOCK_SMS_FEATURE: ISms = {
+    twilioAccountSid: 'ACrandomTwilioSid',
+    twilioApiKey: 'SKrandomTwilioAPIKEY',
+    twilioApiSecret: 'this is a super secret',
+    twilioMsgSrvcSid: 'formsg-is-great-pleasehelpme',
+  }
+  const expectedTwilioConfig: TwilioConfig = {
+    msgSrvcSid: MOCK_SMS_FEATURE.twilioMsgSrvcSid,
+    client: MOCKED_TWILIO,
+  }
+  const SmsFactory = createSmsFactory(MOCK_SMS_FEATURE)
 
-    const SmsFactory = createSmsFactory(MOCK_DISABLED_SMS_FEATURE)
+  it('should call SmsService counterpart when invoking sendAdminContactOtp', async () => {
+    // Arrange
+    MockSmsService.sendAdminContactOtp.mockReturnValueOnce(okAsync(true))
 
-    it('should return MissingFeatureError when invoking sendAdminContactOtp', async () => {
-      // Act
-      const result = await SmsFactory.sendAdminContactOtp(
-        'anything',
-        'anything',
-        'anything',
-      )
+    const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
+      'mockRecipient',
+      'mockOtp',
+      'mockFormId',
+    ]
 
-      // Assert
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new MissingFeatureError(FeatureNames.Sms),
-      )
-    })
+    // Act
+    await SmsFactory.sendAdminContactOtp(...mockArguments)
 
-    it('should return MissingFeatureError when invoking sendVerificationOtp', async () => {
-      // Act
-      const result = await SmsFactory.sendVerificationOtp(
-        'anything',
-        'anything',
-        'anything',
-      )
-
-      // Assert
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new MissingFeatureError(FeatureNames.Sms),
-      )
-    })
-
-    it('should return MissingFeatureError when invoking sendFormDeactivatedSms', async () => {
-      // Act
-      const result = await SmsFactory.sendFormDeactivatedSms(
-        MOCK_BOUNCE_SMS_PARAMS,
-      )
-
-      // Assert
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new MissingFeatureError(FeatureNames.Sms),
-      )
-    })
-
-    it('should return MissingFeatureError when invoking sendBouncedSubmissionSms', async () => {
-      // Act
-      const result = await SmsFactory.sendBouncedSubmissionSms(
-        MOCK_BOUNCE_SMS_PARAMS,
-      )
-
-      // Assert
-      expect(result._unsafeUnwrapErr()).toEqual(
-        new MissingFeatureError(FeatureNames.Sms),
-      )
-    })
+    // Assert
+    expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledTimes(1)
+    expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledWith(
+      ...mockArguments,
+      expectedTwilioConfig,
+    )
   })
 
-  describe('sms feature enabled', () => {
-    const MOCK_ENABLED_SMS_FEATURE: Required<
-      RegisteredFeature<FeatureNames.Sms>
-    > = {
-      isEnabled: true,
-      props: {
-        twilioAccountSid: 'ACrandomTwilioSid',
-        twilioApiKey: 'SKrandomTwilioAPIKEY',
-        twilioApiSecret: 'this is a super secret',
-        twilioMsgSrvcSid: 'formsg-is-great-pleasehelpme',
-      },
-    }
-    const expectedTwilioConfig: TwilioConfig = {
-      msgSrvcSid: MOCK_ENABLED_SMS_FEATURE.props.twilioMsgSrvcSid,
-      client: MOCKED_TWILIO,
-    }
-    const SmsFactory = createSmsFactory(MOCK_ENABLED_SMS_FEATURE)
+  it('should call SmsService counterpart when invoking sendVerificationOtp', async () => {
+    // Arrange
+    MockSmsService.sendVerificationOtp.mockReturnValue(okAsync(true))
 
-    it('should call SmsService counterpart when invoking sendAdminContactOtp', async () => {
-      // Arrange
-      MockSmsService.sendAdminContactOtp.mockReturnValueOnce(okAsync(true))
+    const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
+      'mockRecipient',
+      'mockOtp',
+      'mockUserId',
+    ]
 
-      const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
-        'mockRecipient',
-        'mockOtp',
-        'mockFormId',
-      ]
+    // Act
+    await SmsFactory.sendVerificationOtp(...mockArguments)
 
-      // Act
-      await SmsFactory.sendAdminContactOtp(...mockArguments)
+    // Assert
+    expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledTimes(1)
+    expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledWith(
+      ...mockArguments,
+      expectedTwilioConfig,
+    )
+  })
 
-      // Assert
-      expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledTimes(1)
-      expect(MockSmsService.sendAdminContactOtp).toHaveBeenCalledWith(
-        ...mockArguments,
-        expectedTwilioConfig,
-      )
-    })
+  it('should call SmsService when sendFormDeactivatedSms is called', async () => {
+    MockSmsService.sendFormDeactivatedSms.mockReturnValue(okAsync(true))
 
-    it('should call SmsService counterpart when invoking sendVerificationOtp', async () => {
-      // Arrange
-      MockSmsService.sendVerificationOtp.mockResolvedValue(true)
+    await SmsFactory.sendFormDeactivatedSms(MOCK_BOUNCE_SMS_PARAMS)
 
-      const mockArguments: Parameters<typeof SmsFactory.sendAdminContactOtp> = [
-        'mockRecipient',
-        'mockOtp',
-        'mockUserId',
-      ]
+    expect(MockSmsService.sendFormDeactivatedSms).toHaveBeenCalledWith(
+      MOCK_BOUNCE_SMS_PARAMS,
+      expectedTwilioConfig,
+    )
+  })
 
-      // Act
-      await SmsFactory.sendVerificationOtp(...mockArguments)
+  it('should call SmsService when sendBouncedSubmissionSms is called', async () => {
+    MockSmsService.sendBouncedSubmissionSms.mockReturnValue(okAsync(true))
 
-      // Assert
-      expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledTimes(1)
-      expect(MockSmsService.sendVerificationOtp).toHaveBeenCalledWith(
-        ...mockArguments,
-        expectedTwilioConfig,
-      )
-    })
+    await SmsFactory.sendBouncedSubmissionSms(MOCK_BOUNCE_SMS_PARAMS)
 
-    it('should call SmsService when sendFormDeactivatedSms is called', async () => {
-      MockSmsService.sendFormDeactivatedSms.mockResolvedValueOnce(true)
-
-      await SmsFactory.sendFormDeactivatedSms(MOCK_BOUNCE_SMS_PARAMS)
-
-      expect(MockSmsService.sendFormDeactivatedSms).toHaveBeenCalledWith(
-        MOCK_BOUNCE_SMS_PARAMS,
-        expectedTwilioConfig,
-      )
-    })
-
-    it('should call SmsService when sendBouncedSubmissionSms is called', async () => {
-      MockSmsService.sendBouncedSubmissionSms.mockResolvedValueOnce(true)
-
-      await SmsFactory.sendBouncedSubmissionSms(MOCK_BOUNCE_SMS_PARAMS)
-
-      expect(MockSmsService.sendBouncedSubmissionSms).toHaveBeenCalledWith(
-        MOCK_BOUNCE_SMS_PARAMS,
-        expectedTwilioConfig,
-      )
-    })
+    expect(MockSmsService.sendBouncedSubmissionSms).toHaveBeenCalledWith(
+      MOCK_BOUNCE_SMS_PARAMS,
+      expectedTwilioConfig,
+    )
   })
 })

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -1,11 +1,6 @@
-import { errAsync } from 'neverthrow'
 import Twilio from 'twilio'
 
-import FeatureManager, {
-  FeatureNames,
-  RegisteredFeature,
-} from '../../config/feature-manager'
-import { MissingFeatureError } from '../../modules/core/core.errors'
+import { ISms, smsConfig } from '../../config/feature-manager/sms.config'
 
 import {
   sendAdminContactOtp,
@@ -56,25 +51,10 @@ interface ISmsFactory {
   ) => ReturnType<typeof sendBouncedSubmissionSms>
 }
 
-const smsFeature = FeatureManager.get(FeatureNames.Sms)
-
 // Exported for testing.
-export const createSmsFactory = (
-  smsFeature: RegisteredFeature<FeatureNames.Sms>,
-): ISmsFactory => {
-  if (!smsFeature.isEnabled || !smsFeature.props) {
-    // Not enabled, return passthrough functions.
-    const error = new MissingFeatureError(FeatureNames.Sms)
-    return {
-      sendAdminContactOtp: () => errAsync(error),
-      sendVerificationOtp: () => errAsync(error),
-      sendFormDeactivatedSms: () => errAsync(error),
-      sendBouncedSubmissionSms: () => errAsync(error),
-    }
-  }
-
+export const createSmsFactory = (smsConfig: ISms): ISmsFactory => {
   const { twilioAccountSid, twilioApiKey, twilioApiSecret, twilioMsgSrvcSid } =
-    smsFeature.props
+    smsConfig
 
   const twilioClient = Twilio(twilioApiKey, twilioApiSecret, {
     accountSid: twilioAccountSid,
@@ -96,4 +76,4 @@ export const createSmsFactory = (
   }
 }
 
-export const SmsFactory = createSmsFactory(smsFeature)
+export const SmsFactory = createSmsFactory(smsConfig)


### PR DESCRIPTION
Removes the SMS feature from feature manager.

Part of #1842

## Solution

The implementation is along the same lines as all previous PRs related to #1842. Note that the `.factory` file in the `sms` service was maintained due to the function signatures in `sms.service` requiring a default Twilio config.

However, there was a slight wrinkle when deciding how to mock Twilio credentials in the dev environment. Twilio does provide [test credentials](https://www.twilio.com/docs/iam/test-credentials) which are not linked to the data in the production account. However, the test credentials are specific to each account, and the Twilio console still says to keep the test credentials secure. Hence the test credentials were not added as dev environment defaults.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Verified fields can be added in dev environment, but attempts to send SMSes fail

## Manual tests
- [ ] Submit a form with a verified SMS field

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**Note that the server will now fail to start if any of the required Twilio env vars are missing.** Mock defaults have been added in `docker-compose` in order to avoid disruption to the dev environment.