### PR TITLE
chore: enable chromatic to build on pushes to form-v2/develop branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,9 @@ defaults:
 
 # Event for the workflow
 on:
+  push:
+    branches:
+      - 'form-v2/develop'
   pull_request:
     branches:
       # PR events to branches matching refs/heads/form-v2


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Chromatic is not generating story differences properly as develop branch is not being kept up to date. This PR updates the CI workflow of Chromatic to also build on pushes to `form-v2/develop`
