### PR TITLE
fix(radio): Remove unnecessary nbsp from option text

### DIFF
--- a/src/public/modules/forms/base/componentViews/field-radiobutton.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-radiobutton.client.view.html
@@ -41,7 +41,8 @@
               aria-labelledby="label-{{ vm.field._id || 'defaultID'}}"
               aria-describedby="description-{{ vm.field._id || 'defaultID'}}"
             />
-            {{ option }}
+            <span ng-if="option">{{ option }}</span>
+            <span ng-if="!option">&nbsp;</span>
             <span
               class="radiomark"
               ng-class="vm.field.fieldValue === option ? '{{ vm.colortheme }}-border' : ''"

--- a/src/public/modules/forms/base/componentViews/field-radiobutton.client.view.html
+++ b/src/public/modules/forms/base/componentViews/field-radiobutton.client.view.html
@@ -41,8 +41,7 @@
               aria-labelledby="label-{{ vm.field._id || 'defaultID'}}"
               aria-describedby="description-{{ vm.field._id || 'defaultID'}}"
             />
-            {{ option }} &nbsp;
-            <!-- Empty space is to prevent visual bug when radio button is empty-->
+            {{ option }}
             <span
               class="radiomark"
               ng-class="vm.field.fieldValue === option ? '{{ vm.colortheme }}-border' : ''"


### PR DESCRIPTION
## Context

We append a `&nbsp;` (non-breakable space) to **all** radio fields, which can cause a rendering error on mobile when the radio text just about covers the available space, as reported by a user for [this form](https://form.gov.sg/#!/611d22357f4b5f0012537c4a) on mobile.

![image](https://user-images.githubusercontent.com/935223/131961724-a544476f-486e-417f-9820-05a6b4101762.png)


## Solution
The empty line is caused by a non-breakable character forcefully added in code to **all** radio fields.

The code had the comment: "Empty space is to prevent visual bug when radio button is empty".

I am assuming that:
* that comment might no longer be applicable? (checkbox fields don't have the same `&nbsp;` for example)
* There shouldn't be empty options anyway?

~~A better option is probably to make the rendering conditional where `&nbsp;` is not appended to the value, it is instead the default when the value is falsy. I might look at this later, but I'm opening the PR first anyway to get some early feedback.~~

~~@liangyuanruo might remember how old the `&nbsp;` is and if it is still relevant?~~

The current form definition really cannot have empty option values for radios, but the comment still scares me that some old form entries in DB could have empty fields?

I have added a commit to conditionally show the option OR use an `&nbsp;`, instead of forcefully appending `&nbsp;` to **all** entries.

Tested locally with valid radio values
