### PR TITLE
feat(Checkbox): implement Others option

### DIFF
--- a/frontend/src/assets/icons/BxCheckAnimated.tsx
+++ b/frontend/src/assets/icons/BxCheckAnimated.tsx
@@ -1,15 +1,19 @@
 import { motion } from 'framer-motion'
+import { omit } from 'lodash'
 
-export const BxCheckAnimated = (
-  props: React.SVGProps<SVGSVGElement> & { isChecked?: boolean },
-): JSX.Element => {
+export const BxCheckAnimated = ({
+  isChecked,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { isChecked?: boolean }): JSX.Element => {
+  // Required to prevent React warnings about unsupported props
+  const svgProps = omit(props, ['isIndeterminate'])
   return (
     <svg
       viewBox="0 0 12 10"
       fill="currentColor"
       height="1em"
       width="1em"
-      {...props}
+      {...svgProps}
     >
       <motion.polyline
         points="1.5 6 4.5 9 10.5 1"
@@ -32,7 +36,7 @@ export const BxCheckAnimated = (
             strokeDashoffset: 16,
           },
         }}
-        animate={props.isChecked ? 'checked' : 'unchecked'}
+        animate={isChecked ? 'checked' : 'unchecked'}
         initial="unchecked"
       />
     </svg>

--- a/frontend/src/components/Checkbox/Checkbox.stories.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.stories.tsx
@@ -103,11 +103,6 @@ const TemplateGroup: Story<CheckboxProps> = (args) => {
 export const CheckboxStates = TemplateGroup.bind({})
 CheckboxStates.storyName = 'States and themes'
 
-type PlaygroundFieldValues = {
-  Checkbox: string[] | false
-  Others: string
-}
-
 export const Playground: Story = ({
   name = 'checkbox',
   othersInputName = 'others-input',
@@ -137,7 +132,7 @@ export const Playground: Story = ({
       trigger(othersInputName)
     }
   }, [isOthersChecked, trigger, othersInputName])
-  const onSubmit = (data: PlaygroundFieldValues) => {
+  const onSubmit = (data: unknown) => {
     alert(JSON.stringify(data))
   }
   return (

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -33,9 +33,8 @@ type CheckboxWithOthers = ComponentWithAs<'input', CheckboxProps> & {
 
 export const Checkbox = forwardRef<CheckboxProps, 'input'>(
   ({ children, colorScheme = 'primary', ...props }, ref) => {
-    const { icon: iconStyles } = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
-      size: props.size,
-    })
+    // Passing all props for cleanliness but the size prop is the most relevant
+    const { icon: iconStyles } = useMultiStyleConfig(CHECKBOX_THEME_KEY, props)
     return (
       <ChakraCheckbox
         icon={
@@ -70,16 +69,13 @@ export interface CheckboxOthersWrapperProps {
  * Provides context values for the Others option.
  */
 const OthersWrapper = ({
-  colorScheme,
-  size,
   children,
+  ...props
 }: CheckboxOthersWrapperProps): JSX.Element => {
   const checkboxRef = useRef<HTMLInputElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
-    size,
-    colorScheme,
-  })
+  // Passing all props for cleanliness but size and colorScheme are the most relevant
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, props)
 
   return (
     <CheckboxOthersContext.Provider value={{ checkboxRef, inputRef }}>
@@ -93,10 +89,8 @@ const OthersWrapper = ({
  */
 const OthersCheckbox = forwardRef<CheckboxProps, 'input'>((props, ref) => {
   const { checkboxRef, inputRef } = useCheckboxOthers()
-  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
-    size: props.size,
-    colorScheme: props.colorScheme,
-  })
+  // Passing all props for cleanliness but size and colorScheme are the most relevant
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, props)
 
   const mergedCheckboxRef = useMergeRefs(checkboxRef, ref)
 
@@ -125,10 +119,8 @@ const OthersCheckbox = forwardRef<CheckboxProps, 'input'>((props, ref) => {
  */
 const OthersInput = forwardRef<InputProps, 'input'>((props, ref) => {
   const { checkboxRef, inputRef } = useCheckboxOthers()
-  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
-    size: props.size,
-    colorScheme: props.colorScheme,
-  })
+  // Passing all props for cleanliness but size and colorScheme are the most relevant
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, props)
 
   const mergedInputRef = useMergeRefs(inputRef, ref)
 

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -1,8 +1,12 @@
+import { ChangeEventHandler, ReactNode, useRef } from 'react'
 import {
+  Box,
   Checkbox as ChakraCheckbox,
   CheckboxProps as ChakraCheckboxProps,
+  ComponentWithAs,
   forwardRef,
   Icon,
+  useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
@@ -10,8 +14,21 @@ import { BxCheckAnimated } from '~/assets/icons'
 import { CHECKBOX_THEME_KEY } from '~/theme/components/Checkbox'
 import { FieldColorScheme } from '~/theme/foundations/colours'
 
+import Input, { InputProps } from '../Input'
+
+import { CheckboxOthersContext, useCheckboxOthers } from './useCheckboxOthers'
+
 export interface CheckboxProps extends ChakraCheckboxProps {
+  /**
+   * Background and shadow colors of checkbox.
+   */
   colorScheme?: FieldColorScheme
+}
+
+type CheckboxWithOthers = ComponentWithAs<'input', CheckboxProps> & {
+  OthersCheckbox: typeof OthersCheckbox
+  OthersInput: typeof OthersInput
+  OthersWrapper: typeof OthersWrapper
 }
 
 export const Checkbox = forwardRef<CheckboxProps, 'input'>(
@@ -37,4 +54,102 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
       </ChakraCheckbox>
     )
   },
-)
+) as CheckboxWithOthers
+
+/**
+ * Components to support the "Others" option.
+ */
+
+export interface CheckboxOthersWrapperProps {
+  colorScheme?: FieldColorScheme
+  size?: string
+  children: ReactNode
+}
+
+/**
+ * Provides context values for the Others option.
+ */
+const OthersWrapper = ({
+  colorScheme,
+  size,
+  children,
+}: CheckboxOthersWrapperProps): JSX.Element => {
+  const checkboxRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
+    size,
+    colorScheme,
+  })
+
+  return (
+    <CheckboxOthersContext.Provider value={{ checkboxRef, inputRef }}>
+      <Box __css={styles.othersContainer}>{children}</Box>
+    </CheckboxOthersContext.Provider>
+  )
+}
+
+/**
+ * Wrapper for the checkbox part of the Others option.
+ */
+const OthersCheckbox = forwardRef<CheckboxProps, 'input'>((props, ref) => {
+  const { checkboxRef, inputRef } = useCheckboxOthers()
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
+    size: props.size,
+    colorScheme: props.colorScheme,
+  })
+
+  const mergedCheckboxRef = useMergeRefs(checkboxRef, ref)
+
+  const handleCheckboxChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    // Upon checking checkbox, focus text input
+    if (e.target.checked) {
+      inputRef.current?.focus()
+    }
+    props.onChange?.(e)
+  }
+
+  return (
+    <Checkbox
+      ref={mergedCheckboxRef}
+      __css={styles.othersCheckbox}
+      {...props}
+      onChange={handleCheckboxChange}
+    >
+      Other
+    </Checkbox>
+  )
+})
+
+/**
+ * Wrapper for the input part of the Others option.
+ */
+const OthersInput = forwardRef<InputProps, 'input'>((props, ref) => {
+  const { checkboxRef, inputRef } = useCheckboxOthers()
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
+    size: props.size,
+    colorScheme: props.colorScheme,
+  })
+
+  const mergedInputRef = useMergeRefs(inputRef, ref)
+
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    // If there is text in the input, ensure the checkbox is checked.
+    if (e.target.value && !checkboxRef.current?.checked) {
+      checkboxRef.current?.click()
+    }
+    props.onChange?.(e)
+  }
+
+  return (
+    <Input
+      sx={styles.othersInput}
+      ref={mergedInputRef}
+      {...props}
+      onChange={handleInputChange}
+    />
+  )
+})
+
+Checkbox.OthersWrapper = OthersWrapper
+Checkbox.OthersCheckbox = OthersCheckbox
+Checkbox.OthersInput = OthersInput

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import {
   Checkbox as ChakraCheckbox,
   CheckboxProps as ChakraCheckboxProps,
+  forwardRef,
   Icon,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
@@ -13,28 +14,27 @@ export interface CheckboxProps extends ChakraCheckboxProps {
   colorScheme?: FieldColorScheme
 }
 
-export const Checkbox = ({
-  children,
-  colorScheme = 'primary',
-  ...props
-}: CheckboxProps): JSX.Element => {
-  const { icon: iconStyles } = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
-    size: props.size,
-  })
-  return (
-    <ChakraCheckbox
-      icon={
-        <Icon
-          as={BxCheckAnimated}
-          __css={iconStyles}
-          // This prop needs to be passed explicitly for animations
-          isChecked={props.isChecked}
-        />
-      }
-      colorScheme={colorScheme}
-      {...props}
-    >
-      {children}
-    </ChakraCheckbox>
-  )
-}
+export const Checkbox = forwardRef<CheckboxProps, 'input'>(
+  ({ children, colorScheme = 'primary', ...props }, ref) => {
+    const { icon: iconStyles } = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
+      size: props.size,
+    })
+    return (
+      <ChakraCheckbox
+        icon={
+          <Icon
+            as={BxCheckAnimated}
+            __css={iconStyles}
+            // This prop needs to be passed explicitly for animations
+            isChecked={props.isChecked}
+          />
+        }
+        colorScheme={colorScheme}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </ChakraCheckbox>
+    )
+  },
+)

--- a/frontend/src/components/Checkbox/useCheckboxOthers.ts
+++ b/frontend/src/components/Checkbox/useCheckboxOthers.ts
@@ -1,0 +1,20 @@
+import { createContext, RefObject, useContext } from 'react'
+
+export type CheckboxOthersContextProps = {
+  checkboxRef: RefObject<HTMLInputElement>
+  inputRef: RefObject<HTMLInputElement>
+}
+
+export const CheckboxOthersContext = createContext<
+  CheckboxOthersContextProps | undefined
+>(undefined)
+
+export const useCheckboxOthers = (): CheckboxOthersContextProps => {
+  const context = useContext(CheckboxOthersContext)
+  if (!context) {
+    throw new Error(
+      `useCheckboxOthers must be used within a CheckboxOthersProvider component`,
+    )
+  }
+  return context
+}

--- a/frontend/src/components/Checkbox/useCheckboxOthers.ts
+++ b/frontend/src/components/Checkbox/useCheckboxOthers.ts
@@ -13,7 +13,7 @@ export const useCheckboxOthers = (): CheckboxOthersContextProps => {
   const context = useContext(CheckboxOthersContext)
   if (!context) {
     throw new Error(
-      `useCheckboxOthers must be used within a CheckboxOthersProvider component`,
+      `useCheckboxOthers must be used within a Checkbox.OthersWrapper component`,
     )
   }
   return context

--- a/frontend/src/theme/components/Checkbox.ts
+++ b/frontend/src/theme/components/Checkbox.ts
@@ -13,7 +13,15 @@ export const CHECKBOX_THEME_KEY = 'Checkbox'
  * https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/checkbox.ts
  */
 
-const parts = ['container', 'control', 'label', 'icon']
+const parts = [
+  'container',
+  'control',
+  'label',
+  'icon',
+  'othersInput',
+  'othersContainer',
+  'othersCheckbox',
+]
 
 export const Checkbox: ComponentMultiStyleConfig = {
   parts,
@@ -42,7 +50,7 @@ export const Checkbox: ComponentMultiStyleConfig = {
     container: {
       w: '100%',
       px: '0.25rem',
-      py: '0.5rem',
+      py: '0.625rem',
       _hover: {
         bg: `${c}.100`,
         _disabled: {
@@ -75,6 +83,37 @@ export const Checkbox: ComponentMultiStyleConfig = {
       transform: 'scale(1)',
       transition: 'none',
     },
+    othersContainer: {
+      px: '0.25rem',
+      py: '0.625rem',
+      _hover: {
+        bg: `${c}.100`,
+        _disabled: {
+          bg: 'none',
+        },
+      },
+      _focusWithin: {
+        // use boxShadow instead of border to ensure that control and label
+        // do not move when checkbox is focused
+        boxShadow: `inset 0 0 0 0.125rem ${getColor(theme, `${c}.500`)}`,
+      },
+    },
+    othersInput: {
+      // To align left of input with left of "Others" label
+      ml: '2.625rem',
+      mt: '0.625rem',
+      // Use 100% of the width, not counting the left margin
+      w: 'calc(100% - 2.625rem)',
+    },
+    othersCheckbox: {
+      _focusWithin: {
+        boxShadow: 'none',
+      },
+      _hover: {
+        bg: 'none',
+      },
+      w: '100%',
+    },
   }),
   sizes: {
     // md is the default and we only have one size, so override it
@@ -82,5 +121,8 @@ export const Checkbox: ComponentMultiStyleConfig = {
       control: { w: '1.5rem', h: '1.5rem' },
       icon: { fontSize: '1rem' },
     },
+  },
+  defaultProps: {
+    colorScheme: 'primary',
   },
 }


### PR DESCRIPTION
- Fixes Checkbox component to use `forwardRef`
- Implements "Others" option for checkbox
- Omits unsupported SVG props from `BxCheckAnimated` to get rid of React warnings in console

Part of #2008, purely code review for now. Design review will be done on `form-v2/checkbox-radio` branch when it is complete.