### PR TITLE
feat: Add 4MB attachment support

### DIFF
--- a/shared/types/field/attachmentField.ts
+++ b/shared/types/field/attachmentField.ts
@@ -4,6 +4,7 @@ export enum AttachmentSize {
   OneMb = '1',
   TwoMb = '2',
   ThreeMb = '3',
+  FourMb = '4',
   SevenMb = '7',
   TenMb = '10',
   TwentyMb = '20',

--- a/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/edit-fields-modal.client.controller.js
@@ -20,7 +20,7 @@ const {
 } = require('../../../../../../shared/types/field')
 const CancelToken = axios.CancelToken
 
-const EMAIL_MODE_ALLOWED_SIZES = ['1', '2', '3', '7']
+const EMAIL_MODE_ALLOWED_SIZES = ['1', '2', '3', '4', '7']
 
 angular
   .module('forms')
@@ -326,8 +326,8 @@ function EditFieldsModalController(
   // Modify tooltip to match email or encrypt mode options
   vm.attachmentTooltipText =
     vm.myform.responseMode === responseModeEnum.EMAIL
-      ? 'Guideline: Images & PDFs - 1-3 MB, Slides & Videos - 7 MB. Include up to 7 MB of attachments in a submission (Email mode).'
-      : 'Guideline: Images & PDFs - 1-3 MB, Slides - 7 MB, Videos - 10-20 MB. Include up to 20 MB of attachments in a submission (Storage mode).'
+      ? 'Guideline: Images & PDFs - 1-4 MB, Slides & Videos - 7 MB. Include up to 7 MB of attachments in a submission (Email mode).'
+      : 'Guideline: Images & PDFs - 1-4 MB, Slides - 7 MB, Videos - 10-20 MB. Include up to 20 MB of attachments in a submission (Storage mode).'
 
   let previousAttachmentSize = 0
 

--- a/src/public/modules/forms/services/attachment.client.service.js
+++ b/src/public/modules/forms/services/attachment.client.service.js
@@ -3,9 +3,9 @@ const { zipWith } = require('lodash')
 angular.module('forms').service('Attachment', [Attachment])
 
 function Attachment() {
-  this.sizes = ['1', '2', '3', '7', '10', '20']
+  this.sizes = ['1', '2', '3', '4', '7', '10', '20']
 
-  this.descriptions = ['1 MB', '2 MB', '3 MB', '7 MB', '10 MB', '20 MB']
+  this.descriptions = ['1 MB', '2 MB', '3 MB', '4 MB', '7 MB', '10 MB', '20 MB']
 
   this.dropdown = zipWith(this.descriptions, this.sizes, (desc, size) => {
     return { name: desc, value: size }


### PR DESCRIPTION
## Problem
Adds 4MB attachment so that email attachment users can create a form with a 4MB field and a 3MB field.

Closes #2639 

## Solution
Adds a 4MB parameter to the relevant places.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/691628/132973649-23bc4148-a7d8-4d3d-8d9f-bdadfc593a8b.png)

## Tests
Make sure that the 4MB option is visible when a form is created and that the check for 4MB size when a user uploads a file is working.
