### PR TITLE
fix(login): show Joi validation error correctly

### DIFF
--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -357,7 +357,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(400)
       expect(response.body).toEqual(
         buildCelebrateError({
-          body: { key: 'otp', message: 'Please enter a valid otp' },
+          body: { key: 'otp', message: 'Please enter a valid OTP' },
         }),
       )
     })
@@ -373,7 +373,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(400)
       expect(response.body).toEqual(
         buildCelebrateError({
-          body: { key: 'otp', message: 'Please enter a valid otp' },
+          body: { key: 'otp', message: 'Please enter a valid OTP' },
         }),
       )
     })

--- a/src/app/modules/auth/auth.routes.ts
+++ b/src/app/modules/auth/auth.routes.ts
@@ -82,7 +82,7 @@ AuthRouter.post(
       otp: Joi.string()
         .required()
         .regex(/^\d{6}$/)
-        .message('Please enter a valid otp'),
+        .message('Please enter a valid OTP'),
     }),
   }),
   AuthController.handleLoginVerifyOtp,

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -356,7 +356,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(400)
       expect(response.body).toEqual(
         buildCelebrateError({
-          body: { key: 'otp', message: 'Please enter a valid otp' },
+          body: { key: 'otp', message: 'Please enter a valid OTP' },
         }),
       )
     })
@@ -372,7 +372,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(400)
       expect(response.body).toEqual(
         buildCelebrateError({
-          body: { key: 'otp', message: 'Please enter a valid otp' },
+          body: { key: 'otp', message: 'Please enter a valid OTP' },
         }),
       )
     })

--- a/src/app/routes/api/v3/auth/auth.routes.ts
+++ b/src/app/routes/api/v3/auth/auth.routes.ts
@@ -80,7 +80,7 @@ AuthRouter.post(
       otp: Joi.string()
         .required()
         .regex(/^\d{6}$/)
-        .message('Please enter a valid otp'),
+        .message('Please enter a valid OTP'),
     }),
   }),
   AuthController.handleLoginVerifyOtp,

--- a/src/public/modules/users/controllers/authentication.client.controller.js
+++ b/src/public/modules/users/controllers/authentication.client.controller.js
@@ -245,11 +245,15 @@ function AuthenticationController($q, $scope, $state, $timeout, $window, GTag) {
         GTag.loginSuccess('otp')
       })
       .catch((error) => {
-        let errorMsg = get(
-          error,
-          'response.data',
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-        )
+        let errorMsg =
+          get(error, 'response.data.validation.body.message') ||
+          get(
+            error,
+            // Normally the error message is in response.data.message, but this particular
+            // API is an exception as it sends the error message as a string in response.data
+            'response.data',
+            'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          )
         const errorStatus = get(error, 'response.status')
         if (errorStatus >= StatusCodes.INTERNAL_SERVER_ERROR) {
           errorMsg = 'An unknown error occurred'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2455 

## Solution
<!-- How did you solve the problem? -->

- Correct casing in Joi OTP error message
- In the frontend, search for a Joi validation error and prioritise rendering it over the API response. This is because the presence of a Joi error message implies the absence of an API response.

## Screenshots
### Before
![Screenshot 2021-07-28 at 2 58 35 PM](https://user-images.githubusercontent.com/44049504/127278191-e1cc4f69-ddf0-492d-9ced-62b7ef0b548d.png)

### After
![Screenshot 2021-08-02 at 11 41 32 AM](https://user-images.githubusercontent.com/29480346/127802267-2677003d-bec6-48a8-a11e-8d256b21ab7f.png)
