### PR TITLE
docs(script): add script to sync (has)AllowedEmailDomains

### DIFF
--- a/scripts/20210622_sync-allowedEmailDomains-with-hasAllowedEmailDomains/script.js
+++ b/scripts/20210622_sync-allowedEmailDomains-with-hasAllowedEmailDomains/script.js
@@ -1,0 +1,169 @@
+/* eslint-disable */
+
+// Optional: Retrieve forms with fields that has a populated allowedEmailDomains but has not allowed email domains.
+// For sampling to check if form has been fixed properly after migration.
+db.getCollection('forms').aggregate([
+  { $unwind: '$form_fields' },
+  {
+    $match: {
+      'form_fields.fieldType': 'email',
+      'form_fields.hasAllowedEmailDomains': false,
+      'form_fields.allowedEmailDomains': { $ne: [] },
+    },
+  },
+  {
+    $group: {
+      _id: '$_id',
+      form_fields: { $addToSet: '$form_fields' },
+    },
+  }
+])
+
+// Retrieve counts of various form states
+// Count forms with email fields isVerifiable=true, hasAllowedEmailDomains=true, non-empty allowedEmailDomains
+// Basically forms with restricted domain email fields
+
+// COUNT_A =
+
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      isVerifiable: true,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: { $ne: [] }
+    }
+  }
+})
+
+// Count forms with isVerifiable=true, but hasAllowedEmailDomains=false
+// Basically forms with verification but not restrictions
+
+// COUNT_B = 
+
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      isVerifiable: true,
+      hasAllowedEmailDomains: false,
+    }
+  }
+})
+
+// Count forms with non-empty allowed email domains even if hasAllowedEmailDomains is false, 
+// so we can reset array before removing hasAllowedEmailDomains key.
+
+// COUNT_C = 
+
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: false,
+      allowedEmailDomains: { $ne: [] }
+    }
+  }
+})
+
+// Count forms with inconsistent email states
+// hasAllowedEmailDomains = true but allowedEmailDomains is empty
+// Should not matter since allowedEmailDomains is the source of truth
+
+// COUNT_D = 
+
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: { $eq: [] }
+    }
+  }
+})
+
+
+// !!! Update !!!
+// Set all current fields with hasAllowedEmailDomains = false to empty allowedEmailDomains array [].
+// updateCount should be === COUNT_C
+// updateCount = 
+
+db.getCollection('forms').updateMany(
+  {
+    'form_fields': {
+      $elemMatch: {
+        fieldType: 'email',
+        hasAllowedEmailDomains: false,
+        allowedEmailDomains: { $ne: [] }
+      }
+    }
+  },
+  {
+    $set: {
+      'form_fields.$[elem].allowedEmailDomains': [],
+    },
+  },
+  {
+    arrayFilters: [
+      {
+        'elem.fieldType': 'email',
+        'elem.hasAllowedEmailDomains': false,
+        'elem.allowedEmailDomains': { $ne: [] },
+      },
+    ],
+    multi: true,
+  }
+)
+
+// Should now have 0 non-empty domains if hasAllowedEmailDomains is false
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: false,
+      allowedEmailDomains: { $ne: [] }
+    }
+  }
+})
+
+// !!! Second update
+// Set all current fields with hasAllowedEmailDomains = true WITH empty allowedEmailDomains array [] to hasAllowedEmailDomains = false.
+// updateCount should be === COUNT_D
+// updateCount = 
+db.getCollection('forms').updateMany(
+  {
+    'form_fields': {
+      $elemMatch: {
+        fieldType: 'email',
+        hasAllowedEmailDomains: true,
+        allowedEmailDomains: { $eq: [] }
+      }
+    }
+  },
+  {
+    $set: {
+      'form_fields.$[elem].hasAllowedEmailDomains': false,
+    },
+  },
+  {
+    arrayFilters: [
+      {
+        'elem.fieldType': 'email',
+        'elem.hasAllowedEmailDomains': true,
+        'elem.allowedEmailDomains': { $eq: [] },
+      },
+    ],
+    multi: true,
+  }
+)
+
+// Should now have 0 empty domains if hasAllowedEmailDomains is true
+db.getCollection('forms').count({
+  'form_fields': {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: { $eq: [] }
+    }
+  }
+})


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
As mentioned in https://github.com/opengovsg/FormSG/pull/1698#issuecomment-864894628, we will be sunsetting the hasAllowedEmailDomains key in email form fields in 3 stages. This PR is stage 1 of 3.

This PR will handle
1. Correcting state inconsistency in DB that will arise when we switch from using `hasAllowedEmailDomains` as the source of truth to `allowedEmailDomains`.
2. After DB migration is complete, possible inconsistencies should be fixed.
  - all `hasAllowedEmailDomains = false` will have `allowedEmailDomains = []`
  - all `hasAllowedEmailDomain = true` must have non-empty `allowedEmailDomains`

See #1312.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
  - DB migration, not backwards compatible, though will not have any issues on a roll back since there is still a source of truth.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New scripts**:

docs(script): add script to sync (has)AllowedEmailDomains
