### PR TITLE
fix(sms-limiting): hide counts when forms are onboarded

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-mobile.client.view.html
@@ -12,7 +12,10 @@
           tooltip-trigger="'click mouseenter'"
         ></i>
       </div>
-      <div ng-show="!isLoading && !field.hasRetrievalError">
+      <!-- only show if it has loaded successfully and the form is not onboarded -->
+      <div
+        ng-show="!isLoading && !field.hasRetrievalError && adminVerifiedSmsState !== 'MESSAGE_SERVICE_ID_OBTAINED'"
+      >
         <small class="sms-counts"
           >{{verifiedSmsCount}}/{{smsVerificationLimit}} SMSes used</small
         >


### PR DESCRIPTION
## Problem
1. Modal shows the counts when teh form is onboarded. 

## Solution 
1. Hide the count