### PR TITLE
feat(v2): correct set routes for AdminFormPage stories

### DIFF
--- a/frontend/src/features/admin-form/AdminFormBuilderPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormBuilderPage.stories.tsx
@@ -16,7 +16,7 @@ export default {
       // MemoryRouter is used so react-router-dom#Link components can work
       // (and also to force the initial tab the page renders to be the settings tab).
       return (
-        <MemoryRouter initialEntries={['/:formId']}>
+        <MemoryRouter initialEntries={['/12345']}>
           <Routes>
             <Route path={'/:formId'} element={<AdminFormLayout />}>
               <Route index element={storyFn()} />

--- a/frontend/src/features/admin-form/AdminFormResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResponsesPage.stories.tsx
@@ -16,10 +16,10 @@ export default {
       // MemoryRouter is used so react-router-dom#Link components can work
       // (and also to force the initial tab the page renders to be the settings tab).
       return (
-        <MemoryRouter initialEntries={['/:formId']}>
+        <MemoryRouter initialEntries={['/12345/responses']}>
           <Routes>
             <Route path={'/:formId'} element={<AdminFormLayout />}>
-              <Route index element={storyFn()} />
+              <Route path="responses" element={storyFn()} />
             </Route>
           </Routes>
         </MemoryRouter>

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -25,7 +25,7 @@ export default {
       // MemoryRouter is used so react-router-dom#Link components can work
       // (and also to force the initial tab the page renders to be the settings tab).
       return (
-        <MemoryRouter initialEntries={['/:formId/settings']}>
+        <MemoryRouter initialEntries={['/12345/settings']}>
           <Routes>
             <Route path={'/:formId'} element={<AdminFormLayout />}>
               <Route path="settings" element={storyFn()} />


### PR DESCRIPTION
Routes set in the MemoryRouter decorator of AdminFormPage stories were incorrect, resulting in the AdminFormNavbar always rendering the Create tab as active.

This PR fixes the story