### PR TITLE
fix: Clean-up and right-align home page statistics

### DIFF
--- a/src/public/modules/core/css/landing.css
+++ b/src/public/modules/core/css/landing.css
@@ -162,7 +162,18 @@
   margin-left: 20px;
 }
 
-#landing #landing-hero #landing-banner #main #main-left #stats .stat-counts div,
+#landing
+  #landing-hero
+  #landing-banner
+  #main
+  #main-left
+  #stats
+  .stat-counts
+  div {
+  text-align: right;
+  margin-bottom: 25px;
+}
+
 #landing
   #landing-hero
   #landing-banner

--- a/src/public/modules/core/views/landing.client.view.html
+++ b/src/public/modules/core/views/landing.client.view.html
@@ -50,9 +50,9 @@
         <div id="main-left">
           <div id="stats">
             <div class="stat-counts">
-              <div>{{vm.stats.userCount}}</div>
-              <div>{{vm.stats.formCount}}</div>
-              <div>{{vm.stats.submissionCount}}</div>
+              <div>{{vm.stats.userCount | number}}</div>
+              <div>{{vm.stats.formCount | number}}</div>
+              <div>{{vm.stats.submissionCount | number}}</div>
             </div>
             <div class="stat-titles">
               <div translate="HERO.STATS.USERS"></div>


### PR DESCRIPTION
## Problem
The current numbers on the home page is hard to read (too many digits). This right-aligns numbers and adds commas per locale settings.

## Solution
Fixed the CSS and added Angular's `DecimalPipe`.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
![before-commas](https://user-images.githubusercontent.com/691628/122709424-15fc4d00-d213-11eb-9ecc-da0d65ae3258.JPG)

**AFTER**:
![after-commas](https://user-images.githubusercontent.com/691628/122709437-1b599780-d213-11eb-8a12-80e85a06ebf8.JPG)

## Tests
Verify that the home page loads and looks as expected.
