### PR TITLE
fix(v2): disable IntlPhoneNumberInput's country selector when read only

### DIFF
--- a/frontend/src/components/PhoneNumberInput/IntlPhoneNumberInput.tsx
+++ b/frontend/src/components/PhoneNumberInput/IntlPhoneNumberInput.tsx
@@ -48,7 +48,10 @@ export const IntlPhoneNumberInput = forwardRef<
 
   return (
     <InputGroup>
-      <CountrySelect isDisabled={props.isDisabled} />
+      <CountrySelect
+        isReadOnly={props.isReadOnly}
+        isDisabled={props.isDisabled}
+      />
       <Input
         onBlur={handleInputBlur}
         ref={inputRef}
@@ -65,6 +68,7 @@ export const IntlPhoneNumberInput = forwardRef<
 
 interface CountrySelectProps {
   isDisabled?: boolean
+  isReadOnly?: boolean
 }
 
 const CountrySelect: FC<CountrySelectProps> = (props) => {
@@ -92,6 +96,7 @@ const CountrySelect: FC<CountrySelectProps> = (props) => {
       <Flex>
         <Icon
           aria-disabled={inputProps.disabled}
+          aria-readonly={inputProps.readOnly}
           // Show Flags if available. If value does not exist for any reason,
           // a default fallback icon will be used by ChakraUI.
           // See https://chakra-ui.com/docs/media-and-icons/icon#fallback-icon.
@@ -104,6 +109,7 @@ const CountrySelect: FC<CountrySelectProps> = (props) => {
         aria-label="Country selector"
         sx={styles.selector}
         {...inputProps}
+        disabled={inputProps.disabled || inputProps.readOnly}
         value={country}
         id={`${inputProps.id}-country`}
         // Override props on change with one that takes in ChangeEvent as a param.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When `IntlPhoneNumberInput` component is disabled, the selector is correctly disabled. However, when the input is read-only, the country selector can still be manipulated, which was an edge case missed when developing the component. 

Since the `select` tag does not actually support the readonly tag (see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly#:~:text=The%20attribute%20is%20not%20supported,the%20button%20types%2C%20including%20image.)), the fix is to treat the `readonly` tag as the  `disabled` tag on the country selector input.

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix(IntlPhoneNumberInput): disable country selector when read only
