### PR TITLE
fix(Button): prevent buttons from being stuck at certain width

### DIFF
--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -135,6 +135,7 @@ export const Button: ComponentStyleConfig = {
     border: '1px solid',
     textStyle: 'subhead-1',
     fontWeight: 'medium',
+    flexShrink: 0,
     h: 'auto',
     // -1px for border
     px: '15px',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR fixes the issue where Buttons could not have their widths expand even though there is available space.

This is fixed by setting `flexShrink` property to 0.

See https://cssreference.io/property/flex-shrink/
