### PR TITLE
feat(FormSettings/2): add remaining general settings toggles

### DIFF
--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, Story } from '@storybook/react'
 import {
   getAdminFormResponse,
   getAdminFormSettings,
+  getAdminFormSubmissions,
 } from '~/mocks/msw/handlers/admin-form'
 
 import { viewports } from '~utils/storybook'
@@ -26,7 +27,11 @@ export default {
   ],
   parameters: {
     layout: 'fullscreen',
-    msw: [getAdminFormResponse(), getAdminFormSettings()],
+    msw: [
+      getAdminFormResponse(),
+      getAdminFormSettings(),
+      getAdminFormSubmissions(),
+    ],
   },
 } as Meta
 

--- a/frontend/src/features/admin-form/common/AdminFormPage.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormPage.tsx
@@ -10,13 +10,13 @@ export const AdminFormPage = (): JSX.Element => {
     <AdminFormTabProvider>
       <AdminFormNavbar />
       <TabPanels>
-        <TabPanel>
+        <TabPanel p={0}>
           <p>Insert builder page here!</p>
         </TabPanel>
-        <TabPanel>
+        <TabPanel p={0}>
           <SettingsPage />
         </TabPanel>
-        <TabPanel>
+        <TabPanel p={0}>
           <p>Insert results page here!</p>
         </TabPanel>
       </TabPanels>

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -34,7 +34,17 @@ export const AdminFormNavbar = ({
   handleShareButtonClick,
 }: AdminFormNavbarProps): JSX.Element => {
   return (
-    <Flex py="0.625rem" px="2rem" justify="space-between" align="center">
+    <Flex
+      py="0.3125rem"
+      px="2rem"
+      justify="space-between"
+      align="center"
+      position="sticky"
+      top={0}
+      bg="white"
+      zIndex="docked"
+      boxShadow="0 1px 1px var(--chakra-colors-neutral-300)"
+    >
       <Flex flex={1} align="center">
         <Box>
           <IconButton

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -1,0 +1,26 @@
+import { SubmissionCountQueryDto } from '~shared/types/submission'
+
+import { ApiService } from '~services/ApiService'
+
+import { ADMIN_FORM_ENDPOINT } from '../common/AdminViewFormService'
+
+/**
+ * Counts the number of submissions for a given form
+ * @param urlParameters Mapping of the url parameters to values
+ * @returns The number of form submissions
+ */
+export const countFormSubmissions = async ({
+  formId,
+  dates,
+}: {
+  formId: string
+  dates?: SubmissionCountQueryDto
+}): Promise<number> => {
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
+  if (dates) {
+    return ApiService.get(queryUrl, {
+      params: { ...dates },
+    }).then(({ data }) => data)
+  }
+  return ApiService.get(queryUrl).then(({ data }) => data)
+}

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryResult } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { adminFormKeys } from '../common/queries'
+
+import { countFormSubmissions } from './AdminSubmissionsService'
+
+export const adminFormResponsesKeys = {
+  base: [...adminFormKeys.base, 'responses'] as const,
+  id: (id: string) => [...adminFormResponsesKeys.base, id] as const,
+}
+
+/**
+ * @precondition Must be wrapped in a Router as `useParam` is used.
+ */
+export const useFormResponsesCount = (): UseQueryResult<number> => {
+  const { formId } = useParams<{ formId: string }>()
+  return useQuery(
+    adminFormResponsesKeys.id(formId),
+    () => countFormSubmissions({ formId }),
+    { staleTime: 10 * 60 * 1000 },
+  )
+}

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,9 +1,18 @@
 import { FC } from 'react'
 import { Box, Divider, Text } from '@chakra-ui/react'
 
+import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
+
+const CategoryHeader: FC = ({ children }) => {
+  return (
+    <Text as="h2" textStyle="h2" color="secondary.500" mb="2.5rem">
+      {children}
+    </Text>
+  )
+}
 
 const SubcategoryHeader: FC = ({ children }) => {
   return (
@@ -22,9 +31,7 @@ const SubcategoryHeader: FC = ({ children }) => {
 export const SettingsGeneralPage = (): JSX.Element => {
   return (
     <Box maxW="42.5rem">
-      <Text as="h2" textStyle="h2" color="secondary.500" mb="2.5rem">
-        Respondent access
-      </Text>
+      <CategoryHeader>Respondent access</CategoryHeader>
       <FormStatusToggle />
       <Divider my="2.5rem" />
       <SubcategoryHeader>Scheduling</SubcategoryHeader>
@@ -32,6 +39,10 @@ export const SettingsGeneralPage = (): JSX.Element => {
       <Divider my="2.5rem" />
       <SubcategoryHeader>Customisation</SubcategoryHeader>
       <FormCustomisationSection />
+      <Divider my="2.5rem" />
+      <SubcategoryHeader>Verification</SubcategoryHeader>
+      <FormCaptchaToggle />
+      <Divider my="2.5rem" />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,5 +1,6 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Divider, Text } from '@chakra-ui/react'
 
+import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
 
 export const SettingsGeneralPage = (): JSX.Element => {
@@ -9,6 +10,17 @@ export const SettingsGeneralPage = (): JSX.Element => {
         Respondent access
       </Text>
       <FormStatusToggle />
+      <Divider my="2.5rem" />
+      <Text
+        as="h3"
+        textTransform="uppercase"
+        textStyle="subhead-3"
+        color="primary.500"
+        mb="2rem"
+      >
+        Scheduling
+      </Text>
+      <FormLimitToggle />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,7 +1,23 @@
+import { FC } from 'react'
 import { Box, Divider, Text } from '@chakra-ui/react'
 
+import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
+
+const SubcategoryHeader: FC = ({ children }) => {
+  return (
+    <Text
+      as="h3"
+      textTransform="uppercase"
+      textStyle="subhead-3"
+      color="primary.500"
+      mb="2rem"
+    >
+      {children}
+    </Text>
+  )
+}
 
 export const SettingsGeneralPage = (): JSX.Element => {
   return (
@@ -11,16 +27,11 @@ export const SettingsGeneralPage = (): JSX.Element => {
       </Text>
       <FormStatusToggle />
       <Divider my="2.5rem" />
-      <Text
-        as="h3"
-        textTransform="uppercase"
-        textStyle="subhead-3"
-        color="primary.500"
-        mb="2rem"
-      >
-        Scheduling
-      </Text>
+      <SubcategoryHeader>Scheduling</SubcategoryHeader>
       <FormLimitToggle />
+      <Divider my="2.5rem" />
+      <SubcategoryHeader>Customisation</SubcategoryHeader>
+      <FormCustomisationSection />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -13,8 +13,24 @@ import { SettingsGeneralPage } from './SettingsGeneralPage'
 
 export const SettingsPage = (): JSX.Element => {
   return (
-    <Tabs isLazy isManual orientation="vertical" variant="line">
-      <TabList flexShrink={0} p={0} w="21rem" maxW="100%">
+    <Tabs
+      isLazy
+      isManual
+      orientation="vertical"
+      variant="line"
+      py="4rem"
+      px="2rem"
+    >
+      <TabList
+        flexShrink={0}
+        p={0}
+        h="max-content"
+        w="21rem"
+        maxW="100%"
+        position="sticky"
+        mt="-0.875rem"
+        top="7.125rem"
+      >
         <SettingsTab label="General" icon={BiCog} />
         <SettingsTab label="Singpass" icon={BiKey} />
         <SettingsTab label="Thank you page" icon={BiCheckDouble} />

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -30,6 +30,13 @@ export const updateFormLimit = async (
   return updateFormSettings(formId, { submissionLimit: newLimit })
 }
 
+export const updateFormCaptcha = async (
+  formId: string,
+  newHasCaptcha: boolean,
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { hasCaptcha: newHasCaptcha })
+}
+
 export const updateFormInactiveMessage = async (
   formId: string,
   newMessage: string,

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -23,6 +23,13 @@ export const updateFormStatus = async (
   return updateFormSettings(formId, { status })
 }
 
+export const updateFormLimit = async (
+  formId: string,
+  newLimit: number | null,
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { submissionLimit: newLimit })
+}
+
 /**
  * Internal function that calls the PATCH API.
  * @param formId the id of the form to update

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -30,6 +30,13 @@ export const updateFormLimit = async (
   return updateFormSettings(formId, { submissionLimit: newLimit })
 }
 
+export const updateFormInactiveMessage = async (
+  formId: string,
+  newMessage: string,
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { inactiveMessage: newMessage })
+}
+
 /**
  * Internal function that calls the PATCH API.
  * @param formId the id of the form to update

--- a/frontend/src/features/admin-form/settings/components/FormCaptchaToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormCaptchaToggle.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useMemo } from 'react'
+import { Skeleton } from '@chakra-ui/react'
+
+import Toggle from '~components/Toggle'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+export const FormCaptchaToggle = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const hasCaptcha = useMemo(() => settings && settings?.hasCaptcha, [settings])
+
+  const { mutateFormCaptcha } = useMutateFormSettings()
+
+  const handleToggleCaptcha = useCallback(() => {
+    if (!settings || isLoadingSettings || mutateFormCaptcha.isLoading) return
+    const nextHasCaptcha = !settings.hasCaptcha
+    return mutateFormCaptcha.mutate(nextHasCaptcha)
+  }, [isLoadingSettings, mutateFormCaptcha, settings])
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
+      <Toggle
+        isLoading={mutateFormCaptcha.isLoading}
+        isChecked={hasCaptcha}
+        label="Enable reCAPTCHA"
+        onChange={() => handleToggleCaptcha()}
+      />
+    </Skeleton>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormCustomisationSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormCustomisationSection.tsx
@@ -54,7 +54,11 @@ const PrivateFormMessageInput = ({
       return setValue(initialMessage)
     }
 
-    return mutateFormInactiveMessage.mutate(value)
+    return mutateFormInactiveMessage.mutate(value, {
+      onError: () => {
+        setValue(initialMessage)
+      },
+    })
   }, [initialMessage, mutateFormInactiveMessage, value])
 
   const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(

--- a/frontend/src/features/admin-form/settings/components/FormCustomisationSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormCustomisationSection.tsx
@@ -1,0 +1,79 @@
+import {
+  ChangeEventHandler,
+  KeyboardEventHandler,
+  useCallback,
+  useRef,
+  useState,
+} from 'react'
+import { FormControl, Skeleton } from '@chakra-ui/react'
+
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+export const FormCustomisationSection = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
+      <FormControl mt="2rem">
+        <FormLabel isRequired>Set message for closed form</FormLabel>
+        {settings && (
+          <PrivateFormMessageInput initialMessage={settings.inactiveMessage} />
+        )}
+      </FormControl>
+    </Skeleton>
+  )
+}
+
+interface PrivateFormMessageInputProps {
+  initialMessage: string
+}
+const PrivateFormMessageInput = ({
+  initialMessage,
+}: PrivateFormMessageInputProps): JSX.Element => {
+  const [value, setValue] = useState(initialMessage)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { mutateFormInactiveMessage } = useMutateFormSettings()
+
+  // TODO: Show error when given value is below current submission counts.
+  const handleValueChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      setValue(e.target.value)
+    },
+    [],
+  )
+
+  const handleBlur = useCallback(() => {
+    if (value === initialMessage) return
+    if (value === '') {
+      return setValue(initialMessage)
+    }
+
+    return mutateFormInactiveMessage.mutate(value)
+  }, [initialMessage, mutateFormInactiveMessage, value])
+
+  const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        inputRef.current?.blur()
+      }
+    },
+    [],
+  )
+
+  return (
+    <Input
+      ref={inputRef}
+      value={value}
+      onChange={handleValueChange}
+      onKeyDown={handleKeydown}
+      onBlur={handleBlur}
+    />
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -1,0 +1,106 @@
+import {
+  KeyboardEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { FormControl, Skeleton } from '@chakra-ui/react'
+
+import FormLabel from '~components/FormControl/FormLabel'
+import NumberInput from '~components/NumberInput'
+import Toggle from '~components/Toggle'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+interface FormLimitBlockProps {
+  initialLimit: string
+}
+const FormLimitBlock = ({ initialLimit }: FormLimitBlockProps): JSX.Element => {
+  const [value, setValue] = useState(initialLimit)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { mutateFormLimit } = useMutateFormSettings()
+
+  // TODO: Show error when given value is below current submission counts.
+  const handleValueChange = useCallback((val: string) => {
+    // Only allow numeric inputs
+    setValue(val.replace(/\D/g, ''))
+  }, [])
+
+  const handleBlur = useCallback(() => {
+    if (value === initialLimit) return
+    if (value === '') {
+      return setValue(initialLimit)
+    }
+
+    return mutateFormLimit.mutate(parseInt(value, 10))
+  }, [initialLimit, mutateFormLimit, value])
+
+  const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        inputRef.current?.blur()
+      }
+    },
+    [],
+  )
+
+  return (
+    <FormControl mt="2rem">
+      <FormLabel
+        isRequired
+        description="Your form will automatically close once it reaches the set limit. Enable
+        reCaptcha to prevent spam submissions from triggering this limit."
+      >
+        Maximum number of responses allowed
+      </FormLabel>
+      <NumberInput
+        maxW="16rem"
+        ref={inputRef}
+        min={0}
+        inputMode="numeric"
+        allowMouseWheel
+        precision={0}
+        value={value}
+        onChange={handleValueChange}
+        onKeyDown={handleKeydown}
+        onBlur={handleBlur}
+      />
+    </FormControl>
+  )
+}
+
+export const FormLimitToggle = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const isLimit = useMemo(
+    () => settings && settings?.submissionLimit !== null,
+    [settings],
+  )
+
+  const { mutateFormLimit } = useMutateFormSettings()
+
+  const handleToggleLimit = useCallback(() => {
+    if (!settings || isLoadingSettings || mutateFormLimit.isLoading) return
+    const nextLimit = settings.submissionLimit === null ? 1000 : null
+    return mutateFormLimit.mutate(nextLimit)
+  }, [isLoadingSettings, mutateFormLimit, settings])
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
+      <Toggle
+        isLoading={mutateFormLimit.isLoading}
+        isChecked={isLimit}
+        label="Set a response limit"
+        onChange={() => handleToggleLimit()}
+      />
+      {settings && settings?.submissionLimit !== null && (
+        <FormLimitBlock initialLimit={String(settings.submissionLimit)} />
+      )}
+    </Skeleton>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -35,7 +35,11 @@ const FormLimitBlock = ({ initialLimit }: FormLimitBlockProps): JSX.Element => {
       return setValue(initialLimit)
     }
 
-    return mutateFormLimit.mutate(parseInt(value, 10))
+    return mutateFormLimit.mutate(parseInt(value, 10), {
+      onError: () => {
+        setValue(initialLimit)
+      },
+    })
   }, [initialLimit, mutateFormLimit, value])
 
   const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
 import { Flex, Skeleton, Text } from '@chakra-ui/react'
 
-import { FormId, FormStatus } from '~shared/types/form/form'
+import { FormStatus } from '~shared/types/form/form'
 
 import { Switch } from '~components/Toggle/Switch'
 
@@ -10,7 +9,6 @@ import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
 
 export const FormStatusToggle = (): JSX.Element => {
-  const { formId } = useParams<{ formId: FormId }>()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -19,18 +17,17 @@ export const FormStatusToggle = (): JSX.Element => {
     [settings?.status],
   )
 
-  const { mutate, isLoading: isLoadingMutation } = useMutateFormSettings({
-    formId,
-  })
+  const { mutateFormStatus } = useMutateFormSettings()
 
   const handleToggleStatus = useCallback(() => {
-    if (!settings?.status || isLoadingSettings || isLoadingMutation) return
+    if (!settings?.status || isLoadingSettings || mutateFormStatus.isLoading)
+      return
     const nextStatus =
       settings.status === FormStatus.Public
         ? FormStatus.Private
         : FormStatus.Public
-    return mutate(nextStatus)
-  }, [isLoadingMutation, isLoadingSettings, mutate, settings?.status])
+    return mutateFormStatus.mutate(nextStatus)
+  }, [isLoadingSettings, mutateFormStatus, settings?.status])
 
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!settings}>
@@ -45,7 +42,7 @@ export const FormStatusToggle = (): JSX.Element => {
           responses
         </Text>
         <Switch
-          isLoading={isLoadingMutation}
+          isLoading={mutateFormStatus.isLoading}
           isChecked={isFormPublic}
           onChange={handleToggleStatus}
         />

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -8,7 +8,11 @@ import { useToast } from '~hooks/useToast'
 import { formatOrdinal } from '~utils/stringFormat'
 
 import { adminFormSettingsKeys } from './queries'
-import { updateFormLimit, updateFormStatus } from './SettingsService'
+import {
+  updateFormInactiveMessage,
+  updateFormLimit,
+  updateFormStatus,
+} from './SettingsService'
 
 export const useMutateFormSettings = () => {
   const { formId } = useParams<{ formId: FormId }>()
@@ -19,6 +23,7 @@ export const useMutateFormSettings = () => {
     (nextStatus: FormStatus) => updateFormStatus(formId, nextStatus),
     {
       onSuccess: (newData) => {
+        toast.closeAll()
         // Update new settings data in cache.
         queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
 
@@ -38,6 +43,7 @@ export const useMutateFormSettings = () => {
     (nextLimit: number | null) => updateFormLimit(formId, nextLimit),
     {
       onSuccess: (newData) => {
+        toast.closeAll()
         // Update new settings data in cache.
         queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
 
@@ -55,5 +61,21 @@ export const useMutateFormSettings = () => {
     },
   )
 
-  return { mutateFormStatus, mutateFormLimit }
+  const mutateFormInactiveMessage = useMutation(
+    (nextMessage: string) => updateFormInactiveMessage(formId, nextMessage),
+    {
+      onSuccess: (newData) => {
+        toast.closeAll()
+        // Update new settings data in cache.
+        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+
+        // Show toast on success.
+        toast({
+          description: "Your form's inactive message has been updated.",
+        })
+      },
+    },
+  )
+
+  return { mutateFormStatus, mutateFormLimit, mutateFormInactiveMessage }
 }

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -1,27 +1,19 @@
-import { useMutation, UseMutationResult, useQueryClient } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
+import { useParams } from 'react-router-dom'
 
-import { FormId, FormSettings, FormStatus } from '~shared/types/form/form'
+import { FormId, FormStatus } from '~shared/types/form/form'
 
 import { useToast } from '~hooks/useToast'
 
 import { adminFormSettingsKeys } from './queries'
 import { updateFormStatus } from './SettingsService'
 
-type UseMutateFormSettingsProps = {
-  formId: FormId
-}
-export const useMutateFormSettings = ({
-  formId,
-}: UseMutateFormSettingsProps): UseMutationResult<
-  FormSettings,
-  unknown,
-  FormStatus,
-  unknown
-> => {
+export const useMutateFormSettings = () => {
+  const { formId } = useParams<{ formId: FormId }>()
   const queryClient = useQueryClient()
-  const toast = useToast()
+  const toast = useToast({ status: 'success', isClosable: true })
 
-  return useMutation(
+  const mutateFormStatus = useMutation(
     (nextStatus: FormStatus) => updateFormStatus(formId, nextStatus),
     {
       onSuccess: (newData) => {
@@ -34,11 +26,11 @@ export const useMutateFormSettings = ({
           ? `Congrats! Your form is now open for submission.\n\nFor high-traffic forms, [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to prevent lost responses.`
           : 'Your form is closed for submission.'
         toast({
-          status: 'success',
           description: toastStatusMessage,
-          isClosable: true,
         })
       },
     },
   )
+
+  return { mutateFormStatus }
 }

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -37,6 +37,13 @@ export const useMutateFormSettings = () => {
           description: toastStatusMessage,
         })
       },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
     },
   )
 
@@ -59,6 +66,13 @@ export const useMutateFormSettings = () => {
           description: toastStatusMessage,
         })
       },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
     },
   )
 
@@ -78,6 +92,13 @@ export const useMutateFormSettings = () => {
           description: toastStatusMessage,
         })
       },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
     },
   )
 
@@ -92,6 +113,13 @@ export const useMutateFormSettings = () => {
         // Show toast on success.
         toast({
           description: "Your form's inactive message has been updated.",
+        })
+      },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
         })
       },
     },

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -9,6 +9,7 @@ import { formatOrdinal } from '~utils/stringFormat'
 
 import { adminFormSettingsKeys } from './queries'
 import {
+  updateFormCaptcha,
   updateFormInactiveMessage,
   updateFormLimit,
   updateFormStatus,
@@ -61,6 +62,25 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateFormCaptcha = useMutation(
+    (nextHasCaptcha: boolean) => updateFormCaptcha(formId, nextHasCaptcha),
+    {
+      onSuccess: (newData) => {
+        toast.closeAll()
+        // Update new settings data in cache.
+        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+
+        // Show toast on success.
+        const toastStatusMessage = `reCAPTCHA is now ${
+          newData.hasCaptcha ? 'enabled' : 'disabled'
+        } on your form.`
+        toast({
+          description: toastStatusMessage,
+        })
+      },
+    },
+  )
+
   const mutateFormInactiveMessage = useMutation(
     (nextMessage: string) => updateFormInactiveMessage(formId, nextMessage),
     {
@@ -77,5 +97,10 @@ export const useMutateFormSettings = () => {
     },
   )
 
-  return { mutateFormStatus, mutateFormLimit, mutateFormInactiveMessage }
+  return {
+    mutateFormStatus,
+    mutateFormLimit,
+    mutateFormInactiveMessage,
+    mutateFormCaptcha,
+  }
 }

--- a/frontend/src/mocks/msw/handlers/admin-form/index.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/index.ts
@@ -1,1 +1,2 @@
 export * from './form'
+export * from './submissions'

--- a/frontend/src/mocks/msw/handlers/admin-form/submissions.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/submissions.ts
@@ -1,0 +1,16 @@
+import { rest } from 'msw'
+
+export const getAdminFormSubmissions = ({
+  delay = 0,
+  override,
+}: {
+  delay?: number | 'infinite'
+  override?: number
+} = {}) => {
+  return rest.get(
+    '/api/v3/admin/forms/:formId/submissions/count',
+    (req, res, ctx) => {
+      return res(ctx.delay(delay), ctx.status(200), ctx.json(override ?? 20))
+    },
+  )
+}

--- a/frontend/src/utils/stringFormat.ts
+++ b/frontend/src/utils/stringFormat.ts
@@ -1,0 +1,21 @@
+/**
+ * Function formats given number to its ordinal form.
+ * @example 1 -> "1st", 2 -> "2nd", 3 -> "3rd", 4 -> "4th", etc.
+ * @param number the number to format
+ * @returns the ordinal string of the number
+ */
+export const formatOrdinal = (number: number): string => {
+  const englishOrdinalRules = new Intl.PluralRules('en', {
+    type: 'ordinal',
+  })
+  const suffixes = {
+    zero: 'th',
+    one: 'st',
+    two: 'nd',
+    few: 'rd',
+    many: 'th',
+    other: 'th',
+  }
+  const suffix = suffixes[englishOrdinalRules.select(number)]
+  return number + suffix
+}


### PR DESCRIPTION
Note that this PR builds on #2889

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements the remaining form setting toggles found in the _general_ settings tab. EmailForm specific toggles will come in a later PR.

Related to #2789

## Solution
<!-- How did you solve the problem? -->
**Features**:

- add captcha section to general page
- add FormLimitToggle component and related hooks
- add FormCustomisationSection component 
- add error handling to mutations, including submission limit error handling and checks

**Improvements**:

- useMutateFormSettings hook now exports mutation sub-hooks instead of creating new hooks for each mutation
- add sticky navbar and setting sidebar

## Before & After Screenshots
AdminFormPage/Settings stories have been updated.
