### PR TITLE
chore(deps): bump vm2 to 3.9.4 in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25218,9 +25218,9 @@
       "dev": true
     },
     "vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.4.tgz",
+      "integrity": "sha512-sOdharrJ7KEePIpHekiWaY1DwgueuiBeX/ZBJUPgETsVlJsXuEx0K0/naATq2haFvJrvZnRiORQRubR0b7Ye6g=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",


### PR DESCRIPTION
## Problem
- bumps vm2 to 3.9.4 in package-lock to fix high severity vulnerability