### PR TITLE
refactor: use modern JS constructs to validate NRIC

### DIFF
--- a/shared/utils/nric-validation.ts
+++ b/shared/utils/nric-validation.ts
@@ -18,16 +18,16 @@ export const isNricValid = (value: string): boolean => {
 
   const { prefix, digits, checksum } = parsed.groups as NricParts
 
-  // http://www.ngiam.net/NRIC/NRIC_numbers.pdf
-  const coefficients = [2, 7, 6, 5, 4, 3, 2]
+  // Specifications at: http://www.ngiam.net/NRIC/NRIC_numbers.pdf
+  const weights = [2, 7, 6, 5, 4, 3, 2]
   const startConstant = prefix === 'S' || prefix === 'F' ? 0 : 4
   const checksumEncoding =
     prefix === 'S' || prefix === 'T' ? 'JZIHGFEDCBA' : 'XWUTRQPNMLK'
 
-  const sum = coefficients.reduce(
-    (acc, coef, idx) => acc + coef * parseInt(digits[idx]),
+  const weightedSum = weights.reduce(
+    (acc, weight, idx) => acc + weight * parseInt(digits[idx]),
     startConstant,
   )
 
-  return checksum === checksumEncoding[sum % 11]
+  return checksum === checksumEncoding[weightedSum % 11]
 }

--- a/shared/utils/nric-validation.ts
+++ b/shared/utils/nric-validation.ts
@@ -1,41 +1,33 @@
+type NricParts = {
+  prefix: string
+  digits: string
+  checksum: string
+}
+
+const NIRC_FORMAT = /^(?<prefix>[STFG])(?<digits>\d{7})(?<checksum>[A-Z])$/
+
 /**
  * Validates whether a provided string value adheres to the UIN/FIN format
  * as provided on the Singapore Government's National Registration Identity Card.
  * @param value The value to be validated
  */
 export const isNricValid = (value: string): boolean => {
-  return isFormatValid(value) && isChecksumValid(value)
-}
+  const parsed = value?.toUpperCase().match(NIRC_FORMAT)
 
-/**
- * Tests whether a provided string value obeys a simple format check
- * @param value The value to be validated
- */
-const isFormatValid = (value: string): boolean => {
-  return /^([STFGstfg]{1})([0-9]{7})([A-Za-z]{1})$/.test(value)
-}
+  if (!parsed) return false
 
-/**
- * Algorithm to test whether the NRIC checksum is valid
- * @param value The value to be validated
- */
-const isChecksumValid = (value: string): boolean => {
+  const { prefix, digits, checksum } = parsed.groups as NricParts
+
   // http://www.ngiam.net/NRIC/NRIC_numbers.pdf
-  value = value.toUpperCase()
-  const prefix = value.charAt(0)
-  const suffix = value.charAt(value.length - 1)
   const coefficients = [2, 7, 6, 5, 4, 3, 2]
-  const constant = prefix === 'S' || prefix === 'F' ? 0 : 4
-  const coding =
-    prefix === 'S' || prefix === 'T'
-      ? ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A']
-      : ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K']
-  const sum = value
-    .substring(1, value.length - 1)
-    .split('')
-    .reduce(function (sum, digit, idx) {
-      sum += parseInt(digit) * coefficients[idx]
-      return sum
-    }, constant)
-  return suffix === coding[sum % 11]
+  const start_constant = prefix === 'S' || prefix === 'F' ? 0 : 4
+  const checksum_encoding =
+    prefix === 'S' || prefix === 'T' ? 'JZIHGFEDCBA' : 'XWUTRQPNMLK'
+
+  const sum = coefficients.reduce(
+    (acc, coef, idx) => acc + coef * parseInt(digits[idx]),
+    start_constant,
+  )
+
+  return checksum === checksum_encoding[sum % 11]
 }

--- a/shared/utils/nric-validation.ts
+++ b/shared/utils/nric-validation.ts
@@ -4,7 +4,7 @@ type NricParts = {
   checksum: string
 }
 
-const NIRC_FORMAT = /^(?<prefix>[STFG])(?<digits>\d{7})(?<checksum>[A-Z])$/
+const NRIC_FORMAT = /^(?<prefix>[STFG])(?<digits>\d{7})(?<checksum>[A-Z])$/
 
 /**
  * Validates whether a provided string value adheres to the UIN/FIN format
@@ -12,7 +12,7 @@ const NIRC_FORMAT = /^(?<prefix>[STFG])(?<digits>\d{7})(?<checksum>[A-Z])$/
  * @param value The value to be validated
  */
 export const isNricValid = (value: string): boolean => {
-  const parsed = value?.toUpperCase().match(NIRC_FORMAT)
+  const parsed = value?.toUpperCase().match(NRIC_FORMAT)
 
   if (!parsed) return false
 
@@ -20,14 +20,14 @@ export const isNricValid = (value: string): boolean => {
 
   // http://www.ngiam.net/NRIC/NRIC_numbers.pdf
   const coefficients = [2, 7, 6, 5, 4, 3, 2]
-  const start_constant = prefix === 'S' || prefix === 'F' ? 0 : 4
-  const checksum_encoding =
+  const startConstant = prefix === 'S' || prefix === 'F' ? 0 : 4
+  const checksumEncoding =
     prefix === 'S' || prefix === 'T' ? 'JZIHGFEDCBA' : 'XWUTRQPNMLK'
 
   const sum = coefficients.reduce(
     (acc, coef, idx) => acc + coef * parseInt(digits[idx]),
-    start_constant,
+    startConstant,
   )
 
-  return checksum === checksum_encoding[sum % 11]
+  return checksum === checksumEncoding[sum % 11]
 }


### PR DESCRIPTION
## Context

While following code from the NIRC component, I ended up on the nirc validation where I thought several minor  improvements could be made. Below are some (very minor) issues I thought about when seeing the code
* The regex is using unnecessary constructs like `{1}`
* Regexp specifies both lowercase and uppercase matches, while it would be simpler to uppercase the input prior to running the test
* The regexp captures groups, but these are not used because the format validation and checksum validation are disjointed
* The digits string is exploded to iterate over the characters, but that is unnecessary since the coefficients is an array of the same format that could be used instead
* We can us the string array operator to read digits from the input, and to read checksum markers (i.e. there's no need to create local arrays.)
* the `reduce()` function does an unnecessary assignment to a local variable, which looks confusing because of the shadow variable name `sum`.

The code was working perfectly fine, so the refactor is unnecessary. I initially only wanted to remove the`{1}` and add a `i` flag to the regex, but I ended up refactoring the whole file 😑 

I hesitated to open the PR since it is unplanned and unnecessary, and will consume precious reviewer time, but in the end, since I did the changes, I thought I'd open it up anyway for some discussions, like:
* does using for named groups in regexes affect our browser support matrix?
* does using array operator for string character access affect our browser support matrix? (do we have precedent in code?)

## Approach
I've made changes that addresses all the points above. The code reduces significantly. I am obviously really biased, but I think it is more readable now.

## Testing
- [ ] Create a form with a NIRC component
- [ ] Verify validation works as expected in major browsers (Chrome, FF, safari, Edge)
