### PR TITLE
build(mergify): specify checks and include Snyk

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,8 +1,41 @@
 pull_request_rules:
-  - name: Approve and merge non-major dependency upgrades
+  - name: Approve and merge non-major dependabot dependency upgrades
     conditions:
-      - 'author=dependabot[bot]'
-      - 'title~=bump [^\s]+ from ([\d]+)\..+ to \1\.'
+      - author=dependabot[bot]
+      - title~=bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - check-success~=install
+      - check-success~=test-frontend
+      - check-success~=test-backend
+      - check-success~=test-e2e
+      - check-success~=Analyze # CodeQL / Analyze
+      - check-success~=CodeQL # CodeQL code scanning results
+      - check-success~=GitGuardian
+      - check-success~=Semantic Pull Request
+      - check-success~=Travis CI - Branch
+      - check-success~=coverage/coveralls
+      - check-success~=license/snyk
+      - check-success~=security/snyk
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+  - name: Approve and merge non-major Snyk.io upgrades
+    conditions:
+      - author=snyk-bot
+      - title~=\[Snyk\] Security upgrade [^\s]+ from ([\d]+)\..+ to \1\.
+      - check-success~=install
+      - check-success~=test-frontend
+      - check-success~=test-backend
+      - check-success~=test-e2e
+      - check-success~=Analyze # CodeQL / Analyze
+      - check-success~=CodeQL # CodeQL code scanning results
+      - check-success~=GitGuardian
+      - check-success~=Semantic Pull Request
+      - check-success~=Travis CI - Branch
+      - check-success~=coverage/coveralls
+      - check-success~=license/snyk
+      - check-success~=security/snyk
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- Mergify config does not specify each status check explicitly, against the recommendations of the [docs](https://docs.mergify.io/conditions/#validating-all-status-checks)
- Snyk.io security upgrades are not included in the mergify config, so they have to be approved and merged manually

Closes #1749 

## Solution
<!-- How did you solve the problem? -->

- Specify all status checks explicitly in mergify config
- Include a config rule to approve and major non-major Snyk security upgrades

## Screenshots

Taken from [Mergify config editor](https://dashboard.mergify.io/github/opengovsg/config-editor?repositoryName=FormSG).

### Config passes for dependabot upgrades e.g. #2810
![Screenshot 2021-09-21 at 10 45 58 AM](https://user-images.githubusercontent.com/29480346/134104466-0dfd9526-2399-41f1-b580-561d5d4a0a18.png)

 
### Config passes for Snyk security upgrades e.g. #2412 

Note that the "potential rule" is because this PR was taken when our Snyk license was still under "Open Government Products", so the relevant GitHub branch protection doesn't pass. This should no longer be the case for newer PRs for which the license is under "FormSG".

![Screenshot 2021-09-21 at 10 49 31 AM](https://user-images.githubusercontent.com/29480346/134104534-36404ccb-2629-43aa-816d-67f0586d354f.png)

### Config does not pass for regular PRs e.g. #2776

![Screenshot 2021-09-21 at 10 50 37 AM](https://user-images.githubusercontent.com/29480346/134104657-73612820-1ce3-4898-b923-fce5eb9aaca5.png)