### PR TITLE
fix: only check for sms quota on verified mobile field OTP verifications instead of all verified fields

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -642,7 +642,7 @@ describe('Verification controller', () => {
 
     it('should return 201 when params are valid', async () => {
       // Arrange
-      MockVerificationService.checkShouldDisableVerifiedFields.mockReturnValueOnce(
+      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
         okAsync(true),
       )
 
@@ -666,7 +666,7 @@ describe('Verification controller', () => {
         recipient: MOCK_ANSWER,
       })
       expect(
-        MockVerificationService.checkShouldDisableVerifiedFields,
+        MockVerificationService.disableVerifiedFieldsIfRequired,
       ).toHaveBeenCalledWith(
         MOCK_FORM,
         mockTransaction,

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -624,12 +624,7 @@ describe('Verification controller', () => {
     } as IPopulatedForm
 
     beforeEach(() => {
-      MockFormService.retrieveFormById.mockReturnValue(
-        okAsync({} as IFormSchema),
-      )
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
+      MockFormService.retrieveFullFormById.mockReturnValue(okAsync(MOCK_FORM))
 
       MockOtpUtils.generateOtpWithHash.mockReturnValue(
         okAsync({
@@ -647,7 +642,7 @@ describe('Verification controller', () => {
 
     it('should return 201 when params are valid', async () => {
       // Arrange
-      MockVerificationService.processAdminSmsCounts.mockReturnValueOnce(
+      MockVerificationService.checkShouldDisableVerifiedFields.mockReturnValueOnce(
         okAsync(true),
       )
 
@@ -659,7 +654,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -671,8 +666,12 @@ describe('Verification controller', () => {
         recipient: MOCK_ANSWER,
       })
       expect(
-        MockVerificationService.processAdminSmsCounts,
-      ).toHaveBeenCalledWith(MOCK_FORM)
+        MockVerificationService.checkShouldDisableVerifiedFields,
+      ).toHaveBeenCalledWith(
+        MOCK_FORM,
+        mockTransaction,
+        MOCK_REQ.params.fieldId,
+      )
       expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -693,7 +692,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -725,7 +724,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -757,7 +756,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -790,7 +789,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -823,7 +822,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -877,7 +876,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -894,7 +893,7 @@ describe('Verification controller', () => {
 
     it('should return 404 when form is not found', async () => {
       // Arrange
-      MockFormService.retrieveFormById.mockReturnValueOnce(
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
         errAsync(new FormNotFoundError()),
       )
       const expectedResponse = {
@@ -909,7 +908,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
@@ -935,7 +934,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -967,7 +966,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -999,7 +998,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -1030,7 +1029,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
@@ -1058,7 +1057,7 @@ describe('Verification controller', () => {
       )
 
       // Assert
-      expect(MockFormService.retrieveFormById).toHaveBeenCalledWith(
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -726,7 +726,7 @@ describe('Verification service', () => {
     })
   })
 
-  describe('checkShouldDisableVerifiedFields', () => {
+  describe('disableVerifiedFieldsIfRequired', () => {
     const MOCK_FORM = {
       title: 'some mock form',
       _id: new ObjectId(),
@@ -765,7 +765,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           nonMobileTransaction,
           EMAIL_FIELD._id,
@@ -782,7 +782,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -806,7 +806,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -830,7 +830,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -849,7 +849,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -875,7 +875,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -903,7 +903,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,
@@ -931,7 +931,7 @@ describe('Verification service', () => {
 
       // Act
       const actualResult =
-        await VerificationService.checkShouldDisableVerifiedFields(
+        await VerificationService.disableVerifiedFieldsIfRequired(
           MOCK_FORM,
           mobileTransaction,
           MOBILE_FIELD._id,

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -1,8 +1,19 @@
+/* eslint-disable import/first */
 import { ObjectId } from 'bson'
 import { addHours, subHours, subMinutes, subSeconds } from 'date-fns'
 import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
+
+// These need to be mocked first before the rest of the test
+import * as LoggerModule from 'src/app/config/logger'
+
+import getMockLogger from 'tests/unit/backend/helpers/jest-logger'
+
+const mockLogger = getMockLogger()
+jest.mock('src/app/config/logger')
+const MockLoggerModule = mocked(LoggerModule, true)
+MockLoggerModule.createLoggerWithLabel.mockReturnValue(mockLogger)
 
 import { smsConfig } from 'src/app/config/features/sms.config'
 import formsgSdk from 'src/app/config/formsg-sdk'
@@ -715,7 +726,7 @@ describe('Verification service', () => {
     })
   })
 
-  describe('processAdminSmsCounts', () => {
+  describe('checkShouldDisableVerifiedFields', () => {
     const MOCK_FORM = {
       title: 'some mock form',
       _id: new ObjectId(),
@@ -724,6 +735,9 @@ describe('Verification service', () => {
       },
       permissionList: [{ email: 'some@user.gov.sg' }],
     } as IPopulatedForm
+    let mobileTransaction: IVerificationSchema
+    const EMAIL_FIELD = generateFieldParams({ fieldType: BasicField.Email })
+    const MOBILE_FIELD = generateFieldParams({ fieldType: BasicField.Mobile })
     const onboardSpy = jest.spyOn(FormUtils, 'isFormOnboarded')
     const retrievalSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
     const disableSpy = jest.spyOn(
@@ -731,21 +745,56 @@ describe('Verification service', () => {
       'disableSmsVerificationsForUser',
     )
 
-    it('should not do anything when the form is onboarded', async () => {
+    beforeEach(async () => {
+      mobileTransaction = await VerificationModel.create({
+        formId: MOCK_FORM._id,
+        fields: [MOBILE_FIELD],
+        // Expire 1 hour in future
+        expireAt: addHours(new Date(), 1),
+      })
+    })
+
+    it('should not do anything when the transaction is not for a BasicField.Mobile field', async () => {
+      // Arrange
+      const nonMobileTransaction = await VerificationModel.create({
+        formId: MOCK_FORM._id,
+        fields: [EMAIL_FIELD],
+        // Expire 1 hour in future
+        expireAt: addHours(new Date(), 1),
+      })
+
+      // Act
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          nonMobileTransaction,
+          EMAIL_FIELD._id,
+        )
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual(false)
+      expect(retrievalSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not do anything when the form is onboarded even with Mobile field', async () => {
       // Arrange
       onboardSpy.mockReturnValueOnce(true)
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
 
       // Assert
-      expect(actual._unsafeUnwrap()).toBe(true)
+      expect(actualResult._unsafeUnwrap()).toBe(false)
       expect(retrievalSpy).not.toHaveBeenCalled()
     })
 
     it('should disable sms verifications and send email when sms limit is exceeded', async () => {
       // Arrange
-
       MockMailService.sendSmsVerificationDisabledEmail.mockReturnValueOnce(
         okAsync(true),
       )
@@ -756,10 +805,15 @@ describe('Verification service', () => {
       )
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
 
       // Assert
-      expect(actual._unsafeUnwrap()).toBe(true)
+      expect(actualResult._unsafeUnwrap()).toBe(true)
       expect(
         MockMailService.sendSmsVerificationDisabledEmail,
       ).toHaveBeenCalledWith(MOCK_FORM)
@@ -769,17 +823,20 @@ describe('Verification service', () => {
 
     it('should send a warning when the admin has sent out a certain number of sms', async () => {
       // Arrange
-
       MockMailService.sendSmsVerificationWarningEmail.mockReturnValueOnce(
         okAsync(true),
       )
       retrievalSpy.mockReturnValueOnce(okAsync(SMS_WARNING_TIERS.LOW))
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
-
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
       // Assert
-      expect(actual._unsafeUnwrap()).toBe(true)
+      expect(actualResult._unsafeUnwrap()).toBe(true)
       expect(disableSpy).not.toHaveBeenCalled()
       expect(
         MockMailService.sendSmsVerificationWarningEmail,
@@ -788,14 +845,17 @@ describe('Verification service', () => {
 
     it('should not do anything when the sms sent by admin is not at any limit', async () => {
       // Arrange
-
       retrievalSpy.mockReturnValueOnce(okAsync(SMS_WARNING_TIERS.LOW - 1))
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
-
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
       // Assert
-      expect(actual._unsafeUnwrap()).toBe(true)
+      expect(actualResult._unsafeUnwrap()).toBe(false)
       expect(
         MockMailService.sendSmsVerificationDisabledEmail,
       ).not.toHaveBeenCalled()
@@ -805,7 +865,7 @@ describe('Verification service', () => {
       expect(disableSpy).not.toHaveBeenCalled()
     })
 
-    it('should propagate any errors encountered during warning mail sending', async () => {
+    it('should log any errors encountered during warning mail sending', async () => {
       // Arrange
       const expected = new MailGenerationError('big ded')
       MockMailService.sendSmsVerificationWarningEmail.mockReturnValueOnce(
@@ -814,14 +874,21 @@ describe('Verification service', () => {
       retrievalSpy.mockReturnValueOnce(okAsync(SMS_WARNING_TIERS.LOW))
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
-
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
       // Assert
-      expect(actual._unsafeUnwrapErr()).toBe(expected)
+      expect(actualResult._unsafeUnwrapErr()).toBe(undefined)
       expect(disableSpy).not.toHaveBeenCalled()
       expect(
         MockMailService.sendSmsVerificationWarningEmail,
       ).toHaveBeenCalledWith(MOCK_FORM, SMS_WARNING_TIERS.LOW)
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expected }),
+      )
     })
 
     it('should propagate any errors encountered during disabled mail sending', async () => {
@@ -835,30 +902,46 @@ describe('Verification service', () => {
       )
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
 
       // Assert
       expect(disableSpy).not.toHaveBeenCalled()
       expect(
         MockMailService.sendSmsVerificationWarningEmail,
       ).not.toHaveBeenCalled()
-      expect(actual._unsafeUnwrapErr()).toBe(expected)
+      expect(actualResult._unsafeUnwrapErr()).toBe(undefined)
       expect(
         MockMailService.sendSmsVerificationDisabledEmail,
       ).toHaveBeenCalledWith(MOCK_FORM)
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expected }),
+      )
     })
 
-    it('should return the error received when retrieval of sms counts fails', async () => {
+    it('should log the error received when retrieval of sms counts fails', async () => {
       // Arrange
       const expected = new DatabaseError()
       onboardSpy.mockReturnValueOnce(false)
       retrievalSpy.mockReturnValueOnce(errAsync(expected))
 
       // Act
-      const actual = await VerificationService.processAdminSmsCounts(MOCK_FORM)
+      const actualResult =
+        await VerificationService.checkShouldDisableVerifiedFields(
+          MOCK_FORM,
+          mobileTransaction,
+          MOBILE_FIELD._id,
+        )
 
       // Assert
-      expect(actual._unsafeUnwrapErr()).toBe(expected)
+      expect(actualResult._unsafeUnwrapErr()).toBe(undefined)
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expected }),
+      )
       expect(retrievalSpy).toBeCalledWith(String(MOCK_FORM.admin._id))
     })
   })

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -208,33 +208,32 @@ export const _handleGenerateOtp: ControllerHandler<
   }
   // Step 1: Ensure that the form for the specified transaction exists
   return (
-    FormService.retrieveFormById(formId)
+    FormService.retrieveFullFormById(formId)
       // Step 2: Generate hash and otp
-      .andThen(() => generateOtpWithHash(logMeta, SALT_ROUNDS))
-      .andThen(({ otp, hashedOtp }) =>
-        // Step 3: Send otp
-        VerificationService.sendNewOtp({
-          fieldId,
-          hashedOtp,
-          otp,
-          recipient: answer,
-          transactionId,
-        }),
+      .andThen((form) =>
+        generateOtpWithHash(logMeta, SALT_ROUNDS)
+          .andThen(({ otp, hashedOtp }) =>
+            // Step 3: Send otp
+            VerificationService.sendNewOtp({
+              fieldId,
+              hashedOtp,
+              otp,
+              recipient: answer,
+              transactionId,
+            }),
+          )
+          // Return the required data for next steps.
+          .map((updatedTransaction) => ({ updatedTransaction, form })),
       )
-      .map(() => {
+      .map(({ updatedTransaction, form }) => {
         res.sendStatus(StatusCodes.CREATED)
         // NOTE: This is returned because tests require this to avoid async mocks interfering with each other.
         // However, this is not an issue in reality because express does not require awaiting on the sendStatus call.
-        return FormService.retrieveFullFormById(formId)
-          .andThen((form) => VerificationService.processAdminSmsCounts(form))
-          .mapErr((error) => {
-            logger.error({
-              message:
-                'Error checking sms counts or deactivating OTP verification for admin',
-              meta: logMeta,
-              error,
-            })
-          })
+        return VerificationService.checkShouldDisableVerifiedFields(
+          form,
+          updatedTransaction,
+          fieldId,
+        )
       })
       .mapErr((error) => {
         logger.error({

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -229,7 +229,7 @@ export const _handleGenerateOtp: ControllerHandler<
         res.sendStatus(StatusCodes.CREATED)
         // NOTE: This is returned because tests require this to avoid async mocks interfering with each other.
         // However, this is not an issue in reality because express does not require awaiting on the sendStatus call.
-        return VerificationService.checkShouldDisableVerifiedFields(
+        return VerificationService.disableVerifiedFieldsIfRequired(
           form,
           updatedTransaction,
           fieldId,

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -1,6 +1,7 @@
 import { pick } from 'lodash'
 import { Mongoose, Schema } from 'mongoose'
 
+import { BasicField } from '../../../../shared/types'
 import { TRANSACTION_EXPIRE_AFTER_SECONDS } from '../../../../shared/utils/verification'
 import {
   IFormSchema,
@@ -23,7 +24,7 @@ const VerificationFieldSchema = new Schema<IVerificationFieldSchema>({
     type: String,
     required: true,
   },
-  fieldType: { type: String, required: true },
+  fieldType: { type: String, enum: Object.values(BasicField), required: true },
   signedData: { type: String, default: null },
   hashedOtp: { type: String, default: null },
   // No ttl index is applied on hashCreatedAt, as we do not want to delete the

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -363,6 +363,35 @@ export const sendNewOtp = ({
   })
 }
 
+export const checkShouldDisableVerifiedFields = (
+  form: IPopulatedForm,
+  transaction: IVerificationSchema,
+  fieldId: string,
+): ResultAsync<boolean, void> => {
+  return getFieldFromTransaction(transaction, fieldId)
+    .asyncAndThen((field) => {
+      switch (field.fieldType) {
+        case BasicField.Mobile:
+          return processAdminSmsCounts(form)
+        default:
+          return okAsync(false)
+      }
+    })
+    .mapErr((error) => {
+      logger.error({
+        message:
+          'Error checking sms counts or deactivating OTP verification for admin',
+        meta: {
+          action: 'checkShouldDisabledVerifiedMobileFields',
+          transactionId: transaction._id,
+          fieldId,
+          formId: transaction.formId,
+        },
+        error,
+      })
+    })
+}
+
 /**
  * Compares the given otp. If correct, returns signedData, else returns an error
  * @param transactionId
@@ -500,9 +529,11 @@ const sendOtpForField = (
 }
 
 /**
+ * Exported for testing.
  * Checks the number of free smses sent by the admin of the form and deactivates verification or sends mail as required
  * @param form The form whose admin's sms counts needs to be checked
- * @returns ok(true) when the verification has been deactivated successfully or no action is required
+ * @returns ok(true) when the verification has been deactivated successfully
+ * @returns ok(false) when no action is required
  * @returns err(MailGenerationError) when an error occurred on creating the HTML template for the email
  * @returns err(MailSendError) when an error occurred on sending the email
  * @returns err(PossibleDatabaseError) when an error occurred while retrieving the counts from the database
@@ -510,11 +541,11 @@ const sendOtpForField = (
 export const processAdminSmsCounts = (
   form: IPopulatedForm,
 ): ResultAsync<
-  true,
+  boolean,
   MailGenerationError | MailSendError | PossibleDatabaseError
 > => {
   if (isFormOnboarded(form)) {
-    return okAsync(true)
+    return okAsync(false)
   }
 
   // Convert to string because it's typed as any
@@ -529,6 +560,7 @@ export const processAdminSmsCounts = (
  * Checks the number of free smses sent by the admin of a form and performs the appropriate action
  * @param form The form whose admin's sms counts needs to be checked
  * @returns ok(true) when the action has been performed successfully
+ * @returns ok(false) when no action is required
  * @returns err(MailGenerationError) when an error occurred on creating the HTML template for the email
  * @returns err(MailSendError) when an error occurred on sending the email
  * @returns err(PossibleDatabaseError) when an error occurred while retrieving the counts from the database
@@ -537,7 +569,7 @@ const checkSmsCountAndPerformAction = (
   form: Pick<IPopulatedForm, 'admin' | 'title' | '_id' | 'permissionList'>,
   freeSmsSent: number,
 ): ResultAsync<
-  true,
+  boolean,
   MailGenerationError | MailSendError | PossibleDatabaseError
 > => {
   // Convert to string because it's typed as any
@@ -555,7 +587,7 @@ const checkSmsCountAndPerformAction = (
     return MailService.sendSmsVerificationWarningEmail(form, freeSmsSent)
   }
 
-  return okAsync(true)
+  return okAsync(false)
 }
 
 /**

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -363,7 +363,7 @@ export const sendNewOtp = ({
   })
 }
 
-export const checkShouldDisableVerifiedFields = (
+export const disableVerifiedFieldsIfRequired = (
   form: IPopulatedForm,
   transaction: IVerificationSchema,
   fieldId: string,

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -529,7 +529,6 @@ const sendOtpForField = (
 }
 
 /**
- * Exported for testing.
  * Checks the number of free smses sent by the admin of the form and deactivates verification or sends mail as required
  * @param form The form whose admin's sms counts needs to be checked
  * @returns ok(true) when the verification has been deactivated successfully
@@ -538,7 +537,7 @@ const sendOtpForField = (
  * @returns err(MailSendError) when an error occurred on sending the email
  * @returns err(PossibleDatabaseError) when an error occurred while retrieving the counts from the database
  */
-export const processAdminSmsCounts = (
+const processAdminSmsCounts = (
   form: IPopulatedForm,
 ): ResultAsync<
   boolean,

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -1,10 +1,12 @@
 import { Document, Model } from 'mongoose'
 
+import { BasicField } from '../../shared/types'
+
 import { PublicView } from './database'
 import { IFormSchema } from './form'
 
 export interface IVerificationField {
-  fieldType: string
+  fieldType: BasicField
   signedData: string | null
   hashedOtp: string | null
   hashCreatedAt: Date | null

--- a/tests/unit/backend/helpers/jest-logger.ts
+++ b/tests/unit/backend/helpers/jest-logger.ts
@@ -3,6 +3,7 @@ import winston, { Logger } from 'winston'
 interface MockLogger extends Logger {
   log: jest.Mock
   warn: jest.Mock
+  error: jest.Mock
   info: jest.Mock
   profile: jest.Mock
 }
@@ -10,6 +11,7 @@ interface MockLogger extends Logger {
 const getMockLogger = (): MockLogger => {
   const logger = winston.createLogger()
   logger.log = jest.fn()
+  logger.error = jest.fn()
   logger.warn = jest.fn()
   logger.info = jest.fn()
   logger.profile = jest.fn()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some admins are receiving spammy emails about their free SMS OTP tier quota being hit when the public verifies their email in a verified email field. This is due to the sms check being applied on every OTP generation, regardless of whether the field to verify is a mobile or email field.

This PR fixes the bug by only processing any sms checking action on verified mobile fields.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- Check mobile fieldType before processing admin sms email
