### PR TITLE
chore: freeze test-cafe package version to 1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1447,9 +1447,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
-      "integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+      "integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -2753,9 +2753,9 @@
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
-      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.14.5.tgz",
+      "integrity": "sha512-07aqY1ChoPgIxsuDviptRpVkWCSbXWmzQqcgy65C6YSFOfPFvb/DX3bBRHh7pCd/PMEEYHYWUTSVkCbkVainYQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2770,16 +2770,16 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.5.tgz",
+      "integrity": "sha512-7RylxNeDnxc1OleDm0F5Q/BSL+whYRbOAR+bwgCxIr0L32v7UFh/pz1DLMZideAUxKT6eMoS2zQH6fyODLEi8Q==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.14.5",
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-jsx": "^7.14.5",
-        "@babel/types": "^7.14.9"
+        "@babel/types": "^7.14.5"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
@@ -2807,18 +2807,18 @@
           "dev": true
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
+          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.14.8",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -2859,18 +2859,18 @@
           "dev": true
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
+          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.14.8",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -5164,9 +5164,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.172",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "version": "4.14.171",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
       "dev": true
     },
     "@types/mdast": {
@@ -9611,9 +9611,9 @@
       }
     },
     "dedent": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.4.0.tgz",
-      "integrity": "sha1-h979BAvUwVldljKC7FfzwqhSVkI=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "dedent-js": {
@@ -22908,9 +22908,9 @@
       }
     },
     "testcafe": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.2.tgz",
-      "integrity": "sha512-4MdpG/s88WGUtHuftphv2OBYPGeD+g+LbJPiKS6diRhr43mOfdqvSimdbe1oMWUS9waJhlUXOlsCLP33TcY5Aw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.1.tgz",
+      "integrity": "sha512-t4OYDCFLKeQTg228ss2ZFbJFec0w68Z+LxA4BzQkp9kFXsDA4FFBHk6R+X7gQ3gv1wGfWCkggrskHDx7vjSh1A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -22987,7 +22987,7 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.16",
-        "testcafe-hammerhead": "24.4.3",
+        "testcafe-hammerhead": "24.4.1",
         "testcafe-legacy-api": "5.0.2",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
@@ -23017,9 +23017,9 @@
           }
         },
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==",
+          "version": "12.20.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
+          "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
           "dev": true
         },
         "ci-info": {
@@ -23053,6 +23053,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "dedent": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.4.0.tgz",
+          "integrity": "sha1-h979BAvUwVldljKC7FfzwqhSVkI=",
+          "dev": true
         },
         "execa": {
           "version": "4.1.0",
@@ -23238,6 +23244,15 @@
             "is-utf8": "^0.2.0"
           }
         },
+        "tmp": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
         "typescript": {
           "version": "3.9.10",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -23298,12 +23313,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "dedent": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-          "dev": true
         },
         "del": {
           "version": "5.1.0",
@@ -23448,9 +23457,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.4.3",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.4.3.tgz",
-      "integrity": "sha512-rlUm1Hyxko+I+WC4kn7/Lo/FFJb5FgS73u+cspxaYqlwaPX5XEJ/zAa4ZVLJ/qzGOB/WX65JayZ75f+hb18RHQ==",
+      "version": "24.4.1",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.4.1.tgz",
+      "integrity": "sha512-+H3+tz4n3hoFVDHsyNXHkNOi5QYVBWGcCXu2kxMwNsfsk31njjJvmPPl3Ew1trpkWgnekwZVGRPJzQwcmbsJZQ==",
       "dev": true,
       "requires": {
         "acorn-hammerhead": "0.5.0",
@@ -23721,15 +23730,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-    },
-    "tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.1"
-      }
     },
     "tmp-promise": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "supertest": "^6.1.5",
     "supertest-session": "^4.1.0",
     "terser-webpack-plugin": "^1.2.3",
-    "testcafe": "^1.15.2",
+    "testcafe": "^1.15.1",
     "ts-essentials": "^7.0.3",
     "ts-jest": "^26.5.6",
     "ts-loader": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "supertest": "^6.1.5",
     "supertest-session": "^4.1.0",
     "terser-webpack-plugin": "^1.2.3",
-    "testcafe": "^1.15.1",
+    "testcafe": "=1.15.1",
     "ts-essentials": "^7.0.3",
     "ts-jest": "^26.5.6",
     "ts-loader": "^7.0.5",


### PR DESCRIPTION
Also reverts opengovsg/FormSG#2572

The latest version is causing testcafe to be extremely slow, causing test failures due to tests running before the page renders. Revert and freeze to previous version. There is almost no point in updating testcafe as e2e tests are slowly becoming less and less useful due to the impending React migration. We will probably re-evaluate the e2e testing framework used then.