### PR TITLE
feat(design-system): add Pagination component and stories

### DIFF
--- a/frontend/__tests__/storyshots/jest.config.js
+++ b/frontend/__tests__/storyshots/jest.config.js
@@ -12,7 +12,6 @@ module.exports = {
       'react-scripts/config/jest/fileTransform.js',
   },
   moduleNameMapper: {
-    '~/(.*)': '<rootDir>/../../src/$1',
     '~assets/(.*)': '<rootDir>/../../src/assets/$1',
     '~contexts/(.*)': '<rootDir>/../../src/contexts/$1',
     '~constants/(.*)': '<rootDir>/../../src/constants/$1',
@@ -23,5 +22,6 @@ module.exports = {
     '~services/(.*)': '<rootDir>/../../src/services/$1',
     '~theme/(.*)': '<rootDir>/../../src/theme/$1',
     '~typings/(.*)': '<rootDir>/../../src/typings/$1',
+    '~/(.*)': '<rootDir>/../../src/$1',
   },
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2795,6 +2795,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -3210,6 +3216,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -10318,6 +10330,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -18436,6 +18454,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -19642,6 +19668,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -19874,6 +19908,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -20029,6 +20071,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "strip-bom": {
@@ -20231,6 +20281,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -21517,8 +21575,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -25968,6 +26025,14 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -29017,12 +29082,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "type-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "focus-visible": "^5.2.0",
     "framer-motion": "^4.0.0",
     "libphonenumber-js": "^1.9.20",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.10.1",

--- a/frontend/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination/Pagination.stories.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Meta, Story } from '@storybook/react'
 
+import { viewports } from '~utils/storybook'
+
 import { Pagination, PaginationProps } from './Pagination'
 
 export default {
@@ -29,5 +31,58 @@ Default.args = {
   currentPage: 5,
   totalCount: 1000,
   pageSize: 10,
+}
+
+export const SiblingCountEquals2 = Template.bind({})
+SiblingCountEquals2.args = {
+  currentPage: 31,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 2,
+}
+
+export const LessThan7Pages = Template.bind({})
+LessThan7Pages.args = {
+  currentPage: 1,
+  totalCount: 60,
+  pageSize: 10,
   siblingCount: 1,
+}
+
+export const StartOf100Pages = Template.bind({})
+StartOf100Pages.args = {
+  currentPage: 1,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+}
+
+export const EndOf100Pages = Template.bind({})
+EndOf100Pages.args = {
+  currentPage: 100,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+}
+
+export const MiddleOf100Pages = Template.bind({})
+MiddleOf100Pages.args = {
+  currentPage: 31,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+}
+
+export const Mobile = Template.bind({})
+Mobile.args = {
+  currentPage: 31,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+}
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
 }

--- a/frontend/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination/Pagination.stories.tsx
@@ -49,6 +49,22 @@ SiblingCountEquals2.args = {
   siblingCount: 2,
 }
 
+export const Exactly7Pages = Template.bind({})
+Exactly7Pages.args = {
+  currentPage: 1,
+  totalCount: 70,
+  pageSize: 10,
+  siblingCount: 1,
+}
+
+export const Exactly8Pages = Template.bind({})
+Exactly8Pages.args = {
+  currentPage: 1,
+  totalCount: 80,
+  pageSize: 10,
+  siblingCount: 1,
+}
+
 export const LessThan7Pages = Template.bind({})
 LessThan7Pages.args = {
   currentPage: 1,

--- a/frontend/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination/Pagination.stories.tsx
@@ -33,6 +33,14 @@ Default.args = {
   pageSize: 10,
 }
 
+export const Disabled = Template.bind({})
+Disabled.args = {
+  currentPage: 5,
+  totalCount: 1000,
+  pageSize: 10,
+  isDisabled: true,
+}
+
 export const SiblingCountEquals2 = Template.bind({})
 SiblingCountEquals2.args = {
   currentPage: 31,
@@ -81,6 +89,21 @@ Mobile.args = {
   siblingCount: 1,
 }
 Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}
+
+export const MobileDisabled = Template.bind({})
+MobileDisabled.args = {
+  currentPage: 31,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+  isDisabled: true,
+}
+MobileDisabled.parameters = {
   viewport: {
     defaultViewport: 'mobile1',
   },

--- a/frontend/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { Meta, Story } from '@storybook/react'
+
+import { Pagination, PaginationProps } from './Pagination'
+
+export default {
+  title: 'Components/Pagination',
+  component: Pagination,
+  decorators: [],
+} as Meta
+
+const Template: Story<PaginationProps> = (args) => {
+  const [currentPage, setCurrentPage] = useState(args.currentPage)
+
+  useEffect(() => {
+    setCurrentPage(args.currentPage)
+  }, [args.currentPage])
+
+  return (
+    <Pagination
+      {...args}
+      currentPage={currentPage}
+      onPageChange={setCurrentPage}
+    />
+  )
+}
+export const Default = Template.bind({})
+Default.args = {
+  currentPage: 5,
+  totalCount: 1000,
+  pageSize: 10,
+  siblingCount: 1,
+}

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,9 +1,15 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { useMemo } from 'react'
-import { Box, Button, ButtonProps, Flex, HStack, Text } from '@chakra-ui/react'
-import range from 'lodash/range'
+import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
+import {
+  Button,
+  ButtonProps,
+  Flex,
+  Icon,
+  Text,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
 
-import { usePaginationRange } from '~/hooks/usePaginationRange'
+import { PAGINATION_THEME_KEY } from '~theme/components/Pagination'
+import { usePaginationRange } from '~hooks/usePaginationRange'
 
 // Separate constant to denote a separator in the pagination component.
 const SEPARATOR = '\u2026'
@@ -37,30 +43,22 @@ export interface PaginationProps {
 }
 
 interface PageButtonProps {
-  activePage: PaginationProps['currentPage']
-  page: number
+  selectedPage: PaginationProps['currentPage']
+  page: number | typeof SEPARATOR
   onClick: PaginationProps['onPageChange']
 }
 
-const PageButton = ({ activePage, page, onClick }: PageButtonProps) => {
-  const isActive = page === activePage
+const PageButton = ({ selectedPage, page, onClick }: PageButtonProps) => {
+  const isSelected = page === selectedPage
+
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
+
+  if (page === SEPARATOR) {
+    return <Text sx={styles.separator}>{page}</Text>
+  }
+
   return (
-    <Button
-      p="0.25rem"
-      minH="2rem"
-      minW="2rem"
-      border="none"
-      textStyle="body-2"
-      bg={isActive ? 'secondary.500' : 'transparent'}
-      _active={{
-        bg: isActive ? 'secondary.700' : 'secondary.200',
-      }}
-      _hover={{
-        bg: isActive ? 'secondary.600' : 'secondary.100',
-      }}
-      color={isActive ? 'white' : 'secondary.500'}
-      onClick={() => onClick(page)}
-    >
+    <Button sx={styles.button} onClick={() => onClick(page)}>
       {page}
     </Button>
   )
@@ -68,45 +66,12 @@ const PageButton = ({ activePage, page, onClick }: PageButtonProps) => {
 
 interface StepButtonProps extends ButtonProps {
   onClick: () => void
-  isDisabled?: boolean
   children: React.ReactNode
 }
 
-const StepButton = ({
-  onClick,
-  isDisabled,
-  children,
-  ...props
-}: StepButtonProps) => {
+const StepButton = ({ onClick, children, ...props }: StepButtonProps) => {
   return (
-    <Button
-      bg="transparent"
-      _hover={{
-        bg: 'secondary.100',
-        color: 'secondary.600',
-      }}
-      _active={{
-        bg: 'secondary.200',
-      }}
-      _disabled={{
-        bg: 'transparent',
-        cursor: 'not-allowed',
-        color: 'secondary.300',
-        _hover: {
-          bg: 'transparent',
-          color: 'secondary.300',
-        },
-      }}
-      isDisabled={isDisabled}
-      p="0.25rem"
-      minH="2rem"
-      minW="2rem"
-      border="none"
-      textStyle="body-2"
-      color="secondary.500"
-      onClick={onClick}
-      {...props}
-    >
+    <Button onClick={onClick} {...props}>
       {children}
     </Button>
   )
@@ -129,32 +94,33 @@ export const Pagination = ({
 
   const totalPageCount = Math.ceil(totalCount / pageSize)
 
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+
   return (
-    <Flex>
+    <Flex __css={styles.container}>
       <StepButton
-        mr="1rem"
+        sx={styles.stepperback}
         isDisabled={currentPage === 1}
         onClick={() => onPageChange(currentPage - 1)}
       >
+        <Icon fontSize="1.5rem" as={BiChevronLeft} />
         Back
       </StepButton>
-      {paginationRange.map((p, i) => {
-        if (p === SEPARATOR) return <Text key={i}>{p}</Text>
-        return (
-          <PageButton
-            key={i}
-            page={p}
-            activePage={currentPage}
-            onClick={onPageChange}
-          />
-        )
-      })}
+      {paginationRange.map((p, i) => (
+        <PageButton
+          key={i}
+          page={p}
+          selectedPage={currentPage}
+          onClick={onPageChange}
+        />
+      ))}
       <StepButton
-        ml="1rem"
+        sx={styles.steppernext}
         isDisabled={currentPage === totalPageCount}
         onClick={() => onPageChange(currentPage + 1)}
       >
         Next
+        <Icon fontSize="1.5rem" as={BiChevronRight} />
       </StepButton>
     </Flex>
   )

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useMemo } from 'react'
+import { Box, Button, ButtonProps, Flex, HStack, Text } from '@chakra-ui/react'
+import range from 'lodash/range'
+
+import { usePaginationRange } from '~/hooks/usePaginationRange'
+
+// Separate constant to denote a separator in the pagination component.
+const SEPARATOR = '\u2026'
+
+export interface PaginationProps {
+  /**
+   * Number of pages to display to left and right of current page.
+   * Defaults to `1`.
+   */
+  siblingCount?: number
+
+  /**
+   * Total number of elements to paginate.
+   */
+  totalCount: number
+
+  /**
+   * Size of each page. Determines the number of rendered page counts.
+   */
+  pageSize: number
+
+  /**
+   * Callback function invoked with the updated page when the page is changed.
+   */
+  onPageChange: (page: number) => void
+
+  /**
+   * Represents the current active page. Note that a `1-based index` is used.
+   */
+  currentPage: number
+}
+
+interface PageButtonProps {
+  activePage: PaginationProps['currentPage']
+  page: number
+  onClick: PaginationProps['onPageChange']
+}
+
+const PageButton = ({ activePage, page, onClick }: PageButtonProps) => {
+  const isActive = page === activePage
+  return (
+    <Button
+      p="0.25rem"
+      minH="2rem"
+      minW="2rem"
+      border="none"
+      textStyle="body-2"
+      bg={isActive ? 'secondary.500' : 'transparent'}
+      _active={{
+        bg: isActive ? 'secondary.700' : 'secondary.200',
+      }}
+      _hover={{
+        bg: isActive ? 'secondary.600' : 'secondary.100',
+      }}
+      color={isActive ? 'white' : 'secondary.500'}
+      onClick={() => onClick(page)}
+    >
+      {page}
+    </Button>
+  )
+}
+
+interface StepButtonProps extends ButtonProps {
+  onClick: () => void
+  isDisabled?: boolean
+  children: React.ReactNode
+}
+
+const StepButton = ({
+  onClick,
+  isDisabled,
+  children,
+  ...props
+}: StepButtonProps) => {
+  return (
+    <Button
+      bg="transparent"
+      _hover={{
+        bg: 'secondary.100',
+        color: 'secondary.600',
+      }}
+      _active={{
+        bg: 'secondary.200',
+      }}
+      _disabled={{
+        bg: 'transparent',
+        cursor: 'not-allowed',
+        color: 'secondary.300',
+        _hover: {
+          bg: 'transparent',
+          color: 'secondary.300',
+        },
+      }}
+      isDisabled={isDisabled}
+      p="0.25rem"
+      minH="2rem"
+      minW="2rem"
+      border="none"
+      textStyle="body-2"
+      color="secondary.500"
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </Button>
+  )
+}
+
+export const Pagination = ({
+  siblingCount = 1,
+  pageSize,
+  onPageChange,
+  totalCount,
+  currentPage,
+}: PaginationProps): JSX.Element => {
+  const paginationRange = usePaginationRange<typeof SEPARATOR>({
+    totalCount,
+    pageSize,
+    currentPage,
+    siblingCount,
+    separator: SEPARATOR,
+  })
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+
+  return (
+    <Flex>
+      <StepButton
+        mr="1rem"
+        isDisabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+      >
+        Back
+      </StepButton>
+      {paginationRange.map((p, i) => {
+        if (p === SEPARATOR) return <Text key={i}>{p}</Text>
+        return (
+          <PageButton
+            key={i}
+            page={p}
+            activePage={currentPage}
+            onClick={onPageChange}
+          />
+        )
+      })}
+      <StepButton
+        ml="1rem"
+        isDisabled={currentPage === totalPageCount}
+        onClick={() => onPageChange(currentPage + 1)}
+      >
+        Next
+      </StepButton>
+    </Flex>
+  )
+}

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,12 +1,6 @@
+import { useCallback } from 'react'
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
-import {
-  Button,
-  ButtonProps,
-  Flex,
-  Icon,
-  Text,
-  useMultiStyleConfig,
-} from '@chakra-ui/react'
+import { Button, Flex, Icon, Text, useMultiStyleConfig } from '@chakra-ui/react'
 
 import { PAGINATION_THEME_KEY } from '~theme/components/Pagination'
 import { usePaginationRange } from '~hooks/usePaginationRange'
@@ -53,26 +47,18 @@ const PageButton = ({ selectedPage, page, onClick }: PageButtonProps) => {
 
   const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
 
+  const handleClick = useCallback(() => {
+    if (page === SEPARATOR) return
+    onClick(page)
+  }, [onClick, page])
+
   if (page === SEPARATOR) {
     return <Text sx={styles.separator}>{page}</Text>
   }
 
   return (
-    <Button sx={styles.button} onClick={() => onClick(page)}>
+    <Button sx={styles.button} onClick={handleClick}>
       {page}
-    </Button>
-  )
-}
-
-interface StepButtonProps extends ButtonProps {
-  onClick: () => void
-  children: React.ReactNode
-}
-
-const StepButton = ({ onClick, children, ...props }: StepButtonProps) => {
-  return (
-    <Button onClick={onClick} {...props}>
-      {children}
     </Button>
   )
 }
@@ -92,20 +78,32 @@ export const Pagination = ({
     separator: SEPARATOR,
   })
 
-  const totalPageCount = Math.ceil(totalCount / pageSize)
-
   const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+  const isDisableNextPage = currentPage >= totalPageCount
+  const isDisablePrevPage = currentPage <= 1
+
+  const handlePageBack = useCallback(() => {
+    if (isDisablePrevPage) return
+    onPageChange(currentPage - 1)
+  }, [currentPage, isDisablePrevPage, onPageChange])
+
+  const handlePageNext = useCallback(() => {
+    if (isDisableNextPage) return
+    onPageChange(currentPage + 1)
+  }, [currentPage, isDisableNextPage, onPageChange])
 
   return (
     <Flex __css={styles.container}>
-      <StepButton
+      <Button
         sx={styles.stepperback}
-        isDisabled={currentPage === 1}
-        onClick={() => onPageChange(currentPage - 1)}
+        isDisabled={isDisablePrevPage}
+        onClick={handlePageBack}
       >
         <Icon fontSize="1.5rem" as={BiChevronLeft} />
         Back
-      </StepButton>
+      </Button>
       {paginationRange.map((p, i) => (
         <PageButton
           key={i}
@@ -114,14 +112,14 @@ export const Pagination = ({
           onClick={onPageChange}
         />
       ))}
-      <StepButton
+      <Button
         sx={styles.steppernext}
-        isDisabled={currentPage === totalPageCount}
-        onClick={() => onPageChange(currentPage + 1)}
+        isDisabled={isDisableNextPage}
+        onClick={handlePageNext}
       >
         Next
         <Icon fontSize="1.5rem" as={BiChevronRight} />
-      </StepButton>
+      </Button>
     </Flex>
   )
 }

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -29,6 +29,11 @@ export interface PaginationProps {
    * Represents the current active page. Note that a `1-based index` is used.
    */
   currentPage: number
+
+  /**
+   * Whether pagination buttons are disabled.
+   */
+  isDisabled?: boolean
 }
 
 export const Pagination = (props: PaginationProps): JSX.Element => {

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,12 +1,7 @@
-import { useCallback } from 'react'
-import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
-import { Button, Flex, Icon, Text, useMultiStyleConfig } from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/react'
 
-import { PAGINATION_THEME_KEY } from '~theme/components/Pagination'
-import { usePaginationRange } from '~hooks/usePaginationRange'
-
-// Separate constant to denote a separator in the pagination component.
-const SEPARATOR = '\u2026'
+import { PaginationDesktop } from './PaginationDesktop'
+import { PaginationMobile } from './PaginationMobile'
 
 export interface PaginationProps {
   /**
@@ -36,90 +31,22 @@ export interface PaginationProps {
   currentPage: number
 }
 
-interface PageButtonProps {
-  selectedPage: PaginationProps['currentPage']
-  page: number | typeof SEPARATOR
-  onClick: PaginationProps['onPageChange']
-}
-
-const PageButton = ({ selectedPage, page, onClick }: PageButtonProps) => {
-  const isSelected = page === selectedPage
-
-  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
-
-  const handleClick = useCallback(() => {
-    if (page === SEPARATOR) return
-    onClick(page)
-  }, [onClick, page])
-
-  if (page === SEPARATOR) {
-    return <Text sx={styles.separator}>{page}</Text>
-  }
-
-  return (
-    <Button sx={styles.button} onClick={handleClick}>
-      {page}
-    </Button>
-  )
-}
-
-export const Pagination = ({
-  siblingCount = 1,
-  pageSize,
-  onPageChange,
-  totalCount,
-  currentPage,
-}: PaginationProps): JSX.Element => {
-  const paginationRange = usePaginationRange<typeof SEPARATOR>({
-    totalCount,
-    pageSize,
-    currentPage,
-    siblingCount,
-    separator: SEPARATOR,
+export const Pagination = (props: PaginationProps): JSX.Element => {
+  const isShowMobileVariant = useBreakpointValue({
+    base: true,
+    xs: true,
+    sm: true,
+    md: false,
+    lg: false,
+    xl: false,
   })
 
-  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
-
-  const totalPageCount = Math.ceil(totalCount / pageSize)
-  const isDisableNextPage = currentPage >= totalPageCount
-  const isDisablePrevPage = currentPage <= 1
-
-  const handlePageBack = useCallback(() => {
-    if (isDisablePrevPage) return
-    onPageChange(currentPage - 1)
-  }, [currentPage, isDisablePrevPage, onPageChange])
-
-  const handlePageNext = useCallback(() => {
-    if (isDisableNextPage) return
-    onPageChange(currentPage + 1)
-  }, [currentPage, isDisableNextPage, onPageChange])
-
-  return (
-    <Flex __css={styles.container}>
-      <Button
-        sx={styles.stepperback}
-        isDisabled={isDisablePrevPage}
-        onClick={handlePageBack}
-      >
-        <Icon fontSize="1.5rem" as={BiChevronLeft} />
-        Back
-      </Button>
-      {paginationRange.map((p, i) => (
-        <PageButton
-          key={i}
-          page={p}
-          selectedPage={currentPage}
-          onClick={onPageChange}
-        />
-      ))}
-      <Button
-        sx={styles.steppernext}
-        isDisabled={isDisableNextPage}
-        onClick={handlePageNext}
-      >
-        Next
-        <Icon fontSize="1.5rem" as={BiChevronRight} />
-      </Button>
-    </Flex>
+  return isShowMobileVariant ? (
+    <Pagination.Mobile {...props} />
+  ) : (
+    <Pagination.Desktop {...props} />
   )
 }
+
+Pagination.Desktop = PaginationDesktop
+Pagination.Mobile = PaginationMobile

--- a/frontend/src/components/Pagination/PaginationDesktop.tsx
+++ b/frontend/src/components/Pagination/PaginationDesktop.tsx
@@ -1,0 +1,114 @@
+/**
+ * Desktop variant for the Pagination component.
+ */
+
+import { useCallback } from 'react'
+import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Text,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
+
+import { PAGINATION_THEME_KEY } from '~theme/components/Pagination'
+import { usePaginationRange } from '~hooks/usePaginationRange'
+
+import { PaginationProps } from './Pagination'
+
+// Separate constant to denote a separator in the pagination component.
+const SEPARATOR = '\u2026'
+
+interface DesktopPageButtonProps {
+  selectedPage: PaginationProps['currentPage']
+  page: number | typeof SEPARATOR
+  onClick: PaginationProps['onPageChange']
+}
+
+const DesktopPageButton = ({
+  selectedPage,
+  page,
+  onClick,
+}: DesktopPageButtonProps) => {
+  const isSelected = page === selectedPage
+
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
+
+  const handleClick = useCallback(() => {
+    if (page === SEPARATOR) return
+    onClick(page)
+  }, [onClick, page])
+
+  if (page === SEPARATOR) {
+    return <Text sx={styles.separator}>{page}</Text>
+  }
+
+  return (
+    <Button sx={styles.button} onClick={handleClick}>
+      {page}
+    </Button>
+  )
+}
+
+export const PaginationDesktop = ({
+  siblingCount = 1,
+  pageSize,
+  onPageChange,
+  totalCount,
+  currentPage,
+}: PaginationProps): JSX.Element => {
+  const paginationRange = usePaginationRange<typeof SEPARATOR>({
+    totalCount,
+    pageSize,
+    currentPage,
+    siblingCount,
+    separator: SEPARATOR,
+  })
+
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+  const isDisableNextPage = currentPage >= totalPageCount
+  const isDisablePrevPage = currentPage <= 1
+
+  const handlePageBack = useCallback(() => {
+    if (isDisablePrevPage) return
+    onPageChange(currentPage - 1)
+  }, [currentPage, isDisablePrevPage, onPageChange])
+
+  const handlePageNext = useCallback(() => {
+    if (isDisableNextPage) return
+    onPageChange(currentPage + 1)
+  }, [currentPage, isDisableNextPage, onPageChange])
+
+  return (
+    <Box __css={styles.container}>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Previous page"
+        isDisabled={isDisablePrevPage}
+        onClick={handlePageBack}
+        icon={<BiChevronLeft />}
+      />
+      <HStack spacing="0.125rem">
+        {paginationRange.map((p, i) => (
+          <DesktopPageButton
+            key={i}
+            page={p}
+            selectedPage={currentPage}
+            onClick={onPageChange}
+          />
+        ))}
+      </HStack>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Next page"
+        isDisabled={isDisableNextPage}
+        onClick={handlePageNext}
+        icon={<BiChevronRight />}
+      />
+    </Box>
+  )
+}

--- a/frontend/src/components/Pagination/PaginationDesktop.tsx
+++ b/frontend/src/components/Pagination/PaginationDesktop.tsx
@@ -25,12 +25,14 @@ interface DesktopPageButtonProps {
   selectedPage: PaginationProps['currentPage']
   page: number | typeof SEPARATOR
   onClick: PaginationProps['onPageChange']
+  isDisabled: PaginationProps['isDisabled']
 }
 
 const DesktopPageButton = ({
   selectedPage,
   page,
   onClick,
+  isDisabled,
 }: DesktopPageButtonProps) => {
   const isSelected = page === selectedPage
 
@@ -46,7 +48,7 @@ const DesktopPageButton = ({
   }
 
   return (
-    <Button sx={styles.button} onClick={handleClick}>
+    <Button sx={styles.button} onClick={handleClick} isDisabled={isDisabled}>
       {page}
     </Button>
   )
@@ -58,6 +60,7 @@ export const PaginationDesktop = ({
   onPageChange,
   totalCount,
   currentPage,
+  isDisabled,
 }: PaginationProps): JSX.Element => {
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount,
@@ -70,8 +73,8 @@ export const PaginationDesktop = ({
   const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
 
   const totalPageCount = Math.ceil(totalCount / pageSize)
-  const isDisableNextPage = currentPage >= totalPageCount
-  const isDisablePrevPage = currentPage <= 1
+  const isDisableNextPage = isDisabled || currentPage >= totalPageCount
+  const isDisablePrevPage = isDisabled || currentPage <= 1
 
   const handlePageBack = useCallback(() => {
     if (isDisablePrevPage) return
@@ -97,6 +100,7 @@ export const PaginationDesktop = ({
           <DesktopPageButton
             key={i}
             page={p}
+            isDisabled={isDisabled}
             selectedPage={currentPage}
             onClick={onPageChange}
           />

--- a/frontend/src/components/Pagination/PaginationMobile.tsx
+++ b/frontend/src/components/Pagination/PaginationMobile.tsx
@@ -1,0 +1,58 @@
+/**
+ * Mobile variant for the Pagination component.
+ */
+
+import { useCallback } from 'react'
+import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
+import { Box, IconButton, Text, useMultiStyleConfig } from '@chakra-ui/react'
+
+import { PAGINATION_THEME_KEY } from '~theme/components/Pagination'
+
+import { PaginationProps } from './Pagination'
+
+type PaginationMobileProps = Omit<PaginationProps, 'siblingCount'>
+
+export const PaginationMobile = ({
+  pageSize,
+  onPageChange,
+  totalCount,
+  currentPage,
+}: PaginationMobileProps): JSX.Element => {
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+  const isDisableNextPage = currentPage >= totalPageCount
+  const isDisablePrevPage = currentPage <= 1
+
+  const handlePageBack = useCallback(() => {
+    if (isDisablePrevPage) return
+    onPageChange(currentPage - 1)
+  }, [currentPage, isDisablePrevPage, onPageChange])
+
+  const handlePageNext = useCallback(() => {
+    if (isDisableNextPage) return
+    onPageChange(currentPage + 1)
+  }, [currentPage, isDisableNextPage, onPageChange])
+
+  return (
+    <Box __css={styles.container}>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Previous page"
+        isDisabled={isDisablePrevPage}
+        onClick={handlePageBack}
+        icon={<BiChevronLeft />}
+      />
+      <Text sx={styles.text}>
+        Page {currentPage} of {totalPageCount}
+      </Text>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Next page"
+        isDisabled={isDisableNextPage}
+        onClick={handlePageNext}
+        icon={<BiChevronRight />}
+      />
+    </Box>
+  )
+}

--- a/frontend/src/components/Pagination/PaginationMobile.tsx
+++ b/frontend/src/components/Pagination/PaginationMobile.tsx
@@ -17,12 +17,13 @@ export const PaginationMobile = ({
   onPageChange,
   totalCount,
   currentPage,
+  isDisabled,
 }: PaginationMobileProps): JSX.Element => {
-  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isDisabled })
 
   const totalPageCount = Math.ceil(totalCount / pageSize)
-  const isDisableNextPage = currentPage >= totalPageCount
-  const isDisablePrevPage = currentPage <= 1
+  const isDisableNextPage = isDisabled || currentPage >= totalPageCount
+  const isDisablePrevPage = isDisabled || currentPage <= 1
 
   const handlePageBack = useCallback(() => {
     if (isDisablePrevPage) return
@@ -43,7 +44,7 @@ export const PaginationMobile = ({
         onClick={handlePageBack}
         icon={<BiChevronLeft />}
       />
-      <Text sx={styles.text}>
+      <Text sx={styles.text} aria-disabled={isDisabled}>
         Page {currentPage} of {totalPageCount}
       </Text>
       <IconButton

--- a/frontend/src/components/Pagination/index.ts
+++ b/frontend/src/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination as default } from './Pagination'

--- a/frontend/src/hooks/usePaginationRange.ts
+++ b/frontend/src/hooks/usePaginationRange.ts
@@ -77,9 +77,6 @@ export const usePaginationRange = <T extends unknown = string>({
     const shouldShowRightSeparator =
       totalPageCount - rightSiblingIndex > minGapSize
 
-    const firstPageIndex = 1
-    const lastPageIndex = totalPageCount
-
     /**
      * Case 2: No left separator to show, but right separator to be shown.
      */
@@ -101,7 +98,7 @@ export const usePaginationRange = <T extends unknown = string>({
         totalPageCount - rightItemCount + 1,
         totalPageCount + 1,
       )
-      return [firstPageIndex, separator, ...rightRange]
+      return [1, separator, ...rightRange]
     }
 
     /**
@@ -109,13 +106,7 @@ export const usePaginationRange = <T extends unknown = string>({
      */
     if (shouldShowLeftSeparator && shouldShowRightSeparator) {
       const middleRange = range(leftSiblingIndex, rightSiblingIndex + 1)
-      return [
-        firstPageIndex,
-        separator,
-        ...middleRange,
-        separator,
-        lastPageIndex,
-      ]
+      return [1, separator, ...middleRange, separator, totalPageCount]
     }
 
     // This should never be reached, but in case it is, return the range

--- a/frontend/src/hooks/usePaginationRange.ts
+++ b/frontend/src/hooks/usePaginationRange.ts
@@ -1,0 +1,119 @@
+/**
+ * Custom hook to generate page ranges for any pagination component.
+ * Referenced from
+ * https://www.freecodecamp.org/news/build-a-custom-pagination-component-in-react/
+ */
+
+import { useMemo } from 'react'
+import range from 'lodash/range'
+
+interface UsePaginationRangeProps<T extends unknown = string> {
+  /**
+   * Number of pages to display to left and right of current page.
+   */
+  siblingCount: number
+
+  /**
+   * Total number of elements to paginate.
+   */
+  totalCount: number
+
+  /**
+   * Size of each page. Determines the number of rendered page counts.
+   */
+  pageSize: number
+
+  /**
+   * Represents the current active page. Note that a `1-based index` is used.
+   */
+  currentPage: number
+
+  /**
+   * A constant to denote a separator in the pagination component.
+   */
+  separator: T
+}
+
+export const usePaginationRange = <T extends unknown = string>({
+  totalCount,
+  pageSize,
+  siblingCount,
+  currentPage,
+  separator,
+}: UsePaginationRangeProps<T>): (T | number)[] => {
+  const paginationRange = useMemo(() => {
+    const totalPageCount = Math.ceil(totalCount / pageSize)
+
+    // Pages count is determined as siblingCount + firstPage + lastPage + currentPage + 2*separator
+    const totalPageNumbers = siblingCount + 5
+
+    /**
+     * Case 1:
+     * If the number of pages is less than the page numbers we want to show in
+     * the component, we return the range [1..totalPageCount]
+     */
+    if (totalPageNumbers >= totalPageCount) {
+      return range(1, totalPageCount + 1)
+    }
+
+    // Calculate left and right sibling index and make sure they are within
+    // range [1..totalPageCount]
+    const leftSiblingIndex = Math.max(currentPage - siblingCount, 1)
+    const rightSiblingIndex = Math.min(
+      currentPage + siblingCount,
+      totalPageCount,
+    )
+
+    // Do not show separator just when there is just one page number to be
+    // inserted between the extremes of sibling and the page limits
+    // i.e 1 and totalPageCount.
+    // Hence checking with leftSiblingIndex > 2 and rightSiblingIndex < totalPageCount - 2
+    const shouldShowLeftSeparator = leftSiblingIndex > 2
+    const shouldShowRightSeparator = rightSiblingIndex < totalPageCount - 2
+
+    const firstPageIndex = 1
+    const lastPageIndex = totalPageCount
+
+    /**
+     * Case 2: No left separator to show, but rights separator to be shown.
+     */
+    if (!shouldShowLeftSeparator && shouldShowRightSeparator) {
+      const leftItemCount = 3 + 2 * siblingCount
+      const leftRange = range(1, leftItemCount + 1)
+
+      return [...leftRange, separator, totalPageCount]
+    }
+
+    /**
+     * Case 3: No right separator to show, but left separator to be shown.
+     */
+    if (shouldShowLeftSeparator && !shouldShowRightSeparator) {
+      const rightItemCount = 3 + 2 * siblingCount
+      const rightRange = range(
+        totalPageCount - rightItemCount + 1,
+        totalPageCount + 1,
+      )
+      return [firstPageIndex, separator, ...rightRange]
+    }
+
+    /**
+     * Case 4: Both left and right separator to be shown
+     */
+    if (shouldShowLeftSeparator && shouldShowRightSeparator) {
+      const middleRange = range(leftSiblingIndex, rightSiblingIndex + 1)
+      return [
+        firstPageIndex,
+        separator,
+        ...middleRange,
+        separator,
+        lastPageIndex,
+      ]
+    }
+
+    // This should never be reached, but in case it is, return the range
+    // [1..totalPageCount]
+    return range(1, totalPageCount + 1)
+  }, [totalCount, pageSize, siblingCount, currentPage, separator])
+
+  return paginationRange
+}

--- a/frontend/src/hooks/usePaginationRange.ts
+++ b/frontend/src/hooks/usePaginationRange.ts
@@ -67,8 +67,7 @@ export const usePaginationRange = <T extends unknown = string>({
     // Do not show separator just when there is just one page number to be
     // inserted between the extremes of sibling and the page limits
     // i.e 1 and totalPageCount.
-    // Hence checking with leftSiblingIndex > 2 and rightSiblingIndex < totalPageCount - 2
-    const shouldShowLeftSeparator = leftSiblingIndex > 2
+    const shouldShowLeftSeparator = leftSiblingIndex - 1 > 2
     const shouldShowRightSeparator = rightSiblingIndex < totalPageCount - 2
 
     const firstPageIndex = 1

--- a/frontend/src/theme/components/Pagination.ts
+++ b/frontend/src/theme/components/Pagination.ts
@@ -5,10 +5,11 @@ export const PAGINATION_THEME_KEY = 'Pagination'
 const baseButtonStyling = (props: Record<string, any>) => {
   const { isSelected } = props
   return {
-    p: '0.25rem 0.75rem',
+    p: '0.25rem 0.625rem',
     minH: '2rem',
     minW: '2rem',
     border: 'none',
+    borderRadius: '0.25rem',
     bg: isSelected ? 'secondary.500' : 'transparent',
     _active: {
       bg: isSelected ? 'secondary.700' : 'secondary.200',
@@ -33,12 +34,13 @@ const baseButtonStyling = (props: Record<string, any>) => {
 }
 
 export const Pagination: ComponentMultiStyleConfig = {
-  parts: ['button', 'container', 'separator', 'stepperback', 'steppernext'],
+  parts: ['button', 'container', 'separator', 'stepper', 'text'],
   variants: {
     solid: (props) => {
       const buttonStyling = baseButtonStyling(props)
       return {
         container: {
+          display: 'flex',
           textStyle: 'body-2',
         },
         separator: {
@@ -47,17 +49,21 @@ export const Pagination: ComponentMultiStyleConfig = {
           minH: '2rem',
           minW: '2rem',
         },
-        stepperback: {
-          ...buttonStyling,
-          pr: '0.5rem',
-          pl: 0,
-          mr: '0.5rem',
+        text: {
+          alignSelf: 'center',
+          p: '0.25rem 0.75rem',
         },
-        steppernext: {
+        stepper: {
           ...buttonStyling,
-          pl: '0.5rem',
+          fontSize: '1.5rem',
+          pl: 0,
           pr: 0,
-          ml: '0.5rem',
+          _first: {
+            mr: '0.25rem',
+          },
+          _last: {
+            ml: '0.25rem',
+          },
         },
         button: buttonStyling,
       }

--- a/frontend/src/theme/components/Pagination.ts
+++ b/frontend/src/theme/components/Pagination.ts
@@ -1,0 +1,69 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+
+export const PAGINATION_THEME_KEY = 'Pagination'
+
+const baseButtonStyling = (props: Record<string, any>) => {
+  const { isSelected } = props
+  return {
+    p: '0.25rem 0.75rem',
+    minH: '2rem',
+    minW: '2rem',
+    border: 'none',
+    bg: isSelected ? 'secondary.500' : 'transparent',
+    _active: {
+      bg: isSelected ? 'secondary.700' : 'secondary.200',
+    },
+    _hover: {
+      bg: isSelected ? 'secondary.600' : 'secondary.100',
+    },
+    _focus: {
+      boxShadow: `0 0 0 2px var(--chakra-colors-secondary-300)`,
+    },
+    _disabled: {
+      bg: 'transparent',
+      cursor: 'not-allowed',
+      color: 'secondary.300',
+      _hover: {
+        bg: 'transparent',
+        color: 'secondary.300',
+      },
+    },
+    color: isSelected ? 'white' : 'secondary.500',
+  }
+}
+
+export const Pagination: ComponentMultiStyleConfig = {
+  parts: ['button', 'container', 'separator', 'stepperback', 'steppernext'],
+  variants: {
+    solid: (props) => {
+      const buttonStyling = baseButtonStyling(props)
+      return {
+        container: {
+          textStyle: 'body-2',
+        },
+        separator: {
+          display: 'inline-block',
+          p: '0.25rem 0.75rem',
+          minH: '2rem',
+          minW: '2rem',
+        },
+        stepperback: {
+          ...buttonStyling,
+          pr: '0.5rem',
+          pl: 0,
+          mr: '0.5rem',
+        },
+        steppernext: {
+          ...buttonStyling,
+          pl: '0.5rem',
+          pr: 0,
+          ml: '0.5rem',
+        },
+        button: buttonStyling,
+      }
+    },
+  },
+  defaultProps: {
+    variant: 'solid',
+  },
+}

--- a/frontend/src/theme/components/Pagination.ts
+++ b/frontend/src/theme/components/Pagination.ts
@@ -21,12 +21,12 @@ const baseButtonStyling = (props: Record<string, any>) => {
       boxShadow: `0 0 0 2px var(--chakra-colors-secondary-300)`,
     },
     _disabled: {
-      bg: 'transparent',
+      bg: isSelected ? 'secondary.300' : 'transparent',
       cursor: 'not-allowed',
-      color: 'secondary.300',
+      color: isSelected ? 'white' : 'secondary.300',
       _hover: {
-        bg: 'transparent',
-        color: 'secondary.300',
+        bg: isSelected ? 'secondary.300' : 'transparent',
+        color: isSelected ? 'white' : 'secondary.300',
       },
     },
     color: isSelected ? 'white' : 'secondary.500',
@@ -38,6 +38,8 @@ export const Pagination: ComponentMultiStyleConfig = {
   variants: {
     solid: (props) => {
       const buttonStyling = baseButtonStyling(props)
+      const { isDisabled } = props
+
       return {
         container: {
           display: 'flex',
@@ -52,6 +54,7 @@ export const Pagination: ComponentMultiStyleConfig = {
         text: {
           alignSelf: 'center',
           p: '0.25rem 0.75rem',
+          color: isDisabled ? 'secondary.300' : 'secondary.500',
         },
         stepper: {
           ...buttonStyling,

--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -8,6 +8,7 @@ import { FormLabel } from './FormLabel'
 import { Input } from './Input'
 import { Link } from './Link'
 import { NumberInput } from './NumberInput'
+import { Pagination, PAGINATION_THEME_KEY } from './Pagination'
 import { PhoneNumberInput } from './PhoneNumberInput'
 import { Textarea } from './Textarea'
 
@@ -22,6 +23,7 @@ export const components = {
   NumberInput,
   PhoneNumberInput,
   Textarea,
+  [PAGINATION_THEME_KEY]: Pagination,
   [RATING_THEME_KEY]: RatingField,
   [YESNO_THEME_KEY]: YesNoField,
 }

--- a/frontend/tsconfig.paths.json
+++ b/frontend/tsconfig.paths.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"],
       "~assets/*": ["./src/assets/*"],
       "~contexts/*": ["./src/contexts/*"],
       "~constants/*": ["./src/constants/*"],
@@ -12,7 +11,8 @@
       "~pages/*": ["./src/pages/*"],
       "~services/*": ["./src/services/*"],
       "~theme/*": ["./src/theme/*"],
-      "~typings/*": ["./src/typings/*"]
+      "~typings/*": ["./src/typings/*"],
+      "~/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the Pagination component, along with its stories. Uses a `usePagination` hook to generate the correct buttons.

Closes #2016 

## Solution
<!-- How did you solve the problem? -->

**Features**:
- add Pagination component and stories

**Improvements**
- chore: move root path alias to bottom
  - in a bid to let other paths resolve first before trying to use the root import, not sure if it works

## Before & After Screenshots
In storybook

## Dependencies
- "lodash": "^4.17.21"
