### PR TITLE
feat(client): add EncryptionService to validate encrypt submission responses

### DIFF
--- a/shared/types/response.ts
+++ b/shared/types/response.ts
@@ -1,55 +1,5 @@
 import { z } from 'zod'
-
-// TODO(#2209): Replace when #2355 is merged in.
-enum BasicField {
-  Section = 'section',
-  Statement = 'statement',
-  Email = 'email',
-  Mobile = 'mobile',
-  HomeNo = 'homeno',
-  Number = 'number',
-  Decimal = 'decimal',
-  Image = 'image',
-  ShortText = 'textfield',
-  LongText = 'textarea',
-  Dropdown = 'dropdown',
-  YesNo = 'yes_no',
-  Checkbox = 'checkbox',
-  Radio = 'radiobutton',
-  Attachment = 'attachment',
-  Date = 'date',
-  Rating = 'rating',
-  Nric = 'nric',
-  Table = 'table',
-  Uen = 'uen',
-}
-// TODO(#2209): Replace when #2355 is merged in.
-enum MyInfoAttribute {
-  Name = 'name',
-  PassportNumber = 'passportnumber',
-  RegisteredAddress = 'regadd',
-  Employment = 'employment',
-  VehicleNo = 'vehno',
-  MarriageCertNo = 'marriagecertno',
-  Sex = 'sex',
-  Race = 'race',
-  Dialect = 'dialect',
-  Nationality = 'nationality',
-  BirthCountry = 'birthcountry',
-  ResidentialStatus = 'residentialstatus',
-  HousingType = 'housingtype',
-  HdbType = 'hdbtype',
-  Marital = 'marital',
-  CountryOfMarriage = 'countryofmarriage',
-  WorkpassStatus = 'workpassstatus',
-  Occupation = 'occupation',
-  MobileNo = 'mobileno',
-  DateOfBirth = 'dob',
-  PassportExpiryDate = 'passportexpirydate',
-  MarriageDate = 'marriagedate',
-  DivorceDate = 'divorcedate',
-  WorkpassExpiryDate = 'workpassexpirydate',
-}
+import { BasicField, MyInfoAttribute } from './field'
 
 const ResponseBase = z.object({
   _id: z.string(),

--- a/shared/types/response.ts
+++ b/shared/types/response.ts
@@ -1,0 +1,191 @@
+import { z } from 'zod'
+
+// TODO(#2209): Replace when #2355 is merged in.
+enum BasicField {
+  Section = 'section',
+  Statement = 'statement',
+  Email = 'email',
+  Mobile = 'mobile',
+  HomeNo = 'homeno',
+  Number = 'number',
+  Decimal = 'decimal',
+  Image = 'image',
+  ShortText = 'textfield',
+  LongText = 'textarea',
+  Dropdown = 'dropdown',
+  YesNo = 'yes_no',
+  Checkbox = 'checkbox',
+  Radio = 'radiobutton',
+  Attachment = 'attachment',
+  Date = 'date',
+  Rating = 'rating',
+  Nric = 'nric',
+  Table = 'table',
+  Uen = 'uen',
+}
+// TODO(#2209): Replace when #2355 is merged in.
+enum MyInfoAttribute {
+  Name = 'name',
+  PassportNumber = 'passportnumber',
+  RegisteredAddress = 'regadd',
+  Employment = 'employment',
+  VehicleNo = 'vehno',
+  MarriageCertNo = 'marriagecertno',
+  Sex = 'sex',
+  Race = 'race',
+  Dialect = 'dialect',
+  Nationality = 'nationality',
+  BirthCountry = 'birthcountry',
+  ResidentialStatus = 'residentialstatus',
+  HousingType = 'housingtype',
+  HdbType = 'hdbtype',
+  Marital = 'marital',
+  CountryOfMarriage = 'countryofmarriage',
+  WorkpassStatus = 'workpassstatus',
+  Occupation = 'occupation',
+  MobileNo = 'mobileno',
+  DateOfBirth = 'dob',
+  PassportExpiryDate = 'passportexpirydate',
+  MarriageDate = 'marriagedate',
+  DivorceDate = 'divorcedate',
+  WorkpassExpiryDate = 'workpassexpirydate',
+}
+
+const ResponseBase = z.object({
+  _id: z.string(),
+  question: z.string(),
+})
+const MyInfoResponseBase = z.object({
+  myInfo: z
+    .object({
+      attr: z.nativeEnum(MyInfoAttribute),
+    })
+    .optional(),
+})
+
+const VerifiableResponseBase = z.object({
+  signature: z.string().optional(),
+})
+
+const SingleAnswerResponse = ResponseBase.extend({
+  answer: z.string(),
+})
+
+const MultiAnswerResponse = ResponseBase.extend({
+  answerArray: z.array(z.string()),
+})
+
+const MyInfoableSingleResponse = SingleAnswerResponse.merge(MyInfoResponseBase)
+
+export const HeaderResponse = SingleAnswerResponse.extend({
+  isHeader: z.literal(true),
+  fieldType: z.literal(BasicField.Section),
+})
+export type HeaderResponse = z.infer<typeof HeaderResponse>
+
+export const EmailResponse = SingleAnswerResponse.merge(
+  VerifiableResponseBase,
+).extend({ fieldType: z.literal(BasicField.Email) })
+export type EmailResponse = z.infer<typeof EmailResponse>
+
+export const MobileResponse = MyInfoableSingleResponse.merge(
+  VerifiableResponseBase,
+).extend({ fieldType: z.literal(BasicField.Mobile) })
+export type MobileResponse = z.infer<typeof MobileResponse>
+
+export const HomeNoResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.HomeNo),
+})
+export type HomeNoResponse = z.infer<typeof HomeNoResponse>
+
+export const NumberResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.Number),
+})
+export type NumberResponse = z.infer<typeof NumberResponse>
+
+export const DecimalResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Decimal),
+})
+export type DecimalResponse = z.infer<typeof DecimalResponse>
+
+export const ShortTextResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.ShortText),
+})
+export type ShortTextResponse = z.infer<typeof ShortTextResponse>
+
+export const LongTextResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.LongText),
+})
+export type LongTextResponse = z.infer<typeof LongTextResponse>
+
+export const DropdownResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.Dropdown),
+})
+export type DropdownResponse = z.infer<typeof DropdownResponse>
+
+export const YesNoResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.YesNo),
+})
+export type YesNoResponse = z.infer<typeof YesNoResponse>
+
+export const CheckboxResponse = MultiAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Checkbox),
+})
+export type CheckboxResponse = z.infer<typeof CheckboxResponse>
+
+export const RadioResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Radio),
+})
+export type RadioResponse = z.infer<typeof RadioResponse>
+
+export const AttachmentResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Attachment),
+})
+export type AttachmentResponse = z.infer<typeof AttachmentResponse>
+
+export const DateResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.Date),
+})
+export type DateResponse = z.infer<typeof DateResponse>
+
+export const RatingResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Rating),
+})
+export type RatingResponse = z.infer<typeof RatingResponse>
+
+export const NricResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Nric),
+})
+export type NricResponse = z.infer<typeof NricResponse>
+
+export const TableResponse = ResponseBase.extend({
+  // Table fields have an array of array of strings.
+  answerArray: z.array(z.array(z.string())),
+  fieldType: z.literal(BasicField.Table),
+})
+export type TableResponse = z.infer<typeof TableResponse>
+
+export const UenResponse = SingleAnswerResponse.extend({
+  fieldType: z.literal(BasicField.Uen),
+})
+export type UenResponse = z.infer<typeof UenResponse>
+
+export type FieldResponse =
+  | HeaderResponse
+  | EmailResponse
+  | MobileResponse
+  | HomeNoResponse
+  | NumberResponse
+  | DecimalResponse
+  | ShortTextResponse
+  | LongTextResponse
+  | DropdownResponse
+  | YesNoResponse
+  | CheckboxResponse
+  | RadioResponse
+  | AttachmentResponse
+  | DateResponse
+  | RatingResponse
+  | NricResponse
+  | TableResponse
+  | UenResponse

--- a/src/public/.eslintrc
+++ b/src/public/.eslintrc
@@ -76,7 +76,7 @@
         "import/no-duplicates": "error",
         "@typescript-eslint/no-floating-promises": 2,
         "@typescript-eslint/no-unused-vars": 2,
-        "typesafe/no-throw-sync-func": "error"
+        "typesafe/no-throw-sync-func": "warn"
       }
     },
     {

--- a/src/public/modules/forms/viewmodels/Form.class.js
+++ b/src/public/modules/forms/viewmodels/Form.class.js
@@ -1,5 +1,4 @@
 const _ = require('lodash')
-const formsg = require('@opengovsg/formsg-sdk')()
 
 const FieldFactory = require('../helpers/field-factory')
 const {
@@ -8,6 +7,9 @@ const {
   fieldHasAttachment,
 } = require('../helpers/attachments-map')
 const { NoAnswerField } = require('./Fields')
+const {
+  encryptSubmissionResponses,
+} = require('../../../services/EncryptionService')
 
 // The current encrypt version to assign to the encrypted submission.
 // This is needed if we ever break backwards compatibility with
@@ -83,7 +85,7 @@ class Form {
    */
   _getEncryptedContent() {
     if (this.responseMode === 'encrypt') {
-      return formsg.crypto.encrypt(this._getResponses(), this.publicKey)
+      return encryptSubmissionResponses(this._getResponses(), this.publicKey)
     }
     return null
   }

--- a/src/public/services/EncryptionService.ts
+++ b/src/public/services/EncryptionService.ts
@@ -39,11 +39,11 @@ export const encryptSubmissionResponses = (
 
 const isPossibleResponse = (
   o: unknown,
-): o is Record<string, unknown> & { fieldType: BasicField } => {
+): o is Record<string, unknown> & { fieldType: string } => {
   const isPossibleObject = typeof o === 'object' && o !== null
   if (!isPossibleObject) return false
 
-  return !!(o as Record<string, unknown>).fieldType
+  return typeof (o as Record<string, unknown>).fieldType === 'string'
 }
 
 const validateResponses = (responses: unknown): FieldResponse[] => {

--- a/src/public/services/EncryptionService.ts
+++ b/src/public/services/EncryptionService.ts
@@ -1,0 +1,102 @@
+import {
+  AttachmentResponse,
+  CheckboxResponse,
+  DateResponse,
+  DecimalResponse,
+  DropdownResponse,
+  EmailResponse,
+  FieldResponse,
+  HeaderResponse,
+  HomeNoResponse,
+  LongTextResponse,
+  MobileResponse,
+  NricResponse,
+  NumberResponse,
+  RadioResponse,
+  RatingResponse,
+  ShortTextResponse,
+  TableResponse,
+  UenResponse,
+  YesNoResponse,
+} from '../../../shared/types/response'
+import { BasicField } from '../../types'
+
+import { FormSgSdk } from './FormSgSdkService'
+
+/**
+ * Encrypts given submission responses with the public key.
+ * @param responses the responses to encrypt
+ * @param publicKey the public key to encrypt with
+ * @returns the encrypted responses
+ * @throws error if the given responses are malformed
+ */
+export const encryptSubmissionResponses = (
+  responses: unknown,
+  publicKey: string,
+): string => {
+  return FormSgSdk.crypto.encrypt(validateResponses(responses), publicKey)
+}
+
+const isPossibleResponse = (
+  o: unknown,
+): o is Record<string, unknown> & { fieldType: BasicField } => {
+  const isPossibleObject = typeof o === 'object' && o !== null
+  if (!isPossibleObject) return false
+
+  return !!(o as Record<string, unknown>).fieldType
+}
+
+const validateResponses = (responses: unknown): FieldResponse[] => {
+  if (!Array.isArray(responses)) {
+    throw new Error('Input submission is malformed')
+  }
+
+  return responses.map((response) => {
+    if (!isPossibleResponse(response)) {
+      throw new Error('Input shape not a response')
+    }
+
+    switch (response.fieldType) {
+      case BasicField.Section:
+        return HeaderResponse.parse(response)
+      case BasicField.Mobile:
+        return MobileResponse.parse(response)
+      case BasicField.Decimal:
+        return DecimalResponse.parse(response)
+      case BasicField.Attachment:
+        return AttachmentResponse.parse(response)
+      case BasicField.Checkbox:
+        return CheckboxResponse.parse(response)
+      case BasicField.Date:
+        return DateResponse.parse(response)
+      case BasicField.Dropdown:
+        return DropdownResponse.parse(response)
+      case BasicField.Email:
+        return EmailResponse.parse(response)
+      case BasicField.HomeNo:
+        return HomeNoResponse.parse(response)
+      case BasicField.LongText:
+        return LongTextResponse.parse(response)
+      case BasicField.Nric:
+        return NricResponse.parse(response)
+      case BasicField.Rating:
+        return RatingResponse.parse(response)
+      case BasicField.Radio:
+        return RadioResponse.parse(response)
+      case BasicField.ShortText:
+        return ShortTextResponse.parse(response)
+      case BasicField.Table:
+        return TableResponse.parse(response)
+      case BasicField.Uen:
+        return UenResponse.parse(response)
+      case BasicField.Number:
+        return NumberResponse.parse(response)
+      case BasicField.YesNo:
+        return YesNoResponse.parse(response)
+      default:
+        throw new Error(
+          `Invalid fieldType provided for encrypt submission validation: ${response.fieldType}`,
+        )
+    }
+  })
+}

--- a/src/public/services/__tests__/EncryptionService.test.ts
+++ b/src/public/services/__tests__/EncryptionService.test.ts
@@ -1,0 +1,89 @@
+import { mocked } from 'ts-jest/utils'
+
+import * as EncryptionService from '../EncryptionService'
+import { FormSgSdk } from '../FormSgSdkService'
+
+jest.mock('../FormSgSdkService')
+const MockFormSgSdk = mocked(FormSgSdk, true)
+
+describe('EncryptionService', () => {
+  describe('encryptSubmissionResponses', () => {
+    const MOCK_PUBLIC_KEY = 'mockpublickey'
+    const MOCK_ENCRYPTED_RESPONSES = 'this is a success!'
+
+    const VALID_EMAIL_RESPONSE = {
+      _id: 'some-id',
+      question: 'some-question',
+      answer: 'some-answer',
+      fieldType: 'email',
+    }
+
+    const VALID_TABLE_RESPONSE = {
+      _id: 'some-table-id',
+      question: 'some-table-question',
+      answerArray: [
+        ['r1c1-answer', 'r1c2-answer'],
+        ['r2c1-answer', 'r2c2-answer'],
+      ],
+      fieldType: 'table',
+    }
+
+    beforeEach(() => {
+      MockFormSgSdk.crypto.encrypt.mockReturnValue(MOCK_ENCRYPTED_RESPONSES)
+    })
+
+    it('should throw error when given responses is not an array', () => {
+      // Arrange
+      const mockResponses = 'not an array'
+
+      // Act
+      const fn = () =>
+        EncryptionService.encryptSubmissionResponses(
+          mockResponses,
+          MOCK_PUBLIC_KEY,
+        )
+
+      // Assert
+      expect(fn).toThrow('Input submission is malformed')
+      expect(MockFormSgSdk.crypto.encrypt).not.toHaveBeenCalled()
+    })
+
+    it('should throw error when responses contains invalid shapes', async () => {
+      const invalidResponse = {
+        _id: 'some-id-2',
+        question: 'some-question, no answer and no fieldType',
+      }
+      const mockResponses = [VALID_EMAIL_RESPONSE, invalidResponse]
+
+      // Act
+      const fn = () =>
+        EncryptionService.encryptSubmissionResponses(
+          mockResponses,
+          MOCK_PUBLIC_KEY,
+        )
+
+      // Assert
+      expect(fn).toThrow('Input shape not a response')
+      expect(MockFormSgSdk.crypto.encrypt).not.toHaveBeenCalled()
+    })
+
+    it('should return original responses when given input responses passes validation', () => {
+      // Arrange
+      const mockResponses = [VALID_EMAIL_RESPONSE, VALID_TABLE_RESPONSE]
+
+      // Act
+      const actual = EncryptionService.encryptSubmissionResponses(
+        mockResponses,
+        MOCK_PUBLIC_KEY,
+      )
+
+      // Assert
+      expect(actual).toEqual(MOCK_ENCRYPTED_RESPONSES)
+      expect(MockFormSgSdk.crypto.encrypt).toHaveBeenCalledTimes(1)
+      expect(MockFormSgSdk.crypto.encrypt).toHaveBeenCalledWith(
+        mockResponses,
+        MOCK_PUBLIC_KEY,
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Storage mode submissions saved to the database cannot be updated due to end-to-end encryption. This means that submissions saved in the wrong format can be difficult or impossible to salvage.

This PR introduces `EncryptionService` which contains a validation function, enforcing the shape of the submission response. Using this service with the present AngularJS code in production and subsequently reusing it with React can assure us that it the encryption is being performed correctly in the new frontend.

To implement the above service, various field response zod schema constants are created in the new rooted `/shared` folder and used for the validation.

Closes #2209

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
  - Pure client side validation

**Features**:

- feat: add shared field response types with zod validation
- feat: add EncryptionService for validating and encrypting responses
- ref(Form.class): use EncryptionService to get encrypted content string

**Improvements**:
- chore: set eslint rule for typesafe to be warn in /public folder

## Tests
<!-- What tests should be run to confirm functionality? -->
- unit tests have been added for the new exported EncryptionService function.

### Manual tests
- Submit a storage mode form with all field types, should submit properly. The submission should also be decrypted properly.
- Submit an email mode form with all field types. Enable email copy. Should submit properly. Should receive submission with all the correct fields.
- Submit an email MyInfo form with all MyInfo fields. Same as above.