### PR TITLE
chore: add workflow_dispatch event handler for ci.yml github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
     types: [opened, reopened]


### PR DESCRIPTION
Sometimes we want to manually trigger CI from the CLI or on Github itself, and adding the `workflow_dispatch` event to the CI config is a way to do that.