### PR TITLE
chore(db): db script to create index on smscounts

### DIFF
--- a/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
+++ b/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
@@ -51,7 +51,7 @@ db.getCollection('smscounts').updateMany(
 // Count of forms using our twilio acc
 db.getCollection('smscounts').count({
   smsType: 'VERIFICATION',
-msgSrvcSid: {$eq: formTwilioId},
+  msgSrvcSid: { $eq: formTwilioId },
 })
 
 // Count of forms using their own twilio acc

--- a/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
+++ b/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+
+/*
+This script creates a new key, isOnboardedAccount, on the smscounts db which indexes the msgSrvcId variable
+*/
+
+let formTwilioId = 'insert the form twilio id here'
+
+// == PRE-UPDATE CHECKS ==
+// Count the number of verifications
+db.getCollection('smscounts').count({ smsType: 'VERIFICATION' })
+
+// == UPDATE ==
+// Update verifications which have message service id equal to form twilio id
+db.getCollection('smscounts').updateMany(
+  { smsType: 'VERIFICATION', msgSrvcSid: { $eq: formTwilioId } },
+  {
+    $set: {
+      isOnboardedAccount: false,
+    },
+  }
+)
+
+// Update verifications whose message service id is not equal to form twilio id
+db.getCollection('smscounts').updateMany(
+  { smsType: 'VERIFICATION', msgSrvcSid: { $ne: formTwilioId } },
+  {
+    $set: {
+      isOnboardedAccount: true,
+    },
+  }
+)
+
+// == POST-UPDATE CHECKS ==
+
+// Check number of verifications updated
+// Sum of these two should be equal to the initial count
+db.getCollection('smscounts').count({
+  smsType: 'VERIFICATION',
+msgSrvcSid: {$eq: formTwilioId},
+})
+db.getCollection('smscounts').count({
+  smsType: 'VERIFICATION',
+  msgSrvcSid: { $ne: formTwilioId },
+})

--- a/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
+++ b/scripts/20210628_create-isOnboardedAcc/create-isOnboardedAcc.js
@@ -7,8 +7,22 @@ This script creates a new key, isOnboardedAccount, on the smscounts db which ind
 let formTwilioId = 'insert the form twilio id here'
 
 // == PRE-UPDATE CHECKS ==
-// Count the number of verifications
+// Count the number of verifications (A)
 db.getCollection('smscounts').count({ smsType: 'VERIFICATION' })
+
+// Count of forms using our twilio acc (B)
+db.getCollection('smscounts').count({
+  smsType: 'VERIFICATION',
+msgSrvcSid: {$eq: formTwilioId},
+})
+
+// Count of forms using their own twilio acc (C)
+// A === B + C
+db.getCollection('smscounts').count({
+  smsType: 'VERIFICATION',
+  msgSrvcSid: { $ne: formTwilioId },
+})
+
 
 // == UPDATE ==
 // Update verifications which have message service id equal to form twilio id
@@ -32,13 +46,15 @@ db.getCollection('smscounts').updateMany(
 )
 
 // == POST-UPDATE CHECKS ==
-
 // Check number of verifications updated
 // Sum of these two should be equal to the initial count
+// Count of forms using our twilio acc
 db.getCollection('smscounts').count({
   smsType: 'VERIFICATION',
 msgSrvcSid: {$eq: formTwilioId},
 })
+
+// Count of forms using their own twilio acc
 db.getCollection('smscounts').count({
   smsType: 'VERIFICATION',
   msgSrvcSid: { $ne: formTwilioId },

--- a/scripts/20210628_create-isOnboardedAcc/delete-isOnboardedAcc.js
+++ b/scripts/20210628_create-isOnboardedAcc/delete-isOnboardedAcc.js
@@ -1,0 +1,30 @@
+/* eslint-disable */
+
+/*
+This script creates a new key, isOnboardedAccount, on the smscounts db which indexes the msgSrvcId variable
+*/
+
+// == PRE-UPDATE CHECKS ==
+// Count the number of verifications we have to update
+db.getCollection('smscounts').count({ smsType: 'VERIFICATION' })
+
+// == UPDATE ==
+// Update verified smses
+db.getCollection('smscounts').updateMany(
+  { smsType: 'VERIFICATION' },
+  {
+    $unset: {
+      isOnboardedAccount: false,
+    },
+  }
+)
+
+// == POST-UPDATE CHECKS ==
+// Check number of verifications updated
+// SHOULD BE 0
+db.getCollection('smscounts').count({
+  smsType: 'VERIFICATION',
+  isOnboardedAccount: {
+    $exists: true
+  }
+})

--- a/src/app/services/sms/sms_count.server.model.ts
+++ b/src/app/services/sms/sms_count.server.model.ts
@@ -34,9 +34,6 @@ const VerificationSmsCountSchema = new Schema<IVerificationSmsCountSchema>({
       required: true,
     },
   },
-  isOnboardedAccount: {
-    type: Boolean,
-  },
 })
 
 const AdminContactSmsCountSchema = new Schema<IAdminContactSmsCountSchema>({

--- a/src/app/services/sms/sms_count.server.model.ts
+++ b/src/app/services/sms/sms_count.server.model.ts
@@ -34,6 +34,9 @@ const VerificationSmsCountSchema = new Schema<IVerificationSmsCountSchema>({
       required: true,
     },
   },
+  isOnboardedAccount: {
+    type: Boolean,
+  },
 })
 
 const AdminContactSmsCountSchema = new Schema<IAdminContactSmsCountSchema>({


### PR DESCRIPTION
## Problem
querying smscounts is slow, even when we index on `formAdmin` and `msgSrvcId`. This PR aims to solve that by creating a boolean key to index on, so that we can speed up the query.

## Solution
Creates a boolean key in `smscounts` that tracks whether the `msgSrvcSid` used in the verification is formSG's own.