### PR TITLE
feat(react): allow markdown usage, other useToast functions in toasts

### DIFF
--- a/frontend/src/components/Toast/Toast.stories.tsx
+++ b/frontend/src/components/Toast/Toast.stories.tsx
@@ -63,6 +63,14 @@ const ButtonWithToastTemplate: Story<UseToastProps> = (args) => {
   )
 }
 
+export const WithMarkdown = ToastTemplate.bind({})
+WithMarkdown.args = {
+  ...ToastStateProps.Success,
+  title: `Markdown can be used in the _title_`,
+  description: `Markdown can be used in the _description_ too`,
+  useMarkdown: true,
+}
+
 export const Success = ToastTemplate.bind({})
 Success.args = ToastStateProps.Success
 

--- a/frontend/src/components/Toast/Toast.stories.tsx
+++ b/frontend/src/components/Toast/Toast.stories.tsx
@@ -2,7 +2,7 @@
 import { SimpleGrid, Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
-import { useToast, UseToastOptions } from '~hooks/useToast'
+import { useToast, UseToastProps } from '~hooks/useToast'
 import Button from '~components/Button'
 
 import { Toast, ToastProps } from './Toast'
@@ -47,7 +47,7 @@ export default {
 
 const ToastTemplate: Story<ToastProps> = (args) => <Toast {...args} />
 
-const ButtonWithToastTemplate: Story<UseToastOptions> = (args) => {
+const ButtonWithToastTemplate: Story<UseToastProps> = (args) => {
   const toast = useToast()
   return (
     <Button

--- a/frontend/src/components/Toast/Toast.stories.tsx
+++ b/frontend/src/components/Toast/Toast.stories.tsx
@@ -2,7 +2,7 @@
 import { SimpleGrid, Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
-import { useToast, UseToastProps } from '~hooks/useToast'
+import { useToast, UseToastOptions } from '~hooks/useToast'
 import Button from '~components/Button'
 
 import { Toast, ToastProps } from './Toast'
@@ -47,7 +47,7 @@ export default {
 
 const ToastTemplate: Story<ToastProps> = (args) => <Toast {...args} />
 
-const ButtonWithToastTemplate: Story<UseToastProps> = (args) => {
+const ButtonWithToastTemplate: Story<UseToastOptions> = (args) => {
   const toast = useToast()
   return (
     <Button

--- a/frontend/src/components/Toast/Toast.tsx
+++ b/frontend/src/components/Toast/Toast.tsx
@@ -15,7 +15,7 @@ import {
 import { BxsCheckCircle, BxsErrorCircle } from '~assets/icons'
 import { useMdComponents } from '~hooks/useMdComponents'
 
-type ToastStatus = 'danger' | 'success' | 'warning'
+export type ToastStatus = 'danger' | 'success' | 'warning'
 
 export interface ToastProps
   extends Omit<

--- a/frontend/src/components/Toast/Toast.tsx
+++ b/frontend/src/components/Toast/Toast.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { useMemo } from 'react'
 import { BiX } from 'react-icons/bi'
+import ReactMarkdown from 'react-markdown'
 import {
   Alert,
   AlertDescription,
@@ -12,6 +13,7 @@ import {
 } from '@chakra-ui/react'
 
 import { BxsCheckCircle, BxsErrorCircle } from '~assets/icons'
+import { useMdComponents } from '~hooks/useMdComponents'
 
 type ToastStatus = 'danger' | 'success' | 'warning'
 
@@ -21,17 +23,23 @@ export interface ToastProps
     'duration' | 'position' | 'render' | 'status' | 'variant'
   > {
   /**
-   * The status of the Toast.
+   * The status variant of the toast.
    */
   status: ToastStatus
-  // RenderProps that chakra passes to all custom components that uses the render function
+  /**
+   * RenderProps that chakra passes to all custom components that uses the
+   * render function
+   */
   onClose: () => void
+  /**
+   * Whether markdown is enabled for rendering strings in toast.
+   * Defaults to `true`.
+   */
+  useMarkdown?: boolean
 }
 
-const getIconForStatus = (status: ToastStatus) =>
-  status === 'success' ? BxsCheckCircle : BxsErrorCircle
-
 export const Toast = ({
+  useMarkdown = true,
   status,
   title,
   id,
@@ -44,13 +52,38 @@ export const Toast = ({
     variant: status,
   })
 
+  const StatusIcon = useMemo(
+    () => (status === 'success' ? BxsCheckCircle : BxsErrorCircle),
+    [status],
+  )
+
+  const mdComponents = useMdComponents(styles)
+
+  const descriptionComponent = useMemo(() => {
+    // ReactMarkdown requires children to be of string type. If description is
+    // not a string, return description as is.
+    if (!description || !useMarkdown || typeof description !== 'string')
+      return description
+    return (
+      <ReactMarkdown components={mdComponents}>{description}</ReactMarkdown>
+    )
+  }, [description, mdComponents, useMarkdown])
+
+  const titleComponent = useMemo(() => {
+    // ReactMarkdown requires children to be of string type. If title is not a
+    // string, return title as is.
+    if (!title || !useMarkdown || typeof title !== 'string') return title
+
+    return <ReactMarkdown components={mdComponents}>{title}</ReactMarkdown>
+  }, [title, mdComponents, useMarkdown])
+
   return (
     <Box sx={styles.wrapper}>
       <Alert sx={styles.container} id={String(id)} aria-live="assertive">
-        <Icon sx={styles.icon} as={getIconForStatus(status)} />
+        <Icon sx={styles.icon} as={StatusIcon} />
         <Box sx={styles.content}>
-          {title && <AlertTitle>{title}</AlertTitle>}
-          {description && <AlertDescription>{description}</AlertDescription>}
+          <AlertTitle>{titleComponent}</AlertTitle>
+          <AlertDescription>{descriptionComponent}</AlertDescription>
         </Box>
         {isClosable && (
           <CloseButton

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -4,7 +4,6 @@ import {
   useToast as useChakraToast,
   UseToastOptions as ChakraUseToastOptions,
 } from '@chakra-ui/react'
-import { SetRequired } from 'type-fest'
 
 import { Toast, ToastProps, ToastStatus } from '~/components/Toast/Toast'
 
@@ -19,10 +18,8 @@ export type UseToastProps = Omit<
   'onClose' | 'status'
 > & { status?: ToastStatus }
 
-export type UseToastOptions = SetRequired<UseToastProps, 'status'>
-
 export type UseToastReturn = {
-  (options: UseToastOptions): string | number | undefined
+  (options: UseToastProps): string | number | undefined
   close: ReturnType<typeof useChakraToast>['close']
   closeAll: ReturnType<typeof useChakraToast>['closeAll']
   isActive: ReturnType<typeof useChakraToast>['isActive']
@@ -30,7 +27,7 @@ export type UseToastReturn = {
 }
 
 export const useToast = ({
-  status,
+  status: initialStatus = 'success',
   ...initialProps
 }: UseToastProps = {}): UseToastReturn => {
   const toast = useChakraToast(initialProps)
@@ -42,7 +39,7 @@ export const useToast = ({
       render,
       status,
       ...rest
-    }: UseToastOptions) =>
+    }: UseToastProps) =>
       toast({
         duration,
         position,
@@ -52,7 +49,9 @@ export const useToast = ({
           // Omitting the createElement causes a visual bug, where our own theme providers are not used.
           // Using createElement also allows the file to be pure ts rather than tsx.
           render ??
-          React.createElement(() => Toast({ status, ...rest, ...props })),
+          React.createElement(() =>
+            Toast({ status: status ?? initialStatus, ...rest, ...props }),
+          ),
       })
 
     impl.close = toast.close
@@ -61,7 +60,7 @@ export const useToast = ({
     impl.update = toast.update
 
     return impl
-  }, [toast])
+  }, [initialStatus, toast])
 
   return customToastImpl
 }

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,41 +1,67 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
   RenderProps,
   useToast as useChakraToast,
-  UseToastOptions,
+  UseToastOptions as ChakraUseToastOptions,
 } from '@chakra-ui/react'
+import { SetRequired } from 'type-fest'
 
-import { Toast, ToastProps } from '~/components/Toast/Toast'
+import { Toast, ToastProps, ToastStatus } from '~/components/Toast/Toast'
 
 type ToastBehaviourProps = Pick<
-  UseToastOptions,
+  ChakraUseToastOptions,
   'duration' | 'position' | 'render'
 >
 
 // onClose is provided by the chakra hook and should not be exposed to clients
-export type UseToastProps = Omit<ToastBehaviourProps & ToastProps, 'onClose'>
+export type UseToastProps = Omit<
+  ToastBehaviourProps & ToastProps,
+  'onClose' | 'status'
+> & { status?: ToastStatus }
 
-type UseToast = (
-  // NOTE: Chakra's toast status is different from ours, hence we need to omit it for type compatibility
-  initialProps?: Omit<UseToastProps, 'status'>,
-) => (props: UseToastProps) => void
+export type UseToastOptions = SetRequired<UseToastProps, 'status'>
 
-export const useToast: UseToast = (initialProps) => {
+export type UseToastReturn = {
+  (options: UseToastOptions): string | number | undefined
+  close: ReturnType<typeof useChakraToast>['close']
+  closeAll: ReturnType<typeof useChakraToast>['closeAll']
+  isActive: ReturnType<typeof useChakraToast>['isActive']
+  update: ReturnType<typeof useChakraToast>['update']
+}
+
+export const useToast = ({
+  status,
+  ...initialProps
+}: UseToastProps = {}): UseToastReturn => {
   const toast = useChakraToast(initialProps)
 
-  return ({
-    duration = 6000,
-    position = 'top',
-    render,
-    ...rest
-  }: UseToastProps) =>
-    toast({
-      duration,
-      position,
-      render: (props: RenderProps) =>
-        // NOTE: Because chakra expects this to be JSX, this has to be called with createElement.
-        // Omitting the createElement causes a visual bug, where our own theme providers are not used.
-        // Using createElement also allows the file to be pure ts rather than tsx.
-        render ?? React.createElement(() => Toast({ ...rest, ...props })),
-    })
+  const customToastImpl = useMemo(() => {
+    const impl = ({
+      duration = 6000,
+      position = 'top',
+      render,
+      status,
+      ...rest
+    }: UseToastOptions) =>
+      toast({
+        duration,
+        position,
+        ...rest,
+        render: (props: RenderProps) =>
+          // NOTE: Because chakra expects this to be JSX, this has to be called with createElement.
+          // Omitting the createElement causes a visual bug, where our own theme providers are not used.
+          // Using createElement also allows the file to be pure ts rather than tsx.
+          render ??
+          React.createElement(() => Toast({ status, ...rest, ...props })),
+      })
+
+    impl.close = toast.close
+    impl.closeAll = toast.closeAll
+    impl.isActive = toast.isActive
+    impl.update = toast.update
+
+    return impl
+  }, [toast])
+
+  return customToastImpl
 }

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -50,7 +50,12 @@ export const useToast = ({
           // Using createElement also allows the file to be pure ts rather than tsx.
           render ??
           React.createElement(() =>
-            Toast({ status: status ?? initialStatus, ...rest, ...props }),
+            Toast({
+              status: status ?? initialStatus,
+              isClosable: initialProps.isClosable,
+              ...rest,
+              ...props,
+            }),
           ),
       })
 
@@ -60,7 +65,7 @@ export const useToast = ({
     impl.update = toast.update
 
     return impl
-  }, [initialStatus, toast])
+  }, [initialProps.isClosable, initialStatus, toast])
 
   return customToastImpl
 }

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -12,9 +12,11 @@ type ToastBehaviourProps = Pick<
   'duration' | 'position' | 'render'
 >
 
-// onClose is provided by the chakra hook and should not be exposed to clients
 export type UseToastProps = Omit<
   ToastBehaviourProps & ToastProps,
+  // onClose is provided by the chakra hook and should not be exposed to clients.
+  // ChakraToast's status is different from this custom component, hence replaced
+  // with ToastStatus for type compatibility.
   'onClose' | 'status'
 > & { status?: ToastStatus }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some toasts require something like links to be appended. This PR adds the capability to Toasts, much like on Banners and InlineMessage components

ChakraUI's default useToast hook also has quite a few toast-related functions, which should also be exposed by our custom hook. This PR also adds the relevant hook functions into our custom hooks.


A new story has been added for markdown usage in toasts