### PR TITLE
chore(v2): update Github actions for form-v2 branches

### DIFF
--- a/.github/workflows/ci-angularjs.yml
+++ b/.github/workflows/ci-angularjs.yml
@@ -2,9 +2,13 @@ name: CI (AngularJS)
 
 on:
   push:
-  pull_request:
     branches-ignore:
       # Push events to branches matching refs/heads/form-v2
+      - 'form-v2'
+      - 'form-v2/**'
+  pull_request:
+    branches-ignore:
+      # PRs to branches matching refs/heads/form-v2
       - 'form-v2'
       - 'form-v2/**'
     types: [opened, reopened]

--- a/.github/workflows/ci-angularjs.yml
+++ b/.github/workflows/ci-angularjs.yml
@@ -1,8 +1,12 @@
-name: CI
+name: CI (AngularJS)
 
 on:
   push:
   pull_request:
+    branches-ignore:
+      # Push events to branches matching refs/heads/form-v2
+      - 'form-v2'
+      - 'form-v2/**'
     types: [opened, reopened]
 
 jobs:

--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -2,9 +2,13 @@ name: CI (React)
 
 on:
   push:
-  pull_request:
     branches:
       # Push events to branches matching refs/heads/form-v2
+      - 'form-v2'
+      - 'form-v2/**'
+  pull_request:
+    branches:
+      # PR events to branches matching refs/heads/form-v2
       - 'form-v2'
       - 'form-v2/**'
     types: [opened, reopened]

--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -1,0 +1,50 @@
+name: CI (React)
+
+on:
+  push:
+  pull_request:
+    branches:
+      # Push events to branches matching refs/heads/form-v2
+      - 'form-v2'
+      - 'form-v2/**'
+    types: [opened, reopened]
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci
+
+  test-frontend:
+    needs: install
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run test-frontend


### PR DESCRIPTION
Irrelevant (and sometimes flakey) CI builds are slowing down the reviewing and merging of PRs for the React migration.

This PR updates the current CI github actions to only run on non form-v2 branches, and adds a new  `ci-react` github action that only runs on form-v2 branches.