### PR TITLE
fix(verification): prevents otp request when limit exceeded

### DIFF
--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -209,10 +209,12 @@ export const _handleGenerateOtp: ControllerHandler<
   // Step 1: Ensure that the form for the specified transaction exists
   return (
     FormService.retrieveFormById(formId)
-      // Step 2: Generate hash and otp
+      // Step 2: Check if we should allow public user to request for OTP
+      .andThen((form) => VerificationService.shouldGenerateOtp(form))
+      // Step 3: Generate hash and otp
       .andThen(() => generateOtpWithHash(logMeta, SALT_ROUNDS))
       .andThen(({ otp, hashedOtp }) =>
-        // Step 3: Send otp
+        // Step 4: Send otp
         VerificationService.sendNewOtp({
           fieldId,
           hashedOtp,

--- a/src/app/modules/verification/verification.errors.ts
+++ b/src/app/modules/verification/verification.errors.ts
@@ -93,3 +93,14 @@ export class SmsLimitExceededError extends ApplicationError {
     super(message)
   }
 }
+
+/**
+ * Public user attempts to request for an OTP on a form without OTP enabled.
+ */
+export class OtpRequestError extends ApplicationError {
+  constructor(
+    message = 'Please ensure that the form you are trying to request OTP for has the feature enabled.',
+  ) {
+    super(message)
+  }
+}

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../types'
 import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
+import { SmsLimitExceededError } from '../../modules/verification/verification.errors'
 import { MailSendError } from '../../services/mail/mail.errors'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { HashingError } from '../../utils/hash'
@@ -190,6 +191,12 @@ export const mapRouteError: MapRouteError = (
       return {
         errorMessage: coreErrorMsg,
         statusCode: StatusCodes.NOT_FOUND,
+      }
+    case SmsLimitExceededError:
+      return {
+        errorMessage:
+          'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
+        statusCode: StatusCodes.BAD_REQUEST,
       }
     case HashingError:
     case DatabaseError:


### PR DESCRIPTION
## Problem
At the present moment, users that have already loaded the page can continue to verify their mobile number, even when the form then disables OTP verification 
Closes #2531

## Solution
1. check if the form is onboarded 
2. check if the form has verifiable mobile fields

**Notes** 
users can request OTP from 2 endpoints - `handleGetOtp` or `handleGenerateOtp`. this check is only added on `handleGenerateOtp` because there are very few calls to `handleGetOtp` and we would have to query for actual form level data from the db to establish if the otp generation is valid. 