### PR TITLE
fix(snyk): Fix vulnerability in Twilio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24319,9 +24319,9 @@
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "twilio": {
-      "version": "3.66.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.66.0.tgz",
-      "integrity": "sha512-2jek7akXcRMusoR20EWA1+e5TQp9Ahosvo81wTUoeS7H24A1xbVQJV4LfSWQN4DLUY1oZ4d6tH2oCe/+ELcpNA==",
+      "version": "3.66.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.66.1.tgz",
+      "integrity": "sha512-BmIgfx2VuS7tj4IscBhyEj7CdmtfIaaJ1IuNeGoJFYBx5xikpuwkR0Ceo5CNtK5jnN3SCKmxHxToec/MYEXl0A==",
       "requires": {
         "axios": "^0.21.1",
         "dayjs": "^1.8.29",
@@ -24747,9 +24747,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "toastr": "^2.1.4",
     "triple-beam": "^1.3.0",
     "tweetnacl": "^1.0.1",
-    "twilio": "^3.66.0",
+    "twilio": "^3.66.1",
     "ui-select": "^0.19.8",
     "uid-generator": "^2.0.0",
     "uuid": "^8.3.2",


### PR DESCRIPTION
## Context
An open redirect issue was flagged in [`url-parse@1.5.1`](https://github.com/opengovsg/FormSG/pull/2469#issue-699316411) used by [twilio@3.66.0](https://www.npmjs.com/package/twilio)

closes [this snyk issue](https://app.snyk.io/org/open-government-products/project/d5cee0f2-80bf-4efc-9f84-61ab911f7cef#issue-SNYK-JS-URLPARSE-1533425)

## Approach
Upgrade Twilio to next patch version 3.66.1 (released 12h ago! 💪 ), which upgrades the offending dependency (url-parse 1.5.1 -> 1.5.3)
