### PR TITLE
feat(form-v2): add `/client/env` route for sending client env vars as JSON

### DIFF
--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -1,0 +1,7 @@
+import { ClientEnvVars } from '~shared/types/core'
+
+import { ApiService } from '~services/ApiService'
+
+export const getClientEnvVars = async (): Promise<ClientEnvVars> => {
+  return ApiService.get<ClientEnvVars>('/client/env').then(({ data }) => data)
+}

--- a/frontend/src/features/env/queries.ts
+++ b/frontend/src/features/env/queries.ts
@@ -1,0 +1,13 @@
+import { useQuery, UseQueryResult } from 'react-query'
+
+import { ClientEnvVars } from '~shared/types/core'
+
+import { getClientEnvVars } from './EnvService'
+
+const envKeys = {
+  base: ['env'],
+}
+
+export const useEnv = (): UseQueryResult<ClientEnvVars, unknown> => {
+  return useQuery<ClientEnvVars>(envKeys.base, () => getClientEnvVars())
+}

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -10,3 +10,20 @@ export interface PrivateFormErrorDto extends ErrorDto {
   isPageFound: true
   formTitle: string
 }
+
+// List of env vars expected from the server that client uses
+export type ClientEnvVars = {
+  isGeneralMaintenance: string
+  isLoginBanner: string
+  siteBannerContent: string
+  adminBannerContent: string
+  logoBucketUrl: string // S3 bucket
+  formsgSdkMode: 'staging' | 'production' | 'development' | 'test'
+  captchaPublicKey: string // Recaptcha
+  sentryConfigUrl: string // Sentry.IO
+  isSPMaintenance: string // Singpass maintenance message
+  isCPMaintenance: string // Corppass maintenance message
+  myInfoBannerContent: string // MyInfo maintenance message
+  GATrackingID: string | null
+  spcpCookieDomain: string // Cookie domain used for removing spcp cookies
+}

--- a/src/app/modules/frontend/frontend.controller.ts
+++ b/src/app/modules/frontend/frontend.controller.ts
@@ -1,9 +1,12 @@
 import ejs from 'ejs'
 import { StatusCodes } from 'http-status-codes'
 
+import { ClientEnvVars } from '../../../../shared/types/core'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
+
+import { getClientEnvVars } from './frontend.service'
 
 const logger = createLoggerWithLabel(module)
 
@@ -46,6 +49,7 @@ export const addGoogleAnalyticsData: ControllerHandler<
 }
 
 /**
+ * @deprecated use object json returned from handleGetEnvironment instead
  * Handler for GET /frontend/environment endpoint.
  * @param req - Express request object
  * @param res - Express response object
@@ -73,6 +77,17 @@ export const addEnvVarData: ControllerHandler<unknown, { message: string }> = (
       message: 'There was an unexpected error. Please refresh and try again.',
     })
   }
+}
+
+/**
+ * Handler for GET /frontend/env endpoint.
+ * @returns the environment variables needed to hydrate the frontend.
+ */
+export const handleGetEnvironment: ControllerHandler<never, ClientEnvVars> = (
+  _req,
+  res,
+) => {
+  return res.json(getClientEnvVars())
 }
 
 /**

--- a/src/app/modules/frontend/frontend.routes.ts
+++ b/src/app/modules/frontend/frontend.routes.ts
@@ -6,6 +6,7 @@ import * as FrontendServerController from './frontend.controller'
 export const FrontendRouter = Router()
 
 /**
+ * @deprecated use routes in src/app/routes/api/v3/client/client.routes.ts instead
  * Generate the templated Javascript code for the frontend to initialise Google Tag Manager
  * Code depends on whether googleAnalyticsFeature.isEnabled
  * @route GET /frontend/datalayer
@@ -18,6 +19,7 @@ FrontendRouter.get(
 )
 
 /**
+ * @deprecated use routes in src/app/routes/api/v3/client/client.routes.ts instead
  * Generate the templated Javascript code with environment variables for the frontend
  * @route GET /frontend/environment
  * @return 200 when code generation is successful
@@ -26,6 +28,7 @@ FrontendRouter.get(
 FrontendRouter.get('/environment', FrontendServerController.addEnvVarData)
 
 /**
+ * @deprecated use routes in src/app/routes/api/v3/client/client.routes.ts instead
  * Generate a json of current activated features
  * @route GET /frontend/features
  * @return json with featureManager.states
@@ -35,6 +38,7 @@ FrontendRouter.get('/environment', FrontendServerController.addEnvVarData)
 FrontendRouter.get('/features', FrontendServerController.showFeaturesStates)
 
 /**
+ * @deprecated use routes in src/app/routes/api/v3/client/client.routes.ts instead
  * Generate the javascript code to redirect to the correct url
  * @route GET /frontend/redirect
  * @return 200 when redirect code is  successful

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -1,0 +1,24 @@
+import { ClientEnvVars } from '../../../../shared/types/core'
+import config from '../../config/config'
+import { captchaConfig } from '../../config/features/captcha.config'
+import { googleAnalyticsConfig } from '../../config/features/google-analytics.config'
+import { sentryConfig } from '../../config/features/sentry.config'
+import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
+
+export const getClientEnvVars = (): ClientEnvVars => {
+  return {
+    isGeneralMaintenance: config.isGeneralMaintenance,
+    isLoginBanner: config.isLoginBanner,
+    siteBannerContent: config.siteBannerContent,
+    adminBannerContent: config.adminBannerContent,
+    logoBucketUrl: config.aws.logoBucketUrl, // S3 bucket
+    formsgSdkMode: config.formsgSdkMode,
+    captchaPublicKey: captchaConfig.captchaPublicKey, // Recaptcha
+    sentryConfigUrl: sentryConfig.sentryConfigUrl, // Sentry.IO
+    isSPMaintenance: spcpMyInfoConfig.isSPMaintenance, // Singpass maintenance message
+    isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
+    myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
+    GATrackingID: googleAnalyticsConfig.GATrackingID,
+    spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
+  }
+}

--- a/src/app/routes/api/v3/client/client.routes.ts
+++ b/src/app/routes/api/v3/client/client.routes.ts
@@ -18,12 +18,20 @@ ClientRouter.get(
 )
 
 /**
+ * @deprecated use '/env' endpoint instead.
  * Generate the templated Javascript code with environment variables for the frontend
  * @route GET /api/v3/client/environment
  * @return 200 when code generation is successful
  * @return 400 when code generation fails
  */
 ClientRouter.get('/environment', FrontendServerController.addEnvVarData)
+
+/**
+ * Retrieve the environment variables for the frontend.
+ * @route GET /api/v3/client/env
+ * @return 200 with environment variables needed for the client
+ */
+ClientRouter.get('/env', FrontendServerController.handleGetEnvironment)
 
 /**
  * Generate a json of current activated features


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The old route was `/client/environment`, which sent back the appropriate env vars as a javascript file to be merged into some header in the html. This seems unnecessary in React and we can just send the environment variables as an object instead.

For backwards compatibility, create new service and endpoint.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- feat: add `api/v3/client/env` endpoint for sending client related env vars
- feat: add env service and query to retrieve env vars from server

