### PR TITLE
feat: part one checkbox logic - logic module

### DIFF
--- a/src/shared/util/__tests__/logic.spec.ts
+++ b/src/shared/util/__tests__/logic.spec.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/shared/util/logic'
 import {
   BasicField,
-  CheckboxConditionValue,
+  FieldResponse,
   IField,
   IFieldSchema,
   IFormDocument,
@@ -17,7 +17,6 @@ import {
   IShortTextFieldSchema,
   IShowFieldsLogicSchema,
   LogicConditionState,
-  LogicFieldResponse,
   LogicIfValue,
   LogicType,
 } from 'src/types'
@@ -35,19 +34,18 @@ describe('Logic validation', () => {
    */
   const makeResponse = (
     fieldId: string,
-    answer: string | number | null = null,
-    answerArray: string[] | CheckboxConditionValue | null = null,
-    fieldType: string | null = null,
+    answer: string | number,
+    answerArray: string[] | null = null,
     isVisible = true,
-  ): LogicFieldResponse => {
-    const response: Record<string, any> = { _id: fieldId, isVisible, fieldType }
+  ): FieldResponse => {
+    const response: Record<string, any> = { _id: fieldId, answer, isVisible }
     if (answer !== null) {
       response.answer = answer
     }
     if (answerArray) {
       response.answerArray = answerArray
     }
-    return response as LogicFieldResponse
+    return response as FieldResponse
   }
 
   describe('visibility for different states', () => {
@@ -219,83 +217,6 @@ describe('Logic validation', () => {
       expect(
         getVisibleFieldIds(
           [makeResponse(CONDITION_FIELD._id, 'invalid option'), LOGIC_RESPONSE],
-          form,
-        ).has(LOGIC_FIELD._id),
-      ).toEqual(false)
-    })
-    it('should compute the correct visibility for checkbox fields with state "is one of the following"', () => {
-      // Arrange
-      const validOptions = ['Option 1', 'Option 2', 'Option 3']
-      const conditions = [
-        { options: [validOptions[0], validOptions[1]], others: false },
-        { options: [validOptions[2]], others: true },
-      ]
-      const anyOfCondition = {
-        show: [LOGIC_FIELD._id],
-        conditions: [
-          {
-            ifValueType: LogicIfValue.MultiValue,
-            _id: '58169',
-            field: CONDITION_FIELD._id,
-            state: LogicConditionState.AnyOf,
-            value: conditions,
-          },
-        ],
-        _id: MOCK_LOGIC_ID,
-        logicType: LogicType.ShowFields,
-      } as IShowFieldsLogicSchema
-
-      form.form_logics = [anyOfCondition]
-
-      // Act + Assert
-      expect(
-        getVisibleFieldIds(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              conditions[1],
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
-          form,
-        ).has(LOGIC_FIELD._id),
-      ).toEqual(true)
-
-      // should be able to match condition even if options in different order
-      expect(
-        getVisibleFieldIds(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              {
-                options: [validOptions[1], validOptions[0]],
-                others: false,
-              },
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
-          form,
-        ).has(LOGIC_FIELD._id),
-      ).toEqual(true)
-
-      expect(
-        getVisibleFieldIds(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              {
-                options: [validOptions[2], validOptions[0]],
-                others: true,
-              },
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
           form,
         ).has(LOGIC_FIELD._id),
       ).toEqual(false)
@@ -472,83 +393,6 @@ describe('Logic validation', () => {
       expect(
         getLogicUnitPreventingSubmit(
           [makeResponse(CONDITION_FIELD._id, 'Option 3'), LOGIC_RESPONSE],
-          form,
-        ),
-      ).toBeUndefined()
-    })
-    it('should compute that submission should be prevented for checkbox fields with state "is one of the following"', () => {
-      // Arrange
-      const validOptions = ['Option 1', 'Option 2', 'Option 3']
-      const conditions = [
-        { options: [validOptions[0], validOptions[1]], others: false },
-        { options: [validOptions[2]], others: true },
-      ]
-      const anyOfCondition = {
-        conditions: [
-          {
-            ifValueType: LogicIfValue.MultiValue,
-            _id: '58169',
-            field: CONDITION_FIELD._id,
-            state: LogicConditionState.AnyOf,
-            value: conditions,
-          },
-        ],
-        _id: MOCK_LOGIC_ID,
-        logicType: LogicType.PreventSubmit,
-        preventSubmitMessage: 'you shall not pass',
-      } as IPreventSubmitLogicSchema
-
-      form.form_logics = [anyOfCondition]
-
-      // Act + Assert
-      // Should be able to match even if options are in different order
-      expect(
-        getLogicUnitPreventingSubmit(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              {
-                options: [validOptions[1], validOptions[0]],
-                others: false,
-              },
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
-          form,
-        ),
-      ).toEqual(form.form_logics[0])
-
-      expect(
-        getLogicUnitPreventingSubmit(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              conditions[1],
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
-          form,
-        ),
-      ).toEqual(form.form_logics[0])
-
-      expect(
-        getLogicUnitPreventingSubmit(
-          [
-            makeResponse(
-              CONDITION_FIELD._id,
-              null,
-              {
-                options: [validOptions[2]],
-                others: false,
-              },
-              BasicField.Checkbox,
-            ),
-            LOGIC_RESPONSE,
-          ],
           form,
         ),
       ).toBeUndefined()

--- a/src/shared/util/__tests__/logic.spec.ts
+++ b/src/shared/util/__tests__/logic.spec.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/shared/util/logic'
 import {
   BasicField,
-  FieldResponse,
+  CheckboxConditionValue,
   IField,
   IFieldSchema,
   IFormDocument,
@@ -17,6 +17,7 @@ import {
   IShortTextFieldSchema,
   IShowFieldsLogicSchema,
   LogicConditionState,
+  LogicFieldResponse,
   LogicIfValue,
   LogicType,
 } from 'src/types'
@@ -34,15 +35,19 @@ describe('Logic validation', () => {
    */
   const makeResponse = (
     fieldId: string,
-    answer: string | number,
-    answerArray: string[] | null = null,
+    answer: string | number | null = null,
+    answerArray: string[] | CheckboxConditionValue | null = null,
+    fieldType: string | null = null,
     isVisible = true,
-  ): FieldResponse => {
-    const response: Record<string, any> = { _id: fieldId, answer, isVisible }
+  ): LogicFieldResponse => {
+    const response: Record<string, any> = { _id: fieldId, isVisible, fieldType }
+    if (answer !== null) {
+      response.answer = answer
+    }
     if (answerArray) {
       response.answerArray = answerArray
     }
-    return response as FieldResponse
+    return response as LogicFieldResponse
   }
 
   describe('visibility for different states', () => {
@@ -214,6 +219,83 @@ describe('Logic validation', () => {
       expect(
         getVisibleFieldIds(
           [makeResponse(CONDITION_FIELD._id, 'invalid option'), LOGIC_RESPONSE],
+          form,
+        ).has(LOGIC_FIELD._id),
+      ).toEqual(false)
+    })
+    it('should compute the correct visibility for checkbox fields with state "is one of the following"', () => {
+      // Arrange
+      const validOptions = ['Option 1', 'Option 2', 'Option 3']
+      const conditions = [
+        { options: [validOptions[0], validOptions[1]], others: false },
+        { options: [validOptions[2]], others: true },
+      ]
+      const anyOfCondition = {
+        show: [LOGIC_FIELD._id],
+        conditions: [
+          {
+            ifValueType: LogicIfValue.MultiValue,
+            _id: '58169',
+            field: CONDITION_FIELD._id,
+            state: LogicConditionState.AnyOf,
+            value: conditions,
+          },
+        ],
+        _id: MOCK_LOGIC_ID,
+        logicType: LogicType.ShowFields,
+      } as IShowFieldsLogicSchema
+
+      form.form_logics = [anyOfCondition]
+
+      // Act + Assert
+      expect(
+        getVisibleFieldIds(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              conditions[1],
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
+          form,
+        ).has(LOGIC_FIELD._id),
+      ).toEqual(true)
+
+      // should be able to match condition even if options in different order
+      expect(
+        getVisibleFieldIds(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              {
+                options: [validOptions[1], validOptions[0]],
+                others: false,
+              },
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
+          form,
+        ).has(LOGIC_FIELD._id),
+      ).toEqual(true)
+
+      expect(
+        getVisibleFieldIds(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              {
+                options: [validOptions[2], validOptions[0]],
+                others: true,
+              },
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
           form,
         ).has(LOGIC_FIELD._id),
       ).toEqual(false)
@@ -390,6 +472,83 @@ describe('Logic validation', () => {
       expect(
         getLogicUnitPreventingSubmit(
           [makeResponse(CONDITION_FIELD._id, 'Option 3'), LOGIC_RESPONSE],
+          form,
+        ),
+      ).toBeUndefined()
+    })
+    it('should compute that submission should be prevented for checkbox fields with state "is one of the following"', () => {
+      // Arrange
+      const validOptions = ['Option 1', 'Option 2', 'Option 3']
+      const conditions = [
+        { options: [validOptions[0], validOptions[1]], others: false },
+        { options: [validOptions[2]], others: true },
+      ]
+      const anyOfCondition = {
+        conditions: [
+          {
+            ifValueType: LogicIfValue.MultiValue,
+            _id: '58169',
+            field: CONDITION_FIELD._id,
+            state: LogicConditionState.AnyOf,
+            value: conditions,
+          },
+        ],
+        _id: MOCK_LOGIC_ID,
+        logicType: LogicType.PreventSubmit,
+        preventSubmitMessage: 'you shall not pass',
+      } as IPreventSubmitLogicSchema
+
+      form.form_logics = [anyOfCondition]
+
+      // Act + Assert
+      // Should be able to match even if options are in different order
+      expect(
+        getLogicUnitPreventingSubmit(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              {
+                options: [validOptions[1], validOptions[0]],
+                others: false,
+              },
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
+          form,
+        ),
+      ).toEqual(form.form_logics[0])
+
+      expect(
+        getLogicUnitPreventingSubmit(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              conditions[1],
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
+          form,
+        ),
+      ).toEqual(form.form_logics[0])
+
+      expect(
+        getLogicUnitPreventingSubmit(
+          [
+            makeResponse(
+              CONDITION_FIELD._id,
+              null,
+              {
+                options: [validOptions[2]],
+                others: false,
+              },
+              BasicField.Checkbox,
+            ),
+            LOGIC_RESPONSE,
+          ],
           form,
         ),
       ).toBeUndefined()

--- a/src/shared/util/logic-utils/checkbox/checkbox-logic-guards.ts
+++ b/src/shared/util/logic-utils/checkbox/checkbox-logic-guards.ts
@@ -1,0 +1,33 @@
+import {
+  CheckboxConditionValue,
+  IConditionSchema,
+  LogicCheckboxCondition,
+} from '../../../../types'
+import { hasProp } from '../../has-prop'
+
+/**
+ * Typeguard to check if the condition has the backend/logic representation for checkbox condition values
+ * @param condition Logic Condition
+ */
+export const isLogicCheckboxCondition = (
+  condition: IConditionSchema,
+): condition is LogicCheckboxCondition => {
+  return (
+    Array.isArray(condition.value) &&
+    (condition.value as unknown[]).every(isCheckboxConditionValue)
+  )
+}
+
+export const isCheckboxConditionValue = (
+  value: unknown,
+): value is CheckboxConditionValue => {
+  const hasValue =
+    hasProp(value, 'options') &&
+    Array.isArray(value.options) &&
+    value.options.every((val) => typeof val === 'string')
+
+  const hasOthers =
+    hasProp(value, 'others') && typeof value.others === 'boolean'
+
+  return hasValue && hasOthers
+}

--- a/src/shared/util/logic-utils/checkbox/checkbox-response-value-transformer.ts
+++ b/src/shared/util/logic-utils/checkbox/checkbox-response-value-transformer.ts
@@ -1,0 +1,139 @@
+/* eslint-disable typesafe/no-throw-sync-func */
+import { cloneDeep, omit } from 'lodash'
+
+import {
+  BasicField,
+  FieldSchemaOrResponse,
+  ICheckboxField,
+  ICheckboxResponse,
+  IField,
+  ILogicCheckboxResponse,
+  ILogicClientFieldSchema,
+  ILogicInputClientSchema,
+  IPopulatedForm,
+} from '../../../../types'
+import { isCheckboxField } from '../../../../types/field/utils/guards'
+import { hasProp } from '../../has-prop'
+import { LogicFieldSchemaOrResponse } from '../../logic'
+
+/**
+ * Adaptor function to transform checkbox field response values into checkbox condition shape
+ * @param field Logic field from either the backend or frontend
+ * @param form
+ * @returns Checkbox field response in checkbox condition shape
+ * @throws Error if checkbox value has invalid shape or if field cannot be found in the form
+ */
+export const transformCheckboxForLogic = (
+  field: FieldSchemaOrResponse,
+  formFields: IPopulatedForm['form_fields'],
+): LogicFieldSchemaOrResponse => {
+  field = cloneDeep(field) // clone field to prevent changes to original
+  if (isClientCheckboxValue(field)) {
+    return convertClientCheckboxValue(field, formFields)
+  } else if (isServerCheckboxValue(field)) {
+    return convertServerCheckboxValue(field, formFields)
+  } else {
+    // eslint-disable-next-line typesafe/no-throw-sync-func
+    throw new Error('Checkbox value shape is invalid')
+  }
+}
+
+type ClientCheckboxField = Omit<ILogicInputClientSchema, 'fieldValue'> & {
+  fieldValue: boolean[]
+}
+
+type TransformedClientCheckboxField = ILogicClientFieldSchema
+
+const isClientCheckboxValue = (
+  field: FieldSchemaOrResponse,
+): field is ClientCheckboxField => {
+  if (field.fieldType !== BasicField.Checkbox) {
+    return false
+  }
+  return (
+    hasProp(field, 'fieldValue') &&
+    Array.isArray(field.fieldValue) &&
+    (field.fieldValue as unknown[]).every((value) => typeof value === 'boolean')
+  )
+}
+
+const convertClientCheckboxValue = (
+  field: ClientCheckboxField,
+  formFields: IPopulatedForm['form_fields'],
+): TransformedClientCheckboxField => {
+  const completeField = getCheckboxField(field, formFields)
+  const others = field.fieldValue[completeField.fieldOptions.length]
+  const options = completeField.fieldOptions.filter(
+    (_, i) => field.fieldValue[i],
+  )
+
+  return {
+    ...omit(field, ['fieldValue']),
+    fieldValue: { options, others },
+  }
+}
+
+type ServerCheckboxField = ICheckboxResponse
+
+type TransformedServerCheckboxField = ILogicCheckboxResponse
+
+const isServerCheckboxValue = (
+  field: FieldSchemaOrResponse,
+): field is ServerCheckboxField => {
+  if (field.fieldType !== BasicField.Checkbox) {
+    return false
+  }
+  return (
+    hasProp(field, 'answerArray') &&
+    Array.isArray(field.answerArray) &&
+    field.answerArray.every((value) => typeof value === 'string')
+  )
+}
+
+const convertServerCheckboxValue = (
+  field: ServerCheckboxField,
+  formFields: IPopulatedForm['form_fields'],
+): TransformedServerCheckboxField => {
+  const completeField = getCheckboxField(field, formFields)
+  const withOthersPrefix = field.answerArray.filter((value) =>
+    value.startsWith('Others: '),
+  )
+  // In-built others option is selected if at least one of them is not
+  // a user-defined option i.e. is one of the field options
+  const inBuiltOthers = withOthersPrefix.find(
+    (value) => !completeField.fieldOptions.includes(value),
+  )
+
+  let others = false
+  if (inBuiltOthers) {
+    field.answerArray.splice(field.answerArray.indexOf(inBuiltOthers), 1)
+    others = true
+  }
+
+  return {
+    ...omit(field, ['answerArray']),
+    answerArray: { options: field.answerArray, others },
+  }
+}
+
+const findField = (
+  field: FieldSchemaOrResponse,
+  formFields: IPopulatedForm['form_fields'],
+): IField | undefined => {
+  const fieldId = field._id
+  return formFields.find((field) => String(field._id) === fieldId) // cast to string because some ids are ObjectIds
+}
+
+const getCheckboxField = (
+  field: FieldSchemaOrResponse,
+  formFields: IPopulatedForm['form_fields'],
+): ICheckboxField => {
+  const completeField = findField(field, formFields)
+  if (!completeField) {
+    throw new Error('Field cannot be found')
+  }
+  if (!isCheckboxField(completeField)) {
+    throw new Error(`${completeField} is not a checkbox field`)
+  }
+  return completeField
+}

--- a/src/shared/util/logic-utils/checkbox/index.ts
+++ b/src/shared/util/logic-utils/checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from './checkbox-logic-guards'

--- a/src/shared/util/logic-utils/index.ts
+++ b/src/shared/util/logic-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './checkbox'

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -294,7 +294,7 @@ const getCurrentValue = (
   | string
   | string[]
   | boolean[]
-  | ITableRow[] // TODO: will be removed after transformer functions are inserted
+  | ITableRow[]
   | CheckboxConditionValue
   | undefined
   | null => {

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -4,15 +4,14 @@ import {
   BasicField,
   CheckboxConditionValue,
   FieldSchemaOrResponse,
-  IClientFieldSchema,
   IConditionSchema,
   IField,
   IFormDocument,
   ILogicClientFieldSchema,
+  ILogicInputClientSchema,
   ILogicSchema,
   IPreventSubmitLogicSchema,
   IShowFieldsLogicSchema,
-  ITableRow,
   LogicCondition,
   LogicConditionState,
   LogicFieldResponse,
@@ -76,7 +75,7 @@ export const getApplicableIfStates = (
 ): LogicConditionState[] => LOGIC_MAP.get(fieldType) ?? []
 
 type GroupedLogic = Record<string, IConditionSchema[][]>
-export type FieldIdSet = Set<IClientFieldSchema['_id']>
+export type FieldIdSet = Set<ILogicInputClientSchema['_id']>
 // This module handles logic on both the client side (IFieldSchema[])
 // and server side (FieldResponse[])
 export type LogicFieldSchemaOrResponse =
@@ -295,7 +294,6 @@ const getCurrentValue = (
   | string[]
   | boolean[]
   | CheckboxConditionValue
-  | ITableRow[]
   | undefined
   | null => {
   if ('fieldValue' in field) {
@@ -377,9 +375,7 @@ const isConditionFulfilled = (
         obj.options = obj.options.sort()
       })
       currentValue.options = currentValue.options.sort()
-      return condition.value.some((val) =>
-        isEqual(JSON.stringify(currentValue), JSON.stringify(val)),
-      )
+      return condition.value.some((val) => isEqual(currentValue, val))
     } else {
       return false
     }

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -3,6 +3,7 @@ import { isEqual } from 'lodash'
 import {
   BasicField,
   CheckboxConditionValue,
+  FieldSchemaOrResponse,
   IClientFieldSchema,
   IConditionSchema,
   IField,
@@ -81,6 +82,7 @@ export type FieldIdSet = Set<IClientFieldSchema['_id']>
 export type LogicFieldSchemaOrResponse =
   | ILogicClientFieldSchema
   | LogicFieldResponse
+  | FieldSchemaOrResponse // TODO: remove after applying transformations outside this module
 
 // Returns typed ShowFields logic unit
 const isShowFieldsLogic = (

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -12,6 +12,7 @@ import {
   ILogicSchema,
   IPreventSubmitLogicSchema,
   IShowFieldsLogicSchema,
+  ITableRow,
   LogicCondition,
   LogicConditionState,
   LogicFieldResponse,
@@ -293,6 +294,7 @@ const getCurrentValue = (
   | string
   | string[]
   | boolean[]
+  | ITableRow[] // TODO: will be removed after transformer functions are inserted
   | CheckboxConditionValue
   | undefined
   | null => {

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -82,7 +82,6 @@ export type FieldIdSet = Set<IClientFieldSchema['_id']>
 export type LogicFieldSchemaOrResponse =
   | ILogicClientFieldSchema
   | LogicFieldResponse
-  | FieldSchemaOrResponse // TODO: remove after applying transformations outside this module
 
 // Returns typed ShowFields logic unit
 const isShowFieldsLogic = (
@@ -192,7 +191,7 @@ const getPreventSubmitConditions = (
  * @returns a condition if submission is to prevented, otherwise `undefined`
  */
 export const getLogicUnitPreventingSubmit = (
-  submission: LogicFieldSchemaOrResponse[],
+  submission: FieldSchemaOrResponse[],
   form: IFormDocument,
   visibleFieldIds?: FieldIdSet,
 ): IPreventSubmitLogicSchema | undefined => {
@@ -233,7 +232,7 @@ const allConditionsExist = (
  * @returns a set of IDs of visible fields in the submission
  */
 export const getVisibleFieldIds = (
-  submission: LogicFieldSchemaOrResponse[],
+  submission: FieldSchemaOrResponse[],
   form: IFormDocument,
 ): FieldIdSet => {
   const logicUnitsGroupedByField = groupLogicUnitsByField(form)
@@ -275,7 +274,7 @@ export const getVisibleFieldIds = (
  * @returns true if all the conditions are satisfied, false otherwise
  */
 const isLogicUnitSatisfied = (
-  submission: LogicFieldSchemaOrResponse[],
+  submission: FieldSchemaOrResponse[],
   logicUnit: IConditionSchema[],
   visibleFieldIds: FieldIdSet,
 ): boolean => {
@@ -290,7 +289,7 @@ const isLogicUnitSatisfied = (
 }
 
 const getCurrentValue = (
-  field: LogicFieldSchemaOrResponse,
+  field: FieldSchemaOrResponse,
 ):
   | string
   | string[]
@@ -318,7 +317,7 @@ const getCurrentValue = (
  * @param {String} condition.state - The type of condition
  */
 const isConditionFulfilled = (
-  field: LogicFieldSchemaOrResponse,
+  field: FieldSchemaOrResponse,
   condition: IConditionSchema,
 ): boolean => {
   if (!field || !condition) {
@@ -401,9 +400,9 @@ const isConditionFulfilled = (
  * @returns the condition field if it exists, `undefined` otherwise
  */
 const findConditionField = (
-  submission: LogicFieldSchemaOrResponse[],
+  submission: FieldSchemaOrResponse[],
   fieldId: IConditionSchema['field'],
-): LogicFieldSchemaOrResponse | undefined => {
+): FieldSchemaOrResponse | undefined => {
   return submission.find(
     (submittedField) => String(submittedField._id) === String(fieldId),
   )

--- a/src/types/field/baseField.ts
+++ b/src/types/field/baseField.ts
@@ -47,7 +47,7 @@ export interface IFieldSchema extends IField, Document {
 // needs it as a variable to store the client's answer to a field.
 // Hence we need this interface for client-side fields.
 export interface IClientFieldSchema extends IFieldSchema {
-  fieldValue: string
+  fieldValue: string | string[] | boolean[]
 }
 
 export enum TextSelectedValidation {

--- a/src/types/field/baseField.ts
+++ b/src/types/field/baseField.ts
@@ -43,13 +43,6 @@ export interface IFieldSchema extends IField, Document {
   getQuestion(): string
 }
 
-// We don't store a fieldValue in the database, but the client
-// needs it as a variable to store the client's answer to a field.
-// Hence we need this interface for client-side fields.
-export interface IClientFieldSchema extends IFieldSchema {
-  fieldValue: string | string[] | boolean[]
-}
-
 export enum TextSelectedValidation {
   Maximum = 'Maximum',
   Minimum = 'Minimum',

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -2,7 +2,13 @@ import { Document } from 'mongoose'
 
 import { IFieldSchema } from './field/baseField'
 import { BasicField } from './field/fieldTypes'
-import { FieldResponse, ICheckboxResponse, ISingleAnswerResponse } from '.'
+import {
+  FieldResponse,
+  IAttachmentResponse,
+  ICheckboxResponse,
+  ISingleAnswerResponse,
+  ITableResponse,
+} from '.'
 
 export enum LogicConditionState {
   Equal = 'is equals to',
@@ -144,7 +150,11 @@ export interface ILogicClientFieldSchema
 }
 
 // Type for server logic fields after being transformation
-export type LogicFieldResponse = ISingleAnswerResponse | ILogicCheckboxResponse
+export type LogicFieldResponse =
+  | ISingleAnswerResponse
+  | ILogicCheckboxResponse
+  | ITableResponse
+  | IAttachmentResponse
 
 /**
  * Types for checkbox logic field

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -2,7 +2,7 @@ import { Document } from 'mongoose'
 
 import { IFieldSchema } from './field/baseField'
 import { BasicField } from './field/fieldTypes'
-import { ICheckboxResponse, ISingleAnswerResponse } from '.'
+import { FieldResponse, ICheckboxResponse, ISingleAnswerResponse } from '.'
 
 export enum LogicConditionState {
   Equal = 'is equals to',
@@ -132,13 +132,8 @@ export interface ILogicInputClientSchema extends IFieldSchema {
   fieldValue: string | boolean[]
 }
 
-// Type of server logic fields (passed into the logic module)
-export type LogicInputFieldResponse = ISingleAnswerResponse | ICheckboxResponse
-
 // Type for fields that are passed into the logic module
-export type FieldSchemaOrResponse =
-  | ILogicInputClientSchema
-  | LogicInputFieldResponse
+export type FieldSchemaOrResponse = ILogicInputClientSchema | FieldResponse
 
 // Type for client logic fields after transformation
 export interface ILogicClientFieldSchema

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -1,14 +1,8 @@
 import { Document } from 'mongoose'
 
-import { IClientFieldSchema, IFieldSchema } from './field/baseField'
+import { IFieldSchema } from './field/baseField'
 import { BasicField } from './field/fieldTypes'
-import {
-  FieldResponse,
-  IAttachmentResponse,
-  ICheckboxResponse,
-  ISingleAnswerResponse,
-  ITableResponse,
-} from '.'
+import { ICheckboxResponse, ISingleAnswerResponse } from '.'
 
 export enum LogicConditionState {
   Equal = 'is equals to',
@@ -22,7 +16,7 @@ export enum LogicIfValue {
   Number = 'number',
   SingleSelect = 'single-select',
   MultiSelect = 'multi-select',
-  MultiValue = 'multi-value',
+  MultiCombination = 'multi-combination',
 }
 
 export enum LogicType {
@@ -33,13 +27,7 @@ export enum LogicType {
 export interface ICondition {
   field: IFieldSchema['_id']
   state: LogicConditionState
-  value:
-    | string
-    | number
-    | string[]
-    | number[]
-    | CheckboxConditionValue[]
-    | ClientCheckboxConditionOption[][] // frontend representation of checkbox condition value, will not be added to backend (ensured by Joi validators)
+  value: string | number | string[] | number[] | CheckboxConditionValue[]
   ifValueType?: LogicIfValue
 }
 
@@ -134,6 +122,36 @@ export type LogicCondition =
   | MultiValuedLogicCondition
 
 /**
+ * Types needed for logic module inputs
+ */
+
+// Type of client logic fields before transformation (passed into logic module).
+// We don't store a fieldValue in the database, but the client
+// needs it as a variable to store the client's answer to a field.
+export interface ILogicInputClientSchema extends IFieldSchema {
+  fieldValue: string | boolean[]
+}
+
+// Type of server logic fields (passed into the logic module)
+export type LogicInputFieldResponse = ISingleAnswerResponse | ICheckboxResponse
+
+// Type for fields that are passed into the logic module
+export type FieldSchemaOrResponse =
+  | ILogicInputClientSchema
+  | LogicInputFieldResponse
+
+// Type for client logic fields after transformation
+export interface ILogicClientFieldSchema
+  extends Omit<ILogicInputClientSchema, 'fieldValue'> {
+  // Use omit instead of directly extending IFieldSchema
+  // to prevent typescript from complaining about return type in adaptor function
+  fieldValue: string | CheckboxConditionValue
+}
+
+// Type for server logic fields after being transformation
+export type LogicFieldResponse = ISingleAnswerResponse | ILogicCheckboxResponse
+
+/**
  * Types for checkbox logic field
  */
 // Representation of an option in the logic tab
@@ -142,18 +160,11 @@ export type ClientCheckboxConditionOption = {
   other: boolean
 }
 
-// Representation of frontend checkbox response after being transformed
-export type ClientLogicCheckboxResponse = Omit<
-  IClientFieldSchema,
-  'fieldValue'
-> & {
-  fieldValue: CheckboxConditionValue
-}
-
 // Representation of backend checkbox response after being transformed
 export type ILogicCheckboxResponse = Omit<ICheckboxResponse, 'answerArray'> & {
   answerArray: CheckboxConditionValue
 }
+
 // Representation of a Checkbox condition
 export interface LogicCheckboxCondition
   extends Omit<IConditionSchema, 'value'> {
@@ -164,24 +175,6 @@ export type CheckboxConditionValue = {
   options: string[]
   others: boolean
 }
-
-/**
- * Types needed for logic module inputs
- */
-// Type for fields before being transformed and passed into the logic module
-export type FieldSchemaOrResponse = IClientFieldSchema | FieldResponse
-
-// Type for client fields after being transformed and passed into the logic module
-export type ILogicClientFieldSchema =
-  | IClientFieldSchema
-  | ClientLogicCheckboxResponse
-
-// Type for backend fields after being transformed and passed into the logic module
-export type LogicFieldResponse =
-  | ISingleAnswerResponse
-  | ILogicCheckboxResponse
-  | ITableResponse
-  | IAttachmentResponse
 
 /**
  * Logic POJO with functions removed

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -1,19 +1,28 @@
 import { Document } from 'mongoose'
 
-import { IFieldSchema } from './field/baseField'
+import { IClientFieldSchema, IFieldSchema } from './field/baseField'
 import { BasicField } from './field/fieldTypes'
+import {
+  FieldResponse,
+  IAttachmentResponse,
+  ICheckboxResponse,
+  ISingleAnswerResponse,
+  ITableResponse,
+} from '.'
 
 export enum LogicConditionState {
   Equal = 'is equals to',
   Lte = 'is less than or equal to',
   Gte = 'is more than or equal to',
   Either = 'is either',
+  AnyOf = 'is one of the following',
 }
 
 export enum LogicIfValue {
   Number = 'number',
   SingleSelect = 'single-select',
   MultiSelect = 'multi-select',
+  MultiValue = 'multi-value',
 }
 
 export enum LogicType {
@@ -24,7 +33,13 @@ export enum LogicType {
 export interface ICondition {
   field: IFieldSchema['_id']
   state: LogicConditionState
-  value: string | number | string[] | number[]
+  value:
+    | string
+    | number
+    | string[]
+    | number[]
+    | CheckboxConditionValue[]
+    | ClientCheckboxConditionOption[][] // frontend representation of checkbox condition value, will not be added to backend (ensured by Joi validators)
   ifValueType?: LogicIfValue
 }
 
@@ -61,12 +76,21 @@ type LogicField = Extract<
   | BasicField.Number
   | BasicField.Decimal
   | BasicField.Rating
+  | BasicField.Checkbox
 >
 
 type LogicAssociation<K extends LogicField, VS extends LogicConditionState> = [
   K,
   Array<VS>,
 ]
+
+// Logic fields that are multi-valued
+type MultiValuedLogicField = Extract<BasicField, BasicField.Checkbox>
+type MultiValuedLogicStates = LogicConditionState.AnyOf
+type MultiValuedLogicCondition = LogicAssociation<
+  MultiValuedLogicField,
+  MultiValuedLogicStates
+>
 
 // Logic fields that are categorical
 type CategoricalLogicField = Extract<
@@ -107,6 +131,57 @@ export type LogicCondition =
   | CategoricalLogicCondition
   | BinaryLogicCondition
   | NumericalLogicCondition
+  | MultiValuedLogicCondition
+
+/**
+ * Types for checkbox logic field
+ */
+// Representation of an option in the logic tab
+export type ClientCheckboxConditionOption = {
+  value: string
+  other: boolean
+}
+
+// Representation of frontend checkbox response after being transformed
+export type ClientLogicCheckboxResponse = Omit<
+  IClientFieldSchema,
+  'fieldValue'
+> & {
+  fieldValue: CheckboxConditionValue
+}
+
+// Representation of backend checkbox response after being transformed
+export type ILogicCheckboxResponse = Omit<ICheckboxResponse, 'answerArray'> & {
+  answerArray: CheckboxConditionValue
+}
+// Representation of a Checkbox condition
+export interface LogicCheckboxCondition
+  extends Omit<IConditionSchema, 'value'> {
+  value: CheckboxConditionValue[]
+}
+// Representation of a checkbox condition value
+export type CheckboxConditionValue = {
+  options: string[]
+  others: boolean
+}
+
+/**
+ * Types needed for logic module inputs
+ */
+// Type for fields before being transformed and passed into the logic module
+export type FieldSchemaOrResponse = IClientFieldSchema | FieldResponse
+
+// Type for client fields after being transformed and passed into the logic module
+export type ILogicClientFieldSchema =
+  | IClientFieldSchema
+  | ClientLogicCheckboxResponse
+
+// Type for backend fields after being transformed and passed into the logic module
+export type LogicFieldResponse =
+  | ISingleAnswerResponse
+  | ILogicCheckboxResponse
+  | ITableResponse
+  | IAttachmentResponse
 
 /**
  * Logic POJO with functions removed


### PR DESCRIPTION
## Problem
This PR implements the extension of the logic feature to logic fields. This first part defines the types needed for this logic extension and implements the logic checks for checkboxes.

Part 1/3 of #30

## Solution
Refer to the design document [here](https://docs.google.com/document/d/1ggEb9UyHjK3EipQjXpCmOwaenM6_f1AqcE46VxBkIZI/edit#).
Handling of checkbox fields in logic is done separately from existing logic fields and hence should not affect correctness of existing logic. 

## Tests
### Unit tests
Added tests to `logic.spec.ts`
