### PR TITLE
feat(FormSettings/1): create initial FormSettingsPage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15648,9 +15648,9 @@
       }
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
     },
     "date-format": {
       "version": "0.0.2",
@@ -28817,9 +28817,9 @@
       }
     },
     "react-dropzone": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.0.tgz",
-      "integrity": "sha512-5NRpAN4ZmpEn0kvtkO18rPInE7n4eVjGeTLP/c0JcGAnV+5yrpr5QHdPH27M05SP2tsjkRoRf02DCK/4fxbsog==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.2.tgz",
+      "integrity": "sha512-ocYzYn7Qgp0tFc1gQtUTOaHHSzVTwhWHxxY+r7cj2jJTPfMTZB5GWSJHdIVoxsl+EQENpjJ/6Zvcw0BqKZQ+Eg==",
       "requires": {
         "attr-accept": "^2.2.1",
         "file-selector": "^0.2.2",

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -1,7 +1,10 @@
 import { MemoryRouter, Route } from 'react-router'
 import { Meta, Story } from '@storybook/react'
 
-import { getAdminFormResponse } from '~/mocks/msw/handlers/admin-form'
+import {
+  getAdminFormResponse,
+  getAdminFormSettings,
+} from '~/mocks/msw/handlers/admin-form'
 
 import { viewports } from '~utils/storybook'
 
@@ -23,7 +26,7 @@ export default {
   ],
   parameters: {
     layout: 'fullscreen',
-    msw: [getAdminFormResponse()],
+    msw: [getAdminFormResponse(), getAdminFormSettings()],
   },
 } as Meta
 

--- a/frontend/src/features/admin-form/common/AdminFormPage.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormPage.tsx
@@ -1,5 +1,7 @@
 import { TabPanel, TabPanels } from '@chakra-ui/react'
 
+import { SettingsPage } from '../settings/SettingsPage'
+
 import AdminFormNavbar from './components/AdminFormNavbar'
 import { AdminFormTabProvider } from './components/AdminFormTabProvider'
 
@@ -12,7 +14,7 @@ export const AdminFormPage = (): JSX.Element => {
           <p>Insert builder page here!</p>
         </TabPanel>
         <TabPanel>
-          <p>Insert settings page here!</p>
+          <SettingsPage />
         </TabPanel>
         <TabPanel>
           <p>Insert results page here!</p>

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -6,8 +6,10 @@ import {
   PreviewFormViewDto,
 } from '~shared/types/form/form'
 
+import { ApiService } from '~services/ApiService'
+
 // endpoint exported for testing
-export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
+export const ADMIN_FORM_ENDPOINT = 'admin/forms'
 
 /**
  * Gets admin view of form.
@@ -17,9 +19,9 @@ export const ADMIN_FORM_ENDPOINT = '/api/v3/admin/forms'
 export const getAdminFormView = async (
   formId: string,
 ): Promise<AdminFormDto> => {
-  return axios
-    .get<AdminFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
-    .then(({ data }) => data.form)
+  return ApiService.get<AdminFormViewDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}`,
+  ).then(({ data }) => data.form)
 }
 
 /**

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -7,7 +7,7 @@ import { ApiError } from '~typings/core'
 
 import { getAdminFormView } from './AdminViewFormService'
 
-const adminFormKeys = {
+export const adminFormKeys = {
   base: ['adminForm'] as const,
   id: (id: string) => ['adminForm', id] as const,
 }

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,0 +1,14 @@
+import { Box, Text } from '@chakra-ui/react'
+
+import { FormStatusToggle } from './components/FormStatusToggle'
+
+export const SettingsGeneralPage = (): JSX.Element => {
+  return (
+    <Box maxW="42.5rem">
+      <Text as="h2" textStyle="h2" color="secondary.500" mb="2.5rem">
+        Respondent access
+      </Text>
+      <FormStatusToggle />
+    </Box>
+  )
+}

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
 import { TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
 
 import { SettingsTab } from './components/SettingsTab'
+import { SettingsGeneralPage } from './SettingsGeneralPage'
 
 export const SettingsPage = (): JSX.Element => {
   return (
@@ -23,7 +24,7 @@ export const SettingsPage = (): JSX.Element => {
       </TabList>
       <TabPanels>
         <TabPanel>
-          <p>one!</p>
+          <SettingsGeneralPage />
         </TabPanel>
         <TabPanel>
           <p>two!</p>

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -1,0 +1,46 @@
+import {
+  BiCheckDouble,
+  BiCodeBlock,
+  BiCog,
+  BiKey,
+  BiMailSend,
+  BiRocket,
+} from 'react-icons/bi'
+import { TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
+
+import { SettingsTab } from './components/SettingsTab'
+
+export const SettingsPage = (): JSX.Element => {
+  return (
+    <Tabs isLazy isManual orientation="vertical" variant="line">
+      <TabList flexShrink={0} p={0} w="21rem" maxW="100%">
+        <SettingsTab label="General" icon={BiCog} />
+        <SettingsTab label="Singpass" icon={BiKey} />
+        <SettingsTab label="Thank you page" icon={BiCheckDouble} />
+        <SettingsTab label="Email notifications" icon={BiMailSend} />
+        <SettingsTab label="Webhooks" icon={BiCodeBlock} />
+        <SettingsTab label="Workflow" icon={BiRocket} />
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <p>one!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>two!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>3!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>4!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>5!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>6!</p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  )
+}

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -1,0 +1,40 @@
+import {
+  FormSettings,
+  FormStatus,
+  SettingsUpdateDto,
+} from '~shared/types/form/form'
+
+import { ApiService } from '~services/ApiService'
+
+import { ADMIN_FORM_ENDPOINT } from '../common/AdminViewFormService'
+
+export const getFormSettings = async (
+  formId: string,
+): Promise<FormSettings> => {
+  return ApiService.get<FormSettings>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/settings`,
+  ).then(({ data }) => data)
+}
+
+export const updateFormStatus = async (
+  formId: string,
+  status: FormStatus,
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { status })
+}
+
+/**
+ * Internal function that calls the PATCH API.
+ * @param formId the id of the form to update
+ * @param settingsToUpdate the partial settings object to update
+ * @returns updated form settings
+ */
+const updateFormSettings = async (
+  formId: string,
+  settingsToUpdate: SettingsUpdateDto,
+): Promise<FormSettings> => {
+  return ApiService.patch<FormSettings>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/settings`,
+    settingsToUpdate,
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { Flex, Skeleton, Text } from '@chakra-ui/react'
+
+import { FormId, FormStatus } from '~shared/types/form/form'
+
+import { Switch } from '~components/Toggle/Switch'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+export const FormStatusToggle = (): JSX.Element => {
+  const { formId } = useParams<{ formId: FormId }>()
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const isFormPublic = useMemo(
+    () => settings?.status === FormStatus.Public,
+    [settings?.status],
+  )
+
+  const { mutate, isLoading: isLoadingMutation } = useMutateFormSettings({
+    formId,
+  })
+
+  const handleToggleStatus = useCallback(() => {
+    if (!settings?.status || isLoadingSettings || isLoadingMutation) return
+    const nextStatus =
+      settings.status === FormStatus.Public
+        ? FormStatus.Private
+        : FormStatus.Public
+    return mutate(nextStatus)
+  }, [isLoadingMutation, isLoadingSettings, mutate, settings?.status])
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings}>
+      <Flex
+        bg={isFormPublic ? 'success.100' : 'danger.200'}
+        py="1rem"
+        px="1.125rem"
+        justify="space-between"
+      >
+        <Text textStyle="subhead-1">
+          Your form is <b>{isFormPublic ? 'OPEN' : 'CLOSED'}</b> to new
+          responses
+        </Text>
+        <Switch
+          isLoading={isLoadingMutation}
+          isChecked={isFormPublic}
+          onChange={handleToggleStatus}
+        />
+      </Flex>
+    </Skeleton>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -33,7 +33,7 @@ export const FormStatusToggle = (): JSX.Element => {
   }, [isLoadingMutation, isLoadingSettings, mutate, settings?.status])
 
   return (
-    <Skeleton isLoaded={!isLoadingSettings}>
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
       <Flex
         bg={isFormPublic ? 'success.100' : 'danger.200'}
         py="1rem"

--- a/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
+++ b/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
@@ -1,0 +1,15 @@
+import { As, Icon, Tab } from '@chakra-ui/react'
+
+export interface SettingsTabProps {
+  label: string
+  icon: As
+}
+
+export const SettingsTab = ({ label, icon }: SettingsTabProps): JSX.Element => {
+  return (
+    <Tab justifyContent="flex-start" p="1rem">
+      <Icon as={icon} color="currentcolor" fontSize="1.5rem" mr="1.5rem" />
+      {label}
+    </Tab>
+  )
+}

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -1,0 +1,44 @@
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query'
+
+import { FormId, FormSettings, FormStatus } from '~shared/types/form/form'
+
+import { useToast } from '~hooks/useToast'
+
+import { adminFormSettingsKeys } from './queries'
+import { updateFormStatus } from './SettingsService'
+
+type UseMutateFormSettingsProps = {
+  formId: FormId
+}
+export const useMutateFormSettings = ({
+  formId,
+}: UseMutateFormSettingsProps): UseMutationResult<
+  FormSettings,
+  unknown,
+  FormStatus,
+  unknown
+> => {
+  const queryClient = useQueryClient()
+  const toast = useToast()
+
+  return useMutation(
+    (nextStatus: FormStatus) => updateFormStatus(formId, nextStatus),
+    {
+      onSuccess: (newData) => {
+        // Update new settings data in cache.
+        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+
+        // Show toast on success.
+        const isNowPublic = newData.status === FormStatus.Public
+        const toastStatusMessage = isNowPublic
+          ? `Congrats! Your form is now open for submission.\n\nFor high-traffic forms, [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to prevent lost responses.`
+          : 'Your form is closed for submission.'
+        toast({
+          status: 'success',
+          description: toastStatusMessage,
+          isClosable: true,
+        })
+      },
+    },
+  )
+}

--- a/frontend/src/features/admin-form/settings/queries.ts
+++ b/frontend/src/features/admin-form/settings/queries.ts
@@ -3,10 +3,12 @@ import { useParams } from 'react-router-dom'
 
 import { FormSettings } from '~shared/types/form/form'
 
+import { adminFormKeys } from '../common/queries'
+
 import { getFormSettings } from './SettingsService'
 
 export const adminFormSettingsKeys = {
-  base: ['adminFormSettings'] as const,
+  base: [...adminFormKeys.base, 'settings'] as const,
   id: (id: string) => [...adminFormSettingsKeys.base, id] as const,
 }
 
@@ -15,7 +17,9 @@ export const adminFormSettingsKeys = {
  */
 export const useAdminFormSettings = (): UseQueryResult<FormSettings> => {
   const { formId } = useParams<{ formId: string }>()
-  return useQuery(adminFormSettingsKeys.id(formId), () =>
-    getFormSettings(formId),
+  return useQuery(
+    adminFormSettingsKeys.id(formId),
+    () => getFormSettings(formId),
+    { staleTime: 10 * 60 * 1000 },
   )
 }

--- a/frontend/src/features/admin-form/settings/queries.ts
+++ b/frontend/src/features/admin-form/settings/queries.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryResult } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { FormSettings } from '~shared/types/form/form'
+
+import { getFormSettings } from './SettingsService'
+
+export const adminFormSettingsKeys = {
+  base: ['adminFormSettings'] as const,
+  id: (id: string) => [...adminFormSettingsKeys.base, id] as const,
+}
+
+/**
+ * @precondition Must be wrapped in a Router as `useParam` is used.
+ */
+export const useAdminFormSettings = (): UseQueryResult<FormSettings> => {
+  const { formId } = useParams<{ formId: string }>()
+  return useQuery(adminFormSettingsKeys.id(formId), () =>
+    getFormSettings(formId),
+  )
+}

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -1,6 +1,7 @@
-import { merge } from 'lodash'
+import { merge, pick } from 'lodash'
 import { rest } from 'msw'
 
+import { EMAIL_FORM_SETTINGS_FIELDS } from '~shared/constants/form'
 import { AgencyId } from '~shared/types/agency'
 import {
   AdminFormDto,
@@ -9,6 +10,7 @@ import {
   FormColorTheme,
   FormId,
   FormResponseMode,
+  FormSettings,
   FormStatus,
 } from '~shared/types/form/form'
 import { FormLogoState } from '~shared/types/form/form_logo'
@@ -79,6 +81,30 @@ export const getAdminFormResponse = (
         ctx.delay(delay),
         ctx.status(200),
         ctx.json(createMockForm({ _id: req.params.formId, ...props })),
+      )
+    },
+  )
+}
+
+export const getAdminFormSettings = ({
+  delay = 0,
+  overrides,
+}: {
+  delay?: number | 'infinite'
+  overrides?: Partial<FormSettings>
+} = {}) => {
+  return rest.get<FormSettings>(
+    '/api/v3/admin/forms/:formId/settings',
+    (req, res, ctx) => {
+      return res(
+        ctx.delay(delay),
+        ctx.status(200),
+        ctx.json(
+          pick(
+            createMockForm({ _id: req.params.formId, ...overrides }).form,
+            EMAIL_FORM_SETTINGS_FIELDS,
+          ),
+        ),
       )
     },
   )

--- a/frontend/src/theme/components/Tabs.ts
+++ b/frontend/src/theme/components/Tabs.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   ChakraTheme,
   ComponentMultiStyleConfig,
@@ -80,7 +81,18 @@ const createSizes = () => ({
 
 const variantLine: ThemingPropsThunk<SystemStyleObjectRecord, ChakraTheme> =
   () => ({
+    tablist: {
+      // overflowX and whiteSpace required for use-drag-scroll library
+      overflowX: 'scroll',
+      whiteSpace: 'nowrap',
+    },
     tab: {
+      textStyle: 'subhead-3',
+      _selected: {
+        textStyle: 'subhead-3',
+        fontSize: '1rem',
+      },
+      textTransform: 'uppercase',
       borderBottom: '0.125rem solid transparent',
       _focusVisible: {
         _selected: {
@@ -148,18 +160,15 @@ const variantDark: ThemingPropsThunk<SystemStyleObjectRecord, ChakraTheme> = (
 
 export const Tabs: ComponentMultiStyleConfig = {
   parts,
+  sizes: createSizes(),
   baseStyle: {
-    tablist: {
-      // overflowX and whiteSpace required for use-drag-scroll library
-      overflowX: 'scroll',
-      whiteSpace: 'nowrap',
-    },
     tab: {
-      textStyle: 'subhead-3',
-      textTransform: 'uppercase',
+      textStyle: 'body-1',
+      _selected: {
+        textStyle: 'subhead-1',
+      },
     },
   },
-  sizes: createSizes(),
   variants: {
     // Chakra UI already has a line variant, these are our custom variants
     'line-light': variantLight,


### PR DESCRIPTION
Note that this PR builds on the scaffolding created in #2762
Note that vertical tab styling is still a little jank, pending #2806 

This PR is mostly to check for logic completeness.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR creates the initial settings page component render, with initial `GET` and `PATCH` setting queries, along with a FormStatusToggle component to be used in the activation/deactivation of forms.

Related to #2789 

## Solution
<!-- How did you solve the problem? -->
**Features**:

- add initial SettingsPage component
- add initial SettingsGeneralPage component
- add form settings query hooks and mutations
- add FormStatusToggle component
- add msw handler for getAdminFormSettings

**Improvements**:

- update AdminVIewFormService to use ApiService


## Before & After Screenshots
FormAdminPage/Settings stories have been updated.

