### PR TITLE
fix(otp): Ensure uniform distribution of digits

### DIFF
--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -10,15 +10,11 @@ const DEFAULT_SALT_ROUNDS = 10
  * @returns 6 digit OTP string
  */
 export const generateOtp = (): string => {
-  const length = 6
-  const chars = '0123456789'
   // Generates cryptographically strong pseudo-random data.
-  // The size argument is a number indicating the number of bytes to generate.
-  const digits = new Array(length)
-  for (let i = 0; i < length; i++) {
-    digits[i] = chars[crypto.randomInt(0, chars.length)]
-  }
-  return digits.join('')
+  return Array(6)
+    .fill(0)
+    .map(() => crypto.randomInt(0, 10))
+    .join('')
 }
 
 /**

--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -14,11 +14,9 @@ export const generateOtp = (): string => {
   const chars = '0123456789'
   // Generates cryptographically strong pseudo-random data.
   // The size argument is a number indicating the number of bytes to generate.
-  const rnd = crypto.randomBytes(length)
-  const d = chars.length / 256
   const digits = new Array(length)
   for (let i = 0; i < length; i++) {
-    digits[i] = chars[Math.floor(rnd[i] * d)]
+    digits[i] = chars[crypto.randomInt(0, chars.length)]
   }
   return digits.join('')
 }


### PR DESCRIPTION
## Problem
We have received a report that our OTP generation method does not have a uniform distribution of digits. While is not a serious security issue, it is clearly not an intended behaviour.

Closes #2768 (issue contains more details description of the distribution problem)

## Solution
Use the native API [`crypto.randomInt()`](https://nodejs.org/api/crypto.html#crypto_crypto_randomint_min_max_callback), which was introduced in node 14.10 / 12.19, to avoid quantisation issues.

This is **not** a breaking change and is fully backward compatible

**Bug Fixes**
Uniform distribution brings back the guarantee that a random OTP guess only has 1/10e6 of being right.

## Tests
- Log in: Verify OTP flow is working
