### PR TITLE
feat(sms-limiting): disabled email

### DIFF
--- a/shared/utils/verification.ts
+++ b/shared/utils/verification.ts
@@ -33,3 +33,11 @@ export enum SMS_WARNING_TIERS {
   MED = 5000,
   HIGH = 7500,
 }
+
+export const stringifiedSmsWarningTiers: {
+  [K in keyof typeof SMS_WARNING_TIERS]: string
+} = {
+  LOW: '2.5k',
+  MED: '5K',
+  HIGH: '7.5K',
+}

--- a/shared/utils/verification.ts
+++ b/shared/utils/verification.ts
@@ -37,7 +37,7 @@ export enum SMS_WARNING_TIERS {
 export const stringifiedSmsWarningTiers: {
   [K in keyof typeof SMS_WARNING_TIERS]: string
 } = {
-  LOW: '2.5k',
+  LOW: '2.5K',
   MED: '5K',
   HIGH: '7.5K',
 }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1929,17 +1929,21 @@ describe('Form Model', () => {
     })
 
     describe('retrievePublicFormsWithSmsVerification', () => {
-      it('should retrieve only forms that are public and with verifiable mobile fields', async () => {
+      const MOCK_MSG_SRVC_NAME = 'mockTwilioName'
+      it('should retrieve only public forms with verifiable mobile fields that are not onboarded', async () => {
         // Arrange
-        const mockFormPromises = range(4).map((_, idx) => {
+        const mockFormPromises = range(8).map((_, idx) => {
+          // Extract bits and use them to represent state
           const isPublic = !!(idx % 2)
-          const isVerifiable = idx > 1
+          const isVerifiable = !!((idx >> 1) % 2)
+          const isOnboarded = !!((idx >> 2) % 2)
           return Form.create({
             admin: populatedAdmin._id,
             responseMode: ResponseMode.Email,
             title: 'mock mobile form',
             emails: [populatedAdmin.email],
             status: isPublic ? Status.Public : Status.Private,
+            ...(isOnboarded && { msgSrvcName: MOCK_MSG_SRVC_NAME }),
             form_fields: [
               generateDefaultField(BasicField.Mobile, { isVerifiable }),
             ],
@@ -1956,6 +1960,7 @@ describe('Form Model', () => {
         expect(forms.length).toBe(1)
         expect(forms[0].form_fields[0].isVerifiable).toBe(true)
         expect(forms[0].status).toBe(Status.Public)
+        expect(forms[0].msgSrvcName).toBeUndefined()
       })
 
       it('should return an empty array when there are no forms', async () => {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -828,6 +828,22 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     ).exec()
   }
 
+  /**
+   * Retrieves all the public forms for a user which has sms verifications enabled
+   * @param userId The userId to retrieve the forms for
+   * @returns All public forms that have sms verifications enabled
+   */
+  FormSchema.statics.retrievePublicFormsWithSmsVerification = async function (
+    userId: IUserSchema['_id'],
+  ) {
+    return this.find({
+      admin: userId,
+      'form_fields.fieldType': BasicField.Mobile,
+      'form_fields.isVerifiable': true,
+      status: Status.Public,
+    }).exec()
+  }
+
   // Hooks
   FormSchema.pre<IFormSchema>('validate', function (next) {
     // Reject save if form document is too large

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -830,6 +830,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   /**
    * Retrieves all the public forms for a user which has sms verifications enabled
+   * This only retrieves forms that are using FormSG credentials
    * @param userId The userId to retrieve the forms for
    * @returns All public forms that have sms verifications enabled
    */
@@ -841,6 +842,9 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       'form_fields.fieldType': BasicField.Mobile,
       'form_fields.isVerifiable': true,
       status: Status.Public,
+      msgSrvcName: {
+        $exists: false,
+      },
     })
       .read('secondary')
       .exec()

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -841,7 +841,9 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       'form_fields.fieldType': BasicField.Mobile,
       'form_fields.isVerifiable': true,
       status: Status.Public,
-    }).exec()
+    })
+      .read('secondary')
+      .exec()
   }
 
   // Hooks

--- a/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/src/app/modules/form/__tests__/form.service.spec.ts
@@ -459,4 +459,42 @@ describe('FormService', () => {
       expect(actual._unsafeUnwrapErr()).toEqual(new ApplicationError())
     })
   })
+
+  describe('retrievePublicFormsWithSmsVerification', () => {
+    it('should call the db method successfully', async () => {
+      // Arrange
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'retrievePublicFormsWithSmsVerification')
+        .mockResolvedValueOnce([])
+      const MOCK_ADMIN_ID = MOCK_ADMIN_OBJ_ID.toString()
+      const expected: IFormSchema[] = []
+
+      // Act
+      const actual = await FormService.retrievePublicFormsWithSmsVerification(
+        MOCK_ADMIN_ID,
+      )
+
+      // Assert
+      expect(actual._unsafeUnwrap()).toEqual(expected)
+      expect(retrieveFormSpy).toBeCalledWith(MOCK_ADMIN_ID)
+    })
+
+    it('should propagate the error received when error occurs while querying', async () => {
+      // Arrange
+      const expected = new DatabaseError('whoops')
+      const retrieveFormSpy = jest
+        .spyOn(Form, 'retrievePublicFormsWithSmsVerification')
+        .mockRejectedValueOnce(expected)
+      const MOCK_ADMIN_ID = MOCK_ADMIN_OBJ_ID.toString()
+
+      // Act
+      const actual = await FormService.retrievePublicFormsWithSmsVerification(
+        MOCK_ADMIN_ID,
+      )
+
+      // Assert
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+      expect(retrieveFormSpy).toBeCalledWith(MOCK_ADMIN_ID)
+    })
+  })
 })

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -5,6 +5,7 @@ import {
   AuthType,
   IEmailFormModel,
   IEncryptedFormModel,
+  IFormDocument,
   IFormSchema,
   IPopulatedForm,
   ResponseMode,
@@ -302,4 +303,39 @@ export const checkIsIntranetFormAccess = (
     })
   }
   return isIntranetUser
+}
+
+export const retrievePublicFormsWithSmsVerification = (
+  userId: string,
+): ResultAsync<IFormDocument[], PossibleDatabaseError> => {
+  return ResultAsync.fromPromise(
+    FormModel.retrievePublicFormsWithSmsVerification(userId),
+    (error) => {
+      logger.error({
+        message: 'Error retrieving public forms with sms verifications',
+        meta: {
+          action: 'retrievePublicFormsWithSmsVerification',
+          userId: userId,
+        },
+        error,
+      })
+
+      return transformMongoError(error)
+    },
+  ).andThen((forms) => {
+    if (!forms.length) {
+      // NOTE: Warn here because this is supposed to be called to generate a list of form titles
+      // When the admin has used up their sms verification limit.
+      // It is not an error because there are potential cases where the admins privatize their form after.
+      logger.warn({
+        message:
+          'Attempted to retrieve public forms with sms verifications but none was found',
+        meta: {
+          action: 'retrievePublicFormsWithSmsVerification',
+          userId: userId,
+        },
+      })
+    }
+    return okAsync(forms)
+  })
 }

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -1,8 +1,10 @@
 import {
   FormFieldSchema,
+  FormLinkView,
   FormLogicSchema,
   IEncryptedFormSchema,
   IForm,
+  IFormDocument,
   IFormSchema,
   IOnboardedForm,
   IPopulatedEmailForm,
@@ -136,4 +138,14 @@ export const isFormOnboarded = <T extends IForm = IForm>(
   return form.msgSrvcName
     ? !(form.msgSrvcName === smsConfig.twilioMsgSrvcSid)
     : false
+}
+
+export const extractFormLinkView = <T extends IFormDocument>(
+  form: Pick<T, 'title' | '_id'>,
+): FormLinkView<T> => {
+  const { title, _id } = form
+  return {
+    title,
+    link: `https://form.gov.sg/${_id}`,
+  }
 }

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -142,10 +142,11 @@ export const isFormOnboarded = <T extends IForm = IForm>(
 
 export const extractFormLinkView = <T extends IFormDocument>(
   form: Pick<T, 'title' | '_id'>,
+  appUrl: string,
 ): FormLinkView<T> => {
   const { title, _id } = form
   return {
     title,
-    link: `https://form.gov.sg/${_id}`,
+    link: `${appUrl}/${_id}`,
   }
 }

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -1285,7 +1285,8 @@ describe('mail.service', () => {
       const result =
         await MailUtils.generateSmsVerificationDisabledHtmlForAdmin({
           forms: [extractFormLinkView(MOCK_FORM, MOCK_APP_URL)],
-          smsVerificationLimit: smsConfig.smsVerificationLimit,
+          smsVerificationLimit:
+            smsConfig.smsVerificationLimit.toLocaleString('en-US'),
           smsWarningTiers: stringifiedSmsWarningTiers,
         }).map((emailHtml) => {
           return {
@@ -1307,7 +1308,8 @@ describe('mail.service', () => {
       const result =
         await MailUtils.generateSmsVerificationDisabledHtmlForCollab({
           form: extractFormLinkView(MOCK_FORM, MOCK_APP_URL),
-          smsVerificationLimit: smsConfig.smsVerificationLimit,
+          smsVerificationLimit:
+            smsConfig.smsVerificationLimit.toLocaleString('en-US'),
           smsWarningTiers: stringifiedSmsWarningTiers,
         }).map((emailHtml) => {
           return {
@@ -1427,8 +1429,11 @@ describe('mail.service', () => {
     ) => {
       const result = await MailUtils.generateSmsVerificationWarningHtml({
         forms: [extractFormLinkView(MOCK_FORM, MOCK_APP_URL)],
-        numAvailable: smsConfig.smsVerificationLimit - count,
-        smsVerificationLimit: smsConfig.smsVerificationLimit,
+        numAvailable: (smsConfig.smsVerificationLimit - count).toLocaleString(
+          'en-US',
+        ),
+        smsVerificationLimit:
+          smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       }).map((emailHtml) => {
         return {
           to: admin,

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -641,6 +641,7 @@ export class MailService {
     const htmlData: CollabSmsDisabledData = {
       form: extractFormLinkView(form, this.#appUrl),
       smsVerificationLimit:
+        // Formatted using localeString so that the displayed number has commas
         smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       smsWarningTiers: stringifiedSmsWarningTiers,
     }
@@ -675,6 +676,7 @@ export class MailService {
     const htmlData: AdminSmsDisabledData = {
       forms: forms.map((f) => extractFormLinkView(f, this.#appUrl)),
       smsVerificationLimit:
+        // Formatted using localeString so that the displayed number has commas
         smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       smsWarningTiers: stringifiedSmsWarningTiers,
     }
@@ -719,6 +721,7 @@ export class MailService {
     ).andThen((forms) => {
       const htmlData: SmsVerificationWarningData = {
         forms: forms.map((f) => extractFormLinkView(f, this.#appUrl)),
+        // Formatted using localeString so that the displayed number has commas
         numAvailable: (
           smsConfig.smsVerificationLimit - smsVerifications
         ).toLocaleString('en-US'),

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -640,7 +640,8 @@ export class MailService {
   ): ResultAsync<true, MailGenerationError | MailSendError> => {
     const htmlData: CollabSmsDisabledData = {
       form: extractFormLinkView(form, this.#appUrl),
-      smsVerificationLimit: smsConfig.smsVerificationLimit,
+      smsVerificationLimit:
+        smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       smsWarningTiers: stringifiedSmsWarningTiers,
     }
     const collaborators = form.permissionList.map(({ email }) => email)
@@ -673,7 +674,8 @@ export class MailService {
   ): ResultAsync<true, MailGenerationError | MailSendError> => {
     const htmlData: AdminSmsDisabledData = {
       forms: forms.map((f) => extractFormLinkView(f, this.#appUrl)),
-      smsVerificationLimit: smsConfig.smsVerificationLimit,
+      smsVerificationLimit:
+        smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       smsWarningTiers: stringifiedSmsWarningTiers,
     }
 
@@ -717,8 +719,11 @@ export class MailService {
     ).andThen((forms) => {
       const htmlData: SmsVerificationWarningData = {
         forms: forms.map((f) => extractFormLinkView(f, this.#appUrl)),
-        numAvailable: smsConfig.smsVerificationLimit - smsVerifications,
-        smsVerificationLimit: smsConfig.smsVerificationLimit,
+        numAvailable: (
+          smsConfig.smsVerificationLimit - smsVerifications
+        ).toLocaleString('en-US'),
+        smsVerificationLimit:
+          smsConfig.smsVerificationLimit.toLocaleString('en-US'),
       }
 
       // Step 2: Generate HTML from template

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -11,11 +11,14 @@ import {
   EmailAdminDataField,
   IEmailFormSchema,
   IPopulatedForm,
+  IPopulatedUser,
   ISubmissionSchema,
 } from '../../../types'
 import config from '../../config/config'
 import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
+import * as FormService from '../../modules/form/form.service'
+import { extractFormLinkView } from '../../modules/form/form.utils'
 
 import { EMAIL_HEADERS, EmailType } from './mail.constants'
 import { MailGenerationError, MailSendError } from './mail.errors'
@@ -35,7 +38,7 @@ import {
   generateAutoreplyPdf,
   generateBounceNotificationHtml,
   generateLoginOtpHtml,
-  generateSmsVerificationDisabledHtml,
+  generateSmsVerificationDisabledHtmlForAdmin,
   generateSmsVerificationWarningHtml,
   generateSubmissionToAdminHtml,
   generateVerificationOtpHtml,
@@ -581,71 +584,135 @@ export class MailService {
 
   /**
    * Sends a email to the admin and collaborators of the form when the verified sms feature will be disabled.
-   * This happens only when the admin has hit a certain limit of sms verifications on his account
+   * This happens only when the admin has hit a certain limit of sms verifications on his account.
+   *
+   * Note that the email sent to the admin and collaborators will differ.
+   * This is because the admin will see all of their forms that are affected but collaborators
+   * only see forms which they are a part of.
+   *
    * @param form The form whose admin and collaborators will be issued the email
    * @returns ok(true) when mail sending is successful
    * @returns err(MailGenerationError) when there was an error in generating the html data for the mail
    * @returns err(MailSendError) when there was an error in sending the mail
    */
   sendSmsVerificationDisabledEmail = (
-    form: Pick<IPopulatedForm, 'permissionList' | 'admin' | 'title' | '_id'>,
+    form: Pick<IPopulatedForm, 'admin' | '_id'>,
   ): ResultAsync<true, MailGenerationError | MailSendError> => {
-    const htmlData: SmsVerificationDisabledData = {
-      formTitle: form.title,
-      formLink: `${this.#appUrl}/${form._id}`,
-      smsVerificationLimit: smsConfig.smsVerificationLimit,
-    }
+    // Step 1: Retrieve all public forms of admin that have sms verification enabled
+    return FormService.retrievePublicFormsWithSmsVerification(form.admin._id)
+      .andThen((forms) => {
+        return this.sendDisabledMailForAdmin(forms, form.admin).map(() => forms)
+      })
+      .andThen((forms) => {})
 
-    return generateSmsVerificationDisabledHtml(htmlData).andThen((mailHtml) => {
-      const formCollaborators = form.permissionList.map(({ email }) => email)
+    // const htmlData: SmsVerificationDisabledData = {
+    //   formTitle: form.title,
+    //   formLink: `${this.#appUrl}/${form._id}`,
+    //   smsVerificationLimit: smsConfig.smsVerificationLimit,
+    // }
 
-      const mailOptions: MailOptions = {
-        to: form.admin.email,
-        cc: formCollaborators,
-        from: this.#senderFromString,
-        html: mailHtml,
-        subject: '[FormSG] SMS Verification - Free Tier Limit Reached',
-        replyTo: this.#senderMail,
-        bcc: this.#senderMail,
+    // return generateSmsVerificationDisabledHtmlForAdmin(htmlData).andThen(
+    //   (mailHtml) => {
+    //     const formCollaborators = form.permissionList.map(({ email }) => email)
+
+    //     const mailOptions: MailOptions = {
+    //       to: form.admin.email,
+    //       cc: formCollaborators,
+    //       from: this.#senderFromString,
+    //       html: mailHtml,
+    //       subject: '[FormSG] SMS Verification - Free Tier Limit Reached',
+    //       replyTo: this.#senderMail,
+    //       bcc: this.#senderMail,
+    //     }
+
+    //     return this.#sendNodeMail(mailOptions, { formId: form._id })
+    //   },
+    // )
+  }
+
+  sendDisabledMailForCollab = (
+    forms: IPopulatedForm[],
+    admin: IPopulatedUser,
+  ): ResultAsync<true, MailGenerationError | MailSendError> => {
+    const mailSendResult = forms.map((form) => {
+      const htmlData: SmsVerificationDisabledData = {
+        form: {title:},
+        smsVerificationLimit: smsConfig.smsVerificationLimit,
       }
-
-      return this.#sendNodeMail(mailOptions, { formId: form._id })
     })
   }
 
+  sendDisabledMailForAdmin = (
+    forms: IPopulatedForm[],
+    admin: IPopulatedUser,
+  ): ResultAsync<true, MailGenerationError | MailSendError> => {
+    const htmlData: SmsVerificationDisabledData = {
+      forms: extractFormLinkView(forms),
+      smsVerificationLimit: smsConfig.smsVerificationLimit,
+    }
+
+    return (
+      // Step 1: Generate HTML data for admin
+      generateSmsVerificationDisabledHtmlForAdmin(htmlData).andThen(
+        (mailHtml) => {
+          const mailOptions: MailOptions = {
+            to: admin.email,
+            from: this.#senderFromString,
+            html: mailHtml,
+            subject: '[FormSG] SMS Verification - Free Tier Limit Reached',
+            replyTo: this.#senderMail,
+            bcc: this.#senderMail,
+          }
+
+          // Step 2: Send mail out to admin ONLY
+          return this.#sendNodeMail(mailOptions, {
+            mailId: 'sendDisabledMailForAdmin',
+          })
+        },
+      )
+    )
+  }
+
   /**
-   * Sends a warning email to the admin and collaborators of the form when their current verified sms counts hits a limit
-   * @param form The form whose admin and collaborators will be issued a warning
+   * Sends a warning email to the admin of the form when their current verified sms counts hits a limit
+   * @param form The form whose admin will be issued a warning
    * @param smsVerifications The current total sms verifications for the form
    * @returns ok(true) when mail sending is successful
    * @returns err(MailGenerationError) when there was an error in generating the html data for the mail
    * @returns err(MailSendError) when there was an error in sending the mail
    */
   sendSmsVerificationWarningEmail = (
-    form: Pick<IPopulatedForm, 'permissionList' | 'admin' | 'title' | '_id'>,
+    form: Pick<IPopulatedForm, 'admin' | '_id'>,
     smsVerifications: number,
   ): ResultAsync<true, MailGenerationError | MailSendError> => {
-    const htmlData: SmsVerificationWarningData = {
-      formTitle: form.title,
-      formLink: `${this.#appUrl}/${form._id}`,
-      numAvailable: smsConfig.smsVerificationLimit - smsVerifications,
-      smsVerificationLimit: smsConfig.smsVerificationLimit,
-    }
-
-    return generateSmsVerificationWarningHtml(htmlData).andThen((mailHtml) => {
-      const formCollaborators = form.permissionList.map(({ email }) => email)
-
-      const mailOptions: MailOptions = {
-        to: form.admin.email,
-        cc: formCollaborators,
-        from: this.#senderFromString,
-        html: mailHtml,
-        subject: '[FormSG] SMS Verification - Free Tier Limit Alert',
-        replyTo: this.#senderMail,
-        bcc: this.#senderMail,
+    // Step 1: Retrieve all public forms of admin that have sms verification enabled
+    return FormService.retrievePublicFormsWithSmsVerification(
+      form.admin._id,
+    ).andThen((forms) => {
+      const htmlData: SmsVerificationWarningData = {
+        forms: forms.map((f) => extractFormLinkView(f)),
+        numAvailable: smsConfig.smsVerificationLimit - smsVerifications,
+        smsVerificationLimit: smsConfig.smsVerificationLimit,
       }
 
-      return this.#sendNodeMail(mailOptions, { formId: form._id })
+      // Step 2: Generate HTML from template
+      return generateSmsVerificationWarningHtml(htmlData).andThen(
+        (mailHtml) => {
+          const mailOptions: MailOptions = {
+            to: form.admin.email,
+            from: this.#senderFromString,
+            html: mailHtml,
+            subject: '[FormSG] SMS Verification - Free Tier Limit Alert',
+            replyTo: this.#senderMail,
+            bcc: this.#senderMail,
+          }
+
+          // Step 3: Send mail out
+          return this.#sendNodeMail(mailOptions, {
+            mailId: 'sendSmsVerificationWarningEmail',
+          })
+        },
+      )
     })
   }
 }

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -1,5 +1,6 @@
 import Mail from 'nodemailer/lib/mailer'
 import { OperationOptions } from 'retry'
+import { SMS_WARNING_TIERS } from 'shared/utils/verification'
 
 import {
   AutoReplyOptions,
@@ -88,10 +89,18 @@ export type BounceNotificationHtmlData = {
   appName: string
 }
 
-export type SmsVerificationDisabledData = {
-  formLink: string
-  formTitle: string
+export type AdminSmsDisabledData = {
+  forms: FormLinkView<IPopulatedForm>[]
+} & SmsVerificationTiers
+
+export type CollabSmsDisabledData = {
+  form: FormLinkView<IPopulatedForm>
+} & SmsVerificationTiers
+
+type SmsVerificationTiers = {
   smsVerificationLimit: number
+  // Ensure that all tiers are covered
+  smsWarningTiers: { [K in keyof typeof SMS_WARNING_TIERS]: string }
 }
 
 export type SmsVerificationWarningData = {

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -4,6 +4,7 @@ import { OperationOptions } from 'retry'
 import {
   AutoReplyOptions,
   EmailAdminDataField,
+  FormLinkView,
   IFormSchema,
   IPopulatedForm,
   ISubmissionSchema,
@@ -94,8 +95,7 @@ export type SmsVerificationDisabledData = {
 }
 
 export type SmsVerificationWarningData = {
-  formTitle: string
-  formLink: string
+  forms: FormLinkView<IPopulatedForm>[]
   numAvailable: number
   smsVerificationLimit: number
 }

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -98,13 +98,13 @@ export type CollabSmsDisabledData = {
 } & SmsVerificationTiers
 
 type SmsVerificationTiers = {
-  smsVerificationLimit: number
+  smsVerificationLimit: string
   // Ensure that all tiers are covered
   smsWarningTiers: { [K in keyof typeof SMS_WARNING_TIERS]: string }
 }
 
 export type SmsVerificationWarningData = {
   forms: FormLinkView<IPopulatedForm>[]
-  numAvailable: number
-  smsVerificationLimit: number
+  numAvailable: string
+  smsVerificationLimit: string
 }

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -11,10 +11,11 @@ import { createLoggerWithLabel } from '../../config/logger'
 
 import { MailGenerationError, MailSendError } from './mail.errors'
 import {
+  AdminSmsDisabledData,
   AutoreplyHtmlData,
   AutoreplySummaryRenderData,
   BounceNotificationHtmlData,
-  SmsVerificationDisabledData,
+  CollabSmsDisabledData,
   SmsVerificationWarningData,
   SubmissionToAdminHtmlData,
 } from './mail.types'
@@ -172,10 +173,17 @@ export const isToFieldValid = (addresses: string | string[]): boolean => {
   return mails.every((addr) => validator.isEmail(addr))
 }
 
-export const generateSmsVerificationDisabledHtml = (
-  htmlData: SmsVerificationDisabledData,
+export const generateSmsVerificationDisabledHtmlForAdmin = (
+  htmlData: AdminSmsDisabledData,
 ): ResultAsync<string, MailGenerationError> => {
-  const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-disabled.server.view.html`
+  const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-disabled-admin.server.view.html`
+  return safeRenderFile(pathToTemplate, htmlData)
+}
+
+export const generateSmsVerificationDisabledHtmlForCollab = (
+  htmlData: CollabSmsDisabledData,
+): ResultAsync<string, MailGenerationError> => {
+  const pathToTemplate = `${process.cwd()}/src/app/views/templates/sms-verification-disabled-collab.server.view.html`
   return safeRenderFile(pathToTemplate, htmlData)
 }
 

--- a/src/app/views/templates/sms-verification-disabled-admin.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-admin.server.view.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head> </head>
+  <body>
+    <p>Dear form admin(s),</p>
+    <p>
+      You are receiving this as you have enabled SMS OTP verification on a
+      Mobile Number field of your form:
+    </p>
+    <ol>
+      <% forms.forEach(function({title, link}) { %>
+      <li><a href="<%= link %>"> <%= title %> </a>.</li>
+      <% }) %>
+    </ol>
+    <p>
+      SMS OTP verification has been <b>automatically disabled</b> on your form
+      as you have reached the free tier limit of <%= smsVerificationLimit %>
+      responses.
+    </p>
+
+    <p>
+      We would have previously notified all form admins upon your account
+      reaching <%= smsWarningTiers.LOW %>, <%= smsWarningTiers.MED %> and <%=
+      smsWarningTiers.HIGH %> responses while free SMS OTP verification was
+      enabled.
+    </p>
+    <p>
+      If you require SMS OTP verification for more than <%= smsVerificationLimit
+      %> responses, please
+      <a
+        href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
+      >
+        arrange advance billing with us.
+      </a>
+    </p>
+    <p>
+      <b>Important: </b> Please refrain from creating multiple forms for the
+      same use case in order to avoid this limit, as such forms risk being
+      flagged for abuse and blacklisted.
+    </p>
+    <p>The FormSG Team</p>
+  </body>
+</html>

--- a/src/app/views/templates/sms-verification-disabled-admin.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-admin.server.view.html
@@ -33,11 +33,6 @@
         arrange advance billing with us.
       </a>
     </p>
-    <p>
-      <b>Important: </b> Please refrain from creating multiple forms for the
-      same use case in order to avoid this limit, as such forms risk being
-      flagged for abuse and blacklisted.
-    </p>
-    <p>The FormSG Team</p>
+    <p>FormSG Team</p>
   </body>
 </html>

--- a/src/app/views/templates/sms-verification-disabled-admin.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-admin.server.view.html
@@ -2,10 +2,10 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head> </head>
   <body>
-    <p>Dear form admin(s),</p>
+    <p>Dear form admin,</p>
     <p>
-      You are receiving this as you have enabled SMS OTP verification on a
-      Mobile Number field of your form:
+      You are receiving this email as you own forms with SMS OTP verification
+      enabled:
     </p>
     <ol>
       <% forms.forEach(function({title, link}) { %>
@@ -13,20 +13,20 @@
       <% }) %>
     </ol>
     <p>
-      SMS OTP verification has been <b>automatically disabled</b> on your form
-      as you have reached the free tier limit of <%= smsVerificationLimit %>
-      responses.
+      As you have reached the free tier limit of <%= smsVerificationLimit %>
+      verifications sent, SMS OTP verification has been
+      <b>automatically disabled</b> on all your form(s). Respondents will still
+      be able to submit to your form(s) but will not be prompted to verify their
+      mobile numbers.
     </p>
 
     <p>
       We would have previously notified all form admins upon your account
       reaching <%= smsWarningTiers.LOW %>, <%= smsWarningTiers.MED %> and <%=
-      smsWarningTiers.HIGH %> responses while free SMS OTP verification was
-      enabled.
+      smsWarningTiers.HIGH %> free verifications.
     </p>
     <p>
-      If you require SMS OTP verification for more than <%= smsVerificationLimit
-      %> responses, please
+      If you need to send more SMS OTP verifications, please
       <a
         href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
       >

--- a/src/app/views/templates/sms-verification-disabled-admin.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-admin.server.view.html
@@ -9,7 +9,7 @@
     </p>
     <ol>
       <% forms.forEach(function({title, link}) { %>
-      <li><a href="<%= link %>"> <%= title %> </a>.</li>
+      <li><a href="<%= link %>"> <%= title %> </a></li>
       <% }) %>
     </ol>
     <p>

--- a/src/app/views/templates/sms-verification-disabled-collab.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-collab.server.view.html
@@ -6,7 +6,7 @@
     <p>
       You are receiving this email as you are a collaborator on a form with SMS
       OTP verification enabled:
-      <a href="<%= form.link %>"> <%= form.title %> </a>.
+      <a href="<%= form.link %>"> <%= form.title %></a>.
     </p>
     <p>
       As the owner has reached the free tier limit of <%= smsVerificationLimit

--- a/src/app/views/templates/sms-verification-disabled-collab.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-collab.server.view.html
@@ -29,11 +29,6 @@
         arrange advance billing with us.
       </a>
     </p>
-    <p>
-      <b>Important: </b> Please refrain from creating multiple forms for the
-      same use case in order to avoid this limit, as such forms risk being
-      flagged for abuse and blacklisted.
-    </p>
-    <p>The FormSG Team</p>
+    <p>FormSG Team</p>
   </body>
 </html>

--- a/src/app/views/templates/sms-verification-disabled-collab.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-collab.server.view.html
@@ -2,16 +2,17 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head> </head>
   <body>
-    <p>Dear form admin(s),</p>
+    <p>Dear form admin,</p>
     <p>
-      You are receiving this as you have enabled SMS OTP verification on a
-      Mobile Number field of your form:
+      You are receiving this email as you are a collaborator on a form with SMS
+      OTP verification enabled:
       <a href="<%= form.link %>"> <%= form.title %> </a>.
     </p>
     <p>
-      SMS OTP verification has been <b>automatically disabled</b> on your form
-      as you have reached the free tier limit of <%= smsVerificationLimit %>
-      responses.
+      As the owner has reached the free tier limit of <%= smsVerificationLimit
+      %> verifications sent, SMS OTP verification has been automatically
+      disabled on this form. Respondents will still be able to submit to this
+      form but will not be prompted to verify their mobile numbers.
     </p>
 
     <p>
@@ -21,8 +22,7 @@
       enabled.
     </p>
     <p>
-      If you require SMS OTP verification for more than <%= smsVerificationLimit
-      %> responses, please
+      If you need to send more SMS OTP verifications, please
       <a
         href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
       >

--- a/src/app/views/templates/sms-verification-disabled-collab.server.view.html
+++ b/src/app/views/templates/sms-verification-disabled-collab.server.view.html
@@ -6,7 +6,7 @@
     <p>
       You are receiving this as you have enabled SMS OTP verification on a
       Mobile Number field of your form:
-      <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
+      <a href="<%= form.link %>"> <%= form.title %> </a>.
     </p>
     <p>
       SMS OTP verification has been <b>automatically disabled</b> on your form
@@ -16,7 +16,8 @@
 
     <p>
       We would have previously notified all form admins upon your account
-      reaching 2500, 5000 and 7500 responses while free SMS OTP verification was
+      reaching <%= smsWarningTiers.LOW %>, <%= smsWarningTiers.MED %> and <%=
+      smsWarningTiers.HIGH %> responses while free SMS OTP verification was
       enabled.
     </p>
     <p>

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -5,9 +5,13 @@
     <p>Dear form admin(s),</p>
     <p>
       You are receiving this as you have enabled SMS OTP verification on a
-      Mobile Number field of your form:
-      <a href="<%= formLink %>"> '<%= formTitle %>' </a>.
+      Mobile Number field of your form(s):
     </p>
+    <ol>
+      <% forms.forEach(function({title, link}) { %>
+      <li><a href="<%= link %>"> <%= title %> </a>.</li>
+      <% }) %>
+    </ol>
     <p>
       You can receive <b><%= numAvailable %></b> more responses until free SMS
       OTP verification is automatically disabled.

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -23,11 +23,6 @@
         >arrange advance billing with us.
       </a>
     </p>
-    <p>
-      <b>Important: </b> Please refrain from creating multiple forms for the
-      same use case in order to avoid this limit, as such forms risk being
-      flagged for abuse and blacklisted.
-    </p>
-    <p>The FormSG Team</p>
+    <p>FormSG Team</p>
   </body>
 </html>

--- a/src/app/views/templates/sms-verification-warning.view.html
+++ b/src/app/views/templates/sms-verification-warning.view.html
@@ -2,22 +2,23 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head> </head>
   <body>
-    <p>Dear form admin(s),</p>
+    <p>Dear form admin,</p>
     <p>
-      You are receiving this as you have enabled SMS OTP verification on a
-      Mobile Number field of your form(s):
+      You are receiving this email as you own forms with SMS OTP verification
+      enabled:
     </p>
     <ol>
       <% forms.forEach(function({title, link}) { %>
-      <li><a href="<%= link %>"> <%= title %> </a>.</li>
+      <li><a href="<%= link %>"> <%= title %> </a></li>
       <% }) %>
     </ol>
     <p>
-      You can receive <b><%= numAvailable %></b> more responses until free SMS
-      OTP verification is automatically disabled.
+      Your account can use <b><%= numAvailable %></b> more free verifications
+      until free SMS OTP verification is automatically disabled for all owned
+      forms.
     </p>
     <p>
-      If you require SMS OTP verification for more than 10,000 responses, please
+      If you need to send more than 10,000 SMS OTP verifications, please
       <a
         href="https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms"
         >arrange advance billing with us.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -306,6 +306,15 @@ export interface IFormModel extends Model<IFormSchema> {
   ): Promise<UpdateWriteOpResult>
 
   /**
+   * Retrieves all the public forms for a user which has sms verifications enabled
+   * @param userId The userId to retrieve the forms for
+   * @returns All public forms that have sms verifications enabled
+   */
+  retrievePublicFormsWithSmsVerification(
+    userId: IUserSchema['_id'],
+  ): Promise<IFormDocument[]>
+
+  /**
    * Update the end page of form with given endpage object.
    * @param formId the id of the form to update
    * @param newEndPage the new EndPage object to replace with

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -350,7 +350,7 @@ export type IOnboardedForm<T extends IForm> = T & {
   msgSrvcName: string
 }
 
-export type FormLinkView<T extends IFormSchema> = {
+export type FormLinkView<T extends IFormDocument> = {
   title: T['title']
   link: string
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -349,3 +349,8 @@ export type IEmailFormModel = IFormModel & Model<IEmailFormSchema>
 export type IOnboardedForm<T extends IForm> = T & {
   msgSrvcName: string
 }
+
+export type FormLinkView<T extends IFormSchema> = {
+  title: T['title']
+  link: string
+}


### PR DESCRIPTION
## Problem
We want to inform admins on the email sent out about forms that would be affected by SMS verification being disabled so that they are able to accurately assess the impact.

## Solution
This solution has 3 parts. 

1. write a db query + wrapper to interface with the database and retrieve the forms of the admin that will be impacted.
2. Refactor disabled mail sending into 2 portions 
    a. Send mail to admin - this includes all forms that will be impacted
    b. Send mail to collaborators - only the forms that they are a part of 
3. Refactor warning mail sending - same as point 2a. 

## Screenshots 
**Disabled mail for admin**
<img width="1030" alt="Screenshot 2021-08-05 at 4 59 13 PM" src="https://user-images.githubusercontent.com/44049504/128322768-35c4b6f6-9006-4fd5-b591-bf2d1ddaa9e6.png">

**Disabled mail for collaborator**
<img width="1033" alt="Screenshot 2021-08-05 at 5 00 16 PM" src="https://user-images.githubusercontent.com/44049504/128322924-d99bc6b7-4a9f-4abf-a7dc-45a3dbfdd55f.png">

**Warning mail for admin**
<img width="853" alt="Screenshot 2021-08-05 at 5 01 02 PM" src="https://user-images.githubusercontent.com/44049504/128323030-05d02723-3f90-4d03-9ea3-86195fb00e5b.png">

