### PR TITLE
feat(FormSettings/3): add email-form specific email setting input 

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,10 +1,14 @@
 import { FC } from 'react'
 import { Box, Divider, Text } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types/form/form'
+
+import { EmailFormSection } from './components/EmailFormSection'
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
+import { useAdminFormSettings } from './queries'
 
 const CategoryHeader: FC = ({ children }) => {
   return (
@@ -29,6 +33,8 @@ const SubcategoryHeader: FC = ({ children }) => {
 }
 
 export const SettingsGeneralPage = (): JSX.Element => {
+  const { data: settings } = useAdminFormSettings()
+
   return (
     <Box maxW="42.5rem">
       <CategoryHeader>Respondent access</CategoryHeader>
@@ -42,7 +48,13 @@ export const SettingsGeneralPage = (): JSX.Element => {
       <Divider my="2.5rem" />
       <SubcategoryHeader>Verification</SubcategoryHeader>
       <FormCaptchaToggle />
-      <Divider my="2.5rem" />
+      {settings?.responseMode === FormResponseMode.Email && (
+        <>
+          <Divider my="2.5rem" />
+          <CategoryHeader>Responses recipients</CategoryHeader>
+          <EmailFormSection settings={settings} />
+        </>
+      )}
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -44,6 +44,13 @@ export const updateFormInactiveMessage = async (
   return updateFormSettings(formId, { inactiveMessage: newMessage })
 }
 
+export const updateFormEmails = async (
+  formId: string,
+  newEmails: string[],
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { emails: newEmails })
+}
+
 /**
  * Internal function that calls the PATCH API.
  * @param formId the id of the form to update

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useMemo } from 'react'
+import {
+  Controller,
+  FormProvider,
+  useForm,
+  useFormContext,
+} from 'react-hook-form'
+import { FormControl } from '@chakra-ui/react'
+import { get, isEmpty, isEqual } from 'lodash'
+import validator from 'validator'
+
+import { EmailFormSettings } from '~shared/types/form/form'
+
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { useMutateFormSettings } from '../mutations'
+
+const MAX_EMAIL_LENGTH = 30
+interface EmailFormSectionProps {
+  settings: EmailFormSettings
+}
+
+export const EmailFormSection = ({
+  settings,
+}: EmailFormSectionProps): JSX.Element => {
+  const initialEmailSet = useMemo(
+    () => new Set(settings.emails),
+    [settings.emails],
+  )
+  const formMethods = useForm({
+    mode: 'onChange',
+    defaultValues: {
+      emails: settings.emails,
+    },
+  })
+
+  const {
+    formState: { errors },
+    reset,
+  } = formMethods
+
+  const { mutateFormEmails } = useMutateFormSettings()
+
+  const handleSubmitEmails = ({ emails: nextEmails }: { emails: string[] }) => {
+    if (isEqual(new Set(nextEmails.filter(Boolean)), initialEmailSet)) {
+      return reset()
+    }
+
+    return mutateFormEmails.mutate(nextEmails)
+  }
+
+  return (
+    <FormProvider {...formMethods}>
+      <FormControl mt="2rem" isInvalid={!isEmpty(errors)}>
+        <FormLabel
+          isRequired
+          useMarkdownForDescription
+          description="Add at least **2 recipients** to prevent loss of response. Learn more [how to guard against bounce emails](https://go.gov.sg/form-prevent-bounce)."
+        >
+          Emails where responses will be sent
+        </FormLabel>
+        <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
+        <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
+      </FormControl>
+    </FormProvider>
+  )
+}
+
+interface AdminEmailRecipientsInputProps {
+  onSubmit: (params: { emails: [] }) => void
+}
+
+const AdminEmailRecipientsInput = ({
+  onSubmit,
+}: AdminEmailRecipientsInputProps): JSX.Element => {
+  const { control, handleSubmit, reset } =
+    useFormContext<{ emails: string[] }>()
+
+  // Functions to transform input and output of the field.
+  const inputTransform = useMemo(
+    () => ({
+      // Combine and display all emails in a single string in the input field.
+      input: (value: string[]) => value.join(','),
+      // Convert joined email string into an array of emails.
+      output: (value: string) =>
+        value
+          .replace(/\s/g, '')
+          .split(',')
+          .map((v) => v.trim()),
+    }),
+    [],
+  )
+
+  const handleBlur = useCallback(() => {
+    return handleSubmit(onSubmit, () => reset())()
+  }, [handleSubmit, onSubmit, reset])
+
+  const validationRules = useMemo(() => {
+    return {
+      validate: {
+        required: (emails: string[]) => {
+          return (
+            emails.filter(Boolean).length > 0 ||
+            'You must at least enter one email to receive responses'
+          )
+        },
+        valid: (emails: string[]) => {
+          return (
+            emails.filter(Boolean).every((e) => validator.isEmail(e)) ||
+            'Please enter valid email(s) (e.g. me@example.com) separated by commas.'
+          )
+        },
+        duplicate: (emails: string[]) => {
+          return (
+            new Set(emails).size === emails.length ||
+            'Please remove duplicate emails.'
+          )
+        },
+        maxLength: (emails: string[]) => {
+          return (
+            emails.length <= MAX_EMAIL_LENGTH ||
+            'Please limit number of emails to 30.'
+          )
+        },
+      },
+    }
+  }, [])
+
+  return (
+    <Controller
+      control={control}
+      name="emails"
+      rules={validationRules}
+      render={({ field }) => (
+        <Input
+          value={inputTransform.input(field.value)}
+          onChange={(e) =>
+            field.onChange(inputTransform.output(e.target.value))
+          }
+          onBlur={handleBlur}
+        />
+      )}
+    />
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -37,11 +37,12 @@ export const FormStatusToggle = (): JSX.Element => {
         px="1.125rem"
         justify="space-between"
       >
-        <Text textStyle="subhead-1">
+        <Text textStyle="subhead-1" id="form-status">
           Your form is <b>{isFormPublic ? 'OPEN' : 'CLOSED'}</b> to new
           responses
         </Text>
         <Switch
+          aria-describedby="form-status"
           isLoading={mutateFormStatus.isLoading}
           isChecked={isFormPublic}
           onChange={handleToggleStatus}

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -10,6 +10,7 @@ import { formatOrdinal } from '~utils/stringFormat'
 import { adminFormSettingsKeys } from './queries'
 import {
   updateFormCaptcha,
+  updateFormEmails,
   updateFormInactiveMessage,
   updateFormLimit,
   updateFormStatus,
@@ -125,10 +126,34 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateFormEmails = useMutation(
+    (nextEmails: string[]) => updateFormEmails(formId, nextEmails),
+    {
+      onSuccess: (newData) => {
+        toast.closeAll()
+        // Update new settings data in cache.
+        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+
+        // Show toast on success.
+        toast({
+          description: 'Emails successfully updated.',
+        })
+      },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
+    },
+  )
+
   return {
     mutateFormStatus,
     mutateFormLimit,
     mutateFormInactiveMessage,
     mutateFormCaptcha,
+    mutateFormEmails,
   }
 }

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -20,6 +20,7 @@ export const STORAGE_PUBLIC_FORM_FIELDS = <const>[
 ]
 
 const FORM_SETTINGS_FIELDS = <const>[
+  'responseMode',
   'authType',
   'esrvcId',
   'hasCaptcha',


### PR DESCRIPTION
Note that this PR builds on #2890

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds email-form specific settings to the general settings page (basically only the email respondent input)

Related to #2789 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - New return object shape for GET form settings (add responseMode)
- [ ] No - this PR is backwards compatible  

**Features**:

- add responseMode to form settings return object
- add updateFormEmails fn and mutateFormEmails hook to form settings mutation hook
- add EmailFormSection component to update responses recipients

**Improvements**:
- add aria-describedby to form status toggle

## Before & After Screenshots
AdminFormPage/Settings stories have been updated.
