### PR TITLE
fix: visiting archived form URL to show correct error message

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -2529,7 +2529,9 @@ describe('admin-form.routes', () => {
 
       // Assert
       expect(response.status).toEqual(410)
-      expect(response.body).toEqual({ message: 'Form has been deleted' })
+      expect(response.body).toEqual({
+        message: 'This form is no longer active',
+      })
     })
 
     it('should return 500 when database error occurs whilst retrieving form', async () => {
@@ -2879,7 +2881,7 @@ describe('admin-form.routes', () => {
       // Assert
       expect(response.status).toEqual(410)
       expect(response.body).toEqual({
-        message: 'Form has been deleted',
+        message: 'This form is no longer active',
       })
     })
 

--- a/src/app/modules/form/form.errors.ts
+++ b/src/app/modules/form/form.errors.ts
@@ -9,7 +9,7 @@ export class FormNotFoundError extends ApplicationError {
 }
 
 export class FormDeletedError extends ApplicationError {
-  constructor(message = 'Form has been deleted') {
+  constructor(message = 'This form is no longer active') {
     super(message)
   }
 }

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -221,7 +221,9 @@ describe('public-form.controller', () => {
       expect(MockFormService.isFormPublic).toHaveBeenCalledWith(MOCK_FORM)
       expect(MockPublicFormService.insertFormFeedback).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(410)
-      expect(mockRes.json).toHaveBeenCalledWith({ message: 'Gone' })
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'This form is no longer active',
+      })
     })
 
     it('should return 500 when database errors occur', async () => {

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -257,7 +257,7 @@ describe('public-form.routes', () => {
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
-          message: 'Gone',
+          message: 'This form is no longer active',
         }),
       )
 

--- a/src/app/modules/form/public-form/public-form.utils.ts
+++ b/src/app/modules/form/public-form/public-form.utils.ts
@@ -1,4 +1,4 @@
-import { getReasonPhrase, StatusCodes } from 'http-status-codes'
+import { StatusCodes } from 'http-status-codes'
 
 import { MapRouteError } from 'src/types'
 
@@ -33,7 +33,7 @@ export const mapRouteError = (
     case FormErrors.FormDeletedError:
       return {
         statusCode: StatusCodes.GONE,
-        errorMessage: getReasonPhrase(StatusCodes.GONE),
+        errorMessage: error.message,
       }
     case FormErrors.PrivateFormError:
       return {

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.feedback.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.feedback.routes.spec.ts
@@ -1,4 +1,3 @@
-import { getReasonPhrase, StatusCodes } from 'http-status-codes'
 import { errAsync } from 'neverthrow'
 import supertest, { Session } from 'supertest-session'
 
@@ -112,7 +111,7 @@ describe('public-form.feedback.routes', () => {
       }
       const expectedResponse = JSON.parse(
         JSON.stringify({
-          message: getReasonPhrase(StatusCodes.GONE),
+          message: 'This form is no longer active',
         }),
       )
 

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
@@ -264,7 +264,7 @@ describe('public-form.form.routes', () => {
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
-          message: 'Gone',
+          message: 'This form is no longer active',
         }),
       )
 


### PR DESCRIPTION
## Problem
Visiting archived form URL shows uninformative error message

Closes #1759

## Solution
Instead of getting the HTTP Reason code for 410 Gone, using the exception's `message` property.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

Shows the correct error message!

## Before & After Screenshots

**BEFORE**:
<img width="605" alt="Screenshot 2021-07-07 at 1 53 34 AM" src="https://user-images.githubusercontent.com/932949/124645679-4ce68a00-dec6-11eb-8c8b-10d598a7af4b.png">

**AFTER**:
<img width="635" alt="Screenshot 2021-07-07 at 1 54 14 AM" src="https://user-images.githubusercontent.com/932949/124645634-3e986e00-dec6-11eb-9430-fed208bbc1c9.png">

## Tests
A unit test has been updated, also for manual testing,

1. Create a form.
2. Get the link.
3. Archive it.
4. Visit the link.
5. See the error message in all its glory.