### PR TITLE
feat: clean up all naming discrepancies between shared and backend types

### DIFF
--- a/src/app/models/__tests__/encrypt-submission.server.model.spec.ts
+++ b/src/app/models/__tests__/encrypt-submission.server.model.spec.ts
@@ -9,7 +9,7 @@ import getSubmissionModel, {
 } from 'src/app/models/submission.server.model'
 import {
   IEncryptedSubmissionSchema,
-  SubmissionMetadata,
+  StorageModeSubmissionMetadata,
   SubmissionType,
 } from 'src/types'
 
@@ -49,7 +49,7 @@ describe('Encrypt Submission Model', () => {
         )
 
         // Assert
-        const expected: SubmissionMetadata = {
+        const expected: StorageModeSubmissionMetadata = {
           number: 1,
           refNo: validSubmission._id,
           submissionTime: moment(createdDate)

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -12,21 +12,21 @@ import getFormModel, {
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
 import {
-  AuthType,
   BasicField,
-  EndPage,
+  FormAuthType,
+  FormEndPage,
   FormFieldWithId,
   FormLogoState,
   FormPermission,
+  FormResponseMode,
+  FormStartPage,
+  FormStatus,
   IEncryptedForm,
   IFieldSchema,
   IFormSchema,
   ILogicSchema,
   IPopulatedUser,
   LogicType,
-  ResponseMode,
-  StartPage,
-  Status,
 } from 'src/types'
 
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
@@ -47,12 +47,12 @@ const MOCK_FORM_PARAMS = {
 const MOCK_ENCRYPTED_FORM_PARAMS = {
   ...MOCK_FORM_PARAMS,
   publicKey: 'mockPublicKey',
-  responseMode: ResponseMode.Encrypt,
+  responseMode: FormResponseMode.Encrypt,
 }
 const MOCK_EMAIL_FORM_PARAMS = {
   ...MOCK_FORM_PARAMS,
   emails: [MOCK_ADMIN_EMAIL],
-  responseMode: ResponseMode.Email,
+  responseMode: FormResponseMode.Email,
 }
 
 const FORM_DEFAULTS = {
@@ -617,27 +617,27 @@ describe('Form Model', () => {
       it('should set authType to NIL when given authType is MyInfo', async () => {
         // Arrange
         const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
         })
 
         // Act
         const invalidForm = await EncryptedForm.create(malformedParams)
 
         // Assert
-        await expect(invalidForm.authType).toBe(AuthType.NIL)
+        await expect(invalidForm.authType).toBe(FormAuthType.NIL)
       })
 
       it('should set authType to NIL when given authType is SGID', async () => {
         // Arrange
         const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-          authType: AuthType.SGID,
+          authType: FormAuthType.SGID,
         })
 
         // Act
         const invalidForm = await EncryptedForm.create(malformedParams)
 
         // Assert
-        await expect(invalidForm.authType).toBe(AuthType.NIL)
+        await expect(invalidForm.authType).toBe(FormAuthType.NIL)
       })
     })
 
@@ -924,7 +924,7 @@ describe('Form Model', () => {
       it('should correctly deactivate form for valid ID', async () => {
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
+          status: FormStatus.Public,
         })
         const form = await Form.create(formParams)
         await Form.deactivateById(form._id)
@@ -935,7 +935,7 @@ describe('Form Model', () => {
       it('should not deactivate archived form', async () => {
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Archived,
+          status: FormStatus.Archived,
         })
         const form = await Form.create(formParams)
         await Form.deactivateById(form._id)
@@ -1136,7 +1136,7 @@ describe('Form Model', () => {
         // Should not be fetched since form is archived.
         await Form.create({
           ...MOCK_ENCRYPTED_FORM_PARAMS,
-          status: Status.Archived,
+          status: FormStatus.Archived,
         })
         // Should not be fetched (not collab or admin).
         await Form.create({
@@ -1207,8 +1207,8 @@ describe('Form Model', () => {
         // arrange
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           form_logics: [],
         })
         const form = await Form.create(formParams)
@@ -1225,9 +1225,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has been added
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1241,8 +1241,8 @@ describe('Form Model', () => {
         // arrange
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           form_logics: [],
         })
         const form = await Form.create(formParams)
@@ -1261,9 +1261,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedFormRepeat?.responseMode).not.toBeNull()
-        expect(modifiedFormRepeat?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedFormRepeat?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedFormRepeat?.status).not.toBeNull()
-        expect(modifiedFormRepeat?.status).toEqual(Status.Public)
+        expect(modifiedFormRepeat?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has been added
         expect(modifiedFormRepeat?.form_logics).toBeDefined()
@@ -1280,8 +1280,8 @@ describe('Form Model', () => {
         // arrange
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockExistingFormLogic,
         })
         const form = await Form.create(formParams)
@@ -1298,9 +1298,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has been added
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1345,8 +1345,8 @@ describe('Form Model', () => {
         // arrange
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockFormLogic,
         })
         const form = await Form.create(formParams)
@@ -1360,9 +1360,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has been deleted
         expect(modifiedForm?.form_logics).toBeEmpty()
@@ -1387,8 +1387,8 @@ describe('Form Model', () => {
 
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockFormLogicMultiple,
         })
         const form = await Form.create(formParams)
@@ -1402,9 +1402,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that correct form logic has been deleted
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1488,7 +1488,7 @@ describe('Form Model', () => {
           },
         })
         const form = (await Form.create(formParams)).toObject()
-        const updatedEndPage: EndPage = {
+        const updatedEndPage: FormEndPage = {
           title: 'some new title',
           paragraph: 'some description paragraph',
           buttonText: 'custom button text',
@@ -1512,7 +1512,7 @@ describe('Form Model', () => {
           admin: MOCK_ADMIN_OBJ_ID,
         })
         const form = (await Form.create(formParams)).toObject()
-        const updatedEndPage: EndPage = {
+        const updatedEndPage: FormEndPage = {
           paragraph: 'some description paragraph',
         }
 
@@ -1536,7 +1536,7 @@ describe('Form Model', () => {
       it('should return null when formId given is not in the database', async () => {
         // Arrange
         await expect(Form.countDocuments()).resolves.toEqual(0)
-        const updatedEndPage: EndPage = {
+        const updatedEndPage: FormEndPage = {
           title: 'some new title',
           paragraph: 'does not really matter',
         }
@@ -1588,8 +1588,8 @@ describe('Form Model', () => {
 
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockExistingFormLogicSingle,
         })
         const form = await Form.create(formParams)
@@ -1607,9 +1607,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has been updated
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1623,8 +1623,8 @@ describe('Form Model', () => {
         // arrange
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockExistingFormLogic,
         })
         const form = await Form.create(formParams)
@@ -1642,9 +1642,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that first form logic has been updated but second is unchanges
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1687,8 +1687,8 @@ describe('Form Model', () => {
 
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: populatedAdmin,
-          status: Status.Public,
-          responseMode: ResponseMode.Email,
+          status: FormStatus.Public,
+          responseMode: FormResponseMode.Email,
           ...mockExistingFormLogicSingle,
         })
         const form = await Form.create(formParams)
@@ -1706,9 +1706,9 @@ describe('Form Model', () => {
 
         // Form should have correct status, responsemode
         expect(modifiedForm?.responseMode).not.toBeNull()
-        expect(modifiedForm?.responseMode).toEqual(ResponseMode.Email)
+        expect(modifiedForm?.responseMode).toEqual(FormResponseMode.Email)
         expect(modifiedForm?.status).not.toBeNull()
-        expect(modifiedForm?.status).toEqual(Status.Public)
+        expect(modifiedForm?.status).toEqual(FormStatus.Public)
 
         // Check that form logic has not been updated and there are no new form logics introduced
         expect(modifiedForm?.form_logics).toBeDefined()
@@ -1730,7 +1730,7 @@ describe('Form Model', () => {
         })
         const form = (await Form.create(formParams)).toObject()
         const prevModifiedDate = form.lastModified
-        const updatedStartPage: StartPage = {
+        const updatedStartPage: FormStartPage = {
           paragraph: 'some description paragraph',
           // This is a huge form.
           estTimeTaken: 10000000,
@@ -1758,7 +1758,7 @@ describe('Form Model', () => {
           admin: MOCK_ADMIN_OBJ_ID,
         })
         const form = (await Form.create(formParams)).toObject()
-        const updatedStartPage: StartPage = {
+        const updatedStartPage: FormStartPage = {
           paragraph: 'some description paragraph',
         }
 
@@ -1787,7 +1787,7 @@ describe('Form Model', () => {
       it('should return null when formId given is not in the database', async () => {
         // Arrange
         await expect(Form.countDocuments()).resolves.toEqual(0)
-        const updatedStartPage: StartPage = {
+        const updatedStartPage: FormStartPage = {
           paragraph: 'does not really matter',
         }
 
@@ -1811,7 +1811,7 @@ describe('Form Model', () => {
     beforeEach(async () => {
       validForm = await Form.create({
         admin: populatedAdmin._id,
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         title: 'mock email form',
         emails: [populatedAdmin.email],
       })
@@ -1823,9 +1823,9 @@ describe('Form Model', () => {
         const form = await Form.create({
           admin: populatedAdmin._id,
           emails: [populatedAdmin.email],
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
-          status: Status.Private,
+          status: FormStatus.Private,
         })
         expect(form).toBeDefined()
 
@@ -1833,7 +1833,7 @@ describe('Form Model', () => {
         const actual = await form.archive()
 
         // Assert
-        expect(actual.status).toEqual(Status.Archived)
+        expect(actual.status).toEqual(FormStatus.Archived)
       })
 
       it('should successfully set encrypt form status to archived', async () => {
@@ -1841,9 +1841,9 @@ describe('Form Model', () => {
         const form = await Form.create({
           admin: populatedAdmin._id,
           publicKey: 'any public key',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'mock encrypt form',
-          status: Status.Public,
+          status: FormStatus.Public,
         })
         expect(form).toBeDefined()
 
@@ -1851,7 +1851,7 @@ describe('Form Model', () => {
         const actual = await form.archive()
 
         // Assert
-        expect(actual.status).toEqual(Status.Archived)
+        expect(actual.status).toEqual(FormStatus.Archived)
       })
 
       it('should stay archived if original form is already archived', async () => {
@@ -1859,9 +1859,9 @@ describe('Form Model', () => {
         const form = await Form.create({
           admin: populatedAdmin._id,
           publicKey: 'any public key',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'mock encrypt form',
-          status: Status.Archived,
+          status: FormStatus.Archived,
         })
         expect(form).toBeDefined()
 
@@ -1869,7 +1869,7 @@ describe('Form Model', () => {
         const actual = await form.archive()
 
         // Assert
-        expect(actual.status).toEqual(Status.Archived)
+        expect(actual.status).toEqual(FormStatus.Archived)
       })
     })
 
@@ -1879,9 +1879,9 @@ describe('Form Model', () => {
         const form = await Form.create({
           admin: populatedAdmin._id,
           emails: [populatedAdmin.email],
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
-          status: Status.Private,
+          status: FormStatus.Private,
         })
         expect(form).toBeDefined()
         // Add additional user.
@@ -1912,10 +1912,10 @@ describe('Form Model', () => {
         // Arrange
         const form = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: 'some public key',
           title: 'mock email form',
-          status: Status.Private,
+          status: FormStatus.Private,
         })
         expect(form).toBeDefined()
         // Add additional user.
@@ -1972,7 +1972,7 @@ describe('Form Model', () => {
         // Arrange
         const emailForm = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
           emails: [populatedAdmin.email],
         })
@@ -1990,7 +1990,7 @@ describe('Form Model', () => {
         // Arrange
         const emailForm = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
           emails: [populatedAdmin.email],
         })
@@ -2018,7 +2018,7 @@ describe('Form Model', () => {
         // Arrange
         const encryptForm = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'mock encrypt form',
           publicKey: 'mock public key',
         })
@@ -2036,7 +2036,7 @@ describe('Form Model', () => {
         // Arrange
         const encryptForm = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'mock encrypt form electric boogaloo',
           publicKey: 'some public key again',
         })
@@ -2067,7 +2067,7 @@ describe('Form Model', () => {
       beforeEach(async () => {
         form = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
           emails: [populatedAdmin.email],
           form_fields: [
@@ -2252,7 +2252,7 @@ describe('Form Model', () => {
       beforeEach(async () => {
         form = await Form.create({
           admin: populatedAdmin._id,
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           title: 'mock email form',
           emails: [populatedAdmin.email],
           form_fields: [

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -17,13 +17,13 @@ import {
   EndPage,
   FormFieldWithId,
   FormLogoState,
+  FormPermission,
   IEncryptedForm,
   IFieldSchema,
   IFormSchema,
   ILogicSchema,
   IPopulatedUser,
   LogicType,
-  Permission,
   ResponseMode,
   StartPage,
   Status,
@@ -266,7 +266,7 @@ describe('Form Model', () => {
         // Remove indeterministic id from actual permission list
         const actualPermissionList = saved
           .toObject()
-          .permissionList?.map((permission: Permission) =>
+          .permissionList?.map((permission: FormPermission) =>
             omit(permission, '_id'),
           )
         expect(actualPermissionList).toEqual(permissionList)
@@ -781,7 +781,7 @@ describe('Form Model', () => {
         // Remove indeterministic id from actual permission list
         const actualPermissionList = saved
           .toObject()
-          .permissionList?.map((permission: Permission) =>
+          .permissionList?.map((permission: FormPermission) =>
             omit(permission, '_id'),
           )
         expect(actualPermissionList).toEqual(permissionList)

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -2,7 +2,7 @@ import { ObjectID } from 'bson'
 import mongoose from 'mongoose'
 
 import getFormModel from 'src/app/models/form.server.model'
-import { BasicField, IFieldSchema, ResponseMode } from 'src/types'
+import { BasicField, FormResponseMode, IFieldSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -90,15 +90,15 @@ describe('Form Field Schema', () => {
 
 const createAndReturnFormField = async (
   formFieldParams: Record<string, any>,
-  formType: ResponseMode = ResponseMode.Email,
+  formType: FormResponseMode = FormResponseMode.Email,
 ) => {
   let baseParams
 
   switch (formType) {
-    case ResponseMode.Email:
+    case FormResponseMode.Email:
       baseParams = MOCK_EMAIL_FORM_PARAMS
       break
-    case ResponseMode.Encrypt:
+    case FormResponseMode.Encrypt:
       baseParams = MOCK_ENCRYPTED_FORM_PARAMS
       break
     default:

--- a/src/app/models/__tests__/login.server.model.spec.ts
+++ b/src/app/models/__tests__/login.server.model.spec.ts
@@ -6,7 +6,7 @@ import mongoose from 'mongoose'
 
 import getLoginModel from 'src/app/models/login.server.model'
 import {
-  AuthType,
+  FormAuthType,
   IFormSchema,
   ILoginSchema,
   IPopulatedForm,
@@ -26,7 +26,7 @@ describe('login.server.model', () => {
     const DEFAULT_PARAMS: mongoose.LeanDocument<ILoginSchema> = {
       admin: new ObjectId(),
       agency: new ObjectId(),
-      authType: AuthType.SP,
+      authType: FormAuthType.SP,
       esrvcId: 'mock-esrvc-id',
       form: new ObjectId(),
     }
@@ -176,7 +176,7 @@ describe('login.server.model', () => {
             form: form._id,
             admin: user._id,
             agency: agency._id,
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             esrvcId: VALID_ESRVC_ID,
             created: CURR_DATE,
           },
@@ -185,7 +185,7 @@ describe('login.server.model', () => {
             form: form._id,
             admin: user._id,
             agency: agency._id,
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             esrvcId: VALID_ESRVC_ID,
             created: CURR_DATE,
           },
@@ -194,7 +194,7 @@ describe('login.server.model', () => {
             form: form._id,
             admin: user._id,
             agency: agency._id,
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             esrvcId: VALID_ESRVC_ID,
             created: CURR_DATE,
           },
@@ -203,7 +203,7 @@ describe('login.server.model', () => {
             form: form._id,
             admin: user._id,
             agency: agency._id,
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             esrvcId: VALID_ESRVC_ID,
             created: FUTURE_DATE,
           },
@@ -250,7 +250,7 @@ describe('login.server.model', () => {
           {
             adminEmail: testUser.email,
             formId: testForm._id,
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             formName: testForm.title,
             total: loginsInRange.length,
           },

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -14,8 +14,8 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 import {
   FormAuthType,
   ISubmissionSchema,
-  IWebhookResponse,
   SubmissionType,
+  WebhookResponse,
 } from '../../../../src/types'
 
 jest.mock('dns', () => ({
@@ -403,7 +403,7 @@ describe('Submission Model', () => {
             status: 200,
             headers: '{}',
           },
-        }) as IWebhookResponse
+        }) as WebhookResponse
 
         // Act
         const actualSubmission = await EncryptedSubmission.addWebhookResponse(
@@ -446,7 +446,7 @@ describe('Submission Model', () => {
             headers: '',
             data: '',
           },
-        } as IWebhookResponse
+        } as WebhookResponse
 
         const invalidSubmissionId = new ObjectId().toHexString()
 

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -12,7 +12,7 @@ import getSubmissionModel, {
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import {
-  AuthType,
+  FormAuthType,
   ISubmissionSchema,
   IWebhookResponse,
   SubmissionType,
@@ -255,7 +255,7 @@ describe('Submission Model', () => {
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           webhookResponses: [],
         })
@@ -287,7 +287,7 @@ describe('Submission Model', () => {
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           verifiedContent: MOCK_VERIFIED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           webhookResponses: [],
         })
@@ -326,7 +326,7 @@ describe('Submission Model', () => {
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           verifiedContent: MOCK_VERIFIED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           webhookResponses: [],
         })
@@ -360,7 +360,7 @@ describe('Submission Model', () => {
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           recipientEmails: [],
           responseHash: 'hash',
@@ -385,7 +385,7 @@ describe('Submission Model', () => {
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           recipientEmails: [],
           responseHash: 'hash',
@@ -428,7 +428,7 @@ describe('Submission Model', () => {
           form: formId,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           myInfoFields: [],
           recipientEmails: [],
           responseHash: 'hash',

--- a/src/app/models/agency.server.model.ts
+++ b/src/app/models/agency.server.model.ts
@@ -1,12 +1,11 @@
 import { pick } from 'lodash'
 import { Mongoose, Schema } from 'mongoose'
 
-import { PublicAgencyDto } from '../../../shared/types/agency'
 import {
   AgencyInstanceMethods,
   IAgencyDocument,
   IAgencyModel,
-  PublicAgency,
+  PublicAgencyDto,
 } from '../../types'
 
 export const AGENCY_SCHEMA_ID = 'Agency'
@@ -61,8 +60,8 @@ const AgencySchema = new Schema<
 )
 
 // Methods
-AgencySchema.methods.getPublicView = function (): PublicAgency {
-  return pick(this, Object.keys(PublicAgencyDto.shape)) as PublicAgency
+AgencySchema.methods.getPublicView = function (): PublicAgencyDto {
+  return pick(this, Object.keys(PublicAgencyDto.shape)) as PublicAgencyDto
 }
 
 const compileAgencyModel = (db: Mongoose): IAgencyModel => {

--- a/src/app/models/field/__tests__/emailField.spec.ts
+++ b/src/app/models/field/__tests__/emailField.spec.ts
@@ -1,7 +1,7 @@
 import merge from 'lodash/merge'
 import { Model, Schema } from 'mongoose'
 
-import { EmailFieldBase, IEmailFieldSchema, ResponseMode } from 'src/types'
+import { EmailFieldBase, FormResponseMode, IEmailFieldSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -10,7 +10,7 @@ import createEmailFieldSchema from '../emailField'
 describe('models.fields.emailField', () => {
   // Required as the field validator has a this.parent() check for response mode.
   let MockParent: Model<{
-    responseMode: ResponseMode
+    responseMode: FormResponseMode
     field: IEmailFieldSchema
   }>
 
@@ -35,7 +35,7 @@ describe('models.fields.emailField', () => {
       new Schema({
         responseMode: {
           type: String,
-          enum: Object.values(ResponseMode),
+          enum: Object.values(FormResponseMode),
         },
         field: emailFieldSchema,
       }),
@@ -58,7 +58,7 @@ describe('models.fields.emailField', () => {
     }
     // Act
     const actual = await MockParent.create({
-      responseMode: ResponseMode.Encrypt,
+      responseMode: FormResponseMode.Encrypt,
       field: mockEmailField,
     })
 
@@ -87,7 +87,7 @@ describe('models.fields.emailField', () => {
     }
     // Act
     const actual = await MockParent.create({
-      responseMode: ResponseMode.Email,
+      responseMode: FormResponseMode.Email,
       field: mockEmailField,
     })
 

--- a/src/app/models/field/__tests__/emailField.spec.ts
+++ b/src/app/models/field/__tests__/emailField.spec.ts
@@ -1,7 +1,7 @@
 import merge from 'lodash/merge'
 import { Model, Schema } from 'mongoose'
 
-import { IEmailField, IEmailFieldSchema, ResponseMode } from 'src/types'
+import { EmailFieldBase, IEmailFieldSchema, ResponseMode } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -14,7 +14,7 @@ describe('models.fields.emailField', () => {
     field: IEmailFieldSchema
   }>
 
-  const EMAIL_FIELD_DEFAULTS: Partial<IEmailField> = {
+  const EMAIL_FIELD_DEFAULTS: Partial<EmailFieldBase> = {
     autoReplyOptions: {
       hasAutoReply: true,
       autoReplySubject: '',

--- a/src/app/models/field/attachmentField.ts
+++ b/src/app/models/field/attachmentField.ts
@@ -1,14 +1,6 @@
-import { Document, Schema } from 'mongoose'
+import { Schema } from 'mongoose'
 
-import { AttachmentSize, IAttachmentField, IFormSchema } from '../../../types'
-
-// Manual override since mongoose types don't have generics yet.
-interface IAttachmentFieldSchema extends IAttachmentField, Document {
-  /** Returns the top level document of this sub-document. */
-  ownerDocument(): IFormSchema
-  /** Returns this sub-documents parent document. */
-  parent(): IFormSchema
-}
+import { AttachmentSize, IAttachmentFieldSchema } from '../../../types/field'
 
 const createAttachmentFieldSchema = () => {
   const AttachmentFieldSchema = new Schema<IAttachmentFieldSchema>({

--- a/src/app/models/field/baseField.ts
+++ b/src/app/models/field/baseField.ts
@@ -3,11 +3,11 @@ import UIDGenerator from 'uid-generator'
 
 import {
   BasicField,
+  FormResponseMode,
   IFieldSchema,
   IMyInfoSchema,
   ITableFieldSchema,
   MyInfoAttribute,
-  ResponseMode,
 } from '../../../types'
 
 const uidgen3 = new UIDGenerator(256, UIDGenerator.BASE62)
@@ -65,7 +65,7 @@ BaseFieldSchema.pre<IFieldSchema>('validate', function (next) {
   }
 
   // Prevent MyInfo fields from being set in encrypt mode.
-  if (this.parent().responseMode === ResponseMode.Encrypt) {
+  if (this.parent().responseMode === FormResponseMode.Encrypt) {
     if (this.myInfo?.attr) {
       return next(Error('MyInfo fields are not allowed for storage mode forms'))
     }

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'mongoose'
 
 import { validateEmailDomains } from '../../../../shared/utils/email-domain-validation'
-import { IEmailFieldSchema, ResponseMode } from '../../../types'
+import { FormResponseMode, IEmailFieldSchema } from '../../../types'
 
 const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
   const EmailFieldSchema = new Schema<IEmailFieldSchema>({
@@ -31,7 +31,9 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
         default: false,
         set: function (this: IEmailFieldSchema, v: boolean) {
           // Set to false if encrypt mode regardless of initial value.
-          return this.parent().responseMode === ResponseMode.Encrypt ? false : v
+          return this.parent().responseMode === FormResponseMode.Encrypt
+            ? false
+            : v
         },
       },
     },

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -30,6 +30,7 @@ import {
   FormLogicSchema,
   FormLogoState,
   FormOtpData,
+  FormPermission,
   FormSettings,
   IEmailFormModel,
   IEmailFormSchema,
@@ -44,7 +45,6 @@ import {
   LogicConditionState,
   LogicDto,
   LogicType,
-  Permission,
   PickDuplicateForm,
   PublicForm,
   ResponseMode,
@@ -274,7 +274,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           },
         ],
         validate: {
-          validator: async (users: Permission[]) => {
+          validator: async (users: FormPermission[]) => {
             // Retrieve count of users that exist in the Agency collection.
             // Map is used instead of for...of loop so that this runs in
             // parallel.
@@ -587,7 +587,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   }
 
   FormDocumentSchema.methods.updateFormCollaborators = async function (
-    updatedPermissions: Permission[],
+    updatedPermissions: FormPermission[],
   ) {
     this.permissionList = updatedPermissions
     return this.save()

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -20,18 +20,21 @@ import {
 import { reorder } from '../../../shared/utils/immutable-array-fns'
 import { getApplicableIfStates } from '../../shared/util/logic'
 import {
-  AuthType,
   BasicField,
-  Colors,
   EmailFormSettings,
-  EndPage,
+  FormAuthType,
+  FormColorTheme,
+  FormEndPage,
   FormField,
   FormFieldWithId,
   FormLogicSchema,
   FormLogoState,
   FormOtpData,
   FormPermission,
+  FormResponseMode,
   FormSettings,
+  FormStartPage,
+  FormStatus,
   IEmailFormModel,
   IEmailFormSchema,
   IEncryptedFormModel,
@@ -47,9 +50,6 @@ import {
   LogicType,
   PickDuplicateForm,
   PublicForm,
-  ResponseMode,
-  StartPage,
-  Status,
   StorageFormSettings,
 } from '../../types'
 import { AdminDashboardFormMetaDto } from '../../types/api/form'
@@ -182,8 +182,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
             )
             return (
               myInfoFieldCount === 0 ||
-              (this.authType === AuthType.MyInfo &&
-                this.responseMode === ResponseMode.Email &&
+              (this.authType === FormAuthType.MyInfo &&
+                this.responseMode === FormResponseMode.Email &&
                 myInfoFieldCount <= 30)
             )
           },
@@ -302,8 +302,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         estTimeTaken: Number,
         colorTheme: {
           type: String,
-          enum: Object.values(Colors),
-          default: Colors.Blue,
+          enum: Object.values(FormColorTheme),
+          default: FormColorTheme.Blue,
         },
         logo: {
           type: FormLogoSchema,
@@ -331,26 +331,26 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
       authType: {
         type: String,
-        enum: Object.values(AuthType),
-        default: AuthType.NIL,
-        set: function (this: IFormSchema, v: AuthType) {
+        enum: Object.values(FormAuthType),
+        default: FormAuthType.NIL,
+        set: function (this: IFormSchema, v: FormAuthType) {
           // TODO (#1222): Convert to validator
           // Do not allow authType to be changed if form is published
-          if (this.authType !== v && this.status === Status.Public) {
+          if (this.authType !== v && this.status === FormStatus.Public) {
             return this.authType
             // Singpass/Corppass authentication is available for both email
             // and storage mode
             // Important - this case must come before the MyInfo/SGID + storage
             // mode case, or else we may accidentally set Singpass/Corppass storage
             // mode forms to AuthType.NIL
-          } else if ([AuthType.SP, AuthType.CP].includes(v)) {
+          } else if ([FormAuthType.SP, FormAuthType.CP].includes(v)) {
             return v
           } else if (
-            this.responseMode === ResponseMode.Encrypt &&
+            this.responseMode === FormResponseMode.Encrypt &&
             // SGID and MyInfo are not available for storage mode
-            (v === AuthType.MyInfo || v === AuthType.SGID)
+            (v === FormAuthType.MyInfo || v === FormAuthType.SGID)
           ) {
-            return AuthType.NIL
+            return FormAuthType.NIL
           } else {
             return v
           }
@@ -359,16 +359,16 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
       status: {
         type: String,
-        enum: Object.values(Status),
-        default: Status.Private,
-        set: function (this: IFormSchema, v: Status) {
+        enum: Object.values(FormStatus),
+        default: FormStatus.Private,
+        set: function (this: IFormSchema, v: FormStatus) {
           if (
-            this.status === Status.Private &&
-            v === Status.Public &&
-            this.authType !== AuthType.NIL &&
+            this.status === FormStatus.Private &&
+            v === FormStatus.Public &&
+            this.authType !== FormAuthType.NIL &&
             !this.esrvcId
           ) {
-            return Status.Private
+            return FormStatus.Private
           }
 
           return v
@@ -491,7 +491,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   // Method to return myInfo attributes
   FormSchema.methods.getUniqueMyInfoAttrs = function () {
-    if (this.authType !== AuthType.MyInfo) {
+    if (this.authType !== FormAuthType.MyInfo) {
       return []
     }
 
@@ -519,11 +519,11 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   // Archives form.
   FormSchema.methods.archive = function () {
     // Return instantly when form is already archived.
-    if (this.status === Status.Archived) {
+    if (this.status === FormStatus.Archived) {
       return Promise.resolve(this)
     }
 
-    this.status = Status.Archived
+    this.status = FormStatus.Archived
     return this.save()
   }
 
@@ -544,7 +544,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   FormDocumentSchema.methods.getSettings = function (): FormSettings {
     const formSettings =
-      this.responseMode === ResponseMode.Encrypt
+      this.responseMode === FormResponseMode.Encrypt
         ? (pick(this, STORAGE_FORM_SETTINGS_FIELDS) as StorageFormSettings)
         : (pick(this, EMAIL_FORM_SETTINGS_FIELDS) as EmailFormSettings)
 
@@ -553,7 +553,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   FormDocumentSchema.methods.getPublicView = function (): PublicForm {
     const basePublicView =
-      this.responseMode === ResponseMode.Encrypt
+      this.responseMode === FormResponseMode.Encrypt
         ? (pick(this, STORAGE_PUBLIC_FORM_FIELDS) as PublicForm)
         : (pick(this, EMAIL_PUBLIC_FORM_FIELDS) as PublicForm)
 
@@ -691,8 +691,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   ): Promise<IFormSchema | null> {
     const form = await this.findById(formId)
     if (!form) return null
-    if (form.status === Status.Public) {
-      form.status = Status.Private
+    if (form.status === FormStatus.Public) {
+      form.status = FormStatus.Private
     }
     return form.save()
   }
@@ -707,7 +707,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         .or([{ 'permissionList.email': userEmail }, { admin: userId }])
         // Filter out archived forms.
         .where('status')
-        .ne(Status.Archived)
+        .ne(FormStatus.Archived)
         // Project selected fields.
         // `responseMode` is a discriminator key and is returned regardless,
         // selection is made for explicitness.
@@ -788,7 +788,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   FormSchema.statics.updateEndPageById = async function (
     formId: string,
-    newEndPage: EndPage,
+    newEndPage: FormEndPage,
   ) {
     return this.findByIdAndUpdate(
       formId,
@@ -799,7 +799,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   FormSchema.statics.updateStartPageById = async function (
     formId: string,
-    newStartPage: StartPage,
+    newStartPage: FormStartPage,
   ) {
     return this.findByIdAndUpdate(
       formId,
@@ -860,8 +860,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   )
 
   // Adding form discriminators
-  FormModel.discriminator(ResponseMode.Email, EmailFormSchema)
-  FormModel.discriminator(ResponseMode.Encrypt, EncryptedFormSchema)
+  FormModel.discriminator(FormResponseMode.Email, EmailFormSchema)
+  FormModel.discriminator(FormResponseMode.Encrypt, EncryptedFormSchema)
 
   return FormModel
 }
@@ -877,13 +877,13 @@ const getFormModel = (db: Mongoose): IFormModel => {
 export const getEmailFormModel = (db: Mongoose): IEmailFormModel => {
   // Load or build base model first
   getFormModel(db)
-  return db.model(ResponseMode.Email) as IEmailFormModel
+  return db.model(FormResponseMode.Email) as IEmailFormModel
 }
 
 export const getEncryptedFormModel = (db: Mongoose): IEncryptedFormModel => {
   // Load or build base model first
   getFormModel(db)
-  return db.model(ResponseMode.Encrypt) as IEncryptedFormModel
+  return db.model(FormResponseMode.Encrypt) as IEncryptedFormModel
 }
 
 export default getFormModel

--- a/src/app/models/login.server.model.ts
+++ b/src/app/models/login.server.model.ts
@@ -1,7 +1,7 @@
 import { Mongoose, Schema } from 'mongoose'
 
 import {
-  AuthType,
+  FormAuthType,
   ILoginModel,
   ILoginSchema,
   IPopulatedForm,
@@ -33,7 +33,7 @@ const LoginSchema = new Schema<ILoginSchema, ILoginModel>(
     },
     authType: {
       type: String,
-      enum: Object.values(AuthType),
+      enum: Object.values(FormAuthType),
       required: true,
     },
     esrvcId: {

--- a/src/app/models/login.server.model.ts
+++ b/src/app/models/login.server.model.ts
@@ -2,10 +2,10 @@ import { Mongoose, Schema } from 'mongoose'
 
 import {
   FormAuthType,
+  FormBillingStatistic,
   ILoginModel,
   ILoginSchema,
   IPopulatedForm,
-  LoginStatistic,
 } from '../../types'
 
 import { AGENCY_SCHEMA_ID } from './agency.server.model'
@@ -70,8 +70,8 @@ LoginSchema.statics.aggregateLoginStats = function (
   esrvcId: string,
   gte: Date,
   lte: Date,
-): Promise<LoginStatistic[]> {
-  return this.aggregate<LoginStatistic>([
+): Promise<FormBillingStatistic[]> {
+  return this.aggregate<FormBillingStatistic>([
     {
       $match: {
         esrvcId,

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -3,8 +3,8 @@ import mongoose, { Mongoose, QueryCursor, Schema } from 'mongoose'
 import { FixedLengthArray } from 'type-fest'
 
 import {
-  AuthType,
   FindFormsWithSubsAboveResult,
+  FormAuthType,
   IEmailSubmissionModel,
   IEmailSubmissionSchema,
   IEncryptedSubmissionSchema,
@@ -38,8 +38,8 @@ const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
     },
     authType: {
       type: String,
-      enum: Object.values(AuthType),
-      default: AuthType.NIL,
+      enum: Object.values(FormAuthType),
+      default: FormAuthType.NIL,
     },
     myInfoFields: {
       type: [

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -12,15 +12,15 @@ import {
   IPopulatedWebhookSubmission,
   ISubmissionModel,
   ISubmissionSchema,
-  IWebhookResponse,
   IWebhookResponseSchema,
   MyInfoAttribute,
+  StorageModeSubmissionMetadata,
   SubmissionCursorData,
   SubmissionData,
-  SubmissionMetadata,
   SubmissionType,
   SubmissionWebhookInfo,
   WebhookData,
+  WebhookResponse,
   WebhookView,
 } from '../../types'
 import { createQueryWithDateParam } from '../utils/date'
@@ -208,7 +208,7 @@ EncryptSubmissionSchema.methods.getWebhookView = function (
 
 EncryptSubmissionSchema.statics.addWebhookResponse = function (
   submissionId: string,
-  webhookResponse: IWebhookResponse,
+  webhookResponse: WebhookResponse,
 ): Promise<IEncryptedSubmissionSchema | null> {
   return this.findByIdAndUpdate(
     submissionId,
@@ -236,7 +236,7 @@ EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
 EncryptSubmissionSchema.statics.findSingleMetadata = function (
   formId: string,
   submissionId: string,
-): Promise<SubmissionMetadata | null> {
+): Promise<StorageModeSubmissionMetadata | null> {
   return (
     this.findOne(
       {
@@ -255,7 +255,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
         }
 
         // Build submissionMetadata object.
-        const metadata: SubmissionMetadata = {
+        const metadata: StorageModeSubmissionMetadata = {
           number: 1,
           refNo: result._id,
           submissionTime: moment(result.created)
@@ -287,7 +287,7 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
     pageSize?: number
   } = {},
 ): Promise<{
-  metadata: SubmissionMetadata[]
+  metadata: StorageModeSubmissionMetadata[]
   count: number
 }> {
   const numToSkip = (page - 1) * pageSize
@@ -322,7 +322,7 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
         let currentNumber = count - numToSkip
 
         const metadata = pageResults.map((data) => {
-          const metadataEntry: SubmissionMetadata = {
+          const metadataEntry: StorageModeSubmissionMetadata = {
             number: currentNumber,
             refNo: data._id,
             submissionTime: moment(data.created)

--- a/src/app/modules/analytics/__tests__/analytics.service.spec.ts
+++ b/src/app/modules/analytics/__tests__/analytics.service.spec.ts
@@ -6,9 +6,9 @@ import getFormModel from 'src/app/models/form.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import getUserModel from 'src/app/models/user.server.model'
 import {
+  FormResponseMode,
   IAgencySchema,
   IUserSchema,
-  ResponseMode,
   SubmissionType,
 } from 'src/types'
 
@@ -66,7 +66,7 @@ describe('analytics.service', () => {
         FormModel.create({
           admin: testUser._id,
           title: 'Test form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: ['a@abc.com'],
         }),
       )

--- a/src/app/modules/billing/__tests__/billing.controller.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.controller.spec.ts
@@ -3,7 +3,7 @@ import moment from 'moment-timezone'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { FormAuthType, LoginStatistic } from 'src/types'
+import { FormAuthType, FormBillingStatistic } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -51,7 +51,7 @@ describe('billing.controller', () => {
 
     it('should return 200 with login statistics successfully', async () => {
       // Arrange
-      const mockLoginStats: LoginStatistic[] = [
+      const mockLoginStats: FormBillingStatistic[] = [
         {
           adminEmail: 'mockemail@example.com',
           authType: FormAuthType.CP,

--- a/src/app/modules/billing/__tests__/billing.controller.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.controller.spec.ts
@@ -3,7 +3,7 @@ import moment from 'moment-timezone'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { AuthType, LoginStatistic } from 'src/types'
+import { FormAuthType, LoginStatistic } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -54,7 +54,7 @@ describe('billing.controller', () => {
       const mockLoginStats: LoginStatistic[] = [
         {
           adminEmail: 'mockemail@example.com',
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           formId: 'mock form id',
           formName: 'some form name',
           total: 100,

--- a/src/app/modules/billing/__tests__/billing.routes.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.routes.spec.ts
@@ -5,7 +5,7 @@ import supertest, { Session } from 'supertest-session'
 
 import getFormModel from 'src/app/models/form.server.model'
 import getLoginModel from 'src/app/models/login.server.model'
-import { AuthType, IUserSchema, ResponseMode } from 'src/types'
+import { FormAuthType, FormResponseMode, IUserSchema } from 'src/types'
 
 import { createAuthedSession } from 'tests/integration/helpers/express-auth'
 import { setupApp } from 'tests/integration/helpers/express-setup'
@@ -75,14 +75,14 @@ describe('billing.routes', () => {
           formName: generatedForms[0].title,
           total: generatedLoginTimes[0],
           formId: String(generatedForms[0]._id),
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         },
         {
           adminEmail: defaultUser.email,
           formName: generatedForms[1].title,
           total: generatedLoginTimes[1],
           formId: String(generatedForms[1]._id),
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         },
       ]
       expect(response.status).toEqual(200)
@@ -229,7 +229,7 @@ const generateLoginStatistics = async ({
     FormModel.create({
       title: `example form title ${idx}`,
       admin: user._id,
-      responseMode: ResponseMode.Email,
+      responseMode: FormResponseMode.Email,
       emails: [user.email],
     }),
   )
@@ -244,7 +244,7 @@ const generateLoginStatistics = async ({
           form: form._id,
           admin: user._id,
           agency: user.agency,
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: esrvcIdToCheck,
         }),
       ),
@@ -257,7 +257,7 @@ const generateLoginStatistics = async ({
         form: forms[2]._id,
         admin: user._id,
         agency: user.agency,
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: altEsrvcId,
       }),
     ),

--- a/src/app/modules/billing/__tests__/billing.service.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.service.spec.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose'
 import getLoginModel from 'src/app/models/login.server.model'
 import { getMongoErrorMessage } from 'src/app/utils/handle-mongo-error'
 import {
-  AuthType,
+  FormAuthType,
   ILoginSchema,
   IPopulatedForm,
   LoginStatistic,
@@ -19,7 +19,9 @@ describe('billing.service', () => {
   describe('recordLoginByForm', () => {
     beforeEach(() => jest.restoreAllMocks())
     it('should call LoginModel.addLoginFromForm with the given form', async () => {
-      const mockForm = { authType: AuthType.SP } as unknown as IPopulatedForm
+      const mockForm = {
+        authType: FormAuthType.SP,
+      } as unknown as IPopulatedForm
       const mockLogin = { esrvcId: 'esrvcId' } as unknown as ILoginSchema
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
@@ -30,7 +32,9 @@ describe('billing.service', () => {
     })
 
     it('should return FormHasNoAuthError when form has authType NIL', async () => {
-      const mockForm = { authType: AuthType.NIL } as unknown as IPopulatedForm
+      const mockForm = {
+        authType: FormAuthType.NIL,
+      } as unknown as IPopulatedForm
       const mockLogin = { esrvcId: 'esrvcId' } as unknown as ILoginSchema
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
@@ -41,7 +45,9 @@ describe('billing.service', () => {
     })
 
     it('should return DatabaseError when adding login fails', async () => {
-      const mockForm = { authType: AuthType.SP } as unknown as IPopulatedForm
+      const mockForm = {
+        authType: FormAuthType.SP,
+      } as unknown as IPopulatedForm
       const addLoginSpy = jest
         .spyOn(LoginModel, 'addLoginFromForm')
         .mockRejectedValueOnce('')
@@ -58,7 +64,7 @@ describe('billing.service', () => {
       const mockLoginStats: LoginStatistic[] = [
         {
           adminEmail: 'mockemail@example.com',
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           formId: 'mock form id',
           formName: 'some form name',
           total: 100,

--- a/src/app/modules/billing/__tests__/billing.service.spec.ts
+++ b/src/app/modules/billing/__tests__/billing.service.spec.ts
@@ -4,9 +4,9 @@ import getLoginModel from 'src/app/models/login.server.model'
 import { getMongoErrorMessage } from 'src/app/utils/handle-mongo-error'
 import {
   FormAuthType,
+  FormBillingStatistic,
   ILoginSchema,
   IPopulatedForm,
-  LoginStatistic,
 } from 'src/types'
 
 import { DatabaseError } from '../../core/core.errors'
@@ -61,7 +61,7 @@ describe('billing.service', () => {
   describe('getSpLoginStats', () => {
     it('should return result of aggregate query successfully', async () => {
       // Arrange
-      const mockLoginStats: LoginStatistic[] = [
+      const mockLoginStats: FormBillingStatistic[] = [
         {
           adminEmail: 'mockemail@example.com',
           authType: FormAuthType.CP,

--- a/src/app/modules/billing/billing.service.ts
+++ b/src/app/modules/billing/billing.service.ts
@@ -3,9 +3,9 @@ import { errAsync, ResultAsync } from 'neverthrow'
 
 import {
   FormAuthType,
+  FormBillingStatistic,
   ILoginSchema,
   IPopulatedForm,
-  LoginStatistic,
 } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getLoginModel from '../../models/login.server.model'
@@ -30,7 +30,7 @@ export const getSpLoginStats = (
   esrvcId: string,
   minDate: Date,
   maxDate: Date,
-): ResultAsync<LoginStatistic[], DatabaseError> => {
+): ResultAsync<FormBillingStatistic[], DatabaseError> => {
   return ResultAsync.fromPromise(
     LoginModel.aggregateLoginStats(esrvcId, minDate, maxDate),
     (error) => {

--- a/src/app/modules/billing/billing.service.ts
+++ b/src/app/modules/billing/billing.service.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 import { errAsync, ResultAsync } from 'neverthrow'
 
 import {
-  AuthType,
+  FormAuthType,
   ILoginSchema,
   IPopulatedForm,
   LoginStatistic,
@@ -60,7 +60,7 @@ export const recordLoginByForm = (
     action: 'recordLoginByForm',
     formId: form._id,
   }
-  if (form.authType === AuthType.NIL) {
+  if (form.authType === FormAuthType.NIL) {
     return errAsync(new FormHasNoAuthError())
   }
   return ResultAsync.fromPromise(LoginModel.addLoginFromForm(form), (error) => {

--- a/src/app/modules/examples/__tests__/examples.controller.spec.ts
+++ b/src/app/modules/examples/__tests__/examples.controller.spec.ts
@@ -1,7 +1,7 @@
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { Colors } from 'src/types'
+import { FormColorTheme } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -97,7 +97,7 @@ describe('examples.controller', () => {
           _id: 'mock randomId',
           agency: 'mock agencyId',
           avgFeedback: 5,
-          colorTheme: Colors.Blue,
+          colorTheme: FormColorTheme.Blue,
           count: 20,
           form_fields: [],
           lastSubmission: new Date(),

--- a/src/app/modules/examples/__tests__/helpers/prepareTestData.ts
+++ b/src/app/modules/examples/__tests__/helpers/prepareTestData.ts
@@ -6,13 +6,13 @@ import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
 import getFormStatisticsTotalModel from 'src/app/models/form_statistics_total.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import {
-  AuthType,
+  FormAuthType,
+  FormResponseMode,
+  FormStatus,
   IAgencySchema,
   IFormFeedbackSchema,
   IFormSchema,
   IUserSchema,
-  ResponseMode,
-  Status,
   SubmissionType,
 } from 'src/types'
 
@@ -83,13 +83,13 @@ const prepareTestData = async (
 
   const baseFormParams = {
     admin: user._id,
-    responseMode: ResponseMode.Email,
+    responseMode: FormResponseMode.Email,
     emails: [user.email],
     // Important for form status to be public and listed so examples can
     // surface.
-    status: Status.Public,
+    status: FormStatus.Public,
     isListed: true,
-    authType: AuthType.NIL,
+    authType: FormAuthType.NIL,
   }
 
   // Populate forms in database with prespecified number of times.

--- a/src/app/modules/examples/examples.queries.ts
+++ b/src/app/modules/examples/examples.queries.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 
-import { Status } from '../../../types'
+import { FormStatus } from '../../../types'
 
 /**
  * Precondition: Must be called as the **first** step in the aggregation
@@ -53,7 +53,7 @@ export const searchFormsById = (formId: string): Record<string, unknown>[] => [
 export const filterInactiveAndUnlistedForms: Record<string, unknown>[] = [
   {
     $match: {
-      'formInfo.status': Status.Public,
+      'formInfo.status': FormStatus.Public,
       'formInfo.isListed': true,
     },
   },

--- a/src/app/modules/examples/examples.types.ts
+++ b/src/app/modules/examples/examples.types.ts
@@ -1,9 +1,9 @@
 import {
+  FormStartPage,
   IAgencyDocument,
   IForm,
   IFormFeedbackSchema,
   IFormStatisticsTotalModel,
-  StartPage,
 } from 'src/types'
 
 export type QueryDataMap = {
@@ -21,7 +21,7 @@ export type QueryExecResult = {
   form_fields: IForm['form_fields']
   logo: IAgencyDocument['logo']
   agency: IAgencyDocument['shortName']
-  colorTheme: StartPage['colorTheme']
+  colorTheme: FormStartPage['colorTheme']
   avgFeedback: number | null
 }
 

--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -5,11 +5,11 @@ import mongoose from 'mongoose'
 import getFormModel from 'src/app/models/form.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import {
+  FormResponseMode,
+  FormStatus,
   IEncryptedSubmissionSchema,
   IFormSchema,
   IPopulatedForm,
-  ResponseMode,
-  Status,
   SubmissionType,
 } from 'src/types'
 
@@ -35,7 +35,7 @@ const MOCK_FORM_PARAMS = {
 const MOCK_ENCRYPTED_FORM_PARAMS = {
   ...MOCK_FORM_PARAMS,
   publicKey: 'mockPublicKey',
-  responseMode: ResponseMode.Encrypt,
+  responseMode: FormResponseMode.Encrypt,
 }
 
 describe('FormService', () => {
@@ -331,7 +331,7 @@ describe('FormService', () => {
     it('should return the form when the submission limit is not reached', async () => {
       // Arrange
       const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-        status: Status.Public,
+        status: FormStatus.Public,
         submissionLimit: 10,
       })
       const validForm = new Form(formParams)
@@ -362,7 +362,7 @@ describe('FormService', () => {
     it('should not let requests through and deactivate form when form has reached submission limit', async () => {
       // Arrange
       const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-        status: Status.Public,
+        status: FormStatus.Public,
         submissionLimit: 5,
       })
       const validForm = new Form(formParams)
@@ -402,7 +402,7 @@ describe('FormService', () => {
       const form = {
         _id: new ObjectId(),
         // Form public.
-        status: Status.Public,
+        status: FormStatus.Public,
       } as IPopulatedForm
 
       // Act
@@ -417,7 +417,7 @@ describe('FormService', () => {
       const form = {
         _id: new ObjectId(),
         // Form deleted.
-        status: Status.Archived,
+        status: FormStatus.Archived,
       } as IPopulatedForm
 
       // Act
@@ -432,7 +432,7 @@ describe('FormService', () => {
       const form = {
         _id: new ObjectId(),
         // Form private.
-        status: Status.Private,
+        status: FormStatus.Private,
         inactiveMessage: 'test inactive message',
       } as IPopulatedForm
 

--- a/src/app/modules/form/__tests__/form.utils.spec.ts
+++ b/src/app/modules/form/__tests__/form.utils.spec.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'bson-ext'
 import { Types } from 'mongoose'
 
-import { BasicField, FormFieldSchema, Permission } from 'src/types'
+import { BasicField, FormFieldSchema, FormPermission } from 'src/types'
 
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
 
@@ -21,7 +21,7 @@ describe('form.utils', () => {
     })
 
     it('should return all collaborators when writePermission is undefined', () => {
-      const collabs: Permission[] = [
+      const collabs: FormPermission[] = [
         { email: MOCK_EMAIL_1, write: true },
         { email: MOCK_EMAIL_2, write: false },
       ]
@@ -30,7 +30,7 @@ describe('form.utils', () => {
     })
 
     it('should return write-only collaborators when writePermission is true', () => {
-      const collabs: Permission[] = [
+      const collabs: FormPermission[] = [
         { email: MOCK_EMAIL_1, write: true },
         { email: MOCK_EMAIL_2, write: false },
       ]
@@ -39,7 +39,7 @@ describe('form.utils', () => {
     })
 
     it('should return read-only collaborators when writePermission is false', () => {
-      const collabs: Permission[] = [
+      const collabs: FormPermission[] = [
         { email: MOCK_EMAIL_1, write: true },
         { email: MOCK_EMAIL_2, write: false },
       ]

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -41,9 +41,11 @@ import {
 import MailService from 'src/app/services/mail/mail.service'
 import { EditFieldActions } from 'src/shared/constants'
 import {
-  AuthType,
   BasicField,
+  FormAuthType,
+  FormResponseMode,
   FormSettings,
+  FormStatus,
   IEmailSubmissionSchema,
   IEncryptedSubmissionSchema,
   IFieldSchema,
@@ -57,8 +59,6 @@ import {
   IUserSchema,
   LogicDto,
   PublicForm,
-  ResponseMode,
-  Status,
 } from 'src/types'
 import {
   AdminDashboardFormMetaDto,
@@ -222,7 +222,7 @@ describe('admin-form.controller', () => {
       title: 'mock title',
     } as IFormSchema
     const MOCK_FORM_PARAMS: CreateFormBodyDto = {
-      responseMode: ResponseMode.Encrypt,
+      responseMode: FormResponseMode.Encrypt,
       publicKey: 'some public key',
       title: 'some form title',
     }
@@ -3022,7 +3022,7 @@ describe('admin-form.controller', () => {
     it('should return duplicated form view on duplicate success', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
@@ -3095,7 +3095,7 @@ describe('admin-form.controller', () => {
     it('should return 404 when form to duplicate cannot be found', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
@@ -3229,7 +3229,7 @@ describe('admin-form.controller', () => {
     it('should return 500 when database error occurs whilst duplicating form', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
@@ -3455,7 +3455,7 @@ describe('admin-form.controller', () => {
     it('should return copied template form view on duplicate success', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: ['some-email@example.com'],
         title: 'mock new template title',
       }
@@ -3530,7 +3530,7 @@ describe('admin-form.controller', () => {
     it('should return 404 when form to duplicate cannot be found', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
@@ -3678,7 +3678,7 @@ describe('admin-form.controller', () => {
     it('should return 500 when database error occurs whilst duplicating form', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'mock title',
       }
@@ -4486,7 +4486,7 @@ describe('admin-form.controller', () => {
         formId: MOCK_FORM_ID,
       },
       body: {
-        status: Status.Private,
+        status: FormStatus.Private,
       },
       session: {
         user: {
@@ -4498,10 +4498,10 @@ describe('admin-form.controller', () => {
     it('should return 200 with updated settings successfully', async () => {
       // Arrange
       const mockUpdatedSettings: FormSettings = {
-        authType: AuthType.NIL,
+        authType: FormAuthType.NIL,
         hasCaptcha: false,
         inactiveMessage: 'some inactive message',
-        status: Status.Private,
+        status: FormStatus.Private,
         submissionLimit: 42069,
         title: 'new title',
         webhook: {
@@ -4843,10 +4843,10 @@ describe('admin-form.controller', () => {
 
   describe('handleGetSettings', () => {
     const MOCK_FORM_SETTINGS: FormSettings = {
-      authType: AuthType.NIL,
+      authType: FormAuthType.NIL,
       hasCaptcha: false,
       inactiveMessage: 'some inactive message',
-      status: Status.Private,
+      status: FormStatus.Private,
       submissionLimit: 42069,
       title: 'mock title',
       webhook: {
@@ -5548,7 +5548,12 @@ describe('admin-form.controller', () => {
 
     it('should return 400 when form is not email mode', async () => {
       MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
-        err(new ResponseModeError(ResponseMode.Encrypt, ResponseMode.Email)),
+        err(
+          new ResponseModeError(
+            FormResponseMode.Encrypt,
+            FormResponseMode.Email,
+          ),
+        ),
       )
       const mockReq = expressHandler.mockRequest({
         params: {
@@ -6487,7 +6492,12 @@ describe('admin-form.controller', () => {
 
     it('should return 400 when form is not encrypt mode', async () => {
       MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValueOnce(
-        err(new ResponseModeError(ResponseMode.Email, ResponseMode.Encrypt)),
+        err(
+          new ResponseModeError(
+            FormResponseMode.Email,
+            FormResponseMode.Encrypt,
+          ),
+        ),
       )
       const mockReq = expressHandler.mockRequest({
         params: {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -39,14 +39,14 @@ import { SubmissionHash } from 'src/app/modules/submission/email-submission/emai
 import { EditFieldActions } from 'src/shared/constants'
 import {
   BasicField,
+  FormResponseMode,
+  FormStatus,
   IFieldSchema,
   IFormDocument,
   IFormSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
   IUserSchema,
-  ResponseMode,
-  Status,
   SubmissionCursorData,
   SubmissionType,
 } from 'src/types'
@@ -114,7 +114,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_TEXT_FIELD],
           admin: defaultUser._id,
         },
@@ -143,7 +143,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [
             { ...MOCK_TEXT_FIELD, required: false } as IFieldSchema,
           ],
@@ -174,7 +174,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_ATTACHMENT_FIELD],
           admin: defaultUser._id,
         },
@@ -208,7 +208,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_SECTION_FIELD],
           admin: defaultUser._id,
         },
@@ -237,7 +237,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_OPTIONAL_VERIFIED_FIELD],
           admin: defaultUser._id,
         },
@@ -266,7 +266,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_CHECKBOX_FIELD],
           admin: defaultUser._id,
         },
@@ -295,7 +295,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -316,7 +316,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -341,7 +341,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -366,7 +366,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -393,7 +393,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -418,7 +418,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -443,7 +443,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -468,7 +468,7 @@ describe('admin-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -857,7 +857,7 @@ describe('admin-form.routes', () => {
         title: 'Archived form',
         emails: defaultUser.email,
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
       // Create form that user is not collaborator/admin of. Should not be
       // fetched.
@@ -956,8 +956,8 @@ describe('admin-form.routes', () => {
         expect.objectContaining({
           admin: String(defaultUser._id),
           emails: [defaultUser.email],
-          responseMode: ResponseMode.Email,
-          status: Status.Private,
+          responseMode: FormResponseMode.Email,
+          status: FormStatus.Private,
           title: createEmailParams.form.title,
           form_fields: [],
           form_logics: [],
@@ -986,8 +986,8 @@ describe('admin-form.routes', () => {
         expect.objectContaining({
           admin: String(defaultUser._id),
           publicKey: createStorageParams.form.publicKey,
-          responseMode: ResponseMode.Encrypt,
-          status: Status.Private,
+          responseMode: FormResponseMode.Encrypt,
+          status: FormStatus.Private,
           title: createStorageParams.form.title,
           form_fields: [],
           form_logics: [],
@@ -1034,7 +1034,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           // title is missing.
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: 'some@example.com',
         },
       })
@@ -1051,7 +1051,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           // body.emails missing.
         },
       })
@@ -1070,7 +1070,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: '',
         },
       })
@@ -1092,7 +1092,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: [],
         },
       })
@@ -1114,7 +1114,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           // publicKey missing.
         },
       })
@@ -1135,7 +1135,7 @@ describe('admin-form.routes', () => {
       const response = await request.post('/adminform').send({
         form: {
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: '',
         },
       })
@@ -1384,8 +1384,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -1546,7 +1546,7 @@ describe('admin-form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
@@ -1657,7 +1657,7 @@ describe('admin-form.routes', () => {
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
-      expect(formToArchive.status).toEqual(Status.Private)
+      expect(formToArchive.status).toEqual(FormStatus.Private)
 
       // Act
       const response = await request.delete(`/${formToArchive._id}/adminform`)
@@ -1666,7 +1666,7 @@ describe('admin-form.routes', () => {
       const form = await EmailFormModel.findById(formToArchive._id)
       expect(response.status).toEqual(200)
       expect(response.body).toEqual({ message: 'Form has been archived' })
-      expect(form?.status).toEqual(Status.Archived)
+      expect(form?.status).toEqual(FormStatus.Archived)
     })
 
     it('should return 401 when user is not logged in', async () => {
@@ -1733,7 +1733,7 @@ describe('admin-form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
@@ -1796,7 +1796,7 @@ describe('admin-form.routes', () => {
       })
 
       const dupeParams = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         title: 'new duplicated form title',
         publicKey: 'some public key',
       }
@@ -1816,7 +1816,7 @@ describe('admin-form.routes', () => {
           }),
           responseMode: dupeParams.responseMode,
           title: dupeParams.title,
-          status: Status.Private,
+          status: FormStatus.Private,
         }),
       )
     })
@@ -1832,7 +1832,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         title: 'new email form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         // body.emails missing.
       })
 
@@ -1856,7 +1856,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         title: 'new email form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: '',
       })
 
@@ -1883,7 +1883,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         title: 'new email form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [],
       })
 
@@ -1910,7 +1910,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         title: 'new storage mode form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         // publicKey missing.
       })
 
@@ -1936,7 +1936,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         title: 'new storage mode form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: '',
       })
 
@@ -1963,7 +1963,7 @@ describe('admin-form.routes', () => {
       // Act
       const response = await request.post(`/${formToDupe._id}/adminform`).send({
         // title is missing.
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: 'test@example.com',
       })
 
@@ -2040,7 +2040,7 @@ describe('admin-form.routes', () => {
 
       // Act
       const response = await request.post(`/${randomForm._id}/adminform`).send({
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         title: 'new duplicated form title',
         publicKey: 'some public key',
       })
@@ -2058,7 +2058,7 @@ describe('admin-form.routes', () => {
 
       // Act
       const response = await request.post(`/${invalidFormId}/adminform`).send({
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         title: 'new duplicated form title',
         publicKey: 'some public key',
       })
@@ -2075,14 +2075,14 @@ describe('admin-form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
       const response = await request
         .post(`/${archivedForm._id}/adminform`)
         .send({
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: 'anyrandomEmail@example.com',
           title: 'cool new title',
         })
@@ -2099,7 +2099,7 @@ describe('admin-form.routes', () => {
 
       // Act
       const response = await request.post(`/${new ObjectId()}/adminform`).send({
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         title: 'does not matter',
         publicKey: 'some public key',
       })
@@ -2121,7 +2121,7 @@ describe('admin-form.routes', () => {
       // Force validation error that will be returned as database error
       // TODO(#614): Return transformMongoError instead of DatabaseError for better mongoose error handling.
       const invalidEmailDupeParams = {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: 'notAnEmail, should return error',
         title: 'cool new title',
       }
@@ -2345,7 +2345,7 @@ describe('admin-form.routes', () => {
         admin: defaultUser._id,
         publicKey: 'some public key',
         // Already deleted.
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
       const anotherUser = (
         await dbHandler.insertFormCollectionReqs({
@@ -2406,8 +2406,8 @@ describe('admin-form.routes', () => {
       // Create public form
       const publicForm = await FormModel.create({
         title: 'some public form',
-        status: Status.Public,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: anotherUser._id,
         form_fields: [
@@ -2457,8 +2457,8 @@ describe('admin-form.routes', () => {
       // Create private form
       const privateForm = await FormModel.create({
         title: 'some private form',
-        status: Status.Private,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Private,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: anotherUser._id,
         form_fields: [generateDefaultField(BasicField.Nric)],
@@ -2500,8 +2500,8 @@ describe('admin-form.routes', () => {
       ).user
       const archivedForm = await FormModel.create({
         title: 'some archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: anotherUser._id,
         form_fields: [generateDefaultField(BasicField.Nric)],
@@ -2523,8 +2523,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const formToRetrieve = await FormModel.create({
         title: 'some form',
-        status: Status.Public,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
         form_fields: [generateDefaultField(BasicField.Nric)],
@@ -2564,7 +2564,7 @@ describe('admin-form.routes', () => {
         admin: anotherUser._id,
         publicKey: 'some random key',
         // Must be public to copy
-        status: Status.Public,
+        status: FormStatus.Public,
       })) as IFormDocument
     })
 
@@ -2572,7 +2572,7 @@ describe('admin-form.routes', () => {
       // Act
       const bodyParams = {
         title: 'some title',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
       }
       const response = await request
@@ -2596,7 +2596,7 @@ describe('admin-form.routes', () => {
       // Act
       const bodyParams = {
         title: 'some other title',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
       }
       const response = await request
@@ -2652,7 +2652,7 @@ describe('admin-form.routes', () => {
           body: {
             key: 'responseMode',
             message: `"responseMode" must be one of [${Object.values(
-              ResponseMode,
+              FormResponseMode,
             ).join(', ')}]`,
           },
         }),
@@ -2665,7 +2665,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           // body.title missing
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: [defaultUser.email],
         })
 
@@ -2684,7 +2684,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           // body.emails missing.
         })
 
@@ -2703,7 +2703,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: '',
         })
 
@@ -2725,7 +2725,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: [],
         })
 
@@ -2747,7 +2747,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           // publicKey missing.
         })
 
@@ -2768,7 +2768,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: '',
         })
 
@@ -2800,14 +2800,14 @@ describe('admin-form.routes', () => {
       // Arrange
       const bodyParams = {
         title: 'some title',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
       }
       // Create private form
       const privateForm = await FormModel.create({
         title: 'some private form',
-        status: Status.Private,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Private,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: anotherUser._id,
         form_fields: [generateDefaultField(BasicField.Nric)],
@@ -2831,7 +2831,7 @@ describe('admin-form.routes', () => {
         .post(`/${new ObjectId()}/adminform/copy`)
         .send({
           title: 'some new title',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: 'booyeah',
         })
 
@@ -2848,8 +2848,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: anotherUser._id,
       })
@@ -2859,7 +2859,7 @@ describe('admin-form.routes', () => {
         .post(`/${archivedForm._id}/adminform/copy`)
         .send({
           title: 'some new title',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: 'booyeah',
         })
 
@@ -2880,7 +2880,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'some new title',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: 'booyeah',
         })
 
@@ -2903,7 +2903,7 @@ describe('admin-form.routes', () => {
         .post(`/${formToCopy._id}/adminform/copy`)
         .send({
           title: 'some new title',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: 'booyeah',
         })
 
@@ -2923,7 +2923,7 @@ describe('admin-form.routes', () => {
         admin: defaultUser._id,
         publicKey: 'some random key',
         // Private status.
-        status: Status.Private,
+        status: FormStatus.Private,
       })
 
       // Act
@@ -3029,8 +3029,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -3052,7 +3052,7 @@ describe('admin-form.routes', () => {
       const formToPreview = await EmailFormModel.create({
         title: 'some other form',
         admin: defaultUser._id,
-        status: Status.Public,
+        status: FormStatus.Public,
         emails: [defaultUser.email],
       })
       // Delete user after login.
@@ -3075,7 +3075,7 @@ describe('admin-form.routes', () => {
       const formToPreview = await EmailFormModel.create({
         title: 'some other form',
         admin: defaultUser._id,
-        status: Status.Public,
+        status: FormStatus.Public,
         emails: [defaultUser.email],
       })
       // Mock database error.
@@ -3223,8 +3223,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -3379,8 +3379,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -3546,8 +3546,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -3584,7 +3584,7 @@ describe('admin-form.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -3665,7 +3665,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const emailForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -3768,8 +3768,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -3867,7 +3867,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -3886,7 +3886,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -3906,7 +3906,7 @@ describe('admin-form.routes', () => {
       const expectedSubmissionCount = 5
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -3936,7 +3936,7 @@ describe('admin-form.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -3970,7 +3970,7 @@ describe('admin-form.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -4008,7 +4008,7 @@ describe('admin-form.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -4044,7 +4044,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -4073,7 +4073,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -4102,7 +4102,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -4131,7 +4131,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -4161,7 +4161,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -4250,8 +4250,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -4285,8 +4285,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const form = await EmailFormModel.create({
         title: 'normal form',
-        status: Status.Private,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Private,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -4314,7 +4314,7 @@ describe('admin-form.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -4500,8 +4500,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -4582,7 +4582,7 @@ describe('admin-form.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -4787,7 +4787,7 @@ describe('admin-form.routes', () => {
       // Arrange
       const emailForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -4867,8 +4867,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -5105,8 +5105,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -5343,8 +5343,8 @@ describe('admin-form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -23,14 +23,17 @@ import * as UserService from 'src/app/modules/user/user.service'
 import { formatErrorRecoveryMessage } from 'src/app/utils/handle-mongo-error'
 import { EditFieldActions } from 'src/shared/constants'
 import {
-  AuthType,
   BasicField,
-  Colors,
   CustomFormLogo,
-  EndPage,
+  FormAuthType,
+  FormColorTheme,
+  FormEndPage,
   FormLogicSchema,
   FormLogoState,
+  FormResponseMode,
   FormSettings,
+  FormStartPage,
+  FormStatus,
   IEmailFormSchema,
   IFormDocument,
   IFormSchema,
@@ -39,9 +42,6 @@ import {
   LogicDto,
   LogicType,
   PickDuplicateForm,
-  ResponseMode,
-  StartPage,
-  Status,
 } from 'src/types'
 import {
   AdminDashboardFormMetaDto,
@@ -116,13 +116,13 @@ describe('admin-form.service', () => {
           admin: {},
           title: 'test form 1',
           _id: 'any',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
         },
         {
           admin: {},
           title: 'test form 2',
           _id: 'any2',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
         },
       ] as AdminDashboardFormMetaDto[]
       // Mock user admin success.
@@ -367,7 +367,7 @@ describe('admin-form.service', () => {
       const mockArchivedForm = {
         _id: new ObjectId(),
         admin: new ObjectId(),
-        status: Status.Archived,
+        status: FormStatus.Archived,
       } as IEmailFormSchema
       const mockArchiveFn = jest.fn().mockResolvedValue(mockArchivedForm)
       const mockInitialForm = {
@@ -421,12 +421,12 @@ describe('admin-form.service', () => {
       },
     } as unknown as IFormDocument
     const MOCK_EMAIL_OVERRIDE_PARAMS: DuplicateFormBodyDto = {
-      responseMode: ResponseMode.Email,
+      responseMode: FormResponseMode.Email,
       title: 'mock new title',
       emails: ['mockExample@example.com'],
     }
     const MOCK_ENCRYPT_OVERRIDE_PARAMS: DuplicateFormBodyDto = {
-      responseMode: ResponseMode.Encrypt,
+      responseMode: FormResponseMode.Encrypt,
       title: 'mock new title',
       publicKey: 'some public key',
     }
@@ -591,7 +591,7 @@ describe('admin-form.service', () => {
         _id: new ObjectId(),
         admin: MOCK_CURRENT_OWNER,
         emails: [MOCK_NEW_OWNER_EMAIL],
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         title: 'some mock form',
         populate: jest.fn().mockReturnValue({
           execPopulate: jest.fn().mockResolvedValue(expectedPopulateResult),
@@ -768,7 +768,7 @@ describe('admin-form.service', () => {
         _id: new ObjectId(),
         admin: MOCK_CURRENT_OWNER,
         emails: [MOCK_NEW_OWNER_EMAIL],
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         title: 'some mock form',
         populate: jest.fn().mockReturnValue({
           // Mock populate error.
@@ -816,7 +816,7 @@ describe('admin-form.service', () => {
       const formParams: Parameters<typeof createForm>[0] = {
         title: 'create form title',
         admin: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: 'example@example.com',
       }
       const expectedForm = {
@@ -840,7 +840,7 @@ describe('admin-form.service', () => {
       const formParams: Parameters<typeof createForm>[0] = {
         title: 'create form title',
         admin: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some key',
       }
       const createSpy = jest
@@ -864,7 +864,7 @@ describe('admin-form.service', () => {
       const formParams: Parameters<typeof createForm>[0] = {
         title: 'create form title',
         admin: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some key',
       }
       const createSpy = jest.spyOn(FormModel, 'create').mockRejectedValueOnce(
@@ -887,7 +887,7 @@ describe('admin-form.service', () => {
       const formParams: Parameters<typeof createForm>[0] = {
         title: 'create form title',
         admin: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some key',
       }
       const mockErrorString = 'some payload size error'
@@ -915,7 +915,7 @@ describe('admin-form.service', () => {
       const formParams: Parameters<typeof createForm>[0] = {
         title: 'create form title',
         admin: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some key',
       }
       const mockErrorString = 'no'
@@ -1032,7 +1032,7 @@ describe('admin-form.service', () => {
     const MOCK_UPDATED_FORM = {
       _id: new ObjectId(),
       admin: new ObjectId(),
-      status: Status.Private,
+      status: FormStatus.Private,
       form_fields: [
         generateDefaultField(BasicField.Mobile),
         generateDefaultField(BasicField.Dropdown),
@@ -1042,7 +1042,7 @@ describe('admin-form.service', () => {
     const MOCK_INITIAL_FORM = mocked({
       _id: MOCK_UPDATED_FORM._id,
       admin: MOCK_UPDATED_FORM.admin,
-      status: Status.Public,
+      status: FormStatus.Public,
       form_fields: MOCK_UPDATED_FORM.form_fields,
       save: jest.fn().mockResolvedValue(MOCK_UPDATED_FORM),
     } as unknown as IPopulatedForm)
@@ -1050,7 +1050,7 @@ describe('admin-form.service', () => {
     it('should successfully update given form keys', async () => {
       // Arrange
       const formUpdateParams: Parameters<typeof updateForm>[1] = {
-        status: Status.Private,
+        status: FormStatus.Private,
       }
 
       // Act
@@ -1090,10 +1090,10 @@ describe('admin-form.service', () => {
 
   describe('updateFormSettings', () => {
     const MOCK_UPDATED_SETTINGS: FormSettings = {
-      authType: AuthType.NIL,
+      authType: FormAuthType.NIL,
       hasCaptcha: false,
       inactiveMessage: 'some inactive message',
-      status: Status.Private,
+      status: FormStatus.Private,
       submissionLimit: 42069,
       title: 'new title',
       webhook: {
@@ -1104,20 +1104,20 @@ describe('admin-form.service', () => {
 
     const MOCK_UPDATED_FORM = {
       ...MOCK_UPDATED_SETTINGS,
-      responseMode: ResponseMode.Encrypt,
+      responseMode: FormResponseMode.Encrypt,
       publicKey: 'some public key',
       getSettings: jest.fn().mockReturnValue(MOCK_UPDATED_SETTINGS),
     } as unknown as IFormDocument
 
     const MOCK_EMAIL_FORM = mocked({
       _id: new ObjectId(),
-      status: Status.Public,
-      responseMode: ResponseMode.Email,
+      status: FormStatus.Public,
+      responseMode: FormResponseMode.Email,
     } as unknown as IPopulatedForm)
     const MOCK_ENCRYPT_FORM = mocked({
       _id: new ObjectId(),
-      status: Status.Public,
-      responseMode: ResponseMode.Encrypt,
+      status: FormStatus.Public,
+      responseMode: FormResponseMode.Encrypt,
     } as unknown as IPopulatedForm)
 
     const EMAIL_UPDATE_SPY = jest
@@ -1140,7 +1140,7 @@ describe('admin-form.service', () => {
     it('should return updated form settings when successfully updating email form settings', async () => {
       // Arrange
       const settingsToUpdate: SettingsUpdateDto = {
-        status: Status.Private,
+        status: FormStatus.Private,
         title: 'new title',
       }
 
@@ -1383,14 +1383,14 @@ describe('admin-form.service', () => {
     beforeEach(() => {
       mockEmailForm = {
         _id: new ObjectId(),
-        status: Status.Public,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Email,
         ...mockFormLogic,
       } as unknown as IPopulatedForm
       mockEncryptForm = {
         _id: new ObjectId(),
-        status: Status.Public,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Encrypt,
         ...mockFormLogic,
       } as unknown as IPopulatedForm
     })
@@ -1738,14 +1738,14 @@ describe('admin-form.service', () => {
     beforeEach(() => {
       mockEmailForm = {
         _id: mockEmailFormId,
-        status: Status.Public,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Email,
         ...mockFormLogicOld,
       } as unknown as IPopulatedForm
       mockEncryptForm = {
         _id: mockEncryptFormId,
-        status: Status.Public,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Encrypt,
         ...mockFormLogicOld,
       } as unknown as IPopulatedForm
       mockEmailFormUpdated = {
@@ -1948,7 +1948,7 @@ describe('admin-form.service', () => {
   describe('updateEndPage', () => {
     const updateSpy = jest.spyOn(FormModel, 'updateEndPageById')
     const MOCK_FORM_ID = new ObjectId().toHexString()
-    const MOCK_NEW_END_PAGE: EndPage = {
+    const MOCK_NEW_END_PAGE: FormEndPage = {
       title: 'expected end page title',
       buttonLink: 'https://some-button-link.example.com',
       buttonText: 'expected button text',
@@ -2001,8 +2001,8 @@ describe('admin-form.service', () => {
   describe('updateStartPage', () => {
     const updateSpy = jest.spyOn(FormModel, 'updateStartPageById')
     const MOCK_FORM_ID = new ObjectId().toHexString()
-    const MOCK_NEW_START_PAGE: StartPage = {
-      colorTheme: Colors.Blue,
+    const MOCK_NEW_START_PAGE: FormStartPage = {
+      colorTheme: FormColorTheme.Blue,
       paragraph: 'some paragraph',
       estTimeTaken: 10000000,
       logo: {
@@ -2105,14 +2105,14 @@ describe('admin-form.service', () => {
     beforeEach(() => {
       mockEmailForm = {
         _id: mockEmailFormId,
-        status: Status.Public,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Email,
         ...mockFormLogicOld,
       } as unknown as IPopulatedForm
       mockEncryptForm = {
         _id: mockEncryptFormId,
-        status: Status.Public,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Encrypt,
         ...mockFormLogicOld,
       } as unknown as IPopulatedForm
       mockEmailFormUpdated = {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -26,11 +26,11 @@ import {
   AuthType,
   BasicField,
   Colors,
+  CustomFormLogo,
   EndPage,
   FormLogicSchema,
   FormLogoState,
   FormSettings,
-  ICustomFormLogo,
   IEmailFormSchema,
   IFormDocument,
   IFormSchema,
@@ -417,7 +417,7 @@ describe('admin-form.service', () => {
           fileId: 'some file_id',
           fileName: 'some file name',
           fileSizeInBytes: 10000,
-        } as ICustomFormLogo,
+        } as CustomFormLogo,
       },
     } as unknown as IFormDocument
     const MOCK_EMAIL_OVERRIDE_PARAMS: DuplicateFormBodyDto = {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -5,10 +5,10 @@ import { EditFieldActions } from 'src/shared/constants'
 import {
   BasicField,
   FormFieldSchema,
+  FormPermission,
   IEmailFieldSchema,
   IPopulatedForm,
   IPopulatedUser,
-  Permission,
   ResponseMode,
   Status,
 } from 'src/types'
@@ -89,7 +89,7 @@ describe('admin-form.utils', () => {
         admin: {
           _id: new ObjectId(),
         } as IPopulatedUser,
-        permissionList: [] as Permission[],
+        permissionList: [] as FormPermission[],
       } as IPopulatedForm
 
       // Act
@@ -187,7 +187,7 @@ describe('admin-form.utils', () => {
         admin: {
           _id: new ObjectId(),
         } as IPopulatedUser,
-        permissionList: [] as Permission[],
+        permissionList: [] as FormPermission[],
       } as IPopulatedForm
 
       // Act

--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -6,11 +6,11 @@ import {
   BasicField,
   FormFieldSchema,
   FormPermission,
+  FormResponseMode,
+  FormStatus,
   IEmailFieldSchema,
   IPopulatedForm,
   IPopulatedUser,
-  ResponseMode,
-  Status,
 } from 'src/types'
 import { DuplicateFormBodyDto, EditFormFieldParams } from 'src/types/api'
 
@@ -40,7 +40,7 @@ describe('admin-form.utils', () => {
       // Arrange
       const mockForm = {
         title: 'mockForm',
-        status: Status.Private,
+        status: FormStatus.Private,
         _id: new ObjectId(),
         // User is form admin.
         admin: MOCK_USER,
@@ -59,7 +59,7 @@ describe('admin-form.utils', () => {
       // Form is owned by another admin, but MOCK_USER has permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin.
         admin: {
@@ -83,7 +83,7 @@ describe('admin-form.utils', () => {
       // permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin, no permissionsList.
         admin: {
@@ -110,7 +110,7 @@ describe('admin-form.utils', () => {
       // Arrange
       const mockForm = {
         title: 'mockForm',
-        status: Status.Private,
+        status: FormStatus.Private,
         _id: new ObjectId(),
         // User is form admin.
         admin: MOCK_USER,
@@ -129,7 +129,7 @@ describe('admin-form.utils', () => {
       // Form is owned by another admin, but MOCK_USER has permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin.
         admin: {
@@ -153,7 +153,7 @@ describe('admin-form.utils', () => {
       // permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin, no permissionsList.
         admin: {
@@ -181,7 +181,7 @@ describe('admin-form.utils', () => {
       // permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin, no permissionsList.
         admin: {
@@ -208,7 +208,7 @@ describe('admin-form.utils', () => {
       // Arrange
       const mockForm = {
         title: 'mockForm',
-        status: Status.Private,
+        status: FormStatus.Private,
         _id: new ObjectId(),
         // User is form admin.
         admin: MOCK_USER,
@@ -227,7 +227,7 @@ describe('admin-form.utils', () => {
       // Form is owned by another admin, but MOCK_USER has permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin.
         admin: {
@@ -254,7 +254,7 @@ describe('admin-form.utils', () => {
       // Form is owned by another admin, but MOCK_USER has permissions.
       const mockForm = {
         title: 'mockForm',
-        status: Status.Public,
+        status: FormStatus.Public,
         _id: new ObjectId(),
         // New admin.
         admin: {
@@ -282,7 +282,7 @@ describe('admin-form.utils', () => {
       // Arrange
       const newAdminId = new ObjectId().toHexString()
       const params: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'some title',
       }
@@ -304,7 +304,7 @@ describe('admin-form.utils', () => {
       // Arrange
       const newAdminId = new ObjectId().toHexString()
       const params: DuplicateFormBodyDto = {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: ['some@example.com', 'another@example.com'],
         title: 'some title',
       }

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -11,11 +11,12 @@ import {
 } from '../../../../../shared/constants/file'
 import { DeserializeTransform } from '../../../../../shared/types/utils'
 import {
-  AuthType,
   BasicField,
-  Colors,
+  FormAuthType,
+  FormColorTheme,
   FormFieldWithId,
   FormLogoState,
+  FormResponseMode,
   FormSettings,
   IForm,
   IFormDocument,
@@ -25,7 +26,6 @@ import {
   LogicIfValue,
   LogicType,
   PublicFormDto,
-  ResponseMode,
 } from '../../../../types'
 import {
   AdminDashboardFormMetaDto,
@@ -106,14 +106,14 @@ const createFormValidator = celebrate({
       .keys({
         // Require valid responsesMode field.
         responseMode: Joi.string()
-          .valid(...Object.values(ResponseMode))
+          .valid(...Object.values(FormResponseMode))
           .required(),
         // Require title field.
         title: Joi.string().min(4).max(200).required(),
         // Require emails string (for backwards compatibility) or string
         // array if form to be created in Email mode.
         emails: Joi.when('responseMode', {
-          is: ResponseMode.Email,
+          is: FormResponseMode.Email,
           then: Joi.alternatives()
             .try(Joi.array().items(Joi.string()).min(1), Joi.string())
             .required(),
@@ -129,7 +129,7 @@ const createFormValidator = celebrate({
         publicKey: Joi.string()
           .allow('')
           .when('responseMode', {
-            is: ResponseMode.Encrypt,
+            is: FormResponseMode.Encrypt,
             then: Joi.string().required().disallow(''),
           }),
       })
@@ -143,14 +143,14 @@ const duplicateFormValidator = celebrate({
   [Segments.BODY]: BaseJoi.object<DuplicateFormBodyDto>({
     // Require valid responsesMode field.
     responseMode: Joi.string()
-      .valid(...Object.values(ResponseMode))
+      .valid(...Object.values(FormResponseMode))
       .required(),
     // Require title field.
     title: Joi.string().min(4).max(200).required(),
     // Require emails string (for backwards compatibility) or string array
     // if form to be duplicated in Email mode.
     emails: Joi.when('responseMode', {
-      is: ResponseMode.Email,
+      is: FormResponseMode.Email,
       then: Joi.alternatives()
         .try(Joi.array().items(Joi.string()).min(1), Joi.string())
         .required(),
@@ -163,7 +163,7 @@ const duplicateFormValidator = celebrate({
     publicKey: Joi.string()
       .allow('')
       .when('responseMode', {
-        is: ResponseMode.Encrypt,
+        is: FormResponseMode.Encrypt,
         then: Joi.string().required().disallow(''),
       }),
   }),
@@ -1558,12 +1558,12 @@ export const submitEmailPreview: ControllerHandler<
 
   // Handle SingPass, CorpPass and MyInfo authentication and validation
   const { authType } = form
-  if (authType === AuthType.SP || authType === AuthType.MyInfo) {
+  if (authType === FormAuthType.SP || authType === FormAuthType.MyInfo) {
     parsedResponses.addNdiResponses({
       authType,
       uinFin: PREVIEW_SINGPASS_UINFIN,
     })
-  } else if (authType === AuthType.CP) {
+  } else if (authType === FormAuthType.CP) {
     parsedResponses.addNdiResponses({
       authType,
       uinFin: PREVIEW_CORPPASS_UINFIN,
@@ -2440,7 +2440,7 @@ export const handleUpdateStartPage = [
       paragraph: Joi.string().allow('').optional(),
       estTimeTaken: Joi.number().min(1).max(1000).required(),
       colorTheme: Joi.string()
-        .valid(...Object.values(Colors))
+        .valid(...Object.values(FormColorTheme))
         .required(),
       logo: Joi.object({
         state: Joi.string().valid(...Object.values(FormLogoState)),

--- a/src/app/modules/form/admin-form/admin-form.routes.ts
+++ b/src/app/modules/form/admin-form/admin-form.routes.ts
@@ -6,7 +6,7 @@ import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
 import { Router } from 'express'
 
-import { ResponseMode } from '../../../../types'
+import { FormResponseMode } from '../../../../types'
 import { DuplicateFormBodyDto } from '../../../../types/api'
 import { withUserAuthentication } from '../../auth/auth.middlewares'
 import * as EncryptSubmissionController from '../../submission/encrypt-submission/encrypt-submission.controller'
@@ -22,14 +22,14 @@ const duplicateFormValidator = celebrate({
   [Segments.BODY]: Joi.object<DuplicateFormBodyDto>({
     // Require valid responsesMode field.
     responseMode: Joi.string()
-      .valid(...Object.values(ResponseMode))
+      .valid(...Object.values(FormResponseMode))
       .required(),
     // Require title field.
     title: Joi.string().min(4).max(200).required(),
     // Require emails string (for backwards compatibility) or string array
     // if form to be duplicated in Email mode.
     emails: Joi.when('responseMode', {
-      is: ResponseMode.Email,
+      is: FormResponseMode.Email,
       then: Joi.alternatives()
         .try(Joi.array().items(Joi.string()).min(1), Joi.string())
         .required(),
@@ -42,7 +42,7 @@ const duplicateFormValidator = celebrate({
     publicKey: Joi.string()
       .allow('')
       .when('responseMode', {
-        is: ResponseMode.Encrypt,
+        is: FormResponseMode.Encrypt,
         then: Joi.string().required().disallow(''),
       }),
   }),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -13,6 +13,7 @@ import {
   FormFieldSchema,
   FormLogicSchema,
   FormLogoState,
+  FormPermission,
   FormSettings,
   IForm,
   IFormDocument,
@@ -20,7 +21,6 @@ import {
   IPopulatedForm,
   IUserSchema,
   LogicDto,
-  Permission,
 } from '../../../../types'
 import {
   AdminDashboardFormMetaDto,
@@ -704,8 +704,8 @@ export const updateForm = (
  */
 export const updateFormCollaborators = (
   form: IPopulatedForm,
-  updatedCollaborators: Permission[],
-): ResultAsync<Permission[], PossibleDatabaseError> => {
+  updatedCollaborators: FormPermission[],
+): ResultAsync<FormPermission[], PossibleDatabaseError> => {
   return ResultAsync.fromPromise(
     form.updateFormCollaborators(updatedCollaborators),
     (error) => {

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -2,10 +2,10 @@ import { Result } from 'neverthrow'
 
 import {
   FormFieldSchema,
+  FormResponseMode,
   IForm,
   IPopulatedForm,
   IUserSchema,
-  ResponseMode,
 } from '../../../../types'
 import { ForbiddenFormError } from '../form.errors'
 
@@ -27,7 +27,7 @@ export type OverrideProps = {
   startPage?: IForm['startPage']
   admin: string
   title: string
-  responseMode: ResponseMode
+  responseMode: FormResponseMode
   emails?: string | string[]
   publicKey?: string
 }

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -8,9 +8,9 @@ import {
 import { EditFieldActions } from '../../../../shared/constants'
 import {
   FormFieldSchema,
+  FormResponseMode,
+  FormStatus,
   IPopulatedForm,
-  ResponseMode,
-  Status,
 } from '../../../../types'
 import {
   DuplicateFormBodyDto,
@@ -148,7 +148,7 @@ export const mapRouteError = (
 export const assertFormAvailable = (
   form: IPopulatedForm,
 ): Result<true, FormDeletedError> => {
-  return form.status === Status.Archived
+  return form.status === FormStatus.Archived
     ? err(new FormDeletedError('Form has been archived'))
     : ok(true)
 }
@@ -252,10 +252,10 @@ export const processDuplicateOverrideProps = (
   }
 
   switch (params.responseMode) {
-    case ResponseMode.Encrypt:
+    case FormResponseMode.Encrypt:
       overrideProps.publicKey = params.publicKey
       break
-    case ResponseMode.Email:
+    case FormResponseMode.Email:
       overrideProps.emails = params.emails
       break
   }

--- a/src/app/modules/form/form.errors.ts
+++ b/src/app/modules/form/form.errors.ts
@@ -1,4 +1,4 @@
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import { ApplicationError } from '../core/core.errors'
 
@@ -67,7 +67,7 @@ export class LogicNotFoundError extends ApplicationError {
  * Error to be returned when the form's auth type does not match what is required
  */
 export class AuthTypeMismatchError extends ApplicationError {
-  constructor(attemptedAuthType: AuthType, formAuthType?: AuthType) {
+  constructor(attemptedAuthType: FormAuthType, formAuthType?: FormAuthType) {
     super(
       `Attempted authentication type ${attemptedAuthType} did not match form auth type ${formAuthType}`,
     )

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -2,13 +2,13 @@ import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import {
-  AuthType,
+  FormAuthType,
+  FormResponseMode,
+  FormStatus,
   IEmailFormModel,
   IEncryptedFormModel,
   IFormSchema,
   IPopulatedForm,
-  ResponseMode,
-  Status,
 } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getFormModel, {
@@ -196,11 +196,11 @@ export const isFormPublic = (
     return err(new ApplicationError())
   }
   switch (form.status) {
-    case Status.Public:
+    case FormStatus.Public:
       return ok(true)
-    case Status.Archived:
+    case FormStatus.Archived:
       return err(new FormDeletedError())
-    case Status.Private:
+    case FormStatus.Private:
       return err(new PrivateFormError(form.inactiveMessage, form.title))
   }
 }
@@ -264,12 +264,12 @@ export const checkFormSubmissionLimitAndDeactivateForm = (
 }
 
 export const getFormModelByResponseMode = (
-  responseMode: ResponseMode,
+  responseMode: FormResponseMode,
 ): IEmailFormModel | IEncryptedFormModel => {
   switch (responseMode) {
-    case ResponseMode.Email:
+    case FormResponseMode.Email:
       return EmailFormModel
-    case ResponseMode.Encrypt:
+    case FormResponseMode.Encrypt:
       return EncryptedFormModel
   }
 }
@@ -290,7 +290,9 @@ export const checkIsIntranetFormAccess = (
   // and the form has authentication set
   if (
     isIntranetUser &&
-    [AuthType.SP, AuthType.CP, AuthType.MyInfo].includes(form.authType)
+    [FormAuthType.SP, FormAuthType.CP, FormAuthType.MyInfo].includes(
+      form.authType,
+    )
   ) {
     logger.warn({
       message:

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,11 +1,11 @@
 import {
   FormFieldSchema,
   FormLogicSchema,
+  FormPermission,
   IEncryptedFormSchema,
   IFormSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
-  Permission,
   ResponseMode,
 } from '../../../types'
 import { isMongooseDocumentArray } from '../../utils/mongoose'
@@ -53,7 +53,7 @@ export const isFormEncryptMode = (
  * @returns Array of emails
  */
 export const getCollabEmailsWithPermission = (
-  permissionList?: Permission[],
+  permissionList?: FormPermission[],
   writePermission?: boolean,
 ): string[] => {
   if (!permissionList) {

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -2,11 +2,11 @@ import {
   FormFieldSchema,
   FormLogicSchema,
   FormPermission,
+  FormResponseMode,
   IEncryptedFormSchema,
   IFormSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
-  ResponseMode,
 } from '../../../types'
 import { isMongooseDocumentArray } from '../../utils/mongoose'
 
@@ -42,7 +42,7 @@ export const transformEmails = (v: string | string[]): string[] => {
 export const isFormEncryptMode = (
   form: IFormSchema | IPopulatedForm,
 ): form is IEncryptedFormSchema => {
-  return form.responseMode === ResponseMode.Encrypt
+  return form.responseMode === FormResponseMode.Encrypt
 }
 
 /**
@@ -77,7 +77,7 @@ export const getCollabEmailsWithPermission = (
 export const isEmailModeForm = (
   form: IPopulatedForm,
 ): form is IPopulatedEmailForm => {
-  return form.responseMode === ResponseMode.Email
+  return form.responseMode === FormResponseMode.Email
 }
 
 /**

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -20,7 +20,7 @@ import {
 } from 'src/app/modules/myinfo/myinfo.types'
 import { JwtPayload, SpcpForm } from 'src/app/modules/spcp/spcp.types'
 import {
-  AuthType,
+  FormAuthType,
   IFormSchema,
   IPopulatedForm,
   IPopulatedUser,
@@ -493,7 +493,7 @@ describe('public-form.controller', () => {
         // Arrange
         const MOCK_NIL_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
         } as unknown as IPopulatedForm
         const mockRes = expressHandler.mockResponse()
 
@@ -528,7 +528,7 @@ describe('public-form.controller', () => {
         }
         const MOCK_SP_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         } as unknown as IPopulatedForm
         const mockRes = expressHandler.mockResponse()
 
@@ -567,7 +567,7 @@ describe('public-form.controller', () => {
         }
         const MOCK_CP_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
         } as unknown as IPopulatedForm
         const mockRes = expressHandler.mockResponse()
 
@@ -600,7 +600,7 @@ describe('public-form.controller', () => {
         const MOCK_MYINFO_AUTH_FORM = {
           ...BASE_FORM,
           esrvcId: 'thing',
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           toJSON: jest.fn().mockReturnValue(BASE_FORM),
         } as unknown as IPopulatedForm
         const MOCK_MYINFO_DATA = new MyInfoData({
@@ -647,7 +647,7 @@ describe('public-form.controller', () => {
       const MOCK_MYINFO_FORM = {
         ...BASE_FORM,
         toJSON: jest.fn().mockReturnThis(),
-        authType: AuthType.MyInfo,
+        authType: FormAuthType.MyInfo,
       } as unknown as IPopulatedForm
 
       // Setup because this gets invoked at the start of the controller to decide which branch to take
@@ -862,7 +862,7 @@ describe('public-form.controller', () => {
     describe('errors in spcp', () => {
       const MOCK_SPCP_FORM = {
         ...BASE_FORM,
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
       } as unknown as IPopulatedForm
       it('should return 200 with the form but without a spcpSession when the JWT token could not be found', async () => {
         // Arrange
@@ -1013,7 +1013,7 @@ describe('public-form.controller', () => {
         // Arrange
         const MOCK_NIL_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
         } as unknown as IPopulatedForm
         const mockRes = expressHandler.mockResponse()
 
@@ -1043,7 +1043,7 @@ describe('public-form.controller', () => {
         // Arrange
         const MOCK_SP_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         } as unknown as IPopulatedForm
 
         const mockRes = expressHandler.mockResponse()
@@ -1078,7 +1078,7 @@ describe('public-form.controller', () => {
         // Arrange
         const MOCK_CP_AUTH_FORM = {
           ...BASE_FORM,
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
         } as unknown as IPopulatedForm
 
         const mockRes = expressHandler.mockResponse()
@@ -1114,7 +1114,7 @@ describe('public-form.controller', () => {
         const MOCK_MYINFO_AUTH_FORM = {
           ...BASE_FORM,
           esrvcId: 'thing',
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           toJSON: jest.fn().mockReturnValue(BASE_FORM),
         } as unknown as IPopulatedForm
         const mockRes = expressHandler.mockResponse({
@@ -1173,7 +1173,7 @@ describe('public-form.controller', () => {
     it('should return 200 with the redirect url when the request is valid and the form has authType SP', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1204,7 +1204,7 @@ describe('public-form.controller', () => {
         },
       })
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1238,7 +1238,7 @@ describe('public-form.controller', () => {
         },
       })
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1264,7 +1264,7 @@ describe('public-form.controller', () => {
     it('should return 200 with the redirect url when the request is valid and the form has authType CP', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.CP,
+        authType: FormAuthType.CP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
 
@@ -1291,7 +1291,7 @@ describe('public-form.controller', () => {
     it('should return 200 with the redirect url when the request is valid and the form has authType MyInfo', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.MyInfo,
+        authType: FormAuthType.MyInfo,
         esrvcId: '12345',
         getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
       } as unknown as MyInfoForm<IFormSchema>
@@ -1319,7 +1319,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType NIL', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.NIL,
+        authType: FormAuthType.NIL,
         esrvcId: '12345',
       }
 
@@ -1346,7 +1346,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType MyInfo and is missing esrvcId', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.MyInfo,
+        authType: FormAuthType.MyInfo,
       } as unknown as MyInfoForm<IFormSchema>
 
       const mockRes = expressHandler.mockResponse()
@@ -1372,7 +1372,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType SP and is missing esrvcId', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
       } as unknown as SpcpForm<IFormSchema>
 
       const mockRes = expressHandler.mockResponse()
@@ -1398,7 +1398,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType CP and is missing esrvcId', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.CP,
+        authType: FormAuthType.CP,
       } as unknown as SpcpForm<IFormSchema>
 
       const mockRes = expressHandler.mockResponse()
@@ -1447,7 +1447,7 @@ describe('public-form.controller', () => {
       // Arrange
       const MOCK_FORM = {
         esrvcId: '234',
-        authType: AuthType.CP,
+        authType: FormAuthType.CP,
       } as unknown as SpcpForm<IFormSchema>
 
       const mockRes = expressHandler.mockResponse()
@@ -1475,7 +1475,7 @@ describe('public-form.controller', () => {
 
   describe('handlePublicAuthLogout', () => {
     it('should return 200 if authType is SP and call clearCookie()', async () => {
-      const authType = AuthType.SP
+      const authType = FormAuthType.SP
       MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
         JwtName[authType],
       )
@@ -1502,7 +1502,7 @@ describe('public-form.controller', () => {
     })
 
     it('should return 200 if authType is CP and call clearCookie()', async () => {
-      const authType = AuthType.CP
+      const authType = FormAuthType.CP
       MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
         JwtName[authType],
       )
@@ -1529,7 +1529,7 @@ describe('public-form.controller', () => {
     })
 
     it('should return 200 if authType is MyInfo and call clearCookie()', async () => {
-      const authType = AuthType.MyInfo
+      const authType = FormAuthType.MyInfo
       MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
         MYINFO_COOKIE_NAME,
       )
@@ -1556,7 +1556,7 @@ describe('public-form.controller', () => {
     })
 
     it('should return 200 if authType is SGID and call clearCookie()', async () => {
-      const authType = AuthType.SGID
+      const authType = FormAuthType.SGID
       MockPublicFormService.getCookieNameByAuthType.mockReturnValueOnce(
         SGID_COOKIE_NAME,
       )
@@ -1594,7 +1594,7 @@ describe('public-form.controller', () => {
     it('should return 200 with isValid set to true when a valid MyInfo form authenticates successfully', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.MyInfo,
+        authType: FormAuthType.MyInfo,
         esrvcId: '12345',
       } as MyInfoForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1623,7 +1623,7 @@ describe('public-form.controller', () => {
     it('should return 200 with isValid set to true when a valid SP form authenticates successfully', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1651,7 +1651,7 @@ describe('public-form.controller', () => {
     it('should return 200 with isValid set to false when an invalid MyInfo form authenticates successfully', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.MyInfo,
+        authType: FormAuthType.MyInfo,
         esrvcId: '12345',
       } as MyInfoForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1680,7 +1680,7 @@ describe('public-form.controller', () => {
     it('should return 200 with isValid set to false when an invalid SP form authenticates successfully', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1709,7 +1709,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType.NIL', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.NIL,
+        authType: FormAuthType.NIL,
         esrvcId: '12345',
       } as IFormSchema
       const mockRes = expressHandler.mockResponse()
@@ -1734,7 +1734,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form has authType.CP', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.CP,
+        authType: FormAuthType.CP,
         esrvcId: '12345',
       } as IFormSchema
       const mockRes = expressHandler.mockResponse()
@@ -1759,7 +1759,7 @@ describe('public-form.controller', () => {
     it('should return 400 when the form does not have an eServiceId', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
       const expectedError = {
@@ -1806,7 +1806,7 @@ describe('public-form.controller', () => {
     it('should return 500 when the returned html has no title', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1859,7 +1859,7 @@ describe('public-form.controller', () => {
     it('should return 500 when the redirect url could not be generated', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()
@@ -1886,7 +1886,7 @@ describe('public-form.controller', () => {
     it('should return 503 when the login page for the form could not be retrieved', async () => {
       // Arrange
       const MOCK_FORM = {
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: '12345',
       } as SpcpForm<IFormSchema>
       const mockRes = expressHandler.mockResponse()

--- a/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.routes.spec.ts
@@ -7,7 +7,7 @@ import { mocked } from 'ts-jest/utils'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
 import { MYINFO_COOKIE_NAME } from 'src/app/modules/myinfo/myinfo.constants'
 import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
-import { AuthType, Status } from 'src/types'
+import { FormAuthType, FormStatus } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -59,7 +59,7 @@ describe('public-form.routes', () => {
     it('should return 200 with public form when form has AuthType.NIL and valid formId', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Public },
+        formOptions: { status: FormStatus.Public },
       })
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(form._id)
@@ -91,9 +91,9 @@ describe('public-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const formId = form._id
@@ -134,9 +134,9 @@ describe('public-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const formId = form._id
@@ -169,9 +169,9 @@ describe('public-form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       // NOTE: This is needed to inject admin info into the form
@@ -232,7 +232,7 @@ describe('public-form.routes', () => {
     it('should return 404 if the form is private', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Private },
+        formOptions: { status: FormStatus.Private },
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
@@ -253,7 +253,7 @@ describe('public-form.routes', () => {
     it('should return 410 if the form has been archived', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Archived },
+        formOptions: { status: FormStatus.Archived },
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
@@ -272,7 +272,7 @@ describe('public-form.routes', () => {
     it('should return 500 if a database error occurs', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Public },
+        formOptions: { status: FormStatus.Public },
       })
       const expectedError = new DatabaseError('all your base are belong to us')
       const expectedResponseBody = JSON.parse(

--- a/src/app/modules/form/public-form/__tests__/public-form.service.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.service.spec.ts
@@ -6,7 +6,7 @@ import { PartialDeep } from 'type-fest'
 import getFormModel from 'src/app/models/form.server.model'
 import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
-import { AuthType, IFormSchema } from 'src/types'
+import { FormAuthType, IFormSchema } from 'src/types'
 
 import { MYINFO_COOKIE_NAME } from '../../../myinfo/myinfo.constants'
 import { SGID_COOKIE_NAME } from '../../../sgid/sgid.constants'
@@ -24,29 +24,29 @@ describe('public-form.service', () => {
   describe('getCookieNameByAuthType', () => {
     it('should return JwtName[AuthType.SP] when authType is SP', () => {
       // Arrange
-      const authType = AuthType.SP
+      const authType = FormAuthType.SP
 
       // Act
       const result = PublicFormService.getCookieNameByAuthType(authType)
 
       // Assert
-      expect(result).toEqual(JwtName[AuthType.SP])
+      expect(result).toEqual(JwtName[FormAuthType.SP])
     })
 
     it('should return JwtName[AuthType.CP] when authType is CP', () => {
       // Arrange
-      const authType = AuthType.CP
+      const authType = FormAuthType.CP
 
       // Act
       const result = PublicFormService.getCookieNameByAuthType(authType)
 
       // Assert
-      expect(result).toEqual(JwtName[AuthType.CP])
+      expect(result).toEqual(JwtName[FormAuthType.CP])
     })
 
     it('should return MYINFO_COOKIE_NAME when authType is MyInfo', () => {
       // Arrange
-      const authType = AuthType.MyInfo
+      const authType = FormAuthType.MyInfo
 
       // Act
       const result = PublicFormService.getCookieNameByAuthType(authType)
@@ -57,7 +57,7 @@ describe('public-form.service', () => {
 
     it('should return SGID_COOKIE_NAME when authType is SGID', () => {
       // Arrange
-      const authType = AuthType.SGID
+      const authType = FormAuthType.SGID
 
       // Act
       const result = PublicFormService.getCookieNameByAuthType(authType)

--- a/src/app/modules/form/public-form/public-form.service.ts
+++ b/src/app/modules/form/public-form/public-form.service.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
-import { AuthType, IFormFeedbackSchema } from '../../../../types'
+import { FormAuthType, IFormFeedbackSchema } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import getFormModel from '../../../models/form.server.model'
 import getFormFeedbackModel from '../../../models/form_feedback.server.model'
@@ -64,12 +64,16 @@ export const insertFormFeedback = ({
  * Valid AuthTypes are SP / CP / MyInfo / SGID
  */
 export const getCookieNameByAuthType = (
-  authType: AuthType.SP | AuthType.CP | AuthType.MyInfo | AuthType.SGID,
+  authType:
+    | FormAuthType.SP
+    | FormAuthType.CP
+    | FormAuthType.MyInfo
+    | FormAuthType.SGID,
 ): string => {
   switch (authType) {
-    case AuthType.MyInfo:
+    case FormAuthType.MyInfo:
       return MYINFO_COOKIE_NAME
-    case AuthType.SGID:
+    case FormAuthType.SGID:
       return SGID_COOKIE_NAME
     default:
       return JwtName[authType]

--- a/src/app/modules/myinfo/__tests__/myinfo.controller.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.controller.spec.ts
@@ -2,7 +2,12 @@ import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
-import { AuthType, IFormSchema, ILoginSchema, IPopulatedForm } from 'src/types'
+import {
+  FormAuthType,
+  IFormSchema,
+  ILoginSchema,
+  IPopulatedForm,
+} from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -162,7 +167,7 @@ describe('MyInfoController', () => {
       await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_MYINFO_FORM._id,
         MOCK_MYINFO_FORM.esrvcId,
       )
@@ -192,7 +197,7 @@ describe('MyInfoController', () => {
       await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_MYINFO_FORM._id,
         MOCK_MYINFO_FORM.esrvcId,
       )
@@ -220,7 +225,7 @@ describe('MyInfoController', () => {
       await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_MYINFO_FORM._id,
         MOCK_MYINFO_FORM.esrvcId,
       )
@@ -250,7 +255,7 @@ describe('MyInfoController', () => {
       await MyInfoController.checkMyInfoEServiceId(mockReq, mockRes, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_MYINFO_FORM._id,
         MOCK_MYINFO_FORM.esrvcId,
       )
@@ -343,7 +348,7 @@ describe('MyInfoController', () => {
         okAsync({
           ...MOCK_MYINFO_FORM,
           // Modify authType to SingPass
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         } as IPopulatedForm),
       )
 

--- a/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.routes.spec.ts
@@ -6,7 +6,7 @@ import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 import { v4 as uuidv4 } from 'uuid'
 
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
@@ -73,7 +73,7 @@ describe('myinfo.routes', () => {
       await dbHandler.insertEmailForm({
         formId: new ObjectId(MOCK_FORM_ID),
         formOptions: {
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           esrvcId: MOCK_ESRVC_ID,
         },
       })
@@ -131,7 +131,7 @@ describe('myinfo.routes', () => {
       await dbHandler.insertEmailForm({
         formId: new ObjectId(MOCK_FORM_ID),
         formOptions: {
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           esrvcId: MOCK_ESRVC_ID,
         },
       })
@@ -221,7 +221,7 @@ describe('myinfo.routes', () => {
       await dbHandler.insertEmailForm({
         formId: new ObjectId(MOCK_FORM_ID),
         formOptions: {
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           esrvcId: MOCK_ESRVC_ID,
         },
       })
@@ -302,7 +302,7 @@ describe('myinfo.routes', () => {
         // inserted in the beforeEach block
         mailDomain: 'test2.gov.sg',
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: MOCK_ESRVC_ID,
         },
       })

--- a/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.service.spec.ts
@@ -13,8 +13,8 @@ import {
   IHashes,
   IMyInfoHashSchema,
   IPopulatedForm,
-  IPossiblyPrefilledField,
   MyInfoAttribute,
+  PossiblyPrefilledField,
 } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -221,7 +221,7 @@ describe('MyInfoServiceClass', () => {
       const result = await myInfoService.saveMyInfoHashes(
         MOCK_UINFIN,
         MOCK_FORM_ID,
-        MOCK_POPULATED_FORM_FIELDS as IPossiblyPrefilledField[],
+        MOCK_POPULATED_FORM_FIELDS as PossiblyPrefilledField[],
       )
 
       expect(mockUpdateHashes).toHaveBeenCalledWith(
@@ -239,7 +239,7 @@ describe('MyInfoServiceClass', () => {
       const result = await myInfoService.saveMyInfoHashes(
         MOCK_UINFIN,
         MOCK_FORM_ID,
-        MOCK_POPULATED_FORM_FIELDS as IPossiblyPrefilledField[],
+        MOCK_POPULATED_FORM_FIELDS as PossiblyPrefilledField[],
       )
 
       expect(result._unsafeUnwrapErr()).toEqual(
@@ -253,7 +253,7 @@ describe('MyInfoServiceClass', () => {
       const result = await myInfoService.saveMyInfoHashes(
         MOCK_UINFIN,
         MOCK_FORM_ID,
-        MOCK_POPULATED_FORM_FIELDS as IPossiblyPrefilledField[],
+        MOCK_POPULATED_FORM_FIELDS as PossiblyPrefilledField[],
       )
       expect(result._unsafeUnwrapErr()).toEqual(
         new DatabaseError('Failed to save MyInfo hashes to database'),

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -8,7 +8,12 @@ import { ObjectId } from 'bson'
 import { merge, omit, zipWith } from 'lodash'
 
 import { ISpcpMyInfo } from 'src/app/config/feature-manager'
-import { AuthType, Environment, IFormSchema, MyInfoAttribute } from 'src/types'
+import {
+  Environment,
+  FormAuthType,
+  IFormSchema,
+  MyInfoAttribute,
+} from 'src/types'
 
 import {
   IMyInfoServiceConfig,
@@ -148,7 +153,7 @@ export const MOCK_SERVICE_PARAMS: IMyInfoServiceConfig = {
 export const MOCK_MYINFO_FORM = {
   _id: MOCK_FORM_ID,
   esrvcId: MOCK_ESRVC_ID,
-  authType: AuthType.MyInfo,
+  authType: FormAuthType.MyInfo,
   admin: {
     _id: new ObjectId().toHexString(),
     agency: new ObjectId().toHexString(),

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -1,7 +1,7 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import { PublicFormAuthValidateEsrvcIdDto } from '../../../types/api'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
@@ -106,7 +106,7 @@ export const checkMyInfoEServiceId: ControllerHandler<
   return FormService.retrieveFormById(formId)
     .andThen((form) => validateMyInfoForm(form))
     .andThen((form) =>
-      SpcpService.createRedirectUrl(AuthType.SP, formId, form.esrvcId),
+      SpcpService.createRedirectUrl(FormAuthType.SP, formId, form.esrvcId),
     )
     .andThen(SpcpService.fetchLoginPage)
     .andThen(SpcpService.validateLoginPage)
@@ -214,7 +214,7 @@ export const loginToMyInfo: ControllerHandler<
   }
 
   // Ensure form is a MyInfo form
-  if (form.authType !== AuthType.MyInfo) {
+  if (form.authType !== FormAuthType.MyInfo) {
     logger.error({
       message: "Log in attempt to wrong endpoint for form's authType",
       meta: logMeta,

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -16,8 +16,8 @@ import {
   IHashes,
   IMyInfoHashSchema,
   IPopulatedForm,
-  IPossiblyPrefilledField,
   MyInfoAttribute,
+  PossiblyPrefilledField,
 } from '../../../types'
 import config from '../../config/config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
@@ -300,17 +300,14 @@ export class MyInfoServiceClass {
     formId: string,
     myInfoData: MyInfoData,
     currFormFields: LeanDocument<IFieldSchema[]>,
-  ): ResultAsync<
-    IPossiblyPrefilledField[],
-    MyInfoHashingError | DatabaseError
-  > {
+  ): ResultAsync<PossiblyPrefilledField[], MyInfoHashingError | DatabaseError> {
     const prefilledFields = currFormFields.map((field) => {
       if (!field.myInfo?.attr) return field
 
       const myInfoAttr = field.myInfo.attr
       const { fieldValue, isReadOnly } =
         myInfoData.getFieldValueForAttr(myInfoAttr)
-      const prefilledField = cloneDeep(field) as IPossiblyPrefilledField
+      const prefilledField = cloneDeep(field) as PossiblyPrefilledField
       prefilledField.fieldValue = fieldValue
 
       // Disable field
@@ -335,7 +332,7 @@ export class MyInfoServiceClass {
   saveMyInfoHashes(
     uinFin: string,
     formId: string,
-    prefilledFormFields: IPossiblyPrefilledField[],
+    prefilledFormFields: PossiblyPrefilledField[],
   ): ResultAsync<IMyInfoHashSchema | null, MyInfoHashingError | DatabaseError> {
     const readOnlyHashPromises = hashFieldValues(prefilledFormFields)
     return ResultAsync.fromPromise(

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -1,6 +1,6 @@
 import {
-  AuthType,
   Environment,
+  FormAuthType,
   IFormSchema,
   IMyInfo,
   MyInfoAttribute,
@@ -63,6 +63,6 @@ export type MyInfoParsedRelayState = MyInfoRelayState & {
 }
 
 export type MyInfoForm<T extends IFormSchema> = T & {
-  authType: AuthType.MyInfo
+  authType: FormAuthType.MyInfo
   esrvcId: string
 }

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -8,8 +8,8 @@ import { v4 as uuidv4, validate as validateUUID } from 'uuid'
 import { types as myInfoTypes } from '../../../../shared/constants/field/myinfo'
 import { hasProp } from '../../../../shared/utils/has-prop'
 import {
-  AuthType,
   BasicField,
+  FormAuthType,
   IFormSchema,
   IHashes,
   IMyInfo,
@@ -292,14 +292,14 @@ export const validateMyInfoForm = <T extends IFormSchema>(
   if (isMyInfoFormWithEsrvcId(form)) {
     return ok(form)
   }
-  return err(new AuthTypeMismatchError(AuthType.MyInfo, form.authType))
+  return err(new AuthTypeMismatchError(FormAuthType.MyInfo, form.authType))
 }
 
 // Typeguard to ensure that form has eserviceId and MyInfo authType
 const isMyInfoFormWithEsrvcId = <F extends IFormSchema>(
   form: F,
 ): form is MyInfoForm<F> => {
-  return form.authType === AuthType.MyInfo && !!form.esrvcId
+  return form.authType === FormAuthType.MyInfo && !!form.esrvcId
 }
 
 /**

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -13,8 +13,8 @@ import {
   IFormSchema,
   IHashes,
   IMyInfo,
-  IPossiblyPrefilledField,
   MapRouteError,
+  PossiblyPrefilledField,
 } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import { DatabaseError } from '../core/core.errors'
@@ -60,7 +60,7 @@ const HASH_SALT_ROUNDS = 10
  * @returns object mapping MyInfo attributes to Promises of their hashes
  */
 export const hashFieldValues = (
-  prefilledFormFields: IPossiblyPrefilledField[],
+  prefilledFormFields: PossiblyPrefilledField[],
 ): MyInfoHashPromises => {
   const readOnlyHashPromises: MyInfoHashPromises = {}
 

--- a/src/app/modules/sgid/sgid.controller.ts
+++ b/src/app/modules/sgid/sgid.controller.ts
@@ -1,7 +1,7 @@
 import { ParamsDictionary } from 'express-serve-static-core'
 import { StatusCodes } from 'http-status-codes'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
@@ -44,13 +44,13 @@ export const handleLogin: ControllerHandler<
   }
 
   const form = formResult.value
-  if (form.authType !== AuthType.SGID) {
+  if (form.authType !== FormAuthType.SGID) {
     logger.error({
       message: "Log in attempt to wrong endpoint for form's authType",
       meta: {
         ...meta,
         formAuthType: form.authType,
-        endpointAuthType: AuthType.SGID,
+        endpointAuthType: FormAuthType.SGID,
       },
     })
     res.cookie('isLoginError', true)

--- a/src/app/modules/sgid/sgid.types.ts
+++ b/src/app/modules/sgid/sgid.types.ts
@@ -1,5 +1,5 @@
-import { AuthType, IFormSchema } from 'src/types'
+import { FormAuthType, IFormSchema } from 'src/types'
 
 export type SgidForm<T extends IFormSchema> = T & {
-  authType: AuthType.SGID
+  authType: FormAuthType.SGID
 }

--- a/src/app/modules/sgid/sgid.util.ts
+++ b/src/app/modules/sgid/sgid.util.ts
@@ -3,8 +3,8 @@ import { err, ok, Result } from 'neverthrow'
 import { NricResponse } from '../../../../shared/types/response'
 import { hasProp } from '../../../../shared/utils/has-prop'
 import {
-  AuthType,
   BasicField,
+  FormAuthType,
   IFormSchema,
   SgidFieldTitle,
 } from '../../../types'
@@ -22,12 +22,12 @@ export const validateSgidForm = <T extends IFormSchema>(
 ): Result<SgidForm<T>, AuthTypeMismatchError> => {
   return isSgidForm(form)
     ? ok(form)
-    : err(new AuthTypeMismatchError(AuthType.SGID, form.authType))
+    : err(new AuthTypeMismatchError(FormAuthType.SGID, form.authType))
 }
 
 // Typeguard to ensure that form has the correct authType
 const isSgidForm = <F extends IFormSchema>(form: F): form is SgidForm<F> => {
-  return form.authType === AuthType.SGID
+  return form.authType === FormAuthType.SGID
 }
 
 /**

--- a/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.controller.spec.ts
@@ -4,7 +4,7 @@ import { mocked } from 'ts-jest/utils'
 import config from 'src/app/config/config'
 import * as FormService from 'src/app/modules/form/form.service'
 import { MOCK_COOKIE_AGE } from 'src/app/modules/myinfo/__tests__/myinfo.test.constants'
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
@@ -56,14 +56,14 @@ const MOCK_RESPONSE = expressHandler.mockResponse()
 const MOCK_REDIRECT_REQ = expressHandler.mockRequest({
   query: {
     target: MOCK_RELAY_STATE,
-    authType: AuthType.SP as const,
+    authType: FormAuthType.SP as const,
     esrvcId: MOCK_ESRVCID,
   },
 })
 const MOCK_VALIDATE_REQ = expressHandler.mockRequest({
   query: {
     target: MOCK_TARGET,
-    authType: AuthType.SP as const,
+    authType: FormAuthType.SP as const,
     esrvcId: MOCK_ESRVCID,
   },
 })
@@ -86,7 +86,7 @@ describe('spcp.controller', () => {
       SpcpController.handleRedirect(MOCK_REDIRECT_REQ, MOCK_RESPONSE, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
       )
@@ -104,7 +104,7 @@ describe('spcp.controller', () => {
       SpcpController.handleRedirect(MOCK_REDIRECT_REQ, MOCK_RESPONSE, jest.fn())
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_RELAY_STATE,
         MOCK_ESRVCID,
       )
@@ -134,7 +134,7 @@ describe('spcp.controller', () => {
       )
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -168,7 +168,7 @@ describe('spcp.controller', () => {
       )
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -200,7 +200,7 @@ describe('spcp.controller', () => {
       )
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -232,7 +232,7 @@ describe('spcp.controller', () => {
       )
 
       expect(MockSpcpService.createRedirectUrl).toHaveBeenCalledWith(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -251,7 +251,7 @@ describe('spcp.controller', () => {
 
   describe('handleLogin', () => {
     describe('(Singpass)', () => {
-      const loginHandler = SpcpController.handleLogin(AuthType.SP)
+      const loginHandler = SpcpController.handleLogin(FormAuthType.SP)
 
       beforeEach(() => {
         MockSpcpService.parseOOBParams.mockReturnValue(
@@ -282,7 +282,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -290,17 +290,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_DESTINATION,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockBillingService.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -323,7 +323,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MOCK_RESPONSE.sendStatus).toHaveBeenCalledWith(400)
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
@@ -345,7 +345,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -370,7 +370,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -392,7 +392,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -400,7 +400,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_DESTINATION,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -418,7 +418,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -426,12 +426,12 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_DESTINATION,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -446,7 +446,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -454,17 +454,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_DESTINATION,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -480,7 +480,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -488,17 +488,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_SP_SAML,
           MOCK_DESTINATION,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.SP,
+          FormAuthType.SP,
         )
         expect(MockBillingService.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_SP_FORM,
@@ -510,7 +510,7 @@ describe('spcp.controller', () => {
     })
 
     describe('(Corppass)', () => {
-      const loginHandler = SpcpController.handleLogin(AuthType.CP)
+      const loginHandler = SpcpController.handleLogin(FormAuthType.CP)
 
       beforeEach(() => {
         MockSpcpService.parseOOBParams.mockReturnValue(
@@ -541,7 +541,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -549,17 +549,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_DESTINATION,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockBillingService.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,
@@ -582,7 +582,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MOCK_RESPONSE.sendStatus).toHaveBeenCalledWith(400)
         expect(MOCK_RESPONSE.cookie).not.toHaveBeenCalled()
@@ -605,7 +605,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -627,7 +627,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -651,7 +651,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -659,7 +659,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_DESTINATION,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -677,7 +677,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -685,12 +685,12 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_DESTINATION,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -705,7 +705,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -713,17 +713,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_DESTINATION,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MOCK_RESPONSE.cookie).toHaveBeenCalledWith('isLoginError', true)
         expect(MOCK_RESPONSE.redirect).toHaveBeenCalledWith(MOCK_DESTINATION)
@@ -739,7 +739,7 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.parseOOBParams).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_RELAY_STATE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
           MOCK_TARGET,
@@ -747,17 +747,17 @@ describe('spcp.controller', () => {
         expect(MockSpcpService.getSpcpAttributes).toHaveBeenCalledWith(
           MOCK_CP_SAML,
           MOCK_DESTINATION,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWTPayload).toHaveBeenCalledWith(
           MOCK_ATTRIBUTES,
           MOCK_REMEMBER_ME,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockSpcpService.createJWT).toHaveBeenCalledWith(
           MOCK_JWT_PAYLOAD,
           MOCK_COOKIE_AGE,
-          AuthType.CP,
+          FormAuthType.CP,
         )
         expect(MockBillingService.recordLoginByForm).toHaveBeenCalledWith(
           MOCK_CP_FORM,

--- a/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.routes.spec.ts
@@ -6,7 +6,7 @@ import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 
 import getLoginModel from 'src/app/models/login.server.model'
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
@@ -332,7 +332,7 @@ describe('spcp.routes', () => {
       await dbHandler.insertEmailForm({
         formId: new ObjectId(MOCK_TARGET),
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: MOCK_ESRVCID,
         },
       })
@@ -456,7 +456,7 @@ describe('spcp.routes', () => {
       await dbHandler.insertEmailForm({
         formId: new ObjectId(MOCK_TARGET),
         formOptions: {
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           esrvcId: MOCK_ESRVCID,
         },
       })

--- a/src/app/modules/spcp/__tests__/spcp.service.spec.ts
+++ b/src/app/modules/spcp/__tests__/spcp.service.spec.ts
@@ -6,7 +6,7 @@ import { mocked } from 'ts-jest/utils'
 
 import { ISpcpMyInfo } from 'src/app/config/features/spcp-myinfo.config'
 import { MOCK_COOKIE_AGE } from 'src/app/modules/myinfo/__tests__/myinfo.test.constants'
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -96,7 +96,7 @@ describe('spcp.service', () => {
       const mockClient = mocked(MockAuthClient.mock.instances[0], true)
       mockClient.createRedirectURL.mockReturnValueOnce(MOCK_REDIRECT_URL)
       const redirectUrl = spcpServiceClass.createRedirectUrl(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -114,7 +114,7 @@ describe('spcp.service', () => {
       const mockClient = mocked(MockAuthClient.mock.instances[1], true)
       mockClient.createRedirectURL.mockReturnValueOnce(MOCK_REDIRECT_URL)
       const redirectUrl = spcpServiceClass.createRedirectUrl(
-        AuthType.CP,
+        FormAuthType.CP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -132,7 +132,7 @@ describe('spcp.service', () => {
       const mockClient = mocked(MockAuthClient.mock.instances[1], true)
       mockClient.createRedirectURL.mockReturnValueOnce(new Error())
       const redirectUrl = spcpServiceClass.createRedirectUrl(
-        AuthType.CP,
+        FormAuthType.CP,
         MOCK_TARGET,
         MOCK_ESRVCID,
       )
@@ -301,7 +301,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -318,7 +318,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -335,7 +335,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -352,7 +352,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -369,7 +369,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -386,7 +386,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -403,7 +403,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -420,7 +420,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrap()).toEqual({
         formId: MOCK_TARGET,
@@ -436,7 +436,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -449,7 +449,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -462,7 +462,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -475,7 +475,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -488,7 +488,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -501,7 +501,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_CP_SAML,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -514,7 +514,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML_WRONG_TYPECODE,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -527,7 +527,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML_WRONG_TYPECODE,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -540,7 +540,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML_WRONG_HASH,
         mockRelayState,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -553,7 +553,7 @@ describe('spcp.service', () => {
       const parsedResult = spcpServiceClass.parseOOBParams(
         MOCK_SP_SAML_WRONG_HASH,
         mockRelayState,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(parsedResult._unsafeUnwrapErr()).toEqual(
         new InvalidOOBParamsError(),
@@ -573,7 +573,7 @@ describe('spcp.service', () => {
       const result = await spcpServiceClass.getSpcpAttributes(
         MOCK_SP_SAML,
         MOCK_DESTINATION,
-        AuthType.SP,
+        FormAuthType.SP,
       )
 
       expect(mockClient.getAttributes).toHaveBeenCalledWith(
@@ -597,7 +597,7 @@ describe('spcp.service', () => {
       const result = await spcpServiceClass.getSpcpAttributes(
         MOCK_CP_SAML,
         MOCK_DESTINATION,
-        AuthType.CP,
+        FormAuthType.CP,
       )
 
       expect(mockClient.getAttributes).toHaveBeenCalledWith(
@@ -621,7 +621,7 @@ describe('spcp.service', () => {
       const result = await spcpServiceClass.getSpcpAttributes(
         MOCK_SP_SAML,
         MOCK_DESTINATION,
-        AuthType.SP,
+        FormAuthType.SP,
       )
 
       expect(mockClient.getAttributes).toHaveBeenCalledWith(
@@ -643,7 +643,7 @@ describe('spcp.service', () => {
       const result = await spcpServiceClass.getSpcpAttributes(
         MOCK_CP_SAML,
         MOCK_DESTINATION,
-        AuthType.CP,
+        FormAuthType.CP,
       )
 
       expect(mockClient.getAttributes).toHaveBeenCalledWith(
@@ -664,7 +664,7 @@ describe('spcp.service', () => {
       const jwtResult = spcpServiceClass.createJWT(
         MOCK_JWT_PAYLOAD,
         MOCK_COOKIE_AGE,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(mockClient.createJWT).toHaveBeenCalledWith(
         MOCK_JWT_PAYLOAD,
@@ -681,7 +681,7 @@ describe('spcp.service', () => {
       const jwtResult = spcpServiceClass.createJWT(
         MOCK_JWT_PAYLOAD,
         MOCK_COOKIE_AGE,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(mockClient.createJWT).toHaveBeenCalledWith(
         MOCK_JWT_PAYLOAD,
@@ -697,7 +697,7 @@ describe('spcp.service', () => {
       const result = spcpServiceClass.createJWTPayload(
         { UserName: MOCK_JWT_PAYLOAD.userName },
         true,
-        AuthType.SP,
+        FormAuthType.SP,
       )
       expect(result._unsafeUnwrap()).toEqual({
         userName: MOCK_JWT_PAYLOAD.userName,
@@ -707,7 +707,11 @@ describe('spcp.service', () => {
 
     it('should return MissingAttributesError if SP UserName does not exist', () => {
       const spcpServiceClass = new SpcpServiceClass(MOCK_PARAMS)
-      const result = spcpServiceClass.createJWTPayload({}, true, AuthType.SP)
+      const result = spcpServiceClass.createJWTPayload(
+        {},
+        true,
+        FormAuthType.SP,
+      )
       expect(result._unsafeUnwrapErr()).toEqual(new MissingAttributesError())
     })
 
@@ -721,7 +725,7 @@ describe('spcp.service', () => {
           },
         },
         true,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(result._unsafeUnwrap()).toEqual({
         userName: MOCK_JWT_PAYLOAD.userName,
@@ -732,7 +736,11 @@ describe('spcp.service', () => {
 
     it('should return MissingAttributesError if CorpPass UserInfo is missing', () => {
       const spcpServiceClass = new SpcpServiceClass(MOCK_PARAMS)
-      const result = spcpServiceClass.createJWTPayload({}, true, AuthType.SP)
+      const result = spcpServiceClass.createJWTPayload(
+        {},
+        true,
+        FormAuthType.SP,
+      )
       expect(result._unsafeUnwrapErr()).toEqual(new MissingAttributesError())
     })
 
@@ -745,7 +753,7 @@ describe('spcp.service', () => {
           },
         },
         true,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(result._unsafeUnwrapErr()).toEqual(new MissingAttributesError())
     })
@@ -759,7 +767,7 @@ describe('spcp.service', () => {
           },
         },
         true,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       expect(result._unsafeUnwrapErr()).toEqual(new MissingAttributesError())
     })
@@ -785,19 +793,19 @@ describe('spcp.service', () => {
   describe('extractJwt', () => {
     it('should return SingPass JWT correctly', () => {
       const spcpServiceClass = new SpcpServiceClass(MOCK_PARAMS)
-      const result = spcpServiceClass.extractJwt(MOCK_COOKIES, AuthType.SP)
+      const result = spcpServiceClass.extractJwt(MOCK_COOKIES, FormAuthType.SP)
       expect(result._unsafeUnwrap()).toEqual(MOCK_COOKIES[JwtName.SP])
     })
 
     it('should return CorpPass JWT correctly', () => {
       const spcpServiceClass = new SpcpServiceClass(MOCK_PARAMS)
-      const result = spcpServiceClass.extractJwt(MOCK_COOKIES, AuthType.CP)
+      const result = spcpServiceClass.extractJwt(MOCK_COOKIES, FormAuthType.CP)
       expect(result._unsafeUnwrap()).toEqual(MOCK_COOKIES[JwtName.CP])
     })
 
     it('should return MissingJwtError if there is no JWT', () => {
       const spcpServiceClass = new SpcpServiceClass(MOCK_PARAMS)
-      const result = spcpServiceClass.extractJwt({}, AuthType.CP)
+      const result = spcpServiceClass.extractJwt({}, FormAuthType.CP)
       expect(result._unsafeUnwrapErr()).toEqual(new MissingJwtError())
     })
   })
@@ -814,7 +822,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_COOKIES,
       )
 
@@ -833,7 +841,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.CP,
+        FormAuthType.CP,
         MOCK_COOKIES,
       )
 
@@ -848,7 +856,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.SP,
+        FormAuthType.SP,
         {},
       )
 
@@ -863,7 +871,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.CP,
+        FormAuthType.CP,
         {},
       )
 
@@ -883,7 +891,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_COOKIES,
       )
 
@@ -903,7 +911,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.CP,
+        FormAuthType.CP,
         MOCK_COOKIES,
       )
 
@@ -920,7 +928,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.SP,
+        FormAuthType.SP,
         MOCK_COOKIES,
       )
 
@@ -938,7 +946,7 @@ describe('spcp.service', () => {
 
       // Act
       const result = await spcpServiceClass.extractJwtPayloadFromRequest(
-        AuthType.CP,
+        FormAuthType.CP,
         MOCK_COOKIES,
       )
 

--- a/src/app/modules/spcp/spcp.controller.ts
+++ b/src/app/modules/spcp/spcp.controller.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import { PublicFormAuthValidateEsrvcIdDto } from '../../../types/api'
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
@@ -25,7 +25,7 @@ export const handleRedirect: ControllerHandler<
   { redirectURL: string } | { message: string },
   unknown,
   {
-    authType: AuthType.SP | AuthType.CP
+    authType: FormAuthType.SP | FormAuthType.CP
     target: string
     esrvcId: string
   }
@@ -63,7 +63,7 @@ export const handleValidate: ControllerHandler<
   PublicFormAuthValidateEsrvcIdDto | { message: string },
   unknown,
   {
-    authType: AuthType.SP | AuthType.CP
+    authType: FormAuthType.SP | FormAuthType.CP
     target: string
     esrvcId: string
   }
@@ -96,7 +96,7 @@ export const handleValidate: ControllerHandler<
  * @param authType 'SP' or 'CP'
  */
 export const handleLogin: (
-  authType: AuthType.SP | AuthType.CP,
+  authType: FormAuthType.SP | FormAuthType.CP,
 ) => ControllerHandler<
   unknown,
   unknown,

--- a/src/app/modules/spcp/spcp.middlewares.ts
+++ b/src/app/modules/spcp/spcp.middlewares.ts
@@ -1,11 +1,11 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 
 export const redirectParamsMiddleware = celebrate({
   [Segments.QUERY]: Joi.object({
     target: Joi.string().required(),
-    authType: Joi.string().required().valid(AuthType.SP, AuthType.CP),
+    authType: Joi.string().required().valid(FormAuthType.SP, FormAuthType.CP),
     esrvcId: Joi.string().required(),
   }),
 })

--- a/src/app/modules/spcp/spcp.routes.ts
+++ b/src/app/modules/spcp/spcp.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 
 import * as SpcpController from './spcp.controller'
 import {
@@ -71,7 +71,7 @@ export const SingpassLoginRouter = Router()
 SingpassLoginRouter.get(
   '/',
   loginParamsMiddleware,
-  SpcpController.handleLogin(AuthType.SP),
+  SpcpController.handleLogin(FormAuthType.SP),
 )
 
 // Handles CorpPass login requests
@@ -93,5 +93,5 @@ export const CorppassLoginRouter = Router()
 CorppassLoginRouter.get(
   '/',
   loginParamsMiddleware,
-  SpcpController.handleLogin(AuthType.CP),
+  SpcpController.handleLogin(FormAuthType.CP),
 )

--- a/src/app/modules/spcp/spcp.service.ts
+++ b/src/app/modules/spcp/spcp.service.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import { PublicFormAuthValidateEsrvcIdDto } from '../../../types/api'
 import {
   ISpcpMyInfo,
@@ -89,8 +89,8 @@ export class SpcpServiceClass {
    * Retrieve the correct auth client.
    * @param authType 'SP' or 'CP'
    */
-  getAuthClient(authType: AuthType.SP | AuthType.CP): SPCPAuthClient {
-    if (authType === AuthType.SP) {
+  getAuthClient(authType: FormAuthType.SP | FormAuthType.CP): SPCPAuthClient {
+    if (authType === FormAuthType.SP) {
       return this.#singpassAuthClient
     } else {
       return this.#corppassAuthClient
@@ -105,7 +105,7 @@ export class SpcpServiceClass {
    * @param esrvcId SP/CP e-service ID
    */
   createRedirectUrl(
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
     target: string,
     esrvcId: string,
   ): Result<string, CreateRedirectUrlError> {
@@ -209,9 +209,9 @@ export class SpcpServiceClass {
    */
   extractJwt(
     cookies: SpcpCookies,
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
   ): Result<string, MissingJwtError> {
-    const jwtName = authType === AuthType.SP ? JwtName.SP : JwtName.CP
+    const jwtName = authType === FormAuthType.SP ? JwtName.SP : JwtName.CP
     const cookie = cookies[jwtName]
     return cookie ? ok(cookie) : err(new MissingJwtError())
   }
@@ -229,7 +229,7 @@ export class SpcpServiceClass {
     const logMeta = {
       action: 'extractSingpassJwtPayload',
     }
-    const authClient = this.getAuthClient(AuthType.SP)
+    const authClient = this.getAuthClient(FormAuthType.SP)
     return ResultAsync.fromPromise(
       verifyJwtPromise(authClient, jwt),
       (error) => {
@@ -272,7 +272,7 @@ export class SpcpServiceClass {
     const logMeta = {
       action: 'extractCorppassJwtPayload',
     }
-    const authClient = this.getAuthClient(AuthType.CP)
+    const authClient = this.getAuthClient(FormAuthType.CP)
     return ResultAsync.fromPromise(
       verifyJwtPromise(authClient, jwt),
       (error) => {
@@ -312,7 +312,7 @@ export class SpcpServiceClass {
   parseOOBParams(
     samlArt: string,
     relayState: string,
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
   ): Result<ParsedSpcpParams, InvalidOOBParamsError> {
     const logMeta = {
       action: 'validateOOBParams',
@@ -332,11 +332,11 @@ export class SpcpServiceClass {
     const destination = payloads[0]
     const rememberMe = payloads[1] === 'true'
     const idpId =
-      authType === AuthType.SP
+      authType === FormAuthType.SP
         ? this.#spcpProps.spIdpId
         : this.#spcpProps.cpIdpId
     let cookieDuration: number
-    if (authType === AuthType.CP) {
+    if (authType === FormAuthType.CP) {
       cookieDuration = this.#spcpProps.cpCookieMaxAge
     } else {
       cookieDuration = rememberMe
@@ -369,7 +369,7 @@ export class SpcpServiceClass {
   getSpcpAttributes(
     samlArt: string,
     destination: string,
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
   ): ResultAsync<Record<string, unknown>, RetrieveAttributesError> {
     const logMeta = {
       action: 'getSpcpAttributes',
@@ -401,7 +401,7 @@ export class SpcpServiceClass {
   createJWT(
     payload: JwtPayload,
     cookieDuration: number,
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
   ): Result<string, ApplicationError> {
     const authClient = this.getAuthClient(authType)
     return ok(
@@ -423,9 +423,9 @@ export class SpcpServiceClass {
   createJWTPayload(
     attributes: Record<string, unknown>,
     rememberMe: boolean,
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
   ): Result<JwtPayload, MissingAttributesError> {
-    if (authType === AuthType.SP) {
+    if (authType === FormAuthType.SP) {
       const userName = (attributes as SingpassAttributes).UserName
       return userName && typeof userName === 'string'
         ? ok({ userName, rememberMe })
@@ -457,7 +457,7 @@ export class SpcpServiceClass {
    * @return err(InvalidJwtError) if the jwt exists but the payload is invalid
    */
   extractJwtPayloadFromRequest(
-    authType: AuthType.SP | AuthType.CP,
+    authType: FormAuthType.SP | FormAuthType.CP,
     cookies: SpcpCookies,
   ): ResultAsync<
     JwtPayloadFromCookie,
@@ -465,9 +465,9 @@ export class SpcpServiceClass {
   > {
     return this.extractJwt(cookies, authType).asyncAndThen((jwtResult) => {
       switch (authType) {
-        case AuthType.SP:
+        case FormAuthType.SP:
           return this.extractSingpassJwtPayload(jwtResult)
-        case AuthType.CP:
+        case FormAuthType.CP:
           return this.extractCorppassJwtPayload(jwtResult)
       }
     })

--- a/src/app/modules/spcp/spcp.types.ts
+++ b/src/app/modules/spcp/spcp.types.ts
@@ -1,4 +1,4 @@
-import { AuthType, IFormSchema } from '../../../types'
+import { FormAuthType, IFormSchema } from '../../../types'
 
 export enum JwtName {
   SP = 'jwtSp',
@@ -65,6 +65,6 @@ export interface ParsedSpcpParams {
 }
 
 export type SpcpForm<T extends IFormSchema> = T & {
-  authType: AuthType.SP | AuthType.CP
+  authType: FormAuthType.SP | FormAuthType.CP
   esrvcId: string
 }

--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -5,8 +5,8 @@ import { err, ok, Result } from 'neverthrow'
 
 import { hasProp } from '../../../../shared/utils/has-prop'
 import {
-  AuthType,
   BasicField,
+  FormAuthType,
   IFormSchema,
   MapRouteError,
   SPCPFieldTitle,
@@ -238,14 +238,14 @@ export const validateSpcpForm = <T extends IFormSchema>(
   if (isSpcpForm(form)) {
     return ok(form)
   }
-  return err(new AuthTypeMismatchError(AuthType.CP, form.authType))
+  return err(new AuthTypeMismatchError(FormAuthType.CP, form.authType))
 }
 
 // Typeguard to ensure that form has eserviceId and correct authType
 const isSpcpForm = <F extends IFormSchema>(form: F): form is SpcpForm<F> => {
   return (
     !!form.authType &&
-    [AuthType.SP, AuthType.CP].includes(form.authType) &&
+    [FormAuthType.SP, FormAuthType.CP].includes(form.authType) &&
     !!form.esrvcId
   )
 }
@@ -300,12 +300,12 @@ export const mapRouteError: MapRouteError = (
 // Generates the target to redirect to for the given form id
 export const getRedirectTarget = (
   formId: string,
-  authType: AuthType.SP | AuthType.CP,
+  authType: FormAuthType.SP | FormAuthType.CP,
   isPersistentLogin?: boolean,
 ): string =>
   `/${formId},${
     // Need to cast to boolean because undefined is allowed as a valid value
     // We are not following corppass's official spec for
     // the target parameter
-    authType === AuthType.SP ? !!isPersistentLogin : false
+    authType === FormAuthType.SP ? !!isPersistentLogin : false
   }`

--- a/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
@@ -1,5 +1,5 @@
 import { getModeFilter } from 'src/app/modules/submission/submission.utils'
-import { BasicField, ResponseMode } from 'src/types'
+import { BasicField, FormResponseMode } from 'src/types'
 
 describe('submission.utils', () => {
   describe('getModeFilter', () => {
@@ -9,7 +9,7 @@ describe('submission.utils', () => {
 
     it('should return emailMode filter when ResponseMode.Email is passed', async () => {
       // Act
-      const modeFilter = getModeFilter(ResponseMode.Email)
+      const modeFilter = getModeFilter(FormResponseMode.Email)
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert
@@ -30,7 +30,7 @@ describe('submission.utils', () => {
 
     it('should return encryptMode filter when ResponseMode.Encrypt is passed', async () => {
       // Act
-      const modeFilter = getModeFilter(ResponseMode.Encrypt)
+      const modeFilter = getModeFilter(FormResponseMode.Encrypt)
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert

--- a/src/app/modules/submission/email-submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/email-submission/ParsedResponsesObject.class.ts
@@ -1,11 +1,11 @@
 import { err, ok, Result } from 'neverthrow'
 
 import {
-  AuthType,
   FieldResponse,
+  FormAuthType,
   FormFieldSchema,
+  FormResponseMode,
   IFormDocument,
-  ResponseMode,
 } from '../../../../types'
 import { validateField } from '../../../utils/field-validation'
 import {
@@ -26,8 +26,11 @@ import { ProcessedFieldResponse } from '../submission.types'
 import { getFilteredResponses } from '../submission.utils'
 
 type NdiUserInfo =
-  | { authType: AuthType.SP | AuthType.MyInfo | AuthType.SGID; uinFin: string }
-  | { authType: AuthType.CP; uinFin: string; userInfo: string }
+  | {
+      authType: FormAuthType.SP | FormAuthType.MyInfo | FormAuthType.SGID
+      uinFin: string
+    }
+  | { authType: FormAuthType.CP; uinFin: string; userInfo: string }
 
 export default class ParsedResponsesObject {
   public ndiResponses: ProcessedFieldResponse[] = []
@@ -40,17 +43,17 @@ export default class ParsedResponsesObject {
      * destructured variable switch cases.
      */
     switch (info.authType) {
-      case AuthType.SP:
-      case AuthType.MyInfo:
+      case FormAuthType.SP:
+      case FormAuthType.MyInfo:
         this.ndiResponses = createSingpassParsedResponses(info.uinFin)
         break
-      case AuthType.CP:
+      case FormAuthType.CP:
         this.ndiResponses = createCorppassParsedResponses(
           info.uinFin,
           info.userInfo,
         )
         break
-      case AuthType.SGID:
+      case FormAuthType.SGID:
         this.ndiResponses = createSgidParsedResponses(info.uinFin)
         break
     }
@@ -137,7 +140,7 @@ export default class ParsedResponsesObject {
           // encrypt mode submissions with responses on unhidden fields
           // TODO(#780): Remove this once submission service is separated into
           // Email and Encrypted services
-          form.responseMode === ResponseMode.Encrypt
+          form.responseMode === FormResponseMode.Encrypt
             ? 'answer' in response &&
               typeof response.answer === 'string' &&
               response.answer.trim() !== ''

--- a/src/app/modules/submission/email-submission/__tests__/ParsedResponsesObject.class.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/ParsedResponsesObject.class.spec.ts
@@ -6,11 +6,11 @@ import {
 import * as LogicUtil from '../../../../../shared/util/logic'
 import {
   BasicField,
+  FormResponseMode,
   IEmailFormSchema,
   IFormSchema,
   IPreventSubmitLogicSchema,
   LogicType,
-  ResponseMode,
 } from '../../../../../types'
 import {
   ConflictError,
@@ -44,7 +44,7 @@ describe('ParsedResponsesObject', () => {
 
     const result = ParsedResponsesObject.parseResponses(
       {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         form_fields: [shortTextField, decimalField],
       } as unknown as IFormSchema,
       [shortTextResponse, decimalResponse],
@@ -64,7 +64,7 @@ describe('ParsedResponsesObject', () => {
 
     const result = ParsedResponsesObject.parseResponses(
       {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         form_fields: [extraField],
       } as unknown as IEmailFormSchema,
       [],
@@ -83,7 +83,7 @@ describe('ParsedResponsesObject', () => {
 
     const result = ParsedResponsesObject.parseResponses(
       {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         form_fields: [nricField],
       } as unknown as IEmailFormSchema,
       [nricResponse],
@@ -110,7 +110,7 @@ describe('ParsedResponsesObject', () => {
 
     const result = ParsedResponsesObject.parseResponses(
       {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         form_fields: [],
       } as unknown as IEmailFormSchema,
       [],

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts
@@ -11,7 +11,7 @@ import {
 } from 'src/app/modules/myinfo/__tests__/myinfo.test.constants'
 import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
 import getMyInfoHashModel from 'src/app/modules/myinfo/myinfo_hash.model'
-import { AuthType, IFieldSchema, Status } from 'src/types'
+import { FormAuthType, FormStatus, IFieldSchema } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -91,7 +91,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_TEXT_FIELD],
         },
       })
@@ -118,7 +118,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [
             { ...MOCK_TEXT_FIELD, required: false } as IFieldSchema,
           ],
@@ -146,7 +146,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_ATTACHMENT_FIELD],
         },
       })
@@ -177,7 +177,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_SECTION_FIELD],
         },
       })
@@ -203,7 +203,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_OPTIONAL_VERIFIED_FIELD],
         },
       })
@@ -229,7 +229,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_CHECKBOX_FIELD],
         },
       })
@@ -255,7 +255,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -273,7 +273,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -295,7 +295,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -317,7 +317,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -341,7 +341,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -363,7 +363,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -385,7 +385,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -407,7 +407,7 @@ describe('email-submission.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
 
@@ -437,9 +437,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -460,9 +460,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -484,9 +484,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -513,9 +513,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -543,9 +543,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -570,9 +570,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.MyInfo,
+            authType: FormAuthType.MyInfo,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
         await MyInfoHashModel.updateHashes(
@@ -607,9 +607,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.MyInfo,
+            authType: FormAuthType.MyInfo,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -631,9 +631,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.MyInfo,
+            authType: FormAuthType.MyInfo,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -660,9 +660,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.MyInfo,
+            authType: FormAuthType.MyInfo,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
         const cookie = JSON.stringify({
@@ -692,9 +692,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
         const cookie = JSON.stringify({
@@ -733,9 +733,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -756,9 +756,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -780,9 +780,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -809,9 +809,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -839,9 +839,9 @@ describe('email-submission.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -7,8 +7,8 @@ import mongoose from 'mongoose'
 import { getEmailSubmissionModel } from 'src/app/models/submission.server.model'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
 import {
-  AuthType,
   BasicField,
+  FormAuthType,
   IEmailFormSchema,
   IEmailSubmissionSchema,
   IPopulatedEmailForm,
@@ -323,7 +323,7 @@ describe('email-submission.service', () => {
     const MOCK_EMAIL_FORM = {
       _id: new ObjectId(),
       title: 'title',
-      authType: AuthType.SP,
+      authType: FormAuthType.SP,
       getUniqueMyInfoAttrs: () => MYINFO_ATTRS,
       emails: ['a@abc.com', 'b@cde.com'],
     } as IEmailFormSchema

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.test.constants.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.test.constants.ts
@@ -2,9 +2,9 @@ import fs from 'fs'
 
 import {
   BasicField,
+  FieldBase,
   IAttachmentFieldSchema,
   ICheckboxFieldSchema,
-  IField,
 } from 'src/types'
 
 import {
@@ -43,7 +43,7 @@ export const MOCK_OPTIONAL_VERIFIED_FIELD = generateDefaultField(
   {
     isVerifiable: true,
     required: false,
-  } as Partial<IField>,
+  } as Partial<FieldBase>,
 )
 export const MOCK_OPTIONAL_VERIFIED_RESPONSE = generateSingleAnswerResponse(
   MOCK_OPTIONAL_VERIFIED_FIELD,

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -7,9 +7,10 @@ import {
   BasicField,
   FieldResponse,
   IAttachmentResponse,
-  ISingleAnswerResponse,
   MyInfoAttribute,
+  SingleAnswerFieldResponse,
   SPCPFieldTitle,
+  TableRow,
 } from 'src/types'
 
 import {
@@ -88,20 +89,13 @@ const zipOnlyValid = {
 
 const MOCK_ANSWER = 'mockAnswer'
 
-type WithQuestion<T> = T & {
-  answer: string
-}
-
-const getResponse = (
-  _id: string,
-  answer: string,
-): WithQuestion<ISingleAnswerResponse> =>
+const getResponse = (_id: string, answer: string): SingleAnswerFieldResponse =>
   ({
     _id,
     fieldType: BasicField.Attachment,
     question: 'mockQuestion',
     answer,
-  } as unknown as WithQuestion<ISingleAnswerResponse>)
+  } as unknown as SingleAnswerFieldResponse)
 
 const ALL_SINGLE_SUBMITTED_RESPONSES = basicTypes
   // Attachments are special cases, requiring filename and content
@@ -557,7 +551,9 @@ describe('email-submission.util', () => {
     })
 
     it('should split table answers by newline', () => {
-      const answerArray = [['firstLine\nsecondLine', 'thirdLine\nfourthLine']]
+      const answerArray = [
+        ['firstLine\nsecondLine', 'thirdLine\nfourthLine'],
+      ] as TableRow[]
       const response = generateNewTableResponse({ answerArray })
 
       const emailData = new SubmissionEmailObj(

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -3,9 +3,9 @@ import { readFileSync } from 'fs'
 import { cloneDeep, merge } from 'lodash'
 
 import {
-  AuthType,
   BasicField,
   FieldResponse,
+  FormAuthType,
   IAttachmentResponse,
   MyInfoAttribute,
   SingleAnswerFieldResponse,
@@ -353,7 +353,7 @@ describe('email-submission.util', () => {
       new ObjectId().toHexString(),
       new ObjectId().toHexString(),
     ])
-    const authType = AuthType.NIL
+    const authType = FormAuthType.NIL
     const submissionEmailObj = new SubmissionEmailObj(
       [response1, response2],
       hashedFields,
@@ -364,7 +364,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         ALL_SINGLE_SUBMITTED_RESPONSES,
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
       const expectedAutoReplyData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerAutoreply,
@@ -386,7 +386,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
       expect(emailData.dataCollationData).toEqual([])
       expect(emailData.autoReplyData).toEqual([
@@ -405,7 +405,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       expect(emailData.dataCollationData).toEqual([
@@ -423,7 +423,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -466,7 +466,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -494,7 +494,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -527,7 +527,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -559,7 +559,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -592,7 +592,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -624,7 +624,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [response],
         new Set(),
-        AuthType.NIL,
+        FormAuthType.NIL,
       )
 
       const question = response.question
@@ -668,7 +668,7 @@ describe('email-submission.util', () => {
       const emailData = new SubmissionEmailObj(
         [nameResponse, vehicleResponse],
         new Set([nameResponse._id]),
-        AuthType.MyInfo,
+        FormAuthType.MyInfo,
       )
 
       const expectedDataCollationData = [
@@ -781,7 +781,7 @@ describe('email-submission.util', () => {
       const submissionEmailObjCP = new SubmissionEmailObj(
         [response1, response2, responseCPUID],
         hashedFields,
-        AuthType.CP,
+        FormAuthType.CP,
       )
       const correctConfirmation = [
         {

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -1,6 +1,6 @@
 import { ok, okAsync, ResultAsync } from 'neverthrow'
 
-import { AuthType, IPopulatedEmailForm } from '../../../../types'
+import { FormAuthType, IPopulatedEmailForm } from '../../../../types'
 import {
   ParsedEmailModeSubmissionBody,
   SubmissionErrorDto,
@@ -150,7 +150,7 @@ const submitEmailModeForm: ControllerHandler<
       .andThen(({ parsedResponses, form }) => {
         const { authType } = form
         switch (authType) {
-          case AuthType.CP:
+          case FormAuthType.CP:
             return SpcpService.extractJwt(req.cookies, authType)
               .asyncAndThen((jwt) => SpcpService.extractCorppassJwtPayload(jwt))
               .map<IPopulatedEmailFormWithResponsesAndHash>((jwt) => ({
@@ -170,7 +170,7 @@ const submitEmailModeForm: ControllerHandler<
                 })
                 return error
               })
-          case AuthType.SP:
+          case FormAuthType.SP:
             return SpcpService.extractJwt(req.cookies, authType)
               .asyncAndThen((jwt) => SpcpService.extractSingpassJwtPayload(jwt))
               .map<IPopulatedEmailFormWithResponsesAndHash>((jwt) => ({
@@ -189,7 +189,7 @@ const submitEmailModeForm: ControllerHandler<
                 })
                 return error
               })
-          case AuthType.MyInfo:
+          case FormAuthType.MyInfo:
             return MyInfoUtil.extractMyInfoCookie(req.cookies)
               .andThen(MyInfoUtil.extractAccessTokenFromCookie)
               .andThen((accessToken) =>
@@ -223,7 +223,7 @@ const submitEmailModeForm: ControllerHandler<
                 })
                 return error
               })
-          case AuthType.SGID:
+          case FormAuthType.SGID:
             return SgidService.extractSgidJwtPayload(req.cookies.jwtSgid)
               .map<IPopulatedEmailFormWithResponsesAndHash>(
                 ({ userName: uinFin }) => ({

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -5,11 +5,11 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import {
   BasicField,
   EmailAdminDataField,
+  FormResponseMode,
   IAttachmentInfo,
   IEmailSubmissionSchema,
   IPopulatedEmailForm,
   IPopulatedForm,
-  ResponseMode,
   SubmissionType,
 } from '../../../../types'
 import { ParsedEmailFormFieldResponse } from '../../../../types/api'
@@ -188,7 +188,7 @@ export const checkFormIsEmailMode = (
   if (isEmailModeForm(form)) {
     return ok(form)
   }
-  return err(new ResponseModeError(ResponseMode.Email, form.responseMode))
+  return err(new ResponseModeError(FormResponseMode.Email, form.responseMode))
 }
 
 /**

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -3,13 +3,13 @@ import { compact, flattenDeep, sumBy } from 'lodash'
 
 import * as FileValidation from '../../../../../shared/utils/file-validation'
 import {
-  AuthType,
   BasicField,
   EmailAdminDataField,
   EmailDataCollationToolField,
   EmailDataFields,
   EmailDataForOneField,
   EmailRespondentConfirmationField,
+  FormAuthType,
   IAttachmentInfo,
   MapRouteError,
   SPCPFieldTitle,
@@ -698,12 +698,12 @@ const getAutoReplyFormattedResponse = (
 export class SubmissionEmailObj {
   parsedResponses: ProcessedFieldResponse[]
   hashedFields: Set<string>
-  authType: AuthType
+  authType: FormAuthType
 
   constructor(
     parsedResponses: ProcessedFieldResponse[],
     hashedFields: Set<string> = new Set<string>(),
-    authType: AuthType,
+    authType: FormAuthType,
   ) {
     this.parsedResponses = parsedResponses
     this.hashedFields = hashedFields
@@ -745,7 +745,7 @@ export class SubmissionEmailObj {
       ),
     )
 
-    return this.authType === AuthType.CP
+    return this.authType === FormAuthType.CP
       ? maskUidOnLastField(unmaskedAutoReplyData)
       : unmaskedAutoReplyData
   }

--- a/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
@@ -9,10 +9,10 @@ import {
 import * as LogicUtil from '../../../../../shared/util/logic'
 import {
   BasicField,
+  FormResponseMode,
   IPopulatedEncryptedForm,
   IPreventSubmitLogicSchema,
   LogicType,
-  ResponseMode,
 } from '../../../../../types'
 import { checkIsEncryptedEncoding } from '../../../../utils/encryption'
 import {
@@ -41,7 +41,7 @@ describe('IncomingEncryptSubmission', () => {
     const responses = [mobileResponse, emailResponse]
     const initResult = IncomingEncryptSubmission.init(
       {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         form_fields: [mobileField, emailField],
       } as unknown as IPopulatedEncryptedForm,
       responses,
@@ -61,7 +61,7 @@ describe('IncomingEncryptSubmission', () => {
     const responses = [mobileResponse]
     const initResult = IncomingEncryptSubmission.init(
       {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         form_fields: [mobileField, emailField],
       } as unknown as IPopulatedEncryptedForm,
       responses,
@@ -105,7 +105,7 @@ describe('IncomingEncryptSubmission', () => {
 
     const result = IncomingEncryptSubmission.init(
       {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         form_fields: [mobileField, emailField],
       } as unknown as IPopulatedEncryptedForm,
       responses,
@@ -125,7 +125,7 @@ describe('IncomingEncryptSubmission', () => {
 
     const result = IncomingEncryptSubmission.init(
       {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         form_fields: [mobileField],
       } as unknown as IPopulatedEncryptedForm,
       [mobileResponse],
@@ -150,7 +150,7 @@ describe('IncomingEncryptSubmission', () => {
 
     const result = IncomingEncryptSubmission.init(
       {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         form_fields: [],
       } as unknown as IPopulatedEncryptedForm,
       [],

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -18,8 +18,8 @@ import {
   IPopulatedEncryptedForm,
   IPopulatedForm,
   IPopulatedUser,
+  StorageModeSubmissionMetadata,
   SubmissionData,
-  SubmissionMetadata,
 } from 'src/types'
 
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
@@ -673,7 +673,7 @@ describe('encrypt-submission.controller', () => {
       })
       const mockRes = expressHandler.mockResponse()
       // Mock service result.
-      const expectedMetadata: SubmissionMetadata = {
+      const expectedMetadata: StorageModeSubmissionMetadata = {
         number: 2,
         refNo: mockSubmissionId,
         submissionTime: 'some submission time',
@@ -759,7 +759,7 @@ describe('encrypt-submission.controller', () => {
             refNo: new ObjectId().toHexString(),
             submissionTime: 'some submission time',
           },
-        ] as SubmissionMetadata[],
+        ] as StorageModeSubmissionMetadata[],
         count: 32,
       }
       MockEncryptSubService.getSubmissionMetadataList.mockReturnValueOnce(

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -14,10 +14,10 @@ import {
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
 import {
+  FormResponseMode,
   IPopulatedEncryptedForm,
   IPopulatedForm,
   IPopulatedUser,
-  ResponseMode,
   SubmissionData,
   SubmissionMetadata,
 } from 'src/types'
@@ -137,8 +137,8 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       const expectedError = new ResponseModeError(
-        ResponseMode.Encrypt,
-        ResponseMode.Email,
+        FormResponseMode.Encrypt,
+        FormResponseMode.Email,
       )
       MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
         err(expectedError),
@@ -430,8 +430,8 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       const expectedError = new ResponseModeError(
-        ResponseMode.Encrypt,
-        ResponseMode.Email,
+        FormResponseMode.Encrypt,
+        FormResponseMode.Email,
       )
       MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
         err(expectedError),
@@ -794,8 +794,8 @@ describe('encrypt-submission.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       const expectedError = new ResponseModeError(
-        ResponseMode.Encrypt,
-        ResponseMode.Email,
+        FormResponseMode.Encrypt,
+        FormResponseMode.Email,
       )
       MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
         err(expectedError),
@@ -1070,8 +1070,8 @@ describe('encrypt-submission.controller', () => {
         okAsync(MOCK_FORM),
       )
       const expectedError = new ResponseModeError(
-        ResponseMode.Encrypt,
-        ResponseMode.Email,
+        FormResponseMode.Encrypt,
+        FormResponseMode.Email,
       )
       MockEncryptSubService.checkFormIsEncryptMode.mockReturnValueOnce(
         err(expectedError),

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.routes.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.routes.spec.ts
@@ -2,7 +2,7 @@ import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 
-import { AuthType, Status } from 'src/types'
+import { FormAuthType, FormStatus } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -54,9 +54,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -77,9 +77,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -101,9 +101,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -130,9 +130,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -160,9 +160,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.SP,
+            authType: FormAuthType.SP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -192,9 +192,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -215,9 +215,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -239,9 +239,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -268,9 +268,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -298,9 +298,9 @@ describe('encrypt-submission.routes', () => {
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
             esrvcId: 'mockEsrvcId',
-            authType: AuthType.CP,
+            authType: FormAuthType.CP,
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -14,9 +14,9 @@ import { CreatePresignedUrlError } from 'src/app/modules/form/admin-form/admin-f
 import { formatErrorRecoveryMessage } from 'src/app/utils/handle-mongo-error'
 import {
   IPopulatedEncryptedForm,
+  StorageModeSubmissionMetadata,
   SubmissionCursorData,
   SubmissionData,
-  SubmissionMetadata,
 } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -588,7 +588,7 @@ describe('encrypt-submission.service', () => {
     it('should return metadata successfully', async () => {
       // Arrange
       const mockSubmissionId = new ObjectId().toHexString()
-      const expectedMetadata: SubmissionMetadata = {
+      const expectedMetadata: StorageModeSubmissionMetadata = {
         number: 200,
         refNo: mockSubmissionId,
         submissionTime: 'some submission time',

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -7,8 +7,8 @@ import mongoose from 'mongoose'
 import { SetOptional } from 'type-fest'
 
 import {
-  AuthType,
   EncryptedSubmissionDto,
+  FormAuthType,
   SubmissionMetadataList,
 } from '../../../../types'
 import {
@@ -186,7 +186,7 @@ const submitEncryptModeForm: ControllerHandler<
   let userInfo
   const { authType } = form
   switch (authType) {
-    case AuthType.MyInfo: {
+    case FormAuthType.MyInfo: {
       logger.error({
         message:
           'Storage mode form is not allowed to have MyInfo authorisation',
@@ -199,7 +199,7 @@ const submitEncryptModeForm: ControllerHandler<
       )
       return res.status(statusCode).json({ message: errorMessage })
     }
-    case AuthType.SP: {
+    case FormAuthType.SP: {
       const jwtPayloadResult = await SpcpService.extractJwt(
         req.cookies,
         authType,
@@ -221,7 +221,7 @@ const submitEncryptModeForm: ControllerHandler<
       uinFin = jwtPayloadResult.value.userName
       break
     }
-    case AuthType.CP: {
+    case FormAuthType.CP: {
       const jwtPayloadResult = await SpcpService.extractJwt(
         req.cookies,
         authType,
@@ -248,7 +248,7 @@ const submitEncryptModeForm: ControllerHandler<
 
   // Encrypt Verified SPCP Fields
   let verified
-  if (form.authType === AuthType.SP || form.authType === AuthType.CP) {
+  if (form.authType === FormAuthType.SP || form.authType === FormAuthType.CP) {
     const encryptVerifiedContentResult =
       VerifiedContentService.getVerifiedContent({
         type: form.authType,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -7,9 +7,9 @@ import mongoose from 'mongoose'
 import { SetOptional } from 'type-fest'
 
 import {
-  EncryptedSubmissionDto,
   FormAuthType,
-  SubmissionMetadataList,
+  StorageModeSubmissionDto,
+  StorageModeSubmissionMetadataList,
 } from '../../../../types'
 import {
   EncryptSubmissionDto,
@@ -543,7 +543,7 @@ const validateSubmissionId = celebrate({
  */
 export const getEncryptedResponseUsingQueryParams: ControllerHandler<
   { formId: string },
-  EncryptedSubmissionDto | ErrorDto,
+  StorageModeSubmissionDto | ErrorDto,
   unknown,
   { submissionId: string }
 > = async (req, res) => {
@@ -623,7 +623,7 @@ export const handleGetEncryptedResponseUsingQueryParams = [
  */
 export const handleGetEncryptedResponse: ControllerHandler<
   { formId: string; submissionId: string },
-  EncryptedSubmissionDto | ErrorDto
+  StorageModeSubmissionDto | ErrorDto
 > = async (req, res) => {
   const sessionUserId = (req.session as AuthedSessionData).user._id
   const { formId, submissionId } = req.params
@@ -690,7 +690,7 @@ export const handleGetEncryptedResponse: ControllerHandler<
  */
 export const getMetadata: ControllerHandler<
   { formId: string },
-  SubmissionMetadataList | ErrorDto,
+  StorageModeSubmissionMetadataList | ErrorDto,
   unknown,
   FormSubmissionMetadataQueryDto
 > = async (req, res) => {
@@ -724,7 +724,7 @@ export const getMetadata: ControllerHandler<
         // Step 4a: Retrieve specific submission id.
         if (submissionId) {
           return getSubmissionMetadata(formId, submissionId).map((metadata) => {
-            const metadataList: SubmissionMetadataList = metadata
+            const metadataList: StorageModeSubmissionMetadataList = metadata
               ? { metadata: [metadata], count: 1 }
               : { metadata: [], count: 0 }
             return metadataList

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -6,10 +6,10 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import { Transform } from 'stream'
 
 import {
+  FormResponseMode,
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
-  ResponseMode,
   SubmissionCursorData,
   SubmissionData,
   SubmissionMetadata,
@@ -350,7 +350,7 @@ export const checkFormIsEncryptMode = (
 ): Result<IPopulatedEncryptedForm, ResponseModeError> => {
   return isFormEncryptMode(form)
     ? ok(form)
-    : err(new ResponseModeError(ResponseMode.Encrypt, form.responseMode))
+    : err(new ResponseModeError(FormResponseMode.Encrypt, form.responseMode))
 }
 
 /**

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -10,10 +10,10 @@ import {
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
+  StorageModeSubmissionMetadata,
+  StorageModeSubmissionMetadataList,
   SubmissionCursorData,
   SubmissionData,
-  SubmissionMetadata,
-  SubmissionMetadataList,
 } from '../../../../types'
 import { aws as AwsConfig } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -301,7 +301,7 @@ export const transformAttachmentMetasToSignedUrls = (
 export const getSubmissionMetadata = (
   formId: string,
   submissionId: string,
-): ResultAsync<SubmissionMetadata | null, DatabaseError> => {
+): ResultAsync<StorageModeSubmissionMetadata | null, DatabaseError> => {
   // Early return, do not even retrieve from database.
   if (!mongoose.Types.ObjectId.isValid(submissionId)) {
     return okAsync(null)
@@ -327,7 +327,7 @@ export const getSubmissionMetadata = (
 export const getSubmissionMetadataList = (
   formId: string,
   page?: number,
-): ResultAsync<SubmissionMetadataList, DatabaseError> => {
+): ResultAsync<StorageModeSubmissionMetadataList, DatabaseError> => {
   return ResultAsync.fromPromise(
     EncryptSubmissionModel.findAllMetadataByFormId(formId, { page }),
     (error) => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -2,8 +2,8 @@ import { StatusCodes } from 'http-status-codes'
 import moment from 'moment-timezone'
 
 import {
-  EncryptedSubmissionDto,
   MapRouteErrors,
+  StorageModeSubmissionDto,
   SubmissionData,
 } from '../../../../types'
 import { MapRouteError } from '../../../../types/routing'
@@ -207,7 +207,7 @@ export const mapRouteError: MapRouteErrors =
 export const createEncryptedSubmissionDto = (
   submissionData: SubmissionData,
   attachmentPresignedUrls: Record<string, string>,
-): EncryptedSubmissionDto => {
+): StorageModeSubmissionDto => {
   return {
     refNo: submissionData._id,
     submissionTime: moment(submissionData.created)

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -1,4 +1,4 @@
-import { ResponseMode } from '../../../types'
+import { FormResponseMode } from '../../../types'
 import { ApplicationError } from '../core/core.errors'
 
 /**
@@ -58,8 +58,8 @@ export class SendEmailConfirmationError extends ApplicationError {
  */
 export class ResponseModeError extends ApplicationError {
   constructor(
-    formResponseMode: ResponseMode,
-    attemptedResponseMode: ResponseMode,
+    formResponseMode: FormResponseMode,
+    attemptedResponseMode: FormResponseMode,
   ) {
     super(
       `Attempted to submit ${formResponseMode} form to ${attemptedResponseMode} endpoint`,

--- a/src/app/modules/submission/submission.types.ts
+++ b/src/app/modules/submission/submission.types.ts
@@ -6,10 +6,10 @@ import {
 } from '../../../types/api'
 import { BasicField, FormFieldSchema } from '../../../types/field'
 import {
+  CheckboxResponse,
   FieldResponse,
-  ICheckboxResponse,
-  ISingleAnswerResponse,
-  ITableResponse,
+  SingleAnswerFieldResponse,
+  TableResponse,
 } from '../../../types/response'
 
 export type ProcessedResponse = {
@@ -48,11 +48,11 @@ export type ColumnResponse = {
 }
 
 export type ProcessedSingleAnswerResponse<
-  T extends ISingleAnswerResponse = ISingleAnswerResponse,
+  T extends SingleAnswerFieldResponse = SingleAnswerFieldResponse,
 > = T & ProcessedResponse
 
-export type ProcessedCheckboxResponse = ICheckboxResponse & ProcessedResponse
-export type ProcessedTableResponse = ITableResponse & ProcessedResponse
+export type ProcessedCheckboxResponse = CheckboxResponse & ProcessedResponse
+export type ProcessedTableResponse = TableResponse & ProcessedResponse
 /**
  * Can be either email or storage mode attachment response.
  * Email mode attachment response in the server will have extra metadata injected

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -6,8 +6,8 @@ import {
   BasicField,
   FieldResponse,
   FormFieldSchema,
+  FormResponseMode,
   IFormDocument,
-  ResponseMode,
 } from '../../../types'
 import { AutoReplyMailData } from '../../services/mail/mail.types'
 
@@ -20,12 +20,12 @@ type ModeFilterParam = {
 }
 
 export const getModeFilter = (
-  responseMode: ResponseMode,
+  responseMode: FormResponseMode,
 ): (<T extends ModeFilterParam>(responses: T[]) => T[]) => {
   switch (responseMode) {
-    case ResponseMode.Email:
+    case FormResponseMode.Email:
       return emailModeFilter
-    case ResponseMode.Encrypt:
+    case FormResponseMode.Encrypt:
       return encryptModeFilter
   }
 }

--- a/src/app/modules/verified-content/__tests__/verified-content.service.spec.ts
+++ b/src/app/modules/verified-content/__tests__/verified-content.service.spec.ts
@@ -1,5 +1,5 @@
 import formsgSdk from 'src/app/config/formsg-sdk'
-import { AuthType } from 'src/types'
+import { FormAuthType } from 'src/types'
 
 import {
   EncryptVerifiedContentError,
@@ -25,7 +25,10 @@ describe('verified-content.service', () => {
       }
 
       // Act
-      const result = getVerifiedContent({ type: AuthType.SP, data: mockData })
+      const result = getVerifiedContent({
+        type: FormAuthType.SP,
+        data: mockData,
+      })
 
       // Assert
       expect(result._unsafeUnwrap()).toEqual(expected)
@@ -44,7 +47,10 @@ describe('verified-content.service', () => {
       }
 
       // Act
-      const result = getVerifiedContent({ type: AuthType.CP, data: mockData })
+      const result = getVerifiedContent({
+        type: FormAuthType.CP,
+        data: mockData,
+      })
 
       // Assert
       expect(result._unsafeUnwrap()).toEqual(expected)
@@ -59,7 +65,7 @@ describe('verified-content.service', () => {
 
       // Act
       const result = getVerifiedContent({
-        type: AuthType.SP,
+        type: FormAuthType.SP,
         data: mockDataWithoutUin,
       })
 
@@ -80,7 +86,7 @@ describe('verified-content.service', () => {
 
       // Act
       const result = getVerifiedContent({
-        type: AuthType.CP,
+        type: FormAuthType.CP,
         data: mockDataWithoutUin,
       })
 

--- a/src/app/modules/verified-content/verified-content.service.ts
+++ b/src/app/modules/verified-content/verified-content.service.ts
@@ -1,6 +1,6 @@
 import { err, ok, Result } from 'neverthrow'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import { webhooksAndVerifiedContentConfig } from '../../config/features/webhook-verified-content.config'
 import formsgSdk from '../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../config/logger'
@@ -32,11 +32,11 @@ export const getVerifiedContent = ({
   CpVerifiedContent | SpVerifiedContent
 > => {
   switch (type) {
-    case AuthType.SP:
+    case FormAuthType.SP:
       return getSpVerifiedContent(data)
-    case AuthType.CP:
+    case FormAuthType.CP:
       return getCpVerifiedContent(data)
-    case AuthType.SGID:
+    case FormAuthType.SGID:
       return err(
         new EncryptVerifiedContentError(
           'Fields from sgID not currently supported',

--- a/src/app/modules/verified-content/verified-content.types.ts
+++ b/src/app/modules/verified-content/verified-content.types.ts
@@ -1,7 +1,7 @@
 import { Result } from 'neverthrow'
 
 import { VerifiedKeys } from '../../../../shared/utils/verified-content'
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 
 import { MalformedVerifiedContentError } from './verified-content.errors'
 
@@ -33,6 +33,6 @@ export type EncryptVerificationContentParams = {
 }
 
 export type GetVerifiedContentParams = {
-  type: AuthType.SP | AuthType.CP | AuthType.SGID
+  type: FormAuthType.SP | FormAuthType.CP | FormAuthType.SGID
   data: Record<string, unknown>
 }

--- a/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
@@ -6,7 +6,7 @@ import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
 import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
-import { IWebhookResponse, SubmissionWebhookInfo } from 'src/types'
+import { SubmissionWebhookInfo, WebhookResponse } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -21,7 +21,7 @@ const MockWebhookService = mocked(WebhookService, true)
 
 const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
 
-const MOCK_WEBHOOK_SUCCESS_RESPONSE: IWebhookResponse = {
+const MOCK_WEBHOOK_SUCCESS_RESPONSE: WebhookResponse = {
   signature: 'mockSignature',
   webhookUrl: 'mockWebhookUrl',
   response: {
@@ -30,7 +30,7 @@ const MOCK_WEBHOOK_SUCCESS_RESPONSE: IWebhookResponse = {
     status: 200,
   },
 }
-const MOCK_WEBHOOK_FAILURE_RESPONSE: IWebhookResponse = {
+const MOCK_WEBHOOK_FAILURE_RESPONSE: WebhookResponse = {
   signature: 'mockSignature',
   webhookUrl: 'mockWebhookUrl',
   response: {

--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -11,7 +11,7 @@ import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.valida
 import { transformMongoError } from 'src/app/utils/handle-mongo-error'
 import {
   IEncryptedSubmissionSchema,
-  IWebhookResponse,
+  WebhookResponse,
   WebhookView,
 } from 'src/types'
 
@@ -61,21 +61,21 @@ const MOCK_AXIOS_FAILURE_RESPONSE: AxiosResponse = {
   headers: {},
   config: {},
 }
-const MOCK_WEBHOOK_SUCCESS_RESPONSE: Pick<IWebhookResponse, 'response'> = {
+const MOCK_WEBHOOK_SUCCESS_RESPONSE: Pick<WebhookResponse, 'response'> = {
   response: {
     data: '{"result":"test-result"}',
     status: 200,
     headers: '{}',
   },
 }
-const MOCK_WEBHOOK_FAILURE_RESPONSE: Pick<IWebhookResponse, 'response'> = {
+const MOCK_WEBHOOK_FAILURE_RESPONSE: Pick<WebhookResponse, 'response'> = {
   response: {
     data: '{"result":"test-result"}',
     status: 400,
     headers: '{}',
   },
 }
-const MOCK_WEBHOOK_DEFAULT_FORMAT_RESPONSE: Pick<IWebhookResponse, 'response'> =
+const MOCK_WEBHOOK_DEFAULT_FORMAT_RESPONSE: Pick<WebhookResponse, 'response'> =
   {
     response: {
       data: '',
@@ -139,7 +139,7 @@ describe('webhook.service', () => {
         ...MOCK_WEBHOOK_SUCCESS_RESPONSE,
         signature: MOCK_SIGNATURE,
         webhookUrl: MOCK_WEBHOOK_URL,
-      } as IWebhookResponse
+      } as WebhookResponse
 
       const mockDBError = new Error(DEFAULT_ERROR_MSG)
 
@@ -169,7 +169,7 @@ describe('webhook.service', () => {
         ...MOCK_WEBHOOK_SUCCESS_RESPONSE,
         signature: MOCK_SIGNATURE,
         webhookUrl: MOCK_WEBHOOK_URL,
-      } as IWebhookResponse
+      } as WebhookResponse
 
       // Act
       const actual = await WebhookService.saveWebhookRecord(
@@ -193,7 +193,7 @@ describe('webhook.service', () => {
         ...MOCK_WEBHOOK_SUCCESS_RESPONSE,
         signature: MOCK_SIGNATURE,
         webhookUrl: MOCK_WEBHOOK_URL,
-      } as IWebhookResponse
+      } as WebhookResponse
 
       const expectedSubmission = new EncryptSubmissionModel({
         _id: MOCK_SUBMISSION_ID,

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -7,7 +7,7 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import {
   IEncryptedSubmissionSchema,
   ISubmissionSchema,
-  IWebhookResponse,
+  WebhookResponse,
   WebhookView,
 } from '../../../types'
 import { aws as AwsConfig } from '../../config/config'
@@ -45,7 +45,7 @@ const EncryptSubmission = getEncryptSubmissionModel(mongoose)
  */
 export const saveWebhookRecord = (
   submissionId: ISubmissionSchema['_id'],
-  record: IWebhookResponse,
+  record: WebhookResponse,
 ): ResultAsync<
   IEncryptedSubmissionSchema,
   PossibleDatabaseError | SubmissionNotFoundError
@@ -98,7 +98,7 @@ export const sendWebhook = (
   webhookView: WebhookView,
   webhookUrl: string,
 ): ResultAsync<
-  IWebhookResponse,
+  WebhookResponse,
   | WebhookValidationError
   | WebhookFailedWithAxiosError
   | WebhookFailedWithPresignedUrlGenerationError

--- a/src/app/modules/webhook/webhook.utils.ts
+++ b/src/app/modules/webhook/webhook.utils.ts
@@ -4,7 +4,7 @@ import moment from 'moment-timezone'
 import { err, ok, Result } from 'neverthrow'
 
 import { stringifySafe } from '../../../../shared/utils/stringify-safe'
-import { IWebhookResponse } from '../../../types'
+import { WebhookResponse } from '../../../types'
 import { TIMEZONE } from '../../constants/timezone'
 import { randomUniformInt } from '../../utils/random-uniform'
 
@@ -17,7 +17,7 @@ import { WebhookNoMoreRetriesError } from './webhook.errors'
  */
 export const formatWebhookResponse = (
   response?: AxiosResponse<unknown>,
-): IWebhookResponse['response'] => ({
+): WebhookResponse['response'] => ({
   status: response?.status ?? 0,
   headers: stringifySafe(response?.headers) ?? '',
   data: stringifySafe(response?.data) ?? '',
@@ -59,7 +59,7 @@ export const getNextAttempt = (
  * @returns true if webhook was successful
  */
 export const isSuccessfulResponse = (
-  webhookResponse: IWebhookResponse,
+  webhookResponse: WebhookResponse,
 ): boolean => inRange(webhookResponse.response.status, 200, 300)
 
 /**

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.feedback.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.feedback.routes.spec.ts
@@ -6,7 +6,12 @@ import supertest, { Session } from 'supertest-session'
 import { getEncryptedFormModel } from 'src/app/models/form.server.model'
 import getFormFeedbackModel from 'src/app/models/form_feedback.server.model'
 import getUserModel from 'src/app/models/user.server.model'
-import { IFormDocument, IUserSchema, ResponseMode, Status } from 'src/types'
+import {
+  FormResponseMode,
+  FormStatus,
+  IFormDocument,
+  IUserSchema,
+} from 'src/types'
 
 import {
   createAuthedSession,
@@ -175,8 +180,8 @@ describe('admin-form.feedback.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -331,8 +336,8 @@ describe('admin-form.feedback.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -498,8 +503,8 @@ describe('admin-form.feedback.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -17,13 +17,13 @@ import {
 } from 'src/app/modules/core/core.errors'
 import {
   BasicField,
-  Colors,
+  FormColorTheme,
   FormLogoState,
+  FormResponseMode,
+  FormStartPage,
+  FormStatus,
   IPopulatedForm,
   IUserSchema,
-  ResponseMode,
-  StartPage,
-  Status,
 } from 'src/types'
 
 import {
@@ -112,7 +112,7 @@ describe('admin-form.form.routes', () => {
         title: 'Archived form',
         emails: defaultUser.email,
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
       // Create form that user is not collaborator/admin of. Should not be
       // fetched.
@@ -213,8 +213,8 @@ describe('admin-form.form.routes', () => {
         expect.objectContaining({
           admin: String(defaultUser._id),
           emails: [defaultUser.email],
-          responseMode: ResponseMode.Email,
-          status: Status.Private,
+          responseMode: FormResponseMode.Email,
+          status: FormStatus.Private,
           title: createEmailParams.form.title,
           form_fields: [],
           form_logics: [],
@@ -243,8 +243,8 @@ describe('admin-form.form.routes', () => {
         expect.objectContaining({
           admin: String(defaultUser._id),
           publicKey: createStorageParams.form.publicKey,
-          responseMode: ResponseMode.Encrypt,
-          status: Status.Private,
+          responseMode: FormResponseMode.Encrypt,
+          status: FormStatus.Private,
           title: createStorageParams.form.title,
           form_fields: [],
           form_logics: [],
@@ -291,7 +291,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           // title is missing.
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: 'some@example.com',
         },
       })
@@ -308,7 +308,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           // body.emails missing.
         },
       })
@@ -327,7 +327,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: '',
         },
       })
@@ -349,7 +349,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: [],
         },
       })
@@ -371,7 +371,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           // publicKey missing.
         },
       })
@@ -392,7 +392,7 @@ describe('admin-form.form.routes', () => {
       const response = await request.post('/admin/forms').send({
         form: {
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: '',
         },
       })
@@ -645,8 +645,8 @@ describe('admin-form.form.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -697,7 +697,7 @@ describe('admin-form.form.routes', () => {
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
-      expect(formToArchive.status).toEqual(Status.Private)
+      expect(formToArchive.status).toEqual(FormStatus.Private)
 
       // Act
       const response = await request.delete(`/admin/forms/${formToArchive._id}`)
@@ -706,7 +706,7 @@ describe('admin-form.form.routes', () => {
       const form = await EmailFormModel.findById(formToArchive._id)
       expect(response.status).toEqual(200)
       expect(response.body).toEqual({ message: 'Form has been archived' })
-      expect(form?.status).toEqual(Status.Archived)
+      expect(form?.status).toEqual(FormStatus.Archived)
     })
 
     it('should return 401 when user is not logged in', async () => {
@@ -773,7 +773,7 @@ describe('admin-form.form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
@@ -836,7 +836,7 @@ describe('admin-form.form.routes', () => {
       })
 
       const dupeParams = {
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         title: 'new duplicated form title',
         publicKey: 'some public key',
       }
@@ -856,7 +856,7 @@ describe('admin-form.form.routes', () => {
           }),
           responseMode: dupeParams.responseMode,
           title: dupeParams.title,
-          status: Status.Private,
+          status: FormStatus.Private,
         }),
       )
     })
@@ -874,7 +874,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           // body.emails missing.
         })
 
@@ -900,7 +900,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: '',
         })
 
@@ -929,7 +929,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           title: 'new email form',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: [],
         })
 
@@ -958,7 +958,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           // publicKey missing.
         })
 
@@ -986,7 +986,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           title: 'new storage mode form',
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           publicKey: '',
         })
 
@@ -1015,7 +1015,7 @@ describe('admin-form.form.routes', () => {
         .post(`/admin/forms/${formToDupe._id}/duplicate`)
         .send({
           // title is missing.
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: 'test@example.com',
         })
 
@@ -1096,7 +1096,7 @@ describe('admin-form.form.routes', () => {
       const response = await request
         .post(`/admin/forms/${randomForm._id}/duplicate`)
         .send({
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'new duplicated form title',
           publicKey: 'some public key',
         })
@@ -1116,7 +1116,7 @@ describe('admin-form.form.routes', () => {
       const response = await request
         .post(`/admin/forms/${invalidFormId}/duplicate`)
         .send({
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'new duplicated form title',
           publicKey: 'some public key',
         })
@@ -1133,14 +1133,14 @@ describe('admin-form.form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
       const response = await request
         .post(`/admin/forms/${archivedForm._id}/duplicate`)
         .send({
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           emails: 'anyrandomEmail@example.com',
           title: 'cool new title',
         })
@@ -1159,7 +1159,7 @@ describe('admin-form.form.routes', () => {
       const response = await request
         .post(`/admin/forms/${new ObjectId()}/duplicate`)
         .send({
-          responseMode: ResponseMode.Encrypt,
+          responseMode: FormResponseMode.Encrypt,
           title: 'does not matter',
           publicKey: 'some public key',
         })
@@ -1181,7 +1181,7 @@ describe('admin-form.form.routes', () => {
       // Force validation error that will be returned as database error
       // TODO(#614): Return transformMongoError instead of DatabaseError for better mongoose error handling.
       const invalidEmailDupeParams = {
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: 'notAnEmail, should return error',
         title: 'cool new title',
       }
@@ -1405,7 +1405,7 @@ describe('admin-form.form.routes', () => {
         admin: defaultUser._id,
         publicKey: 'some public key',
         // Already deleted.
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
       const anotherUser = (
         await dbHandler.insertFormCollectionReqs({
@@ -1547,7 +1547,7 @@ describe('admin-form.form.routes', () => {
         title: 'Form already archived',
         emails: [defaultUser.email],
         admin: defaultUser._id,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
 
       // Act
@@ -1756,7 +1756,7 @@ describe('admin-form.form.routes', () => {
         emails: [defaultUser.email],
         admin: defaultUser._id,
         form_fields: [generateDefaultField(BasicField.Date)],
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })) as IPopulatedForm
 
       const fieldToDuplicate = archivedForm.form_fields[0]
@@ -1829,13 +1829,13 @@ describe('admin-form.form.routes', () => {
   })
 
   describe('PUT /admin/forms/:formId/start-page', () => {
-    const MOCK_START_PAGE: StartPage = {
+    const MOCK_START_PAGE: FormStartPage = {
       paragraph: 'old end page',
     }
 
-    const MOCK_UPDATED_START_PAGE: StartPage = {
+    const MOCK_UPDATED_START_PAGE: FormStartPage = {
       paragraph: 'new mock start page title',
-      colorTheme: Colors.Blue,
+      colorTheme: FormColorTheme.Blue,
       logo: {
         state: FormLogoState.None,
       },
@@ -1909,7 +1909,7 @@ describe('admin-form.form.routes', () => {
         title: 'email me',
         admin: defaultUser._id,
         startPage: MOCK_START_PAGE,
-        status: Status.Archived,
+        status: FormStatus.Archived,
       })
       const expectedResponse = { message: 'Form has been archived' }
 

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
@@ -7,7 +7,7 @@ import supertest, { Session } from 'supertest-session'
 import { aws } from 'src/app/config/config'
 import { getEncryptedFormModel } from 'src/app/models/form.server.model'
 import getUserModel from 'src/app/models/user.server.model'
-import { IUserSchema, ResponseMode, Status } from 'src/types'
+import { FormResponseMode, FormStatus, IUserSchema } from 'src/types'
 
 import { createAuthedSession } from 'tests/integration/helpers/express-auth'
 import { setupApp } from 'tests/integration/helpers/express-setup'
@@ -256,8 +256,8 @@ describe('admin-form.presign.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -494,8 +494,8 @@ describe('admin-form.presign.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.preview.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.preview.routes.spec.ts
@@ -23,11 +23,11 @@ import {
 } from 'src/app/modules/submission/email-submission/__tests__/email-submission.test.constants'
 import {
   BasicField,
+  FormResponseMode,
+  FormStatus,
   IFieldSchema,
   IFormSchema,
   IUserSchema,
-  ResponseMode,
-  Status,
 } from 'src/types'
 import { EncryptSubmissionDto } from 'src/types/api'
 
@@ -89,7 +89,7 @@ describe('admin-form.preview.routes', () => {
         admin: defaultUser._id,
         publicKey: 'some random key',
         // Private status.
-        status: Status.Private,
+        status: FormStatus.Private,
       })
 
       // Act
@@ -197,8 +197,8 @@ describe('admin-form.preview.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -220,7 +220,7 @@ describe('admin-form.preview.routes', () => {
       const formToPreview = await EmailFormModel.create({
         title: 'some other form',
         admin: defaultUser._id,
-        status: Status.Public,
+        status: FormStatus.Public,
         emails: [defaultUser.email],
       })
       // Delete user after login.
@@ -243,7 +243,7 @@ describe('admin-form.preview.routes', () => {
       const formToPreview = await EmailFormModel.create({
         title: 'some other form',
         admin: defaultUser._id,
-        status: Status.Public,
+        status: FormStatus.Public,
         emails: [defaultUser.email],
       })
       // Mock database error.
@@ -270,7 +270,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_TEXT_FIELD],
           admin: defaultUser._id,
         },
@@ -299,7 +299,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [
             { ...MOCK_TEXT_FIELD, required: false } as IFieldSchema,
           ],
@@ -330,7 +330,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_ATTACHMENT_FIELD],
           admin: defaultUser._id,
         },
@@ -364,7 +364,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_SECTION_FIELD],
           admin: defaultUser._id,
         },
@@ -393,7 +393,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_OPTIONAL_VERIFIED_FIELD],
           admin: defaultUser._id,
         },
@@ -422,7 +422,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           form_fields: [MOCK_CHECKBOX_FIELD],
           admin: defaultUser._id,
         },
@@ -451,7 +451,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -472,7 +472,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -497,7 +497,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -522,7 +522,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -549,7 +549,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -574,7 +574,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -599,7 +599,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict
@@ -624,7 +624,7 @@ describe('admin-form.preview.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
           admin: defaultUser._id,
         },
         // Avoid default mail domain so that user emails in the database don't conflict

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.settings.routes.spec.ts
@@ -6,7 +6,7 @@ import supertest, { Session } from 'supertest-session'
 
 import getUserModel from 'src/app/models/user.server.model'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
-import { Status } from 'src/types'
+import { FormStatus } from 'src/types'
 import { SettingsUpdateDto } from 'src/types/api'
 
 import { createAuthedSession } from 'tests/integration/helpers/express-auth'
@@ -183,7 +183,7 @@ describe('admin-form.settings.routes', () => {
       })
       const session = await createAuthedSession(user.email, request)
       const settingsToUpdate: SettingsUpdateDto = {
-        status: Status.Public,
+        status: FormStatus.Public,
       }
       const invalidFormId = new ObjectId().toHexString()
 
@@ -203,11 +203,11 @@ describe('admin-form.settings.routes', () => {
       // Arrange
       const { form, user } = await dbHandler.insertEncryptForm()
       // Set form state to archived
-      form.status = Status.Archived
+      form.status = FormStatus.Archived
       await form.save()
       const session = await createAuthedSession(user.email, request)
       const settingsToUpdate: SettingsUpdateDto = {
-        status: Status.Public,
+        status: FormStatus.Public,
       }
 
       // Act
@@ -338,7 +338,7 @@ describe('admin-form.settings.routes', () => {
       // Arrange
       const { form, user } = await dbHandler.insertEmailForm({
         formOptions: {
-          status: Status.Archived,
+          status: FormStatus.Archived,
         },
       })
       const session = await createAuthedSession(user.email, request)
@@ -475,7 +475,7 @@ describe('admin-form.settings.routes', () => {
       // Arrange
       const { form, user } = await dbHandler.insertEmailForm({
         formOptions: {
-          status: Status.Archived,
+          status: FormStatus.Archived,
         },
       })
       const session = await createAuthedSession(user.email, request)

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -17,11 +17,11 @@ import getUserModel from 'src/app/models/user.server.model'
 import { saveSubmissionMetadata } from 'src/app/modules/submission/email-submission/email-submission.service'
 import { SubmissionHash } from 'src/app/modules/submission/email-submission/email-submission.types'
 import {
+  FormResponseMode,
+  FormStatus,
   IFormDocument,
   IPopulatedEmailForm,
   IUserSchema,
-  ResponseMode,
-  Status,
   SubmissionCursorData,
   SubmissionType,
 } from 'src/types'
@@ -79,7 +79,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -98,7 +98,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -118,7 +118,7 @@ describe('admin-form.submissions.routes', () => {
       const expectedSubmissionCount = 5
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -148,7 +148,7 @@ describe('admin-form.submissions.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -182,7 +182,7 @@ describe('admin-form.submissions.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -219,7 +219,7 @@ describe('admin-form.submissions.routes', () => {
       const expectedSubmissionCount = 3
       const newForm = (await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })) as IPopulatedEmailForm
@@ -255,7 +255,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -284,7 +284,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -313,7 +313,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -342,7 +342,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -372,7 +372,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const newForm = await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         admin: defaultUser._id,
       })
@@ -461,8 +461,8 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -496,8 +496,8 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const form = await EmailFormModel.create({
         title: 'normal form',
-        status: Status.Private,
-        responseMode: ResponseMode.Email,
+        status: FormStatus.Private,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -525,7 +525,7 @@ describe('admin-form.submissions.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -802,7 +802,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const emailForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -882,8 +882,8 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -920,7 +920,7 @@ describe('admin-form.submissions.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -1001,7 +1001,7 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const emailForm = await EmailFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: [defaultUser.email],
         admin: defaultUser._id,
       })
@@ -1105,8 +1105,8 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })
@@ -1205,7 +1205,7 @@ describe('admin-form.submissions.routes', () => {
     beforeEach(async () => {
       defaultForm = (await EncryptFormModel.create({
         title: 'new form',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'any public key',
         admin: defaultUser._id,
       })) as IFormDocument
@@ -1391,8 +1391,8 @@ describe('admin-form.submissions.routes', () => {
       // Arrange
       const archivedForm = await EncryptFormModel.create({
         title: 'archived form',
-        status: Status.Archived,
-        responseMode: ResponseMode.Encrypt,
+        status: FormStatus.Archived,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'does not matter',
         admin: defaultUser._id,
       })

--- a/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.settings.routes.ts
@@ -1,7 +1,7 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { Router } from 'express'
 
-import { AuthType, Status } from '../../../../../../types'
+import { FormAuthType, FormStatus } from '../../../../../../types'
 import { SettingsUpdateDto } from '../../../../../../types/api'
 import * as AdminFormController from '../../../../../modules/form/admin-form/admin-form.controller'
 
@@ -12,7 +12,7 @@ export const AdminFormsSettingsRouter = Router()
  */
 const updateSettingsValidator = celebrate({
   [Segments.BODY]: Joi.object<SettingsUpdateDto>({
-    authType: Joi.string().valid(...Object.values(AuthType)),
+    authType: Joi.string().valid(...Object.values(FormAuthType)),
     emails: Joi.alternatives().try(
       Joi.array().items(Joi.string().email()),
       Joi.string().email({ multiple: true }),
@@ -20,7 +20,7 @@ const updateSettingsValidator = celebrate({
     esrvcId: Joi.string().allow(''),
     hasCaptcha: Joi.boolean(),
     inactiveMessage: Joi.string(),
-    status: Joi.string().valid(...Object.values(Status)),
+    status: Joi.string().valid(...Object.values(FormStatus)),
     submissionLimit: Joi.number().allow(null),
     title: Joi.string(),
     webhook: Joi.object({

--- a/src/app/routes/api/v3/billings/__tests__/billings.routes.spec.ts
+++ b/src/app/routes/api/v3/billings/__tests__/billings.routes.spec.ts
@@ -5,7 +5,7 @@ import supertest, { Session } from 'supertest-session'
 
 import getFormModel from 'src/app/models/form.server.model'
 import getLoginModel from 'src/app/models/login.server.model'
-import { AuthType, IUserSchema, ResponseMode } from 'src/types'
+import { FormAuthType, FormResponseMode, IUserSchema } from 'src/types'
 
 import { createAuthedSession } from 'tests/integration/helpers/express-auth'
 import { setupApp } from 'tests/integration/helpers/express-setup'
@@ -75,14 +75,14 @@ describe('billings.routes', () => {
           formName: generatedForms[0].title,
           total: generatedLoginTimes[0],
           formId: String(generatedForms[0]._id),
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         },
         {
           adminEmail: defaultUser.email,
           formName: generatedForms[1].title,
           total: generatedLoginTimes[1],
           formId: String(generatedForms[1]._id),
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
         },
       ]
       expect(response.status).toEqual(200)
@@ -229,7 +229,7 @@ const generateLoginStatistics = async ({
     FormModel.create({
       title: `example form title ${idx}`,
       admin: user._id,
-      responseMode: ResponseMode.Email,
+      responseMode: FormResponseMode.Email,
       emails: [user.email],
     }),
   )
@@ -244,7 +244,7 @@ const generateLoginStatistics = async ({
           form: form._id,
           admin: user._id,
           agency: user.agency,
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: esrvcIdToCheck,
         }),
       ),
@@ -257,7 +257,7 @@ const generateLoginStatistics = async ({
         form: forms[2]._id,
         admin: user._id,
         agency: user.agency,
-        authType: AuthType.SP,
+        authType: FormAuthType.SP,
         esrvcId: altEsrvcId,
       }),
     ),

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.auth.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.auth.routes.spec.ts
@@ -7,7 +7,7 @@ import { mocked } from 'ts-jest/utils'
 
 import { DatabaseError } from 'src/app/modules/core/core.errors'
 import { getRedirectTarget } from 'src/app/modules/spcp/spcp.util'
-import { AuthType, Status } from 'src/types'
+import { FormAuthType, FormStatus } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
@@ -45,8 +45,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEncryptForm({
         formOptions: {
-          authType: AuthType.SP,
-          status: Status.Public,
+          authType: FormAuthType.SP,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -60,7 +60,7 @@ describe('public-form.auth.routes', () => {
       expect(response.status).toEqual(StatusCodes.OK)
       expect(response.body).toMatchObject({
         redirectURL: expect.toIncludeMultiple([
-          encodeURI(getRedirectTarget(form._id, AuthType.SP, false)),
+          encodeURI(getRedirectTarget(form._id, FormAuthType.SP, false)),
           form.esrvcId!,
         ]),
       })
@@ -70,8 +70,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEncryptForm({
         formOptions: {
-          authType: AuthType.CP,
-          status: Status.Public,
+          authType: FormAuthType.CP,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -85,7 +85,7 @@ describe('public-form.auth.routes', () => {
       expect(response.status).toEqual(StatusCodes.OK)
       expect(response.body).toMatchObject({
         redirectURL: expect.toIncludeMultiple([
-          encodeURI(getRedirectTarget(form._id, AuthType.CP, false)),
+          encodeURI(getRedirectTarget(form._id, FormAuthType.CP, false)),
           form.esrvcId!,
         ]),
       })
@@ -95,8 +95,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.MyInfo,
-          status: Status.Public,
+          authType: FormAuthType.MyInfo,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -120,8 +120,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.MyInfo,
-          status: Status.Public,
+          authType: FormAuthType.MyInfo,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -146,7 +146,7 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEncryptForm({
         formOptions: {
-          status: Status.Public,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -169,8 +169,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.MyInfo,
-          status: Status.Public,
+          authType: FormAuthType.MyInfo,
+          status: FormStatus.Public,
         },
       })
       const expectedResponse = jsonParseStringify({
@@ -209,8 +209,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEncryptForm({
         formOptions: {
-          authType: AuthType.SP,
-          status: Status.Public,
+          authType: FormAuthType.SP,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -235,8 +235,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
-          status: Status.Public,
+          authType: FormAuthType.SP,
+          status: FormStatus.Public,
           esrvcId: new ObjectId().toHexString(),
         },
       })
@@ -263,9 +263,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       MockAxios.get.mockResolvedValueOnce({ data: '<title> </title>' })
@@ -283,9 +283,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       MockAxios.get.mockResolvedValueOnce({
@@ -308,9 +308,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.NIL,
+          authType: FormAuthType.NIL,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const expectedResponse = jsonParseStringify({
@@ -330,9 +330,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const expectedResponse = jsonParseStringify({
@@ -352,8 +352,8 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
-          status: Status.Public,
+          authType: FormAuthType.SP,
+          status: FormStatus.Public,
         },
       })
       const expectedResponse = jsonParseStringify({
@@ -390,9 +390,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       MockAxios.get.mockResolvedValueOnce({
@@ -414,9 +414,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       jest
@@ -439,9 +439,9 @@ describe('public-form.auth.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           esrvcId: new ObjectId().toHexString(),
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       MockAxios.get.mockRejectedValueOnce(new FetchLoginPageError())

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.feedback.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.feedback.routes.spec.ts
@@ -2,7 +2,7 @@ import { errAsync } from 'neverthrow'
 import supertest, { Session } from 'supertest-session'
 
 import { DatabaseError } from 'src/app/modules/core/core.errors'
-import { Status } from 'src/types'
+import { FormStatus } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import { buildCelebrateError } from 'tests/unit/backend/helpers/celebrate'
@@ -30,7 +30,7 @@ describe('public-form.feedback.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const MOCK_FEEDBACK = {
@@ -102,7 +102,7 @@ describe('public-form.feedback.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          status: Status.Archived,
+          status: FormStatus.Archived,
         },
       })
       const MOCK_FEEDBACK = {
@@ -129,7 +129,7 @@ describe('public-form.feedback.routes', () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const MOCK_ERROR_MESSAGE = 'mock me'

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.form.routes.spec.ts
@@ -8,7 +8,7 @@ import { mocked } from 'ts-jest/utils'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
 import { MYINFO_COOKIE_NAME } from 'src/app/modules/myinfo/myinfo.constants'
 import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
-import { AuthType, Status } from 'src/types'
+import { FormAuthType, FormStatus } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -68,7 +68,7 @@ describe('public-form.form.routes', () => {
     it('should return 200 with public form when form has AuthType.NIL and valid formId', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Public },
+        formOptions: { status: FormStatus.Public },
       })
       // NOTE: This is needed to inject admin info into the form
       const fullForm = await dbHandler.getFullFormById(form._id)
@@ -99,9 +99,9 @@ describe('public-form.form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.SP,
+          authType: FormAuthType.SP,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const formId = form._id
@@ -140,9 +140,9 @@ describe('public-form.form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.CP,
+          authType: FormAuthType.CP,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       const formId = form._id
@@ -176,9 +176,9 @@ describe('public-form.form.routes', () => {
       const { form } = await dbHandler.insertEmailForm({
         formOptions: {
           esrvcId: 'mockEsrvcId',
-          authType: AuthType.MyInfo,
+          authType: FormAuthType.MyInfo,
           hasCaptcha: false,
-          status: Status.Public,
+          status: FormStatus.Public,
         },
       })
       // NOTE: This is needed to inject admin info into the form
@@ -239,7 +239,7 @@ describe('public-form.form.routes', () => {
     it('should return 404 if the form is private', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Private },
+        formOptions: { status: FormStatus.Private },
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
@@ -260,7 +260,7 @@ describe('public-form.form.routes', () => {
     it('should return 410 if the form has been archived', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Archived },
+        formOptions: { status: FormStatus.Archived },
       })
       const expectedResponseBody = JSON.parse(
         JSON.stringify({
@@ -279,7 +279,7 @@ describe('public-form.form.routes', () => {
     it('should return 500 if a database error occurs', async () => {
       // Arrange
       const { form } = await dbHandler.insertEmailForm({
-        formOptions: { status: Status.Public },
+        formOptions: { status: FormStatus.Public },
       })
       const expectedError = new DatabaseError('all your base are belong to us')
       const expectedResponseBody = JSON.parse(

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.routes.spec.constants.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.routes.spec.constants.ts
@@ -2,9 +2,9 @@ import fs from 'fs'
 
 import {
   BasicField,
+  FieldBase,
   IAttachmentFieldSchema,
   ICheckboxFieldSchema,
-  IField,
 } from 'src/types'
 
 import {
@@ -43,7 +43,7 @@ export const MOCK_OPTIONAL_VERIFIED_FIELD = generateDefaultField(
   {
     isVerifiable: true,
     required: false,
-  } as Partial<IField>,
+  } as Partial<FieldBase>,
 )
 export const MOCK_OPTIONAL_VERIFIED_RESPONSE = generateSingleAnswerResponse(
   MOCK_OPTIONAL_VERIFIED_FIELD,

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
@@ -8,7 +8,7 @@ import { mocked } from 'ts-jest/utils'
 import { MYINFO_COOKIE_NAME } from 'src/app/modules/myinfo/myinfo.constants'
 import { MyInfoCookieState } from 'src/app/modules/myinfo/myinfo.types'
 import getMyInfoHashModel from 'src/app/modules/myinfo/myinfo_hash.model'
-import { AuthType, IFieldSchema, Status } from 'src/types'
+import { FormAuthType, FormStatus, IFieldSchema } from 'src/types'
 
 import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
@@ -91,7 +91,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [MOCK_TEXT_FIELD],
           },
         })
@@ -121,7 +121,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [
               { ...MOCK_TEXT_FIELD, required: false } as IFieldSchema,
             ],
@@ -152,7 +152,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [MOCK_ATTACHMENT_FIELD],
           },
         })
@@ -186,7 +186,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [MOCK_SECTION_FIELD],
           },
         })
@@ -215,7 +215,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [MOCK_OPTIONAL_VERIFIED_FIELD],
           },
         })
@@ -246,7 +246,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
             form_fields: [MOCK_CHECKBOX_FIELD],
           },
         })
@@ -275,7 +275,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -296,7 +296,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -321,7 +321,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -346,7 +346,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -373,7 +373,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -398,7 +398,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -423,7 +423,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -448,7 +448,7 @@ describe('public-form.submissions.routes', () => {
         const { form } = await dbHandler.insertEmailForm({
           formOptions: {
             hasCaptcha: false,
-            status: Status.Public,
+            status: FormStatus.Public,
           },
         })
 
@@ -481,9 +481,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -507,9 +507,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -534,9 +534,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -566,9 +566,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -599,9 +599,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -629,9 +629,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.MyInfo,
+              authType: FormAuthType.MyInfo,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
           const cookie = JSON.stringify({
@@ -669,9 +669,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.MyInfo,
+              authType: FormAuthType.MyInfo,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -696,9 +696,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.MyInfo,
+              authType: FormAuthType.MyInfo,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -728,9 +728,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.MyInfo,
+              authType: FormAuthType.MyInfo,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
           const cookie = JSON.stringify({
@@ -763,9 +763,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
           const cookie = JSON.stringify({
@@ -807,9 +807,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -833,9 +833,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -860,9 +860,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -892,9 +892,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -925,9 +925,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEmailForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -971,9 +971,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -994,9 +994,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1018,9 +1018,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1047,9 +1047,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1077,9 +1077,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.SP,
+              authType: FormAuthType.SP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1109,9 +1109,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1132,9 +1132,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1156,9 +1156,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1185,9 +1185,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 
@@ -1215,9 +1215,9 @@ describe('public-form.submissions.routes', () => {
           const { form } = await dbHandler.insertEncryptForm({
             formOptions: {
               esrvcId: 'mockEsrvcId',
-              authType: AuthType.CP,
+              authType: FormAuthType.CP,
               hasCaptcha: false,
-              status: Status.Public,
+              status: FormStatus.Public,
             },
           })
 

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -7,7 +7,12 @@ import {
   MalformedParametersError,
 } from 'src/app/modules/core/core.errors'
 import { getMongoErrorMessage } from 'src/app/utils/handle-mongo-error'
-import { FormOtpData, IFormSchema, IUserSchema, ResponseMode } from 'src/types'
+import {
+  FormOtpData,
+  FormResponseMode,
+  IFormSchema,
+  IUserSchema,
+} from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
@@ -246,7 +251,7 @@ describe('sms.service', () => {
         title: 'Test Form',
         emails: [testUser.email],
         admin: testUser._id,
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
       })
 
       mockOtpData = {

--- a/src/app/services/sms/sms.types.ts
+++ b/src/app/services/sms/sms.types.ts
@@ -4,9 +4,9 @@ import { Twilio } from 'twilio'
 import {
   AdminContactOtpData,
   FormOtpData,
+  FormPermission,
   IFormSchema,
   IUserSchema,
-  Permission,
 } from '../../../types'
 
 export enum SmsType {
@@ -27,7 +27,7 @@ export type FormDeactivatedSmsData = {
     email: IUserSchema['email']
     userId: IUserSchema['_id']
   }
-  collaboratorEmail: Permission['email']
+  collaboratorEmail: FormPermission['email']
   recipientNumber: string
 }
 

--- a/src/app/utils/field-validation/field-validation.guards.ts
+++ b/src/app/utils/field-validation/field-validation.guards.ts
@@ -1,7 +1,7 @@
 import { get } from 'lodash'
 
 import { types as basicTypes } from '../../../../shared/constants/field/basic'
-import { BasicField, IEmailFieldSchema, ITableRow } from '../../../types'
+import { BasicField, IEmailFieldSchema, TableRow } from '../../../types'
 import {
   ColumnResponse,
   ProcessedAttachmentResponse,
@@ -39,7 +39,7 @@ const isStringArray = (arr: unknown): arr is string[] =>
   Array.isArray(arr) && arr.every((item) => typeof item === 'string')
 
 // Check that the row contains a single array of only string (including empty string)
-export const isTableRow = (row: unknown): row is ITableRow =>
+export const isTableRow = (row: unknown): row is TableRow =>
   isStringArray(row) && row.length > 0
 
 export const isProcessedTableResponse = (

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -2,9 +2,12 @@ import formsgSdk from 'src/app/config/formsg-sdk'
 import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
 import { ProcessedFieldResponse } from 'src/app/modules/submission/submission.types'
 import { validateField } from 'src/app/utils/field-validation'
-import { IFieldSchema } from 'src/types'
-import { BasicField } from 'src/types/field'
-import { ISingleAnswerResponse } from 'src/types/response'
+import {
+  BasicField,
+  IEmailFieldSchema,
+  OmitUnusedValidatorProps,
+} from 'src/types/field'
+import { SingleAnswerFieldResponse } from 'src/types/response'
 
 type VerificationMock = {
   authenticate: () => boolean
@@ -26,20 +29,18 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'valid@email.com',
       isVisible: true,
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -52,20 +53,18 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'abc@163.com',
       isVisible: true,
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -78,20 +77,18 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'abc@126.com',
       isVisible: true,
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -104,20 +101,18 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'invalidemail.com',
       isVisible: true,
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isErr()).toBe(true)
@@ -132,20 +127,18 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       isVisible: false,
       answer: '',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -158,13 +151,11 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
-      disabled: false,
       required: true,
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@test.gov.sg'],
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -172,10 +163,10 @@ describe('Email field validation', () => {
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
       signature: 'some signature',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -188,13 +179,11 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -202,10 +191,10 @@ describe('Email field validation', () => {
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
       signature: 'some signature',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isErr()).toBe(true)
@@ -220,13 +209,19 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: [],
-    }
+      autoReplyOptions: {
+        autoReplyMessage: 'some message',
+        autoReplySender: 'some sender',
+        autoReplySubject: 'some subject',
+        hasAutoReply: true,
+        includeFormSummary: true,
+      },
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -234,10 +229,10 @@ describe('Email field validation', () => {
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
       signature: 'some signature',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -250,13 +245,11 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: true,
       hasAllowedEmailDomains: false,
       allowedEmailDomains: ['@example.com'],
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -264,10 +257,10 @@ describe('Email field validation', () => {
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
       signature: 'some signature',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -280,23 +273,21 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       isVisible: true,
       answer: 'volunteer-testing@test.gov.sg',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isOk()).toBe(true)
@@ -309,23 +300,21 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       isVisible: false,
       answer: 'volunteer-testing@test.gov.sg',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as unknown as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isErr()).toBe(true)
@@ -340,21 +329,19 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: true,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
       question: 'random',
       answer: 'valid@email.com',
       isVisible: true,
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isErr()).toBe(true)
@@ -376,11 +363,9 @@ describe('Email field validation', () => {
       fieldType: BasicField.Email,
       globalId: 'random',
       title: 'random',
-      description: 'random',
       required: true,
-      disabled: false,
       isVerifiable: true,
-    }
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -388,10 +373,10 @@ describe('Email field validation', () => {
       answer: 'valid@email.com',
       isVisible: true,
       signature: 'some signature',
-    } as ISingleAnswerResponse
+    } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
-      formField as IFieldSchema,
+      formField,
       response as ProcessedFieldResponse,
     )
     expect(validateResult.isErr()).toBe(true)

--- a/src/public/services/BetaService.ts
+++ b/src/public/services/BetaService.ts
@@ -4,7 +4,7 @@ import { get } from 'lodash'
 // Given that this is used mostly by JavaScript modules, the lack of
 // mongo-specific types should not present a problem.
 // Change the types to frontend equivalents as and when available.
-import { AuthType, BasicField, IForm, IUser } from '../../types'
+import { BasicField, FormAuthType, IForm, IUser } from '../../types'
 
 type BetaFeature = {
   // User-facing name for the feature
@@ -37,7 +37,7 @@ const BETA_FEATURES: BetaFeature[] = [
   {
     name: 'SGID',
     flag: 'sgid',
-    matches: (form) => form.authType === AuthType.SGID,
+    matches: (form) => form.authType === FormAuthType.SGID,
     // SGID is associated with entire form, not individual field
     fieldType: null,
   },

--- a/src/public/services/__tests__/AdminSubmissionsService.test.ts
+++ b/src/public/services/__tests__/AdminSubmissionsService.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import JSZip from 'jszip'
 import { mocked } from 'ts-jest/utils'
 
-import { SubmissionMetadataList } from 'src/types'
+import { StorageModeSubmissionMetadataList } from 'src/types'
 
 import { DateString } from '../../../../shared/types/generic'
 import { SubmissionId } from '../../../../shared/types/submission'
@@ -70,7 +70,7 @@ describe('AdminSubmissionsService', () => {
   describe('getSubmissionsMetadataByPage', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_PAGE_NUM = 1
-    const MOCK_RESPONSE: SubmissionMetadataList = {
+    const MOCK_RESPONSE: StorageModeSubmissionMetadataList = {
       count: 1,
       metadata: [
         {
@@ -107,7 +107,7 @@ describe('AdminSubmissionsService', () => {
   describe('getSubmissionMetadataById', () => {
     const MOCK_FORM_ID = 'mock–form-id'
     const MOCK_SUBMISSION_ID = 'fake'
-    const MOCK_RESPONSE: SubmissionMetadataList = {
+    const MOCK_RESPONSE: StorageModeSubmissionMetadataList = {
       count: 1,
       metadata: [
         {

--- a/src/public/services/__tests__/AdminViewFormService.test.ts
+++ b/src/public/services/__tests__/AdminViewFormService.test.ts
@@ -1,6 +1,6 @@
 import MockAxios from 'jest-mock-axios'
 
-import { IPopulatedForm, PublicForm, ResponseMode } from 'src/types/form'
+import { FormResponseMode, IPopulatedForm, PublicForm } from 'src/types/form'
 
 import {
   AdminDashboardFormMetaDto,
@@ -30,7 +30,7 @@ describe('AdminViewFormService', () => {
           title: 'title',
           lastModified: new Date(),
           _id: 'mock-form-id',
-          responseMode: ResponseMode.Email,
+          responseMode: FormResponseMode.Email,
           admin: MOCK_USER,
           status: FormStatus.Private,
         },

--- a/src/public/services/__tests__/CreateFormService.test.ts
+++ b/src/public/services/__tests__/CreateFormService.test.ts
@@ -7,7 +7,7 @@ import {
   DuplicateFormBodyDto,
 } from '../../../../shared/types/form/form'
 import { IPopulatedUser, IYesNoFieldSchema } from '../../../types'
-import { ResponseMode } from '../../../types/form'
+import { FormResponseMode } from '../../../types/form'
 import {
   ADMIN_FORM_ENDPOINT,
   createForm,
@@ -29,7 +29,7 @@ describe('CreateFormService', () => {
         title: 'title',
         lastModified: new Date(),
         _id: new ObjectId().toHexString(),
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         admin: MOCK_USER,
       }
       const MOCK_FORM_ID = expected._id
@@ -75,7 +75,7 @@ describe('CreateFormService', () => {
       const expected = { form_fields: [{} as IYesNoFieldSchema] }
       const mockFormParams: CreateStorageFormBodyDto = {
         title: 'title',
-        responseMode: ResponseMode.Encrypt,
+        responseMode: FormResponseMode.Encrypt,
         publicKey: 'test',
       }
       MockAxios.post.mockResolvedValueOnce({ data: expected })
@@ -95,7 +95,7 @@ describe('CreateFormService', () => {
       const expected = new Error('error')
       const mockFormParams: CreateEmailFormBodyDto = {
         title: 'title',
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         emails: ['mock'],
       }
       MockAxios.post.mockRejectedValueOnce(expected)
@@ -114,7 +114,7 @@ describe('CreateFormService', () => {
 const _generateDuplicateFormBody = (): DuplicateFormBodyDto => {
   return {
     title: 'title',
-    responseMode: ResponseMode.Email,
+    responseMode: FormResponseMode.Email,
     emails: 'test@example.com',
   } as DuplicateFormBodyDto
 }

--- a/src/public/services/__tests__/ExamplesService.test.ts
+++ b/src/public/services/__tests__/ExamplesService.test.ts
@@ -1,6 +1,6 @@
 import MockAxios from 'jest-mock-axios'
 
-import { IPopulatedUser, PublicForm, ResponseMode } from '../../../types'
+import { FormResponseMode, IPopulatedUser, PublicForm } from '../../../types'
 import { DuplicateFormBody } from '../../../types/api'
 import * as ExamplesService from '../ExamplesService'
 
@@ -102,7 +102,7 @@ describe('ExamplesService', () => {
         title: 'title',
         lastModified: new Date(),
         _id: MOCK_FORM_ID,
-        responseMode: ResponseMode.Email,
+        responseMode: FormResponseMode.Email,
         admin: MOCK_USER,
       }
       const MOCK_DUPLICATE_FORM_BODY = _generateDuplicateFormBody()
@@ -190,7 +190,7 @@ describe('ExamplesService', () => {
 const _generateDuplicateFormBody = (): DuplicateFormBody => {
   return {
     title: 'title',
-    responseMode: ResponseMode.Email,
+    responseMode: FormResponseMode.Email,
     emails: 'test@example.com',
   } as DuplicateFormBody
 }

--- a/src/public/services/__tests__/PublicFormAuthService.test.ts
+++ b/src/public/services/__tests__/PublicFormAuthService.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { ObjectId } from 'bson'
 import { mocked } from 'ts-jest/utils'
 
-import { AuthType } from '../../../types'
+import { FormAuthType } from '../../../types'
 import * as PublicFormAuthService from '../PublicFormAuthService'
 
 jest.mock('axios')
@@ -105,7 +105,7 @@ describe('PublicFormAuthService', () => {
 
   describe('logoutOfSpcpSession', () => {
     it('should call logout endpoint successfully', async () => {
-      const authType = AuthType.SP
+      const authType = FormAuthType.SP
 
       const mockData = { message: 'Successfully logged out.' }
       MockAxios.get.mockResolvedValueOnce({ data: mockData })
@@ -119,7 +119,7 @@ describe('PublicFormAuthService', () => {
     })
 
     it('should return error message if logout fails', async () => {
-      const authType = AuthType.NIL
+      const authType = FormAuthType.NIL
 
       const mockData = { message: 'Invalid authType.' }
       MockAxios.get.mockResolvedValueOnce({ data: mockData })

--- a/src/shared/util/__tests__/logic.spec.ts
+++ b/src/shared/util/__tests__/logic.spec.ts
@@ -8,8 +8,8 @@ import {
 } from 'src/shared/util/logic'
 import {
   BasicField,
+  FieldBase,
   FieldResponse,
-  IField,
   IFieldSchema,
   IFormDocument,
   IPreventSubmitLogicSchema,
@@ -1022,15 +1022,15 @@ describe('Logic util', () => {
 
   describe('getApplicableIfFields', () => {
     it('should not filter fields suitable as an if-conditional', () => {
-      const validIfFields: IField[] = VALID_IF_CONDITION_FIELDS.map(
-        (fieldType) => ({ fieldType } as unknown as IField),
+      const validIfFields: FieldBase[] = VALID_IF_CONDITION_FIELDS.map(
+        (fieldType) => ({ fieldType } as unknown as FieldBase),
       )
       const fields = getApplicableIfFields(validIfFields)
       validIfFields.forEach((v, i) => expect(v).toStrictEqual(fields[i]))
     })
     it('should filter fields not suitable as an if-conditional', () => {
-      const invalidIfFields: IField[] = INVALID_IF_CONDITION_FIELDS.map(
-        (x) => x as unknown as IField,
+      const invalidIfFields: FieldBase[] = INVALID_IF_CONDITION_FIELDS.map(
+        (x) => x as unknown as FieldBase,
       )
       const fields = getApplicableIfFields(invalidIfFields)
       expect(fields).toStrictEqual([])

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -1,10 +1,10 @@
 // TODO: Import shared code from shared/logic.ts when possible.
 import {
   BasicField,
+  FieldBase,
   FieldResponse,
   IClientFieldSchema,
   IConditionSchema,
-  IField,
   IFormDocument,
   ILogicSchema,
   IPreventSubmitLogicSchema,
@@ -55,7 +55,7 @@ export const LOGIC_MAP = new Map<BasicField, LogicConditionState[]>(
  * Given a list of form fields, returns only the fields that are
  * allowed to be present in the if-condition dropdown in the Logic tab.
  */
-export const getApplicableIfFields = (formFields: IField[]): IField[] =>
+export const getApplicableIfFields = (formFields: FieldBase[]): FieldBase[] =>
   formFields.filter((field) => !!LOGIC_MAP.get(field.fieldType))
 
 /**

--- a/src/types/agency.ts
+++ b/src/types/agency.ts
@@ -4,9 +4,9 @@ import { AgencyBase, PublicAgencyDto } from '../../shared/types/agency'
 
 import { PublicView } from './database'
 
-export type PublicAgency = PublicAgencyDto
+export { PublicAgencyDto }
 
-export type AgencyInstanceMethods = PublicView<PublicAgency>
+export type AgencyInstanceMethods = PublicView<PublicAgencyDto>
 
 export interface IAgencySchema extends AgencyBase {
   _id: any

--- a/src/types/field/attachmentField.ts
+++ b/src/types/field/attachmentField.ts
@@ -6,9 +6,9 @@ import {
 
 import { IFieldSchema } from './baseField'
 
-export { AttachmentSize }
-
-export type IAttachmentField = AttachmentFieldBase
-export interface IAttachmentFieldSchema extends IAttachmentField, IFieldSchema {
+export { AttachmentSize, AttachmentFieldBase }
+export interface IAttachmentFieldSchema
+  extends AttachmentFieldBase,
+    IFieldSchema {
   fieldType: BasicField.Attachment
 }

--- a/src/types/field/baseField.ts
+++ b/src/types/field/baseField.ts
@@ -11,8 +11,6 @@ export interface IMyInfoSchema extends IMyInfo, Document {
   parent(): IFieldSchema
 }
 
-export type IField = FieldBase
-
 // Manual override since mongoose types don't have generics yet.
 export interface IFieldSchema extends AllowMyInfoBase, FieldBase, Document {
   /** Returns the top level document of this sub-document. */

--- a/src/types/field/checkboxField.ts
+++ b/src/types/field/checkboxField.ts
@@ -2,8 +2,8 @@ import { BasicField, CheckboxFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type ICheckboxField = CheckboxFieldBase
+export { CheckboxFieldBase }
 
-export interface ICheckboxFieldSchema extends ICheckboxField, IFieldSchema {
+export interface ICheckboxFieldSchema extends CheckboxFieldBase, IFieldSchema {
   fieldType: BasicField.Checkbox
 }

--- a/src/types/field/dateField.ts
+++ b/src/types/field/dateField.ts
@@ -4,7 +4,7 @@ import { IFieldSchema } from './baseField'
 
 export { DateSelectedValidation } from '../../../shared/types/field'
 
-export type IDateField = DateFieldBase
+export { DateFieldBase }
 
 export interface IDateFieldSchema extends DateFieldBase, IFieldSchema {
   fieldType: BasicField.Date

--- a/src/types/field/decimalField.ts
+++ b/src/types/field/decimalField.ts
@@ -2,8 +2,8 @@ import { BasicField, DecimalFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IDecimalField = DecimalFieldBase
+export { DecimalFieldBase }
 
-export interface IDecimalFieldSchema extends IDecimalField, IFieldSchema {
+export interface IDecimalFieldSchema extends DecimalFieldBase, IFieldSchema {
   fieldType: BasicField.Decimal
 }

--- a/src/types/field/dropdownField.ts
+++ b/src/types/field/dropdownField.ts
@@ -2,8 +2,8 @@ import { BasicField, DropdownFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IDropdownField = DropdownFieldBase
+export { DropdownFieldBase }
 
-export interface IDropdownFieldSchema extends IDropdownField, IFieldSchema {
+export interface IDropdownFieldSchema extends DropdownFieldBase, IFieldSchema {
   fieldType: BasicField.Dropdown
 }

--- a/src/types/field/emailField.ts
+++ b/src/types/field/emailField.ts
@@ -8,8 +8,8 @@ import { IFieldSchema } from './baseField'
 
 export { AutoReplyOptions }
 
-export type IEmailField = EmailFieldBase
-export interface IEmailFieldSchema extends IEmailField, IFieldSchema {
+export { EmailFieldBase }
+export interface IEmailFieldSchema extends EmailFieldBase, IFieldSchema {
   fieldType: BasicField.Email
   isVerifiable: boolean
 }

--- a/src/types/field/homeNoField.ts
+++ b/src/types/field/homeNoField.ts
@@ -2,8 +2,8 @@ import { BasicField, HomenoFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IHomenoField = HomenoFieldBase
+export { HomenoFieldBase }
 
-export interface IHomenoFieldSchema extends IHomenoField, IFieldSchema {
+export interface IHomenoFieldSchema extends HomenoFieldBase, IFieldSchema {
   fieldType: BasicField.HomeNo
 }

--- a/src/types/field/imageField.ts
+++ b/src/types/field/imageField.ts
@@ -2,8 +2,8 @@ import { BasicField, ImageFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IImageField = ImageFieldBase
+export { ImageFieldBase }
 
-export interface IImageFieldSchema extends IImageField, IFieldSchema {
+export interface IImageFieldSchema extends ImageFieldBase, IFieldSchema {
   fieldType: BasicField.Image
 }

--- a/src/types/field/index.ts
+++ b/src/types/field/index.ts
@@ -3,6 +3,7 @@ import { ConditionalExcept, Merge } from 'type-fest'
 
 import {
   BasicField,
+  FieldBase,
   FormField,
   FormFieldDto,
   MyInfoAttribute,
@@ -52,7 +53,7 @@ export * from './statementField'
 export * from './tableField'
 export * from './uenField'
 export * from './yesNoField'
-export { BasicField, MyInfoAttribute, FormField }
+export { BasicField, MyInfoAttribute, FormField, FieldBase }
 
 export enum SPCPFieldTitle {
   SpNric = 'SingPass Validated NRIC',

--- a/src/types/field/longTextField.ts
+++ b/src/types/field/longTextField.ts
@@ -2,8 +2,8 @@ import { BasicField, LongTextFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type ILongTextField = LongTextFieldBase
+export { LongTextFieldBase }
 
-export interface ILongTextFieldSchema extends ILongTextField, IFieldSchema {
+export interface ILongTextFieldSchema extends LongTextFieldBase, IFieldSchema {
   fieldType: BasicField.LongText
 }

--- a/src/types/field/mobileField.ts
+++ b/src/types/field/mobileField.ts
@@ -2,9 +2,9 @@ import { BasicField, MobileFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IMobileField = MobileFieldBase
+export { MobileFieldBase }
 
-export interface IMobileFieldSchema extends IMobileField, IFieldSchema {
+export interface IMobileFieldSchema extends MobileFieldBase, IFieldSchema {
   fieldType: BasicField.Mobile
   isVerifiable: boolean
 }

--- a/src/types/field/myinfoField.ts
+++ b/src/types/field/myinfoField.ts
@@ -2,6 +2,6 @@ import { LeanDocument } from 'mongoose'
 
 import { FormFieldSchema } from '../field'
 
-export type IPossiblyPrefilledField = LeanDocument<FormFieldSchema> & {
+export type PossiblyPrefilledField = LeanDocument<FormFieldSchema> & {
   fieldValue?: string
 }

--- a/src/types/field/nricField.ts
+++ b/src/types/field/nricField.ts
@@ -2,8 +2,8 @@ import { BasicField, NricFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type INricField = NricFieldBase
+export { NricFieldBase }
 
-export interface INricFieldSchema extends INricField, IFieldSchema {
+export interface INricFieldSchema extends NricFieldBase, IFieldSchema {
   fieldType: BasicField.Nric
 }

--- a/src/types/field/numberField.ts
+++ b/src/types/field/numberField.ts
@@ -7,9 +7,8 @@ import {
 
 import { IFieldSchema } from './baseField'
 
-export { NumberValidationOptions, NumberSelectedValidation }
+export { NumberValidationOptions, NumberSelectedValidation, NumberFieldBase }
 
-export type INumberField = NumberFieldBase
-export interface INumberFieldSchema extends INumberField, IFieldSchema {
+export interface INumberFieldSchema extends NumberFieldBase, IFieldSchema {
   fieldType: BasicField.Number
 }

--- a/src/types/field/radioField.ts
+++ b/src/types/field/radioField.ts
@@ -2,7 +2,7 @@ import { BasicField, RadioFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IRadioField = RadioFieldBase
-export interface IRadioFieldSchema extends IRadioField, IFieldSchema {
+export { RadioFieldBase }
+export interface IRadioFieldSchema extends RadioFieldBase, IFieldSchema {
   fieldType: BasicField.Radio
 }

--- a/src/types/field/ratingField.ts
+++ b/src/types/field/ratingField.ts
@@ -6,9 +6,7 @@ import {
 
 import { IFieldSchema } from './baseField'
 
-export { RatingShape }
-
-export type IRatingField = RatingFieldBase
-export interface IRatingFieldSchema extends IRatingField, IFieldSchema {
+export { RatingFieldBase, RatingShape }
+export interface IRatingFieldSchema extends RatingFieldBase, IFieldSchema {
   fieldType: BasicField.Rating
 }

--- a/src/types/field/sectionField.ts
+++ b/src/types/field/sectionField.ts
@@ -2,7 +2,7 @@ import { BasicField, SectionFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type ISectionField = SectionFieldBase
-export interface ISectionFieldSchema extends ISectionField, IFieldSchema {
+export { SectionFieldBase }
+export interface ISectionFieldSchema extends SectionFieldBase, IFieldSchema {
   fieldType: BasicField.Section
 }

--- a/src/types/field/shortTextField.ts
+++ b/src/types/field/shortTextField.ts
@@ -2,7 +2,9 @@ import { BasicField, ShortTextFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IShortTextField = ShortTextFieldBase
-export interface IShortTextFieldSchema extends IShortTextField, IFieldSchema {
+export { ShortTextFieldBase }
+export interface IShortTextFieldSchema
+  extends ShortTextFieldBase,
+    IFieldSchema {
   fieldType: BasicField.ShortText
 }

--- a/src/types/field/statementField.ts
+++ b/src/types/field/statementField.ts
@@ -2,7 +2,9 @@ import { BasicField, StatementFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IStatementField = StatementFieldBase
-export interface IStatementFieldSchema extends IStatementField, IFieldSchema {
+export { StatementFieldBase }
+export interface IStatementFieldSchema
+  extends StatementFieldBase,
+    IFieldSchema {
   fieldType: BasicField.Statement
 }

--- a/src/types/field/tableField.ts
+++ b/src/types/field/tableField.ts
@@ -5,7 +5,7 @@ import { IFormSchema } from '../form'
 
 import { IFieldSchema } from './baseField'
 
-export type IColumn = Column
+export { Column, TableFieldBase }
 
 export type IColumnSchema = Column &
   Document & {

--- a/src/types/field/uenField.ts
+++ b/src/types/field/uenField.ts
@@ -2,8 +2,8 @@ import { BasicField, UenFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IUenField = UenFieldBase
+export { UenFieldBase }
 
-export interface IUenFieldSchema extends IUenField, IFieldSchema {
+export interface IUenFieldSchema extends UenFieldBase, IFieldSchema {
   fieldType: BasicField.Uen
 }

--- a/src/types/field/yesNoField.ts
+++ b/src/types/field/yesNoField.ts
@@ -2,8 +2,8 @@ import { BasicField, YesNoFieldBase } from '../../../shared/types/field'
 
 import { IFieldSchema } from './baseField'
 
-export type IYesNoField = YesNoFieldBase
+export { YesNoFieldBase }
 
-export interface IYesNoFieldSchema extends IYesNoField, IFieldSchema {
+export interface IYesNoFieldSchema extends YesNoFieldBase, IFieldSchema {
   fieldType: BasicField.YesNo
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -39,14 +39,13 @@ import { FormLogicSchema, LogicDto } from './form_logic'
 import { IPopulatedUser, IUserSchema, PublicUser } from './user'
 
 export {
-  FormAuthType as AuthType,
-  FormColorTheme as ColorTheme,
-  FormEndPage as EndPage,
-  FormStartPage as StartPage,
-  FormStatus as Status,
-  FormColorTheme as Colors,
-  FormResponseMode as ResponseMode,
-  FormWebhook as Webhook,
+  FormAuthType,
+  FormColorTheme,
+  FormEndPage,
+  FormStartPage,
+  FormStatus,
+  FormResponseMode,
+  FormWebhook,
   FormSettings,
   StorageFormSettings,
   EmailFormSettings,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -53,6 +53,7 @@ export {
   PublicFormDto,
   PublicStorageFormDto,
   PublicEmailFormDto,
+  FormPermission,
 }
 
 // Typings
@@ -72,8 +73,6 @@ export type FormOtpData = {
   // Used for sending with the correct twilio
   msgSrvcName?: string
 }
-
-export type Permission = FormPermission
 
 /**
  * Keys with defaults in schema.
@@ -97,7 +96,7 @@ export type IForm = Merge<
   {
     // Loosen types here to allow for IPopulatedForm extension
     admin: any
-    permission?: Permission[]
+    permission?: FormPermission[]
     form_fields?: FormFieldSchema[]
     form_logics?: FormLogicSchema[]
 
@@ -150,7 +149,7 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
 
   updateFormCollaborators<T>(
     this: T,
-    updateFormCollaborators: Permission[],
+    updateFormCollaborators: FormPermission[],
   ): Promise<T>
 
   /**

--- a/src/types/form_logic.ts
+++ b/src/types/form_logic.ts
@@ -13,7 +13,15 @@ import {
 
 import { BasicField, IFieldSchema } from './field'
 
-export { LogicConditionState, LogicIfValue, LogicType, LogicDto }
+export {
+  LogicConditionState,
+  LogicIfValue,
+  LogicType,
+  LogicDto,
+  FormLogicBase,
+  ShowFieldLogic,
+  PreventSubmitLogic,
+}
 
 export interface ICondition extends FormCondition {
   field: IFieldSchema['_id']
@@ -23,25 +31,19 @@ export interface ICondition extends FormCondition {
 // String form.
 export interface IConditionSchema extends ICondition, Document<string> {}
 
-export type ILogic = FormLogicBase
-
-export interface ILogicSchema extends ILogic, Document {
+export interface ILogicSchema extends FormLogicBase, Document {
   conditions: IConditionSchema[]
 }
-
-export type IShowFieldsLogic = ShowFieldLogic
 export interface IShowFieldsLogicSchema
   extends ILogicSchema,
-    IShowFieldsLogic,
+    ShowFieldLogic,
     Document {
   logicType: LogicType.ShowFields
   conditions: IConditionSchema[]
 }
-
-export type IPreventSubmitLogic = PreventSubmitLogic
 export interface IPreventSubmitLogicSchema
   extends ILogicSchema,
-    IPreventSubmitLogic,
+    PreventSubmitLogic,
     Document {
   logicType: LogicType.PreventSubmit
   conditions: IConditionSchema[]

--- a/src/types/form_logo.ts
+++ b/src/types/form_logo.ts
@@ -6,12 +6,7 @@ import {
   FormLogoState,
 } from '../../shared/types/form/form_logo'
 
-export { FormLogoState }
+export { FormLogoState, FormLogoBase, CustomFormLogo }
 
-export type IFormLogo = FormLogoBase
-
-export type IFormLogoSchema = IFormLogo & Document
-
-export type ICustomFormLogo = CustomFormLogo
-
-export type ICustomFormLogoSchema = ICustomFormLogo & Document
+export type IFormLogoSchema = FormLogoBase & Document
+export type ICustomFormLogoSchema = CustomFormLogo & Document

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,6 +1,10 @@
 import { Document, Model } from 'mongoose'
+import { Merge } from 'type-fest'
 
-import { FormBillingStatistic, LoginBase } from '../../shared/types/billing'
+import {
+  FormBillingStatistic as SharedFormBillingStatistic,
+  LoginBase,
+} from '../../shared/types/billing'
 
 import { IAgencySchema } from './agency'
 import { IFormSchema, IPopulatedForm } from './form'
@@ -12,17 +16,20 @@ interface ILogin extends LoginBase {
   agency: IAgencySchema['_id']
 }
 
+export type FormBillingStatistic = Merge<
+  SharedFormBillingStatistic,
+  { formId: ILogin['form'] }
+>
+
 export interface ILoginSchema extends ILogin, Document {
   created?: Date
 }
-
-export type LoginStatistic = FormBillingStatistic
 
 export interface ILoginModel extends Model<ILoginSchema> {
   aggregateLoginStats: (
     esrvcId: string,
     gte: Date,
     lte: Date,
-  ) => Promise<LoginStatistic[]>
+  ) => Promise<FormBillingStatistic[]>
   addLoginFromForm: (form: IPopulatedForm) => Promise<ILoginSchema>
 }

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -14,7 +14,7 @@ export type IAttachmentResponse =
   | ParsedEmailAttachmentResponse
   | EncryptAttachmentResponse
 
-export type ISingleAnswerResponse =
+export type SingleAnswerFieldResponse =
   | Exclude<
       EncryptFormFieldResponse,
       TableResponse | CheckboxResponse | IAttachmentResponse
@@ -24,9 +24,7 @@ export type ISingleAnswerResponse =
       TableResponse | CheckboxResponse | IAttachmentResponse
     >
 
-export type ICheckboxResponse = CheckboxResponse
-export type ITableResponse = TableResponse
-export type ITableRow = TableRow
+export { CheckboxResponse, TableResponse, TableRow }
 
 export type FieldResponse =
   | EncryptFormFieldResponse

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -13,11 +13,13 @@ import {
 
 import { IFormSchema } from './form'
 
-export { SubmissionType }
-
-export type EncryptedSubmissionDto = StorageModeSubmissionDto
-export type SubmissionMetadata = StorageModeSubmissionMetadata
-export type SubmissionMetadataList = StorageModeSubmissionMetadataList
+export {
+  SubmissionType,
+  StorageModeSubmissionDto,
+  StorageModeSubmissionMetadata,
+  StorageModeSubmissionMetadataList,
+  WebhookResponse,
+}
 
 export interface WebhookData {
   formId: string
@@ -81,8 +83,6 @@ export interface IEncryptedSubmissionSchema
   getWebhookView(): WebhookView
 }
 
-export type IWebhookResponse = WebhookResponse
-
 // When retrieving from database, the attachmentMetadata type becomes an object
 // instead of a Map.
 // Due to schema changes, some objects may not have attachmentMetadata key.
@@ -115,7 +115,7 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
     findSingleMetadata(
       formId: string,
       submissionId: string,
-    ): Promise<SubmissionMetadata | null>
+    ): Promise<StorageModeSubmissionMetadata | null>
 
     /**
      * Returns all submission metadata of the form for the given formId. The
@@ -130,7 +130,7 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       formId: string,
       params?: { page?: number; pageSize?: number },
     ): Promise<{
-      metadata: SubmissionMetadata[]
+      metadata: StorageModeSubmissionMetadata[]
       count: number
     }>
 
@@ -162,7 +162,7 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
      */
     addWebhookResponse(
       submissionId: string,
-      webhookResponse: IWebhookResponse,
+      webhookResponse: WebhookResponse,
     ): Promise<IEncryptedSubmissionSchema | null>
 
     /**
@@ -175,4 +175,4 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
     ): Promise<SubmissionWebhookInfo | null>
   }
 
-export interface IWebhookResponseSchema extends IWebhookResponse, Document {}
+export interface IWebhookResponseSchema extends WebhookResponse, Document {}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,11 +4,11 @@ import { SetOptional } from 'type-fest'
 
 import { UserBase } from '../../shared/types/user'
 
-import { AgencyDocument, IAgencySchema, PublicAgency } from './agency'
+import { AgencyDocument, IAgencySchema, PublicAgencyDto } from './agency'
 import { PublicView } from './database'
 
 export type PublicUser = {
-  agency: PublicAgency | ObjectId
+  agency: PublicAgencyDto | ObjectId
 }
 
 export type AdminContactOtpData = {

--- a/tests/unit/backend/helpers/generate-email-data.ts
+++ b/tests/unit/backend/helpers/generate-email-data.ts
@@ -1,11 +1,11 @@
 import { pick } from 'lodash'
 
+import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
 import {
   EmailAdminDataField,
   EmailDataCollationToolField,
   EmailRespondentConfirmationField,
-} from 'src/app/modules/submission/email-submission/email-submission.types'
-import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
+} from 'src/types'
 
 export const generateSingleAnswerJson = (
   response: ProcessedSingleAnswerResponse,

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -1,6 +1,7 @@
 /* eslint-disable typesafe/no-throw-sync-func */
 import { ObjectId } from 'bson'
 import { pick } from 'lodash'
+import { TableRow } from 'shared/types/response'
 
 import {
   ProcessedAttachmentResponse,
@@ -11,24 +12,24 @@ import {
 import {
   AttachmentSize,
   BasicField,
+  Column,
+  DropdownFieldBase,
   FormField,
   FormFieldSchema,
   IAttachmentFieldSchema,
   IAttachmentResponse,
   ICheckboxFieldSchema,
   ICheckboxResponse,
-  IColumn,
   IDecimalFieldSchema,
-  IDropdownField,
   IDropdownFieldSchema,
   IHomenoFieldSchema,
   IImageFieldSchema,
   IMobileFieldSchema,
   IRatingFieldSchema,
-  IShortTextField,
   IShortTextFieldSchema,
   ISingleAnswerResponse,
   ITableFieldSchema,
+  ShortTextFieldBase,
 } from 'src/types'
 
 export const generateDefaultField = (
@@ -191,11 +192,8 @@ export const generateSingleAnswerResponse = (
   return {
     _id: field._id,
     answer,
-    fieldType: field.fieldType as Exclude<
-      BasicField,
-      BasicField.Table | BasicField.Checkbox | BasicField.Attachment
-    >,
-  }
+    fieldType: field.fieldType,
+  } as ISingleAnswerResponse
 }
 
 export const generateNewSingleAnswerResponse = (
@@ -215,13 +213,10 @@ export const generateNewSingleAnswerResponse = (
     _id: new ObjectId().toHexString(),
     question: `${fieldType} question`,
     answer: `${fieldType} answer`,
-    fieldType: fieldType as Exclude<
-      BasicField,
-      BasicField.Table | BasicField.Checkbox | BasicField.Attachment
-    >,
+    fieldType: fieldType,
     isVisible: true,
     ...customParams,
-  }
+  } as ProcessedSingleAnswerResponse
 }
 
 export const generateUnprocessedSingleAnswerResponse = (
@@ -233,7 +228,7 @@ export const generateUnprocessedSingleAnswerResponse = (
     'question',
     'fieldType',
     'answer',
-  ])
+  ]) as ISingleAnswerResponse
 }
 
 export const generateAttachmentResponse = (
@@ -241,6 +236,7 @@ export const generateAttachmentResponse = (
   filename = 'filename',
   content = Buffer.from('content'),
 ): IAttachmentResponse => ({
+  question: 'question',
   _id: field._id,
   answer: 'answer',
   fieldType: BasicField.Attachment,
@@ -265,6 +261,7 @@ export const generateCheckboxResponse = (
   field: ICheckboxFieldSchema,
   answerArray?: string[],
 ): ICheckboxResponse => ({
+  question: 'question',
   _id: field._id,
   answerArray: answerArray ?? [field.fieldOptions[0]],
   fieldType: BasicField.Checkbox,
@@ -283,7 +280,7 @@ export const generateNewCheckboxResponse = (
 
 export const generateTableResponse = (
   field: ITableFieldSchema,
-  answerArray?: string[][],
+  answerArray?: TableRow[],
 ): ProcessedTableResponse => {
   if (!answerArray) {
     const rowAnswer: string[] = []
@@ -293,7 +290,7 @@ export const generateTableResponse = (
           rowAnswer.push('answer')
           break
         case BasicField.Dropdown:
-          rowAnswer.push((col as unknown as IDropdownField).fieldOptions[0])
+          rowAnswer.push(col.fieldOptions[0])
       }
     })
     answerArray = Array(field.minimumRows).fill(rowAnswer)
@@ -315,15 +312,15 @@ export const generateNewTableResponse = (
   answerArray: [
     ['Table 1', 'Table 2'],
     ['Table 3', 'Table 4'],
-  ],
+  ] as TableRow[],
   fieldType: BasicField.Table,
   isVisible: true,
   ...customParams,
 })
 
 export const generateTableDropdownColumn = (
-  customParams?: Partial<IDropdownField>,
-): IColumn => {
+  customParams?: Partial<DropdownFieldBase>,
+): Column => {
   return {
     title: 'some title',
     columnType: BasicField.Dropdown,
@@ -342,12 +339,12 @@ export const generateTableDropdownColumn = (
         ...customParams,
       }
     },
-  } as IColumn
+  } as Column
 }
 
 export const generateTableShortTextColumn = (
-  customParams?: Partial<IShortTextField>,
-): IColumn => {
+  customParams?: Partial<ShortTextFieldBase>,
+): Column => {
   return {
     title: 'some title',
     columnType: BasicField.ShortText,
@@ -372,5 +369,5 @@ export const generateTableShortTextColumn = (
         ...customParams,
       }
     },
-  } as IColumn
+  } as Column
 }

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -12,6 +12,7 @@ import {
 import {
   AttachmentSize,
   BasicField,
+  CheckboxResponse,
   Column,
   DropdownFieldBase,
   FormField,
@@ -19,7 +20,6 @@ import {
   IAttachmentFieldSchema,
   IAttachmentResponse,
   ICheckboxFieldSchema,
-  ICheckboxResponse,
   IDecimalFieldSchema,
   IDropdownFieldSchema,
   IHomenoFieldSchema,
@@ -27,9 +27,9 @@ import {
   IMobileFieldSchema,
   IRatingFieldSchema,
   IShortTextFieldSchema,
-  ISingleAnswerResponse,
   ITableFieldSchema,
   ShortTextFieldBase,
+  SingleAnswerFieldResponse,
 } from 'src/types'
 
 export const generateDefaultField = (
@@ -179,7 +179,7 @@ export const generateProcessedSingleAnswerResponse = (
 export const generateSingleAnswerResponse = (
   field: FormFieldSchema,
   answer = field.fieldType === BasicField.Section ? '' : 'answer',
-): ISingleAnswerResponse => {
+): SingleAnswerFieldResponse => {
   if (
     [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
       field.fieldType,
@@ -193,7 +193,7 @@ export const generateSingleAnswerResponse = (
     _id: field._id,
     answer,
     fieldType: field.fieldType,
-  } as ISingleAnswerResponse
+  } as SingleAnswerFieldResponse
 }
 
 export const generateNewSingleAnswerResponse = (
@@ -221,14 +221,14 @@ export const generateNewSingleAnswerResponse = (
 
 export const generateUnprocessedSingleAnswerResponse = (
   fieldType: BasicField,
-  customParams?: Partial<ISingleAnswerResponse>,
-): ISingleAnswerResponse => {
+  customParams?: Partial<SingleAnswerFieldResponse>,
+): SingleAnswerFieldResponse => {
   return pick(generateNewSingleAnswerResponse(fieldType, customParams), [
     '_id',
     'question',
     'fieldType',
     'answer',
-  ]) as ISingleAnswerResponse
+  ]) as SingleAnswerFieldResponse
 }
 
 export const generateAttachmentResponse = (
@@ -260,7 +260,7 @@ export const generateNewAttachmentResponse = (
 export const generateCheckboxResponse = (
   field: ICheckboxFieldSchema,
   answerArray?: string[],
-): ICheckboxResponse => ({
+): CheckboxResponse => ({
   question: 'question',
   _id: field._id,
   answerArray: answerArray ?? [field.fieldOptions[0]],

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -11,48 +11,29 @@ import {
 import {
   AttachmentSize,
   BasicField,
+  FormField,
   FormFieldSchema,
-  IAttachmentField,
   IAttachmentFieldSchema,
   IAttachmentResponse,
-  ICheckboxField,
   ICheckboxFieldSchema,
   ICheckboxResponse,
   IColumn,
-  IDateField,
   IDecimalFieldSchema,
   IDropdownField,
   IDropdownFieldSchema,
-  IField,
   IHomenoFieldSchema,
   IImageFieldSchema,
-  ILongTextField,
-  IMobileField,
   IMobileFieldSchema,
-  INumberField,
-  IRatingField,
   IRatingFieldSchema,
   IShortTextField,
   IShortTextFieldSchema,
   ISingleAnswerResponse,
-  ITableField,
   ITableFieldSchema,
 } from 'src/types'
 
 export const generateDefaultField = (
   fieldType: BasicField,
-  customParams?: Partial<
-    | IField
-    | IAttachmentField
-    | ICheckboxField
-    | IMobileField
-    | ITableField
-    | IDateField
-    | INumberField
-    | IRatingField
-    | IShortTextField
-    | ILongTextField
-  > & { _id?: string },
+  customParams?: Partial<FormField> & { _id?: string },
 ): FormFieldSchema => {
   const defaultParams = {
     title: `test ${fieldType} field title`,
@@ -189,12 +170,9 @@ export const generateProcessedSingleAnswerResponse = (
     _id: field._id,
     question: field.title,
     answer,
-    fieldType: field.fieldType as Exclude<
-      BasicField,
-      BasicField.Table | BasicField.Checkbox | BasicField.Attachment
-    >,
+    fieldType: field.fieldType,
     isVisible: true,
-  }
+  } as ProcessedSingleAnswerResponse
 }
 
 export const generateSingleAnswerResponse = (

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -8,6 +8,7 @@ import {
 } from 'src/app/models/form.server.model'
 import getUserModel from 'src/app/models/user.server.model'
 import {
+  FormResponseMode,
   IAgencySchema,
   IEmailForm,
   IEmailFormSchema,
@@ -15,7 +16,6 @@ import {
   IEncryptedFormSchema,
   IPopulatedForm,
   IUserSchema,
-  ResponseMode,
 } from 'src/types'
 
 import MemoryDatabaseServer from 'tests/database'
@@ -160,7 +160,7 @@ const insertEmailForm = async ({
   const form = await EmailFormModel.create({
     title: 'example form title',
     admin: user._id,
-    responseMode: ResponseMode.Email,
+    responseMode: FormResponseMode.Email,
     emails: [user.email],
     _id: formId,
     ...formOptions,
@@ -204,7 +204,7 @@ const insertEncryptForm = async ({
   const form = await EncryptFormModel.create({
     title: 'example form title',
     admin: user._id,
-    responseMode: ResponseMode.Encrypt,
+    responseMode: FormResponseMode.Encrypt,
     _id: formId,
     publicKey: 'vuUYOfkrC7eiyqZ1OCZhMcjAvMQ7R4Z4zzDWB+og4G4=',
     ...formOptions,

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -124,7 +124,7 @@ const insertFormCollectionReqs = async ({
   const user = await User.create({
     email: `${mailName}@${mailDomain}`,
     _id: userId ?? new ObjectID(),
-    agency: agency.id,
+    agency: agency._id,
   })
 
   return { agency, user }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Final PR????
Remove all aliases, reexport as same names as they are imported from the root shared folder.

Closes #2066 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible 
  - Type refactoring in the backend

**Improvements**:

- Remove all aliased types in the backend. Re-export as is from shared folder
