### PR TITLE
fix(react/FormLabel): remove extra height when optional indicator is shown

### DIFF
--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -58,7 +58,7 @@ export const FormLabel = ({
       display="flex"
       flexDir="column"
     >
-      <Box display="block">
+      <Box>
         {questionNumber && (
           <FormLabel.QuestionNumber>{questionNumber}</FormLabel.QuestionNumber>
         )}
@@ -91,11 +91,11 @@ FormLabel.QuestionNumber = ({ children, ...props }: TextProps): JSX.Element => {
   return (
     <Text
       as="span"
-      verticalAlign="top"
       textStyle="caption-1"
       color="secondary.700"
       mr="0.5rem"
-      lineHeight="1.5rem"
+      verticalAlign="baseline"
+      lineHeight={0}
       {...props}
     >
       <VisuallyHidden>Question number:</VisuallyHidden>
@@ -120,6 +120,7 @@ FormLabel.OptionalIndicator = (
       textStyle="body-2"
       ml="0.5rem"
       color="neutral.700"
+      lineHeight={0}
       {...props}
     >
       (optional)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Styling bug where height of label with optional text is different from one without the optional text. See gif of before and after.


## Before & After Screenshots

**BEFORE**:
![recording (21)](https://user-images.githubusercontent.com/22133008/129884374-3d664293-1432-4297-bc28-4dc0b2ec6506.gif)


**AFTER**:
<!-- [insert screenshot here] -->
![recording (22)](https://user-images.githubusercontent.com/22133008/129884382-8c154b11-7ad2-49be-a80c-8d171f32fc99.gif)

