### PR TITLE
feat(sms-limiting): prerelease

### DIFF
--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -4,7 +4,6 @@ import config from '../../config/config'
 import { captchaConfig } from '../../config/features/captcha.config'
 import { googleAnalyticsConfig } from '../../config/features/google-analytics.config'
 import { sentryConfig } from '../../config/features/sentry.config'
-import { smsConfig } from '../../config/features/sms.config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
 
 // Construct js with environment variables needed by frontend
@@ -23,7 +22,6 @@ const frontendVars = {
   GATrackingID: googleAnalyticsConfig.GATrackingID,
   spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
   oldSpcpCookieDomain: spcpMyInfoConfig.oldSpcpCookieDomain, // Old cookie domain used for backward compatibility. TODO (#2329): Delete env var
-  smsVerificationLimit: smsConfig.smsVerificationLimit,
 }
 const environment = ejs.render(
   `
@@ -49,8 +47,6 @@ const environment = ejs.render(
     var spcpCookieDomain = "<%= spcpCookieDomain%>"
     // Old SPCP Cookie
     var oldSpcpCookieDomain = "<%= oldSpcpCookieDomain%>"
-    // Sms verification limit
-    var smsVerificationLimit = "<%= smsVerificationLimit%>"
   `,
   frontendVars,
 )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -78,6 +78,7 @@ import {
 } from 'tests/unit/backend/helpers/generate-form-data'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
+import { smsConfig } from '../../../../config/features/sms.config'
 import * as SmsService from '../../../../services/sms/sms.service'
 import ParsedResponsesObject from '../../../submission/email-submission/ParsedResponsesObject.class'
 import * as UserService from '../../../user/user.service'
@@ -10083,7 +10084,7 @@ describe('admin-form.controller', () => {
       )
     })
 
-    it('should retrieve counts and msgSrvcId when the user and the form exist', async () => {
+    it('should retrieve sms counts and quota when the user and the form exist', async () => {
       // Arrange
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
@@ -10096,7 +10097,10 @@ describe('admin-form.controller', () => {
         },
       })
       const mockRes = expressHandler.mockResponse()
-      const expected = VERIFICATION_SMS_COUNT
+      const expected = {
+        freeSmsCounts: VERIFICATION_SMS_COUNT,
+        quota: smsConfig.smsVerificationLimit,
+      }
 
       // Act
       await AdminFormController.handleGetFreeSmsCountForFormAdmin(

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -44,10 +44,12 @@ import {
   PreviewFormViewDto,
   PrivateFormErrorDto,
   SettingsUpdateDto,
+  SmsCountsDto,
   StartPageUpdateDto,
   SubmissionCountQueryDto,
 } from '../../../../types/api'
 import { DeserializeTransform } from '../../../../types/utils'
+import { smsConfig } from '../../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import MailService from '../../../services/mail/mail.service'
 import * as SmsService from '../../../services/sms/sms.service'
@@ -2468,10 +2470,10 @@ export const handleUpdateStartPage = [
 ] as ControllerHandler[]
 
 /**
- * Handler to retrieve the free sms counts used by a form's administrator
+ * Handler to retrieve the free sms counts used by a form's administrator and the sms verifications quota
  * This is the controller for GET /admin/forms/:formId/verified-sms/count/free
  * @param formId The id of the form to retrieve the free sms counts for
- * @returns 200 with free sms counts when successful
+ * @returns 200 with free sms counts and quota when successful
  * @returns 404 when the formId is not found in the database
  * @returns 500 when a database error occurs during retrieval
  */
@@ -2479,7 +2481,7 @@ export const handleGetFreeSmsCountForFormAdmin: ControllerHandler<
   {
     formId: string
   },
-  ErrorDto | number
+  ErrorDto | SmsCountsDto
 > = (req, res) => {
   const { formId } = req.params
   const logMeta = {
@@ -2497,7 +2499,10 @@ export const handleGetFreeSmsCountForFormAdmin: ControllerHandler<
       })
       // Step 3: Map/MapErr accordingly
       .map((freeSmsCountForAdmin) =>
-        res.status(StatusCodes.OK).json(freeSmsCountForAdmin),
+        res.status(StatusCodes.OK).json({
+          freeSmsCounts: freeSmsCountForAdmin,
+          quota: smsConfig.smsVerificationLimit,
+        }),
       )
       .mapErr((error) => {
         logger.error({

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -199,10 +199,10 @@ AdminFormsFormRouter.put(
 )
 
 /**
- * Retrieves the free sms counts used by a form's administrator
+ * Retrieves the free sms counts used by a form's administrator and the sms verification quota
  * @security session
  *
- * @returns 200 with the free sms counts
+ * @returns 200 with the free sms counts and the quota
  * @returns 401 when user does not exist in session
  * @returns 404 when the formId is not found in the database
  * @returns 500 when a database error occurs during retrieval

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -63,7 +63,7 @@ export interface IVerificationSmsCount extends ISmsCount {
   isOnboardedAccount: boolean
 }
 
-export type IVerificationSmsCountSchema = ISmsCountSchema & {
+export interface IVerificationSmsCountSchema extends ISmsCountSchema {
   isOnboardedAccount: boolean
 }
 

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -38,3 +38,8 @@ export type FormUpdateParams = {
   title?: IForm['title']
   webhook?: IForm['webhook']
 }
+
+export interface SmsCountsDto {
+  quota: number
+  freeSmsCounts: number
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3,11 +3,3 @@
 export interface PublicView<T> {
   getPublicView(): T
 }
-
-// The returned object from updateMany
-// Refer here: https://mongoosejs.com/docs/api/model.html#model_Model.updateMany
-export interface UpdateManyMeta {
-  n: number
-  nModified: number
-  ok: number
-}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,4 +1,11 @@
-import { Document, LeanDocument, Model, ToObjectOptions, Types } from 'mongoose'
+import {
+  Document,
+  LeanDocument,
+  Model,
+  ToObjectOptions,
+  Types,
+  UpdateWriteOpResult,
+} from 'mongoose'
 import { Merge, SetOptional } from 'type-fest'
 
 import {
@@ -21,7 +28,7 @@ import {
 } from '../../shared/types/form/form'
 import { OverrideProps } from '../app/modules/form/admin-form/admin-form.types'
 
-import { PublicView, UpdateManyMeta } from './database'
+import { PublicView } from './database'
 import {
   FormField,
   FormFieldSchema,
@@ -296,7 +303,7 @@ export interface IFormModel extends Model<IFormSchema> {
 
   disableSmsVerificationsForUser(
     userId: IUserSchema['_id'],
-  ): Promise<UpdateManyMeta>
+  ): Promise<UpdateWriteOpResult>
 
   /**
    * Update the end page of form with given endpage object.


### PR DESCRIPTION
## Problem
This PR is part 1 of `sms-limiting`; this PR does a few things. 

1. Adds in methods for sending warning/disabling mail
2. Adds in a new endpoint for count retrieval (`/:formId/verified-sms/count/free`) 
3. Adds in a db script for updating the `smscounts` table to have the `isOnboardedAcc` key. 
4. Adds in service/db method to disabling sms verifications for admin (this is **unused** here)

## Tests
This PR should not have any observable interface by which we can perform manual testing, except for `/count/free`. 

**preconditions**
1. run this query to obtain your sms counts: 
```
db.getCollection('smscounts').countDocuments({
    "formAdmin.userId": ObjectId("your userId here"),
    smsType: 'VERIFICATION', 
    isOnboardedAccount: false, 
})
```

2. the db should already be populated with the `isOnboardedAccount` key

- [ ] Do not login and query the route at `http://localhost:5000/api/v3/admin/forms/609a520ead304e002c5a362f/verified-sms/count/free`. This should fail with `401 unauthorized`
- [ ] Subsequently, login and query the route again. This should succeed and return the sms count of the current logged in user and the sms quota (currently 10k). This sms count should be equivalent to the one obtained from the query.