### PR TITLE
fix: allow creation of storage form when emails are invalid

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -102,12 +102,19 @@ const createFormValidator = celebrate({
         title: Joi.string().min(4).max(200).required(),
         // Require emails string (for backwards compatibility) or string
         // array if form to be created in Email mode.
-        emails: Joi.alternatives()
-          .try(Joi.array().items(Joi.string()).min(1), Joi.string())
-          .when('responseMode', {
-            is: ResponseMode.Email,
-            then: Joi.required(),
-          }),
+        emails: Joi.when('responseMode', {
+          is: ResponseMode.Email,
+          then: Joi.alternatives()
+            .try(Joi.array().items(Joi.string()).min(1), Joi.string())
+            .required(),
+          // TODO (#2264): disallow the 'emails' key when responseMode is not Email
+          // Allow old clients to send this key but optionally and without restrictions
+          // on array length or type
+          otherwise: Joi.alternatives().try(
+            Joi.array(),
+            Joi.string().allow(''),
+          ),
+        }),
         // Require publicKey field if form to be created in Storage mode.
         publicKey: Joi.string()
           .allow('')
@@ -132,12 +139,16 @@ const duplicateFormValidator = celebrate({
     title: Joi.string().min(4).max(200).required(),
     // Require emails string (for backwards compatibility) or string array
     // if form to be duplicated in Email mode.
-    emails: Joi.alternatives()
-      .try(Joi.array().items(Joi.string()).min(1), Joi.string())
-      .when('responseMode', {
-        is: ResponseMode.Email,
-        then: Joi.required(),
-      }),
+    emails: Joi.when('responseMode', {
+      is: ResponseMode.Email,
+      then: Joi.alternatives()
+        .try(Joi.array().items(Joi.string()).min(1), Joi.string())
+        .required(),
+      // TODO (#2264): disallow the 'emails' key when responseMode is not Email
+      // Allow old clients to send this key but optionally and without restrictions
+      // on array length or type
+      otherwise: Joi.alternatives().try(Joi.array(), Joi.string().allow('')),
+    }),
     // Require publicKey field if form to be duplicated in Storage mode.
     publicKey: Joi.string()
       .allow('')

--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -28,12 +28,16 @@ const duplicateFormValidator = celebrate({
     title: Joi.string().min(4).max(200).required(),
     // Require emails string (for backwards compatibility) or string array
     // if form to be duplicated in Email mode.
-    emails: Joi.alternatives()
-      .try(Joi.array().items(Joi.string()).min(1), Joi.string())
-      .when('responseMode', {
-        is: ResponseMode.Email,
-        then: Joi.required(),
-      }),
+    emails: Joi.when('responseMode', {
+      is: ResponseMode.Email,
+      then: Joi.alternatives()
+        .try(Joi.array().items(Joi.string()).min(1), Joi.string())
+        .required(),
+      // TODO (#2264): disallow the 'emails' key when responseMode is not Email
+      // Allow old clients to send this key but optionally and without restrictions
+      // on array length or type
+      otherwise: Joi.alternatives().try(Joi.array(), Joi.string().allow('')),
+    }),
     // Require publicKey field if form to be duplicated in Storage mode.
     publicKey: Joi.string()
       .allow('')

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -173,6 +173,7 @@ require('./modules/forms/admin/controllers/pop-up-modal.client.controller.js')
 
 // forms admin directives
 require('./modules/forms/admin/directives/settings-form.client.directive.js')
+require('./modules/forms/admin/directives/validate-form-emails-input.directive.js')
 require('./modules/forms/admin/directives/edit-form.client.directive.js')
 require('./modules/forms/admin/directives/is-verifiable-save-interceptor.directive.js')
 require('./modules/forms/admin/directives/validate-email-domain-from-text.directive.js')

--- a/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
+++ b/src/public/modules/forms/admin/componentViews/form-emails-input.client.view.html
@@ -34,12 +34,12 @@
       placeholder="e.g. leo@data.gov.sg, john@data.gov.sg"
       ng-model="vm.formData.emails"
       name="emailList"
-      ng-required="true"
-      ng-change="vm.validateEmails(vm.formData.emails)"
+      ng-required="vm.formData.responseMode === 'email'"
       autocomplete="off"
       ng-keyup="($event.keyCode === 13 && vm.formController.emailList.$valid) && vm.saveForm()"
       ng-blur="vm.saveForm()"
       ng-class="vm.formController.emailList.$valid ? '' : 'input-error'"
+      validate-form-emails-input
     />
   </div>
 
@@ -52,9 +52,29 @@
   </div>
   <div
     ng-show="vm.formController.emailList.$invalid && vm.formController.emailList.$dirty"
+    ng-messages="vm.formController.emailList.$error"
     class="alert-custom alert-error"
   >
-    <i class="bx bx-exclamation bx-md icon-spacing"></i>
-    <span class="alert-msg">{{vm.emailErrorMsg}}</span>
+    <div ng-message="required">
+      <i class="bx bx-exclamation bx-md icon-spacing"></i>
+      <span class="alert-msg"
+        >You must at least enter one email to receive responses</span
+      >
+    </div>
+    <div ng-message="validEmails">
+      <i class="bx bx-exclamation bx-md icon-spacing"></i>
+      <span class="alert-msg"
+        >Please enter valid email(s) (e.g. me@example.com) separated by
+        commas</span
+      >
+    </div>
+    <div ng-message="duplicateEmails">
+      <i class="bx bx-exclamation bx-md icon-spacing"></i>
+      <span class="alert-msg">Please remove duplicate emails</span>
+    </div>
+    <div ng-message="maxNumEmails">
+      <i class="bx bx-exclamation bx-md icon-spacing"></i>
+      <span class="alert-msg">Please limit number of emails to 30</span>
+    </div>
   </div>
 </div>

--- a/src/public/modules/forms/admin/components/form-emails-input.client.component.js
+++ b/src/public/modules/forms/admin/components/form-emails-input.client.component.js
@@ -1,5 +1,3 @@
-const validator = require('validator')
-
 angular.module('forms').component('formEmailsInputComponent', {
   templateUrl:
     'modules/forms/admin/componentViews/form-emails-input.client.view.html',
@@ -21,38 +19,4 @@ function formEmailsInputController($scope) {
         ? 'Recommended: at least 2 recipients to prevent response loss from bounced emails'
         : null
   })
-
-  vm.validateEmails = (emails) => {
-    const emailsToCheck = emails ? String(emails).split(',') : undefined
-    vm.emailErrorMsg = checkForErrors(emailsToCheck)
-    vm.formController.emailList.$setValidity('text', !vm.emailErrorMsg)
-  }
-
-  function checkForErrors(emailsToCheck) {
-    if (!emailsToCheck) {
-      return 'You must at least enter one email to receive responses'
-    }
-
-    const emails = String(emailsToCheck).split(',')
-
-    if (emails.some((email) => isInvalid(email))) {
-      return 'Please enter valid email(s) (e.g. me@example.com) separated by commas'
-    }
-    if (hasDuplicates(emails)) {
-      return 'Please remove duplicate emails'
-    }
-    if (emails.length > 30) {
-      return 'Please limit number of emails to 30'
-    }
-    return null
-  }
-
-  function hasDuplicates(emails) {
-    const trimmed = emails.map((email) => email.trim())
-    return new Set(trimmed).size !== emails.length
-  }
-
-  function isInvalid(email) {
-    return !validator.isEmail(email.trim())
-  }
 }

--- a/src/public/modules/forms/admin/directives/validate-form-emails-input.directive.js
+++ b/src/public/modules/forms/admin/directives/validate-form-emails-input.directive.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const validator = require('validator')
+const get = require('lodash/get')
 
 angular
   .module('forms')
@@ -10,19 +11,28 @@ function validateFormEmailsInput() {
   return {
     restrict: 'A',
     require: 'ngModel',
-    link: (scope, elem, attr, ngModel) => {
+    link: (scope, _elem, _attr, ngModel) => {
       ngModel.$validators.validEmails = (rawInput) => {
         const emails = String(rawInput).split(',')
-        return emails.every((email) => validator.isEmail(email.trim()))
+        return (
+          get(scope, 'vm.formData.responseMode') !== 'email' ||
+          emails.every((email) => validator.isEmail(email.trim()))
+        )
       }
       ngModel.$validators.duplicateEmails = (rawInput) => {
         const emails = String(rawInput).split(',')
         const trimmed = emails.map((email) => email.trim())
-        return new Set(trimmed).size === emails.length
+        return (
+          get(scope, 'vm.formData.responseMode') !== 'email' ||
+          new Set(trimmed).size === emails.length
+        )
       }
       ngModel.$validators.maxNumEmails = (rawInput) => {
         const emails = String(rawInput).split(',')
-        return emails.length <= 30
+        return (
+          get(scope, 'vm.formData.responseMode') !== 'email' ||
+          emails.length <= 30
+        )
       }
     },
   }

--- a/src/public/modules/forms/admin/directives/validate-form-emails-input.directive.js
+++ b/src/public/modules/forms/admin/directives/validate-form-emails-input.directive.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const validator = require('validator')
+
+angular
+  .module('forms')
+  .directive('validateFormEmailsInput', validateFormEmailsInput)
+
+function validateFormEmailsInput() {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    link: (scope, elem, attr, ngModel) => {
+      ngModel.$validators.validEmails = (rawInput) => {
+        const emails = String(rawInput).split(',')
+        return emails.every((email) => validator.isEmail(email.trim()))
+      }
+      ngModel.$validators.duplicateEmails = (rawInput) => {
+        const emails = String(rawInput).split(',')
+        const trimmed = emails.map((email) => email.trim())
+        return new Set(trimmed).size === emails.length
+      }
+      ngModel.$validators.maxNumEmails = (rawInput) => {
+        const emails = String(rawInput).split(',')
+        return emails.length <= 30
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Problem

Closes #2189 

## Solution

- https://github.com/opengovsg/FormSG/commit/dd7bd161a89beb93884156749f63b0f924e8268d: refactor the form emails input to use `ng-message` with a validation directive instead of manually validating on `ng-change`
- https://github.com/opengovsg/FormSG/commit/aa4d6423968336c401616fe034d408960e7f34a1: update the validation directive to return true for all validators as long as the response mode is not `'email'`
- https://github.com/opengovsg/FormSG/pull/2263/commits/f55660530e269cac30b148b55f316e221bef5824: update Joi validation on all form creation (including duplication and copy) endpoints to allow empty strings or arrays for the `emails` key if the response mode is not email mode

## Breaking changes
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

## Manual tests
- [ ] Go to the create form modal and select "Email mode". Make the email list input invalid, e.g. by deleting all content in the input. Switch back to "Storage mode". You should still be able to create the form as long as the form title is valid. Make sure to go all the way through and create the form.
- [ ] Select "Storage mode" and type an invalid form title. You should be prevented from creating the form.
- [ ] Select "Email mode" and ensure that you are prevented from creating the form with the following types of inputs for the email list, with the correct error message in each case:
    - No input
    - Any invalid email present
    - Duplicate emails present
    - More than 30 non-duplicate emails present
- [ ] Repeat previous test for email list in the Settings tab for an email mode form. If the input is invalid, it should revert to its previous value on blur.