### PR TITLE
fix(admin-form.service): fixed logical error in duplicate form field

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -499,8 +499,9 @@ export const duplicateFormField = (
     },
   ).andThen((updatedForm) => {
     if (!updatedForm) {
-      // Null return could be due to form or field not existing.
-      // Hence, check if field exists in form and return the appropriate error
+      // Success means field is in initial form object but query still returned null.
+      // Return best guess error that form is now not found in the DB.
+      // Otherwise, err(FieldNotFoundError) will be returned by the function.
       return getFormField(form, fieldId).asyncAndThen(() =>
         errAsync(new FormNotFoundError()),
       )

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -499,7 +499,11 @@ export const duplicateFormField = (
     },
   ).andThen((updatedForm) => {
     if (!updatedForm) {
-      return errAsync(new FormNotFoundError())
+      // Null return could be due to form or field not existing.
+      // Hence, check if field exists in form and return the appropriate error
+      return getFormField(form, fieldId).asyncAndThen(() =>
+        errAsync(new FormNotFoundError()),
+      )
     }
     const updatedField = last(updatedForm.form_fields)
     return updatedField

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1743,7 +1743,9 @@ describe('admin-form.form.routes', () => {
 
       // Assert
       expect(response.status).toEqual(404)
-      expect(response.body).toEqual({ message: 'Form not found' })
+      expect(response.body).toEqual({
+        message: `Attempted to retrieve field ${randomFieldId} from ${formToUpdate._id} but field was not present`,
+      })
     })
 
     it('should return 410 when form is already archived', async () => {


### PR DESCRIPTION
## Problem
`AdminFormService.duplicateFormField` occasionally returns the wrong error type. This is because the underlying schema method returns null when either the field or the form was not found.

## Solution
Insert a check after calling `form.duplicateFormFieldById` to see if there is a field and return the error appropriately.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Tests
This also fixes an erroneous integration test where the property being tested was when teh field wasn't found but the `expect` block checks that the _form_ was not found.