### PR TITLE
Revert "refactor: use modern JS constructs to validate NRIC"

### DIFF
--- a/shared/utils/nric-validation.ts
+++ b/shared/utils/nric-validation.ts
@@ -1,33 +1,41 @@
-type NricParts = {
-  prefix: string
-  digits: string
-  checksum: string
-}
-
-const NRIC_FORMAT = /^(?<prefix>[STFG])(?<digits>\d{7})(?<checksum>[A-Z])$/
-
 /**
  * Validates whether a provided string value adheres to the UIN/FIN format
  * as provided on the Singapore Government's National Registration Identity Card.
  * @param value The value to be validated
  */
 export const isNricValid = (value: string): boolean => {
-  const parsed = value?.toUpperCase().match(NRIC_FORMAT)
+  return isFormatValid(value) && isChecksumValid(value)
+}
 
-  if (!parsed) return false
+/**
+ * Tests whether a provided string value obeys a simple format check
+ * @param value The value to be validated
+ */
+const isFormatValid = (value: string): boolean => {
+  return /^([STFGstfg]{1})([0-9]{7})([A-Za-z]{1})$/.test(value)
+}
 
-  const { prefix, digits, checksum } = parsed.groups as NricParts
-
-  // Specifications at: http://www.ngiam.net/NRIC/NRIC_numbers.pdf
-  const weights = [2, 7, 6, 5, 4, 3, 2]
-  const startConstant = prefix === 'S' || prefix === 'F' ? 0 : 4
-  const checksumEncoding =
-    prefix === 'S' || prefix === 'T' ? 'JZIHGFEDCBA' : 'XWUTRQPNMLK'
-
-  const weightedSum = weights.reduce(
-    (acc, weight, idx) => acc + weight * parseInt(digits[idx]),
-    startConstant,
-  )
-
-  return checksum === checksumEncoding[weightedSum % 11]
+/**
+ * Algorithm to test whether the NRIC checksum is valid
+ * @param value The value to be validated
+ */
+const isChecksumValid = (value: string): boolean => {
+  // http://www.ngiam.net/NRIC/NRIC_numbers.pdf
+  value = value.toUpperCase()
+  const prefix = value.charAt(0)
+  const suffix = value.charAt(value.length - 1)
+  const coefficients = [2, 7, 6, 5, 4, 3, 2]
+  const constant = prefix === 'S' || prefix === 'F' ? 0 : 4
+  const coding =
+    prefix === 'S' || prefix === 'T'
+      ? ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A']
+      : ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K']
+  const sum = value
+    .substring(1, value.length - 1)
+    .split('')
+    .reduce(function (sum, digit, idx) {
+      sum += parseInt(digit) * coefficients[idx]
+      return sum
+    }, constant)
+  return suffix === coding[sum % 11]
 }


### PR DESCRIPTION
Reverts opengovsg/FormSG#2785

The PR was not compatible with IE11, which is not acceptable for end users.

Reverting now, to keep `develop:HEAD` release-clean. The PR will be re-introduced once it has been made compatible.

@mantariksh @tshuli 