### PR TITLE
feat(form-v2): toast component

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import 'focus-visible/dist/focus-visible.min.js'
 import '../src/assets/fonts/inter.css'
 
 import { ChakraProvider } from '@chakra-ui/react'
+import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { DecoratorFn } from '@storybook/react'
 
 import { theme } from '../src/theme'
@@ -16,9 +17,32 @@ const withChakra: DecoratorFn = (storyFn) => (
 
 export const decorators = [withChakra]
 
+// taken from https://support.microsoft.com/en-us/windows/change-your-screen-resolution-5effefe3-2eac-e306-0b5d-2073b765876b
+const desktopViewports = {
+  standardDesktop: {
+    name: '19-inch standard desktop',
+    styles: {
+      width: '1280px',
+      height: '1080px',
+    },
+  },
+  widescreenDesktop: {
+    name: '24-inch widescreen desktop',
+    styles: {
+      width: '1900px',
+      height: '1200px',
+    },
+  },
+}
 export const parameters = {
   docs: {
     theme: StorybookTheme.docs,
     inlineStories: true,
+  },
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...desktopViewports,
+    },
   },
 }

--- a/frontend/src/components/Toast/Toast.stories.tsx
+++ b/frontend/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,93 @@
+import { SimpleGrid, Text } from '@chakra-ui/react'
+import { Meta, Story } from '@storybook/react'
+
+import { useToast, UseToastProps } from '~hooks/useToast'
+import Button from '~components/Button'
+
+import { Toast, ToastProps } from './Toast'
+
+const ToastStateProps = {
+  Warning: {
+    status: 'warning',
+    title: 'Warning',
+    description: 'This is a toast for warning states',
+    isClosable: true,
+  },
+  Success: {
+    status: 'success',
+    title: 'Success',
+    description: 'This is a toast for success states',
+    isClosable: true,
+  },
+  Error: {
+    status: 'danger',
+    title: 'Error',
+    description: 'This is a toast for error states',
+    isClosable: true,
+  },
+}
+export default {
+  title: 'Components/Toast',
+  component: Toast,
+  parameters: { backgrounds: { default: 'light' } },
+  decorators: [
+    // NOTE: The toast component requires this to display properly with theming
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (Story: Function) => (
+      <>
+        <Story />
+      </>
+    ),
+  ],
+} as Meta
+
+const ToastTemplate: Story<ToastProps> = (args) => <Toast {...args} />
+const ButtonWithToastTemplate: Story<UseToastProps> = (args) => {
+  const toast = useToast()
+  return (
+    <Button
+      onClick={() =>
+        toast({
+          onCloseComplete: () => console.log('hi'),
+          ...args,
+        })
+      }
+    >
+      Toast!
+    </Button>
+  )
+}
+
+export const Success = ToastTemplate.bind({})
+Success.args = ToastStateProps.Success
+
+export const Error = ToastTemplate.bind({})
+Error.args = ToastStateProps.Error
+export const Warning = ToastTemplate.bind({})
+Warning.args = ToastStateProps.Warning
+
+export const ButtonWithToast = ButtonWithToastTemplate.bind({})
+ButtonWithToast.args = {
+  title: 'Some title',
+  description: 'Some description',
+  duration: 6000,
+  isClosable: true,
+  status: 'warning',
+  position: 'top',
+}
+
+export const CombinedToasts: Story<ToastProps> = () => (
+  <SimpleGrid
+    columns={3}
+    spacing={8}
+    templateColumns="min-content auto"
+    alignItems="center"
+  >
+    <Text>Success</Text>
+    <Toast {...ToastStateProps.Success} />
+    <Text>Warning</Text>
+    <Toast {...ToastStateProps.Warning} />
+    <Text>Error</Text>
+    <Toast {...ToastStateProps.Error} />
+  </SimpleGrid>
+)

--- a/frontend/src/components/Toast/Toast.tsx
+++ b/frontend/src/components/Toast/Toast.tsx
@@ -1,0 +1,84 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertProps,
+  AlertTitle,
+  Box,
+  CloseButton,
+  useMediaQuery,
+  UseToastOptions,
+} from '@chakra-ui/react'
+
+type ToastStatus = 'danger' | 'success' | 'warning'
+
+export interface ToastProps
+  extends Omit<
+    UseToastOptions,
+    'duration' | 'position' | 'render' | 'status' | 'variant'
+  > {
+  /**
+   * The status of the Toast.
+   */
+  status: ToastStatus
+  // RenderProps that chakra passes to all custom components that uses the render function
+  onClose: () => void
+}
+
+const getChakraAlertStatus = (status: ToastStatus): AlertProps['status'] =>
+  status === 'danger' ? 'error' : status
+
+export const Toast = ({
+  status,
+  title,
+  id,
+  description,
+  isClosable,
+  onClose,
+  onCloseComplete,
+}: ToastProps): JSX.Element => {
+  // Dynamically determine the size of the modal based on screen breakpoints
+  const [isDesktop] = useMediaQuery('(min-width: 1080px)')
+  const width = isDesktop ? '680px' : 'auto'
+  const horizontalMargins = isDesktop ? 'inherit' : 2
+
+  return (
+    <Alert
+      status={getChakraAlertStatus(status)}
+      variant="toast"
+      colorScheme={status}
+      padding={4}
+      id={String(id)}
+      // Padding right is 4 rem (normal padding) + width of the button.
+      // This is to prevent the button overlapping the text on resize.
+      pr={10}
+      width={width}
+      mx={horizontalMargins}
+      mt={2}
+    >
+      <AlertIcon />
+      <Box>
+        {title && <AlertTitle>{title}</AlertTitle>}
+        {description && (
+          <AlertDescription display="block">{description}</AlertDescription>
+        )}
+      </Box>
+      {isClosable && (
+        <CloseButton
+          position="absolute"
+          right={4}
+          top={4}
+          size="sm"
+          onClick={() => {
+            if (onClose) {
+              onClose()
+            }
+            if (onCloseComplete) {
+              onCloseComplete()
+            }
+          }}
+        />
+      )}
+    </Alert>
+  )
+}

--- a/frontend/src/components/Toast/index.ts
+++ b/frontend/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast as default } from './Toast'

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,38 @@
+import { PropsWithChildren } from 'react'
+import {
+  RenderProps,
+  useToast as useChakraToast,
+  UseToastOptions,
+} from '@chakra-ui/react'
+
+import { Toast, ToastProps } from '~/components/Toast/Toast'
+
+type ToastBehaviourProps = Pick<
+  UseToastOptions,
+  'duration' | 'position' | 'render'
+>
+
+// onClose is provided by the chakra hook and should not be exposed to clients
+export type UseToastProps = Omit<ToastBehaviourProps & ToastProps, 'onClose'>
+
+type UseToast = () => (props: UseToastProps) => void
+
+export const useToast: UseToast = () => {
+  const toast = useChakraToast()
+
+  return ({
+    duration = 6000,
+    position = 'top',
+    render,
+    ...rest
+  }: UseToastProps) => {
+    toast({
+      duration,
+      position,
+      render:
+        render ??
+        ((props: PropsWithChildren<RenderProps>) =>
+          Toast({ ...rest, ...props })),
+    })
+  }
+}

--- a/frontend/src/theme/components/Alert.ts
+++ b/frontend/src/theme/components/Alert.ts
@@ -1,0 +1,28 @@
+import {
+  ChakraTheme,
+  ComponentStyleConfig,
+  CSSObject,
+  ThemingPropsThunk,
+} from '@chakra-ui/react'
+
+const variantToast: ThemingPropsThunk<CSSObject, ChakraTheme> = (props) => {
+  const { colorScheme: c } = props
+
+  return {
+    container: {
+      bg: `${c}.100`,
+      border: `1px solid var(--chakra-colors-${c}-500)`,
+      borderRadius: '3px',
+      boxSizing: 'border-box',
+    },
+    icon: {
+      color: `${c}.500`,
+    },
+  }
+}
+
+export const Alert: ComponentStyleConfig = {
+  variants: {
+    toast: variantToast,
+  },
+}

--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -1,4 +1,5 @@
+import { Alert } from './Alert'
 import { Button } from './Button'
 import { Input } from './Input'
 
-export const components = { Button, Input }
+export const components = { Button, Input, Alert }


### PR DESCRIPTION
## Problem
Form requires our own toasting system, with different design considerations compared to the toast built by chakra ui. This PR solves that issue by adding a custom toast component.

This PR also adds additional viewports to test desktop vs mobile views (base views only went up tablet size).

Closes #2022 

## Solution
1. Adds an (unexposed) `Toast` variant for `Alert`. This controls the base UI theming (borders, colours etc) for the component
2. Adds a `Toast` component. This composes `Alert`  and other various sub-components. There is a media query here to dynamically resize the toast component and determine its margin. This component receives an [`onClose` prop](https://github.com/chakra-ui/chakra-ui/blob/ae42755583e38fe04c2c19685e096d1800e22cca/packages/toast/src/use-toast.tsx#L36-L39) that Chakra ui uses to close the toast with animation. 
    1. we can't use a ref and the `toast.close` method as described [here](https://chakra-ui.com/docs/feedback/toast#closing-toasts) because it only closes the last opened toast. 
3.  Adds a custom `useToast` hook, with sensible defaults set for the toast. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Screenshots
screen shots are available in the storybook preview