### PR TITLE
chore(ci): add semantic.yml to modify CI behaviour

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,18 @@
+# Always validate the PR title, and ignore the commits
+# since we only squash commits
+titleOnly: true
+
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  # alias of refactor
+  - ref
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds config for our semantic PR checker github action.

The changes are to only validate titles since we only squash commits, and add ref type for refactor shorthand
