### PR TITLE
feat(shared-types): move billing related types to shared folder

### DIFF
--- a/shared/types/billing.ts
+++ b/shared/types/billing.ts
@@ -1,0 +1,37 @@
+import { AgencyDto } from './agency'
+import { FormDto } from './form/form'
+import { UserDto } from './user'
+
+/**
+ * The name `Login` may cause confusion.
+ * This type relates to the data stored when a form respondent logs in to the
+ * form via any of the public form auth methods (Singpass, Corppass, MyInfo,
+ * etc).
+ */
+export type LoginBase = {
+  admin: UserDto['_id']
+  form: FormDto['_id']
+  agency: AgencyDto['_id']
+  authType: FormDto['authType']
+  // A login must be for a form that has an esrvcId.
+  esrvcId: NonNullable<FormDto['esrvcId']>
+}
+
+export type FormBillingStatistic = {
+  adminEmail: UserDto['email']
+  formName: FormDto['title']
+  formId: FormDto['_id']
+  authType: FormDto['authType']
+  total: number
+}
+
+// yr: The year to get the billing information for
+// mth: The month to get the billing information for
+// esrvcId: The id of the form
+export type BillingQueryDto = {
+  esrvcId: NonNullable<FormDto['esrvcId']>
+  yr: string
+  mth: string
+}
+
+export type BillingInfoDto = { loginStats: FormBillingStatistic[] }

--- a/src/app/models/__tests__/login.server.model.spec.ts
+++ b/src/app/models/__tests__/login.server.model.spec.ts
@@ -9,6 +9,7 @@ import {
   AuthType,
   IFormSchema,
   ILogin,
+  ILoginSchema,
   IPopulatedForm,
   IUserSchema,
 } from 'src/types'
@@ -163,6 +164,7 @@ describe('login.server.model', () => {
 
       it('should reject when the form does not contain an authType', async () => {
         await expect(
+          // @ts-ignore
           LoginModel.addLoginFromForm(omit(fullForm, 'authType')),
         ).rejects.toThrow('Form does not contain authType or e-service ID')
       })
@@ -175,7 +177,7 @@ describe('login.server.model', () => {
       const FUTURE_MOMENT = CURR_MOMENT.clone().add(2, 'years')
       const FUTURE_DATE = FUTURE_MOMENT.toDate()
 
-      let mockLoginDocuments: ILogin[]
+      let mockLoginDocuments: ILoginSchema[]
       let testUser: IUserSchema
       let testForm: IFormSchema
 
@@ -219,7 +221,7 @@ describe('login.server.model', () => {
             esrvcId: VALID_ESRVC_ID,
             created: FUTURE_DATE,
           },
-        ]
+        ] as ILoginSchema[]
 
         await LoginModel.insertMany(mockLoginDocuments)
         testUser = user

--- a/src/app/models/__tests__/login.server.model.spec.ts
+++ b/src/app/models/__tests__/login.server.model.spec.ts
@@ -8,7 +8,6 @@ import getLoginModel from 'src/app/models/login.server.model'
 import {
   AuthType,
   IFormSchema,
-  ILogin,
   ILoginSchema,
   IPopulatedForm,
   IUserSchema,
@@ -24,7 +23,7 @@ describe('login.server.model', () => {
   afterAll(async () => await dbHandler.closeDatabase())
 
   describe('Schema', () => {
-    const DEFAULT_PARAMS: ILogin = {
+    const DEFAULT_PARAMS: mongoose.LeanDocument<ILoginSchema> = {
       admin: new ObjectId(),
       agency: new ObjectId(),
       authType: AuthType.SP,

--- a/src/public/services/BillingService.ts
+++ b/src/public/services/BillingService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { BillingInfoDto, BillingQueryDto } from '../../types/api/billing'
+import { BillingInfoDto, BillingQueryDto } from '../../../shared/types/billing'
 
 // Exported for testing
 export const BILLING_ENDPOINT = '/api/v3/billings'

--- a/src/types/api/billing.ts
+++ b/src/types/api/billing.ts
@@ -1,12 +1,1 @@
-import { LoginStatistic } from '../../types'
-
-// yr: The year to get the billing information for
-// mth: The month to get the billing information for
-// esrvcId: The id of the form
-export type BillingQueryDto = {
-  esrvcId: string
-  yr: string
-  mth: string
-}
-
-export type BillingInfoDto = { loginStats: LoginStatistic[] }
+export { BillingQueryDto, BillingInfoDto } from '../../../shared/types/billing'

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,27 +1,22 @@
 import { Document, Model } from 'mongoose'
 
+import { FormBillingStatistic, LoginBase } from '../../shared/types/billing'
+
 import { IAgencySchema } from './agency'
-import { AuthType, IFormSchema, IPopulatedForm } from './form'
+import { IFormSchema, IPopulatedForm } from './form'
 import { IUserSchema } from './user'
 
-export interface ILogin {
+export interface ILogin extends LoginBase {
   admin: IUserSchema['_id']
   form: IFormSchema['_id']
   agency: IAgencySchema['_id']
-  authType: AuthType
-  esrvcId: string
+}
+
+export interface ILoginSchema extends ILogin, Document {
   created?: Date
 }
 
-export interface ILoginSchema extends ILogin, Document {}
-
-export type LoginStatistic = {
-  adminEmail: IUserSchema['email']
-  formName: IFormSchema['title']
-  total: number
-  formId: IFormSchema['_id']
-  authType: ILoginSchema['authType']
-}
+export type LoginStatistic = FormBillingStatistic
 
 export interface ILoginModel extends Model<ILoginSchema> {
   aggregateLoginStats: (

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -6,7 +6,7 @@ import { IAgencySchema } from './agency'
 import { IFormSchema, IPopulatedForm } from './form'
 import { IUserSchema } from './user'
 
-export interface ILogin extends LoginBase {
+interface ILogin extends LoginBase {
   admin: IUserSchema['_id']
   form: IFormSchema['_id']
   agency: IAgencySchema['_id']


### PR DESCRIPTION
> Note that this PR builds on the typings exposed by #2385

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR extracts out billing related types to the root shared folder

Related to #2066

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
  - Only type changes

**Features**:

- move billing related types to root shared folder
- use relocated types in client and server
