### PR TITLE
feat: client to delete spcp cookie

### DIFF
--- a/src/app/config/features/spcp-myinfo.config.ts
+++ b/src/app/config/features/spcp-myinfo.config.ts
@@ -11,6 +11,7 @@ type ISpcpConfig = {
   spCookieMaxAge: number
   spCookieMaxAgePreserved: number
   spcpCookieDomain: string
+  oldSpcpCookieDomain: string // TODO (#2329): To remove after old cookies have expired
   cpCookieMaxAge: number
   spIdpId: string
   cpIdpId: string
@@ -75,6 +76,13 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: String,
     default: '',
     env: 'SPCP_COOKIE_DOMAIN',
+  },
+  oldSpcpCookieDomain: {
+    // TODO (#2329): To remove after old cookies have expired
+    doc: 'Old domain name set on cookie that holds the SPCP jwt',
+    format: String,
+    default: '',
+    env: 'OLD_SPCP_COOKIE_DOMAIN',
   },
   cpCookieMaxAge: {
     doc: 'Max CorpPass cookie age',

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -43,6 +43,8 @@ const environment = ejs.render(
     var formsgSdkMode = "<%= formsgSdkMode%>"
     // SPCP Cookie
     var spcpCookieDomain = "<%= spcpCookieDomain%>"
+    // Old SPCP Cookie
+    var oldSpcpCookieDomain = "<%= oldSpcpCookieDomain%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -20,6 +20,7 @@ const frontendVars = {
   isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
   GATrackingID: googleAnalyticsConfig.GATrackingID,
   spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
+  oldSpcpCookieDomain: spcpMyInfoConfig.oldSpcpCookieDomain, // Old cookie domain used for backward compatibility. TODO (#2329): Delete env var
 }
 const environment = ejs.render(
   `

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -16,7 +16,6 @@ angular
 function SpcpSession($interval, $q, Toastr, $window, $cookies) {
   let session = {
     userName: null,
-    cookieName: null,
     rememberMe: null,
     issuedAt: null,
     cookieNames: {
@@ -43,7 +42,7 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
     logout: function (authType) {
       $cookies.remove(
         // TODO (#2329): To remove after old cookies have expired
-        session.cookieName,
+        session.cookieNames[authType],
         $window.oldSpcpCookieDomain
           ? { domain: $window.oldSpcpCookieDomain }
           : {},

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -41,6 +41,10 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
       session.userName = undefined
     },
     logout: function (authType) {
+      $cookies.remove(
+        session.cookieName,
+        $window.spcpCookieDomain ? { domain: $window.spcpCookieDomain } : {},
+      )
       $q.when(PublicFormAuthService.logoutOfSpcpSession(authType))
         .then(() => {
           $cookies.put('isJustLogOut', true)

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -43,7 +43,9 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
     logout: function (authType) {
       $cookies.remove(
         session.cookieName,
-        $window.spcpCookieDomain ? { domain: $window.spcpCookieDomain } : {},
+        $window.oldSpcpCookieDomain
+          ? { domain: $window.oldSpcpCookieDomain }
+          : {},
       )
       $q.when(PublicFormAuthService.logoutOfSpcpSession(authType))
         .then(() => {

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -42,6 +42,7 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
     },
     logout: function (authType) {
       $cookies.remove(
+        // TODO (#2329): To remove after old cookies have expired
         session.cookieName,
         $window.oldSpcpCookieDomain
           ? { domain: $window.oldSpcpCookieDomain }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- Server was unable to delete spcp cookie in production due to different domain name (cookies had . prefix)

## Solution

- Env vars will be updated to remove . prefix
- However, server will not still be able to remove existing cookies as they were set with (.) domain. These cookies may remain valid for up to 30 days (SP remember me option)
- To resolve this, client will continue to attempt to delete cookie upon clicking 'logout', in addition to calling `/logout` endpoint. TODO: Remove in #2329

## Tests
- [ ] Create sp form and log in
  - [ ] In dev tools, add a . prefix to the cookie domain (.staging.form.gov.sg) and change `HttpOnly` to false
  - [ ] Check that form can be submitted
  - [ ] Check that user can log out and jwt cookie is deleted thereafter
  - [ ] Log in again. Check that submission and log out works
- [ ] Repeat above with 'remember me' enabled
- [ ] Repeat above with CP form

## Deploy notes

- new env var of `OLD_SPCP_COOKIE_DOMAIN` should be set to .form.gov.sg for prod at the time of deployment
- existing env var of `SPCP_COOKIE_DOMAIN` should be changed to blank for prod at time of deployment

## New Env Vars

- Added new env var `OLD_SPCP_COOKIE_DOMAIN` for client to delete old cookie.