### PR TITLE
feat: part two of checkbox logic - adaptor functions

### DIFF
--- a/src/public/modules/forms/services/form-logic/__tests__/form-logic-checkbox.client.service.spec.ts
+++ b/src/public/modules/forms/services/form-logic/__tests__/form-logic-checkbox.client.service.spec.ts
@@ -1,0 +1,123 @@
+import { LogicCheckboxCondition } from '../../../../../../types'
+import {
+  ClientCheckboxCondition,
+  convertArrayCheckboxCondition,
+  convertObjectCheckboxCondition,
+} from '../form-logic-checkbox.client.service'
+
+describe('convertObjectCheckboxCondition', () => {
+  describe('condition value with object representation', () => {
+    const OPTIONS = ['Option 1', 'Option 2', 'Option 3']
+    it('should correctly convert condition value with others true into array representation', () => {
+      // Arrange
+      const conditionWithObjectRepresentation = {
+        value: [
+          {
+            options: [OPTIONS[0], OPTIONS[2]],
+            others: true,
+          },
+        ],
+      } as unknown as LogicCheckboxCondition // only care about the value portion of the condition
+      const expected = {
+        value: [
+          [
+            { value: OPTIONS[0], other: false },
+            { value: OPTIONS[2], other: false },
+            { value: 'Others', other: true },
+          ],
+        ],
+      }
+
+      // Act
+      const transformed = convertObjectCheckboxCondition(
+        conditionWithObjectRepresentation,
+      )
+
+      // Assert
+      expect(transformed.value.length).toEqual(1) // should only have one condition
+      expect(new Set(transformed.value[0])).toEqual(new Set(expected.value[0]))
+    })
+    it('should correctly convert condition value with others false into array representation', () => {
+      // Arrange
+      const conditionWithObjectRepresentation = {
+        value: [
+          {
+            options: [OPTIONS[0], OPTIONS[2]],
+            others: false,
+          },
+        ],
+      } as unknown as LogicCheckboxCondition // only care about the value portion of the condition
+      const expected = {
+        value: [
+          [
+            { value: OPTIONS[0], other: false },
+            { value: OPTIONS[2], other: false },
+          ],
+        ],
+      }
+
+      // Act
+      const transformed = convertObjectCheckboxCondition(
+        conditionWithObjectRepresentation,
+      )
+
+      // Assert
+      expect(transformed.value.length).toEqual(1) // should only have one condition
+      expect(new Set(transformed.value[0])).toEqual(new Set(expected.value[0]))
+    })
+  })
+  describe('condition value with array representation', () => {
+    const OPTIONS = [
+      { value: 'Option 1', others: false },
+      { value: 'Option 2', others: false },
+      { value: 'Option 3', others: false },
+    ]
+    const OTHERS = { value: 'Others', other: true }
+    it('should correctly convert condition value with others into object representation', () => {
+      // Arrange
+      const conditionWithArrayRepresentation = {
+        value: [[OPTIONS[0], OPTIONS[2], OTHERS]],
+      } as unknown as ClientCheckboxCondition // only care about the value portion of the condition
+
+      const expected = {
+        value: [
+          {
+            options: [OPTIONS[0].value, OPTIONS[2].value],
+            others: true,
+          },
+        ],
+      }
+
+      // Act
+      const transformed = convertArrayCheckboxCondition(
+        conditionWithArrayRepresentation,
+      )
+
+      // Assert
+      expect(transformed).toEqual(expected)
+    })
+    it('should correctly convert condition value without others into object representation', () => {
+      // Arrange
+      const conditionWithArrayRepresentation = {
+        value: [[OPTIONS[0], OPTIONS[2]]],
+      } as unknown as ClientCheckboxCondition // only care about the value portion of the condition
+
+      const expected = {
+        value: [
+          {
+            options: [OPTIONS[0].value, OPTIONS[2].value],
+            others: false,
+          },
+        ],
+      }
+
+      // Act
+      const transformed = convertArrayCheckboxCondition(
+        conditionWithArrayRepresentation,
+      )
+
+      // Assert
+      expect(transformed).toEqual(expected)
+    })
+  })
+})

--- a/src/public/modules/forms/services/form-logic/form-logic-checkbox.client.service.ts
+++ b/src/public/modules/forms/services/form-logic/form-logic-checkbox.client.service.ts
@@ -2,9 +2,15 @@ import { cloneDeep, omit } from 'lodash'
 
 import {
   ClientCheckboxConditionOption,
-  IConditionSchema,
+  IClientConditionSchema,
   LogicCheckboxCondition,
 } from '../../../../../types'
+
+// exported for testing
+export interface ClientCheckboxCondition
+  extends Omit<IClientConditionSchema, 'value'> {
+  value: ClientCheckboxConditionOption[][]
+}
 
 /**
  * Converts checkbox condition value with backend representation to frontend 2D array representation.
@@ -58,14 +64,8 @@ export const convertArrayCheckboxCondition = (
   }
 }
 
-// exported for testing
-export interface ClientCheckboxCondition
-  extends Omit<IConditionSchema, 'value'> {
-  value: ClientCheckboxConditionOption[][]
-}
-
 export const isClientCheckboxCondition = (
-  condition: IConditionSchema,
+  condition: IClientConditionSchema,
 ): condition is ClientCheckboxCondition => {
   const conditionValue = condition.value
   return (

--- a/src/public/modules/forms/services/form-logic/form-logic-checkbox.client.service.ts
+++ b/src/public/modules/forms/services/form-logic/form-logic-checkbox.client.service.ts
@@ -1,0 +1,84 @@
+import { cloneDeep, omit } from 'lodash'
+
+import {
+  ClientCheckboxConditionOption,
+  IConditionSchema,
+  LogicCheckboxCondition,
+} from '../../../../../types'
+
+/**
+ * Converts checkbox condition value with backend representation to frontend 2D array representation.
+ * @param conditionValue Backend representation of checkbox logic condition value
+ * @param field Corresponding checkbox field
+ * @returns Transformed logic condition with frontend representation
+ */
+export const convertObjectCheckboxCondition = (
+  condition: LogicCheckboxCondition,
+): ClientCheckboxCondition => {
+  condition = cloneDeep(condition) // clone to prevent changes to original
+  const convertedValue: ClientCheckboxConditionOption[][] = []
+  condition.value.forEach((value) => {
+    const combination = []
+    if (value.others) {
+      combination.push({ value: 'Others', other: true })
+    }
+    value.options.forEach((option) => {
+      combination.push({ value: option, other: false })
+    })
+    convertedValue.push(combination)
+  })
+  return {
+    ...omit(condition, ['value']),
+    value: convertedValue,
+  }
+}
+
+/**
+ * Converts checkbox condition with frontend 2D array representation to backend object representation.
+ * @param conditionValue Frontend representation of checkbox logic condition value
+ * @param field Corresponding checkbox field
+ * @throws Error if checkbox field does not have othersRadioButton key
+ * @returns Transformed logic condition with backend representation
+ */
+export const convertArrayCheckboxCondition = (
+  condition: ClientCheckboxCondition,
+): LogicCheckboxCondition => {
+  condition = cloneDeep(condition) // clone to prevent changes to original
+  const convertedValue = condition.value.map((options) => {
+    const indexOfOthers = options.findIndex((option) => option.other)
+    const others = indexOfOthers > -1
+    if (others) {
+      options.splice(indexOfOthers, 1)
+    }
+    return { options: options.map((option) => option.value), others }
+  })
+  return {
+    ...omit(condition, ['value']),
+    value: convertedValue,
+  }
+}
+
+// exported for testing
+export interface ClientCheckboxCondition
+  extends Omit<IConditionSchema, 'value'> {
+  value: ClientCheckboxConditionOption[][]
+}
+
+export const isClientCheckboxCondition = (
+  condition: IConditionSchema,
+): condition is ClientCheckboxCondition => {
+  const conditionValue = condition.value
+  return (
+    Array.isArray(conditionValue) &&
+    (conditionValue as unknown[]).every((val) => {
+      return (
+        Array.isArray(val) &&
+        val.every(
+          (option) =>
+            typeof option.value === 'string' &&
+            typeof option.other === 'boolean',
+        )
+      )
+    })
+  )
+}

--- a/src/public/modules/forms/services/form-logic/form-logic.client.service.ts
+++ b/src/public/modules/forms/services/form-logic/form-logic.client.service.ts
@@ -1,5 +1,12 @@
+import { omit } from 'lodash'
+
 import { isLogicCheckboxCondition } from '../../../../../shared/util/logic-utils'
-import { ILogicSchema } from '../../../../../types'
+import {
+  IClientConditionSchema,
+  IClientLogicSchema,
+  IConditionSchema,
+  ILogicSchema,
+} from '../../../../../types'
 
 import {
   convertArrayCheckboxCondition,
@@ -15,16 +22,16 @@ import {
  */
 export const transformBackendLogic = (
   formLogic: ILogicSchema,
-): ILogicSchema => {
-  formLogic.conditions = formLogic.conditions.map((condition) => {
+): IClientLogicSchema => {
+  const transformedLogic = formLogic.conditions.map((condition) => {
     if (isLogicCheckboxCondition(condition)) {
       return convertObjectCheckboxCondition(condition)
     } else {
-      return condition
+      return condition as IClientConditionSchema
     }
   })
 
-  return formLogic
+  return { ...omit(formLogic, ['conditions']), conditions: transformedLogic }
 }
 
 /**
@@ -35,14 +42,14 @@ export const transformBackendLogic = (
  * @returns Tranformed logic object
  */
 export const transformFrontendLogic = (
-  formLogic: ILogicSchema,
+  formLogic: IClientLogicSchema,
 ): ILogicSchema => {
-  formLogic.conditions = formLogic.conditions.map((condition) => {
+  const transformedLogic = formLogic.conditions.map((condition) => {
     if (isClientCheckboxCondition(condition)) {
       return convertArrayCheckboxCondition(condition)
     } else {
-      return condition
+      return condition as IConditionSchema
     }
   })
-  return formLogic
+  return { ...omit(formLogic, ['conditions']), conditions: transformedLogic }
 }

--- a/src/public/modules/forms/services/form-logic/form-logic.client.service.ts
+++ b/src/public/modules/forms/services/form-logic/form-logic.client.service.ts
@@ -1,0 +1,48 @@
+import { isLogicCheckboxCondition } from '../../../../../shared/util/logic-utils'
+import { ILogicSchema } from '../../../../../types'
+
+import {
+  convertArrayCheckboxCondition,
+  convertObjectCheckboxCondition,
+  isClientCheckboxCondition,
+} from './form-logic-checkbox.client.service'
+
+/**
+ * Transforms logic conditions retrieved from the backend into frontend representation.
+ * This function should be used when retrieving logic objects from the backend.
+ * @param formLogic Logic object
+ * @returns Transformed logic object
+ */
+export const transformBackendLogic = (
+  formLogic: ILogicSchema,
+): ILogicSchema => {
+  formLogic.conditions = formLogic.conditions.map((condition) => {
+    if (isLogicCheckboxCondition(condition)) {
+      return convertObjectCheckboxCondition(condition)
+    } else {
+      return condition
+    }
+  })
+
+  return formLogic
+}
+
+/**
+ * Transforms logic conditions retrieved from the frontend into backend representation.
+ * This function should be used before sending logic objects to the backend.
+ * @param formLogic Logic object
+ * @param formFields Form fields of the form.
+ * @returns Tranformed logic object
+ */
+export const transformFrontendLogic = (
+  formLogic: ILogicSchema,
+): ILogicSchema => {
+  formLogic.conditions = formLogic.conditions.map((condition) => {
+    if (isClientCheckboxCondition(condition)) {
+      return convertArrayCheckboxCondition(condition)
+    } else {
+      return condition
+    }
+  })
+  return formLogic
+}

--- a/src/shared/util/__tests__/logic.spec.ts
+++ b/src/shared/util/__tests__/logic.spec.ts
@@ -24,14 +24,6 @@ import {
 describe('Logic validation', () => {
   /** Mock a field's bare essentials */
   const makeField = (fieldId: string) => ({ _id: fieldId } as IFieldSchema)
-  it('should return valid logic states for multi-value field types', () => {
-    const multiValueFields = [BasicField.Checkbox]
-    multiValueFields.forEach((fieldType) => {
-      const states = FormLogic.getApplicableIfStates(fieldType)
-      expect(states).toIncludeSameMembers([LogicConditionState.AnyOf])
-      expect(states).toBeArrayOfSize(1)
-    })
-  })
   /**
    *  Mock a response
    * @param fieldId field id of the field that this response is meant for
@@ -1024,6 +1016,7 @@ describe('Logic util', () => {
     BasicField.Rating,
     BasicField.YesNo,
     BasicField.Radio,
+    BasicField.Checkbox,
   ]
 
   const INVALID_IF_CONDITION_FIELDS = Object.values(BasicField).filter(

--- a/src/shared/util/__tests__/logic.spec.ts
+++ b/src/shared/util/__tests__/logic.spec.ts
@@ -24,7 +24,14 @@ import {
 describe('Logic validation', () => {
   /** Mock a field's bare essentials */
   const makeField = (fieldId: string) => ({ _id: fieldId } as IFieldSchema)
-
+  it('should return valid logic states for multi-value field types', () => {
+    const multiValueFields = [BasicField.Checkbox]
+    multiValueFields.forEach((fieldType) => {
+      const states = FormLogic.getApplicableIfStates(fieldType)
+      expect(states).toIncludeSameMembers([LogicConditionState.AnyOf])
+      expect(states).toBeArrayOfSize(1)
+    })
+  })
   /**
    *  Mock a response
    * @param fieldId field id of the field that this response is meant for
@@ -1071,6 +1078,14 @@ describe('Logic util', () => {
           LogicConditionState.Gte,
         ])
         expect(states).toBeArrayOfSize(3)
+      })
+    })
+    it('should return valid logic states for multi-value field types', () => {
+      const multiValueFields = [BasicField.Checkbox]
+      multiValueFields.forEach((fieldType) => {
+        const states = getApplicableIfStates(fieldType)
+        expect(states).toIncludeSameMembers([LogicConditionState.AnyOf])
+        expect(states).toBeArrayOfSize(1)
       })
     })
     it('should return empty array for invalid conditional fields', () => {

--- a/src/shared/util/logic-utils/__tests__/checkbox-response-value-transformer.spec.ts
+++ b/src/shared/util/logic-utils/__tests__/checkbox-response-value-transformer.spec.ts
@@ -1,0 +1,204 @@
+import { ObjectId } from 'bson-ext'
+
+import {
+  BasicField,
+  FieldSchemaOrResponse,
+  ICheckboxFieldSchema,
+} from '../../../../types'
+import { transformCheckboxForLogic } from '../checkbox/checkbox-response-value-transformer'
+
+describe('transformCheckboxForLogic', () => {
+  describe('Frontend Checkbox value with others option', () => {
+    const OPTIONS = ['Option 1', 'Option 2', 'Option 3']
+    const CHECKBOX_FIELD = {
+      _id: new ObjectId(),
+      fieldOptions: OPTIONS,
+      othersRadioButton: true,
+      fieldType: BasicField.Checkbox,
+    } as ICheckboxFieldSchema
+    it('should correctly convert frontend checkbox response without others selected to its logic representation', () => {
+      // Arrange
+      const frontendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        fieldValue: [true, false, true, false],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...frontendCheckbox,
+        fieldValue: {
+          options: [OPTIONS[0], OPTIONS[2]],
+          others: false,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        frontendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+    it('should correctly convert frontend checkbox response with others selected to its logic representation', () => {
+      // Arrange
+      const frontendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        fieldValue: [true, false, true, true],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...frontendCheckbox,
+        fieldValue: {
+          options: [OPTIONS[0], OPTIONS[2]],
+          others: true,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        frontendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+  })
+  describe('Frontend Checkbox value without others option', () => {
+    const OPTIONS = ['Option 1', 'Option 2', 'Option 3']
+    const CHECKBOX_FIELD = {
+      _id: new ObjectId(),
+      fieldOptions: OPTIONS,
+      othersRadioButton: false,
+      fieldType: BasicField.Checkbox,
+    } as ICheckboxFieldSchema
+    it('should correctly convert frontend checkbox response without others selected to its logic representation', () => {
+      // Arrange
+      const frontendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        fieldValue: [true, false, true, false],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...frontendCheckbox,
+        fieldValue: {
+          options: [OPTIONS[0], OPTIONS[2]],
+          others: false,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        frontendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+  })
+  describe('Backend Checkbox value with others option', () => {
+    const OPTIONS = ['Option 1', 'Others: this is a user-defined option']
+    const OTHERS_RESPONSE = 'Others: this is a user input'
+    const CHECKBOX_FIELD = {
+      _id: new ObjectId(),
+      fieldOptions: OPTIONS,
+      othersRadioButton: true,
+      fieldType: BasicField.Checkbox,
+    } as ICheckboxFieldSchema
+    it('should correctly convert backend checkbox response without others selected to its logic representation', () => {
+      // Arrange
+      const backendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        answerArray: [OPTIONS[0], OPTIONS[1]],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...backendCheckbox,
+        answerArray: {
+          options: [OPTIONS[0], OPTIONS[1]],
+          others: false,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        backendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+    it('should correctly convert backend checkbox response with others selected to its logic representation', () => {
+      // Arrange
+      const backendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        answerArray: [OPTIONS[0], OPTIONS[1], OTHERS_RESPONSE],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...backendCheckbox,
+        answerArray: {
+          options: [OPTIONS[0], OPTIONS[1]],
+          others: true,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        backendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+  })
+  describe('Backend Checkbox value without others option', () => {
+    const OPTIONS = ['Option 1', 'Others: this is a user-defined option']
+    const CHECKBOX_FIELD = {
+      _id: new ObjectId(),
+      fieldOptions: OPTIONS,
+      othersRadioButton: false,
+      fieldType: BasicField.Checkbox,
+    } as ICheckboxFieldSchema
+    it('should correctly convert backend checkbox response without others selected to its logic representation', () => {
+      // Arrange
+      const backendCheckbox = {
+        _id: String(CHECKBOX_FIELD._id),
+        answerArray: [OPTIONS[0], OPTIONS[1]],
+        fieldType: BasicField.Checkbox,
+      } as FieldSchemaOrResponse
+      const formFields = [CHECKBOX_FIELD]
+
+      const expected = {
+        ...backendCheckbox,
+        answerArray: {
+          options: [OPTIONS[0], OPTIONS[1]],
+          others: false,
+        },
+      }
+
+      // Act
+      const transformedCheckbox = transformCheckboxForLogic(
+        backendCheckbox,
+        formFields,
+      )
+
+      // Assert
+      expect(transformedCheckbox).toEqual(expected)
+    })
+  })
+})

--- a/src/shared/util/logic-utils/checkbox/index.ts
+++ b/src/shared/util/logic-utils/checkbox/index.ts
@@ -1,1 +1,2 @@
 export * from './checkbox-logic-guards'
+export * from './checkbox-response-value-transformer'

--- a/src/shared/util/logic-utils/index.ts
+++ b/src/shared/util/logic-utils/index.ts
@@ -1,1 +1,2 @@
+export * from './logic-formatter'
 export * from './checkbox'

--- a/src/shared/util/logic-utils/logic-formatter.ts
+++ b/src/shared/util/logic-utils/logic-formatter.ts
@@ -1,0 +1,30 @@
+import { cloneDeep } from 'lodash'
+
+import {
+  BasicField,
+  FieldSchemaOrResponse,
+  IPopulatedForm,
+} from '../../../types'
+import { LogicFieldSchemaOrResponse } from '../logic'
+
+import { transformCheckboxForLogic } from './checkbox/checkbox-response-value-transformer'
+
+/**
+ * Transforms fields into the correct shape for logic module
+ * @param fields Form fields
+ * @param form
+ * @returns Transformed fields to be input into logic module
+ * @throws Error if any transformation fails
+ */
+export const formatFieldsForLogic = (
+  fields: FieldSchemaOrResponse[],
+  formFields: IPopulatedForm['form_fields'],
+): LogicFieldSchemaOrResponse[] => {
+  return fields.map((field) => {
+    if (field.fieldType === BasicField.Checkbox) {
+      return transformCheckboxForLogic(field, formFields)
+    } else {
+      return cloneDeep(field)
+    }
+  })
+}

--- a/src/shared/util/logic-utils/logic-formatter.ts
+++ b/src/shared/util/logic-utils/logic-formatter.ts
@@ -24,7 +24,7 @@ export const formatFieldsForLogic = (
     if (field.fieldType === BasicField.Checkbox) {
       return transformCheckboxForLogic(field, formFields)
     } else {
-      return cloneDeep(field)
+      return cloneDeep(field) as LogicFieldSchemaOrResponse
     }
   })
 }

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -25,6 +25,7 @@ import {
 } from './logic-utils'
 
 const LOGIC_CONDITIONS: LogicCondition[] = [
+  [BasicField.Checkbox, [LogicConditionState.AnyOf]],
   [
     BasicField.Dropdown,
     [LogicConditionState.Equal, LogicConditionState.Either],
@@ -290,11 +291,7 @@ const isLogicUnitSatisfied = (
 }
 
 const getCurrentValue = (
-<<<<<<< HEAD
   field: FieldSchemaOrResponse,
-=======
-  field: LogicFieldSchemaOrResponse,
->>>>>>> 4c2ffe1b (feat: add checkbox to logic module with tests)
 ):
   | string
   | string[]

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -83,7 +83,6 @@ export type FieldIdSet = Set<ILogicInputClientSchema['_id']>
 export type LogicFieldSchemaOrResponse =
   | ILogicClientFieldSchema
   | LogicFieldResponse
-  | FieldSchemaOrResponse // TODO: remove after applying transformations outside this module
 
 // Returns typed ShowFields logic unit
 const isShowFieldsLogic = (

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -82,6 +82,7 @@ export type FieldIdSet = Set<ILogicInputClientSchema['_id']>
 export type LogicFieldSchemaOrResponse =
   | ILogicClientFieldSchema
   | LogicFieldResponse
+  | FieldSchemaOrResponse // TODO: remove after applying transformations outside this module
 
 // Returns typed ShowFields logic unit
 const isShowFieldsLogic = (

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -289,7 +289,11 @@ const isLogicUnitSatisfied = (
 }
 
 const getCurrentValue = (
+<<<<<<< HEAD
   field: FieldSchemaOrResponse,
+=======
+  field: LogicFieldSchemaOrResponse,
+>>>>>>> 4c2ffe1b (feat: add checkbox to logic module with tests)
 ):
   | string
   | string[]

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -40,14 +40,24 @@ export interface ICondition {
 // Override ObjectId with String type since the field id passed in is in
 // String form.
 export interface IConditionSchema extends ICondition, Document<string> {}
-
+export interface IClientConditionSchema
+  extends Omit<IConditionSchema, 'value'> {
+  value:
+    | string
+    | number
+    | string[]
+    | number[]
+    | ClientCheckboxConditionOption[][]
+}
 export interface ILogic {
   conditions: IConditionSchema[]
   logicType: LogicType
 }
 
 export interface ILogicSchema extends ILogic, Document {}
-
+export interface IClientLogicSchema extends Omit<ILogicSchema, 'conditions'> {
+  conditions: IClientConditionSchema[]
+}
 export interface IShowFieldsLogic extends ILogic {
   show: IFieldSchema['_id'][]
 }


### PR DESCRIPTION
## Problem
This PR implements the extension of the logic feature to logic fields. This second part implements adaptor functions that transform:
* Frontend/Backend checkbox field responses to same shape as checkbox condition values
* Checkbox condition values between the frontend and backend

Part 2/3 of #30

## Solution
Refer to the design document [here](https://docs.google.com/document/d/1ggEb9UyHjK3EipQjXpCmOwaenM6_f1AqcE46VxBkIZI/edit#).

## Tests
### Unit tests
 - `checkbox-response-value-transformer.spec`  
 - `form-logic-checkbox.client.service.spec`  
 -  Add tests to `form-logic.client.service.spec`
