### PR TITLE
fix: constrain the mongodb objectid regex format and use match

### DIFF
--- a/src/app/modules/spcp/spcp.util.ts
+++ b/src/app/modules/spcp/spcp.util.ts
@@ -28,7 +28,9 @@ import {
 } from './spcp.types'
 
 const logger = createLoggerWithLabel(module)
-const DESTINATION_REGEX = /^\/([\w]+)\/?/
+
+// Matches the MongoDB ObjectID hex format exactly (24 hex characters)
+const DESTINATION_REGEX = /^\/([a-fA-F0-9]{24})\/?$/
 
 // Checks the format of a SAML artifact
 const isArtifactValid = function (
@@ -75,7 +77,7 @@ export const isValidAuthenticationQuery = (
  * @param destination Redirect destination
  */
 export const extractFormId = (destination: string): string | null => {
-  const regexSplit = DESTINATION_REGEX.exec(destination)
+  const regexSplit = destination.match(DESTINATION_REGEX)
   if (!regexSplit || regexSplit.length < 2) {
     return null
   }


### PR DESCRIPTION
## Problem
See #2539, which this closes.

## Solution
1. Applies a more intense regex check to the SPCP return path (making sure that the ObjectID in the path is actually a valid ObjectID)
2. Use `str.match(regex)` instead of `regex.exec(str)` as part of best practices.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
Make sure that SPCP login still works.