### PR TITLE
build: move end-to-end tests to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,25 @@ jobs:
             ${{ runner.OS }}-
       - run: npm ci
 
+  test-e2e:
+    needs: install
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run test-e2e
+
   test-frontend:
     needs: install
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,6 @@ jobs:
         create:
           name: build
           paths: .
-    - stage: Tests
-      name: End-to-end tests
-      workspaces:
-        use: build
-      addons:
-        chrome: stable
-      script:
-        - npm run test-e2e-ci
     - stage: Deploy
       services:
         - docker

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-e2e": "npm run test-e2e-build && npm run test-e2e-ci",
     "test-e2e-build": "npm run build-backend && npm run build-frontend-dev",
     "test-e2e-ci": "env-cmd -f tests/.test-env --use-shell \"npm run download-binary && npm run testcafe-command\"",
-    "testcafe-command": "testcafe --skip-js-errors -c 3 chrome:headless ./tests/end-to-end --app \"npm run test-e2e-server\" --app-init-delay 10000",
+    "testcafe-command": "testcafe --skip-js-errors -c 2 chrome:headless ./tests/end-to-end --app \"npm run test-e2e-server\" --app-init-delay 10000",
     "test-e2e-server": "concurrently --success last --kill-others \"mockpass\" \"maildev\" \"node dist/backend/app/server.js\" \"node ./tests/mock-webhook-server.js\"",
     "lint-code": "eslint src/ --quiet --fix",
     "lint-style": "stylelint '*/**/*.css' --quiet --fix",

--- a/tests/end-to-end/helpers/encrypt-mode.js
+++ b/tests/end-to-end/helpers/encrypt-mode.js
@@ -126,7 +126,7 @@ async function checkDownloadCsv(t, formData, authData, formId) {
   formFields = formFields.concat(getAuthFields(formOptions.authType, authData))
   await t.click(dataTab.exportBtn)
   await t.click(dataTab.exportBtnDropdownResponses)
-  await t.wait(2000)
+  await t.wait(5000)
   const csvContent = await fs.promises.readFile(
     `${getDownloadsFolder()}/${formOptions.title}-${formId}.csv`,
   )

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,17 +5,6 @@ module.exports = [
   merge(jsBundle, {
     mode: 'development',
     devtool: 'source-map',
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: [/node_modules/, /@babel(?:\/|\\{1,2})runtime|core-js/],
-          use: {
-            loader: 'babel-loader',
-          },
-        },
-      ],
-    },
   }),
   merge(cssBundle, { mode: 'development' }),
 ]


### PR DESCRIPTION
## Problem

End-to-end tests are extremely flaky on Travis, and have been failing every other build.

Part of #573

## Solution

Migrate the end-to-end tests to GitHub Actions. I encountered a series of problems which are explained in the commit messages.