### PR TITLE
chore: run travis only on staging alt branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 os: linux
 dist: xenial
 
+if: branch = $STAGING_ALT_BRANCH
+
 services:
   - xvfb
 


### PR DESCRIPTION
Travis has been running for every push after adding it back in #2675. This PR allows Travis to only run on the staging-alt branch on form-v2/develop