### PR TITLE
feat: add MYINFO_BANNER_CONTENT env var for bannering myinfo forms

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -107,6 +107,7 @@ FORMSG_SDK_MODE=
 
 # IS_SP_MAINTENANCE=
 # IS_CP_MAINTENANCE=
+# MYINFO_BANNER_CONTENT=
 
 ## Per-minute, per-IP request limits applied to specific endpoints
 # SUBMISSIONS_RATE_LIMIT=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - CORPPASS_IDP_ID=https://saml.corppass.gov.sg/FIM/sps/CorpIDPFed/saml20
       - IS_SP_MAINTENANCE
       - IS_CP_MAINTENANCE
+      - MYINFO_BANNER_CONTENT
       - MYINFO_CLIENT_CONFIG=dev
       - MYINFO_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
       - MYINFO_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/spcp.crt

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -106,7 +106,7 @@ The following env variables are set in Travis:
 ## Environment Variables
 
 These are configured by creating groups of environment variables formatted like `.env` files in the Parameter
-Store of AWS Service Manager. These groups have names formatted as `<environment>-<category>`. 
+Store of AWS Service Manager. These groups have names formatted as `<environment>-<category>`.
 
 The environment for each group is user-defined, and should be specified in the Elastic Beanstalk configuration
 as the environment variable `SSM_PREFIX`.
@@ -117,9 +117,9 @@ The list of categories can be inferred by looking at the file `.ebextensions/env
 
 #### AWS Service Manager
 
-| Variable            | Description                                                                                                      |
-| :------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `SSM_PREFIX`        | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG.     |
+| Variable     | Description                                                                                                  |
+| :----------- | ------------------------------------------------------------------------------------------------------------ |
+| `SSM_PREFIX` | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG. |
 
 #### App Config
 
@@ -190,6 +190,7 @@ SITE_BANNER_CONTENT=hello:This is an invalid banner type, and the full text will
 | `ADMIN_BANNER_CONTENT`   | If set, displays a banner message on private admin routes such as the form list page as well as form builder pages.                                                                                           |
 | `IS_LOGIN_BANNER`        | If set, displays a banner message on the login page.                                                                                                                                                          |
 | `IS_GENERAL_MAINTENANCE` | If set, displays a banner message on all forms. Overrides `IS_SP_MAINTENANCE` and `IS_CP_MAINTENANCE`.                                                                                                        |
+| `MYINFO_BANNER_CONTENT`  | all public **MyInfo-enabled** forms                                                                                                                                                                           |
 | `IS_SP_MAINTENANCE`      | all public **SingPass-enabled** forms                                                                                                                                                                         |
 | `IS_CP_MAINTENANCE`      | all public **CorpPass-enabled** forms                                                                                                                                                                         |
 

--- a/src/app/config/features/spcp-myinfo.config.ts
+++ b/src/app/config/features/spcp-myinfo.config.ts
@@ -8,6 +8,7 @@ const DAY_IN_MILLIS = 24 * HOUR_IN_MILLIS
 type ISpcpConfig = {
   isSPMaintenance: string
   isCPMaintenance: string
+  myInfoBannerContent: string
   spCookieMaxAge: number
   spCookieMaxAgePreserved: number
   spcpCookieDomain: string
@@ -58,6 +59,12 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: '*',
     default: null,
     env: 'IS_CP_MAINTENANCE',
+  },
+  myInfoBannerContent: {
+    doc: 'If set, displays a banner message on MyInfo forms',
+    format: '*',
+    default: null,
+    env: 'MYINFO_BANNER_CONTENT',
   },
   spCookieMaxAge: {
     doc: 'Max SingPass cookie age with remember me unchecked',

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -18,6 +18,7 @@ const frontendVars = {
   sentryConfigUrl: sentryConfig.sentryConfigUrl, // Sentry.IO
   isSPMaintenance: spcpMyInfoConfig.isSPMaintenance, // Singpass maintenance message
   isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
+  myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
   GATrackingID: googleAnalyticsConfig.GATrackingID,
   spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
   oldSpcpCookieDomain: spcpMyInfoConfig.oldSpcpCookieDomain, // Old cookie domain used for backward compatibility. TODO (#2329): Delete env var
@@ -27,6 +28,7 @@ const environment = ejs.render(
     // Singpass/Corppass maintenance message
     var isSPMaintenance = "<%- isSPMaintenance %>"
     var isCPMaintenance = "<%- isCPMaintenance %>"
+    var myInfoBannerContent = "<%- myInfoBannerContent %>"
     var isGeneralMaintenance = "<%- isGeneralMaintenance %>"
     var isLoginBanner = "<%- isLoginBanner %>"
     var siteBannerContent = "<%- siteBannerContent %>"

--- a/src/app/modules/spcp/__tests__/spcp.test.constants.ts
+++ b/src/app/modules/spcp/__tests__/spcp.test.constants.ts
@@ -3,7 +3,7 @@ import { ObjectId } from 'bson'
 import crypto from 'crypto'
 import _ from 'lodash'
 
-import { ISpcpMyInfo } from 'src/app/config/feature-manager'
+import { ISpcpMyInfo } from 'src/app/config/features/spcp-myinfo.config'
 import { ILoginSchema, IPopulatedForm } from 'src/types'
 
 import { JwtName } from '../spcp.types'
@@ -11,8 +11,10 @@ import { JwtName } from '../spcp.types'
 export const MOCK_SERVICE_PARAMS: ISpcpMyInfo = {
   isSPMaintenance: 'isSPMaintenance',
   isCPMaintenance: 'isCPMaintenance',
+  myInfoBannerContent: 'myInfoBannerContent',
   spCookieMaxAge: 1,
   spCookieMaxAgePreserved: 2,
+  oldSpcpCookieDomain: 'oldSpcpCookieDomain',
   spcpCookieDomain: 'spcpCookieDomain',
   cpCookieMaxAge: 3,
   // spIdpId and cpIdpId need to match the injected environment values

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -78,6 +78,10 @@ function SubmitFormController(
     vm.banner = {
       msg: $window.isCPMaintenance,
     }
+  } else if (vm.myform.authType === 'MyInfo' && $window.myInfoBannerContent) {
+    vm.banner = {
+      msg: $window.myInfoBannerContent,
+    }
   } else {
     vm.banner = {}
   }

--- a/src/public/utils/injectedVariables.ts
+++ b/src/public/utils/injectedVariables.ts
@@ -11,6 +11,7 @@ interface FrontendInjectedVariables {
   sentryConfigUrl: string | null
   isSPMaintenance: string | null
   isCPMaintenance: string | null
+  myInfoBannerContent: string | null
   GATrackingID: string | null
   spcpCookieDomain: string | null
 }
@@ -31,6 +32,7 @@ export const injectedVariables: FrontendInjectedVariables = {
   sentryConfigUrl: formsgWindow.sentryConfigUrl ?? null,
   isSPMaintenance: formsgWindow.isSPMaintenance ?? null,
   isCPMaintenance: formsgWindow.isCPMaintenance ?? null,
+  myInfoBannerContent: formsgWindow.myInfoBannerContent ?? null,
   GATrackingID: formsgWindow.GATrackingID ?? null,
   spcpCookieDomain: formsgWindow.spcpCookieDomain ?? null,
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We have had to use the basic IS_GENERAL_MAINTENANCE environment variable for MyInfo specific banners for a couple times now, and thus should really have a MyInfo specific banner environment variable.

Closes #1779 

