### PR TITLE
feat(design-system): use FormHelperText for label description so SRs are aware

### DIFF
--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -85,6 +85,12 @@ const FormLabelDescription = ({
   children,
   ...props
 }: TextProps): JSX.Element => {
+  // useFormControlContext is a ChakraUI hook that returns props passed down
+  // from a parent ChakraUI's `FormControl` component.
+  // The return object is used to determine whether FormHelperText or Text is
+  // used.
+  // Using FormHelperText allows for the children text to be added to the parent
+  // FormLabel's aria-describedby attribute. This is done internally by ChakraUI.
   const field = useFormControlContext()
 
   // Render normal Text component if no form context is found.
@@ -127,6 +133,8 @@ FormLabel.OptionalIndicator = ({
   isRequired,
   ...props
 }: TextProps & { isRequired?: boolean }): JSX.Element | null => {
+  // useFormControlContext is a ChakraUI hook that returns props passed down
+  // from a parent ChakraUI's `FormControl` component.
   // Valid hook usage since composited component is still a component.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const field = useFormControlContext()

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  FormHelperText,
   FormLabel as ChakraFormLabel,
   FormLabelProps as ChakraFormLabelProps,
   Icon,
@@ -81,9 +82,9 @@ FormLabel.Label = ChakraFormLabel
 
 FormLabel.Description = ({ children, ...props }: TextProps): JSX.Element => {
   return (
-    <Text textStyle="body-2" color="secondary.400">
+    <FormHelperText mt={0} textStyle="body-2" color="secondary.400">
       {children}
-    </Text>
+    </FormHelperText>
   )
 }
 

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   Box,
   FormHelperText,
@@ -80,13 +81,30 @@ export const FormLabel = ({
 
 FormLabel.Label = ChakraFormLabel
 
-FormLabel.Description = ({ children, ...props }: TextProps): JSX.Element => {
+const FormLabelDescription = ({
+  children,
+  ...props
+}: TextProps): JSX.Element => {
+  const field = useFormControlContext()
+
+  // Render normal Text component if no form context is found.
+  const ComponentToRender = useMemo(() => {
+    if (field) return FormHelperText
+    return Text
+  }, [field])
+
   return (
-    <FormHelperText mt={0} textStyle="body-2" color="secondary.400">
+    <ComponentToRender
+      mt={0}
+      textStyle="body-2"
+      color="secondary.400"
+      {...props}
+    >
       {children}
-    </FormHelperText>
+    </ComponentToRender>
   )
 }
+FormLabel.Description = FormLabelDescription
 
 FormLabel.QuestionNumber = ({ children, ...props }: TextProps): JSX.Element => {
   return (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When focusing on the input field, only the label is being spoken out loud. The description should also be spoken out loud. 
This PR uses Chakra's FormHelperText component instead of Text to render so the input's aria-describedby prop contains the description id too.

