### PR TITLE
chore: add postinstall step for including shared folder in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "gen:theme-typings": "chakra-cli tokens src/theme/index.ts",
-    "postinstall": "npm run gen:theme-typings",
+    "postinstall": "npm run gen:theme-typings && npm --prefix ../shared install",
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true react-app-rewired start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true react-app-rewired build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true react-app-rewired test",


### PR DESCRIPTION
Some Chromatic builds (see #2888, #2891 before the fix commit) are failing due to having dependencies on some shared types and node modules.
This PR fixes that by installing shared dependencies in the Chromatic workflow (by adding installation of shared dependencies in the frontend/postinstall script)