### PR TITLE
feat: Set up React Web Workers for decrypting storage mode responses

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -11,6 +11,7 @@ import {
 } from '~constants/routes'
 
 import { AdminFormLayout } from '~features/admin-form/common/AdminFormLayout'
+import ResponsesPage from '~features/admin-form/responses/ResponsesPage'
 import { SettingsPage } from '~features/admin-form/settings/SettingsPage'
 import { PublicFormPage } from '~features/public-form/PublicFormPage'
 
@@ -51,7 +52,7 @@ export const AppRouter = (): JSX.Element => {
           />
           <Route
             path={ADMINFORM_RESPONSES_SUBROUTE}
-            element={<div>Responses subpage</div>}
+            element={<ResponsesPage />}
           />
         </Route>
         <Route path="*" element={<div>404!!!</div>} />

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -1,3 +1,7 @@
+import { Remote, wrap } from 'comlink'
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import DecryptionWorker from 'worker-loader!./workers/decryption.worker'
+
 import { SubmissionCountQueryDto } from '~shared/types/submission'
 
 import { ApiService } from '~services/ApiService'
@@ -23,4 +27,51 @@ export const countFormSubmissions = async ({
     }).then(({ data }) => data)
   }
   return ApiService.get(queryUrl).then(({ data }) => data)
+}
+
+/**
+ * Get of submissions metadata for a given form
+ * @param urlParameters Mapping of the url parameters to values
+ * @returns The number of form submissions
+ */
+export const getFormSubmissionsMetadata = async (
+  formId: string,
+): Promise<any> => {
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata?page=1`
+  return ApiService.get(queryUrl).then(({ data }) => data)
+}
+
+interface Worker {
+  worker: DecryptionWorker
+  workerApi: Remote<{
+    decryptIntoCsv: (data: any) => any
+  }>
+}
+
+export const downloadEncryptedResponses = async (
+  formId: string,
+  formTitle: string,
+  secretKey: string,
+) => {
+  console.log('DECRYPTING')
+
+  const numWorkers = window.navigator.hardwareConcurrency || 4
+
+  const workerPool: Worker[] = []
+
+  for (let i = 0; i < numWorkers; i++) {
+    const worker = new DecryptionWorker()
+    const workerApi =
+      wrap<import('./workers/decryption.worker').DecryptionWorker>(worker)
+    console.log('New Worker!', i)
+    workerPool.push({ worker, workerApi })
+    const test = i + ' is running!'
+    workerPool[i].workerApi.decryptIntoCsv(test)
+  }
+
+  for (let i = 0; i < numWorkers; i++) {
+    workerPool[i].worker.terminate()
+  }
+
+  return null
 }

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -73,7 +73,7 @@ export const downloadEncryptedResponses = async (
 
   Promise.all(
     workerPool.map(async (worker: Worker, idx: number) => {
-      await worker.workerApi.log(idx)
+      console.log(await worker.workerApi.log(idx), ' finished running!')
       return worker.worker
     }),
   ).then((workers) =>

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -41,10 +41,7 @@ export const getFormSubmissionsMetadata = async (
   formId: string,
 ): Promise<StorageModeSubmissionMetadataList> => {
   const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata?page=1`
-  return ApiService.get(queryUrl).then(({ data }) => {
-    console.log('DATA', data)
-    return data
-  })
+  return ApiService.get(queryUrl).then(({ data }) => data)
 }
 
 interface Worker {

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -34,8 +34,8 @@ export const countFormSubmissions = async ({
 
 /**
  * Get of submissions metadata for a given form
- * @param urlParameters Mapping of the url parameters to values
- * @returns The number of form submissions
+ * @param formId fomID to retrieve metadata on
+ * @returns The metadata of the form
  */
 export const getFormSubmissionsMetadata = async (
   formId: string,

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -40,7 +40,7 @@ export const countFormSubmissions = async ({
 export const getFormSubmissionsMetadata = async (
   formId: string,
 ): Promise<StorageModeSubmissionMetadataList> => {
-  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata?page=1`
+  const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata?page=1` // To be generalized in later PRs
   return ApiService.get(queryUrl).then(({ data }) => data)
 }
 
@@ -67,6 +67,8 @@ export const downloadEncryptedResponses = async (
       wrap<import('./workers/decryption.worker').DecryptionWorker>(worker)
     workerPool.push({ worker, workerApi })
   }
+
+  // TO DO: Implemantation of decrypting and downloading responses in later PRs
 
   Promise.all(
     workerPool.map(async (worker: Worker, idx: number) => {

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -77,7 +77,8 @@ export const downloadEncryptedResponses = async (
       return worker.worker
     }),
   ).then((workers) =>
-    workers.forEach((worker) => {
+    workers.forEach((worker, idx) => {
+      console.log('Terminating worker ' + idx)
       worker.terminate() // Workerpool teardown
     }),
   )

--- a/frontend/src/features/admin-form/responses/ResponsesPage.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage.tsx
@@ -16,12 +16,7 @@ const ResponsesPage = (): JSX.Element => {
   const [secretKey, setSecretKey] = useState<string>('')
 
   const handleCsvExport = async () => {
-    console.log('EXPORTING CSV')
-    const title = settings!.title
-    console.log(title)
-    console.log(formId)
-    console.log(secretKey)
-    await downloadEncryptedResponses(formId!, title, secretKey)
+    await downloadEncryptedResponses(formId!, settings!.title, secretKey)
   }
 
   return (
@@ -29,7 +24,7 @@ const ResponsesPage = (): JSX.Element => {
       <div>
         Enter secret key:
         <input
-          style={{ backgroundColor: 'red' }}
+          style={{ backgroundColor: 'grey' }}
           type="text"
           value={secretKey}
           onChange={(e) => setSecretKey(e.target.value)}

--- a/frontend/src/features/admin-form/responses/ResponsesPage.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+import { useParams } from 'react-router'
+import { Skeleton } from '@chakra-ui/react'
+
+import Button from '~components/Button'
+
+import { useAdminFormSettings } from '../settings/queries'
+
+import { downloadEncryptedResponses } from './AdminSubmissionsService'
+import { useFormResponses } from './queries'
+
+const ResponsesPage = (): JSX.Element => {
+  const { data: settings } = useAdminFormSettings()
+  const { data, isLoading } = useFormResponses()
+  const { formId } = useParams()
+  const [secretKey, setSecretKey] = useState<string>('')
+
+  const handleCsvExport = async () => {
+    console.log('EXPORTING CSV')
+    const title = settings!.title
+    console.log(title)
+    console.log(formId)
+    console.log(secretKey)
+    await downloadEncryptedResponses(formId!, title, secretKey)
+  }
+
+  return (
+    <Skeleton isLoaded={!isLoading && !!data}>
+      <div>
+        Enter secret key:
+        <input
+          style={{ backgroundColor: 'red' }}
+          type="text"
+          value={secretKey}
+          onChange={(e) => setSecretKey(e.target.value)}
+        />
+        <Button onClick={handleCsvExport}>Export csv </Button>
+        <Button>Export csv and attachments</Button>
+        {!!data &&
+          data.metadata.map((submission: any) => {
+            return (
+              <div key={submission.refNo}>
+                Submission Ref No: {submission.refNo}
+              </div>
+            )
+          })}
+      </div>
+    </Skeleton>
+  )
+}
+export default ResponsesPage

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -39,8 +39,7 @@ export const useFormResponses =
     if (!formId) throw new Error('No formId provided')
 
     return useQuery(
-      'test',
-      //adminFormResponsesKeys.id(formId),
+      adminFormResponsesKeys.id(formId),
       () => getFormSubmissionsMetadata(formId),
       { staleTime: 10 * 60 * 1000 },
     )

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -3,11 +3,15 @@ import { useParams } from 'react-router-dom'
 
 import { adminFormKeys } from '../common/queries'
 
-import { countFormSubmissions } from './AdminSubmissionsService'
+import {
+  countFormSubmissions,
+  getFormSubmissionsMetadata,
+} from './AdminSubmissionsService'
 
 export const adminFormResponsesKeys = {
   base: [...adminFormKeys.base, 'responses'] as const,
   id: (id: string) => [...adminFormResponsesKeys.base, id] as const,
+  count: (id: string) => [...adminFormResponsesKeys.base, id, 'count'] as const,
 }
 
 /**
@@ -18,8 +22,26 @@ export const useFormResponsesCount = (): UseQueryResult<number> => {
   if (!formId) throw new Error('No formId provided')
 
   return useQuery(
-    adminFormResponsesKeys.id(formId),
+    adminFormResponsesKeys.count(formId),
     () => countFormSubmissions({ formId }),
     { staleTime: 10 * 60 * 1000 },
   )
+}
+
+/**
+ * @precondition Must be wrapped in a Router as `useParam` is used.
+ */
+export const useFormResponses = (): UseQueryResult<any> => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  return useQuery(
+    adminFormResponsesKeys.id(formId),
+    () => getFormSubmissionsMetadata(formId),
+    { staleTime: 10 * 60 * 1000 },
+  )
+}
+
+export const downloadResponses = (formId: string, secretKey: string): any => {
+  return ['Here']
 }

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -1,6 +1,8 @@
 import { useQuery, UseQueryResult } from 'react-query'
 import { useParams } from 'react-router-dom'
 
+import { StorageModeSubmissionMetadataList } from '~shared/types/submission'
+
 import { adminFormKeys } from '../common/queries'
 
 import {
@@ -31,17 +33,15 @@ export const useFormResponsesCount = (): UseQueryResult<number> => {
 /**
  * @precondition Must be wrapped in a Router as `useParam` is used.
  */
-export const useFormResponses = (): UseQueryResult<any> => {
-  const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+export const useFormResponses =
+  (): UseQueryResult<StorageModeSubmissionMetadataList> => {
+    const { formId } = useParams()
+    if (!formId) throw new Error('No formId provided')
 
-  return useQuery(
-    adminFormResponsesKeys.id(formId),
-    () => getFormSubmissionsMetadata(formId),
-    { staleTime: 10 * 60 * 1000 },
-  )
-}
-
-export const downloadResponses = (formId: string, secretKey: string): any => {
-  return ['Here']
-}
+    return useQuery(
+      'test',
+      //adminFormResponsesKeys.id(formId),
+      () => getFormSubmissionsMetadata(formId),
+      { staleTime: 10 * 60 * 1000 },
+    )
+  }

--- a/frontend/src/features/admin-form/responses/workers/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/workers/decryption.worker.ts
@@ -1,12 +1,12 @@
 import { expose } from 'comlink'
 
-function decryptIntoCsv(data: any) {
-  console.log(data)
-  return data
+async function log(id: number): Promise<string> {
+  console.log(id + ' web worker is running')
+  return id.toString()
 }
 
 const exports = {
-  decryptIntoCsv,
+  log,
 }
 
 export type DecryptionWorker = typeof exports

--- a/frontend/src/features/admin-form/responses/workers/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/workers/decryption.worker.ts
@@ -1,0 +1,14 @@
+import { expose } from 'comlink'
+
+function decryptIntoCsv(data: any) {
+  console.log(data)
+  return data
+}
+
+const exports = {
+  decryptIntoCsv,
+}
+
+export type DecryptionWorker = typeof exports
+
+expose(exports)

--- a/frontend/src/typings/worker-loader.d.ts
+++ b/frontend/src/typings/worker-loader.d.ts
@@ -1,0 +1,10 @@
+declare module 'worker-loader!*' {
+  // You need to change `Worker`, if you specified a different value for the `workerType` option
+  class WebpackWorker extends Worker {
+    constructor()
+  }
+
+  // Uncomment this if you set the `esModule` option to `false`
+  // export = WebpackWorker;
+  export default WebpackWorker
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8367,6 +8367,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comlink": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
+      "integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA=="
+    },
     "commander": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
@@ -25981,18 +25986,6 @@
         "schema-utils": "^0.4.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "schema-utils": {
           "version": "0.4.7",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "bson-ext": "^2.0.5",
     "busboy": "^0.3.1",
     "celebrate": "^15.0.0",
+    "comlink": "^4.3.1",
     "compression": "~1.7.2",
     "connect-mongo": "^4.4.1",
     "convict": "^6.2.0",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently in the Angular version, Web Workers are used to decrypt the storage mode submissions without blocking the UI. We have to reimplement this for React.

Related to  #3099
## Solution
<!-- How did you solve the problem? -->
- Set up worker-loader (webpack library) to spin up web workers
- Used comlink to communicate with webworkers in a rpc implementation


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:
- Barebone `ResponsesPage` with button and input to test our web workers creation and teardown
- Creation of worker pool and worker pool teardown under `downloadEncryptedResponses`
- `getFormSubmissionsMetadata`  and `useFormResponses` to retrieve form submissions meta data

- `decryption.worker.ts` : script run by web workers for decryption (Implementation will be done in follow up PRs)

**New dependencies**:
- [comlink](https://github.com/GoogleChromeLabs/comlink): Library to communicate with web workers in RPC style