### PR TITLE
fix(v2): correctly assert that public route location shape may be undefined

### DIFF
--- a/frontend/src/app/PublicRoute.tsx
+++ b/frontend/src/app/PublicRoute.tsx
@@ -20,7 +20,7 @@ export const PublicRoute = ({
 }: PublicRouteProps): JSX.Element => {
   const { isAuthenticated } = useAuth()
 
-  const { state } = useLocation<{ from: Location | undefined }>()
+  const { state } = useLocation<{ from?: Location } | undefined>()
 
   return (
     <Route
@@ -29,7 +29,7 @@ export const PublicRoute = ({
         !!isAuthenticated && strict ? (
           <Redirect
             to={{
-              pathname: state.from?.pathname ?? ROOT_ROUTE,
+              pathname: state?.from?.pathname ?? ROOT_ROUTE,
               state: { from: location },
             }}
           />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The application accesses the need to redirect from a public route to a private route if the user is already authenticated. The link to redirect to is done by checking the URL that could possibly be stored in `location.state.from`. However, `location.state` could be undefined if the page had not been redirected from the application, resulting in an error boundary being hit.

This PR correctly types the `location.state` variable as possibly undefined.
