### PR TITLE
feat(sms-limiting): db dependencies

### DIFF
--- a/src/app/config/features/sms.config.ts
+++ b/src/app/config/features/sms.config.ts
@@ -5,6 +5,7 @@ export interface ISms {
   twilioApiKey: string
   twilioApiSecret: string
   twilioMsgSrvcSid: string
+  smsVerificationLimit: number
 }
 
 const smsSchema: Schema<ISms> = {
@@ -31,6 +32,13 @@ const smsSchema: Schema<ISms> = {
     format: String,
     default: null,
     env: 'TWILIO_MESSAGING_SERVICE_SID',
+  },
+  smsVerificationLimit: {
+    doc: 'Sms verification limit for an admin',
+    // Positive int
+    format: 'nat',
+    default: 10000,
+    env: 'SMS_VERIFICATION_LIMIT',
   },
 }
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -78,6 +78,7 @@ import {
 } from 'tests/unit/backend/helpers/generate-form-data'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
+import { smsConfig } from '../../../../config/features/sms.config'
 import * as SmsService from '../../../../services/sms/sms.service'
 import ParsedResponsesObject from '../../../submission/email-submission/ParsedResponsesObject.class'
 import * as UserService from '../../../user/user.service'
@@ -10083,7 +10084,7 @@ describe('admin-form.controller', () => {
       )
     })
 
-    it('should retrieve counts and msgSrvcId when the user and the form exist', async () => {
+    it('should retrieve sms counts and quota when the user and the form exist', async () => {
       // Arrange
       const MOCK_REQ = expressHandler.mockRequest({
         params: {
@@ -10096,7 +10097,10 @@ describe('admin-form.controller', () => {
         },
       })
       const mockRes = expressHandler.mockResponse()
-      const expected = VERIFICATION_SMS_COUNT
+      const expected = {
+        freeSmsCounts: VERIFICATION_SMS_COUNT,
+        quota: smsConfig.smsVerificationLimit,
+      }
 
       // Act
       await AdminFormController.handleGetFreeSmsCountForFormAdmin(

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -78,6 +78,7 @@ import {
 } from 'tests/unit/backend/helpers/generate-form-data'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
+import * as SmsService from '../../../../services/sms/sms.service'
 import ParsedResponsesObject from '../../../submission/email-submission/ParsedResponsesObject.class'
 import * as UserService from '../../../user/user.service'
 import {
@@ -137,6 +138,8 @@ jest.mock('../../../user/user.service')
 const MockUserService = mocked(UserService)
 jest.mock('src/app/services/mail/mail.service')
 const MockMailService = mocked(MailService)
+jest.mock('../../../../services/sms/sms.service')
+const MockSmsService = mocked(SmsService)
 
 describe('admin-form.controller', () => {
   beforeEach(() => jest.clearAllMocks())
@@ -10064,6 +10067,141 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(MockAdminFormService.getFormField).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleGetFreeSmsCountForFormAdmin', () => {
+    const mockForm = {
+      admin: new ObjectId().toHexString(),
+    } as unknown as IFormSchema
+    const VERIFICATION_SMS_COUNT = 3
+
+    beforeAll(() => {
+      MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
+      MockSmsService.retrieveFreeSmsCounts.mockReturnValue(
+        okAsync(VERIFICATION_SMS_COUNT),
+      )
+    })
+
+    it('should retrieve counts and msgSrvcId when the user and the form exist', async () => {
+      // Arrange
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          formId: mockForm._id,
+        },
+        session: {
+          user: {
+            _id: 'exists',
+          },
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      const expected = VERIFICATION_SMS_COUNT
+
+      // Act
+      await AdminFormController.handleGetFreeSmsCountForFormAdmin(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(200)
+      expect(mockRes.json).toBeCalledWith(expected)
+    })
+
+    it('should return 404 when the form is not found in the database', async () => {
+      // Arrange
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          formId: new ObjectId().toHexString(),
+        },
+        session: {
+          user: {
+            _id: 'exists',
+          },
+        },
+      })
+      MockFormService.retrieveFormById.mockReturnValueOnce(
+        errAsync(new FormNotFoundError()),
+      )
+      const mockRes = expressHandler.mockResponse()
+      const expected = {
+        message: 'Form not found',
+      }
+
+      // Act
+      await AdminFormController.handleGetFreeSmsCountForFormAdmin(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(404)
+      expect(mockRes.json).toBeCalledWith(expected)
+    })
+
+    it('should return 500 when a database error occurs during form retrieval', async () => {
+      // Arrange
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          formId: mockForm._id,
+        },
+        session: {
+          user: {
+            _id: 'exists',
+          },
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      const retrieveSpy = jest.spyOn(FormService, 'retrieveFormById')
+      retrieveSpy.mockReturnValueOnce(errAsync(new DatabaseError()))
+      const expected = {
+        message: 'Something went wrong. Please try again.',
+      }
+
+      // Act
+      await AdminFormController.handleGetFreeSmsCountForFormAdmin(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(500)
+      expect(mockRes.json).toBeCalledWith(expected)
+    })
+
+    it('should return 500 when a database error occurs during count retrieval', async () => {
+      // Arrange
+      const MOCK_REQ = expressHandler.mockRequest({
+        params: {
+          formId: mockForm._id,
+        },
+        session: {
+          user: {
+            _id: 'exists',
+          },
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
+      retrieveSpy.mockReturnValueOnce(errAsync(new DatabaseError()))
+      const expected = {
+        message: 'Something went wrong. Please try again.',
+      }
+
+      // Act
+      await AdminFormController.handleGetFreeSmsCountForFormAdmin(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toBeCalledWith(500)
+      expect(mockRes.json).toBeCalledWith(expected)
     })
   })
 })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -50,6 +50,7 @@ import {
 import { DeserializeTransform } from '../../../../types/utils'
 import { createLoggerWithLabel } from '../../../config/logger'
 import MailService from '../../../services/mail/mail.service'
+import * as SmsService from '../../../services/sms/sms.service'
 import { createReqMeta } from '../../../utils/request'
 import * as AuthService from '../../auth/auth.service'
 import {
@@ -2465,3 +2466,47 @@ export const handleUpdateStartPage = [
   }),
   _handleUpdateStartPage,
 ] as ControllerHandler[]
+
+/**
+ * Handler to retrieve the free sms counts used by a form's administrator
+ * This is the controller for GET /admin/forms/:formId/verified-sms/count/free
+ * @param formId The id of the form to retrieve the free sms counts for
+ * @returns 200 with free sms counts when successful
+ * @returns 404 when the formId is not found in the database
+ * @returns 500 when a database error occurs during retrieval
+ */
+export const handleGetFreeSmsCountForFormAdmin: ControllerHandler<
+  {
+    formId: string
+  },
+  ErrorDto | number
+> = (req, res) => {
+  const { formId } = req.params
+  const logMeta = {
+    action: 'handleGetFreeSmsCountForFormAdmin',
+    ...createReqMeta(req),
+    formId,
+  }
+
+  // Step 1: Check that the form exists
+  return (
+    FormService.retrieveFormById(formId)
+      // Step 2: Retrieve the free sms count
+      .andThen(({ admin }) => {
+        return SmsService.retrieveFreeSmsCounts(String(admin))
+      })
+      // Step 3: Map/MapErr accordingly
+      .map((freeSmsCountForAdmin) =>
+        res.status(StatusCodes.OK).json(freeSmsCountForAdmin),
+      )
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error while retrieving sms counts for user',
+          meta: logMeta,
+          error,
+        })
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({ message: errorMessage })
+      })
+  )
+}

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -44,10 +44,12 @@ import {
   PreviewFormViewDto,
   PrivateFormErrorDto,
   SettingsUpdateDto,
+  SmsCountsDto,
   StartPageUpdateDto,
   SubmissionCountQueryDto,
 } from '../../../../types/api'
 import { DeserializeTransform } from '../../../../types/utils'
+import { smsConfig } from '../../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import MailService from '../../../services/mail/mail.service'
 import * as SmsService from '../../../services/sms/sms.service'
@@ -2468,10 +2470,10 @@ export const handleUpdateStartPage = [
 ] as ControllerHandler[]
 
 /**
- * Handler to retrieve the free sms counts used by a form's administrator
+ * Handler to retrieve the free sms counts used by a form's administrator and the sms verifications quota
  * This is the controller for GET /admin/forms/:formId/verified-sms/count/free
  * @param formId The id of the form to retrieve the free sms counts for
- * @returns 200 with free sms counts when successful
+ * @returns 200 with free sms counts and quota when successful
  * @returns 404 when the formId is not found in the database
  * @returns 500 when a database error occurs during retrieval
  */
@@ -2479,7 +2481,7 @@ export const handleGetFreeSmsCountForFormAdmin: ControllerHandler<
   {
     formId: string
   },
-  ErrorDto | number
+  ErrorDto | SmsCountsDto
 > = (req, res) => {
   const { formId } = req.params
   const logMeta = {
@@ -2497,7 +2499,10 @@ export const handleGetFreeSmsCountForFormAdmin: ControllerHandler<
       })
       // Step 3: Map/MapErr accordingly
       .map((freeSmsCountForAdmin) =>
-        res.status(StatusCodes.OK).json(freeSmsCountForAdmin),
+        res.status(StatusCodes.OK).json({
+          freeSmsCounts: freeSmsCountForAdmin,
+          quota: smsConfig.smsVerificationLimit,
+        }),
       )
       .mapErr((error) => {
         logger.error({

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -199,10 +199,10 @@ AdminFormsFormRouter.put(
 )
 
 /**
- * Retrieves the free sms counts used by a form's administrator
+ * Retrieves the free sms counts used by a form's administrator and the sms verification quota
  * @security session
  *
- * @returns 200 with the free sms counts
+ * @returns 200 with the free sms counts and the quota
  * @returns 401 when user does not exist in session
  * @returns 404 when the formId is not found in the database
  * @returns 500 when a database error occurs during retrieval

--- a/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.form.routes.ts
@@ -197,3 +197,17 @@ AdminFormsFormRouter.put(
   '/:formId([a-fA-F0-9]{24})/start-page',
   AdminFormController.handleUpdateStartPage,
 )
+
+/**
+ * Retrieves the free sms counts used by a form's administrator
+ * @security session
+ *
+ * @returns 200 with the free sms counts
+ * @returns 401 when user does not exist in session
+ * @returns 404 when the formId is not found in the database
+ * @returns 500 when a database error occurs during retrieval
+ */
+AdminFormsFormRouter.get(
+  '/:formId([a-fA-F0-9]{24})/verified-sms/count/free',
+  AdminFormController.handleGetFreeSmsCountForFormAdmin,
+)

--- a/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
+++ b/src/app/services/sms/__tests__/sms_count.server.model.spec.ts
@@ -5,6 +5,7 @@ import mongoose from 'mongoose'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
+import { smsConfig } from '../../../config/features/sms.config'
 import { IVerificationSmsCount, LogType, SmsType } from '../sms.types'
 import getSmsCountModel from '../sms_count.server.model'
 
@@ -230,9 +231,22 @@ describe('SmsCount', () => {
   })
 
   describe('VerificationCount Schema', () => {
+    const twilioMsgSrvcSid = smsConfig.twilioMsgSrvcSid
+
+    beforeAll(() => {
+      smsConfig.twilioMsgSrvcSid = MOCK_MSG_SRVC_SID
+    })
+
+    afterAll(() => {
+      smsConfig.twilioMsgSrvcSid = twilioMsgSrvcSid
+    })
+
     it('should create and save successfully', async () => {
       // Arrange
       const smsCountParams = createVerificationSmsCountParams()
+      const expected = merge(smsCountParams, {
+        isOnboardedAccount: false,
+      })
 
       // Act
       const validSmsCount = new SmsCount(smsCountParams)
@@ -249,7 +263,7 @@ describe('SmsCount', () => {
         'createdAt',
         '__v',
       ])
-      expect(actualSavedObject).toEqual(smsCountParams)
+      expect(actualSavedObject).toEqual(expected)
     })
 
     it('should save successfully, but not save fields that is not defined in the schema', async () => {
@@ -260,6 +274,9 @@ describe('SmsCount', () => {
           extra: 'somethingExtra',
         },
       )
+      const expected = merge(omit(smsCountParamsWithExtra, 'extra'), {
+        isOnboardedAccount: false,
+      })
 
       // Act
       const validSmsCount = new SmsCount(smsCountParamsWithExtra)
@@ -278,7 +295,38 @@ describe('SmsCount', () => {
         'createdAt',
         '__v',
       ])
-      expect(actualSavedObject).toEqual(omit(smsCountParamsWithExtra, 'extra'))
+      expect(actualSavedObject).toEqual(expected)
+    })
+
+    it('should save successfully and set isOnboarded to true when the credentials are different from default', async () => {
+      // Arrange
+      const verificationParams = merge(
+        createVerificationSmsCountParams({
+          logType: LogType.success,
+          smsType: SmsType.Verification,
+        }),
+        { msgSrvcSid: 'i am different' },
+      )
+
+      // Act
+      const validSmsCount = new SmsCount(verificationParams)
+      const saved = await validSmsCount.save()
+
+      // Assert
+      // All fields should exist
+      // Object Id should be defined when successfully saved to MongoDB.
+      expect(saved._id).toBeDefined()
+      expect(saved.createdAt).toBeInstanceOf(Date)
+      // Retrieve object and compare to params, remove indeterministic keys
+      const actualSavedObject = omit(saved.toObject(), [
+        '_id',
+        'createdAt',
+        '__v',
+      ])
+      expect(omit(actualSavedObject, 'isOnboardedAccount')).toEqual(
+        verificationParams,
+      )
+      expect(actualSavedObject.isOnboardedAccount).toBe(true)
     })
 
     it('should reject if form key is missing', async () => {
@@ -566,7 +614,6 @@ const createVerificationSmsCountParams = ({
   smsCountParams.logType = logType
   smsCountParams.smsType = smsType
   smsCountParams.msgSrvcSid = MOCK_MSG_SRVC_SID
-
   return smsCountParams
 }
 
@@ -589,6 +636,9 @@ const logAndReturnExpectedLog = async ({
     msgSrvcSid: MOCK_MSG_SRVC_SID,
     smsType,
     logType,
+    ...(smsType === SmsType.Verification && {
+      isOnboardedAccount: !(MOCK_MSG_SRVC_SID === smsConfig.twilioMsgSrvcSid),
+    }),
   }
 
   return expectedLog

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -12,8 +12,12 @@ import getFormModel from '../../models/form.server.model'
 import {
   DatabaseError,
   MalformedParametersError,
+  PossibleDatabaseError,
 } from '../../modules/core/core.errors'
-import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
+import {
+  getMongoErrorMessage,
+  transformMongoError,
+} from '../../utils/handle-mongo-error'
 
 import { InvalidNumberError, SmsSendError } from './sms.errors'
 import {
@@ -459,5 +463,31 @@ export const sendBouncedSubmissionSms = (
     recipient,
     message,
     SmsType.BouncedSubmission,
+  )
+}
+
+/**
+ * Retrieves the free sms count for a particular user
+ * @param userId The id of the user to retrieve the sms counts for
+ * @returns ok(count) when retrieval is successful
+ * @returns err(error) when retrieval fails due to a database error
+ */
+export const retrieveFreeSmsCounts = (
+  userId: string,
+): ResultAsync<number, PossibleDatabaseError> => {
+  return ResultAsync.fromPromise(
+    SmsCount.retrieveFreeSmsCounts(userId),
+    (error) => {
+      logger.error({
+        message: `Retrieving free sms counts failed for ${userId}`,
+        meta: {
+          action: 'retrieveFreeSmsCounts',
+          userId,
+          error,
+        },
+      })
+
+      return transformMongoError(error)
+    },
   )
 }

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -63,7 +63,7 @@ export interface IVerificationSmsCount extends ISmsCount {
   isOnboardedAccount: boolean
 }
 
-export type IVerificationSmsCountSchema = ISmsCountSchema & {
+export interface IVerificationSmsCountSchema extends ISmsCountSchema {
   isOnboardedAccount: boolean
 }
 

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -60,9 +60,12 @@ export interface IVerificationSmsCount extends ISmsCount {
     email: string
     userId: IUserSchema['_id']
   }
+  isOnboardedAccount: boolean
 }
 
-export type IVerificationSmsCountSchema = ISmsCountSchema
+export type IVerificationSmsCountSchema = ISmsCountSchema & {
+  isOnboardedAccount: boolean
+}
 
 export interface IAdminContactSmsCount extends ISmsCount {
   admin: IUserSchema['_id']
@@ -88,6 +91,11 @@ export interface IBouncedSubmissionSmsCountSchema
 
 export interface ISmsCountModel extends Model<ISmsCountSchema> {
   logSms: (logParams: LogSmsParams) => Promise<ISmsCountSchema>
+  /**
+   * Counts the number of sms which an admin has sent using default (formSG) credentials.
+   * NOTE: This counts across all forms which an admin has.
+   */
+  retrieveFreeSmsCounts: (userId: string) => Promise<number>
 }
 
 export type TwilioCredentials = {

--- a/src/types/api/form.ts
+++ b/src/types/api/form.ts
@@ -38,3 +38,8 @@ export type FormUpdateParams = {
   title?: IForm['title']
   webhook?: IForm['webhook']
 }
+
+export interface SmsCountsDto {
+  quota: number
+  freeSmsCounts: number
+}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,4 +1,11 @@
-import { Document, LeanDocument, Model, ToObjectOptions, Types } from 'mongoose'
+import {
+  Document,
+  LeanDocument,
+  Model,
+  ToObjectOptions,
+  Types,
+  UpdateWriteOpResult,
+} from 'mongoose'
 import { Merge, SetOptional } from 'type-fest'
 
 import {
@@ -293,6 +300,10 @@ export interface IFormModel extends Model<IFormSchema> {
     userId: IUserSchema['_id'],
     userEmail: IUserSchema['email'],
   ): Promise<AdminDashboardFormMetaDto[]>
+
+  disableSmsVerificationsForUser(
+    userId: IUserSchema['_id'],
+  ): Promise<UpdateWriteOpResult>
 
   /**
    * Update the end page of form with given endpage object.


### PR DESCRIPTION
## Description
This PR adds a new key (`isOnboardedAccount`) to the database as well as a new (and unused) endpoint. This PR is a dependency of `sms-limiting`. 

This PR goes out 1 week in advance so that the db key can be created ahead of time. The `smscounts` database will then have all previous entries updated through running a db script (included in future PR) the night before the feature release. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  