### PR TITLE
fix(BetaService): make SGID form-level beta feature

### DIFF
--- a/src/app/modules/examples/__tests__/helpers/prepareTestData.ts
+++ b/src/app/modules/examples/__tests__/helpers/prepareTestData.ts
@@ -6,6 +6,7 @@ import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
 import getFormStatisticsTotalModel from 'src/app/models/form_statistics_total.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import {
+  AuthType,
   IAgencySchema,
   IFormFeedbackSchema,
   IFormSchema,
@@ -88,6 +89,7 @@ const prepareTestData = async (
     // surface.
     status: Status.Public,
     isListed: true,
+    authType: AuthType.NIL,
   }
 
   // Populate forms in database with prespecified number of times.
@@ -207,6 +209,7 @@ const prepareTestData = async (
       timeText: 'less than 1 day ago',
       lastSubmission: expect.anything(),
       title: form.title,
+      authType: form.authType,
     }))
   }
 

--- a/src/app/modules/examples/examples.queries.ts
+++ b/src/app/modules/examples/examples.queries.ts
@@ -290,6 +290,7 @@ export const projectFormDetails: Record<string, unknown>[] = [
       logo: '$agencyInfo.logo',
       agency: '$agencyInfo.shortName',
       colorTheme: '$formInfo.startPage.colorTheme',
+      authType: '$formInfo.authType',
     },
   },
 ]

--- a/src/app/modules/examples/examples.queries.ts
+++ b/src/app/modules/examples/examples.queries.ts
@@ -324,6 +324,7 @@ export const selectAndProjectCardInfo = (
       agency: '$agencyInfo.shortName',
       colorTheme: '$formInfo.startPage.colorTheme',
       avgFeedback: { $avg: '$formFeedbackInfo.rating' },
+      authType: '$formInfo.authType',
     },
   },
 ]

--- a/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
@@ -173,7 +173,7 @@ function ListFormsController(
   }
 
   vm.duplicateForm = function (formIndex) {
-    const missingBetaPermissions = BetaService.getMissingFieldPermissions(
+    const missingBetaPermissions = BetaService.getMissingBetaPermissions(
       vm.user,
       vm.myforms[formIndex],
     )

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -148,7 +148,7 @@ function settingsFormDirective(
           return (
             $scope.isFormPublic() ||
             (authType.val === 'SGID' &&
-              !BetaService.userHasAccessToFieldType($scope.user, 'sgid')) ||
+              !BetaService.userHasAccessToFeature($scope.user, 'sgid')) ||
             ($scope.isFormPrivate() && $scope.myInfoSPWarning())
           )
         }

--- a/src/public/modules/users/controllers/examples-card.client.directive.js
+++ b/src/public/modules/users/controllers/examples-card.client.directive.js
@@ -80,7 +80,7 @@ function examplesCardController(
    */
 
   $scope.useTemplate = function () {
-    const missingBetaPermissions = BetaService.getMissingFieldPermissions(
+    const missingBetaPermissions = BetaService.getMissingBetaPermissions(
       $scope.user,
       $scope.form,
     )

--- a/src/public/services/BetaService.ts
+++ b/src/public/services/BetaService.ts
@@ -92,3 +92,7 @@ export const userHasAccessToFieldType = (
     (Boolean(flag) && get(user, ['betaFlags', flag], false))
   )
 }
+
+export const userHasAccessToFeature = (user: IUser, flag: string): boolean => {
+  return get(user, ['betaFlags', flag], false)
+}

--- a/src/public/services/BetaService.ts
+++ b/src/public/services/BetaService.ts
@@ -37,9 +37,6 @@ const BETA_FEATURES: BetaFeature[] = [
   {
     name: 'SGID',
     flag: 'sgid',
-    // Given that it's a _form_ level feature and not a
-    // _field_ level feature, always return true regardless
-    // of form field presented
     matches: (form) => form.authType === AuthType.SGID,
     // SGID is associated with entire form, not individual field
     fieldType: null,

--- a/src/public/services/BetaService.ts
+++ b/src/public/services/BetaService.ts
@@ -4,78 +4,92 @@ import { get } from 'lodash'
 // Given that this is used mostly by JavaScript modules, the lack of
 // mongo-specific types should not present a problem.
 // Change the types to frontend equivalents as and when available.
-import { IField, IForm, IUser } from '../../types'
+import { AuthType, BasicField, IForm, IUser } from '../../types'
 
 type BetaFeature = {
+  // User-facing name for the feature
+  name: string
+  // Flag given to the feature in the User schema's betaFlags object
   flag: string
-  matches: (field: IField) => boolean
+  // Function to match whether a form has this beta feature
+  matches: (form: IForm) => boolean
+  /**
+   * Some beta features are associated with specific field types.
+   * If this is the case for a beta feature, this key indicates
+   * the field type of the beta field.
+   */
+  fieldType: BasicField | null
 }
 
-type BetaFeaturesDictionary = { [featureName: string]: BetaFeature }
-
-const BETA_FEATURES_FIELD: BetaFeaturesDictionary = {
+const BETA_FEATURES: BetaFeature[] = [
   // This is an example of how to add fields to this object
-  // featureName: {
-  //   flag: 'betaFlagName',
-  //   matches: (field) =>
-  //     field.fieldType === 'mobile' &&
-  //     (field.isVerifiable === true),
+  // {
+  //   name: 'betaFlagName',
+  //   flag: 'hasBetaFlag',
+  //   matches: (form) => {
+  //     return form.form_fields.some((field) =>
+  //      field.fieldType === 'mobile' && field.isVerifiable
+  //     )
+  //   },
+  //  fieldType: 'mobile',
   // },
   // sgID: an authentication mechanism similar to Singpass
-  sgid: {
+  {
+    name: 'SGID',
     flag: 'sgid',
     // Given that it's a _form_ level feature and not a
     // _field_ level feature, always return true regardless
     // of form field presented
-    matches: () => true,
+    matches: (form) => form.authType === AuthType.SGID,
+    // SGID is associated with entire form, not individual field
+    fieldType: null,
   },
-}
+]
 
-const getBetaFeaturesForFields = (
-  formFields: IField[] | undefined,
-  betaFeaturesField: BetaFeaturesDictionary,
+const getBetaFeaturesForForm = (
+  form: IForm,
+  betaFeaturesField: BetaFeature[],
 ): string[] => {
   const betaFeatures = new Set<string>()
-  if (formFields) {
-    for (const field of formFields) {
-      for (const [name, feature] of Object.entries(betaFeaturesField)) {
-        if (feature.matches(field)) {
-          betaFeatures.add(name)
-        }
-      }
+  betaFeaturesField.forEach((feature) => {
+    if (feature.matches(form)) {
+      betaFeatures.add(feature.name)
     }
-  }
+  })
   return Array.from(betaFeatures)
 }
 
-export const getMissingFieldPermissions = (
+export const getMissingBetaPermissions = (
   user: IUser,
   form: IForm,
-  betaFeaturesField = BETA_FEATURES_FIELD,
+  betaFeaturesField = BETA_FEATURES,
 ): string[] => {
-  const betaFeatures = getBetaFeaturesForFields(
-    form.form_fields,
-    betaFeaturesField,
-  )
+  const betaFeatures = getBetaFeaturesForForm(form, betaFeaturesField)
   return betaFeatures.filter((name) => {
-    const flag = get(betaFeaturesField, [name, 'flag'])
+    const flag = betaFeaturesField.find(
+      (feature) => feature.name === name,
+    )?.flag
     return flag && !get(user, ['betaFlags', flag], false)
   })
 }
 
 export const isBetaField = (
-  fieldType: string,
-  betaFeaturesField = BETA_FEATURES_FIELD,
+  fieldType: BasicField,
+  betaFeaturesField = BETA_FEATURES,
 ): BetaFeature | undefined => {
-  return betaFeaturesField[fieldType]
+  return betaFeaturesField.find((feature) => feature.fieldType === fieldType)
 }
 
 export const userHasAccessToFieldType = (
   user: IUser,
-  fieldType: string,
-  betaFeaturesField = BETA_FEATURES_FIELD,
+  fieldType: BasicField,
+  betaFeaturesField = BETA_FEATURES,
 ): boolean => {
-  const flag = get(betaFeaturesField, [fieldType, 'flag'])
+  const flag = betaFeaturesField.find((feature) => {
+    return feature.fieldType === fieldType
+  })?.flag
+  // No beta limitations on this field type
+  if (!flag) return true
   return (
     !isBetaField(fieldType, betaFeaturesField) ||
     (Boolean(flag) && get(user, ['betaFlags', flag], false))

--- a/src/public/services/__tests__/BetaService.test.ts
+++ b/src/public/services/__tests__/BetaService.test.ts
@@ -1,36 +1,54 @@
-import { IField, IForm, IUser } from '../../../types'
+import { BasicField, IForm, IUser } from '../../../types'
 import * as BetaService from '../BetaService'
 
 describe('BetaService', () => {
-  const nonBetaFeature = 'nonBetaFeature'
   const featureOne = 'featureOne'
+  const featureOneFieldType = BasicField.ShortText
   const featureTwo = 'featureTwo'
-  const betaFeaturesField = {
-    [featureOne]: {
+  const betaFeaturesField = [
+    {
+      name: featureOne,
       flag: 'betaFlagOne',
-      matches(field: IField) {
-        return field.title === featureOne
+      matches(form: IForm) {
+        return (
+          !!form.form_fields &&
+          form.form_fields.some(
+            (field) => field.fieldType === featureOneFieldType,
+          )
+        )
       },
+      fieldType: featureOneFieldType,
     },
-    [featureTwo]: {
+    {
+      name: featureTwo,
       flag: 'betaFlagTwo',
-      matches(field: IField) {
-        return field.title === featureTwo
+      matches(form: IForm) {
+        return form.title === featureTwo
       },
+      fieldType: null,
     },
-  }
+  ]
   const userWithFeatureOne = {
     betaFlags: {
-      [betaFeaturesField[featureOne].flag]: true,
+      [betaFeaturesField[0].flag]: true,
     },
+  } as IUser
+  const userWithNoFeatures = {
+    betaFlags: {},
   } as IUser
   describe('isBetaField', () => {
     it('returns truthy for defined beta fields', () => {
-      const result = BetaService.isBetaField(featureOne, betaFeaturesField)
+      const result = BetaService.isBetaField(
+        featureOneFieldType,
+        betaFeaturesField,
+      )
       expect(result).toBeTruthy()
     })
     it('returns falsy for fields not defined as beta', () => {
-      const result = BetaService.isBetaField(nonBetaFeature, betaFeaturesField)
+      const result = BetaService.isBetaField(
+        BasicField.Attachment,
+        betaFeaturesField,
+      )
       expect(result).toBeFalsy()
     })
   })
@@ -38,7 +56,8 @@ describe('BetaService', () => {
     it('returns true for features not defined as beta', () => {
       const result = BetaService.userHasAccessToFieldType(
         userWithFeatureOne,
-        nonBetaFeature,
+        // in betaFeaturesField, ShortText is the only beta field type
+        BasicField.Attachment,
         betaFeaturesField,
       )
       expect(result).toBeTrue()
@@ -46,26 +65,29 @@ describe('BetaService', () => {
     it('returns true for beta features that the user has access to', () => {
       const result = BetaService.userHasAccessToFieldType(
         userWithFeatureOne,
-        featureOne,
+        featureOneFieldType,
         betaFeaturesField,
       )
       expect(result).toBeTrue()
     })
     it('returns false for beta features that the user lacks access to', () => {
       const result = BetaService.userHasAccessToFieldType(
-        userWithFeatureOne,
-        featureTwo,
+        userWithNoFeatures,
+        featureOneFieldType,
         betaFeaturesField,
       )
       expect(result).toBeFalse()
     })
   })
   describe('getBetaFeaturesForFields', () => {
+    // Form containing both feature one and feature two
     const form = {
-      form_fields: [{ title: featureTwo }],
+      form_fields: [{ fieldType: featureOneFieldType }],
+      title: featureTwo,
     } as IForm
     it('lists the beta features that the user lacks', () => {
-      const result = BetaService.getMissingFieldPermissions(
+      // User with access to only feature one
+      const result = BetaService.getMissingBetaPermissions(
         userWithFeatureOne,
         form,
         betaFeaturesField,


### PR DESCRIPTION
## Problem

#2370 happened because the frontend `BetaService` is coupled to beta _fields_, as opposed to form-level beta features such as SGID.

Closes #2370 

## Solution

Generalise `BetaService` to be able to apply to any _form_-level feature. Also, return the form `authType` from the examples page queries so we are able to check the auth type when seeing whether the user has permissions to duplicate the form.

## Tests
- [x] Creating non-SGID form from Examples page works
- [x] Creating non-SGID form from template works
- [x] Duplicating non-SGID form works
- [x] Creating SGID form from template **does not work** (assuming user does not have SGID beta flag)