### PR TITLE
fix: Fix express session types based on latest definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,13 +4917,12 @@
       }
     },
     "@types/express-session": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.0.tgz",
-      "integrity": "sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.4.tgz",
+      "integrity": "sha512-7cNlSI8+oOBUHTfPXMwDxF/Lchx5aJ3ho7+p9jJZYVg9dVDJFh3qdMXmJtRsysnvS+C6x46k9DRYmrmCkE+MVg==",
       "dev": true,
       "requires": {
-        "@types/express": "*",
-        "@types/node": "*"
+        "@types/express": "*"
       }
     },
     "@types/glob": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@types/express": "^4.17.13",
     "@types/express-rate-limit": "^5.1.3",
     "@types/express-request-id": "^1.4.2",
-    "@types/express-session": "^1.17.0",
+    "@types/express-session": "^1.17.4",
     "@types/has-ansi": "^3.0.0",
     "@types/helmet": "4.0.0",
     "@types/ip": "^1.1.0",

--- a/src/app/modules/auth/auth.middlewares.ts
+++ b/src/app/modules/auth/auth.middlewares.ts
@@ -1,3 +1,4 @@
+import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../config/logger'
@@ -33,7 +34,7 @@ export const logAdminAction: ControllerHandler<{ formId: string }> = async (
   res,
   next,
 ) => {
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const body = req.body
   const method = req.method
   const query = req.query

--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -1,3 +1,4 @@
+import { AuthedSessionData, SessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 
 import { MapRouteError } from '../../../types/routing'
@@ -52,13 +53,13 @@ export const mapRouteError: MapRouteError = (error, coreErrorMessage) => {
 }
 
 export const isUserInSession = (
-  session?: Express.Session,
-): session is Express.AuthedSession => {
+  session?: SessionData,
+): session is AuthedSessionData => {
   return !!session?.user?._id
 }
 
 export const getUserIdFromSession = (
-  session?: Express.Session,
+  session?: SessionData,
 ): string | undefined => {
   return session?.user?._id as string | undefined
 }

--- a/src/app/modules/billing/billing.controller.ts
+++ b/src/app/modules/billing/billing.controller.ts
@@ -1,3 +1,4 @@
+import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import moment from 'moment-timezone'
 
@@ -25,7 +26,7 @@ export const handleGetBillInfo: ControllerHandler<
   BillingQueryDto
 > = async (req, res) => {
   const { esrvcId, mth, yr } = req.query
-  const authedUser = (req.session as Express.AuthedSession).user
+  const authedUser = (req.session as AuthedSessionData).user
 
   const startOfMonth = moment
     .tz([parseInt(yr), parseInt(mth)], 'Asia/Singapore')

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1,5 +1,6 @@
 import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
+import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
 import { ResultAsync } from 'neverthrow'
@@ -199,7 +200,7 @@ export const handleListDashboardForms: ControllerHandler<
   unknown,
   AdminDashboardFormMetaDto[] | ErrorDto
 > = async (req, res) => {
-  const authedUserId = (req.session as Express.AuthedSession).user._id
+  const authedUserId = (req.session as AuthedSessionData).user._id
 
   return AdminFormService.getDashboardForms(authedUserId)
     .map((dashboardView) => res.json(dashboardView))
@@ -233,7 +234,7 @@ export const handleGetAdminForm: ControllerHandler<{ formId: string }> = (
   res,
 ) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -279,7 +280,7 @@ export const handleGetFormCollaborators: ControllerHandler<
   PermissionsUpdateDto | ErrorDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -327,7 +328,7 @@ export const handlePreviewAdminForm: ControllerHandler<{ formId: string }> = (
   res,
 ) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   return (
     // Step 1: Retrieve currently logged in user.
     UserService.getPopulatedUserById(sessionUserId)
@@ -383,7 +384,7 @@ export const createPresignedPostUrlForImages: ControllerHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { fileId, fileMd5Hash, fileType } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -448,7 +449,7 @@ export const createPresignedPostUrlForLogos: ControllerHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { fileId, fileMd5Hash, fileType } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -521,7 +522,7 @@ export const countFormSubmissions: ControllerHandler<
 > = async (req, res) => {
   const { formId } = req.params
   const { startDate, endDate } = req.query
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   const logMeta = {
     action: 'handleCountFormSubmissions',
@@ -596,7 +597,7 @@ export const handleCountFormFeedback: ControllerHandler<
   number | ErrorDto
 > = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -645,7 +646,7 @@ export const handleStreamFormFeedback: ControllerHandler<{
   formId: string
 }> = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   const hasReadPermissionResult = await UserService.getPopulatedUserById(
@@ -740,7 +741,7 @@ export const handleGetFormFeedback: ControllerHandler<
   FormFeedbackMetaDto | ErrorDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return UserService.getPopulatedUserById(sessionUserId)
     .andThen((user) =>
@@ -784,7 +785,7 @@ export const handleArchiveForm: ControllerHandler<{ formId: string }> = async (
   res,
 ) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -837,7 +838,7 @@ export const duplicateAdminForm: ControllerHandler<
   DuplicateFormBodyDto
 > = (req, res) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = (req.session as AuthedSessionData).user._id
   const overrideParams = req.body
 
   return (
@@ -901,7 +902,7 @@ export const handleGetTemplateForm: ControllerHandler<
   PreviewFormViewDto | ErrorDto | PrivateFormErrorDto
 > = (req, res) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve form only if form is currently public.
@@ -961,7 +962,7 @@ export const handleCopyTemplateForm: ControllerHandler<
   DuplicateFormBodyDto
 > = (req, res) => {
   const { formId } = req.params
-  const userId = (req.session as Express.AuthedSession).user._id
+  const userId = (req.session as AuthedSessionData).user._id
   const overrideParams = req.body
 
   return (
@@ -1023,7 +1024,7 @@ export const transferFormOwnership: ControllerHandler<
 > = (req, res) => {
   const { formId } = req.params
   const { email: newOwnerEmail } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -1082,7 +1083,7 @@ export const createForm: ControllerHandler<
   { form: CreateFormBodyDto }
 > = async (req, res) => {
   const { form: formParams } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -1139,7 +1140,7 @@ export const handleUpdateForm: ControllerHandler<
 > = (req, res) => {
   const { formId } = req.params
   const { form: formUpdateParams } = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return UserService.getPopulatedUserById(sessionUserId)
@@ -1207,7 +1208,7 @@ export const handleDuplicateFormField: ControllerHandler<
   FormFieldDto | ErrorDto
 > = (req, res) => {
   const { formId, fieldId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return UserService.getPopulatedUserById(sessionUserId)
@@ -1261,7 +1262,7 @@ export const handleUpdateSettings: ControllerHandler<
   SettingsUpdateDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const settingsToPatch = req.body
 
   // Step 1: Retrieve currently logged in user.
@@ -1309,7 +1310,7 @@ export const _handleUpdateFormField: ControllerHandler<
   FieldUpdateDto
 > = (req, res) => {
   const { formId, fieldId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -1364,7 +1365,7 @@ export const handleGetSettings: ControllerHandler<
   FormSettings | ErrorDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return UserService.getPopulatedUserById(sessionUserId)
     .andThen((user) =>
@@ -1410,7 +1411,7 @@ export const submitEncryptPreview: ControllerHandler<
   EncryptSubmissionDto
 > = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   // No need to process attachments as we don't do anything with them
   const { encryptedContent, responses, version } = req.body
   const logMeta = {
@@ -1505,7 +1506,7 @@ export const submitEmailPreview: ControllerHandler<
   { captchaResponse?: unknown }
 > = async (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   // No need to process attachments as we don't do anything with them
   const { responses } = req.body
   const logMeta = {
@@ -1697,7 +1698,7 @@ export const _handleCreateFormField: ControllerHandler<
   FieldCreateDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -1752,7 +1753,7 @@ export const _handleCreateLogic: ControllerHandler<
 > = (req, res) => {
   const { formId } = req.params
   const createLogicBody = req.body
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -1853,7 +1854,7 @@ export const handleDeleteLogic: ControllerHandler<{
   logicId: string
 }> = (req, res) => {
   const { formId, logicId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -1935,7 +1936,7 @@ export const _handleReorderFormField: ControllerHandler<
 > = (req, res) => {
   const { formId, fieldId } = req.params
   const { to } = req.query
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -2003,7 +2004,7 @@ export const _handleUpdateLogic: ControllerHandler<
 > = (req, res) => {
   const { formId, logicId } = req.params
   const updatedLogic = { ...req.body }
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -2079,7 +2080,7 @@ export const handleDeleteFormField: ControllerHandler<
   ErrorDto | void
 > = (req, res) => {
   const { formId, fieldId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -2132,7 +2133,7 @@ export const _handleUpdateEndPage: ControllerHandler<
   EndPageUpdateDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (
@@ -2202,7 +2203,7 @@ export const handleGetFormField: ControllerHandler<
   ErrorDto | FormFieldDto
 > = (req, res) => {
   const { formId, fieldId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -2256,7 +2257,7 @@ export const _handleUpdateCollaborators: ControllerHandler<
   PermissionsUpdateDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   // Step 1: Get the form after permission checks
   return (
     UserService.getPopulatedUserById(sessionUserId)
@@ -2329,7 +2330,7 @@ export const handleRemoveSelfFromCollaborators: ControllerHandler<
   PermissionsUpdateDto | ErrorDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   let currentUserEmail = ''
   // Step 1: Get the form after permission checks
   return (
@@ -2393,7 +2394,7 @@ export const _handleUpdateStartPage: ControllerHandler<
   StartPageUpdateDto
 > = (req, res) => {
   const { formId } = req.params
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
   return (

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -1,5 +1,6 @@
 import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
+import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
 import mongoose from 'mongoose'
@@ -405,7 +406,7 @@ export const streamEncryptedResponses: ControllerHandler<
   unknown,
   { startDate?: string; endDate?: string; downloadAttachments: boolean }
 > = async (req, res) => {
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const { formId } = req.params
   const { startDate, endDate } = req.query
 
@@ -545,7 +546,7 @@ export const getEncryptedResponseUsingQueryParams: ControllerHandler<
   unknown,
   { submissionId: string }
 > = async (req, res) => {
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const { submissionId } = req.query
   const { formId } = req.params
 
@@ -623,7 +624,7 @@ export const handleGetEncryptedResponse: ControllerHandler<
   { formId: string; submissionId: string },
   EncryptedSubmissionDto | ErrorDto
 > = async (req, res) => {
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const { formId, submissionId } = req.params
 
   return (
@@ -695,7 +696,7 @@ export const getMetadata: ControllerHandler<
     'page' | 'submissionId'
   >
 > = async (req, res) => {
-  const sessionUserId = (req.session as Express.AuthedSession).user._id
+  const sessionUserId = (req.session as AuthedSessionData).user._id
   const { formId } = req.params
   const { page, submissionId } = req.query
 

--- a/src/types/vendor/express.d.ts
+++ b/src/types/vendor/express.d.ts
@@ -5,17 +5,19 @@ declare global {
     export interface Request {
       id?: string
     }
+  }
+}
 
-    export interface Session {
-      user?: {
-        _id: IUserSchema['_id']
-      }
+declare module 'express-session' {
+  export interface SessionData {
+    user?: {
+      _id: IUserSchema['_id']
     }
+  }
 
-    export interface AuthedSession extends Session {
-      user: {
-        _id: IUserSchema['_id']
-      }
+  export interface AuthedSessionData extends SessionData {
+    user: {
+      _id: IUserSchema['_id']
     }
   }
 }


### PR DESCRIPTION
## Context
The package [`@types/express-session`](https://www.npmjs.com/package/@types/express-session) introduced a breaking change between `1.17.0` and `1.17.1` when it cleaned up its type definition. See discussion [here](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d1259ee31e6b17c31a5a86e27a0d12f3ec7c5a19#r44080605).

Although our `package.json` declaration is `^1.17.0`, we have been protected from typescript compilation errors thanks to the version being locked in `package-lock.json`.

Doing a fresh install from scratch based on package.json alone however yields typescript compilation errors on type isses like these:
```
src/app/modules/auth/auth.controller.ts:163:21 - error TS2339: Property 'user' does not exist on type 'Session & Partial<SessionData>'.
163         req.session.user = { _id }
                        ~~~~
src/app/modules/auth/auth.middlewares.ts:18:23 - error TS2345: Argument of type 'Session & Partial<SessionData>' is not assignable to parameter of type 'Session | undefined'.
  Type 'Session & Partial<SessionData>' has no properties in common with type 'Session'.
18   if (isUserInSession(req.session)) {
                         ~~~~~~~~~~~
src/app/modules/auth/auth.middlewares.ts:36:26 - error TS2352: Conversion of type 'Session & Partial<SessionData>' to type 'AuthedSession' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Property 'user' is missing in type 'Session & Partial<SessionData>' but required in type 'AuthedSession'.
36   const sessionUserId = (req.session as Express.AuthedSession).user._id
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/types/vendor/express.d.ts:16:7
    16       user: {
             ~~~~
    'user' is declared here.
```

## Approach

1. Upgrade explicitly to package `@types/express-session@1.17.4`
2. Fix augmentation of the types for express session to be compatible with [latest declarations](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-session/index.d.ts)

Note in particular that:
* The global Express namespace no longer include `Session` and `SessionData`
* Augmentation of Session must be done via extension on `SessionData`, not `Session`

Still TODO: 
- [X] Verify tests pass
- [x] Test locally

## Risks
Impact: **High**: making code changes affecting authenticated sessions could break user access
Likelihood: **Low**: Functionality of code itself is not changed, only type declarations