### PR TITLE
chore: add postinstall script to install /shared modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "npm": "~6.4.0"
   },
   "scripts": {
+    "postinstall": "cd shared && npm install",
     "test-backend": "env-cmd -f tests/.test-env jest --coverage --maxWorkers=4",
     "test-backend:watch": "env-cmd -f tests/.test-env jest --watch",
     "test-frontend": "jest --config=tests/unit/frontend/jest.config.js",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Add postinstall script to also install node modules inside the root shared folder.
There is no issue yet since all the shared folders' node_modules are also installed in the root package.json, but might be an issue in the future. Pre-emptively adding postinstall step first.
