### PR TITLE
feat(sms-limiting): disable sms verifications toggling

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -34,6 +34,7 @@ import {
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import * as SubmissionUtils from 'src/app/modules/submission/submission.utils'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
+import { SmsLimitExceededError } from 'src/app/modules/verification/verification.errors'
 import {
   MailGenerationError,
   MailSendError,
@@ -6740,10 +6741,10 @@ describe('admin-form.controller', () => {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
     } as IPopulatedUser
-    const MOCK_FIELD = generateDefaultField(BasicField.Rating)
+    const MOCK_FIELD = generateDefaultField(BasicField.Mobile)
     const MOCK_UPDATED_FIELD = {
       ...MOCK_FIELD,
-      title: 'some new title',
+      isVerifiable: true,
     } as FieldUpdateDto
 
     const MOCK_FORM = {
@@ -6771,7 +6772,9 @@ describe('admin-form.controller', () => {
       MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
         okAsync(MOCK_FORM),
       )
-
+      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
       MockAdminFormService.updateFormField.mockReturnValue(
         okAsync(MOCK_UPDATED_FIELD as IFieldSchema),
       )
@@ -6868,6 +6871,29 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(MockAdminFormService.updateFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 409 when the field could not be updated due to a sms limit exceeded error', async () => {
+      // Arrange
+      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
+        errAsync(new SmsLimitExceededError()),
+      )
+      const expected = {
+        message:
+          'You have exceeded the free sms limit. Please refresh and try again.',
+      }
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(409)
+      expect(mockRes.json).toBeCalledWith(expected)
     })
 
     it('should return 410 when form to update form field for is already archived', async () => {
@@ -7019,10 +7045,12 @@ describe('admin-form.controller', () => {
       title: 'mock title',
     } as IPopulatedForm
 
-    const MOCK_RETURNED_FIELD = generateDefaultField(BasicField.Nric)
+    const MOCK_RETURNED_FIELD = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
     const MOCK_CREATE_FIELD_BODY = pick(MOCK_RETURNED_FIELD, [
       'fieldType',
-      'title',
+      'isVerifiable',
     ]) as FieldCreateDto
     const MOCK_REQ = expressHandler.mockRequest({
       session: {
@@ -7038,6 +7066,9 @@ describe('admin-form.controller', () => {
     beforeEach(() => {
       MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
       MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
         okAsync(MOCK_FORM),
       )
       MockAdminFormService.createFormField.mockReturnValue(
@@ -7109,6 +7140,29 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
+    })
+
+    it('should return 409 when the field could not be created due to a sms limit exceeded error', async () => {
+      // Arrange
+      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
+        errAsync(new SmsLimitExceededError()),
+      )
+      const expected = {
+        message:
+          'You have exceeded the free sms limit. Please refresh and try again.',
+      }
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(409)
+      expect(mockRes.json).toBeCalledWith(expected)
     })
 
     it('should return 410 when attempting to create a form field for an archived form', async () => {
@@ -7300,11 +7354,14 @@ describe('admin-form.controller', () => {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
     } as IPopulatedUser
-    const MOCK_FIELDS = [generateDefaultField(BasicField.Rating)]
+    const MOCK_FIELDS = [
+      generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
+    ]
     const MOCK_FIELD_ID = String(MOCK_FIELDS[0]._id)
 
-    const MOCK_DUPLICATED_FIELD = generateDefaultField(BasicField.Rating)
-
+    const MOCK_DUPLICATED_FIELD = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
     const MOCK_FORM = {
       admin: MOCK_USER,
       _id: MOCK_FORM_ID,
@@ -7328,6 +7385,10 @@ describe('admin-form.controller', () => {
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValue(okAsync(MOCK_USER))
       MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.getFormField.mockReturnValue(ok(MOCK_FIELDS[0]))
+      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
         okAsync(MOCK_FORM),
       )
       MockAdminFormService.duplicateFormField.mockReturnValue(
@@ -7467,6 +7528,28 @@ describe('admin-form.controller', () => {
       )
     })
 
+    it('should return 409 when the field could not be duplicated due to a sms limit exceeded error', async () => {
+      // Arrange
+      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
+        errAsync(new SmsLimitExceededError()),
+      )
+      const expected = {
+        message:
+          'You have exceeded the free sms limit. Please refresh and try again.',
+      }
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await AdminFormController._handleUpdateFormField(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(409)
+      expect(mockRes.json).toBeCalledWith(expected)
+    })
     it('should return 410 when form to duplicate form field for is already archived', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -7154,7 +7154,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController._handleUpdateFormField(
+      await AdminFormController._handleCreateFormField(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -7540,7 +7540,7 @@ describe('admin-form.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await AdminFormController._handleUpdateFormField(
+      await AdminFormController.handleDuplicateFormField(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -7560,7 +7560,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleDeleteFormField(
+      await AdminFormController.handleDuplicateFormField(
         MOCK_REQ,
         mockRes,
         jest.fn(),

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -54,7 +54,7 @@ import {
 
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
 
-import { SMS_VERIFICATION_LIMIT } from '../../../../../shared/util/verification'
+import { smsConfig } from '../../../../config/features/sms.config'
 import * as SmsService from '../../../../services/sms/sms.service'
 import {
   FormNotFoundError,
@@ -2266,7 +2266,7 @@ describe('admin-form.service', () => {
 
     it('should return the form when admin is under the limit', async () => {
       // Arrange
-      countSpy.mockReturnValueOnce(okAsync(SMS_VERIFICATION_LIMIT))
+      countSpy.mockReturnValueOnce(okAsync(smsConfig.smsVerificationLimit))
 
       // Act
       const actual = await shouldUpdateFormField(
@@ -2320,7 +2320,7 @@ describe('admin-form.service', () => {
 
     it('should return sms retrieval error when sms limit exceeded and admin is attempting to toggle sms verification for mobile field on', async () => {
       // Arrange
-      countSpy.mockReturnValueOnce(okAsync(SMS_VERIFICATION_LIMIT + 1))
+      countSpy.mockReturnValueOnce(okAsync(smsConfig.smsVerificationLimit + 1))
 
       // Act
       const actual = await shouldUpdateFormField(

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1184,6 +1184,7 @@ export const handleUpdateForm: ControllerHandler<
  * @returns 400 when form field has invalid updates to be performed
  * @returns 403 when current user does not have permissions to update form
  * @returns 404 when form or field to duplicate cannot be found
+ * @returns 409 when saving updated form field causes sms limit to be exceeded
  * @returns 409 when saving updated form incurs a conflict in the database
  * @returns 410 when form to update is archived
  * @returns 413 when updated form is too large to be saved in the database
@@ -1639,6 +1640,7 @@ export const handleEmailPreviewSubmission = [
  * @returns 403 when current user does not have permissions to update form field
  * @returns 404 when form cannot be found
  * @returns 404 when form field cannot be found
+ * @returns 409 when form field update conflicts with database state
  * @returns 410 when updating form field of an archived form
  * @returns 413 when updating form field causes form to be too large to be saved in the database
  * @returns 422 when an invalid form field update is attempted on the form
@@ -1679,6 +1681,7 @@ export const handleUpdateFormField = [
  * @returns 200 with created form field
  * @returns 403 when current user does not have permissions to create a form field
  * @returns 404 when form cannot be found
+ * @returns 409 when form field update conflicts with database state
  * @returns 410 when creating form field for an archived form
  * @returns 413 when creating form field causes form to be too large to be saved in the database
  * @returns 422 when an invalid form field creation is attempted on the form

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1308,7 +1308,9 @@ export const _handleUpdateFormField: ControllerHandler<
           level: PermissionLevel.Write,
         }),
       )
-      // Step 3: User has permissions, update form field of retrieved form.
+      // Step 3: Check if the user has exceeded the allowable limit for sms.
+      .andThen((form) => AdminFormService.isAdminOverFreeSmsLimit(form))
+      // Step 4: User has permissions, update form field of retrieved form.
       .andThen((form) =>
         AdminFormService.updateFormField(form, fieldId, req.body),
       )
@@ -1693,7 +1695,9 @@ export const _handleCreateFormField: ControllerHandler<
           level: PermissionLevel.Write,
         }),
       )
-      // Step 3: User has permissions, proceed to create form field with provided body.
+      // Step 3: Check if the user has exceeded the allowable limit for sms.
+      .andThen((form) => AdminFormService.isAdminOverFreeSmsLimit(form))
+      // Step 4: User has permissions, proceed to create form field with provided body.
       .andThen((form) => AdminFormService.createFormField(form, req.body))
       .map((createdFormField) =>
         res.status(StatusCodes.OK).json(createdFormField),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1081,7 +1081,10 @@ export const disableSmsVerificationsForUser = (
  */
 export const isAdminOverFreeSmsLimit = (
   form: IPopulatedForm,
-): ResultAsync<IPopulatedForm, SmsLimitExceededError> => {
+): ResultAsync<
+  IPopulatedForm,
+  PossibleDatabaseError | SmsLimitExceededError
+> => {
   const formAdminId = String(form.admin._id)
   return SmsService.retrieveFreeSmsCounts(formAdminId).andThen((freeSmsSent) =>
     hasAdminExceededFreeSmsLimit(freeSmsSent)

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1092,12 +1092,12 @@ export const shouldUpdateFormField = (
   IPopulatedForm,
   PossibleDatabaseError | SmsLimitExceededError
 > => {
-  const formAdminId = String(form.admin._id)
-
   // Field can always update if it's not a verifiable field or if the form has been onboarded
   if (!isVerifiableMobileField(formField) || isOnboardedForm(form)) {
     return okAsync(form)
   }
+
+  const formAdminId = String(form.admin._id)
 
   // If the form admin has exceeded the sms limit
   // And the form is not onboarded, refuse to update the field

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1095,16 +1095,18 @@ export const shouldUpdateFormField = (
 > => {
   const formAdminId = String(form.admin._id)
 
-  // Field can always update if it's not a verifiable field
-  if (!isVerifiableMobileField(formField)) {
+  // Field can always update if it's not a verifiable field or if the form has been onboarded
+  if (!isVerifiableMobileField(formField) || isOnboardedForm(form)) {
     return okAsync(form)
   }
 
   // If the form admin has exceeded the sms limit
   // And the form is not onboarded, refuse to update the field
-  return SmsService.retrieveFreeSmsCounts(formAdminId).andThen((freeSmsSent) =>
-    hasAdminExceededFreeSmsLimit(freeSmsSent) && !isOnboardedForm(form)
-      ? errAsync(new SmsLimitExceededError())
-      : okAsync(form),
+  return SmsService.retrieveFreeSmsCounts(formAdminId).andThen(
+    (freeSmsSent) => {
+      return hasAdminExceededFreeSmsLimit(freeSmsSent)
+        ? errAsync(new SmsLimitExceededError())
+        : okAsync(form)
+    },
   )
 }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -4,8 +4,6 @@ import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import { Except, Merge } from 'type-fest'
 
-import { isVerifiableMobileField } from 'src/types/field/utils/guards'
-
 import {
   EditFieldActions,
   MAX_UPLOAD_FILE_SIZE,
@@ -36,6 +34,7 @@ import {
   SettingsUpdateDto,
   StartPageUpdateDto,
 } from '../../../../types/api'
+import { isVerifiableMobileField } from '../../../../types/field/utils/guards'
 import { aws as AwsConfig } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import getFormModel from '../../../models/form.server.model'

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -22,6 +22,7 @@ import {
 } from '../../core/core.errors'
 import { ErrorResponseData } from '../../core/core.types'
 import { MissingUserError } from '../../user/user.errors'
+import { SmsLimitExceededError } from '../../verification/verification.errors'
 import {
   ForbiddenFormError,
   FormDeletedError,
@@ -57,6 +58,11 @@ export const mapRouteError = (
   coreErrorMessage?: string,
 ): ErrorResponseData => {
   switch (error.constructor) {
+    case SmsLimitExceededError:
+      return {
+        statusCode: StatusCodes.CONFLICT,
+        errorMessage: error.message,
+      }
     case InvalidFileTypeError:
     case CreatePresignedUrlError:
       return {

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,8 +1,10 @@
 import {
   IEncryptedFormSchema,
   IFieldSchema,
+  IForm,
   IFormSchema,
   ILogicSchema,
+  IOnboardedForm,
   IPopulatedEmailForm,
   IPopulatedForm,
   Permission,
@@ -120,4 +122,9 @@ export const getLogicById = (
   }
 
   return form_logics.find((logic) => logicId === String(logic._id)) ?? null
+}
+
+// Typeguard to check if a form has a message service id
+export const isOnboardedForm = (form: IForm): form is IOnboardedForm<IForm> => {
+  return !!form.msgSrvcName
 }

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -125,6 +125,8 @@ export const getLogicById = (
 }
 
 // Typeguard to check if a form has a message service id
-export const isOnboardedForm = (form: IForm): form is IOnboardedForm<IForm> => {
+export const isOnboardedForm = <T extends IForm = IForm>(
+  form: T,
+): form is IOnboardedForm<T> => {
   return !!form.msgSrvcName
 }

--- a/src/app/modules/verification/verification.errors.ts
+++ b/src/app/modules/verification/verification.errors.ts
@@ -88,7 +88,7 @@ export class NonVerifiedFieldTypeError extends ApplicationError {
  */
 export class SmsLimitExceededError extends ApplicationError {
   constructor(
-    message = 'You have exceeded the free sms limit. Please contact the FormSG team for further steps on how to resolve this issue.',
+    message = 'You have exceeded the free sms limit. Please refresh and try again.',
   ) {
     super(message)
   }

--- a/src/app/modules/verification/verification.errors.ts
+++ b/src/app/modules/verification/verification.errors.ts
@@ -82,3 +82,14 @@ export class NonVerifiedFieldTypeError extends ApplicationError {
     )
   }
 }
+
+/**
+ * Agency user has sent too many SMSes using default Twilio credentials
+ */
+export class SmsLimitExceededError extends ApplicationError {
+  constructor(
+    message = 'You have exceeded the free sms limit. Please contact the FormSG team for further steps on how to resolve this issue.',
+  ) {
+    super(message)
+  }
+}

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -2,7 +2,6 @@ import { StatusCodes } from 'http-status-codes'
 
 import {
   HASH_EXPIRE_AFTER_SECONDS,
-  SMS_VERIFICATION_LIMIT,
   VERIFIED_FIELDTYPES,
   WAIT_FOR_OTP_SECONDS,
   WAIT_FOR_OTP_TOLERANCE_SECONDS,
@@ -12,6 +11,7 @@ import {
   IVerificationSchema,
   MapRouteError,
 } from '../../../types'
+import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { MailSendError } from '../../services/mail/mail.errors'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
@@ -213,5 +213,5 @@ export const mapRouteError: MapRouteError = (
 }
 
 export const hasAdminExceededFreeSmsLimit = (smsCount: number): boolean => {
-  return smsCount > SMS_VERIFICATION_LIMIT
+  return smsCount > smsConfig.smsVerificationLimit
 }

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import {
   HASH_EXPIRE_AFTER_SECONDS,
+  SMS_VERIFICATION_LIMIT,
   VERIFIED_FIELDTYPES,
   WAIT_FOR_OTP_SECONDS,
   WAIT_FOR_OTP_TOLERANCE_SECONDS,
@@ -209,4 +210,8 @@ export const mapRouteError: MapRouteError = (
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
       }
   }
+}
+
+export const hasAdminExceededFreeSmsLimit = (smsCount: number): boolean => {
+  return smsCount > SMS_VERIFICATION_LIMIT
 }

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1743,7 +1743,9 @@ describe('admin-form.form.routes', () => {
 
       // Assert
       expect(response.status).toEqual(404)
-      expect(response.body).toEqual({ message: 'Form not found' })
+      expect(response.body).toEqual({
+        message: `Attempted to retrieve field ${randomFieldId} from ${formToUpdate._id} but field was not present`,
+      })
     })
 
     it('should return 410 when form is already archived', async () => {

--- a/src/shared/util/verification.ts
+++ b/src/shared/util/verification.ts
@@ -21,5 +21,3 @@ export enum VfnErrors {
   TransactionNotFound = 'TRANSACTION_NOT_FOUND',
   InvalidMobileNumber = 'INVALID_MOBILE_NUMBER',
 }
-
-export const SMS_VERIFICATION_LIMIT = 10000

--- a/src/shared/util/verification.ts
+++ b/src/shared/util/verification.ts
@@ -21,3 +21,5 @@ export enum VfnErrors {
   TransactionNotFound = 'TRANSACTION_NOT_FOUND',
   InvalidMobileNumber = 'INVALID_MOBILE_NUMBER',
 }
+
+export const SMS_VERIFICATION_LIMIT = 10000

--- a/src/types/field/mobileField.ts
+++ b/src/types/field/mobileField.ts
@@ -5,6 +5,10 @@ export interface IMobileField extends IField {
   isVerifiable: boolean
 }
 
+export interface IVerifiableMobileField extends IMobileField {
+  isVerifiable: true
+}
+
 export interface IMobileFieldSchema extends IMobileField, IFieldSchema {
   isVerifiable: boolean
 }

--- a/src/types/field/utils/guards.ts
+++ b/src/types/field/utils/guards.ts
@@ -20,6 +20,7 @@ import {
   IShortTextField,
   ITableFieldSchema,
   IUenField,
+  IVerifiableMobileField,
   IYesNoField,
 } from '..'
 
@@ -71,6 +72,12 @@ export const isMobileNumberField = (
   formField: IField,
 ): formField is IMobileField => {
   return formField.fieldType === BasicField.Mobile
+}
+
+export const isVerifiableMobileField = (
+  formField: IField,
+): formField is IVerifiableMobileField => {
+  return isMobileNumberField(formField) && formField.isVerifiable
 }
 
 export const isAttachmentField = (

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -150,7 +150,9 @@ export interface IForm {
   emails?: string[] | string
 }
 
-export type IOnboardedForm<T extends IForm> = SetRequired<T, 'msgSrvcName'>
+export type IOnboardedForm<T extends IForm> = T & {
+  msgSrvcName: string
+}
 
 export type FormSettings = Pick<
   IFormDocument,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -150,6 +150,8 @@ export interface IForm {
   emails?: string[] | string
 }
 
+export type IOnboardedForm<T extends IForm> = SetRequired<T, 'msgSrvcName'>
+
 export type FormSettings = Pick<
   IFormDocument,
   | 'authType'


### PR DESCRIPTION
## Problem
This PR addresses the edge case when the admin wishes to perform some operation on the form field but should be prohibited from doing so because their sms limit has been exceeded. This PR is dependent on #2276 

## Solution
The solution consists of 2 portions. 

**Checking if the operation should be prohibited**
- this is done though a service method called `shouldUpdateFormField`, where the applicable scenario is checked - the field is of type Mobile and it's verifiable. When this occurs, the free sms counts used of the admin is retrieved and checked to see if the limit has been exceeded, and a `Result` is returned accordingly. 

**Preventing operation if it should be prohibited**
- because the type returned in the error case is `Err<some base type>`, the error returned will be propagated and short-circuited, preventing the operation from taking place

## Technical Choices
1. Placing of `shouldUpdateFormField` in controller rather than service.
    - the choice to update should be clearly visible and not abstracted by the service
    - choice to prohibit the update should be a controller level responsibility; service should just perform a single function