### PR TITLE
fix(v2): attempt deflaking Menu and Tooltip stories with chromatic param

### DIFF
--- a/frontend/src/components/Menu/Menu.stories.tsx
+++ b/frontend/src/components/Menu/Menu.stories.tsx
@@ -18,6 +18,10 @@ import { Menu } from './Menu'
 export default {
   title: 'Components/Menu',
   component: Menu,
+  parameters: {
+    // Required so tooltip does not flake.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 } as Meta
 
 type MenuTemplateProps = {

--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -11,6 +11,10 @@ export default {
   title: 'Components/Tooltip',
   component: Tooltip,
   decorators: [],
+  parameters: {
+    // Required so tooltip does not flake.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 } as Meta
 
 const TooltipStack = (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Tooltip and Menu stories have flaking, possibly due to device width changing and the opened Tooltips/Menu components having to readjust. This PR attempts to fix that issue by requesting chromatic to wait for all "animations" to end before taking a snapshot. (if it persists, will try a delay)


## Solution
<!-- How did you solve the problem? -->


**Bug Fixes**:

- attempt deflaking Menu and Tooltip stories with chromatic param

## Before & After Screenshots
Hopefully the snapshots have been fixed.

