### PR TITLE
build: Release 5.19.1

### DIFF
--- a/src/app/config/features/spcp-myinfo.config.ts
+++ b/src/app/config/features/spcp-myinfo.config.ts
@@ -11,6 +11,7 @@ type ISpcpConfig = {
   spCookieMaxAge: number
   spCookieMaxAgePreserved: number
   spcpCookieDomain: string
+  oldSpcpCookieDomain: string // TODO (#2329): To remove after old cookies have expired
   cpCookieMaxAge: number
   spIdpId: string
   cpIdpId: string
@@ -75,6 +76,13 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: String,
     default: '',
     env: 'SPCP_COOKIE_DOMAIN',
+  },
+  oldSpcpCookieDomain: {
+    // TODO (#2329): To remove after old cookies have expired
+    doc: 'Old domain name set on cookie that holds the SPCP jwt',
+    format: String,
+    default: '',
+    env: 'OLD_SPCP_COOKIE_DOMAIN',
   },
   cpCookieMaxAge: {
     doc: 'Max CorpPass cookie age',

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -20,6 +20,7 @@ const frontendVars = {
   isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
   GATrackingID: googleAnalyticsConfig.GATrackingID,
   spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
+  oldSpcpCookieDomain: spcpMyInfoConfig.oldSpcpCookieDomain, // Old cookie domain used for backward compatibility. TODO (#2329): Delete env var
 }
 const environment = ejs.render(
   `
@@ -42,6 +43,8 @@ const environment = ejs.render(
     var formsgSdkMode = "<%= formsgSdkMode%>"
     // SPCP Cookie
     var spcpCookieDomain = "<%= spcpCookieDomain%>"
+    // Old SPCP Cookie
+    var oldSpcpCookieDomain = "<%= oldSpcpCookieDomain%>"
   `,
   frontendVars,
 )

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -16,7 +16,6 @@ angular
 function SpcpSession($interval, $q, Toastr, $window, $cookies) {
   let session = {
     userName: null,
-    cookieName: null,
     rememberMe: null,
     issuedAt: null,
     cookieNames: {
@@ -41,6 +40,13 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
       session.userName = undefined
     },
     logout: function (authType) {
+      $cookies.remove(
+        // TODO (#2329): To remove after old cookies have expired
+        session.cookieNames[authType],
+        $window.oldSpcpCookieDomain
+          ? { domain: $window.oldSpcpCookieDomain }
+          : {},
+      )
       $q.when(PublicFormAuthService.logoutOfSpcpSession(authType))
         .then(() => {
           $cookies.put('isJustLogOut', true)


### PR DESCRIPTION
## Release 5.19.1

- Re-release after #2310 was rolled back
- Added hotfix #2328 to address issue with cookie domain

## Deploy notes

- new env var of `OLD_SPCP_COOKIE_DOMAIN` should be set to .form.gov.sg for prod at the time of deployment
- existing env var of `SPCP_COOKIE_DOMAIN` should be changed to blank for prod at time of deployment

## New Env Vars

- Added new env var `OLD_SPCP_COOKIE_DOMAIN` for client to delete old cookie.

## Release Summary

**New**
- feat(auth): support sgID for form submissions [`#1986`](https://github.com/opengovsg/FormSG/pull/1986)

**Improvements**
- feat: Set SP/CP JWT cookie to HttpOnly [`#2193`](https://github.com/opengovsg/FormSG/pull/2193)
- feat: client to delete spcp cookie [`#2328`](https://github.com/opengovsg/FormSG/pull/2328)
- refactor: revert the revert of encapsulate parsedResponses [`#2278`](https://github.com/opengovsg/FormSG/pull/2278)

**Fixes**
- feat: Remove self from collaborator list [`#2212`](https://github.com/opengovsg/FormSG/pull/2212)
- fix: allow duplicating email field with PDF to storage mode [`#2303`](https://github.com/opengovsg/FormSG/pull/2303)

**Dependency Changes**
- fix(deps): bump aws-sdk from 2.936.0 to 2.937.0 [`#2287`](https://github.com/opengovsg/FormSG/pull/2287)
- fix(deps): bump aws-sdk from 2.937.0 to 2.939.0 [`#2293`](https://github.com/opengovsg/FormSG/pull/2293)
- fix(deps): bump express-rate-limit from 5.2.6 to 5.3.0 [`#2288`](https://github.com/opengovsg/FormSG/pull/2288)
- fix(deps): bump libphonenumber-js from 1.9.20 to 1.9.21 [`#2291`](https://github.com/opengovsg/FormSG/pull/2291)
- fix(deps): bump neverthrow from 4.2.1 to 4.2.2 [`#2297`](https://github.com/opengovsg/FormSG/pull/2297)
- fix(deps): bump twilio from 3.64.0 to 3.65.0 [`#2284`](https://github.com/opengovsg/FormSG/pull/2284)
- fix(deps): bump zod from 3.2.0 to 3.3.3 [`#2296`](https://github.com/opengovsg/FormSG/pull/2296)
- fix(deps): bump zod from 3.3.3 to 3.3.4 [`#2299`](https://github.com/opengovsg/FormSG/pull/2299)
- fix(deps): unpin typescript [`#2305`](https://github.com/opengovsg/FormSG/pull/2305)
- chore(deps-dev): bump @types/mongodb from 3.6.18 to 3.6.19 [`#2286`](https://github.com/opengovsg/FormSG/pull/2286)
- chore(deps-dev): bump @types/uuid from 8.3.0 to 8.3.1 [`#2294`](https://github.com/opengovsg/FormSG/pull/2294)
- chore(deps-dev): bump @types/validator from 13.1.4 to 13.6.2 [`#2298`](https://github.com/opengovsg/FormSG/pull/2298)
- chore(deps-dev): bump @typescript-eslint/eslint-plugin [`#2307`](https://github.com/opengovsg/FormSG/pull/2307)
- chore(deps-dev): bump @typescript-eslint/parser from 4.28.1 to 4.28.2 [`#2306`](https://github.com/opengovsg/FormSG/pull/2306)
- chore(deps-dev): bump eslint from 7.29.0 to 7.30.0 [`#2295`](https://github.com/opengovsg/FormSG/pull/2295)
- chore(deps-dev): bump ts-node-dev from 1.1.7 to 1.1.8 [`#2285`](https://github.com/opengovsg/FormSG/pull/2285)