### PR TITLE
fix(deps): unpin typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.8",
     "type-fest": "^1.2.1",
-    "typescript": "=4.2.4",
+    "typescript": "^4.2.4",
     "url-loader": "^1.1.2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",


### PR DESCRIPTION
Allows TypeScript version to be upgraded since the bug with `zod` has been [fixed](https://github.com/colinhacks/zod/releases/tag/v3.2).