### PR TITLE
feat(verified-sms): disabling sms verifications

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { ObjectId } from 'bson-ext'
-import _, { cloneDeep, map, merge, omit, orderBy, pick } from 'lodash'
+import { cloneDeep, map, merge, omit, orderBy, pick, range } from 'lodash'
 import mongoose, { Types } from 'mongoose'
 
 import getFormModel, {
@@ -1682,7 +1682,7 @@ describe('Form Model', () => {
     describe('disableSmsVerificationsForUser', () => {
       it('should disable sms verifications for all forms belonging to a user successfully', async () => {
         // Arrange
-        const mockFormPromises = _.range(3).map(() => {
+        const mockFormPromises = range(3).map(() => {
           return Form.create({
             admin: populatedAdmin._id,
             responseMode: ResponseMode.Email,
@@ -1710,7 +1710,7 @@ describe('Form Model', () => {
 
       it('should not disable non mobile fields for a user', async () => {
         // Arrange
-        const mockFormPromises = _.range(3).map(() => {
+        const mockFormPromises = range(3).map(() => {
           return Form.create({
             admin: populatedAdmin._id,
             responseMode: ResponseMode.Email,
@@ -1777,7 +1777,7 @@ describe('Form Model', () => {
         // Arrange
         const disableSpy = jest.spyOn(Form, 'disableSmsVerificationsForUser')
         disableSpy.mockResolvedValueOnce(new Error('tee hee db crashed'))
-        const mockFormPromises = _.range(3).map(() => {
+        const mockFormPromises = range(3).map(() => {
           return Form.create({
             admin: populatedAdmin._id,
             responseMode: ResponseMode.Email,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -751,6 +751,24 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     ).exec()
   }
 
+  FormSchema.statics.disableSmsVerificationsForUser = async function (
+    userId: IUserSchema['_id'],
+  ) {
+    return this.updateMany(
+      // Filter the collection so that only speciified user is selected
+      {
+        admin: userId,
+      },
+      // Next, set the isVerifiable property for each field in form_fields
+      // Refer here for $[identifier] syntax: https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/
+      { $set: { 'form_fields.$[field].isVerifiable': false } },
+      {
+        // Only set if the field has fieldType equal to mobile
+        arrayFilters: [{ 'field.fieldType': 'mobile' }],
+      },
+    ).exec()
+  }
+
   // Hooks
   FormSchema.pre<IFormSchema>('validate', function (next) {
     // Reject save if form document is too large

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -755,7 +755,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     userId: IUserSchema['_id'],
   ) {
     return this.updateMany(
-      // Filter the collection so that only speciified user is selected
+      // Filter the collection so that only specified user is selected
       {
         admin: userId,
       },

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -765,6 +765,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       {
         // Only set if the field has fieldType equal to mobile
         arrayFilters: [{ 'field.fieldType': 'mobile' }],
+        // NOTE: Not updating the timestamp because we should preserve ordering due to user-level modifications
+        timestamps: false,
       },
     ).exec()
   }

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -73,6 +73,7 @@ import {
   createPresignedPostUrlForLogos,
   deleteFormField,
   deleteFormLogic,
+  disableSmsVerificationsForUser,
   duplicateForm,
   duplicateFormField,
   editFormFields,
@@ -2209,6 +2210,36 @@ describe('admin-form.service', () => {
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toEqual(expectedError)
+    })
+  })
+
+  describe('disableSmsVerificationsForUser', () => {
+    it('should return true when the forms are updated successfully', async () => {
+      // Arrange
+      const MOCK_ADMIN_ID = new ObjectId().toHexString()
+      const disableSpy = jest.spyOn(FormModel, 'disableSmsVerificationsForUser')
+      disableSpy.mockResolvedValueOnce({ n: 0, nModified: 0, ok: 0 })
+
+      // Act
+      const expected = await disableSmsVerificationsForUser(MOCK_ADMIN_ID)
+
+      // Assert
+      expect(disableSpy).toHaveBeenCalledWith(MOCK_ADMIN_ID)
+      expect(expected._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should return a database error when the operation fails', async () => {
+      // Arrange
+      const MOCK_ADMIN_ID = new ObjectId().toHexString()
+      const disableSpy = jest.spyOn(FormModel, 'disableSmsVerificationsForUser')
+      disableSpy.mockRejectedValueOnce('whoops')
+
+      // Act
+      const expected = await disableSmsVerificationsForUser(MOCK_ADMIN_ID)
+
+      // Assert
+      expect(disableSpy).toHaveBeenCalledWith(MOCK_ADMIN_ID)
+      expect(expected._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
     })
   })
 })

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1048,14 +1048,14 @@ export const updateStartPage = (
 /**
  * Disables sms verifications for all forms belonging to the specified user
  * @param userId the id of the user whose sms verifications should be disabled
- * @returns ok(IFormDocument[]) when the forms have been successfully disabled
+ * @returns ok(true) when the forms have been successfully disabled
  * @returns err(PossibleDatabaseError) when an error occurred while attempting to disable sms verifications
  */
 export const disableSmsVerificationsForUser = (
   userId: string,
-): ResultAsync<IFormDocument[], PossibleDatabaseError> =>
+): ResultAsync<true, PossibleDatabaseError> =>
   ResultAsync.fromPromise(
-    FormModel.disableSmsVerificationsForUser(userId),
+    FormModel.disableSmsVerificationsForUser(userId).then(() => true),
     (error) => {
       logger.error({
         message:

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1044,3 +1044,28 @@ export const updateStartPage = (
     return okAsync(updatedForm.startPage)
   })
 }
+
+/**
+ * Disables sms verifications for all forms belonging to the specified user
+ * @param userId the id of the user whose sms verifications should be disabled
+ * @returns ok(IFormDocument[]) when the forms have been successfully disabled
+ * @returns err(PossibleDatabaseError) when an error occurred while attempting to disable sms verifications
+ */
+export const disableSmsVerificationsForUser = (
+  userId: string,
+): ResultAsync<IFormDocument[], PossibleDatabaseError> =>
+  ResultAsync.fromPromise(
+    FormModel.disableSmsVerificationsForUser(userId),
+    (error) => {
+      logger.error({
+        message:
+          'Error occurred when attempting to disable sms verifications for user',
+        meta: {
+          action: 'disableSmsVerificationsForUser',
+          userId,
+        },
+        error,
+      })
+      return transformMongoError(error)
+    },
+  )

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1055,7 +1055,7 @@ export const disableSmsVerificationsForUser = (
   userId: string,
 ): ResultAsync<true, PossibleDatabaseError> =>
   ResultAsync.fromPromise(
-    FormModel.disableSmsVerificationsForUser(userId).then(() => true),
+    FormModel.disableSmsVerificationsForUser(userId),
     (error) => {
       logger.error({
         message:
@@ -1068,4 +1068,4 @@ export const disableSmsVerificationsForUser = (
       })
       return transformMongoError(error)
     },
-  )
+  ).map(() => true)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3,3 +3,11 @@
 export interface PublicView<T> {
   getPublicView(): T
 }
+
+// The returned object from updateMany
+// Refer here: https://mongoosejs.com/docs/api/model.html#model_Model.updateMany
+export interface UpdateManyMeta {
+  n: number
+  nModified: number
+  ok: number
+}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -4,7 +4,7 @@ import { SetRequired } from 'type-fest'
 
 import { OverrideProps } from '../app/modules/form/admin-form/admin-form.types'
 
-import { PublicView } from './database'
+import { PublicView, UpdateManyMeta } from './database'
 import {
   FormField,
   FormFieldWithId,
@@ -335,7 +335,7 @@ export interface IFormModel extends Model<IFormSchema> {
 
   disableSmsVerificationsForUser(
     userId: IUserSchema['_id'],
-  ): Promise<IFormDocument[]>
+  ): Promise<UpdateManyMeta>
 
   /**
    * Update the end page of form with given endpage object.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -333,6 +333,10 @@ export interface IFormModel extends Model<IFormSchema> {
     userEmail: IUserSchema['email'],
   ): Promise<FormMetaView[]>
 
+  disableSmsVerificationsForUser(
+    userId: IUserSchema['_id'],
+  ): Promise<IFormDocument[]>
+
   /**
    * Update the end page of form with given endpage object.
    * @param formId the id of the form to update


### PR DESCRIPTION
## Problem
The backend needs a way to disable sms verifications easily. This should also be done in a single query, so that we avoid overloading the database with requests, which can be non-ideal under load. 

## Solution
This PR accomplishes the above through using an `updateMany` function defined on the schema. Some points are noted below for discussion

1. avoid updating timestamps on disabling. this is **intentional** and done to avoid confusion on the admin side. the reason for doing so is because admins expect their own actions to alter the last modified state of the form, and not something beyond their control. (informed @syan-syan on this already)
2. Returning `true` on service level - done because the service has no idea of the actual count it's supposed to update (and it should not). unable to return `IFormDocument` because `updateMany` from mongoose doesn't return the documents :(

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  