### PR TITLE
fix: disable eserviceid check modal for sgid forms

### DIFF
--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -328,7 +328,10 @@ function settingsFormDirective(
 
         $scope.validateThenSave = () => {
           const checkPassword = $scope.isFormEncrypt()
-          const checkESrvcId = $scope.tempForm.authType !== 'NIL'
+          const checkESrvcId = !['NIL', 'SGID'].includes(
+            // No need to validate eSrvcId for SGID
+            $scope.tempForm.authType,
+          )
           // Not possible for both to be true simultaneously as we have disabled spcp for encrypt forms
           // But the validation will handle both cases
           if ($scope.isFormPrivate() && (checkPassword || checkESrvcId)) {


### PR DESCRIPTION
## Problem
- Currently, the modal still pops up when SGID auth type is selected even though there is no need. This may cause confusion, especially if users have entered an invalid esrvcId and then toggled to SGID. The esrvcId check may fail and leave the admin user with no steps to rectify.
- Closes #2512

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible. UI only change.
 
## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create SGID form. Activate. check that eserviceid modal does not show up
- [ ] Check that sgid form can be submitted successfully
- [ ] Create SP form. Activate. check that eserviceid modal shows up
- [ ] Check that SP form can be submitted successfully
