### PR TITLE
feat(builder/1): add initial field preview (only SectionField) when editing field in form builder 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8188,6 +8188,11 @@
         "@types/jest": "*"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "@types/js-levenshtein": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
@@ -11190,6 +11195,11 @@
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
       "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
       "dev": true
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -15102,6 +15112,15 @@
         }
       }
     },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
     "css-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.3.0.tgz",
@@ -16289,7 +16308,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-      "dev": true,
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -18081,8 +18099,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -18121,6 +18138,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.11.0",
@@ -19974,6 +20001,11 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -20139,6 +20171,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
+    "inline-style-prefixer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
+      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "8.2.0",
@@ -20780,8 +20820,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -23700,6 +23739,11 @@
       "integrity": "sha512-SJcJNBg32dGgxhPtM0wQqxqV0ax9k/9TaUskGDSJkSFSQOEWWvQ3zzWdGQRIUry2j1zA5+ReH13t0Mf3StuVZA==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -25921,6 +25965,42 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
+    },
+    "nano-css": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
+      "integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
+      "requires": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "nano-time": {
       "version": "1.0.0",
@@ -29796,6 +29876,32 @@
         "use-latest": "^1.0.0"
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
+    },
+    "react-use": {
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.3.2.tgz",
+      "integrity": "sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==",
+      "requires": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "react-use-measure": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
@@ -30600,8 +30706,7 @@
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.20.0",
@@ -30927,6 +31032,14 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "rtl-css-js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
+      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -31204,6 +31317,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -31413,6 +31531,11 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -31880,8 +32003,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "space-separated-tokens": {
       "version": "1.1.5",
@@ -32001,6 +32123,14 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -32021,8 +32151,33 @@
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-      "dev": true
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "state-toggle": {
       "version": "1.0.3",
@@ -32873,8 +33028,7 @@
     "throttle-debounce": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
-      "dev": true
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
     },
     "through": {
       "version": "2.3.8",
@@ -33094,6 +33248,11 @@
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "dev": true
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "ts-essentials": {
       "version": "2.0.12",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20025,10 +20025,9 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
-      "dev": true
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -28876,6 +28875,12 @@
             "slash": "^3.0.0"
           }
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+          "dev": true
+        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -35941,6 +35946,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zustand": {
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.6.9.tgz",
+      "integrity": "sha512-OvDNu/jEWpRnEC7k8xh8GKjqYog7td6FZrLMuHs/IeI8WhrCwV+FngVuwMIFhp5kysZXr6emaeReMqjLGaldAQ=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33895,6 +33895,11 @@
         "ts-essentials": "^2.0.3"
       }
     },
+    "use-debounce": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
+      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q=="
+    },
     "use-draggable-scroll": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/use-draggable-scroll/-/use-draggable-scroll-0.1.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.0.2",
     "react-table": "^7.7.0",
     "react-textarea-autosize": "^8.3.3",
+    "react-use": "^17.3.1",
     "react-waypoint": "^10.1.0",
     "remark-gfm": "^3.0.1",
     "simplur": "^3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "dayjs": "^1.10.7",
     "focus-visible": "^5.2.0",
     "framer-motion": "^5.4.5",
+    "immer": "^9.0.6",
     "jszip": "^3.7.1",
     "libphonenumber-js": "^1.9.44",
     "lodash": "^4.17.21",
@@ -35,7 +36,8 @@
     "typescript": "^4.5.3",
     "use-draggable-scroll": "^0.1.0",
     "validator": "^13.7.0",
-    "web-vitals": "^2.1.2"
+    "web-vitals": "^2.1.2",
+    "zustand": "^3.6.5"
   },
   "scriptComments": {
     "build": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "simplur": "^3.0.1",
     "type-fest": "^2.8.0",
     "typescript": "^4.5.3",
+    "use-debounce": "^7.0.1",
     "use-draggable-scroll": "^0.1.0",
     "validator": "^13.7.0",
     "web-vitals": "^2.1.2",

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -43,7 +43,7 @@ export const BuilderFields = () => {
   return (
     <>
       {data.form_fields.map((f) => (
-        <FieldRowContainer isActive={false} field={f} />
+        <FieldRowContainer key={f._id} field={f} />
       ))}
     </>
   )

--- a/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence } from 'framer-motion'
 
 import { MotionBox } from '~components/motion'
 
+import { EditFieldDrawer } from './EditFieldDrawer/EditFieldDrawer'
 import { useBuilderDrawer } from './BuilderDrawerContext'
 
 const DRAWER_MOTION_PROPS = {
@@ -39,7 +40,7 @@ export const BuilderDrawer = (): JSX.Element => {
           {...DRAWER_MOTION_PROPS}
         >
           <Box w="100%" h="100%" minW="max-content">
-            Drawer stuff
+            <EditFieldDrawer />
           </Box>
         </MotionBox>
       )}

--- a/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
@@ -8,7 +8,11 @@ import {
   useState,
 } from 'react'
 
-import { activeFieldSelector, useEditFieldStore } from './editFieldStore'
+import {
+  activeFieldSelector,
+  clearActiveFieldSelector,
+  useEditFieldStore,
+} from './editFieldStore'
 
 export enum DrawerTabs {
   Builder,
@@ -59,6 +63,10 @@ export const useBuilderDrawer = (): BuilderDrawerContextProps => {
 const useProvideDrawerContext = (): BuilderDrawerContextProps => {
   const [activeTab, setActiveTab] = useState<DrawerTabs | null>(null)
   const activeField = useEditFieldStore(activeFieldSelector)
+  const hasActiveField = useEditFieldStore(
+    useCallback((state) => !!state.activeField, []),
+  )
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
 
   useEffect(() => {
     if (activeField) {
@@ -71,7 +79,12 @@ const useProvideDrawerContext = (): BuilderDrawerContextProps => {
     [activeTab],
   )
 
-  const handleClose = useCallback(() => setActiveTab(null), [])
+  const handleClose = useCallback(() => {
+    if (hasActiveField) {
+      clearActiveField()
+    }
+    setActiveTab(null)
+  }, [clearActiveField, hasActiveField])
 
   const handleBuilderClick = () => setActiveTab(DrawerTabs.Builder)
   const handleDesignClick = () => setActiveTab(DrawerTabs.Design)

--- a/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
@@ -3,9 +3,12 @@ import {
   FC,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
+
+import { activeFieldSelector, useEditFieldStore } from './editFieldStore'
 
 export enum DrawerTabs {
   Builder,
@@ -55,6 +58,13 @@ export const useBuilderDrawer = (): BuilderDrawerContextProps => {
 
 const useProvideDrawerContext = (): BuilderDrawerContextProps => {
   const [activeTab, setActiveTab] = useState<DrawerTabs | null>(null)
+  const activeField = useEditFieldStore(activeFieldSelector)
+
+  useEffect(() => {
+    if (activeField) {
+      setActiveTab(DrawerTabs.Builder)
+    }
+  }, [activeField])
 
   const isShowDrawer = useMemo(
     () => activeTab !== null && activeTab !== DrawerTabs.Logic,

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -1,0 +1,67 @@
+import { memo, useMemo } from 'react'
+import { BiLeftArrowAlt } from 'react-icons/bi'
+import { Box, Flex } from '@chakra-ui/react'
+
+import { BasicField, FormFieldDto } from '~shared/types/field'
+
+import IconButton from '~components/IconButton'
+
+import {
+  activeFieldSelector,
+  clearActiveFieldSelector,
+  useEditFieldStore,
+} from '../editFieldStore'
+import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
+import { transformBasicFieldToText } from '../utils'
+
+import { EditHeader } from './EditHeader'
+
+export const EditFieldDrawer = (): JSX.Element | null => {
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+  const activeField = useEditFieldStore(activeFieldSelector)
+
+  const basicFieldText = useMemo(
+    () => transformBasicFieldToText(activeField?.fieldType),
+    [activeField?.fieldType],
+  )
+
+  if (!activeField) return null
+
+  return (
+    <Box>
+      <Flex
+        pos="sticky"
+        top={0}
+        px="1.5rem"
+        py="1rem"
+        align="center"
+        borderBottom="1px solid var(--chakra-colors-neutral-300)"
+        bg="white"
+      >
+        <IconButton
+          minH="1.5rem"
+          minW="1.5rem"
+          aria-label="Back to field selection"
+          variant="clear"
+          colorScheme="secondary"
+          onClick={clearActiveField}
+          icon={<BiLeftArrowAlt />}
+        />
+        <Box m="auto">Edit {basicFieldText} field</Box>
+        <BuilderDrawerCloseButton />
+      </Flex>
+      <Flex flexDir="column" py="2rem" px="1.5rem">
+        <MemoFieldDrawerContent field={activeField} />
+      </Flex>
+    </Box>
+  )
+}
+
+const MemoFieldDrawerContent = memo(({ field }: { field: FormFieldDto }) => {
+  switch (field.fieldType) {
+    case BasicField.Section:
+      return <EditHeader field={field} />
+    default:
+      return <div>TODO: Insert field options here</div>
+  }
+})

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
@@ -1,0 +1,111 @@
+import { Controller, useForm } from 'react-hook-form'
+import { ButtonGroup, Divider, FormControl, Stack } from '@chakra-ui/react'
+import { merge } from 'lodash'
+import { useDebouncedCallback } from 'use-debounce'
+
+import Button from '~components/Button'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import { SectionFieldSchema } from '~templates/Field/Section/SectionFieldContainer'
+
+import { useEditFieldStore } from '../editFieldStore'
+import { useMutateFormFields } from '../mutations'
+
+export interface EditHeaderProps {
+  field: SectionFieldSchema
+}
+
+interface EditHeaderInputs {
+  title: string
+  description: string
+}
+
+export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
+  const { updateActiveField } = useEditFieldStore()
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, isSubmitting, errors },
+  } = useForm<EditHeaderInputs>({
+    defaultValues: {
+      title: field.title,
+      description: field.description,
+    },
+  })
+
+  const debouncedUpdateField = useDebouncedCallback(
+    updateActiveField,
+    // delay in ms
+    300,
+  )
+
+  const { mutateFormField } = useMutateFormFields()
+
+  const handleUpdateField = handleSubmit((inputs) => {
+    const updatedFormField: SectionFieldSchema = merge({}, field, inputs)
+    return mutateFormField.mutate(updatedFormField)
+  })
+
+  return (
+    <Stack spacing="2rem" divider={<Divider />}>
+      <FormControl
+        isRequired
+        isReadOnly={isValid && isSubmitting}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Section header title</FormLabel>
+        <Controller
+          control={control}
+          name="title"
+          render={({ field: { onChange, ...rest } }) => (
+            <Input
+              onChange={(e) => {
+                onChange(e)
+                debouncedUpdateField({
+                  title: e.target.value,
+                })
+              }}
+              {...rest}
+            />
+          )}
+        />
+        <FormErrorMessage>
+          {errors.title && errors.title.message}
+        </FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={isValid && isSubmitting}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Description</FormLabel>
+        <Controller
+          control={control}
+          name="description"
+          render={({ field: { onChange, ...rest } }) => (
+            <Textarea
+              onChange={(e) => {
+                onChange(e)
+                debouncedUpdateField({
+                  description: e.target.value,
+                })
+              }}
+              {...rest}
+            />
+          )}
+        />
+        <FormErrorMessage>
+          {errors.title && errors.title.message}
+        </FormErrorMessage>
+      </FormControl>
+      <ButtonGroup justifyContent="end">
+        <Button variant="outline">Cancel</Button>
+        <Button minW="8rem" onClick={handleUpdateField}>
+          Save
+        </Button>
+      </ButtonGroup>
+    </Stack>
+  )
+}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
@@ -1,0 +1,34 @@
+import { FieldValues, UseFormHandleSubmit } from 'react-hook-form'
+import { ButtonGroup } from '@chakra-ui/button'
+
+import Button from '~components/Button'
+
+interface FormFieldDrawerActionsProps {
+  isLoading: boolean
+  isDirty: boolean
+  handleClick: ReturnType<UseFormHandleSubmit<FieldValues>>
+  handleCancel: () => void
+}
+
+export const FormFieldDrawerActions = ({
+  isLoading,
+  isDirty,
+  handleClick,
+  handleCancel,
+}: FormFieldDrawerActionsProps): JSX.Element => {
+  return (
+    <ButtonGroup justifyContent="end" isDisabled={isLoading}>
+      <Button variant="outline" onClick={handleCancel}>
+        Cancel
+      </Button>
+      <Button
+        minW="8rem"
+        isDisabled={!isDirty}
+        isLoading={isLoading}
+        onClick={handleClick}
+      >
+        Save
+      </Button>
+    </ButtonGroup>
+  )
+}

--- a/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
@@ -1,23 +1,10 @@
-import { useCallback } from 'react'
 import { BiX } from 'react-icons/bi'
 import { CloseButton } from '@chakra-ui/react'
 
 import { useBuilderDrawer } from '../BuilderDrawerContext'
-import { clearActiveFieldSelector, useEditFieldStore } from '../editFieldStore'
 
 export const BuilderDrawerCloseButton = (): JSX.Element => {
   const { handleClose } = useBuilderDrawer()
-  const hasActiveField = useEditFieldStore(
-    useCallback((state) => !!state.activeField, []),
-  )
-  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
-
-  const handleDrawerClose = useCallback(() => {
-    if (hasActiveField) {
-      clearActiveField()
-    }
-    handleClose()
-  }, [clearActiveField, handleClose, hasActiveField])
 
   return (
     <CloseButton
@@ -28,7 +15,7 @@ export const BuilderDrawerCloseButton = (): JSX.Element => {
       variant="clear"
       colorScheme="neutral"
       children={<BiX />}
-      onClick={handleDrawerClose}
+      onClick={handleClose}
     />
   )
 }

--- a/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react'
+import { BiX } from 'react-icons/bi'
+import { CloseButton } from '@chakra-ui/react'
+
+import { useBuilderDrawer } from '../BuilderDrawerContext'
+import { clearActiveFieldSelector, useEditFieldStore } from '../editFieldStore'
+
+export const BuilderDrawerCloseButton = (): JSX.Element => {
+  const { handleClose } = useBuilderDrawer()
+  const hasActiveField = useEditFieldStore(
+    useCallback((state) => !!state.activeField, []),
+  )
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+
+  const handleDrawerClose = useCallback(() => {
+    if (hasActiveField) {
+      clearActiveField()
+    }
+    handleClose()
+  }, [clearActiveField, handleClose, hasActiveField])
+
+  return (
+    <CloseButton
+      zIndex={1}
+      fontSize="1.5rem"
+      w="1.5rem"
+      h="1.5rem"
+      variant="clear"
+      colorScheme="neutral"
+      children={<BiX />}
+      onClick={handleDrawerClose}
+    />
+  )
+}

--- a/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
@@ -29,20 +29,34 @@ export const FieldRowContainer = ({
     [activeField, field],
   )
 
-  const handleFieldClick = useCallback(
-    () => updateActiveField(field),
-    [field, updateActiveField],
+  const handleFieldClick = useCallback(() => {
+    if (!isActive) {
+      updateActiveField(field)
+    }
+  }, [field, isActive, updateActiveField])
+
+  const handleKeydown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        handleFieldClick()
+      }
+    },
+    [handleFieldClick],
   )
 
   return (
     <Flex
+      // Focusable
+      tabIndex={0}
+      role="button"
       transitionDuration="normal"
       bg="white"
       _hover={{ bg: 'secondary.100' }}
       borderRadius="4px"
       {...(isActive ? { 'data-active': true } : {})}
       _focusWithin={{
-        boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
+        boxShadow: '0 0 0 2px var(--chakra-colors-primary-500) !important',
       }}
       _active={{
         bg: 'secondary.100',
@@ -51,6 +65,7 @@ export const FieldRowContainer = ({
       flexDir="column"
       align="center"
       onClick={handleFieldClick}
+      onKeyDown={handleKeydown}
     >
       <Icon
         as={BiGridHorizontal}

--- a/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
@@ -1,19 +1,39 @@
+import { memo, useCallback, useMemo } from 'react'
 import { BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
 import { Box, ButtonGroup, Collapse, Flex, Icon } from '@chakra-ui/react'
 
-import { FormFieldDto } from '~shared/types/field'
+import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
 
+import {
+  activeFieldSelector,
+  updateFieldSelector,
+  useEditFieldStore,
+} from '../editFieldStore'
+
+import { SectionFieldRow } from './SectionFieldRow'
+
 export interface FieldRowContainerProps {
-  isActive: boolean
   field: FormFieldDto
 }
 
 export const FieldRowContainer = ({
-  isActive,
   field,
 }: FieldRowContainerProps): JSX.Element => {
+  const updateActiveField = useEditFieldStore(updateFieldSelector)
+  const activeField = useEditFieldStore(activeFieldSelector)
+
+  const isActive = useMemo(
+    () => activeField?._id === field._id,
+    [activeField, field],
+  )
+
+  const handleFieldClick = useCallback(
+    () => updateActiveField(field),
+    [field, updateActiveField],
+  )
+
   return (
     <Flex
       transitionDuration="normal"
@@ -30,6 +50,7 @@ export const FieldRowContainer = ({
       }}
       flexDir="column"
       align="center"
+      onClick={handleFieldClick}
     >
       <Icon
         as={BiGridHorizontal}
@@ -42,7 +63,7 @@ export const FieldRowContainer = ({
         }}
       />
       <Box p="1.5rem" pt={0} w="100%">
-        TODO: Add field row for {field.fieldType}
+        <MemoFieldRow field={isActive && activeField ? activeField : field} />
       </Box>
       <Collapse in={isActive} style={{ width: '100%' }}>
         <Flex
@@ -67,3 +88,12 @@ export const FieldRowContainer = ({
     </Flex>
   )
 }
+
+const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
+  switch (field.fieldType) {
+    case BasicField.Section:
+      return <SectionFieldRow field={field} />
+    default:
+      return <div>TODO: Add field row for {field.fieldType}</div>
+  }
+})

--- a/frontend/src/features/admin-form-builder/FieldRow/SectionFieldRow.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/SectionFieldRow.tsx
@@ -1,0 +1,13 @@
+import { FormFieldWithId, SectionFieldBase } from '~shared/types/field'
+
+import { BaseSectionField } from '~templates/Field/Section/SectionField'
+
+export interface SectionFieldRowProps {
+  field: FormFieldWithId<SectionFieldBase>
+}
+
+export const SectionFieldRow = ({
+  field,
+}: SectionFieldRowProps): JSX.Element => {
+  return <BaseSectionField schema={field} />
+}

--- a/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
+++ b/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
@@ -7,12 +7,12 @@ import { BuilderSidebar } from './BuilderSidebar'
 
 export const FormBuilderPage = (): JSX.Element => {
   return (
-    <BuilderDrawerProvider>
-      <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
+    <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
+      <BuilderDrawerProvider>
         <BuilderSidebar />
         <BuilderDrawer />
-        <BuilderContent />
-      </Flex>
-    </BuilderDrawerProvider>
+      </BuilderDrawerProvider>
+      <BuilderContent />
+    </Flex>
   )
 }

--- a/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
+++ b/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
@@ -1,0 +1,18 @@
+import { FormFieldDto } from '~shared/types/field'
+
+import { ApiService } from '~services/ApiService'
+
+import { ADMIN_FORM_ENDPOINT } from '~features/admin-form/common/AdminViewFormService'
+
+export const updateSingleFormField = async ({
+  formId,
+  updateFieldBody,
+}: {
+  formId: string
+  updateFieldBody: FormFieldDto
+}): Promise<FormFieldDto> => {
+  return ApiService.put<FormFieldDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/fields/${updateFieldBody._id}`,
+    updateFieldBody,
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/admin-form-builder/editFieldStore.ts
+++ b/frontend/src/features/admin-form-builder/editFieldStore.ts
@@ -13,7 +13,7 @@ export type EditFieldStoreState = {
 
 export const activeFieldSelector = (
   state: EditFieldStoreState,
-): FormFieldDto | undefined => state.activeField
+): EditFieldStoreState['activeField'] => state.activeField
 
 export const activeFieldIdSelector = (
   state: EditFieldStoreState,
@@ -21,7 +21,11 @@ export const activeFieldIdSelector = (
 
 export const clearActiveFieldSelector = (
   state: EditFieldStoreState,
-): (() => void) => state.clearActiveField
+): EditFieldStoreState['clearActiveField'] => state.clearActiveField
+
+export const updateFieldSelector = (
+  state: EditFieldStoreState,
+): EditFieldStoreState['updateActiveField'] => state.updateActiveField
 
 export const useEditFieldStore = create<EditFieldStoreState>(
   devtools((set) => ({

--- a/frontend/src/features/admin-form-builder/editFieldStore.ts
+++ b/frontend/src/features/admin-form-builder/editFieldStore.ts
@@ -1,0 +1,41 @@
+import produce from 'immer'
+import { merge } from 'lodash'
+import create from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+import { FormFieldDto } from '~shared/types/field'
+
+export type EditFieldStoreState = {
+  activeField?: FormFieldDto
+  updateActiveField: (field: Partial<FormFieldDto>) => void
+  clearActiveField: () => void
+}
+
+export const activeFieldSelector = (
+  state: EditFieldStoreState,
+): FormFieldDto | undefined => state.activeField
+
+export const activeFieldIdSelector = (
+  state: EditFieldStoreState,
+): string | undefined => state.activeField?._id
+
+export const clearActiveFieldSelector = (
+  state: EditFieldStoreState,
+): (() => void) => state.clearActiveField
+
+export const useEditFieldStore = create<EditFieldStoreState>(
+  devtools((set) => ({
+    clearActiveField: () =>
+      set(
+        produce<Pick<EditFieldStoreState, 'activeField'>>((draft) => {
+          draft.activeField = undefined
+        }),
+      ),
+    updateActiveField: (payload) =>
+      set(
+        produce<Pick<EditFieldStoreState, 'activeField'>>((draft) => {
+          draft.activeField = merge(draft.activeField, payload)
+        }),
+      ),
+  })),
+)

--- a/frontend/src/features/admin-form-builder/mutations.ts
+++ b/frontend/src/features/admin-form-builder/mutations.ts
@@ -1,0 +1,81 @@
+import { useCallback } from 'react'
+import { useMutation, useQueryClient } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { FormFieldDto } from '~shared/types/field'
+import { AdminFormDto } from '~shared/types/form'
+
+import { useToast } from '~hooks/useToast'
+
+import { adminFormKeys } from '~features/admin-form/common/queries'
+
+import { updateSingleFormField } from './UpdateFormFieldService'
+
+export const adminFormFieldKeys = {
+  base: [...adminFormKeys.base, 'fields'] as const,
+  id: (id: string) => [...adminFormFieldKeys.base, id] as const,
+}
+
+export const useMutateFormFields = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  const queryClient = useQueryClient()
+  const toast = useToast({ status: 'success', isClosable: true })
+  const adminFormKey = adminFormKeys.id(formId)
+
+  const handleSuccess = useCallback(
+    ({
+      newData,
+      toastDescription,
+    }: {
+      newData: FormFieldDto
+      toastDescription: string
+    }) => {
+      toast.closeAll()
+      toast({
+        description: toastDescription,
+      })
+      queryClient.setQueryData<AdminFormDto>(adminFormKey, (old) => {
+        // Should not happen, should not be able to update field if there is no
+        // existing data.
+        if (!old) throw new Error('Query should have been set')
+        const currentFieldIndex = old.form_fields.findIndex(
+          (ff) => ff._id === newData._id,
+        )
+        old.form_fields[currentFieldIndex] = newData
+        return old
+      })
+    },
+    [adminFormKey, queryClient, toast],
+  )
+
+  const handleError = useCallback(
+    (error: Error) => {
+      toast.closeAll()
+      toast({
+        description: error.message,
+        status: 'danger',
+      })
+    },
+    [toast],
+  )
+
+  const mutateFormField = useMutation(
+    (updateFieldBody: FormFieldDto) =>
+      updateSingleFormField({ formId, updateFieldBody }),
+    {
+      onSuccess: (newData) => {
+        handleSuccess({
+          newData,
+          toastDescription: `Field "${newData.title}" updated`,
+        })
+      },
+      onError: (error: Error, _newData, context) => {
+        handleError(error)
+      },
+    },
+  )
+
+  return { mutateFormField }
+}

--- a/frontend/src/features/admin-form-builder/utils.ts
+++ b/frontend/src/features/admin-form-builder/utils.ts
@@ -1,0 +1,30 @@
+import { BasicField } from '~shared/types/field'
+
+/**
+ * Maps BasicField enums to their human-readable field type string
+ */
+export const transformBasicFieldToText = (basicField?: BasicField): string => {
+  if (!basicField) return ''
+  switch (basicField) {
+    case BasicField.Section:
+      return 'Header'
+    case BasicField.Statement:
+      return 'Paragraph'
+    case BasicField.Mobile:
+      return 'Mobile Number'
+    case BasicField.HomeNo:
+      return 'Home Number'
+    case BasicField.ShortText:
+      return 'Short Answer'
+    case BasicField.LongText:
+      return 'Long Answer'
+    case BasicField.YesNo:
+      return 'Yes/No'
+    case BasicField.Nric:
+      return 'NRIC'
+    case BasicField.Uen:
+      return 'UEN'
+    default:
+      return basicField.charAt(0).toUpperCase() + basicField.slice(1)
+  }
+}

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -40,15 +40,7 @@ export const SectionField = forwardRef<SectionFieldProps, 'div'>(
     return (
       <Box>
         <SectionDivider color={dividerColor} />
-        {/* id given so app can scrolled to this section */}
-        <Box id={schema._id} ref={ref}>
-          <Text textStyle="h2" color="primary.600">
-            {schema.title}
-          </Text>
-          <Text textStyle="body-1" color="secondary.700" mt="1rem">
-            {schema.description}
-          </Text>
-        </Box>
+        <BaseSectionField schema={schema} ref={ref} />
         <Waypoint
           topOffset="0"
           bottomOffset="20%"
@@ -58,3 +50,20 @@ export const SectionField = forwardRef<SectionFieldProps, 'div'>(
     )
   },
 )
+
+export const BaseSectionField = forwardRef<
+  Pick<SectionFieldProps, 'schema'>,
+  'div'
+>(({ schema }, ref) => {
+  return (
+    // id given so app can scrolled to this section.
+    <Box id={schema._id} ref={ref}>
+      <Text textStyle="h2" color="primary.600">
+        {schema.title}
+      </Text>
+      <Text textStyle="body-1" color="secondary.700" mt="1rem" whiteSpace="pre">
+        {schema.description}
+      </Text>
+    </Box>
+  )
+})

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -61,7 +61,12 @@ export const BaseSectionField = forwardRef<
       <Text textStyle="h2" color="primary.600">
         {schema.title}
       </Text>
-      <Text textStyle="body-1" color="secondary.700" mt="1rem" whiteSpace="pre">
+      <Text
+        textStyle="body-1"
+        color="secondary.700"
+        mt="1rem"
+        whiteSpace="break-spaces"
+      >
         {schema.description}
       </Text>
     </Box>


### PR DESCRIPTION
This PR is part of the chain for `form-v2/feat/builder` branch.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds logic for allowing of real time (but debounced) preview on the field when it is being edited.

Part of #2792 

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add editFieldStore to manipulate currently edited fields
- feat: add updateSingleFormField service function and mutations
- feat: add BuilderDrawerCloseButton to handle closing of builder drawer
- feat: add EditHeader (and container) component for edit example
- feat: add initial renderer for SectionField preview
- feat(BuilderDrawer): use EditFieldDrawer component

**Improvements**:

- feat: extract edit form field actions to FormFieldDrawerActions
- ref(BuilderDrawerContext): move clear active field logic into context

**Bug Fixes**:

- fix(SectionField): use whiteSpace=break-spaces instead of pre
  - this fixes bug where long continuous words could overflow out of the container

## Before & After Screenshots
None... Will add

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `zustand`: state management for managing edit form state without rerendering often (due to context)
- `immer`: immutable mutations
- `react-use`: react hooks, mainly using useDebounce for now (treeshakeable anyways)