### PR TITLE
chore: ignore dependabot commits from CHANGELOG

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,0 +1,4 @@
+{
+	"package": true,
+	"ignoreCommitPattern": "^chore(\\(deps(-dev)?\\))?: bump.*"
+}

--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,4 +1,4 @@
 {
 	"package": true,
-	"ignoreCommitPattern": "^chore(\\(deps(-dev)?\\))?: bump.*"
+	"ignoreCommitPattern": "^((chore)|(fix))(\\(deps(-dev)?\\))?: bump.*"
 }


### PR DESCRIPTION
## Problem

A lot of dependabot commits were clogging up the CHANGELOG. Important commits by humans were not visible under loads of commits from the bot.

Closes #2346.

## Solution

I added a config file to ignore commits that look like: `chore(\(deps(-dev)?\))?: bump.*`

**Improvements**:

- No more weird commits in the CHANGELOG!

## Tests

Run `npm run version` and observe.