### PR TITLE
feat(sms-limiting): ui changes for modal

### DIFF
--- a/src/public/modules/forms/admin/controllers/pop-up-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/pop-up-modal.client.controller.js
@@ -15,7 +15,6 @@ function PopUpModalController($uibModalInstance, externalScope) {
   vm.description = externalScope.description
   vm.confirmButtonText = externalScope.confirmButtonText
   vm.cancelButtonText = externalScope.cancelButtonText
-  vm.isImportant = externalScope.isImportant
   vm.cancel = $uibModalInstance.close
 
   vm.confirm = function () {

--- a/src/public/modules/forms/admin/css/edit-form.css
+++ b/src/public/modules/forms/admin/css/edit-form.css
@@ -1437,3 +1437,7 @@ a.modal-cancel-btn:hover {
   display: flex;
   justify-content: flex-end;
 }
+
+.sms-counts {
+  color: #484848;
+}

--- a/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
@@ -1,15 +1,22 @@
 <div class="row">
-  <div class="toggle-option">
+  <div class="toggle-option label-bottom">
     <div
       ng-class="{'toggle-option--disabled' : field.hasAdminExceededSmsLimit || field.hasRetrievalError}"
-      class="col-xs-8 label-custom label-medium label-bottom"
+      class="col-xs-8 justify-content-start"
     >
-      OTP verification
-      <i
-        class="glyphicon glyphicon-question-sign"
-        uib-tooltip="When enabled, respondents must verify by entering a code sent to their mobile number"
-        tooltip-trigger="'click mouseenter'"
-      ></i>
+      <div class="label-custom label-medium">
+        OTP verification
+        <i
+          class="glyphicon glyphicon-question-sign"
+          uib-tooltip="When enabled, respondents must verify by entering a code sent to their mobile number"
+          tooltip-trigger="'click mouseenter'"
+        ></i>
+      </div>
+      <div>
+        <small class="sms-counts"
+          >{{verifiedSmsCount}}/{{smsVerificationLimit}} SMSes used</small
+        >
+      </div>
     </div>
     <div class="col-xs-4 field-input">
       <div ng-show="isLoading" class="loading-spinner">

--- a/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
@@ -12,7 +12,7 @@
           tooltip-trigger="'click mouseenter'"
         ></i>
       </div>
-      <div>
+      <div ng-show="!isLoading && !field.hasRetrievalError">
         <small class="sms-counts"
           >{{verifiedSmsCount}}/{{smsVerificationLimit}} SMSes used</small
         >

--- a/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
@@ -2,7 +2,7 @@
   <div class="toggle-option label-bottom">
     <div
       ng-class="{'toggle-option--disabled' : field.hasAdminExceededSmsLimit || field.hasRetrievalError}"
-      class="col-xs-8 justify-content-start"
+      class="col-xs-8"
     >
       <div class="label-custom label-medium">
         OTP verification

--- a/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
+++ b/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
@@ -117,20 +117,25 @@ function configureMobileDirective() {
                 externalScope: function () {
                   return {
                     title: `OTP verification will be disabled at ${$scope.smsVerificationLimit} responses`,
-                    confirmButtonText: 'Accept',
+                    confirmButtonText: 'I understand',
                     description: `
-                    We provide SMS OTP verification for free up to ${
+                    We provide ${
                       $scope.smsVerificationLimit
-                    } responses. OTP verification will be automatically disabled when your account reaches ${
-                      $scope.smsVerificationLimit
-                    } responses. 
+                    } free SMS OTP verifications per account, only counting owned forms. 
+
+                    Once this limit is reached, SMS OTP verification will be automatically disabled for all owned forms. 
+
                     <br></br>
-                    If you require OTP verification for more than ${
+
+                    If you are a collaborator, ensure the form's owner has enough free verifications. 
+
+                    <br></br>
+
+                    If you require more than ${
                       $scope.smsVerificationLimit
-                    } responses,
-                    <a href=${
+                    } verifications, please <a href=${
                       $scope.verifiedSmsSetupLink
-                    } target="_blank" class=""> please arrange advance billing with us. </a>  
+                    } target="_blank" class=""> arrange advance billing with us. </a>  
 
                     <br></br>
                     <small>Current response count: ${formatStringAsNumber(

--- a/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
+++ b/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
@@ -137,7 +137,6 @@ function configureMobileDirective() {
                       $scope.verifiedSmsCount,
                     )}/${$scope.smsVerificationLimit}</small>
                     `,
-                    isImportant: true,
                   }
                 },
               },

--- a/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
+++ b/src/public/modules/forms/admin/directives/configure-mobile.client.directive.js
@@ -21,6 +21,8 @@ function configureMobileDirective() {
       form: '<',
       name: '=',
       characterLimit: '=',
+      smsVerificationLimit: '=',
+      verifiedSmsCount: '=',
       isLoading: '<',
     },
     controller: [
@@ -66,7 +68,7 @@ function configureMobileDirective() {
           AdminMetaService.getFreeSmsCountsUsedByFormAdmin($scope.form._id),
         )
           .then(({ quota, freeSmsCounts }) => {
-            $scope.verifiedSmsCount = freeSmsCounts
+            $scope.verifiedSmsCount = formatStringAsNumber(freeSmsCounts)
             $scope.adminVerifiedSmsState = getAdminVerifiedSmsState(
               freeSmsCounts,
               $scope.form.msgSrvcName,
@@ -119,9 +121,7 @@ function configureMobileDirective() {
                     title: `OTP verification will be disabled at ${$scope.smsVerificationLimit} responses`,
                     confirmButtonText: 'I understand',
                     description: `
-                    We provide ${
-                      $scope.smsVerificationLimit
-                    } free SMS OTP verifications per account, only counting owned forms. 
+                    We provide ${$scope.smsVerificationLimit} free SMS OTP verifications per account, only counting owned forms. 
 
                     Once this limit is reached, SMS OTP verification will be automatically disabled for all owned forms. 
 
@@ -131,16 +131,10 @@ function configureMobileDirective() {
 
                     <br></br>
 
-                    If you require more than ${
-                      $scope.smsVerificationLimit
-                    } verifications, please <a href=${
-                      $scope.verifiedSmsSetupLink
-                    } target="_blank" class=""> arrange advance billing with us. </a>  
+                    If you require more than ${$scope.smsVerificationLimit} verifications, please <a href=${$scope.verifiedSmsSetupLink} target="_blank" class=""> arrange advance billing with us. </a>  
 
                     <br></br>
-                    <small>Current response count: ${formatStringAsNumber(
-                      $scope.verifiedSmsCount,
-                    )}/${$scope.smsVerificationLimit}</small>
+                    <small>Current response count: ${$scope.verifiedSmsCount}/${$scope.smsVerificationLimit}</small>
                     `,
                   }
                 },

--- a/src/public/modules/forms/admin/views/pop-up.client.modal.html
+++ b/src/public/modules/forms/admin/views/pop-up.client.modal.html
@@ -6,7 +6,7 @@
       <button
         type="submit"
         ng-click="vm.confirm()"
-        ng-class="vm.isImportant ? 'red-bg-dark' : 'modal-save-btn'"
+        ng-class="modal-save-btn"
         class="btn-custom btn-medium"
       >
         {{ vm.confirmButtonText || 'OK' }}


### PR DESCRIPTION
## Description
This changes the UI to be more polished.

This takes place on 3 fronts: 
1. adding a quota beneath the toggle so that users are able to see their sms counts. 
2. changing the sms counts modal button from red -> blue.
3. updating the sms counts modal description.

## Screenshots
**Quota**
![Screenshot 2021-08-06 at 12 16 54 PM](https://user-images.githubusercontent.com/44049504/128455361-a8ce4aa8-c6ba-4f18-b810-2f9fc09fc87b.png)


**Modal**
![Screenshot 2021-08-06 at 12 17 39 PM](https://user-images.githubusercontent.com/44049504/128455313-60a2232b-5459-459d-a264-ea9c74850327.png)
