### PR TITLE
feat(react): allow markdown in FormLabel description, allow `as` prop in custom Link component

### DIFF
--- a/frontend/src/components/Banner/Banner.tsx
+++ b/frontend/src/components/Banner/Banner.tsx
@@ -32,7 +32,7 @@ export const Banner = ({
 
   const styles = useMultiStyleConfig('Banner', { variant })
 
-  const mdComponents = useMdComponents(styles)
+  const mdComponents = useMdComponents({ styles })
 
   return (
     <Collapse in={isOpen} animateOpacity>

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.stories.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.stories.tsx
@@ -35,6 +35,14 @@ WithDescription.args = {
   children: 'This is a label that is very very very long',
 }
 
+export const WithMarkdownDescription = Template.bind({})
+WithMarkdownDescription.args = {
+  children: 'This is a label',
+  description:
+    'Description _can_ **have** [Markdown](https://guides.github.com/features/mastering-markdown/)',
+  useMarkdownForDescription: true,
+}
+
 export const WithTooltipText = Template.bind({})
 WithTooltipText.args = {
   questionNumber: '1.',

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import ReactMarkdown from 'react-markdown'
 import {
   Box,
   FormHelperText,
@@ -13,6 +14,7 @@ import {
 } from '@chakra-ui/react'
 
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
+import { useMdComponents } from '~hooks/useMdComponents'
 
 export interface FormLabelProps extends ChakraFormLabelProps {
   /**
@@ -36,6 +38,11 @@ export interface FormLabelProps extends ChakraFormLabelProps {
    * provided, the value from it's parent `FormContext` (if any) will be used.
    */
   isRequired?: boolean
+
+  /**
+   * Whether markdown is enabled for description text.
+   */
+  useMarkdownForDescription?: boolean
 }
 
 /**
@@ -52,6 +59,7 @@ export const FormLabel = ({
   tooltipText,
   questionNumber,
   description,
+  useMarkdownForDescription,
   children,
 }: FormLabelProps): JSX.Element => {
   return (
@@ -73,7 +81,9 @@ export const FormLabel = ({
         )}
       </Box>
       {description && (
-        <FormLabel.Description>{description}</FormLabel.Description>
+        <FormLabel.Description useMarkdown={useMarkdownForDescription}>
+          {description}
+        </FormLabel.Description>
       )}
     </FormLabel.Label>
   )
@@ -81,10 +91,15 @@ export const FormLabel = ({
 
 FormLabel.Label = ChakraFormLabel
 
+interface FormLabelDescriptionProps extends TextProps {
+  useMarkdown?: boolean
+  children: string
+}
 const FormLabelDescription = ({
   children,
+  useMarkdown,
   ...props
-}: TextProps): JSX.Element => {
+}: FormLabelDescriptionProps): JSX.Element => {
   // useFormControlContext is a ChakraUI hook that returns props passed down
   // from a parent ChakraUI's `FormControl` component.
   // The return object is used to determine whether FormHelperText or Text is
@@ -99,17 +114,33 @@ const FormLabelDescription = ({
     return Text
   }, [field])
 
-  return (
-    <ComponentToRender
-      mt={0}
-      textStyle="body-2"
-      color="secondary.400"
-      {...props}
-    >
-      {children}
-    </ComponentToRender>
+  const styleProps = {
+    textStyle: 'body-2',
+    color: 'secondary.400',
+    ...props,
+  }
+
+  const mdComponentsStyles = {
+    text: styleProps,
+    link: { display: 'initial' },
+  }
+  const mdComponents = useMdComponents({
+    styles: mdComponentsStyles,
+    overrides: {
+      p: (props) => (
+        <ComponentToRender {...props} sx={mdComponentsStyles.text} />
+      ),
+    },
+  })
+
+  return useMarkdown ? (
+    <ReactMarkdown components={mdComponents}>{children}</ReactMarkdown>
+  ) : (
+    <ComponentToRender {...styleProps}>{children}</ComponentToRender>
   )
 }
+FormLabel.Description = FormLabelDescription
+
 FormLabel.Description = FormLabelDescription
 
 FormLabel.QuestionNumber = ({ children, ...props }: TextProps): JSX.Element => {

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -59,7 +59,7 @@ export const FormLabel = ({
   tooltipText,
   questionNumber,
   description,
-  useMarkdownForDescription,
+  useMarkdownForDescription = false,
   children,
 }: FormLabelProps): JSX.Element => {
   return (
@@ -97,7 +97,7 @@ interface FormLabelDescriptionProps extends TextProps {
 }
 const FormLabelDescription = ({
   children,
-  useMarkdown,
+  useMarkdown = false,
   ...props
 }: FormLabelDescriptionProps): JSX.Element => {
   // useFormControlContext is a ChakraUI hook that returns props passed down

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -117,6 +117,7 @@ const FormLabelDescription = ({
   const styleProps = {
     textStyle: 'body-2',
     color: 'secondary.400',
+    mt: 0,
     ...props,
   }
 

--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -19,7 +19,7 @@ export const InlineMessage = ({
 }: InlineMessageProps): JSX.Element => {
   const styles = useMultiStyleConfig('InlineMessage', { variant })
 
-  const mdComponents = useMdComponents(styles)
+  const mdComponents = useMdComponents({ styles })
 
   return (
     <Flex sx={styles.messagebox}>

--- a/frontend/src/components/Link/Link.tsx
+++ b/frontend/src/components/Link/Link.tsx
@@ -1,5 +1,7 @@
 import { BiLinkExternal } from 'react-icons/bi'
 import {
+  ComponentWithAs,
+  forwardRef,
   Icon,
   Link as ChakraLink,
   LinkProps as ChakraLinkProps,
@@ -12,37 +14,49 @@ export interface LinkProps extends ChakraLinkProps {
   isDisabled?: boolean
 }
 
-export const Link = ({
-  externalLinkIcon = <Link.ExternalIcon />,
-  isDisabled,
-  children,
-  ...props
-}: LinkProps): JSX.Element => {
-  const styles = useStyleConfig('Link', props)
+type LinkWithParts = ComponentWithAs<'a', LinkProps> & {
+  ExternalIcon: typeof ExternalIcon
+}
 
-  if (isDisabled) {
+export const Link = forwardRef<LinkProps, 'a'>(
+  (
+    {
+      externalLinkIcon = <Link.ExternalIcon />,
+      isDisabled,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const styles = useStyleConfig('Link', props)
+
+    if (isDisabled) {
+      return (
+        <Text
+          as="a"
+          ref={ref}
+          sx={styles}
+          aria-disabled
+          d="inline-flex"
+          alignItems="center"
+        >
+          {children}
+          {props.isExternal && externalLinkIcon}
+        </Text>
+      )
+    }
+
     return (
-      <Text
-        as="a"
-        sx={styles}
-        aria-disabled
-        d="inline-flex"
-        alignItems="center"
-      >
+      <ChakraLink d="inline-flex" alignItems="center" {...props} ref={ref}>
         {children}
         {props.isExternal && externalLinkIcon}
-      </Text>
+      </ChakraLink>
     )
-  }
+  },
+) as LinkWithParts
 
-  return (
-    <ChakraLink d="inline-flex" alignItems="center" {...props}>
-      {children}
-      {props.isExternal && externalLinkIcon}
-    </ChakraLink>
-  )
-}
-
-Link.ExternalIcon = (): JSX.Element => {
+const ExternalIcon = (): JSX.Element => {
   return <Icon aria-hidden as={BiLinkExternal} ml="0.25rem" />
 }
+
+Link.ExternalIcon = ExternalIcon

--- a/frontend/src/hooks/useMdComponents.tsx
+++ b/frontend/src/hooks/useMdComponents.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Components } from 'react-markdown/src/ast-to-react'
-import { CSSObject } from '@chakra-ui/react'
+import { CSSObject, Text } from '@chakra-ui/react'
 
 import Link from '~components/Link'
 
@@ -9,9 +9,21 @@ type MdComponentStyles = {
    * If exists, will be used for styling links
    */
   link?: CSSObject
+  /**
+   * If exists, will be used for styling text
+   */
+  text?: CSSObject
 }
 
-export const useMdComponents = (styles: MdComponentStyles): Components => {
+type UseMdComponentsProps = {
+  styles?: MdComponentStyles
+  overrides?: Components
+}
+
+export const useMdComponents = ({
+  styles = {},
+  overrides = {},
+}: UseMdComponentsProps = {}): Components => {
   const mdComponents: Components = useMemo(
     () => ({
       a: (props) => {
@@ -27,8 +39,12 @@ export const useMdComponents = (styles: MdComponentStyles): Components => {
           />
         )
       },
+      p: (props) => (
+        <Text {...props} {...(styles?.text ? { sx: styles.text } : {})} />
+      ),
+      ...overrides,
     }),
-    [styles.link],
+    [overrides, styles],
   )
 
   return mdComponents

--- a/frontend/src/theme/components/Modal.ts
+++ b/frontend/src/theme/components/Modal.ts
@@ -6,7 +6,7 @@ import {
   ThemingPropsThunk,
 } from '@chakra-ui/react'
 
-import { textStyles } from '~theme/textStyles'
+import { textStyles } from '../textStyles'
 
 // Default parts.
 const parts = [


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some designs in Figma contains Form label descriptions with links. This seemed easier to achieve in markdown and thus the ability for markdown in FormLabel.Description is implemented.

See 
![Screenshot 2021-09-13 at 10 50 34 PM](https://user-images.githubusercontent.com/22133008/133105996-bbd28129-d16d-4c89-a083-e6bdef439a41.png)

Whilst doing so, realize the `Link` component cannot be re-morphed into another type using the `as` prop which is a common in ChakraUI.  This commit was cherry picked from commit 22faa66 in #2683.


## Solution
<!-- How did you solve the problem? -->

**Features**:

- Add `useMarkdown` prop in FormLabel.Description and `useMarkdownForDescription` prop in the main FormLabel component to allow markdown in form label descriptions.
- Allow `as` prop in custom Link component


## Before & After Screenshots
New story added in Storybook for markdown in form label description.
