### PR TITLE
feat(v2): add ability to update form title in settings

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormPage.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormPage.tsx
@@ -12,12 +12,7 @@ export const AdminFormPage = (): JSX.Element => {
         <Flex>
           <AdminFormNavbar />
         </Flex>
-        <TabPanels
-          overflow="auto"
-          flex={1}
-          py={{ base: '2.5rem', lg: '3.125rem' }}
-          px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
-        >
+        <TabPanels overflow="auto" flex={1}>
           <TabPanel p={0}>
             <p>Insert builder page here!</p>
           </TabPanel>

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Box, Divider, Text } from '@chakra-ui/react'
+import { Divider, Text } from '@chakra-ui/react'
 
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
@@ -31,7 +31,7 @@ const SubcategoryHeader: FC = ({ children }) => {
 
 export const SettingsGeneralPage = (): JSX.Element => {
   return (
-    <Box mt="1rem">
+    <>
       <CategoryHeader>Respondent access</CategoryHeader>
       <FormStatusToggle />
       <Divider my="2.5rem" />
@@ -46,6 +46,6 @@ export const SettingsGeneralPage = (): JSX.Element => {
       <Divider my="2.5rem" />
       <SubcategoryHeader>Form Details</SubcategoryHeader>
       <FormDetailsSection />
-    </Box>
+    </>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,14 +1,11 @@
 import { FC } from 'react'
 import { Box, Divider, Text } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types/form/form'
-
-import { EmailFormSection } from './components/EmailFormSection'
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
+import { FormDetailsSection } from './components/FormDetailsSection'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
-import { useAdminFormSettings } from './queries'
 
 const CategoryHeader: FC = ({ children }) => {
   return (
@@ -33,8 +30,6 @@ const SubcategoryHeader: FC = ({ children }) => {
 }
 
 export const SettingsGeneralPage = (): JSX.Element => {
-  const { data: settings } = useAdminFormSettings()
-
   return (
     <Box mt="1rem">
       <CategoryHeader>Respondent access</CategoryHeader>
@@ -48,13 +43,9 @@ export const SettingsGeneralPage = (): JSX.Element => {
       <Divider my="2.5rem" />
       <SubcategoryHeader>Verification</SubcategoryHeader>
       <FormCaptchaToggle />
-      {settings?.responseMode === FormResponseMode.Email && (
-        <>
-          <Divider my="2.5rem" />
-          <CategoryHeader>Responses recipients</CategoryHeader>
-          <EmailFormSection settings={settings} />
-        </>
-      )}
+      <Divider my="2.5rem" />
+      <SubcategoryHeader>Form Details</SubcategoryHeader>
+      <FormDetailsSection />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -32,7 +32,14 @@ export const SettingsPage = (): JSX.Element => {
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
 
   return (
-    <Tabs isLazy isManual orientation={tabOrientation} variant="line">
+    <Tabs
+      isLazy
+      isManual
+      orientation={tabOrientation}
+      variant="line"
+      py={{ base: '2.5rem', md: '3.5rem', lg: '4rem' }}
+      px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
+    >
       <Flex
         h="max-content"
         flex={1}
@@ -43,7 +50,9 @@ export const SettingsPage = (): JSX.Element => {
         position={{ base: 'fixed', md: 'sticky' }}
         zIndex={{ base: 'docked', md: 0 }}
         bg={{ base: 'neutral.100', md: 'inherit' }}
-        top={{ base: 'initial', md: 0 }}
+        // Height align text with start of tab panel.
+        mt={{ md: '-1rem', lg: '-0.875rem' }}
+        top={{ base: 'initial', md: '2.5rem', lg: '3.125rem' }}
         bottom={{ base: 0, md: 'initial' }}
         left={{ base: 0, md: 'initial' }}
         borderTop={{ base: '1px solid', md: 'none' }}

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -44,6 +44,13 @@ export const updateFormInactiveMessage = async (
   return updateFormSettings(formId, { inactiveMessage: newMessage })
 }
 
+export const updateFormTitle = async (
+  formId: string,
+  newTitle: string,
+): Promise<FormSettings> => {
+  return updateFormSettings(formId, { title: newTitle })
+}
+
 export const updateFormEmails = async (
   formId: string,
   newEmails: string[],

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -53,7 +53,7 @@ export const EmailFormSection = ({
 
   return (
     <FormProvider {...formMethods}>
-      <FormControl mt="2rem" isInvalid={!isEmpty(errors)}>
+      <FormControl isInvalid={!isEmpty(errors)}>
         <FormLabel
           isRequired
           useMarkdownForDescription

--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -1,0 +1,119 @@
+import { KeyboardEventHandler, useCallback, useMemo } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import { FormControl, Skeleton, Stack, Text, Wrap } from '@chakra-ui/react'
+import { get, isEmpty } from 'lodash'
+
+import { FormResponseMode } from '~shared/types/form/form'
+
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+import { EmailFormSection } from './EmailFormSection'
+
+export const FormDetailsSection = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const readableFormResponseMode = useMemo(() => {
+    switch (settings?.responseMode) {
+      case FormResponseMode.Email:
+        return 'Email'
+      case FormResponseMode.Encrypt:
+        return 'Storage'
+    }
+  }, [settings?.responseMode])
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
+      <Stack spacing="2rem">
+        {settings ? <FormTitleInput initialTitle={settings.title} /> : null}
+        {settings?.responseMode === FormResponseMode.Email ? (
+          <EmailFormSection settings={settings} />
+        ) : null}
+        <Wrap shouldWrapChildren justify="space-between" textStyle="subhead-1">
+          <Text>Mode for receiving responses</Text>
+          <Text>{readableFormResponseMode}</Text>
+        </Wrap>
+      </Stack>
+    </Skeleton>
+  )
+}
+
+interface FormTitleInputProps {
+  initialTitle: string
+}
+const FormTitleInput = ({ initialTitle }: FormTitleInputProps): JSX.Element => {
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm({
+    mode: 'onChange',
+    defaultValues: {
+      title: initialTitle,
+    },
+  })
+
+  const validationRules = useMemo(
+    () => ({
+      required: 'Form name is required',
+      minLength: {
+        value: 2,
+        message: 'Form name must be at least 4 characters',
+      },
+      maxLength: {
+        value: 200,
+        message: 'Form name must be at most 200 characters',
+      },
+      pattern: {
+        value: /^[a-zA-Z0-9_\-./() &`;'"]*$/,
+        message: 'Form name cannot contain special characters',
+      },
+    }),
+    [],
+  )
+
+  const { mutateFormTitle } = useMutateFormSettings()
+
+  const handleBlur = useCallback(() => {
+    return handleSubmit(
+      ({ title }) => {
+        if (title === initialTitle) return
+
+        return mutateFormTitle.mutate(title, { onError: () => reset() })
+      },
+      () => reset(),
+    )()
+  }, [handleSubmit, initialTitle, mutateFormTitle, reset])
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleBlur()
+      }
+    },
+    [handleBlur],
+  )
+
+  return (
+    <FormControl isInvalid={!isEmpty(errors)}>
+      <FormLabel isRequired>Form name</FormLabel>
+
+      <Controller
+        control={control}
+        name="title"
+        rules={validationRules}
+        render={({ field }) => (
+          <Input {...field} onBlur={handleBlur} onKeyDown={handleKeyDown} />
+        )}
+      />
+      <FormErrorMessage>{get(errors, 'title.message')}</FormErrorMessage>
+    </FormControl>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -33,7 +33,6 @@ const FormLimitBlock = ({
   const inputRef = useRef<HTMLInputElement>(null)
   const { mutateFormLimit } = useMutateFormSettings()
 
-  // TODO: Show error when given value is below current submission counts.
   const handleValueChange = useCallback(
     (val: string) => {
       // Only allow numeric inputs and remove leading zeroes.

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -14,6 +14,7 @@ import {
   updateFormInactiveMessage,
   updateFormLimit,
   updateFormStatus,
+  updateFormTitle,
 } from './SettingsService'
 
 export const useMutateFormSettings = () => {
@@ -103,6 +104,29 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateFormTitle = useMutation(
+    (nextTitle: string) => updateFormTitle(formId, nextTitle),
+    {
+      onSuccess: (newData) => {
+        toast.closeAll()
+        // Update new settings data in cache.
+        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+
+        // Show toast on success.
+        toast({
+          description: "Your form's title has been updated.",
+        })
+      },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
+    },
+  )
+
   const mutateFormInactiveMessage = useMutation(
     (nextMessage: string) => updateFormInactiveMessage(formId, nextMessage),
     {
@@ -155,5 +179,6 @@ export const useMutateFormSettings = () => {
     mutateFormInactiveMessage,
     mutateFormCaptcha,
     mutateFormEmails,
+    mutateFormTitle,
   }
 }

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -1,11 +1,19 @@
+import { useCallback } from 'react'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
 import simplur from 'simplur'
 
-import { FormId, FormStatus } from '~shared/types/form/form'
+import {
+  AdminFormDto,
+  FormId,
+  FormSettings,
+  FormStatus,
+} from '~shared/types/form/form'
 
 import { useToast } from '~hooks/useToast'
 import { formatOrdinal } from '~utils/stringFormat'
+
+import { adminFormKeys } from '../common/queries'
 
 import { adminFormSettingsKeys } from './queries'
 import {
@@ -22,13 +30,30 @@ export const useMutateFormSettings = () => {
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
 
+  const updateFormData = useCallback(
+    (newData: FormSettings) => {
+      queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+      // Only update adminForm if it already has prior data.
+      queryClient.setQueryData<AdminFormDto | undefined>(
+        adminFormKeys.id(formId),
+        (oldData) =>
+          oldData
+            ? {
+                ...oldData,
+                ...newData,
+              }
+            : undefined,
+      )
+    },
+    [formId, queryClient],
+  )
+
   const mutateFormStatus = useMutation(
     (nextStatus: FormStatus) => updateFormStatus(formId, nextStatus),
     {
       onSuccess: (newData) => {
         toast.closeAll()
-        // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         const isNowPublic = newData.status === FormStatus.Public
@@ -55,7 +80,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         toast.closeAll()
         // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         const toastStatusMessage = newData.submissionLimit
@@ -84,7 +109,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         toast.closeAll()
         // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         const toastStatusMessage = `reCAPTCHA is now ${
@@ -110,7 +135,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         toast.closeAll()
         // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         toast({
@@ -133,7 +158,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         toast.closeAll()
         // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         toast({
@@ -156,7 +181,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         toast.closeAll()
         // Update new settings data in cache.
-        queryClient.setQueryData(adminFormSettingsKeys.id(formId), newData)
+        updateFormData(newData)
 
         // Show toast on success.
         toast({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds in the last missing feature in the general (sub)page of form settings:
- Update form title
- Form mode (email/storage)

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add update form title mutation and service fn
- add `FormDetailsSection` component for use in `SettingsGeneralPage`

**Improvements**:

- also update adminform query on settings update so navbar gets updated on settings changes
- update padding of admin subpages to be independent of panel 

## Before & After Screenshots
Stories should automatically be updated

## Tests
<!-- What tests should be run to confirm functionality? -->

