### PR TITLE
fix: allow duplicating email field with PDF to storage mode

### DIFF
--- a/src/app/models/field/__tests__/emailField.spec.ts
+++ b/src/app/models/field/__tests__/emailField.spec.ts
@@ -1,0 +1,105 @@
+import merge from 'lodash/merge'
+import { Model, Schema } from 'mongoose'
+
+import { IEmailField, IEmailFieldSchema, ResponseMode } from 'src/types'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import createEmailFieldSchema from '../emailField'
+
+describe('models.fields.emailField', () => {
+  // Required as the field validator has a this.parent() check for response mode.
+  let MockParent: Model<{
+    responseMode: ResponseMode
+    field: IEmailFieldSchema
+  }>
+
+  const EMAIL_FIELD_DEFAULTS: Partial<IEmailField> = {
+    autoReplyOptions: {
+      hasAutoReply: true,
+      autoReplySubject: '',
+      autoReplySender: '',
+      autoReplyMessage: '',
+      includeFormSummary: false,
+    },
+    isVerifiable: false,
+    hasAllowedEmailDomains: false,
+    allowedEmailDomains: [],
+  }
+
+  beforeAll(async () => {
+    const db = await dbHandler.connect()
+    const emailFieldSchema = createEmailFieldSchema()
+    MockParent = db.model(
+      'mockParent',
+      new Schema({
+        responseMode: {
+          type: String,
+          enum: Object.values(ResponseMode),
+        },
+        field: emailFieldSchema,
+      }),
+    )
+  })
+  beforeEach(async () => await dbHandler.clearDatabase())
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  it('should set includeFormSummary to false on ResponseMode.Encrypt forms', async () => {
+    // Arrange
+    const mockEmailField = {
+      autoReplyOptions: {
+        hasAutoReply: true,
+        autoReplySubject: 'some subject',
+        autoReplySender: 'some sender',
+        autoReplyMessage: 'This is a test message',
+        // Set includeFormSummary to true.
+        includeFormSummary: true,
+      },
+    }
+    // Act
+    const actual = await MockParent.create({
+      responseMode: ResponseMode.Encrypt,
+      field: mockEmailField,
+    })
+
+    // Assert
+    const expected = merge(EMAIL_FIELD_DEFAULTS, mockEmailField, {
+      _id: expect.anything(),
+      autoReplyOptions: {
+        // Regardless, should be false since ResponseMode is Encrypt.
+        includeFormSummary: false,
+      },
+    })
+    expect(actual.field.toObject()).toEqual(expected)
+  })
+
+  it('should set includeFormSummary to given value on ResponseMode.Email forms', async () => {
+    // Arrange
+    const mockEmailField = {
+      autoReplyOptions: {
+        hasAutoReply: true,
+        autoReplySubject: 'some subject',
+        autoReplySender: 'some sender',
+        autoReplyMessage: 'This is a test message',
+        // Set includeFormSummary to true.
+        includeFormSummary: true,
+      },
+    }
+    // Act
+    const actual = await MockParent.create({
+      responseMode: ResponseMode.Email,
+      field: mockEmailField,
+    })
+
+    // Assert
+    const expected = merge(EMAIL_FIELD_DEFAULTS, mockEmailField, {
+      _id: expect.anything(),
+      autoReplyOptions: {
+        // Should be initial value (true)
+        // Do not really need to declare here, but here just to be explicit.
+        includeFormSummary: true,
+      },
+    })
+    expect(actual.field.toObject()).toEqual(expected)
+  })
+})

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -29,19 +29,9 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
       includeFormSummary: {
         type: Boolean,
         default: false,
-        validate: {
-          validator: function (this: IEmailFieldSchema, v: boolean) {
-            // always ok to set to false
-            return (
-              !v ||
-              // either true or false is okay if not in storage mode
-              this.parent().responseMode !== ResponseMode.Encrypt ||
-              // in storage mode, we can ignore this field if email confirmation is not enabled anyway
-              !this.autoReplyOptions.hasAutoReply
-            )
-          },
-          message:
-            'PDF response summaries are not allowed for email confirmations in storage mode forms',
+        set: function (this: IEmailFieldSchema, v: boolean) {
+          // Set to false if encrypt mode regardless of initial value.
+          return this.parent().responseMode === ResponseMode.Encrypt ? false : v
         },
       },
     },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Bug was due to regression caused in #1971 where the set hook was converted to a validator hook. Upon further examination, the set hook was needed to set includeFormSummary to false on encrypt-mode forms.

The pre-validate hook will always pass if storage mode forms's email.includeFormSummary is always set to true, and is thus redundant and kept deleted.

Closes #2283

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- fix: allow duplicating email field with PDF to storage mode
## Tests
Add unit tests for emailField to check that storage mode forms set `includeFormSummary` to false regardless

### Manual tests
- [ ] Create an email mode form, with email field that has the include PDF summary option toggled on. 
  - [ ] Duplicate that form to a storage mode form. Should duplicate successfully, but with the include PDF summary option in the email form toggled off.
  - [ ] Duplicate that form to another email mode form. Should duplicate successfully and the include PDF summary option should still be toggled on.
