### PR TITLE
fix(types): recognise User.betaFlags in zod

### DIFF
--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -16,6 +16,7 @@ export const User = z.object({
   _id: z.string() as unknown as z.Schema<UserId>,
   email: z.string().email(),
   agency: Agency,
+  betaFlags: z.record(z.boolean()).optional(),
   created: DateString,
   lastAccessed: DateString,
   updatedAt: DateString,


### PR DESCRIPTION
## Context

Beta flags are returned by the backend, but the Zod types used by the frontend
does not recognise them. Make the appropriate change to do so.