### PR TITLE
ref: remove backend package dependencies from Form (sub-)types and move to shared dir

### DIFF
--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -35,3 +35,12 @@ export const EMAIL_FORM_SETTINGS_FIELDS = <const>[
   'emails',
 ]
 export const STORAGE_FORM_SETTINGS_FIELDS = FORM_SETTINGS_FIELDS
+
+export const ADMIN_FORM_META_FIELDS = <const>[
+  'admin',
+  'title',
+  'lastModified',
+  'status',
+  '_id',
+  'responseMode',
+]

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -1,0 +1,37 @@
+const PUBLIC_FORM_FIELDS = <const>[
+  'admin',
+  'authType',
+  'endPage',
+  'esrvcId',
+  'form_fields',
+  'form_logics',
+  'hasCaptcha',
+  'startPage',
+  'status',
+  'title',
+  '_id',
+  'responseMode',
+]
+
+export const EMAIL_PUBLIC_FORM_FIELDS = PUBLIC_FORM_FIELDS
+export const STORAGE_PUBLIC_FORM_FIELDS = <const>[
+  ...PUBLIC_FORM_FIELDS,
+  'publicKey',
+]
+
+const FORM_SETTINGS_FIELDS = <const>[
+  'authType',
+  'esrvcId',
+  'hasCaptcha',
+  'inactiveMessage',
+  'status',
+  'submissionLimit',
+  'title',
+  'webhook',
+]
+
+export const EMAIL_FORM_SETTINGS_FIELDS = <const>[
+  ...FORM_SETTINGS_FIELDS,
+  'emails',
+]
+export const STORAGE_FORM_SETTINGS_FIELDS = FORM_SETTINGS_FIELDS

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -65,11 +65,16 @@ export type FormField =
   | UenFieldBase
   | YesNoFieldBase
 
-export type PossiblyPrefilledFormField = FormField & {
+export type FormFieldWithId = FormField & { _id: string }
+
+export type PossiblyPrefilledFormField = FormFieldWithId & {
   fieldValue?: string
 }
 
 /**
  * Form field POJO with id
  */
-export type FormFieldDto = PossiblyPrefilledFormField & { _id: string }
+export type FormFieldDto = PossiblyPrefilledFormField | FormFieldWithId
+
+export type FieldCreateDto = FormField
+export type FieldUpdateDto = FormField & { _id: string }

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -65,7 +65,11 @@ export type FormField =
   | UenFieldBase
   | YesNoFieldBase
 
+export type PossiblyPrefilledFormField = FormField & {
+  fieldValue?: string
+}
+
 /**
  * Form field POJO with id
  */
-export type FormFieldDto = FormField & { _id: string }
+export type FormFieldDto = PossiblyPrefilledFormField & { _id: string }

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -3,8 +3,9 @@ import { FormField, FormFieldDto } from '../field'
 
 import { FormLogic } from './form_logic'
 import { FormLogo } from './form_logo'
-import { Merge, SetRequired } from 'type-fest'
+import { Merge, PartialDeep, SetRequired } from 'type-fest'
 import {
+  ADMIN_FORM_META_FIELDS,
   EMAIL_FORM_SETTINGS_FIELDS,
   EMAIL_PUBLIC_FORM_FIELDS,
   STORAGE_FORM_SETTINGS_FIELDS,
@@ -21,6 +22,7 @@ export enum FormColorTheme {
 }
 
 export type FormPermission = {
+  id?: string
   email: string
   write: boolean
 }
@@ -141,6 +143,8 @@ export type EmailFormDto = Merge<
 
 export type FormDto = StorageFormDto | EmailFormDto
 
+export type AdminFormDto = Merge<FormDto, { admin: UserDto }>
+
 type PublicFormBase = {
   admin: PublicUserDto
 }
@@ -178,6 +182,8 @@ export type StorageFormSettings = Pick<
 
 export type FormSettings = EmailFormSettings | StorageFormSettings
 
+export type SettingsUpdateDto = PartialDeep<FormSettings>
+
 /**
  * Misnomer. More of a public form auth session.
  */
@@ -194,3 +200,44 @@ export type PublicFormViewDto = {
   isIntranetUser?: boolean
   myInfoError?: true
 }
+
+export type PreviewFormViewDto = Pick<PublicFormViewDto, 'form'>
+
+export type AdminFormViewDto = {
+  form: AdminFormDto
+}
+
+export type AdminDashboardFormMetaDto = Pick<
+  AdminFormDto,
+  typeof ADMIN_FORM_META_FIELDS[number]
+>
+
+export type DuplicateFormBodyDto = {
+  title: string
+} & (
+  | {
+      responseMode: FormResponseMode.Email
+      emails: string | string[]
+    }
+  | {
+      responseMode: FormResponseMode.Encrypt
+      publicKey: string
+    }
+)
+
+export type CreateEmailFormBodyDto = Pick<
+  EmailFormDto,
+  'emails' | 'responseMode' | 'title'
+>
+export type CreateStorageFormBodyDto = Pick<
+  StorageFormDto,
+  'publicKey' | 'responseMode' | 'title'
+>
+
+export type CreateFormBodyDto =
+  | CreateEmailFormBodyDto
+  | CreateStorageFormBodyDto
+
+export type EndPageUpdateDto = FormEndPage
+export type StartPageUpdateDto = FormStartPage
+export type PermissionsUpdateDto = FormPermission[]

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -1,0 +1,98 @@
+import { UserDto } from '../user'
+import { FormField } from '../field'
+
+import { FormLogic } from './form_logic'
+import { FormLogo } from './form_logo'
+
+export enum FormColorTheme {
+  Blue = 'blue',
+  Red = 'red',
+  Green = 'green',
+  Orange = 'orange',
+  Brown = 'brown',
+  Grey = 'grey',
+}
+
+export type FormPermission = {
+  email: string
+  write: boolean
+}
+
+export type FormStartPage = {
+  paragraph?: string
+  estTimeTaken?: number
+  colorTheme: FormColorTheme
+  logo: FormLogo
+}
+
+export type FormEndPage = {
+  title: string
+  paragraph: string
+  buttonLink: string
+  buttonText: string
+}
+
+export enum FormAuthType {
+  NIL = 'NIL',
+  SP = 'SP',
+  CP = 'CP',
+  MyInfo = 'MyInfo',
+  SGID = 'SGID',
+}
+
+export enum FormStatus {
+  Private = 'PRIVATE',
+  Public = 'PUBLIC',
+  Archived = 'ARCHIVED',
+}
+
+export type FormWebhook = {
+  url: string
+  isRetryEnabled: boolean
+}
+
+export enum FormResponseMode {
+  Encrypt = 'encrypt',
+  Email = 'email',
+}
+
+export interface FormBase {
+  title: string
+  form_fields: FormField[]
+  form_logics: FormLogic[]
+  admin: UserDto['_id']
+  permissionList: FormPermission[]
+
+  startPage: FormStartPage
+  endPage: FormEndPage
+
+  hasCaptcha: boolean
+  authType: FormAuthType
+
+  status: FormStatus
+
+  inactiveMessage: string
+  submissionLimit: number | null
+  isListed: boolean
+
+  esrvcId?: string
+
+  msgSrvcName?: string
+
+  webhook: FormWebhook
+
+  responseMode: FormResponseMode
+
+  created: Date
+  lastModified: Date
+}
+
+export interface EmailFormBase extends FormBase {
+  responseMode: FormResponseMode.Email
+  emails: string[]
+}
+
+export interface StorageFormBase extends FormBase {
+  responseMode: FormResponseMode.Encrypt
+  publicKey: string
+}

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -3,7 +3,7 @@ import { FormField, FormFieldDto } from '../field'
 
 import { FormLogic } from './form_logic'
 import { FormLogo } from './form_logo'
-import { Merge, PartialDeep, SetRequired } from 'type-fest'
+import { Merge, Opaque, PartialDeep } from 'type-fest'
 import {
   ADMIN_FORM_META_FIELDS,
   EMAIL_FORM_SETTINGS_FIELDS,
@@ -11,6 +11,9 @@ import {
   STORAGE_FORM_SETTINGS_FIELDS,
   STORAGE_PUBLIC_FORM_FIELDS,
 } from '../../constants/form'
+import { DateString } from '../generic'
+
+export type FormId = Opaque<string, 'FormId'>
 
 export enum FormColorTheme {
   Blue = 'blue',
@@ -69,32 +72,29 @@ export interface FormBase {
   title: string
   admin: UserDto['_id']
 
-  form_fields?: FormField[]
-  form_logics?: FormLogic[]
-  permissionList?: FormPermission[]
+  form_fields: FormField[]
+  form_logics: FormLogic[]
+  permissionList: FormPermission[]
 
-  startPage?: FormStartPage
-  endPage?: FormEndPage
+  startPage: FormStartPage
+  endPage: FormEndPage
 
-  hasCaptcha?: boolean
-  authType?: FormAuthType
+  hasCaptcha: boolean
+  authType: FormAuthType
 
-  status?: FormStatus
+  status: FormStatus
 
-  inactiveMessage?: string
-  submissionLimit?: number | null
-  isListed?: boolean
+  inactiveMessage: string
+  submissionLimit: number | null
+  isListed: boolean
 
   esrvcId?: string
 
   msgSrvcName?: string
 
-  webhook?: FormWebhook
+  webhook: FormWebhook
 
   responseMode: FormResponseMode
-
-  created?: Date
-  lastModified?: Date
 }
 
 export interface EmailFormBase extends FormBase {
@@ -107,39 +107,19 @@ export interface StorageFormBase extends FormBase {
   publicKey: string
 }
 
-export type Form<T extends FormBase = FormBase> = SetRequired<
-  T,
-  | 'form_fields'
-  | 'form_logics'
-  | 'permissionList'
-  | 'startPage'
-  | 'endPage'
-  | 'hasCaptcha'
-  | 'authType'
-  | 'status'
-  | 'inactiveMessage'
-  | 'submissionLimit'
-  | 'isListed'
-  | 'webhook'
-  | 'created'
-  | 'lastModified'
->
+/**
+ * Additional props to be added/replaced when tranformed into DTO.
+ */
+type FormDtoBase = {
+  _id: FormId
+  form_fields: FormFieldDto[]
+  created: DateString
+  lastModified: DateString
+}
 
-export type StorageFormDto = Merge<
-  Form<StorageFormBase>,
-  {
-    form_fields: FormFieldDto[]
-    _id: string
-  }
->
+export type StorageFormDto = Merge<StorageFormBase, FormDtoBase>
 
-export type EmailFormDto = Merge<
-  Form<EmailFormBase>,
-  {
-    form_fields: FormFieldDto[]
-    _id: string
-  }
->
+export type EmailFormDto = Merge<EmailFormBase, FormDtoBase>
 
 export type FormDto = StorageFormDto | EmailFormDto
 

--- a/shared/types/form/form_logic.ts
+++ b/shared/types/form/form_logic.ts
@@ -1,0 +1,47 @@
+import { FormFieldDto } from '../field'
+
+export enum LogicConditionState {
+  Equal = 'is equals to',
+  Lte = 'is less than or equal to',
+  Gte = 'is more than or equal to',
+  Either = 'is either',
+}
+
+export enum LogicType {
+  ShowFields = 'showFields',
+  PreventSubmit = 'preventSubmit',
+}
+
+export enum LogicIfValue {
+  Number = 'number',
+  SingleSelect = 'single-select',
+  MultiSelect = 'multi-select',
+}
+
+export type FormCondition = {
+  field: FormFieldDto['_id']
+  state: LogicConditionState
+  value: string | number | string[] | number[]
+  ifValueType?: LogicIfValue
+}
+
+export type FormLogicBase = {
+  conditions: FormCondition[]
+}
+
+export interface ShowFieldLogic extends FormLogicBase {
+  logicType: LogicType.ShowFields
+  show: FormFieldDto['_id'][]
+}
+
+export interface PreventSubmitLogic extends FormLogicBase {
+  logicType: LogicType.ShowFields
+  preventSubmitMessage: string
+}
+
+export type FormLogic = ShowFieldLogic | PreventSubmitLogic
+
+export type ShowFieldLogicDto = ShowFieldLogic & { _id: string }
+export type PreventSubmitLogicDto = PreventSubmitLogic & { _id: string }
+
+export type LogicDto = FormLogic & { _id: string }

--- a/shared/types/form/form_logic.ts
+++ b/shared/types/form/form_logic.ts
@@ -26,6 +26,7 @@ export type FormCondition = {
 }
 
 export type FormLogicBase = {
+  logicType: LogicType
   conditions: FormCondition[]
 }
 
@@ -35,7 +36,7 @@ export interface ShowFieldLogic extends FormLogicBase {
 }
 
 export interface PreventSubmitLogic extends FormLogicBase {
-  logicType: LogicType.ShowFields
+  logicType: LogicType.PreventSubmit
   preventSubmitMessage: string
 }
 

--- a/shared/types/form/form_logo.ts
+++ b/shared/types/form/form_logo.ts
@@ -1,0 +1,26 @@
+export enum FormLogoState {
+  Default = 'DEFAULT',
+  None = 'NONE',
+  Custom = 'CUSTOM',
+}
+
+interface FormLogoBase {
+  state: FormLogoState
+}
+
+interface CustomFormLogo extends FormLogoBase {
+  state: FormLogoState.Custom
+  fileId: string
+  fileName: string
+  fileSizeInBytes: number
+}
+
+interface NoFormLogo extends FormLogoBase {
+  state: FormLogoState.None
+}
+
+interface DefaultFormLogo extends FormLogoBase {
+  state: FormLogoState.Default
+}
+
+export type FormLogo = CustomFormLogo | NoFormLogo | DefaultFormLogo

--- a/shared/types/form/form_logo.ts
+++ b/shared/types/form/form_logo.ts
@@ -4,22 +4,22 @@ export enum FormLogoState {
   Custom = 'CUSTOM',
 }
 
-interface FormLogoBase {
+export interface FormLogoBase {
   state: FormLogoState
 }
 
-interface CustomFormLogo extends FormLogoBase {
+export interface CustomFormLogo extends FormLogoBase {
   state: FormLogoState.Custom
   fileId: string
   fileName: string
   fileSizeInBytes: number
 }
 
-interface NoFormLogo extends FormLogoBase {
+export interface NoFormLogo extends FormLogoBase {
   state: FormLogoState.None
 }
 
-interface DefaultFormLogo extends FormLogoBase {
+export interface DefaultFormLogo extends FormLogoBase {
   state: FormLogoState.Default
 }
 

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -2,22 +2,24 @@ import { z } from 'zod'
 import { Opaque } from 'type-fest'
 
 import { DateString } from './generic'
-import { AgencyBase, AgencyDto } from './agency'
+import { AgencyBase, AgencyDto, PublicAgencyDto } from './agency'
 
 type UserId = Opaque<string, 'UserId'>
-type UserContact = Opaque<string, 'UserContact'>
 
 // Base used for being referenced by schema/model in the backend.
 // Note the lack of typing of _id.
 export const UserBase = z.object({
-  _id: z.unknown(),
   email: z.string().email(),
   agency: AgencyBase.shape._id,
-  betaFlags: z.record(z.boolean()).optional(),
+  betaFlags: z
+    .object({
+      sgid: z.boolean().optional(),
+    })
+    .optional(),
   created: z.date(),
   lastAccessed: z.date().optional(),
   updatedAt: z.date(),
-  contact: (z.string() as unknown as z.Schema<UserContact>).optional(),
+  contact: z.string().optional(),
 })
 export type UserBase = z.infer<typeof UserBase>
 
@@ -33,3 +35,7 @@ export const UserDto = UserBase.extend({
   updatedAt: DateString,
 })
 export type UserDto = z.infer<typeof UserDto>
+
+export type PublicUserDto = {
+  agency: PublicAgencyDto | AgencyDto['_id']
+}

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2,9 +2,12 @@
 import { ObjectId } from 'bson-ext'
 import { cloneDeep, map, merge, omit, orderBy, pick } from 'lodash'
 import mongoose, { Types } from 'mongoose'
+import {
+  EMAIL_PUBLIC_FORM_FIELDS,
+  STORAGE_PUBLIC_FORM_FIELDS,
+} from 'shared/constants/form'
 
 import getFormModel, {
-  FORM_PUBLIC_FIELDS,
   getEmailFormModel,
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
@@ -1907,7 +1910,7 @@ describe('Form Model', () => {
         const actual = emailForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(emailForm, FORM_PUBLIC_FIELDS))
+        expect(actual).toEqual(pick(emailForm, EMAIL_PUBLIC_FORM_FIELDS))
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -1931,7 +1934,7 @@ describe('Form Model', () => {
 
         expect(JSON.stringify(actual)).toEqual(
           JSON.stringify({
-            ...pick(populatedEmailForm, FORM_PUBLIC_FIELDS),
+            ...pick(populatedEmailForm, STORAGE_PUBLIC_FORM_FIELDS),
             // Admin should only contain public view of agency since agency is populated.
             admin: {
               agency: expectedPublicAgencyView,
@@ -1953,7 +1956,7 @@ describe('Form Model', () => {
         const actual = encryptForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(encryptForm, FORM_PUBLIC_FIELDS))
+        expect(actual).toEqual(pick(encryptForm, STORAGE_PUBLIC_FORM_FIELDS))
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -1977,7 +1980,7 @@ describe('Form Model', () => {
 
         expect(JSON.stringify(actual)).toEqual(
           JSON.stringify({
-            ...pick(populatedEncryptForm, FORM_PUBLIC_FIELDS),
+            ...pick(populatedEncryptForm, STORAGE_PUBLIC_FORM_FIELDS),
             // Admin should only contain public view of agency since agency is populated.
             admin: {
               agency: expectedPublicAgencyView,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -483,16 +483,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   FormLogicPath.discriminator(LogicType.PreventSubmit, PreventSubmitLogicSchema)
 
   // Methods
-  FormSchema.methods.getDashboardView = function (admin: IPopulatedUser) {
-    return {
-      _id: this._id,
-      title: this.title,
-      status: this.status,
-      lastModified: this.lastModified,
-      responseMode: this.responseMode,
-      admin,
-    }
-  }
 
   // Method to return myInfo attributes
   FormSchema.methods.getUniqueMyInfoAttrs = function () {
@@ -533,6 +523,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   }
 
   const FormDocumentSchema = FormSchema as unknown as Schema<IFormDocument>
+
+  FormDocumentSchema.methods.getDashboardView = function (
+    admin: IPopulatedUser,
+  ) {
+    return {
+      _id: this._id,
+      title: this.title,
+      status: this.status,
+      lastModified: this.lastModified,
+      responseMode: this.responseMode,
+      admin,
+    }
+  }
 
   FormDocumentSchema.methods.getSettings = function (): FormSettings {
     const formSettings =

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -10,6 +10,7 @@ import mongoose, {
 import validator from 'validator'
 
 import {
+  ADMIN_FORM_META_FIELDS,
   EMAIL_FORM_SETTINGS_FIELDS,
   EMAIL_PUBLIC_FORM_FIELDS,
   STORAGE_FORM_SETTINGS_FIELDS,
@@ -27,7 +28,6 @@ import {
   FormField,
   FormFieldWithId,
   FormLogoState,
-  FormMetaView,
   FormOtpData,
   FormSettings,
   IEmailFormModel,
@@ -51,6 +51,7 @@ import {
   Status,
   StorageFormSettings,
 } from '../../types'
+import { AdminDashboardFormMetaDto } from '../../types/api/form'
 import { IPopulatedUser, IUserSchema } from '../../types/user'
 import { OverrideProps } from '../modules/form/admin-form/admin-form.types'
 import { getFormFieldById, transformEmails } from '../modules/form/form.utils'
@@ -688,10 +689,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return form.save()
   }
 
-  FormSchema.statics.getMetaByUserIdOrEmail = async function (
+  FormDocumentSchema.statics.getMetaByUserIdOrEmail = async function (
     userId: IUserSchema['_id'],
     userEmail: IUserSchema['email'],
-  ): Promise<FormMetaView[]> {
+  ): Promise<AdminDashboardFormMetaDto[]> {
     return (
       this.find()
         // List forms when either the user is an admin or collaborator.
@@ -704,7 +705,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         // selection is made for explicitness.
         // `_id` is also returned regardless and selection is made for
         // explicitness.
-        .select('_id title admin lastModified status responseMode')
+        .select(ADMIN_FORM_META_FIELDS.join(' '))
         .sort('-lastModified')
         .populate({
           path: 'admin',

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -27,6 +27,7 @@ import {
   EndPage,
   FormField,
   FormFieldWithId,
+  FormLogicSchema,
   FormLogoState,
   FormOtpData,
   FormSettings,
@@ -746,7 +747,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     const form = await this.findById(formId).exec()
     if (!form?.form_logics) return null
     const newLogic = (
-      form.form_logics as Types.DocumentArray<ILogicSchema>
+      form.form_logics as Types.DocumentArray<FormLogicSchema>
     ).create(createLogicBody)
     form.form_logics.push(newLogic)
     return form.save()

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -9,6 +9,12 @@ import mongoose, {
 } from 'mongoose'
 import validator from 'validator'
 
+import {
+  EMAIL_FORM_SETTINGS_FIELDS,
+  EMAIL_PUBLIC_FORM_FIELDS,
+  STORAGE_FORM_SETTINGS_FIELDS,
+  STORAGE_PUBLIC_FORM_FIELDS,
+} from '../../../shared/constants/form'
 import { MB } from '../../shared/constants'
 import { reorder } from '../../shared/util/immutable-array-fns'
 import { getApplicableIfStates } from '../../shared/util/logic'
@@ -16,6 +22,7 @@ import {
   AuthType,
   BasicField,
   Colors,
+  EmailFormSettings,
   EndPage,
   FormField,
   FormFieldWithId,
@@ -39,10 +46,10 @@ import {
   Permission,
   PickDuplicateForm,
   PublicForm,
-  PublicFormValues,
   ResponseMode,
   StartPage,
   Status,
+  StorageFormSettings,
 } from '../../types'
 import { IPopulatedUser, IUserSchema } from '../../types/user'
 import { OverrideProps } from '../modules/form/admin-form/admin-form.types'
@@ -81,35 +88,6 @@ import { CustomFormLogoSchema, FormLogoSchema } from './form_logo.server.schema'
 import getUserModel from './user.server.model'
 
 export const FORM_SCHEMA_ID = 'Form'
-
-// Exported for testing.
-export const FORM_PUBLIC_FIELDS: (keyof PublicFormValues)[] = [
-  'admin',
-  'authType',
-  'endPage',
-  'esrvcId',
-  'form_fields',
-  'form_logics',
-  'hasCaptcha',
-  'publicKey',
-  'startPage',
-  'status',
-  'title',
-  '_id',
-  'responseMode',
-]
-
-export const FORM_SETTING_FIELDS: (keyof FormSettings)[] = [
-  'authType',
-  'emails',
-  'esrvcId',
-  'hasCaptcha',
-  'inactiveMessage',
-  'status',
-  'submissionLimit',
-  'title',
-  'webhook',
-]
 
 const bson = new BSON([
   BSON.Binary,
@@ -542,21 +520,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return { ...newForm, ...overrideProps }
   }
 
-  FormSchema.methods.getPublicView = function (): PublicForm {
-    const basePublicView = pick(this, FORM_PUBLIC_FIELDS) as PublicFormValues
-
-    // Return non-populated public fields of form if not populated.
-    if (!this.populated('admin')) {
-      return basePublicView
-    }
-
-    // Populated, return public view with user's public view.
-    return {
-      ...basePublicView,
-      admin: (this.admin as IUserSchema).getPublicView(),
-    }
-  }
-
   // Archives form.
   FormSchema.methods.archive = function () {
     // Return instantly when form is already archived.
@@ -571,7 +534,30 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   const FormDocumentSchema = FormSchema as unknown as Schema<IFormDocument>
 
   FormDocumentSchema.methods.getSettings = function (): FormSettings {
-    return pick(this, FORM_SETTING_FIELDS)
+    const formSettings =
+      this.responseMode === ResponseMode.Encrypt
+        ? (pick(this, STORAGE_FORM_SETTINGS_FIELDS) as StorageFormSettings)
+        : (pick(this, EMAIL_FORM_SETTINGS_FIELDS) as EmailFormSettings)
+
+    return formSettings
+  }
+
+  FormDocumentSchema.methods.getPublicView = function (): PublicForm {
+    const basePublicView =
+      this.responseMode === ResponseMode.Encrypt
+        ? (pick(this, STORAGE_PUBLIC_FORM_FIELDS) as PublicForm)
+        : (pick(this, EMAIL_PUBLIC_FORM_FIELDS) as PublicForm)
+
+    // Return non-populated public fields of form if not populated.
+    if (!this.populated('admin')) {
+      return basePublicView
+    }
+
+    // Populated, return public view with user's public view.
+    return {
+      ...basePublicView,
+      admin: (this.admin as IUserSchema).getPublicView(),
+    }
   }
 
   // Transfer ownership of the form to another user

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -423,7 +423,7 @@ describe('BounceService', () => {
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledTimes(2)
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledWith({
         adminEmail: testUser.email,
-        adminId: testUser._id,
+        adminId: String(testUser._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT.contact,
@@ -431,7 +431,7 @@ describe('BounceService', () => {
       })
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledWith({
         adminEmail: testUser.email,
-        adminId: testUser._id,
+        adminId: String(testUser._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT_2.contact,
@@ -467,7 +467,7 @@ describe('BounceService', () => {
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledTimes(2)
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledWith({
         adminEmail: testUser.email,
-        adminId: testUser._id,
+        adminId: String(testUser._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT.contact,
@@ -475,7 +475,7 @@ describe('BounceService', () => {
       })
       expect(MockSmsFactory.sendBouncedSubmissionSms).toHaveBeenCalledWith({
         adminEmail: testUser.email,
-        adminId: testUser._id,
+        adminId: String(testUser._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT_2.contact,
@@ -912,7 +912,7 @@ describe('BounceService', () => {
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledTimes(2)
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledWith({
         adminEmail: form.admin.email,
-        adminId: form.admin._id,
+        adminId: String(form.admin._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT.contact,
@@ -920,7 +920,7 @@ describe('BounceService', () => {
       })
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledWith({
         adminEmail: form.admin.email,
-        adminId: form.admin._id,
+        adminId: String(form.admin._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT_2.contact,
@@ -948,7 +948,7 @@ describe('BounceService', () => {
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledTimes(2)
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledWith({
         adminEmail: form.admin.email,
-        adminId: form.admin._id,
+        adminId: String(form.admin._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT.contact,
@@ -956,7 +956,7 @@ describe('BounceService', () => {
       })
       expect(MockSmsFactory.sendFormDeactivatedSms).toHaveBeenCalledWith({
         adminEmail: form.admin.email,
-        adminId: form.admin._id,
+        adminId: String(form.admin._id),
         formId: form._id,
         formTitle: form.title,
         recipient: MOCK_CONTACT_2.contact,

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -290,7 +290,7 @@ export const sendSmsBounceNotification = (
   const smsResults = possibleSmsRecipients.map((recipient) =>
     SmsFactory.sendBouncedSubmissionSms({
       adminEmail: form.admin.email,
-      adminId: form.admin._id,
+      adminId: String(form.admin._id),
       formId: form._id,
       formTitle: form.title,
       recipient: recipient.contact,
@@ -439,7 +439,7 @@ export const notifyAdminsOfDeactivation = (
   const smsResults = possibleSmsRecipients.map((recipient) =>
     SmsFactory.sendFormDeactivatedSms({
       adminEmail: form.admin.email,
-      adminId: form.admin._id,
+      adminId: String(form.admin._id),
       formId: form._id,
       formTitle: form.title,
       recipient: recipient.contact,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -43,12 +43,10 @@ import { EditFieldActions } from 'src/shared/constants'
 import {
   AuthType,
   BasicField,
-  FormMetaView,
   FormSettings,
   IEmailSubmissionSchema,
   IEncryptedSubmissionSchema,
   IFieldSchema,
-  IForm,
   IFormDocument,
   IFormSchema,
   ILogicSchema,
@@ -57,12 +55,15 @@ import {
   IPopulatedForm,
   IPopulatedUser,
   IUserSchema,
+  LogicDto,
   PublicForm,
   ResponseMode,
   Status,
 } from 'src/types'
 import {
-  DuplicateFormBody,
+  AdminDashboardFormMetaDto,
+  CreateFormBodyDto,
+  DuplicateFormBodyDto,
   EditFormFieldParams,
   EncryptSubmissionDto,
   FieldCreateDto,
@@ -216,7 +217,7 @@ describe('admin-form.controller', () => {
       _id: new ObjectId(),
       title: 'mock title',
     } as IFormSchema
-    const MOCK_FORM_PARAMS: Omit<IForm, 'admin'> = {
+    const MOCK_FORM_PARAMS: CreateFormBodyDto = {
       responseMode: ResponseMode.Encrypt,
       publicKey: 'some public key',
       title: 'some form title',
@@ -394,7 +395,7 @@ describe('admin-form.controller', () => {
     const MOCK_USER = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
-    } as IPopulatedUser
+    } as unknown as IPopulatedUser
     const MOCK_FORM = {
       admin: MOCK_USER,
       _id: MOCK_FORM_ID,
@@ -925,7 +926,7 @@ describe('admin-form.controller', () => {
     const MOCK_USER = {
       _id: MOCK_USER_ID,
       email: 'somerandom@example.com',
-    } as IPopulatedUser
+    } as unknown as IPopulatedUser
     const MOCK_FORM = {
       admin: MOCK_USER,
       _id: MOCK_FORM_ID,
@@ -3011,17 +3012,19 @@ describe('admin-form.controller', () => {
           _id: MOCK_USER_ID,
         },
       },
-      body: {} as DuplicateFormBody,
+      body: {} as DuplicateFormBodyDto,
     })
 
     it('should return duplicated form view on duplicate success', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
-      const mockDupedFormView = { title: 'mock view' } as FormMetaView
+      const mockDupedFormView = {
+        title: 'mock view',
+      } as AdminDashboardFormMetaDto
       const mockDupedForm = merge({}, MOCK_FORM, {
         title: 'duped form with new title',
         _id: new ObjectId(),
@@ -3087,7 +3090,7 @@ describe('admin-form.controller', () => {
 
     it('should return 404 when form to duplicate cannot be found', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
@@ -3221,7 +3224,7 @@ describe('admin-form.controller', () => {
 
     it('should return 500 when database error occurs whilst duplicating form', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
@@ -3442,19 +3445,19 @@ describe('admin-form.controller', () => {
           _id: MOCK_USER_ID,
         },
       },
-      body: {} as DuplicateFormBody,
+      body: {} as DuplicateFormBodyDto,
     })
 
     it('should return copied template form view on duplicate success', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Email,
         emails: ['some-email@example.com'],
         title: 'mock new template title',
       }
       const mockDupedFormView = {
         title: 'mock template view',
-      } as FormMetaView
+      } as AdminDashboardFormMetaDto
       const mockDupedForm = merge({}, MOCK_FORM, {
         title: 'duped form with new title',
         _id: new ObjectId(),
@@ -3522,7 +3525,7 @@ describe('admin-form.controller', () => {
 
     it('should return 404 when form to duplicate cannot be found', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
@@ -3670,7 +3673,7 @@ describe('admin-form.controller', () => {
 
     it('should return 500 when database error occurs whilst duplicating form', async () => {
       // Arrange
-      const expectedParams: DuplicateFormBody = {
+      const expectedParams: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
@@ -7942,7 +7945,7 @@ describe('admin-form.controller', () => {
       )
 
       MockAdminFormService.deleteFormLogic.mockReturnValue(
-        okAsync(MOCK_FORM as IFormSchema),
+        okAsync(MOCK_FORM as IFormDocument),
       )
     })
 
@@ -8297,7 +8300,7 @@ describe('admin-form.controller', () => {
     const MOCK_UPDATED_FORM = {
       ...MOCK_FORM,
       form_fields: [MOCK_FIELDS[0]],
-    } as IFormSchema
+    } as IFormDocument
 
     const MOCK_REQ = expressHandler.mockRequest({
       params: {
@@ -9103,7 +9106,7 @@ describe('admin-form.controller', () => {
 
     const mockUpdatedLogic = {
       _id: logicId,
-    } as ILogicSchema
+    } as LogicDto
 
     const MOCK_FORM = {
       admin: MOCK_USER,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -25,18 +25,18 @@ import { EditFieldActions, VALID_UPLOAD_FILE_TYPES } from 'src/shared/constants'
 import {
   AuthType,
   BasicField,
+  Colors,
   EndPage,
+  FormLogicSchema,
   FormLogoState,
-  FormMetaView,
   FormSettings,
   ICustomFormLogo,
   IEmailFormSchema,
   IFormDocument,
   IFormSchema,
-  ILogicSchema,
   IPopulatedForm,
-  IPopulatedUser,
   IUserSchema,
+  LogicDto,
   LogicType,
   PickDuplicateForm,
   ResponseMode,
@@ -44,7 +44,8 @@ import {
   Status,
 } from 'src/types'
 import {
-  DuplicateFormBody,
+  AdminDashboardFormMetaDto,
+  DuplicateFormBodyDto,
   EditFormFieldParams,
   FieldCreateDto,
   FieldUpdateDto,
@@ -109,20 +110,20 @@ describe('admin-form.service', () => {
         email: 'MOCK_EMAIL@example.com',
         _id: mockUserId,
       } as IUserSchema
-      const mockDashboardForms: FormMetaView[] = [
+      const mockDashboardForms = [
         {
-          admin: {} as IPopulatedUser,
+          admin: {},
           title: 'test form 1',
           _id: 'any',
           responseMode: ResponseMode.Email,
         },
         {
-          admin: {} as IPopulatedUser,
+          admin: {},
           title: 'test form 2',
           _id: 'any2',
           responseMode: ResponseMode.Encrypt,
         },
-      ]
+      ] as AdminDashboardFormMetaDto[]
       // Mock user admin success.
       MockUserService.findUserById.mockReturnValueOnce(
         okAsync(mockUser as IUserSchema),
@@ -418,12 +419,12 @@ describe('admin-form.service', () => {
         } as ICustomFormLogo,
       },
     } as unknown as IFormDocument
-    const MOCK_EMAIL_OVERRIDE_PARAMS: DuplicateFormBody = {
+    const MOCK_EMAIL_OVERRIDE_PARAMS: DuplicateFormBodyDto = {
       responseMode: ResponseMode.Email,
       title: 'mock new title',
       emails: ['mockExample@example.com'],
     }
-    const MOCK_ENCRYPT_OVERRIDE_PARAMS: DuplicateFormBody = {
+    const MOCK_ENCRYPT_OVERRIDE_PARAMS: DuplicateFormBodyDto = {
       responseMode: ResponseMode.Encrypt,
       title: 'mock new title',
       publicKey: 'some public key',
@@ -1096,6 +1097,7 @@ describe('admin-form.service', () => {
       title: 'new title',
       webhook: {
         url: '',
+        isRetryEnabled: false,
       },
     }
 
@@ -1369,7 +1371,7 @@ describe('admin-form.service', () => {
         {
           _id: logicId,
           id: logicId,
-        } as ILogicSchema,
+        } as FormLogicSchema,
       ],
     }
 
@@ -1696,32 +1698,32 @@ describe('admin-form.service', () => {
         {
           _id: logicId1,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
         {
           _id: logicId2,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
       ],
     }
 
     const createLogicBody = {
       logicType: LogicType.PreventSubmit,
-    } as ILogicSchema
+    } as LogicDto
 
     const mockFormLogicUpdated = {
       form_logics: [
         {
           _id: logicId1,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
         {
           _id: logicId2,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
         {
           _id: logicId3,
           logicType: LogicType.PreventSubmit,
-        } as ILogicSchema,
+        } as FormLogicSchema,
       ],
     }
 
@@ -1757,7 +1759,7 @@ describe('admin-form.service', () => {
 
     it('should return ok(created logic) on successful form logic create for email mode form', async () => {
       // Arrange
-      CREATE_SPY.mockResolvedValue(mockEmailFormUpdated as IFormSchema)
+      CREATE_SPY.mockResolvedValue(mockEmailFormUpdated as IFormDocument)
 
       // Act
       const actualResult = await createFormLogic(mockEmailForm, createLogicBody)
@@ -1776,7 +1778,7 @@ describe('admin-form.service', () => {
 
     it('should return ok(created logic) on successful form logic create for encrypt mode form', async () => {
       // Arrange
-      CREATE_SPY.mockResolvedValue(mockEncryptFormUpdated as IFormSchema)
+      CREATE_SPY.mockResolvedValue(mockEncryptFormUpdated as IFormDocument)
 
       // Act
       const actualResult = await createFormLogic(
@@ -1798,7 +1800,7 @@ describe('admin-form.service', () => {
 
     it('should return err(FormNotFoundError) if db does not return form object', async () => {
       // Arrange
-      CREATE_SPY.mockResolvedValue(undefined as unknown as IFormSchema)
+      CREATE_SPY.mockResolvedValue(undefined as unknown as IFormDocument)
 
       // Act
       const actualResult = await createFormLogic(
@@ -1822,7 +1824,7 @@ describe('admin-form.service', () => {
         mockEncryptFormUpdated,
         'form_logics',
       )
-      CREATE_SPY.mockResolvedValue(updatedFormWithoutLogic as IFormSchema)
+      CREATE_SPY.mockResolvedValue(updatedFormWithoutLogic as IFormDocument)
 
       // Act
       const actualResult = await createFormLogic(
@@ -1846,7 +1848,7 @@ describe('admin-form.service', () => {
         ...mockEncryptFormUpdated,
         form_logics: [],
       }
-      CREATE_SPY.mockResolvedValue(updatedFormWithEmptyLogic as IFormSchema)
+      CREATE_SPY.mockResolvedValue(updatedFormWithEmptyLogic as IFormDocument)
 
       // Act
       const actualResult = await createFormLogic(
@@ -1999,8 +2001,12 @@ describe('admin-form.service', () => {
     const updateSpy = jest.spyOn(FormModel, 'updateStartPageById')
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_NEW_START_PAGE: StartPage = {
+      colorTheme: Colors.Blue,
       paragraph: 'some paragraph',
       estTimeTaken: 10000000,
+      logo: {
+        state: FormLogoState.Default,
+      },
     }
 
     it('should return updated start page when update is successful', async () => {
@@ -2057,29 +2063,34 @@ describe('admin-form.service', () => {
         {
           _id: logicId1,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
         {
           _id: logicId2,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
       ],
     }
+
+    const updateLogicBody = {
+      _id: String(logicId1),
+      logicType: LogicType.PreventSubmit,
+    } as LogicDto
 
     const updatedLogic = {
       _id: logicId1,
       logicType: LogicType.PreventSubmit,
-    } as ILogicSchema
+    } as FormLogicSchema
 
     const mockFormLogicUpdated = {
       form_logics: [
         {
           _id: logicId1,
           logicType: LogicType.PreventSubmit,
-        } as ILogicSchema,
+        } as FormLogicSchema,
         {
           _id: logicId2,
           logicType: LogicType.ShowFields,
-        } as ILogicSchema,
+        } as FormLogicSchema,
       ],
     }
 
@@ -2121,7 +2132,7 @@ describe('admin-form.service', () => {
       const actualResult = await updateFormLogic(
         mockEmailForm,
         logicId1.toHexString(),
-        updatedLogic,
+        updateLogicBody,
       )
 
       // Assert
@@ -2131,7 +2142,7 @@ describe('admin-form.service', () => {
       expect(UPDATE_SPY).toHaveBeenCalledWith(
         mockEmailForm._id.toHexString(),
         logicId1.toHexString(),
-        updatedLogic,
+        updateLogicBody,
       )
     })
 
@@ -2143,7 +2154,7 @@ describe('admin-form.service', () => {
       const actualResult = await updateFormLogic(
         mockEncryptForm,
         logicId1.toHexString(),
-        updatedLogic,
+        updateLogicBody,
       )
 
       // Assert
@@ -2153,7 +2164,7 @@ describe('admin-form.service', () => {
       expect(UPDATE_SPY).toHaveBeenCalledWith(
         mockEncryptFormId.toHexString(),
         logicId1.toHexString(),
-        updatedLogic,
+        updateLogicBody,
       )
     })
 
@@ -2163,7 +2174,7 @@ describe('admin-form.service', () => {
       const actualResult = await updateFormLogic(
         mockEmailForm,
         wrongLogicId,
-        updatedLogic,
+        updateLogicBody,
       )
 
       // Assert
@@ -2182,7 +2193,7 @@ describe('admin-form.service', () => {
         // Append created field to end of form_fields.
         form_fields: [MOCK_FIELD],
         _id: new ObjectId(),
-      } as IFormSchema
+      } as IFormDocument
 
       // Act
       const actual = await getFormField(MOCK_FORM, String(MOCK_FIELD._id))
@@ -2199,7 +2210,7 @@ describe('admin-form.service', () => {
         // Append created field to end of form_fields.
         form_fields: [],
         _id: new ObjectId(),
-      } as unknown as IFormSchema
+      } as unknown as IFormDocument
       const expectedError = new FieldNotFoundError(
         `Attempted to retrieve field ${MOCK_ID} from ${MOCK_FORM._id} but field was not present`,
       )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -12,7 +12,7 @@ import {
   ResponseMode,
   Status,
 } from 'src/types'
-import { DuplicateFormBody, EditFormFieldParams } from 'src/types/api'
+import { DuplicateFormBodyDto, EditFormFieldParams } from 'src/types/api'
 
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
 
@@ -281,7 +281,7 @@ describe('admin-form.utils', () => {
     it('should return processed props for ResponseMode.Encrypt', async () => {
       // Arrange
       const newAdminId = new ObjectId().toHexString()
-      const params: DuplicateFormBody = {
+      const params: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'some title',
@@ -303,7 +303,7 @@ describe('admin-form.utils', () => {
     it('should return processed props for ResponseMode.Email', async () => {
       // Arrange
       const newAdminId = new ObjectId().toHexString()
-      const params: DuplicateFormBody = {
+      const params: DuplicateFormBodyDto = {
         responseMode: ResponseMode.Email,
         emails: ['some@example.com', 'another@example.com'],
         title: 'some title',
@@ -370,10 +370,9 @@ describe('admin-form.utils', () => {
     it('should return updated fields successfully on duplicate action', async () => {
       // Arrange
       // Remove globalId from duplicate.
-      const duplicateField: FormFieldSchema = omit(
-        cloneDeep(INITIAL_FIELDS[1]),
-        ['globalId'],
-      )
+      const duplicateField = omit(cloneDeep(INITIAL_FIELDS[1]), [
+        'globalId',
+      ]) as FormFieldSchema
       const dupeFieldParams: EditFormFieldParams = {
         action: { name: EditFieldActions.Duplicate },
         field: duplicateField,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1751,7 +1751,9 @@ export const _handleCreateLogic: ControllerHandler<
       .andThen((retrievedForm) =>
         AdminFormService.createFormLogic(retrievedForm, createLogicBody),
       )
-      .map((createdLogic) => res.status(StatusCodes.OK).json(createdLogic))
+      .map((createdLogic) =>
+        res.status(StatusCodes.OK).json(createdLogic as LogicDto),
+      )
       .mapErr((error) => {
         logger.error({
           message: 'Error occurred when creating form logic',
@@ -2000,7 +2002,9 @@ export const _handleUpdateLogic: ControllerHandler<
       .andThen((retrievedForm) =>
         AdminFormService.updateFormLogic(retrievedForm, logicId, updatedLogic),
       )
-      .map((updatedLogic) => res.status(StatusCodes.OK).json(updatedLogic))
+      .map((updatedLogic) =>
+        res.status(StatusCodes.OK).json(updatedLogic as LogicDto),
+      )
       .mapErr((error) => {
         logger.error({
           message: 'Error occurred when updating form logic',

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -44,6 +44,7 @@ import {
   SettingsUpdateDto,
   StartPageUpdateDto,
 } from '../../../../types/api'
+import { DeserializeTransform } from '../../../../types/utils'
 import { createLoggerWithLabel } from '../../../config/logger'
 import MailService from '../../../services/mail/mail.service'
 import { createReqMeta } from '../../../utils/request'
@@ -1074,7 +1075,7 @@ export const handleTransferFormOwnership = [
  */
 export const createForm: ControllerHandler<
   unknown,
-  FormDto | ErrorDto,
+  DeserializeTransform<FormDto> | ErrorDto,
   { form: CreateFormBodyDto }
 > = async (req, res) => {
   const { form: formParams } = req.body
@@ -1087,9 +1088,11 @@ export const createForm: ControllerHandler<
       .andThen((user) =>
         AdminFormService.createForm({ ...formParams, admin: user._id }),
       )
-      .map((createdForm) =>
-        res.status(StatusCodes.OK).json(createdForm as FormDto),
-      )
+      .map((createdForm) => {
+        return res
+          .status(StatusCodes.OK)
+          .json(createdForm as DeserializeTransform<FormDto>)
+      })
       .mapErr((error) => {
         logger.error({
           message: 'Error occurred when creating form',

--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -7,7 +7,7 @@ import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
 import { Router } from 'express'
 
 import { ResponseMode } from '../../../../types'
-import { DuplicateFormBody } from '../../../../types/api'
+import { DuplicateFormBodyDto } from '../../../../types/api'
 import { withUserAuthentication } from '../../auth/auth.middlewares'
 import * as EncryptSubmissionController from '../../submission/encrypt-submission/encrypt-submission.controller'
 
@@ -19,7 +19,7 @@ const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
 
 // Validators
 const duplicateFormValidator = celebrate({
-  [Segments.BODY]: Joi.object<DuplicateFormBody>({
+  [Segments.BODY]: Joi.object<DuplicateFormBodyDto>({
     // Require valid responsesMode field.
     responseMode: Joi.string()
       .valid(...Object.values(ResponseMode))

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -361,24 +361,27 @@ export const transferFormOwnership = (
 export const createForm = (
   formParams: Merge<IForm, { admin: string }>,
 ): ResultAsync<
-  IFormSchema,
+  IFormDocument,
   | DatabaseError
   | DatabaseValidationError
   | DatabaseConflictError
   | DatabasePayloadSizeError
 > => {
-  return ResultAsync.fromPromise(FormModel.create(formParams), (error) => {
-    logger.error({
-      message: 'Database error encountered when creating form',
-      meta: {
-        action: 'createForm',
-        formParams,
-      },
-      error,
-    })
+  return ResultAsync.fromPromise(
+    FormModel.create(formParams) as Promise<IFormDocument>,
+    (error) => {
+      logger.error({
+        message: 'Database error encountered when creating form',
+        meta: {
+          action: 'createForm',
+          formParams,
+        },
+        error,
+      })
 
-    return transformMongoError(error)
-  })
+      return transformMongoError(error)
+    },
+  )
 }
 
 /**

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -10,11 +10,10 @@ import {
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../shared/constants'
 import {
+  FormFieldSchema,
   FormLogicSchema,
   FormLogoState,
-  FormMetaView,
   FormSettings,
-  IFieldSchema,
   IForm,
   IFormDocument,
   IFormSchema,
@@ -24,7 +23,8 @@ import {
   Permission,
 } from '../../../../types'
 import {
-  DuplicateFormBody,
+  AdminDashboardFormMetaDto,
+  DuplicateFormBodyDto,
   EditFormFieldParams,
   EndPageUpdateDto,
   FieldCreateDto,
@@ -89,7 +89,10 @@ type PresignedPostUrlParams = {
  */
 export const getDashboardForms = (
   userId: string,
-): ResultAsync<FormMetaView[], MissingUserError | DatabaseError> => {
+): ResultAsync<
+  AdminDashboardFormMetaDto[],
+  MissingUserError | DatabaseError
+> => {
   // Step 1: Verify user exists.
   return (
     UserService.findUserById(userId)
@@ -225,7 +228,7 @@ export const createPresignedPostUrlForLogos = (
  * @returns List of IDs of MyInfo fields
  */
 export const extractMyInfoFieldIds = (
-  formFields: IFieldSchema[] | undefined,
+  formFields: FormFieldSchema[] | undefined,
 ): string[] => {
   return formFields
     ? formFields
@@ -388,7 +391,7 @@ export const createForm = (
 export const duplicateForm = (
   originalForm: IFormDocument,
   newAdminId: string,
-  overrideParams: DuplicateFormBody,
+  overrideParams: DuplicateFormBodyDto,
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(
     overrideParams,
@@ -439,7 +442,7 @@ export const updateFormField = (
   form: IPopulatedForm,
   fieldId: string,
   newField: FieldUpdateDto,
-): ResultAsync<IFieldSchema, PossibleDatabaseError | FieldNotFoundError> => {
+): ResultAsync<FormFieldSchema, PossibleDatabaseError | FieldNotFoundError> => {
   return ResultAsync.fromPromise(
     form.updateFormFieldById(fieldId, newField),
     (error) => {
@@ -456,7 +459,7 @@ export const updateFormField = (
 
       return transformMongoError(error)
     },
-  ).andThen<IFieldSchema, FieldNotFoundError>((updatedForm) => {
+  ).andThen<FormFieldSchema, FieldNotFoundError>((updatedForm) => {
     if (!updatedForm) {
       return errAsync(new FieldNotFoundError())
     }
@@ -479,7 +482,7 @@ export const duplicateFormField = (
   form: IPopulatedForm,
   fieldId: string,
 ): ResultAsync<
-  IFieldSchema,
+  FormFieldSchema,
   PossibleDatabaseError | FormNotFoundError | FieldNotFoundError
 > => {
   return ResultAsync.fromPromise(
@@ -524,7 +527,7 @@ export const createFormField = (
   form: IPopulatedForm,
   newField: FieldCreateDto,
 ): ResultAsync<
-  IFieldSchema,
+  FormFieldSchema,
   PossibleDatabaseError | FormNotFoundError | FieldNotFoundError
 > => {
   return ResultAsync.fromPromise(form.insertFormField(newField), (error) => {
@@ -563,7 +566,10 @@ export const reorderFormField = (
   form: IPopulatedForm,
   fieldId: string,
   newPosition: number,
-): ResultAsync<IFieldSchema[], PossibleDatabaseError | FieldNotFoundError> => {
+): ResultAsync<
+  FormFieldSchema[],
+  PossibleDatabaseError | FieldNotFoundError
+> => {
   return ResultAsync.fromPromise(
     form.reorderFormFieldById(fieldId, newPosition),
     (error) => {
@@ -1002,7 +1008,7 @@ export const updateEndPage = (
 export const getFormField = (
   form: IPopulatedForm,
   fieldId: string,
-): Result<IFieldSchema, FieldNotFoundError> => {
+): Result<FormFieldSchema, FieldNotFoundError> => {
   const formField = getFormFieldById(form.form_fields, fieldId)
   if (!formField)
     return err(

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -279,7 +279,7 @@ export const transferFormOwnership = (
 
   return (
     // Step 1: Retrieve current owner of form to transfer.
-    UserService.findUserById(currentForm.admin._id)
+    UserService.findUserById(String(currentForm.admin._id))
       .andThen<IUserSchema, TransferOwnershipError>((currentOwner) => {
         // No need to transfer form ownership if new and current owners are
         // the same.

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -10,6 +10,7 @@ import {
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../shared/constants'
 import {
+  FormLogicSchema,
   FormLogoState,
   FormMetaView,
   FormSettings,
@@ -17,7 +18,6 @@ import {
   IForm,
   IFormDocument,
   IFormSchema,
-  ILogicSchema,
   IPopulatedForm,
   IUserSchema,
   LogicDto,
@@ -772,7 +772,7 @@ export const updateFormSettings = (
 export const createFormLogic = (
   form: IPopulatedForm,
   createLogicBody: LogicDto,
-): ResultAsync<ILogicSchema, DatabaseError | FormNotFoundError> => {
+): ResultAsync<FormLogicSchema, DatabaseError | FormNotFoundError> => {
   // Create new form logic
   return ResultAsync.fromPromise(
     FormModel.createFormLogic(form._id, createLogicBody),
@@ -810,7 +810,7 @@ export const deleteFormLogic = (
   form: IPopulatedForm,
   logicId: string,
 ): ResultAsync<
-  IFormSchema,
+  IFormDocument,
   DatabaseError | LogicNotFoundError | FormNotFoundError
 > => {
   // First check if specified logic exists
@@ -864,7 +864,7 @@ export const updateFormLogic = (
   logicId: string,
   updatedLogic: LogicDto,
 ): ResultAsync<
-  ILogicSchema,
+  FormLogicSchema,
   DatabaseError | LogicNotFoundError | FormNotFoundError
 > => {
   // First check if specified logic exists

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -9,7 +9,10 @@ import {
   ResponseMode,
   Status,
 } from '../../../../types'
-import { DuplicateFormBody, EditFormFieldParams } from '../../../../types/api'
+import {
+  DuplicateFormBodyDto,
+  EditFormFieldParams,
+} from '../../../../types/api'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { isPossibleEmailFieldSchema } from '../../../utils/field-validation/field-validation.guards'
 import {
@@ -234,7 +237,7 @@ export const getAssertPermissionFn = (level: PermissionLevel): AssertFormFn => {
  * @returns override props for use in duplicating a form
  */
 export const processDuplicateOverrideProps = (
-  params: DuplicateFormBody,
+  params: DuplicateFormBodyDto,
   newAdminId: string,
 ): OverrideProps => {
   const { responseMode, title } = params

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,7 +1,7 @@
 import {
+  FormFieldSchema,
   FormLogicSchema,
   IEncryptedFormSchema,
-  IFieldSchema,
   IFormSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
@@ -88,8 +88,8 @@ export const isEmailModeForm = (
  */
 export const getFormFieldById = (
   formFields: IFormSchema['form_fields'],
-  fieldId: IFieldSchema['_id'],
-): IFieldSchema | null => {
+  fieldId: FormFieldSchema['_id'],
+): FormFieldSchema | null => {
   if (!formFields) {
     return null
   }

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,8 +1,8 @@
 import {
+  FormLogicSchema,
   IEncryptedFormSchema,
   IFieldSchema,
   IFormSchema,
-  ILogicSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
   Permission,
@@ -109,8 +109,8 @@ export const getFormFieldById = (
  */
 export const getLogicById = (
   form_logics: IFormSchema['form_logics'],
-  logicId: ILogicSchema['_id'],
-): ILogicSchema | null => {
+  logicId: FormLogicSchema['_id'],
+): FormLogicSchema | null => {
   if (!form_logics) {
     return null
   }

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -4,7 +4,8 @@ import { err } from 'neverthrow'
 import querystring from 'querystring'
 import { UnreachableCaseError } from 'ts-essentials'
 
-import { AuthType } from '../../../../types'
+import { FormFieldDto } from '../../../../../shared/types/field'
+import { AuthType, PublicFormDto } from '../../../../types'
 import {
   ErrorDto,
   PrivateFormErrorDto,
@@ -261,7 +262,7 @@ export const handleGetPublicForm: ControllerHandler<
   }
 
   const form = formResult.value
-  const publicForm = form.getPublicView()
+  const publicForm = form.getPublicView() as PublicFormDto
   const { authType } = form
   const isIntranetUser = FormService.checkIsIntranetFormAccess(
     getRequestIp(req),
@@ -333,7 +334,10 @@ export const handleGetPublicForm: ControllerHandler<
               )
               .json({
                 spcpSession,
-                form: { ...publicForm, form_fields: prefilledFields },
+                form: {
+                  ...publicForm,
+                  form_fields: prefilledFields as FormFieldDto[],
+                },
                 isIntranetUser,
               })
           })

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -158,7 +158,7 @@ export const updateUserContact = (
     if (!admin) {
       return errAsync(new MissingUserError())
     }
-    return okAsync(admin)
+    return okAsync(admin as IPopulatedUser)
   })
 }
 
@@ -201,7 +201,7 @@ export const getPopulatedUserById = (
       })
       return errAsync(new MissingUserError())
     }
-    return okAsync(retrievedUser)
+    return okAsync(retrievedUser as IPopulatedUser)
   })
 }
 

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios').default
 const values = require('lodash/values')
+const range = require('lodash/range')
 const cloneDeep = require('lodash/cloneDeep')
 
 const UserService = require('../../../../services/UserService')
@@ -16,7 +17,7 @@ const { uploadImage } = require('../../../../services/FileHandlerService')
 const {
   DateSelectedValidation: DateValidationOptions,
 } = require('../../../../../shared/constants')
-const { Rating, RatingShape } = require('../../../../../types')
+const { RatingShape } = require('../../../../../types')
 const CancelToken = axios.CancelToken
 
 const EMAIL_MODE_ALLOWED_SIZES = ['1', '2', '3', '7']
@@ -158,7 +159,7 @@ function EditFieldsModalController(
     }
   }
 
-  vm.ratingSteps = Rating
+  vm.ratingSteps = range(1, 11).map(String)
   vm.ratingShapes = Object.values(RatingShape)
 
   vm.showDuplicateOptionsError = function (field) {

--- a/src/public/services/AdminViewFormService.ts
+++ b/src/public/services/AdminViewFormService.ts
@@ -1,7 +1,10 @@
 import axios from 'axios'
 
-import { FormViewDto } from '../..//types/api'
-import { FormMetaView, PublicForm } from '../../types'
+import {
+  AdminDashboardFormMetaDto,
+  AdminFormViewDto,
+  PreviewFormViewDto,
+} from '../../../shared/types/form/form'
 
 // endpoint exported for testing
 export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
@@ -11,9 +14,11 @@ export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
  * owns or collaborates on
  * @returns Metadata required for forms on dashboard view
  */
-export const getDashboardView = async (): Promise<FormMetaView[]> => {
+export const getDashboardView = async (): Promise<
+  AdminDashboardFormMetaDto[]
+> => {
   return axios
-    .get<FormMetaView[]>(`${ADMIN_FORM_ENDPOINT}`)
+    .get<AdminDashboardFormMetaDto[]>(`${ADMIN_FORM_ENDPOINT}`)
     .then(({ data }) => data)
 }
 
@@ -24,9 +29,9 @@ export const getDashboardView = async (): Promise<FormMetaView[]> => {
  */
 export const getAdminFormView = async (
   formId: string,
-): Promise<FormViewDto> => {
+): Promise<AdminFormViewDto> => {
   return axios
-    .get<FormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+    .get<AdminFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
     .then(({ data }) => data)
 }
 
@@ -38,8 +43,8 @@ export const getAdminFormView = async (
  */
 export const previewForm = async (
   formId: string,
-): Promise<{ form: PublicForm }> => {
+): Promise<PreviewFormViewDto> => {
   return axios
-    .get<{ form: PublicForm }>(`${ADMIN_FORM_ENDPOINT}/${formId}/preview`)
+    .get<PreviewFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}/preview`)
     .then(({ data }) => data)
 }

--- a/src/public/services/CreateFormService.ts
+++ b/src/public/services/CreateFormService.ts
@@ -1,9 +1,12 @@
 import axios from 'axios'
 
-import { FormMetaView, IForm, IFormSchema } from '../../types'
-import { DuplicateFormBody } from '../../types/api'
+import {
+  AdminDashboardFormMetaDto,
+  CreateFormBodyDto,
+  DuplicateFormBodyDto,
+  FormDto,
+} from '../../../shared/types/form/form'
 
-// endpoints exported for testing
 export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
 
 /**
@@ -14,10 +17,10 @@ export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
  */
 export const duplicateForm = async (
   formId: string,
-  duplicateFormBody: DuplicateFormBody,
-): Promise<FormMetaView> => {
+  duplicateFormBody: DuplicateFormBodyDto,
+): Promise<AdminDashboardFormMetaDto> => {
   return axios
-    .post<FormMetaView>(
+    .post<AdminDashboardFormMetaDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/duplicate`,
       duplicateFormBody,
     )
@@ -30,9 +33,9 @@ export const duplicateForm = async (
  * @returns Newly created form.
  */
 export const createForm = async (
-  newForm: Omit<IForm, 'admin'>,
-): Promise<IFormSchema> => {
+  newForm: CreateFormBodyDto,
+): Promise<FormDto> => {
   return axios
-    .post<IFormSchema>(`${ADMIN_FORM_ENDPOINT}`, { form: newForm })
+    .post<FormDto>(`${ADMIN_FORM_ENDPOINT}`, { form: newForm })
     .then(({ data }) => data)
 }

--- a/src/public/services/ExamplesService.ts
+++ b/src/public/services/ExamplesService.ts
@@ -1,8 +1,11 @@
 import axios from 'axios'
 
-import { FormMetaView, PublicForm } from '../../types'
 import {
-  DuplicateFormBody,
+  AdminDashboardFormMetaDto,
+  DuplicateFormBodyDto,
+  PreviewFormViewDto,
+} from '../../../shared/types/form/form'
+import {
   ExampleFormsQueryDto,
   ExampleFormsResult,
   ExampleSingleFormResult,
@@ -48,10 +51,10 @@ export const getSingleExampleForm = (
  */
 export const useTemplate = async (
   formId: string,
-  overrideParams: DuplicateFormBody,
-): Promise<FormMetaView> => {
+  overrideParams: DuplicateFormBodyDto,
+): Promise<AdminDashboardFormMetaDto> => {
   return axios
-    .post<FormMetaView>(`${formId}/adminform/copy`, overrideParams)
+    .post<AdminDashboardFormMetaDto>(`${formId}/adminform/copy`, overrideParams)
     .then(({ data }) => data)
 }
 
@@ -62,8 +65,8 @@ export const useTemplate = async (
  */
 export const queryTemplate = async (
   formId: string,
-): Promise<{ form: PublicForm }> => {
+): Promise<PreviewFormViewDto> => {
   return axios
-    .get<{ form: PublicForm }>(`${formId}/adminform/template`)
+    .get<PreviewFormViewDto>(`${formId}/adminform/template`)
     .then(({ data }) => data)
 }

--- a/src/public/services/PublicFormService.ts
+++ b/src/public/services/PublicFormService.ts
@@ -1,9 +1,9 @@
 import axios from 'axios'
 
+import { PublicFormViewDto } from '../../../shared/types/form/form'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
-  PublicFormViewDto,
   SubmissionResponseDto,
 } from '../../types/api'
 import { createEmailSubmissionFormData } from '../utils/submission'

--- a/src/public/services/UpdateFormService.ts
+++ b/src/public/services/UpdateFormService.ts
@@ -1,17 +1,23 @@
 import axios from 'axios'
 
-import { FormSettings, IPopulatedForm, LogicDto } from '../../types'
+import {
+  FieldCreateDto,
+  FormFieldDto,
+  FormFieldWithId,
+} from '../../../shared/types/field'
+import {
+  AdminFormDto,
+  AdminFormViewDto,
+  FormSettings,
+  SettingsUpdateDto,
+} from '../../../shared/types/form/form'
+import { LogicDto } from '../../../shared/types/form/form_logic'
 import {
   EmailSubmissionDto,
   EncryptSubmissionDto,
   EndPageUpdateDto,
-  FieldCreateDto,
-  FieldUpdateDto,
-  FormFieldDto,
   FormUpdateParams,
-  FormViewDto,
   PermissionsUpdateDto,
-  SettingsUpdateDto,
   StartPageUpdateDto,
   SubmissionResponseDto,
 } from '../../types/api'
@@ -44,10 +50,10 @@ export const getSingleFormField = async (
 export const updateSingleFormField = async (
   formId: string,
   fieldId: string,
-  updateFieldBody: FieldUpdateDto,
-): Promise<FieldUpdateDto> => {
+  updateFieldBody: FormFieldDto,
+): Promise<FormFieldDto> => {
   return axios
-    .put<FieldUpdateDto>(
+    .put<FormFieldDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`,
       updateFieldBody,
     )
@@ -57,7 +63,7 @@ export const updateSingleFormField = async (
 export const createSingleFormField = async (
   formId: string,
   createFieldBody: FieldCreateDto,
-): Promise<FormFieldDto> => {
+): Promise<FormFieldWithId> => {
   return axios
     .post<FormFieldDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/fields`,
@@ -289,9 +295,9 @@ export const deleteForm = async (
 export const updateForm = async (
   formId: string,
   update: FormUpdateParams,
-): Promise<IPopulatedForm> => {
+): Promise<AdminFormDto> => {
   return axios
-    .put<IPopulatedForm>(`${formId}/adminform`, { form: update })
+    .put<AdminFormDto>(`${formId}/adminform`, { form: update })
     .then(({ data }) => data)
 }
 
@@ -303,9 +309,9 @@ export const updateForm = async (
 export const transferOwner = async (
   formId: string,
   newOwnerEmail: string,
-): Promise<FormViewDto> => {
+): Promise<AdminFormViewDto> => {
   return axios
-    .post<FormViewDto>(
+    .post<AdminFormViewDto>(
       `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators/transfer-owner`,
       { email: newOwnerEmail },
     )

--- a/src/public/services/__tests__/AdminViewFormService.test.ts
+++ b/src/public/services/__tests__/AdminViewFormService.test.ts
@@ -1,13 +1,12 @@
 import MockAxios from 'jest-mock-axios'
 
-import { IPopulatedUser } from 'src/types'
-import {
-  FormMetaView,
-  IPopulatedForm,
-  PublicForm,
-  ResponseMode,
-} from 'src/types/form'
+import { IPopulatedForm, PublicForm, ResponseMode } from 'src/types/form'
 
+import {
+  AdminDashboardFormMetaDto,
+  FormStatus,
+} from '../../../../shared/types/form/form'
+import { UserDto } from '../../../../shared/types/user'
 import {
   ADMIN_FORM_ENDPOINT,
   getAdminFormView,
@@ -19,20 +18,21 @@ jest.mock('axios', () => MockAxios)
 
 const MOCK_USER = {
   _id: 'mock-user-id',
-} as IPopulatedUser
+} as UserDto
 
 describe('AdminViewFormService', () => {
   afterEach(() => MockAxios.reset())
   describe('getDashboardView', () => {
     it('should successfully return all available forms if GET request succeeds', async () => {
       // Arrange
-      const expected: FormMetaView[] = [
+      const expected: AdminDashboardFormMetaDto[] = [
         {
           title: 'title',
           lastModified: new Date(),
           _id: 'mock-form-id',
           responseMode: ResponseMode.Email,
           admin: MOCK_USER,
+          status: FormStatus.Private,
         },
       ]
       MockAxios.get.mockResolvedValueOnce({ data: expected })
@@ -46,7 +46,7 @@ describe('AdminViewFormService', () => {
 
     it('should successfully return empty array if GET request succeeds and there are no forms', async () => {
       // Arrange
-      const expected: FormMetaView[] = []
+      const expected: AdminDashboardFormMetaDto[] = []
       MockAxios.get.mockResolvedValueOnce({ data: expected })
 
       // Act

--- a/src/public/services/__tests__/CreateFormService.test.ts
+++ b/src/public/services/__tests__/CreateFormService.test.ts
@@ -1,8 +1,12 @@
 import { ObjectId } from 'bson'
 import MockAxios from 'jest-mock-axios'
 
+import {
+  CreateEmailFormBodyDto,
+  CreateStorageFormBodyDto,
+  DuplicateFormBodyDto,
+} from '../../../../shared/types/form/form'
 import { IPopulatedUser, IYesNoFieldSchema } from '../../../types'
-import { DuplicateFormBody } from '../../../types/api'
 import { ResponseMode } from '../../../types/form'
 import {
   ADMIN_FORM_ENDPOINT,
@@ -69,46 +73,48 @@ describe('CreateFormService', () => {
     it('should return created form if POST request succeeds', async () => {
       // Arrange
       const expected = { form_fields: [{} as IYesNoFieldSchema] }
-      const MOCK_FORM_PARAMS = {
+      const mockFormParams: CreateStorageFormBodyDto = {
         title: 'title',
-        responseMode: ResponseMode.Email,
+        responseMode: ResponseMode.Encrypt,
+        publicKey: 'test',
       }
       MockAxios.post.mockResolvedValueOnce({ data: expected })
 
       // Act
-      const actual = await createForm(MOCK_FORM_PARAMS)
+      const actual = await createForm(mockFormParams)
 
       // Assert
       expect(actual).toEqual(expected)
       expect(MockAxios.post).toHaveBeenCalledWith(`${ADMIN_FORM_ENDPOINT}`, {
-        form: MOCK_FORM_PARAMS,
+        form: mockFormParams,
       })
     })
 
     it('should reject with error message if POST request fails', async () => {
       // Arrange
       const expected = new Error('error')
-      const MOCK_FORM_PARAMS = {
+      const mockFormParams: CreateEmailFormBodyDto = {
         title: 'title',
         responseMode: ResponseMode.Email,
+        emails: ['mock'],
       }
       MockAxios.post.mockRejectedValueOnce(expected)
       // Act
-      const actualPromise = createForm(MOCK_FORM_PARAMS)
+      const actualPromise = createForm(mockFormParams)
 
       // Assert
       await expect(actualPromise).rejects.toEqual(expected)
       expect(MockAxios.post).toHaveBeenCalledWith(`${ADMIN_FORM_ENDPOINT}`, {
-        form: MOCK_FORM_PARAMS,
+        form: mockFormParams,
       })
     })
   })
 })
 
-const _generateDuplicateFormBody = (): DuplicateFormBody => {
+const _generateDuplicateFormBody = (): DuplicateFormBodyDto => {
   return {
     title: 'title',
     responseMode: ResponseMode.Email,
     emails: 'test@example.com',
-  } as DuplicateFormBody
+  } as DuplicateFormBodyDto
 }

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -159,9 +159,10 @@ const getPreventSubmitConditions = (
   const formFieldIds = new Set(
     form.form_fields?.map((field) => String(field._id)),
   )
+
   const preventFormLogics =
     form.form_logics?.filter(
-      (formLogic) =>
+      (formLogic): formLogic is IPreventSubmitLogicSchema =>
         isPreventSubmitLogic(formLogic) &&
         allConditionsExist(formLogic.conditions, formFieldIds),
     ) ?? []

--- a/src/types/agency.ts
+++ b/src/types/agency.ts
@@ -9,6 +9,7 @@ export type PublicAgency = PublicAgencyDto
 export type AgencyInstanceMethods = PublicView<PublicAgency>
 
 export interface IAgencySchema extends AgencyBase {
+  _id: any
   created?: Date
   lastModified?: Date
 }

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -1,56 +1,30 @@
-import { LeanDocument } from 'mongoose'
-import { ConditionalPick, PartialDeep, Primitive } from 'type-fest'
-
-import { FormField, FormFieldSchema, FormFieldWithId } from '../field'
-import {
-  EndPage,
-  FormSettings,
-  IForm,
-  IPopulatedForm,
-  Permission,
-  ResponseMode,
-  StartPage,
-} from '../form'
+import { IForm } from '../form'
 
 import { EditFormFieldParams } from './field'
 
-export { PublicFormViewDto } from '../../../shared/types/form/form'
-
-export type SettingsUpdateDto = PartialDeep<FormSettings>
-
-export type FieldUpdateDto = FormFieldWithId
-
-export type FieldCreateDto = FormField
+export {
+  FieldCreateDto,
+  FieldUpdateDto,
+  FormFieldDto,
+} from '../../../shared/types/field'
+export {
+  AdminDashboardFormMetaDto,
+  AdminFormViewDto,
+  CreateFormBodyDto,
+  DuplicateFormBodyDto,
+  EndPageUpdateDto,
+  FormDto,
+  PermissionsUpdateDto,
+  PublicFormViewDto,
+  SettingsUpdateDto,
+  StartPageUpdateDto,
+  PreviewFormViewDto,
+} from '../../../shared/types/form/form'
 
 /**
- * Form field POJO with functions removed
+ * @deprecated not used anymore, this is for the old
+ * PUT /:formId/adminform endpoint.
  */
-export type FormFieldDto = ConditionalPick<
-  LeanDocument<FormFieldSchema>,
-  Primitive
->
-
-export type PermissionsUpdateDto = Permission[]
-
-export type EndPageUpdateDto = EndPage
-
-export type StartPageUpdateDto = StartPage
-
-export type FormViewDto = { form: IPopulatedForm }
-
-export type DuplicateFormBody = {
-  title: string
-} & (
-  | {
-      responseMode: ResponseMode.Email
-      emails: string | string[]
-    }
-  | {
-      responseMode: ResponseMode.Encrypt
-      publicKey: string
-    }
-)
-
 export type FormUpdateParams = {
   editFormField?: EditFormFieldParams
   authType?: IForm['authType']

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -1,26 +1,20 @@
 import { LeanDocument } from 'mongoose'
 import { ConditionalPick, PartialDeep, Primitive } from 'type-fest'
 
-import {
-  FormField,
-  FormFieldSchema,
-  FormFieldWithId,
-  IFieldSchema,
-  IPossiblyPrefilledField,
-} from '../field'
+import { FormField, FormFieldSchema, FormFieldWithId } from '../field'
 import {
   EndPage,
   FormSettings,
   IForm,
   IPopulatedForm,
   Permission,
-  PublicForm,
   ResponseMode,
   StartPage,
 } from '../form'
-import { SpcpSession } from '../spcp'
 
 import { EditFormFieldParams } from './field'
+
+export { PublicFormViewDto } from '../../../shared/types/form/form'
 
 export type SettingsUpdateDto = PartialDeep<FormSettings>
 
@@ -69,17 +63,4 @@ export type FormUpdateParams = {
   status?: IForm['status']
   title?: IForm['title']
   webhook?: IForm['webhook']
-}
-
-// NOTE: This is needed because PublicForm inherits from IFormDocument (where form_fields has type of IFieldSchema).
-// However, the form returned back to the client has form_field of two possible types
-interface PossiblyPrefilledPublicForm extends Omit<PublicForm, 'form_fields'> {
-  form_fields: IPossiblyPrefilledField[] | IFieldSchema[]
-}
-
-export type PublicFormViewDto = {
-  form: PossiblyPrefilledPublicForm
-  spcpSession?: SpcpSession
-  isIntranetUser?: boolean
-  myInfoError?: true
 }

--- a/src/types/field/index.ts
+++ b/src/types/field/index.ts
@@ -4,7 +4,7 @@ import { ConditionalExcept, Merge } from 'type-fest'
 import {
   BasicField,
   FormField,
-  FormFieldDto,
+  FormFieldWithId,
   MyInfoAttribute,
 } from '../../../shared/types/field'
 

--- a/src/types/field/index.ts
+++ b/src/types/field/index.ts
@@ -4,7 +4,7 @@ import { ConditionalExcept, Merge } from 'type-fest'
 import {
   BasicField,
   FormField,
-  FormFieldWithId,
+  FormFieldDto,
   MyInfoAttribute,
 } from '../../../shared/types/field'
 

--- a/src/types/field/myinfoField.ts
+++ b/src/types/field/myinfoField.ts
@@ -1,7 +1,7 @@
 import { LeanDocument } from 'mongoose'
 
-import { IFieldSchema } from '../field'
+import { FormFieldSchema } from '../field'
 
-export interface IPossiblyPrefilledField extends LeanDocument<IFieldSchema> {
+export type IPossiblyPrefilledField = LeanDocument<FormFieldSchema> & {
   fieldValue?: string
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,5 +1,5 @@
 import { Document, LeanDocument, Model, ToObjectOptions, Types } from 'mongoose'
-import { Merge, SetRequired } from 'type-fest'
+import { Merge, SetOptional } from 'type-fest'
 
 import {
   AdminDashboardFormMetaDto,
@@ -68,18 +68,42 @@ export type FormOtpData = {
 
 export type Permission = FormPermission
 
-export interface IForm extends FormBase {
-  // Loosen types here to allow for IPopulatedForm extension
-  admin: any
-  permission?: Permission[]
-  form_fields?: FormFieldSchema[]
-  form_logics?: FormLogicSchema[]
+/**
+ * Keys with defaults in schema.
+ */
+type FormDefaultableKey =
+  | 'form_fields'
+  | 'form_logics'
+  | 'permissionList'
+  | 'startPage'
+  | 'endPage'
+  | 'hasCaptcha'
+  | 'authType'
+  | 'status'
+  | 'inactiveMessage'
+  | 'submissionLimit'
+  | 'isListed'
+  | 'webhook'
 
-  publicKey?: string
-  // string type is allowed due to a setter on the form schema that transforms
-  // strings to string array.
-  emails?: string[] | string
-}
+export type IForm = Merge<
+  SetOptional<FormBase, FormDefaultableKey>,
+  {
+    // Loosen types here to allow for IPopulatedForm extension
+    admin: any
+    permission?: Permission[]
+    form_fields?: FormFieldSchema[]
+    form_logics?: FormLogicSchema[]
+
+    webhook?: Partial<FormBase['webhook']>
+    startPage?: Partial<FormBase['startPage']>
+    endPage?: Partial<FormBase['endPage']>
+
+    publicKey?: string
+    // string type is allowed due to a setter on the form schema that transforms
+    // strings to string array.
+    emails?: string[] | string
+  }
+>
 
 /**
  * Typing for duplicate form with specific keys.
@@ -99,6 +123,9 @@ export type PickDuplicateForm = Pick<
 export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   form_fields?: Types.DocumentArray<FormFieldSchema> | FormFieldSchema[]
   form_logics?: Types.DocumentArray<FormLogicSchema> | FormLogicSchema[]
+
+  created?: Date
+  lastModified?: Date
 
   /**
    * Replaces the field corresponding to given id to given new field
@@ -201,12 +228,9 @@ export interface IFormDocument extends IFormSchema {
   // Hence, using Exclude here over NonNullable.
   submissionLimit: Exclude<IFormSchema['submissionLimit'], undefined>
   isListed: NonNullable<IFormSchema['isListed']>
-  startPage: SetRequired<NonNullable<IFormSchema['startPage']>, 'colorTheme'>
-  endPage: SetRequired<
-    NonNullable<IFormSchema['endPage']>,
-    'title' | 'buttonText'
-  >
-  webhook: SetRequired<NonNullable<IFormSchema['webhook']>, 'url'>
+  startPage: Required<NonNullable<IFormSchema['startPage']>>
+  endPage: Required<NonNullable<IFormSchema['endPage']>>
+  webhook: Required<NonNullable<IFormSchema['webhook']>>
 }
 
 export interface IPopulatedForm extends Omit<IFormDocument, 'toJSON'> {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -12,7 +12,7 @@ import {
   IFieldSchema,
   MyInfoAttribute,
 } from './field'
-import { ILogicSchema, LogicDto } from './form_logic'
+import { FormLogicSchema, ILogicSchema, LogicDto } from './form_logic'
 import { ICustomFormLogo, IFormLogo } from './form_logo'
 import { IPopulatedUser, IUserSchema, PublicUser } from './user'
 
@@ -167,7 +167,7 @@ export type FormSettings = Pick<
 
 export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   form_fields?: Types.DocumentArray<FormFieldSchema> | FormFieldSchema[]
-  form_logics?: Types.DocumentArray<ILogicSchema> | ILogicSchema[]
+  form_logics?: Types.DocumentArray<FormLogicSchema> | FormLogicSchema[]
 
   /**
    * Replaces the field corresponding to given id to given new field
@@ -314,8 +314,11 @@ export interface IFormModel extends Model<IFormSchema> {
   createFormLogic(
     formId: string,
     createLogicBody: LogicDto,
-  ): Promise<IFormSchema | null>
-  deleteFormLogic(formId: string, logicId: string): Promise<IFormSchema | null>
+  ): Promise<IFormDocument | null>
+  deleteFormLogic(
+    formId: string,
+    logicId: string,
+  ): Promise<IFormDocument | null>
 
   /**
    * Deletes specified form field by its id from the form corresponding to given form id.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -2,6 +2,7 @@ import { Document, LeanDocument, Model, ToObjectOptions, Types } from 'mongoose'
 import { Merge, SetRequired } from 'type-fest'
 
 import {
+  AdminDashboardFormMetaDto,
   EmailFormSettings,
   FormAuthType,
   FormBase,
@@ -65,9 +66,7 @@ export type FormOtpData = {
   msgSrvcName?: string
 }
 
-export interface Permission extends FormPermission {
-  _id?: string
-}
+export type Permission = FormPermission
 
 export interface IForm extends FormBase {
   // Loosen types here to allow for IPopulatedForm extension
@@ -155,7 +154,7 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
    * @param admin the admin to inject into the returned object
    * @returns dashboard form view object
    */
-  getDashboardView(admin: IPopulatedUser): FormMetaView
+  getDashboardView(admin: IPopulatedUser): AdminDashboardFormMetaDto
   getUniqueMyInfoAttrs(): MyInfoAttribute[]
   /**
    * Retrieve form settings.
@@ -269,7 +268,7 @@ export interface IFormModel extends Model<IFormSchema> {
   getMetaByUserIdOrEmail(
     userId: IUserSchema['_id'],
     userEmail: IUserSchema['email'],
-  ): Promise<FormMetaView[]>
+  ): Promise<AdminDashboardFormMetaDto[]>
 
   /**
    * Update the end page of form with given endpage object.
@@ -302,11 +301,3 @@ export interface IFormModel extends Model<IFormSchema> {
 
 export type IEncryptedFormModel = IFormModel & Model<IEncryptedFormSchema>
 export type IEmailFormModel = IFormModel & Model<IEmailFormSchema>
-
-/** Typing for the shape of the important meta subset for form document. */
-export type FormMetaView = Pick<
-  IFormSchema,
-  'title' | 'lastModified' | 'status' | '_id' | 'responseMode'
-> & {
-  admin: IPopulatedUser
-}

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -1,56 +1,53 @@
 import { Document } from 'mongoose'
 
+import {
+  FormCondition,
+  FormLogicBase,
+  LogicConditionState,
+  LogicDto,
+  LogicIfValue,
+  LogicType,
+  PreventSubmitLogic,
+  ShowFieldLogic,
+} from '../../shared/types/form/form_logic'
+
 import { BasicField, IFieldSchema } from './field'
 
-export enum LogicConditionState {
-  Equal = 'is equals to',
-  Lte = 'is less than or equal to',
-  Gte = 'is more than or equal to',
-  Either = 'is either',
-}
+export { LogicConditionState, LogicIfValue, LogicType, LogicDto }
 
-export enum LogicIfValue {
-  Number = 'number',
-  SingleSelect = 'single-select',
-  MultiSelect = 'multi-select',
-}
-
-export enum LogicType {
-  ShowFields = 'showFields',
-  PreventSubmit = 'preventSubmit',
-}
-
-export interface ICondition {
+export interface ICondition extends FormCondition {
   field: IFieldSchema['_id']
-  state: LogicConditionState
-  value: string | number | string[] | number[]
-  ifValueType?: LogicIfValue
 }
 
 // Override ObjectId with String type since the field id passed in is in
 // String form.
 export interface IConditionSchema extends ICondition, Document<string> {}
 
-export interface ILogic {
+export type ILogic = FormLogicBase
+
+export interface ILogicSchema extends ILogic, Document {
   conditions: IConditionSchema[]
-  logicType: LogicType
 }
 
-export interface ILogicSchema extends ILogic, Document {}
-
-export interface IShowFieldsLogic extends ILogic {
-  show: IFieldSchema['_id'][]
+export type IShowFieldsLogic = ShowFieldLogic
+export interface IShowFieldsLogicSchema
+  extends ILogicSchema,
+    IShowFieldsLogic,
+    Document {
+  logicType: LogicType.ShowFields
+  conditions: IConditionSchema[]
 }
 
-export interface IShowFieldsLogicSchema extends IShowFieldsLogic, Document {}
-
-export interface IPreventSubmitLogic extends ILogic {
-  preventSubmitMessage?: string
-}
-
+export type IPreventSubmitLogic = PreventSubmitLogic
 export interface IPreventSubmitLogicSchema
-  extends IPreventSubmitLogic,
-    Document {}
+  extends ILogicSchema,
+    IPreventSubmitLogic,
+    Document {
+  logicType: LogicType.PreventSubmit
+  conditions: IConditionSchema[]
+}
+
+export type FormLogicSchema = IShowFieldsLogicSchema | IPreventSubmitLogicSchema
 
 type LogicField = Extract<
   BasicField,
@@ -106,8 +103,3 @@ export type LogicCondition =
   | CategoricalLogicCondition
   | BinaryLogicCondition
   | NumericalLogicCondition
-
-/**
- * Logic POJO with functions removed
- */
-export type LogicDto = ILogic & { _id?: Document['_id'] }

--- a/src/types/form_logo.ts
+++ b/src/types/form_logo.ts
@@ -1,22 +1,17 @@
 import { Document } from 'mongoose'
 
-export enum FormLogoState {
-  Default = 'DEFAULT',
-  None = 'NONE',
-  Custom = 'CUSTOM',
-}
+import {
+  CustomFormLogo,
+  FormLogoBase,
+  FormLogoState,
+} from '../../shared/types/form/form_logo'
 
-export interface IFormLogo {
-  state: FormLogoState
-}
+export { FormLogoState }
+
+export type IFormLogo = FormLogoBase
 
 export type IFormLogoSchema = IFormLogo & Document
 
-export interface ICustomFormLogo extends IFormLogo {
-  state: FormLogoState.Custom
-  fileId: string
-  fileName: string
-  fileSizeInBytes: number
-}
+export type ICustomFormLogo = CustomFormLogo
 
 export type ICustomFormLogoSchema = ICustomFormLogo & Document

--- a/src/types/spcp.ts
+++ b/src/types/spcp.ts
@@ -1,6 +1,1 @@
-export interface SpcpSession {
-  userName: string
-  iat?: number // Optional as these are not returned for MyInfo forms
-  rememberMe?: boolean
-  exp?: number
-}
+export { SpcpSession } from '../../shared/types/form/form'

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -45,6 +45,6 @@ export interface IUserModel extends Model<IUserSchema> {
 }
 
 export interface IPopulatedUser extends IUserSchema {
-  _id: ObjectId
+  _id: any
   agency: AgencyDocument
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,10 @@
-import { Document, Model, ObjectId } from 'mongoose'
+import { ObjectId } from 'bson-ext'
+import { Document, Model } from 'mongoose'
+import { SetOptional } from 'type-fest'
 
-import { AgencyDocument, PublicAgency } from './agency'
+import { UserBase } from '../../shared/types/user'
+
+import { AgencyDocument, IAgencySchema, PublicAgency } from './agency'
 import { PublicView } from './database'
 
 export type PublicUser = {
@@ -11,22 +15,14 @@ export type AdminContactOtpData = {
   admin: IUserSchema['_id']
 }
 
-export interface IUser {
-  email: string
-  agency: AgencyDocument['_id']
-  contact?: string
-  betaFlags?: {
-    sgid?: boolean
-  }
-  lastAccessed?: Date
-  updatedAt?: Date
+export interface IUser
+  extends SetOptional<UserBase, 'created' | 'lastAccessed' | 'updatedAt'> {
+  agency: IAgencySchema['_id']
 }
 
 export type UserContactView = Pick<IUser, 'email' | 'contact'>
 
-export interface IUserSchema extends IUser, Document, PublicView<PublicUser> {
-  created?: Date
-}
+export interface IUserSchema extends IUser, Document, PublicView<PublicUser> {}
 
 export interface IUserModel extends Model<IUserSchema> {
   /**
@@ -49,5 +45,6 @@ export interface IUserModel extends Model<IUserSchema> {
 }
 
 export interface IPopulatedUser extends IUserSchema {
+  _id: ObjectId
   agency: AgencyDocument
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,1 +1,15 @@
+import { DateString } from '../../shared/types/generic'
+
 export type ExtractTypeFromArray<T> = T extends readonly (infer E)[] ? E : T
+
+/**
+ * Helper type to transform DTO types back to their serialized types.
+ * Currently only used to cast DateStrings back to Date types.
+ *
+ * This is useful to transform shared DTO types back to their backend types
+ * for typing express controller return types, relying on implicit
+ * JSON.parse(JSON.stringify()) conversions between client and server.
+ */
+export type DeserializeTransform<T> = {
+  [K in keyof T]: T[K] extends DateString ? Date : T[K]
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Continuation from #2355, this PR moves the form and form sub types (form logic, form, public form slices) to the new shared folder.

Related to #2066

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
  - Pure refactor
