### PR TITLE
feat: loosen esrvcId validation to only restrict whitespace

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -121,6 +121,34 @@ describe('Form Model', () => {
         expect(actualSavedObject).toEqual(expectedObject)
       })
 
+      it('should create and save successfully with valid esrvcId', async () => {
+        // Arrange
+        const validEsrvcId = 'validEsrvcId'
+        const validFormParams = merge({}, MOCK_FORM_PARAMS, {
+          esrvcId: validEsrvcId,
+        })
+
+        // Act
+        const validForm = new Form(validFormParams)
+        const saved = await validForm.save()
+
+        // Assert
+        // All fields should exist
+        // Object Id should be defined when successfully saved to MongoDB.
+        expect(saved._id).toBeDefined()
+        expect(saved.created).toBeInstanceOf(Date)
+        expect(saved.lastModified).toBeInstanceOf(Date)
+        // Retrieve object and compare to params, remove indeterministic keys
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'created',
+          'lastModified',
+          '__v',
+        ])
+        const expectedObject = merge({}, FORM_DEFAULTS, validFormParams)
+        expect(actualSavedObject).toEqual(expectedObject)
+      })
+
       it('should save successfully, but not save fields that is not defined in the schema', async () => {
         // Arrange
         const formParamsWithExtra = merge({}, MOCK_FORM_PARAMS, {
@@ -342,6 +370,22 @@ describe('Form Model', () => {
         // Assert
         await expect(invalidForm.save()).rejects.toThrowError(
           mongoose.Error.ValidationError,
+        )
+      })
+
+      it('should reject when esrvcId id has whitespace', async () => {
+        // Arrange
+        const whitespaceEsrvcId = 'whitespace\tesrvcId'
+        const paramsWithWhitespaceEsrvcId = merge({}, MOCK_FORM_PARAMS, {
+          esrvcId: whitespaceEsrvcId,
+        })
+
+        // Act
+        const invalidForm = new Form(paramsWithWhitespaceEsrvcId)
+
+        // Assert
+        await expect(invalidForm.save()).rejects.toThrowError(
+          'Form validation failed: esrvcId: e-service ID must not contain whitespace',
         )
       })
     })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -390,10 +390,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       esrvcId: {
         type: String,
         required: false,
-        validate: [
-          /^([a-zA-Z0-9-_]){1,25}$/i,
-          'e-service ID must be alphanumeric, underscores and dashes are allowed',
-        ],
+        validate: [/^\S*$/i, 'e-service ID must not contain whitespace'],
       },
 
       webhook: {

--- a/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/settings-form.client.view.html
@@ -301,7 +301,7 @@
                     name="esrvcId"
                     ng-model="tempForm.esrvcId"
                     placeholder="{{ ['SP', 'MyInfo'].includes(type.val) ? 'Enter Singpass e-service ID' : 'Enter Corppass e-service ID' }}"
-                    ng-pattern="/^([a-zA-Z0-9\-\_]){1,25}$/i"
+                    ng-pattern="/^\S*$/i"
                     ng-keyup="($event.keyCode === 13 && settingsForm.esrvcId.$valid) && saveForm()"
                     ng-blur="(settingsForm.esrvcId.$valid) && saveForm()"
                     ng-disabled="(isFormPublic() && !isPublicWithoutEsrvcId())"
@@ -322,8 +322,7 @@
                 >
                   <i class="bx bx-exclamation bx-md icon-spacing"></i>
                   <span class="alert-msg"
-                    >e-service ID must be alphanumeric and a maximum of 25
-                    letters</span
+                    >e-service ID must not contain whitespace</span
                   >
                 </div>
               </div>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2466

## Tests
- Unit tests have been added to form schema
### Manual tests
- [ ] Go to form, add esrvcId with whitespace. Should reject.
- [ ] Go to form, add esrvcId with any characters except whitespace. Should accept.

### Prod tests
- [ ] Go to form, add INVALID esrvcId with any characters except whitespace. Should accept. Activate form. Modal should reject and prevent form from being activated.