### PR TITLE
fix: prevents otp request when limit exceeded

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -640,7 +640,9 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValue(
         okAsync(mockTransaction),
       )
-      MockVerificationService.shouldGenerateOtp.mockReturnValue(okAsync(true))
+      MockVerificationService.shouldGenerateMobileOtp.mockReturnValue(
+        okAsync(true),
+      )
     })
 
     it('should return 201 when params are valid', async () => {
@@ -838,7 +840,7 @@ describe('Verification controller', () => {
 
     it('should return 400 when sms limit has been exceeded and the form is not onboarded', async () => {
       // Arrange
-      MockVerificationService.shouldGenerateOtp.mockReturnValueOnce(
+      MockVerificationService.shouldGenerateMobileOtp.mockReturnValueOnce(
         errAsync(new SmsLimitExceededError()),
       )
       const expected = {

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -840,7 +840,7 @@ describe('Verification controller', () => {
 
     it('should return 400 when sms limit has been exceeded and the form is not onboarded', async () => {
       // Arrange
-      MockVerificationService.shouldGenerateMobileOtp.mockReturnValueOnce(
+      MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new SmsLimitExceededError()),
       )
       const expected = {

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -73,7 +73,8 @@ jest.mock('src/app/utils/hash')
 const MockHashUtils = mocked(HashUtils, true)
 
 describe('Verification service', () => {
-  const mockFieldId = new ObjectId().toHexString()
+  const mockFieldIdObj = new ObjectId()
+  const mockFieldId = mockFieldIdObj.toHexString()
   const mockField = { ...generateFieldParams(), _id: mockFieldId }
   const mockTransactionId = new ObjectId().toHexString()
   const mockFormId = new ObjectId().toHexString()
@@ -298,7 +299,12 @@ describe('Verification service', () => {
       const mockForm = {
         _id: new ObjectId(),
         title: 'mockForm',
-        form_fields: [],
+        form_fields: [
+          generateDefaultField(BasicField.Mobile, {
+            isVerifiable: true,
+            _id: mockFieldIdObj as unknown as string,
+          }),
+        ],
         msgSrvcName: 'abc',
       } as unknown as IFormSchema
 
@@ -462,7 +468,12 @@ describe('Verification service', () => {
       const mockForm = {
         _id: new ObjectId(),
         title: 'mockForm',
-        form_fields: [],
+        form_fields: [
+          generateDefaultField(BasicField.Mobile, {
+            isVerifiable: true,
+            _id: mockFieldIdObj as unknown as string,
+          }),
+        ],
         msgSrvcName: 'abc',
       } as unknown as IFormSchema
 
@@ -473,6 +484,7 @@ describe('Verification service', () => {
       MockSmsFactory.sendVerificationOtp.mockReturnValueOnce(errAsync(error))
       const field = generateFieldParams({
         fieldType: BasicField.Mobile,
+        _id: mockFieldIdObj as unknown as string,
       })
       const transaction = await VerificationModel.create({
         formId: mockFormId,
@@ -481,7 +493,7 @@ describe('Verification service', () => {
 
       const result = await VerificationService.sendNewOtp({
         transactionId: transaction._id,
-        fieldId: field._id,
+        fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
@@ -503,7 +515,12 @@ describe('Verification service', () => {
       const mockForm = {
         _id: new ObjectId(),
         title: 'mockForm',
-        form_fields: [],
+        form_fields: [
+          generateDefaultField(BasicField.Mobile, {
+            isVerifiable: true,
+            _id: mockFieldIdObj as unknown as string,
+          }),
+        ],
         msgSrvcName: 'abc',
       } as unknown as IFormSchema
 

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -295,6 +295,15 @@ describe('Verification service', () => {
     })
 
     it('should send OTP and update hashes when parameters are valid', async () => {
+      const mockForm = {
+        _id: new ObjectId(),
+        title: 'mockForm',
+        form_fields: [],
+        msgSrvcName: 'abc',
+      } as unknown as IFormSchema
+
+      MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
+
       const result = await VerificationService.sendNewOtp({
         transactionId: mockTransactionId,
         fieldId: mockFieldId,
@@ -450,7 +459,17 @@ describe('Verification service', () => {
     })
 
     it('should forward errors returned by SmsFactory.sendVerificationOtp', async () => {
+      const mockForm = {
+        _id: new ObjectId(),
+        title: 'mockForm',
+        form_fields: [],
+        msgSrvcName: 'abc',
+      } as unknown as IFormSchema
+
+      MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
+
       const error = new SmsSendError()
+
       MockSmsFactory.sendVerificationOtp.mockReturnValueOnce(errAsync(error))
       const field = generateFieldParams({
         fieldType: BasicField.Mobile,
@@ -481,6 +500,15 @@ describe('Verification service', () => {
     })
 
     it('should return TransactionNotFoundError when database update returns null', async () => {
+      const mockForm = {
+        _id: new ObjectId(),
+        title: 'mockForm',
+        form_fields: [],
+        msgSrvcName: 'abc',
+      } as unknown as IFormSchema
+
+      MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
+
       updateHashSpy.mockResolvedValueOnce(null)
 
       const result = await VerificationService.sendNewOtp({

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -862,7 +862,9 @@ describe('Verification service', () => {
       )
 
       // Act
-      const actual = await VerificationService.shouldGenerateOtp(MOCK_FORM)
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        MOCK_FORM,
+      )
 
       // Assert
       expect(actual._unsafeUnwrap()).toBe(true)
@@ -880,7 +882,9 @@ describe('Verification service', () => {
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
 
       // Act
-      const actual = await VerificationService.shouldGenerateOtp(MOCK_FORM)
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        MOCK_FORM,
+      )
 
       // Assert
       expect(actual._unsafeUnwrap()).toBe(true)
@@ -903,7 +907,9 @@ describe('Verification service', () => {
       )
 
       // Act
-      const actual = await VerificationService.shouldGenerateOtp(MOCK_FORM)
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        MOCK_FORM,
+      )
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(SmsLimitExceededError)
@@ -920,7 +926,9 @@ describe('Verification service', () => {
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
 
       // Act
-      const actual = await VerificationService.shouldGenerateOtp(MOCK_FORM)
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        MOCK_FORM,
+      )
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
@@ -941,7 +949,9 @@ describe('Verification service', () => {
       retrieveSpy.mockReturnValueOnce(errAsync(new DatabaseError()))
 
       // Act
-      const actual = await VerificationService.shouldGenerateOtp(MOCK_FORM)
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        MOCK_FORM,
+      )
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -284,6 +284,18 @@ describe('Verification service', () => {
       [updateData: UpdateFieldData]
     >
 
+    const mockForm = {
+      _id: new ObjectId(),
+      title: 'mockForm',
+      form_fields: [
+        generateDefaultField(BasicField.Mobile, {
+          isVerifiable: true,
+          _id: mockFieldIdObj as unknown as string,
+        }),
+      ],
+      msgSrvcName: 'abc',
+    } as unknown as IFormSchema
+
     beforeEach(() => {
       updateHashSpy = jest
         .spyOn(VerificationModel, 'updateHashForField')
@@ -296,18 +308,6 @@ describe('Verification service', () => {
     })
 
     it('should send OTP and update hashes when parameters are valid', async () => {
-      const mockForm = {
-        _id: new ObjectId(),
-        title: 'mockForm',
-        form_fields: [
-          generateDefaultField(BasicField.Mobile, {
-            isVerifiable: true,
-            _id: mockFieldIdObj as unknown as string,
-          }),
-        ],
-        msgSrvcName: 'abc',
-      } as unknown as IFormSchema
-
       MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
 
       const result = await VerificationService.sendNewOtp({
@@ -465,18 +465,6 @@ describe('Verification service', () => {
     })
 
     it('should forward errors returned by SmsFactory.sendVerificationOtp', async () => {
-      const mockForm = {
-        _id: new ObjectId(),
-        title: 'mockForm',
-        form_fields: [
-          generateDefaultField(BasicField.Mobile, {
-            isVerifiable: true,
-            _id: mockFieldIdObj as unknown as string,
-          }),
-        ],
-        msgSrvcName: 'abc',
-      } as unknown as IFormSchema
-
       MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
 
       const error = new SmsSendError()
@@ -512,18 +500,6 @@ describe('Verification service', () => {
     })
 
     it('should return TransactionNotFoundError when database update returns null', async () => {
-      const mockForm = {
-        _id: new ObjectId(),
-        title: 'mockForm',
-        form_fields: [
-          generateDefaultField(BasicField.Mobile, {
-            isVerifiable: true,
-            _id: mockFieldIdObj as unknown as string,
-          }),
-        ],
-        msgSrvcName: 'abc',
-      } as unknown as IFormSchema
-
       MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
 
       updateHashSpy.mockResolvedValueOnce(null)

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -856,6 +856,9 @@ describe('Verification service', () => {
           generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
         ],
       }
+      const fieldId = new ObjectId()
+      const fieldIdString = fieldId.toHexString()
+      MOCK_FORM.form_fields[0]._id = fieldId
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
       retrieveSpy.mockReturnValueOnce(
         okAsync(smsConfig.smsVerificationLimit - 1),
@@ -864,6 +867,7 @@ describe('Verification service', () => {
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         MOCK_FORM,
+        fieldIdString,
       )
 
       // Assert
@@ -878,12 +882,19 @@ describe('Verification service', () => {
         admin: {
           _id: 'something',
         },
+        form_fields: [
+          generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
+        ],
       }
+      const fieldId = new ObjectId()
+      const fieldIdString = fieldId.toHexString()
+      MOCK_FORM.form_fields[0]._id = fieldId
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         MOCK_FORM,
+        fieldIdString,
       )
 
       // Assert
@@ -901,6 +912,9 @@ describe('Verification service', () => {
           generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
         ],
       }
+      const fieldId = new ObjectId()
+      const fieldIdString = fieldId.toHexString()
+      MOCK_FORM.form_fields[0]._id = fieldId
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
       retrieveSpy.mockReturnValueOnce(
         okAsync(smsConfig.smsVerificationLimit + 1),
@@ -909,6 +923,7 @@ describe('Verification service', () => {
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         MOCK_FORM,
+        fieldIdString,
       )
 
       // Assert
@@ -922,12 +937,17 @@ describe('Verification service', () => {
         admin: {
           _id: 'something',
         },
+        form_fields: [generateDefaultField(BasicField.Mobile)],
       }
+      const fieldId = new ObjectId()
+      const fieldIdString = fieldId.toHexString()
+      MOCK_FORM.form_fields[0]._id = fieldId
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         MOCK_FORM,
+        fieldIdString,
       )
 
       // Assert
@@ -945,12 +965,16 @@ describe('Verification service', () => {
           generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
         ],
       }
+      const fieldId = new ObjectId()
+      const fieldIdString = fieldId.toHexString()
+      MOCK_FORM.form_fields[0]._id = fieldId
       const retrieveSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
       retrieveSpy.mockReturnValueOnce(errAsync(new DatabaseError()))
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         MOCK_FORM,
+        fieldIdString,
       )
 
       // Assert

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -209,12 +209,10 @@ export const _handleGenerateOtp: ControllerHandler<
   // Step 1: Ensure that the form for the specified transaction exists
   return (
     FormService.retrieveFormById(formId)
-      // Step 2: Check if we should allow public user to request for OTP
-      .andThen((form) => VerificationService.shouldGenerateOtp(form))
-      // Step 3: Generate hash and otp
+      // Step 2: Generate hash and otp
       .andThen(() => generateOtpWithHash(logMeta, SALT_ROUNDS))
       .andThen(({ otp, hashedOtp }) =>
-        // Step 4: Send otp
+        // Step 3: Send otp
         VerificationService.sendNewOtp({
           fieldId,
           hashedOtp,

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -579,12 +579,12 @@ export const shouldGenerateMobileOtp = (
       ({ _id, isVerifiable }) => fieldId === _id.toHexString() && isVerifiable,
     ).length > 0
 
-  if (msgSrvcName) {
-    return okAsync(true)
-  }
-
   if (!isVerifiableMobileField) {
     return errAsync(new OtpRequestError())
+  }
+
+  if (msgSrvcName) {
+    return okAsync(true)
   }
 
   return SmsService.retrieveFreeSmsCounts(admin._id).andThen((counts) =>

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -556,7 +556,7 @@ export const shouldGenerateOtp = ({
   form_fields,
 }: Pick<IFormSchema, 'msgSrvcName' | 'admin' | 'form_fields'>): ResultAsync<
   true,
-  SmsLimitExceededError | PossibleDatabaseError
+  SmsLimitExceededError | OtpRequestError
 > => {
   // This check is here to ensure that programmatic pings are rejected.
   // If the check is solely on whether the form is onboarded,

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -562,10 +562,12 @@ export const shouldGenerateOtp = ({
   // If the check is solely on whether the form is onboarded,
   // Pings to form that are not onboarded will go through
   // Even if the form has no mobile field to verify.
-  const hasVerifiableMobileFields = form_fields?.filter(
-    ({ fieldType, isVerifiable }) =>
-      fieldType === BasicField.Mobile && isVerifiable,
-  )
+  const hasVerifiableMobileFields =
+    !!form_fields &&
+    form_fields.filter(
+      ({ fieldType, isVerifiable }) =>
+        fieldType === BasicField.Mobile && isVerifiable,
+    ).length > 0
 
   if (msgSrvcName) {
     return okAsync(true)

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../types'
 import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
-import { SmsLimitExceededError } from '../../modules/verification/verification.errors'
+import {
+  OtpRequestError,
+  SmsLimitExceededError,
+} from '../../modules/verification/verification.errors'
 import { MailSendError } from '../../services/mail/mail.errors'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { HashingError } from '../../utils/hash'
@@ -193,6 +196,7 @@ export const mapRouteError: MapRouteError = (
         statusCode: StatusCodes.NOT_FOUND,
       }
     case SmsLimitExceededError:
+    case OtpRequestError:
       return {
         errorMessage:
           'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',


### PR DESCRIPTION
## Problem
- Fixes bugs with #2586
  - Checks for disabled verified mobile field using array length instead of falsyness
  - Disallows OTP for fields which are not verifiable even if `msgSrvcName` is set
  - Also fixes missing error message routing on `OtpRequestError` so that the correct error message is shown to user
  - Reimplements check at the field level instead of form level because `handleGenerateOtp`  is used by both email and sms fields, and also because there may be more than one verified mobile field
  - Also adds additional unit tests to prevent code regression

## Tests

- [ ] Create form with mobile verification. Open in public form view. Disable mobile verification. Attempt to verify and check that otp is not sent, and an error message appears in OTP box
- [ ] Now enable mobile verification. Check that OTP is sent normally and form can be submitted
- [ ] Add `msgSrvcName` to form and repeat the first test. Check that OTP cannot be sent.
- [ ] Now enable mobile verification. Add 10000 OTPs. Check that OTPs can still be sent and form can be submitted
- [ ] Check that email otp verification works normally
- [ ] Create form with two verified mobile fields and open in public view. Disable mobile verification for one field. Attempt to verify and check that otp is not sent, and an error message appears in OTP box for non-verified field, but otp is sent for verified field

