### PR TITLE
feat(design-system): allow colorScheme prop to be passed into Link components

### DIFF
--- a/frontend/src/components/Link/Link.stories.tsx
+++ b/frontend/src/components/Link/Link.stories.tsx
@@ -1,5 +1,6 @@
 import { BiRightArrowAlt } from 'react-icons/bi'
 import Icon from '@chakra-ui/icon'
+import { SimpleGrid, Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
 import { Link, LinkProps } from './Link'
@@ -14,12 +15,14 @@ const Template: Story<LinkProps> = (args) => <Link {...args} />
 export const Default = Template.bind({})
 Default.args = {
   children: 'Link',
+  href: '',
 }
 
 export const Disabled = Template.bind({})
 Disabled.args = {
   isDisabled: true,
   children: 'Disabled link',
+  href: '',
 }
 
 export const WithExternalIcon = Template.bind({})
@@ -34,6 +37,7 @@ VariantInline.args = {
   variant: 'inline',
   children: 'Inline variant link',
   isExternal: false,
+  href: '',
 }
 
 export const VariantStandalone = Template.bind({})
@@ -46,5 +50,59 @@ VariantStandalone.args = {
     </>
   ),
   isExternal: false,
+  href: '',
+}
+
+const TemplateGroup: Story<LinkProps> = (args) => (
+  <SimpleGrid
+    columns={2}
+    spacing={8}
+    templateColumns="max-content max-content"
+    alignItems="center"
+  >
+    <Text>primary</Text>
+    <Link {...args} colorScheme="primary" />
+    <Text>secondary</Text>
+    <Link {...args} colorScheme="secondary" />
+    <Text>danger</Text>
+    <Link {...args} colorScheme="danger" />
+    <Text>warning</Text>
+    <Link {...args} colorScheme="warning" />
+    <Text>success</Text>
+    <Link {...args} colorScheme="success" />
+    <Text>neutral</Text>
+    <Link {...args} colorScheme="neutral" />
+    <Text>primary</Text>
+    <Link {...args} colorScheme="primary" />
+    <Text>theme-green</Text>
+    <Link {...args} colorScheme="theme-green" />
+    <Text>theme-teal</Text>
+    <Link {...args} colorScheme="theme-teal" />
+    <Text>theme-purple</Text>
+    <Link {...args} colorScheme="theme-purple" />
+    <Text>theme-grey</Text>
+    <Link {...args} colorScheme="theme-grey" />
+    <Text>theme-yellow</Text>
+    <Link {...args} colorScheme="theme-yellow" />
+    <Text>theme-orange</Text>
+    <Link {...args} colorScheme="theme-orange" />
+    <Text>theme-red</Text>
+    <Link {...args} colorScheme="theme-red" />
+    <Text>theme-brown</Text>
+    <Link {...args} colorScheme="theme-brown" />
+  </SimpleGrid>
+)
+
+export const VariantInlineColorSchemes = TemplateGroup.bind({})
+VariantInlineColorSchemes.args = {
+  children: 'Link with colours',
+  variant: 'inline',
+  href: '',
+}
+
+export const VariantStandaloneColorSchemes = TemplateGroup.bind({})
+VariantStandaloneColorSchemes.args = {
+  children: 'Link with colours',
+  variant: 'standalone',
   href: '',
 }

--- a/frontend/src/theme/components/Link.ts
+++ b/frontend/src/theme/components/Link.ts
@@ -1,20 +1,37 @@
 import { ComponentStyleConfig } from '@chakra-ui/theme'
+import { getColor } from '@chakra-ui/theme-tools'
 
 export const Link: ComponentStyleConfig = {
-  baseStyle: {
-    position: 'relative',
-    color: 'primary.500',
-    borderRadius: '0.25rem',
-    _hover: {
-      color: 'primary.600',
-    },
-    _disabled: {
-      color: 'primary.300',
-      cursor: 'not-allowed',
-    },
-    _focus: {
-      boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
-    },
+  baseStyle: ({ colorScheme: c = 'primary', theme }) => {
+    let linkColor = `${c}.500`
+    let hoverColor = `${c}.600`
+
+    // Special cases for accessibility.
+    if (c === 'warning') {
+      linkColor = `${c}.800`
+      hoverColor = `${c}.900`
+    } else if (
+      ['success', 'neutral', 'theme-yellow', 'theme-orange'].includes(c)
+    ) {
+      linkColor = `${c}.700`
+      hoverColor = `${c}.800`
+    }
+
+    return {
+      position: 'relative',
+      color: linkColor,
+      borderRadius: '0.25rem',
+      _hover: {
+        color: hoverColor,
+      },
+      _disabled: {
+        color: `${c}.300`,
+        cursor: 'not-allowed',
+      },
+      _focus: {
+        boxShadow: `0 0 0 2px ${getColor(theme, linkColor)}`,
+      },
+    }
   },
   variants: {
     inline: {
@@ -31,5 +48,6 @@ export const Link: ComponentStyleConfig = {
   },
   defaultProps: {
     variant: 'inline',
+    colorScheme: 'primary',
   },
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Whilst styling for Footer, see that the links are of a different color. Extends Links to be styleable with colorScheme.

