### PR TITLE
feat(PublicFormPage/1): set up initial route to load public form data

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,7 +1,9 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 
-import { LOGIN_ROUTE, ROOT_ROUTE } from '~constants/routes'
+import { LOGIN_ROUTE, PUBLIC_FORM_REGEX, ROOT_ROUTE } from '~constants/routes'
+
+import { PublicFormPage } from '~features/public-form/PublicFormPage'
 
 import { PrivateRoute } from './PrivateRoute'
 import { PublicRoute } from './PublicRoute'
@@ -14,6 +16,9 @@ export const AppRouter = (): JSX.Element => {
     <BrowserRouter>
       <Suspense fallback={<div>Loading...</div>}>
         <Switch>
+          <PublicRoute strict={false} path={PUBLIC_FORM_REGEX}>
+            <PublicFormPage />
+          </PublicRoute>
           <PublicRoute exact path={LOGIN_ROUTE}>
             <LoginPage />
           </PublicRoute>

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -2,3 +2,5 @@
 export const LANDING_ROUTE = '/'
 export const ROOT_ROUTE = '/'
 export const LOGIN_ROUTE = '/login'
+
+export const PUBLIC_FORM_REGEX = '/:formId([a-fA-F0-9]{24})'

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -3,4 +3,8 @@ export const LANDING_ROUTE = '/'
 export const ROOT_ROUTE = '/'
 export const LOGIN_ROUTE = '/login'
 
-export const PUBLIC_FORM_REGEX = '/:formId([a-fA-F0-9]{24})'
+const PUBLIC_FORM_PARAM = 'formId'
+/** Used for typing useParams in PublicFormPage. */
+export type PublicFormParam = { [PUBLIC_FORM_PARAM]: string }
+export const PUBLIC_FORM_REGEX =
+  `/:${PUBLIC_FORM_PARAM}([a-fA-F0-9]{24})` as const

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,0 +1,17 @@
+import { HttpError } from '~services/ApiService'
+
+import { usePublicFormView } from './queries'
+
+export const PublicFormPage = (): JSX.Element => {
+  const { data, isLoading, error } = usePublicFormView()
+
+  if (isLoading) {
+    return <div>Loading...</div>
+  }
+
+  if (error instanceof HttpError && error.code === 404) {
+    return <div>404</div>
+  }
+
+  return <div>{JSON.stringify(data)}</div>
+}

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -1,0 +1,90 @@
+import { PublicFormViewDto } from '~shared/types/form/form'
+import {
+  EmailModeSubmissionContentDto,
+  StorageModeSubmissionContentDto,
+  SubmissionResponseDto,
+} from '~shared/types/submission'
+
+import { ApiService } from '~services/ApiService'
+
+import { createEmailSubmissionFormData } from './utils/formSubmission'
+
+const PUBLIC_FORMS_ENDPOINT = '/forms'
+
+/**
+ * Submits an email mode form submission.
+ * @param formId id of form to submit submission for
+ * @param content content of submission
+ * @param attachments any attachments included in submission
+ * @param captchaResponse string if captcha to be included, defaults to null
+ *
+ * @returns SubmissionResponseDto if successful, else SubmissionErrorDto on error
+ */
+export const submitEmailModeForm = async ({
+  formId,
+  content,
+  attachments,
+  captchaResponse = null,
+}: {
+  formId: string
+  content: EmailModeSubmissionContentDto
+  attachments?: Record<string, File>
+  captchaResponse?: string | null
+}): Promise<SubmissionResponseDto> => {
+  const formData = createEmailSubmissionFormData({
+    content,
+    attachments,
+  })
+
+  return ApiService.post<SubmissionResponseDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email`,
+    formData,
+    {
+      params: {
+        captchaResponse: String(captchaResponse),
+      },
+    },
+  ).then(({ data }) => data)
+}
+
+/**
+ * Submits a storage mode form's submission.
+ * @param formId id of form to submit submission for
+ * @param content the storage mode submission object to submit
+ * @param captchaResponse string if captcha to be included, defaults to null
+ *
+ * @returns SubmissionResponseDto if successful, else SubmissionErrorDto on error
+ */
+export const submitStorageModeForm = async ({
+  formId,
+  content,
+  captchaResponse = null,
+}: {
+  formId: string
+  content: StorageModeSubmissionContentDto
+  captchaResponse?: string | null
+}): Promise<SubmissionResponseDto> => {
+  return ApiService.post<SubmissionResponseDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt`,
+    content,
+    {
+      params: {
+        captchaResponse: String(captchaResponse),
+      },
+    },
+  ).then(({ data }) => data)
+}
+
+/**
+ * Gets public view of form, along with any
+ * identify information obtained from Singpass/Corppass/MyInfo.
+ * @param formId FormId of form in question
+ * @returns Public view of form, with additional identify information
+ */
+export const getPublicFormView = async (
+  formId: string,
+): Promise<PublicFormViewDto> => {
+  return ApiService.get<PublicFormViewDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/${formId}`,
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -3,6 +3,8 @@ import { useParams } from 'react-router-dom'
 
 import { PublicFormViewDto } from '~shared/types/form/form'
 
+import { PublicFormParam } from '~constants/routes'
+
 import { getPublicFormView } from './PublicFormService'
 
 const publicFormKeys = {
@@ -11,7 +13,7 @@ const publicFormKeys = {
 }
 
 export const usePublicFormView = (): UseQueryResult<PublicFormViewDto> => {
-  const { formId } = useParams<{ formId: string }>()
+  const { formId } = useParams<PublicFormParam>()
 
   return useQuery<PublicFormViewDto>(publicFormKeys.id(formId), () =>
     getPublicFormView(formId),

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryResult } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { PublicFormViewDto } from '~shared/types/form/form'
+
+import { getPublicFormView } from './PublicFormService'
+
+const publicFormKeys = {
+  base: ['publicForm'] as const,
+  id: (formId: string) => [...publicFormKeys.base, formId] as const,
+}
+
+export const usePublicFormView = (): UseQueryResult<PublicFormViewDto> => {
+  const { formId } = useParams<{ formId: string }>()
+
+  return useQuery<PublicFormViewDto>(publicFormKeys.id(formId), () =>
+    getPublicFormView(formId),
+  )
+}

--- a/frontend/src/features/public-form/utils/formSubmission.ts
+++ b/frontend/src/features/public-form/utils/formSubmission.ts
@@ -1,0 +1,25 @@
+import { forOwn, isEmpty } from 'lodash'
+
+import { EmailModeSubmissionContentDto } from '~shared/types/submission'
+
+export const createEmailSubmissionFormData = ({
+  content,
+  attachments = {},
+}: {
+  content: EmailModeSubmissionContentDto
+  attachments?: Record<string, File>
+}): FormData => {
+  // Convert passed content to FormData object.
+  const formData = new FormData()
+  formData.append('body', JSON.stringify(content))
+
+  if (!isEmpty(attachments)) {
+    forOwn(attachments, (attachment, fieldId) => {
+      if (attachment) {
+        formData.append(attachment.name, attachment, fieldId)
+      }
+    })
+  }
+
+  return formData
+}


### PR DESCRIPTION
Note that there is a chain of PRs to set up the public form route

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR sets up the routing for rendering public forms.

Part of #2601

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: copy public form submission utils to public-form feature dir
- feat: move PublicFormService to public-form feature dir
- feat: add usePublicFormView react-query hook
- feat: add placeholder PublicFormPage
- feat: add route handling for public forms
- feat: add better typings for public form param
