### PR TITLE
fix(SGID): disallow SGID authentication in storage mode

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -12,6 +12,7 @@ import getFormModel, {
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
 import {
+  AuthType,
   BasicField,
   EndPage,
   FormFieldWithId,
@@ -567,6 +568,32 @@ describe('Form Model', () => {
         await expect(invalidForm.save()).rejects.toThrowError(
           mongoose.Error.ValidationError,
         )
+      })
+
+      it('should set authType to NIL when given authType is MyInfo', async () => {
+        // Arrange
+        const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          authType: AuthType.MyInfo,
+        })
+
+        // Act
+        const invalidForm = await EncryptedForm.create(malformedParams)
+
+        // Assert
+        await expect(invalidForm.authType).toBe(AuthType.NIL)
+      })
+
+      it('should set authType to NIL when given authType is SGID', async () => {
+        // Arrange
+        const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          authType: AuthType.SGID,
+        })
+
+        // Act
+        const invalidForm = await EncryptedForm.create(malformedParams)
+
+        // Assert
+        await expect(invalidForm.authType).toBe(AuthType.NIL)
       })
     })
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -338,12 +338,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           // Do not allow authType to be changed if form is published
           if (this.authType !== v && this.status === Status.Public) {
             return this.authType
+            // Singpass/Corppass authentication is available for both email
+            // and storage mode
+            // Important - this case must come before the MyInfo/SGID + storage
+            // mode case, or else we may accidentally set Singpass/Corppass storage
+            // mode forms to AuthType.NIL
+          } else if ([AuthType.SP, AuthType.CP].includes(v)) {
+            return v
           } else if (
             this.responseMode === ResponseMode.Encrypt &&
-            v === AuthType.MyInfo
+            // SGID and MyInfo are not available for storage mode
+            (v === AuthType.MyInfo || v === AuthType.SGID)
           ) {
-            // Do not allow storage mode to have MyInfo authentication
-            return this.authType
+            return AuthType.NIL
           } else {
             return v
           }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

SGID is currently not enabled in storage mode, and the settings tab UI prevents users from enabling SGID on a storage mode form. However, SGID email-mode forms can still be duplicated into storage mode while preserving the SGID auth type, resulting in invalid forms which cannot be submitted.

Closes #2390 

## Solution
<!-- How did you solve the problem? -->

Add model-level validation which sets the `authType` to `NIL` when attempting to create an SGID form in storage mode.

## Manual tests
- [ ] Duplicate an SGID email-mode form into storage mode. The authentication type of the new duplicated form should be NIL.