### PR TITLE
feat: rename "Reference Number" to "Response ID"

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
+++ b/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
@@ -50,7 +50,7 @@ const makeEmailNotification = (
         },
       ],
       commonHeaders: {
-        subject: `Title (Ref: ${submissionId})`,
+        subject: `Title (#${submissionId})`,
         to: recipientList,
         from: 'donotreply@form.gov.sg',
       },

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -396,7 +396,7 @@ describe('mail.service', () => {
     // Should include the metadata in the front.
     const EXPECTED_JSON_DATA = [
       {
-        question: 'Reference Number',
+        question: 'Response ID',
         answer: MOCK_VALID_SUBMISSION_PARAMS.submission.id,
       },
       {

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -410,7 +410,7 @@ describe('mail.service', () => {
       return {
         to: toField,
         from: MOCK_SENDER_STRING,
-        subject: `formsg-auto: ${MOCK_VALID_SUBMISSION_PARAMS.form.title} (Ref: ${MOCK_VALID_SUBMISSION_PARAMS.submission.id})`,
+        subject: `formsg-auto: ${MOCK_VALID_SUBMISSION_PARAMS.form.title} (#${MOCK_VALID_SUBMISSION_PARAMS.submission.id})`,
         html: expectedHtml,
         attachments: MOCK_VALID_SUBMISSION_PARAMS.attachments,
         headers: {

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -476,7 +476,7 @@ export class MailService {
       const mail: MailOptions = {
         to: form.emails,
         from: this.#senderFromString,
-        subject: `formsg-auto: ${formTitle} (Ref: ${refNo})`,
+        subject: `formsg-auto: ${formTitle} (#${refNo})`,
         html: mailHtml,
         attachments,
         headers: {

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -453,7 +453,7 @@ export class MailService {
     // Unshift is not used as it mutates the array.
     const fullDataCollationData = [
       {
-        question: 'Reference Number',
+        question: 'Response ID',
         answer: refNo,
       },
       {

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -13,7 +13,7 @@
     >
       <tbody>
         <tr style="border-top: 1px solid #eee">
-          <td width="40%"><strong>Reference Number</strong></td>
+          <td width="40%"><strong>Response ID</strong></td>
           <td><%= refNo %></td>
         </tr>
         <tr style="border-top: 1px solid #eee">

--- a/src/app/views/templates/submit-form-summary-pdf.server.view.html
+++ b/src/app/views/templates/submit-form-summary-pdf.server.view.html
@@ -43,7 +43,7 @@
                     <% } %>
                     <tr style="border-top: 1px solid #eee;">
                         <td class="key-cell" width="50%" style="vertical-align: top;">
-                            <strong>Reference Number</strong>
+                            <strong>Response ID</strong>
                         </td>
                         <td class="value-cell">
                             <%= refNo %>

--- a/src/public/modules/forms/admin/views/view-responses.client.view.html
+++ b/src/public/modules/forms/admin/views/view-responses.client.view.html
@@ -160,7 +160,7 @@
                 {{row.number}}
               </td>
               <td
-                title="'Ref no.'"
+                title="'Response ID'"
                 class="refNo-col"
                 header-class="'refNo-col'"
               >
@@ -182,8 +182,8 @@
             />
             <div class="title">No results found</div>
             <div class="subtitle">
-              Did you enter the right reference number? We can't seem to find
-              the response.
+              Did you enter the right response ID? We can't seem to find the
+              response.
             </div>
           </div>
         </div>
@@ -227,7 +227,7 @@
       <div id="respondent-timestamp">
         <div class="row">
           <div class="col-xs-12 col-sm-4">
-            <b>Reference number</b>
+            <b>Response ID</b>
           </div>
           <div class="col-xs-12 col-sm-8">{{ vm.decryptedResponse.refNo }}</div>
         </div>

--- a/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
+++ b/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
@@ -105,7 +105,7 @@ export class CsvMergedHeadersGenerator extends CsvGenerator {
     if (this.hasBeenProcessed) return
 
     // Create a header row in CSV using the fieldIdToQuestion map.
-    const headers = ['Reference number', 'Timestamp']
+    const headers = ['Response ID', 'Timestamp']
     this.fieldIdToQuestion.forEach((value, fieldId) => {
       for (let i = 0; i < this.fieldIdToNumCols[fieldId]; i++) {
         headers.push(value.question)

--- a/tests/end-to-end/helpers/email-mode.js
+++ b/tests/end-to-end/helpers/email-mode.js
@@ -66,7 +66,7 @@ const verifySubmission = async (t, testFormData, authData) => {
   await t.expect(emailJSONStr).notEql(null)
   const emailJSON = JSON.parse(decodeHtmlEntities(emailJSONStr))
   const response = emailJSON.filter(
-    ({ question }) => !/(Reference Number|Timestamp)/.test(question),
+    ({ question }) => !/(Response ID|Timestamp)/.test(question),
   )
   await t.expect(response.length).notEql(0)
   let rowIdx = 0 // A table could result in multiple rows of answers, so there might be more answers than form fields

--- a/tests/end-to-end/helpers/email-mode.js
+++ b/tests/end-to-end/helpers/email-mode.js
@@ -44,7 +44,7 @@ const verifySubmission = async (t, testFormData, authData) => {
   await t.expect(from).eql('FormSG <donotreply@mail.form.gov.sg>')
 
   // Verify subject of email
-  await t.expect(subject).contains(`formsg-auto: ${title} (Ref:`)
+  await t.expect(subject).contains(`formsg-auto: ${title} (#`)
   // Verify form content in email
   for (let field of formFields) {
     const contained = [

--- a/tests/end-to-end/helpers/encrypt-mode.js
+++ b/tests/end-to-end/helpers/encrypt-mode.js
@@ -22,7 +22,7 @@ const ngrok = require('ngrok')
 // Index of the column headers in the exported CSV. The first 4 rows are
 // metadata about the number of responses decrypted.
 const CSV_HEADER_ROW_INDEX = 5
-// The first two columns are "Reference number" and "Timestamp", so the
+// The first two columns are "Response ID" and "Timestamp", so the
 // fields to check only start from the third column.
 const CSV_ANSWER_COL_INDEX = 3
 
@@ -131,13 +131,12 @@ async function checkDownloadCsv(t, formData, authData, formId) {
     `${getDownloadsFolder()}/${formOptions.title}-${formId}.csv`,
   )
   const records = parse(csvContent, { relax_column_count: true })
-  const headers = ['Reference number', 'Timestamp', 'Download Status']
+  const headers = ['Response ID', 'Timestamp', 'Download Status']
   const answers = []
   formFields.forEach((field) => addExpectedCsvResponse(field, headers, answers))
   await t.expect(records[CSV_HEADER_ROW_INDEX]).eql(headers)
-  const actualAnswers = records[CSV_HEADER_ROW_INDEX + 1].slice(
-    CSV_ANSWER_COL_INDEX,
-  )
+  const actualAnswers =
+    records[CSV_HEADER_ROW_INDEX + 1].slice(CSV_ANSWER_COL_INDEX)
   await t.expect(actualAnswers).eql(answers)
 }
 

--- a/tests/unit/frontend/forms/helpers/CsvMergedHeadersGenerator.test.js
+++ b/tests/unit/frontend/forms/helpers/CsvMergedHeadersGenerator.test.js
@@ -358,7 +358,7 @@ describe('CsvMergedHeadersGenerator', () => {
         // Should have 1 header row and 1 submission row
         expect(generator.records.length).toEqual(2 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockDecryptedRecord[0].question,
           mockDecryptedRecord[1].question,
@@ -420,7 +420,7 @@ describe('CsvMergedHeadersGenerator', () => {
         // Should have 1 header row and 2 submission row
         expect(generator.records.length).toEqual(3 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockFirstDecryptedRecord[0].question,
           mockFirstDecryptedRecord[1].question,
@@ -493,7 +493,7 @@ describe('CsvMergedHeadersGenerator', () => {
         // Should have 1 header row and 2 submission row
         expect(generator.records.length).toEqual(3 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockDecryptedRecord[0].question,
           mockDecryptedRecord[1].question,
@@ -561,7 +561,7 @@ describe('CsvMergedHeadersGenerator', () => {
         // Should have 1 header row and 1 submission row
         expect(generator.records.length).toEqual(2 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockDecryptedRecord[0].question,
         ])
@@ -609,7 +609,7 @@ describe('CsvMergedHeadersGenerator', () => {
         expect(generator.records.length).toEqual(2 + BOM_LENGTH)
         // Question is repeated for two columns
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockDecryptedRecord[0].question,
           mockDecryptedRecord[0].question,
@@ -656,7 +656,7 @@ describe('CsvMergedHeadersGenerator', () => {
         // Should have 1 header row and 2 submission rows
         expect(generator.records.length).toEqual(3 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
-          'Reference number',
+          'Response ID',
           'Timestamp',
           mockAnswerArray[0].question,
         ])


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The UI uses various terms to refer to the submission ID. It would be less confusing to users if we standardised the terminology.

Closes #2187

## Solution
<!-- How did you solve the problem? -->

Update all user-facing references to the submission ID to "Response ID".