### PR TITLE
fix: read email validation error message from Joi response

### DIFF
--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -144,12 +144,18 @@ function AuthenticationController($q, $scope, $state, $timeout, $window, GTag) {
     $q.when(AuthService.checkIsEmailAllowed(vm.credentials.email))
       .then(() => vm.sendOtp())
       .catch((error) => {
-        const errorMsg = get(
+        const validationMsgInBody = get(
           error,
-          'response.data',
-          'Something went wrong while validating your email. Please refresh and try again',
+          'response.data.validation.body.message',
         )
-        setEmailSignInError(errorMsg)
+        const errorMsgInBody = get(error, 'response.data.message')
+        const errorMsgAsPlain = get(error, 'response.data')
+        setEmailSignInError(
+          validationMsgInBody ||
+            errorMsgInBody ||
+            errorMsgAsPlain ||
+            'Something went wrong while validating your email. Please refresh and try again',
+        )
       })
   }
 

--- a/tests/end-to-end/login.e2e.js
+++ b/tests/end-to-end/login.e2e.js
@@ -199,3 +199,13 @@ test
     .expect((await landingPage.tagline.textContent).replace(/  +/g, ' '))
     .contains('Build government forms in minutes')
 })
+
+test('Prevent sign-in if email is invalid', async (t) => {
+  let email = t.ctx.user.email
+  // Enter email
+  await enterEmail(t, email)
+
+  t.expect(signInPage.emailErrorMsg().textContent).contains(
+    'Please enter a valid email',
+  )
+})

--- a/tests/end-to-end/login.e2e.js
+++ b/tests/end-to-end/login.e2e.js
@@ -205,7 +205,7 @@ test('Prevent sign-in if email is invalid', async (t) => {
   // Enter email
   await enterEmail(t, email)
 
-  t.expect(signInPage.emailErrorMsg().textContent).contains(
-    'Please enter a valid email',
-  )
+  await t
+    .expect(signInPage.emailErrorMsg().textContent)
+    .contains('Please enter a valid email')
 })

--- a/tests/end-to-end/login.e2e.js
+++ b/tests/end-to-end/login.e2e.js
@@ -201,7 +201,7 @@ test
 })
 
 test('Prevent sign-in if email is invalid', async (t) => {
-  let email = t.ctx.user.email
+  let email = 'ani@open.gov.rg'
   // Enter email
   await enterEmail(t, email)
 


### PR DESCRIPTION
## Problem
Some emails pass the front-end validation, however, fail the backend validation with `Joi`. The response format is not plain text. Thus, `linky` cannot render the error properly as the correct message is lodged deep in `response.data.validation.body.message`.

Closes #2250

## Solution
I updated the error message capture method in the frontend, to look for `Joi` error messages first, then to fall back on treating the entire response body as the plain-text error message.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Bug Fixes**:
For certain emails that fail frontend validation, a correct error message is displayed.

## Before & After Screenshots

**BEFORE**:
<img width="627" alt="123245647-9c68a580-d517-11eb-9d62-361add98e525" src="https://user-images.githubusercontent.com/932949/124681856-090e7780-defc-11eb-9415-31218c9591af.png">

**AFTER**:
<img width="682" alt="Screenshot 2021-07-07 at 8 19 55 AM" src="https://user-images.githubusercontent.com/932949/124681892-204d6500-defc-11eb-99e7-f90647603427.png">

## Tests
I did add an e2e-test. You can get creative with emails to test to make sure the frontend validator fails. Make it *sneaky*.