### PR TITLE
fix: allow myinfo authtype for logout

### DIFF
--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1471,7 +1471,7 @@ describe('public-form.controller', () => {
     })
   })
 
-  describe('handleSpcpLogout', () => {
+  describe('handlePublicAuthLogout', () => {
     it('should return 200 if authType is SP and call clearCookie()', async () => {
       const authType = AuthType.SP
       const MOCK_REQ = expressHandler.mockRequest({
@@ -1483,7 +1483,11 @@ describe('public-form.controller', () => {
         clearCookie: jest.fn().mockReturnThis(),
       })
 
-      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+      await PublicFormController._handlePublicAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
@@ -1503,7 +1507,11 @@ describe('public-form.controller', () => {
         clearCookie: jest.fn().mockReturnThis(),
       })
 
-      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+      await PublicFormController._handlePublicAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
@@ -1523,7 +1531,11 @@ describe('public-form.controller', () => {
         clearCookie: jest.fn().mockReturnThis(),
       })
 
-      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+      await PublicFormController._handlePublicAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(MYINFO_COOKIE_NAME)
@@ -1543,7 +1555,11 @@ describe('public-form.controller', () => {
         clearCookie: jest.fn().mockReturnThis(),
       })
 
-      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+      await PublicFormController._handlePublicAuthLogout(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
 
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(SGID_COOKIE_NAME)

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -31,8 +31,10 @@ import {
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import * as AuthService from '../../../auth/auth.service'
+import { MYINFO_COOKIE_NAME } from '../../../myinfo/myinfo.constants'
 import { MyInfoCookieStateError } from '../../../myinfo/myinfo.errors'
 import { MyInfoService } from '../../../myinfo/myinfo.service'
+import { SGID_COOKIE_NAME } from '../../../sgid/sgid.constants'
 import {
   CreateRedirectUrlError,
   FetchLoginPageError,
@@ -1524,7 +1526,7 @@ describe('public-form.controller', () => {
       await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(MYINFO_COOKIE_NAME)
       expect(mockRes.json).toBeCalledWith({
         message: 'Successfully logged out.',
       })
@@ -1544,7 +1546,7 @@ describe('public-form.controller', () => {
       await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
 
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(SGID_COOKIE_NAME)
       expect(mockRes.json).toBeCalledWith({
         message: 'Successfully logged out.',
       })

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1509,6 +1509,46 @@ describe('public-form.controller', () => {
         message: 'Successfully logged out.',
       })
     })
+
+    it('should return 200 if authType is MyInfo and call clearCookie()', async () => {
+      const authType = AuthType.MyInfo
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          authType,
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+
+      expect(mockRes.status).toBeCalledWith(200)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.json).toBeCalledWith({
+        message: 'Successfully logged out.',
+      })
+    })
+
+    it('should return 200 if authType is SGID and call clearCookie()', async () => {
+      const authType = AuthType.SGID
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          authType,
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      await PublicFormController._handleSpcpLogout(MOCK_REQ, mockRes, jest.fn())
+
+      expect(mockRes.status).toBeCalledWith(200)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(JwtName[authType])
+      expect(mockRes.json).toBeCalledWith({
+        message: 'Successfully logged out.',
+      })
+    })
   })
 
   describe('handleValidateFormEsrvcId', () => {

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1474,6 +1474,9 @@ describe('public-form.controller', () => {
   describe('handlePublicAuthLogout', () => {
     it('should return 200 if authType is SP and call clearCookie()', async () => {
       const authType = AuthType.SP
+      MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
+        JwtName[authType],
+      )
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
           authType,
@@ -1498,6 +1501,9 @@ describe('public-form.controller', () => {
 
     it('should return 200 if authType is CP and call clearCookie()', async () => {
       const authType = AuthType.CP
+      MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
+        JwtName[authType],
+      )
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
           authType,
@@ -1522,6 +1528,9 @@ describe('public-form.controller', () => {
 
     it('should return 200 if authType is MyInfo and call clearCookie()', async () => {
       const authType = AuthType.MyInfo
+      MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
+        MYINFO_COOKIE_NAME,
+      )
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
           authType,
@@ -1546,6 +1555,9 @@ describe('public-form.controller', () => {
 
     it('should return 200 if authType is SGID and call clearCookie()', async () => {
       const authType = AuthType.SGID
+      MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
+        SGID_COOKIE_NAME,
+      )
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
           authType,

--- a/src/app/modules/form/public-form/__tests__/public-form.service.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.service.spec.ts
@@ -6,8 +6,11 @@ import { PartialDeep } from 'type-fest'
 import getFormModel from 'src/app/models/form.server.model'
 import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
-import { IFormSchema } from 'src/types'
+import { AuthType, IFormSchema } from 'src/types'
 
+import { MYINFO_COOKIE_NAME } from '../../../myinfo/myinfo.constants'
+import { SGID_COOKIE_NAME } from '../../../sgid/sgid.constants'
+import { JwtName } from '../../../spcp/spcp.types'
 import { FormNotFoundError } from '../../form.errors'
 import * as PublicFormService from '../public-form.service'
 import { Metatags } from '../public-form.types'
@@ -17,6 +20,52 @@ const FormModel = getFormModel(mongoose)
 
 describe('public-form.service', () => {
   beforeEach(() => jest.clearAllMocks())
+
+  describe('getCookieNameByAuthType', () => {
+    it('should return JwtName[AuthType.SP] when authType is SP', () => {
+      // Arrange
+      const authType = AuthType.SP
+
+      // Act
+      const result = PublicFormService.getCookieNameByAuthType(authType)
+
+      // Assert
+      expect(result).toEqual(JwtName[AuthType.SP])
+    })
+
+    it('should return JwtName[AuthType.CP] when authType is CP', () => {
+      // Arrange
+      const authType = AuthType.CP
+
+      // Act
+      const result = PublicFormService.getCookieNameByAuthType(authType)
+
+      // Assert
+      expect(result).toEqual(JwtName[AuthType.CP])
+    })
+
+    it('should return MYINFO_COOKIE_NAME when authType is MyInfo', () => {
+      // Arrange
+      const authType = AuthType.MyInfo
+
+      // Act
+      const result = PublicFormService.getCookieNameByAuthType(authType)
+
+      // Assert
+      expect(result).toEqual(MYINFO_COOKIE_NAME)
+    })
+
+    it('should return SGID_COOKIE_NAME when authType is SGID', () => {
+      // Arrange
+      const authType = AuthType.SGID
+
+      // Act
+      const result = PublicFormService.getCookieNameByAuthType(authType)
+
+      // Assert
+      expect(result).toEqual(SGID_COOKIE_NAME)
+    })
+  })
 
   describe('insertFormFeedback', () => {
     const MOCK_FORM_FEEDBACK = new FormFeedbackModel({

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -492,7 +492,7 @@ export const handleFormAuthRedirect = [
  * @returns 200 with success message when user logs out successfully
  * @returns 400 if authType is invalid
  */
-export const _handleSpcpLogout: ControllerHandler<
+export const _handlePublicAuthLogout: ControllerHandler<
   { authType: AuthType.SP | AuthType.CP | AuthType.MyInfo | AuthType.SGID },
   PublicFormAuthLogoutDto
 > = (req, res) => {
@@ -521,7 +521,7 @@ export const _handleSpcpLogout: ControllerHandler<
  * Handler for /forms/auth/:authType/logout
  * Valid AuthTypes are SP / CP / MyInfo / SGID
  */
-export const handleSpcpLogout = [
+export const handlePublicAuthLogout = [
   celebrate({
     [Segments.PARAMS]: Joi.object({
       authType: Joi.string()
@@ -529,7 +529,7 @@ export const handleSpcpLogout = [
         .required(),
     }),
   }),
-  _handleSpcpLogout,
+  _handlePublicAuthLogout,
 ] as ControllerHandler[]
 
 /**

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -498,21 +498,22 @@ export const _handleSpcpLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
-  if (authType === AuthType.MyInfo) {
-    return res
-      .clearCookie(MYINFO_COOKIE_NAME)
-      .status(200)
-      .json({ message: 'Successfully logged out.' })
-  } else if (authType === AuthType.SGID) {
-    return res
-      .clearCookie(SGID_COOKIE_NAME)
-      .status(200)
-      .json({ message: 'Successfully logged out.' })
-  } else {
-    return res
-      .clearCookie(JwtName[authType])
-      .status(200)
-      .json({ message: 'Successfully logged out.' })
+  switch (authType) {
+    case AuthType.MyInfo:
+      return res
+        .clearCookie(MYINFO_COOKIE_NAME)
+        .status(200)
+        .json({ message: 'Successfully logged out.' })
+    case AuthType.SGID:
+      return res
+        .clearCookie(SGID_COOKIE_NAME)
+        .status(200)
+        .json({ message: 'Successfully logged out.' })
+    default:
+      return res
+        .clearCookie(JwtName[authType])
+        .status(200)
+        .json({ message: 'Successfully logged out.' })
   }
 }
 

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -498,17 +498,22 @@ export const _handleSpcpLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
-  const cookieName =
-    authType === AuthType.MyInfo
-      ? MYINFO_COOKIE_NAME
-      : authType === AuthType.SGID
-      ? SGID_COOKIE_NAME
-      : JwtName[authType]
-
-  return res
-    .clearCookie(cookieName)
-    .status(200)
-    .json({ message: 'Successfully logged out.' })
+  if (authType === AuthType.MyInfo) {
+    return res
+      .clearCookie(MYINFO_COOKIE_NAME)
+      .status(200)
+      .json({ message: 'Successfully logged out.' })
+  } else if (authType === AuthType.SGID) {
+    return res
+      .clearCookie(SGID_COOKIE_NAME)
+      .status(200)
+      .json({ message: 'Successfully logged out.' })
+  } else {
+    return res
+      .clearCookie(JwtName[authType])
+      .status(200)
+      .json({ message: 'Successfully logged out.' })
+  }
 }
 
 /**

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -31,6 +31,7 @@ import {
   extractAndAssertMyInfoCookieValidity,
   validateMyInfoForm,
 } from '../../myinfo/myinfo.util'
+import { SGID_COOKIE_NAME } from '../../sgid/sgid.constants'
 import { SgidService } from '../../sgid/sgid.service'
 import { validateSgidForm } from '../../sgid/sgid.util'
 import { InvalidJwtError, VerifyJwtError } from '../../spcp/spcp.errors'
@@ -497,8 +498,15 @@ export const _handleSpcpLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
+  const cookieName =
+    authType === AuthType.MyInfo
+      ? MYINFO_COOKIE_NAME
+      : authType === AuthType.SGID
+      ? SGID_COOKIE_NAME
+      : JwtName[authType]
+
   return res
-    .clearCookie(JwtName[authType])
+    .clearCookie(cookieName)
     .status(200)
     .json({ message: 'Successfully logged out.' })
 }

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -31,17 +31,16 @@ import {
   extractAndAssertMyInfoCookieValidity,
   validateMyInfoForm,
 } from '../../myinfo/myinfo.util'
-import { SGID_COOKIE_NAME } from '../../sgid/sgid.constants'
 import { SgidService } from '../../sgid/sgid.service'
 import { validateSgidForm } from '../../sgid/sgid.util'
 import { InvalidJwtError, VerifyJwtError } from '../../spcp/spcp.errors'
 import { SpcpService } from '../../spcp/spcp.service'
-import { JwtName } from '../../spcp/spcp.types'
 import { getRedirectTarget, validateSpcpForm } from '../../spcp/spcp.util'
 import { AuthTypeMismatchError, PrivateFormError } from '../form.errors'
 import * as FormService from '../form.service'
 
 import * as PublicFormService from './public-form.service'
+import { getCookieNameByAuthType } from './public-form.service'
 import { RedirectParams } from './public-form.types'
 import { mapFormAuthError, mapRouteError } from './public-form.utils'
 
@@ -498,23 +497,12 @@ export const _handlePublicAuthLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
-  switch (authType) {
-    case AuthType.MyInfo:
-      return res
-        .clearCookie(MYINFO_COOKIE_NAME)
-        .status(200)
-        .json({ message: 'Successfully logged out.' })
-    case AuthType.SGID:
-      return res
-        .clearCookie(SGID_COOKIE_NAME)
-        .status(200)
-        .json({ message: 'Successfully logged out.' })
-    default:
-      return res
-        .clearCookie(JwtName[authType])
-        .status(200)
-        .json({ message: 'Successfully logged out.' })
-  }
+  const cookieName = getCookieNameByAuthType(authType)
+
+  return res
+    .clearCookie(cookieName)
+    .status(200)
+    .json({ message: 'Successfully logged out.' })
 }
 
 /**

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -40,7 +40,6 @@ import { AuthTypeMismatchError, PrivateFormError } from '../form.errors'
 import * as FormService from '../form.service'
 
 import * as PublicFormService from './public-form.service'
-import { getCookieNameByAuthType } from './public-form.service'
 import { RedirectParams } from './public-form.types'
 import { mapFormAuthError, mapRouteError } from './public-form.utils'
 
@@ -497,7 +496,7 @@ export const _handlePublicAuthLogout: ControllerHandler<
 > = (req, res) => {
   const { authType } = req.params
 
-  const cookieName = getCookieNameByAuthType(authType)
+  const cookieName = PublicFormService.getCookieNameByAuthType(authType)
 
   return res
     .clearCookie(cookieName)

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -485,14 +485,14 @@ export const handleFormAuthRedirect = [
 
 /**
  * NOTE: This is exported only for testing
- * Logs user out of SP / CP By deleting cookie
+ * Logs user out of SP / CP / MyInfo / SGID by deleting cookie
  * @param authType type of authentication
  *
  * @returns 200 with success message when user logs out successfully
  * @returns 400 if authType is invalid
  */
 export const _handleSpcpLogout: ControllerHandler<
-  { authType: AuthType.SP | AuthType.CP | AuthType.SGID },
+  { authType: AuthType.SP | AuthType.CP | AuthType.MyInfo | AuthType.SGID },
   PublicFormAuthLogoutDto
 > = (req, res) => {
   const { authType } = req.params
@@ -505,13 +505,13 @@ export const _handleSpcpLogout: ControllerHandler<
 
 /**
  * Handler for /forms/auth/:authType/logout
- * Valid AuthTypes are SP or CP
+ * Valid AuthTypes are SP / CP / MyInfo / SGID
  */
 export const handleSpcpLogout = [
   celebrate({
     [Segments.PARAMS]: Joi.object({
       authType: Joi.string()
-        .valid(AuthType.SP, AuthType.CP, AuthType.SGID)
+        .valid(AuthType.SP, AuthType.CP, AuthType.MyInfo, AuthType.SGID)
         .required(),
     }),
   }),

--- a/src/app/modules/form/public-form/public-form.service.ts
+++ b/src/app/modules/form/public-form/public-form.service.ts
@@ -1,11 +1,14 @@
 import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
-import { IFormFeedbackSchema } from '../../../../types'
+import { AuthType, IFormFeedbackSchema } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import getFormModel from '../../../models/form.server.model'
 import getFormFeedbackModel from '../../../models/form_feedback.server.model'
 import { DatabaseError } from '../../core/core.errors'
+import { MYINFO_COOKIE_NAME } from '../../myinfo/myinfo.constants'
+import { SGID_COOKIE_NAME } from '../../sgid/sgid.constants'
+import { JwtName } from '../../spcp/spcp.types'
 import { FormNotFoundError } from '../form.errors'
 
 import { Metatags } from './public-form.types'
@@ -54,6 +57,23 @@ export const insertFormFeedback = ({
       return new DatabaseError('Form feedback could not be created')
     },
   )
+}
+
+/**
+ * Returns the cookie name based on auth type
+ * Valid AuthTypes are SP / CP / MyInfo / SGID
+ */
+export const getCookieNameByAuthType = (
+  authType: AuthType.SP | AuthType.CP | AuthType.MyInfo | AuthType.SGID,
+): string => {
+  switch (authType) {
+    case AuthType.MyInfo:
+      return MYINFO_COOKIE_NAME
+    case AuthType.SGID:
+      return SGID_COOKIE_NAME
+    default:
+      return JwtName[authType]
+  }
 }
 
 /**

--- a/src/app/modules/sgid/__tests__/sgid.controller.spec.ts
+++ b/src/app/modules/sgid/__tests__/sgid.controller.spec.ts
@@ -9,6 +9,7 @@ import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import { ApplicationError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
+import { SGID_COOKIE_NAME } from '../sgid.constants'
 import * as SgidController from '../sgid.controller'
 import {
   SgidFetchAccessTokenError,
@@ -182,13 +183,17 @@ describe('sgid.controller', () => {
         MOCK_USER_INFO.data,
         MOCK_REMEMBER_ME,
       )
-      expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('jwtSgid', MOCK_JWT, {
-        maxAge: MOCK_COOKIE_AGE,
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: !MockConfig.isDev,
-        ...MOCK_COOKIE_SETTINGS,
-      })
+      expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith(
+        SGID_COOKIE_NAME,
+        MOCK_JWT,
+        {
+          maxAge: MOCK_COOKIE_AGE,
+          httpOnly: true,
+          sameSite: 'lax',
+          secure: !MockConfig.isDev,
+          ...MOCK_COOKIE_SETTINGS,
+        },
+      )
       expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
     })
   })

--- a/src/app/modules/sgid/__tests__/sgid.routes.spec.ts
+++ b/src/app/modules/sgid/__tests__/sgid.routes.spec.ts
@@ -11,6 +11,7 @@ import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
 
 import { ApplicationError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
+import { SGID_COOKIE_NAME } from '../sgid.constants'
 import {
   SgidFetchAccessTokenError,
   SgidFetchUserInfoError,
@@ -245,7 +246,7 @@ describe('sgid.controller', () => {
         .query(MOCK_LOGIN_QUERY)
 
       expect(response.headers['set-cookie']).toEqual([
-        expect.stringContaining(`jwtSgid=${MOCK_JWT}`),
+        expect.stringContaining(`${SGID_COOKIE_NAME}=${MOCK_JWT}`),
       ])
       expect(response.status).toBe(302)
       expect(response.headers['location']).toEqual(MOCK_DESTINATION)

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Name of cookie which contains state of sgid login, and access
+ * token if login was successful.
+ */
+export const SGID_COOKIE_NAME = 'jwtSgid'

--- a/src/app/modules/sgid/sgid.controller.ts
+++ b/src/app/modules/sgid/sgid.controller.ts
@@ -7,6 +7,7 @@ import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
 
+import { SGID_COOKIE_NAME } from './sgid.constants'
 import { SgidService } from './sgid.service'
 
 const logger = createLoggerWithLabel(module)
@@ -71,7 +72,7 @@ export const handleLogin: ControllerHandler<
   }
 
   const { maxAge, jwt } = jwtResult.value
-  res.cookie('jwtSgid', jwt, {
+  res.cookie(SGID_COOKIE_NAME, jwt, {
     maxAge,
     httpOnly: true,
     sameSite: 'lax', // Setting to 'strict' prevents Singpass login on Safari, Firefox

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -3,8 +3,6 @@ import { AuthType, IFormSchema } from '../../../types'
 export enum JwtName {
   SP = 'jwtSp',
   CP = 'jwtCp',
-  SGID = 'jwtSgid',
-  MyInfo = 'MyInfoCookie',
 }
 
 export type SpcpCookies = Partial<Record<JwtName, string>>

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -4,6 +4,7 @@ export enum JwtName {
   SP = 'jwtSp',
   CP = 'jwtCp',
   SGID = 'jwtSgid',
+  MyInfo = 'MyInfoCookie',
 }
 
 export type SpcpCookies = Partial<Record<JwtName, string>>

--- a/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.auth.routes.ts
@@ -30,7 +30,7 @@ PublicFormsAuthRouter.route('/:formId([a-fA-F0-9]{24})/auth/redirect').get(
  * @returns 400 if authType is invalid
  */
 PublicFormsAuthRouter.route('/auth/:authType/logout').get(
-  PublicFormController.handleSpcpLogout,
+  PublicFormController.handlePublicAuthLogout,
 )
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2360

## Solution
- Allow MyInfo authtype for `/logout` endpoint and update `JwtName` type to include MyInfoCookie

## Tests
**(tested on staging)**
- [ ] Create myinfo form and publish. Login. Check that you can logout before submission and `MyInfoCookie` is deleted
- [ ] Login again. Check that you can submit, and you are auto logged out after submission