### PR TITLE
refactor(logic): add adaptor layer to backend and refactor getVisibleFieldIds and getLogicUnitPreventSubmit callers

### DIFF
--- a/src/app/utils/logic-adaptor.ts
+++ b/src/app/utils/logic-adaptor.ts
@@ -1,0 +1,32 @@
+import { ok, Result } from 'neverthrow'
+
+import {
+  FieldIdSet,
+  getLogicUnitPreventingSubmit as logicGetLogicUnitPreventingSubmit,
+  getVisibleFieldIds as logicGetVisibleFieldIds,
+} from '../../shared/util/logic'
+import {
+  FieldResponse,
+  IFormDocument,
+  IPreventSubmitLogicSchema,
+} from '../../types'
+import { ProcessingError } from '../modules/submission/submission.errors'
+
+export { FieldIdSet } from '../../shared/util/logic'
+
+export const getVisibleFieldIds = (
+  submission: FieldResponse[],
+  form: IFormDocument,
+): Result<FieldIdSet, ProcessingError> => {
+  return ok(logicGetVisibleFieldIds(submission, form))
+}
+
+export const getLogicUnitPreventingSubmit = (
+  submission: FieldResponse[],
+  form: IFormDocument,
+  visibleFieldIds?: FieldIdSet,
+): Result<IPreventSubmitLogicSchema | undefined, ProcessingError> => {
+  return ok(
+    logicGetLogicUnitPreventingSubmit(submission, form, visibleFieldIds),
+  )
+}


### PR DESCRIPTION
As a lead up to the checkbox logic feature in #2389, an adapter layer is added in between the logic module and the rest of the backend. In this PR, the adapter simply calls the functions in the logic module but returns `neverthrow`'s `Result`.
