### PR TITLE
feat: remove frontend code to delete spcp cookie

### DIFF
--- a/src/app/config/features/spcp-myinfo.config.ts
+++ b/src/app/config/features/spcp-myinfo.config.ts
@@ -12,7 +12,6 @@ type ISpcpConfig = {
   spCookieMaxAge: number
   spCookieMaxAgePreserved: number
   spcpCookieDomain: string
-  oldSpcpCookieDomain: string // TODO (#2329): To remove after old cookies have expired
   cpCookieMaxAge: number
   spIdpId: string
   cpIdpId: string
@@ -83,13 +82,6 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: String,
     default: '',
     env: 'SPCP_COOKIE_DOMAIN',
-  },
-  oldSpcpCookieDomain: {
-    // TODO (#2329): To remove after old cookies have expired
-    doc: 'Old domain name set on cookie that holds the SPCP jwt',
-    format: String,
-    default: '',
-    env: 'OLD_SPCP_COOKIE_DOMAIN',
   },
   cpCookieMaxAge: {
     doc: 'Max CorpPass cookie age',

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -21,7 +21,6 @@ const frontendVars = {
   myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
   GATrackingID: googleAnalyticsConfig.GATrackingID,
   spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
-  oldSpcpCookieDomain: spcpMyInfoConfig.oldSpcpCookieDomain, // Old cookie domain used for backward compatibility. TODO (#2329): Delete env var
 }
 const environment = ejs.render(
   `
@@ -45,8 +44,6 @@ const environment = ejs.render(
     var formsgSdkMode = "<%= formsgSdkMode%>"
     // SPCP Cookie
     var spcpCookieDomain = "<%= spcpCookieDomain%>"
-    // Old SPCP Cookie
-    var oldSpcpCookieDomain = "<%= oldSpcpCookieDomain%>"
   `,
   frontendVars,
 )

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -18,11 +18,6 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
     userName: null,
     rememberMe: null,
     issuedAt: null,
-    cookieNames: {
-      SP: 'jwtSp',
-      CP: 'jwtCp',
-      SGID: 'jwtSgid',
-    },
     setUser: function ({ userName, rememberMe, iat, exp }) {
       session.userName = userName
       session.rememberMe = rememberMe

--- a/src/public/modules/forms/services/spcp-session.client.factory.js
+++ b/src/public/modules/forms/services/spcp-session.client.factory.js
@@ -40,13 +40,6 @@ function SpcpSession($interval, $q, Toastr, $window, $cookies) {
       session.userName = undefined
     },
     logout: function (authType) {
-      $cookies.remove(
-        // TODO (#2329): To remove after old cookies have expired
-        session.cookieNames[authType],
-        $window.oldSpcpCookieDomain
-          ? { domain: $window.oldSpcpCookieDomain }
-          : {},
-      )
       $q.when(PublicFormAuthService.logoutOfSpcpSession(authType))
         .then(() => {
           $cookies.put('isJustLogOut', true)


### PR DESCRIPTION
## Problem
- Hotfix was introduced in #2328 to temporarily allow client to delete sp/cp cookie for backward compatibility
- As affected cookies have all expired, this PR removes the client code to delete the cookie
- Closes #2329

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  (all affected cookies have expired)

**New environment variables**:

- `env var` : env var details

`OLD_SPCP_COOKIE_DOMAIN` env var deleted

## Tests
- [ ] Create sp form and log in
  - [ ] Check that form can be submitted
  - [ ] Check that user can log out and jwt cookie is deleted thereafter
  - [ ] Log in again. Check that submission and log out works
- [ ] Repeat above with 'remember me' enabled
- [ ] Repeat above with CP form
- [ ] Repeat above with MyInfo form
- [ ] Repeat above with SGID form
