### PR TITLE
feat(builder/2): add checkbox field preview when editing field in form builder

### DIFF
--- a/frontend/src/components/Toggle/Toggle.tsx
+++ b/frontend/src/components/Toggle/Toggle.tsx
@@ -13,7 +13,7 @@ import FormLabel from '../FormControl/FormLabel'
 
 import { Switch, SwitchProps } from './Switch'
 
-export interface ToggleProps extends SwitchProps {
+export interface ToggleProps extends Omit<SwitchProps, 'children'> {
   /**
    * Main label of the toggle
    */

--- a/frontend/src/components/Toggle/index.ts
+++ b/frontend/src/components/Toggle/index.ts
@@ -1,1 +1,2 @@
+export type { ToggleProps } from './Toggle'
 export { Toggle as default } from './Toggle'

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react'
 import { Flex, Stack } from '@chakra-ui/react'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
+import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
 
 export const BuilderContent = (): JSX.Element => {
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+
+  useEffect(() => {
+    // Clear field on component unmount.
+    return () => clearActiveField()
+  }, [clearActiveField])
+
   return (
     <Flex flex={1} bg="neutral.200">
       <Flex

--- a/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react'
+import { Flex } from '@chakra-ui/react'
 import { AnimatePresence } from 'framer-motion'
 
 import { MotionBox } from '~components/motion'
@@ -36,12 +36,12 @@ export const BuilderDrawer = (): JSX.Element => {
           key="sidebar"
           pos="relative"
           as="aside"
-          overflow="auto"
+          overflow="hidden"
           {...DRAWER_MOTION_PROPS}
         >
-          <Box w="100%" h="100%" minW="max-content">
+          <Flex w="100%" h="100%" minW="max-content" flexDir="column">
             <EditFieldDrawer />
-          </Box>
+          </Flex>
         </MotionBox>
       )}
     </AnimatePresence>

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/DrawerContentContainer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/DrawerContentContainer.tsx
@@ -1,0 +1,19 @@
+import { Box, BoxProps } from '@chakra-ui/layout'
+
+export interface DrawerContentContainerProps extends BoxProps {
+  children: React.ReactNode
+}
+/**
+ * Component to provide consistent padding to rendered builder/edit field drawer
+ * content. Used as some fields may have tabs that do not need this padding yet.
+ */
+export const DrawerContentContainer = ({
+  children,
+  ...props
+}: DrawerContentContainerProps): JSX.Element => {
+  return (
+    <Box py="2rem" px="1.5rem" {...props}>
+      {children}
+    </Box>
+  )
+}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/DrawerContentContainer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/DrawerContentContainer.tsx
@@ -1,6 +1,6 @@
-import { Box, BoxProps } from '@chakra-ui/layout'
+import { Flex, FlexProps } from '@chakra-ui/layout'
 
-export interface DrawerContentContainerProps extends BoxProps {
+export interface DrawerContentContainerProps extends FlexProps {
   children: React.ReactNode
 }
 /**
@@ -12,8 +12,16 @@ export const DrawerContentContainer = ({
   ...props
 }: DrawerContentContainerProps): JSX.Element => {
   return (
-    <Box py="2rem" px="1.5rem" {...props}>
+    <Flex
+      py="2rem"
+      px="1.5rem"
+      flexDir="column"
+      flex={1}
+      pos="relative"
+      overflow="auto"
+      {...props}
+    >
       {children}
-    </Box>
+    </Flex>
   )
 }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { Divider, FormControl, Stack } from '@chakra-ui/react'
+import { merge } from 'lodash'
+import { useDebouncedCallback } from 'use-debounce'
+
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+import { CheckboxFieldSchema } from '~templates/Field/Checkbox/CheckboxField'
+
+import {
+  clearActiveFieldSelector,
+  updateFieldSelector,
+  useEditFieldStore,
+} from '../editFieldStore'
+import { useMutateFormFields } from '../mutations'
+
+import { FormFieldDrawerActions } from './FormFieldDrawerActions'
+
+export interface EditCheckboxProps {
+  field: CheckboxFieldSchema
+}
+
+interface EditCheckboxInputs {
+  title: string
+  description: string
+  fieldOptions: string
+  required: boolean
+}
+
+export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
+  const updateActiveField = useEditFieldStore(updateFieldSelector)
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+  const debouncedUpdateField = useDebouncedCallback(
+    updateActiveField,
+    // delay in ms
+    300,
+  )
+
+  const transformCheckboxOpts = useMemo(
+    () => ({
+      toArray: (input?: string) =>
+        input
+          ?.split('\n')
+          .map((opt) => opt.trim())
+          .filter(Boolean),
+      toString: (output?: string[]) => output?.filter(Boolean).join('\n'),
+    }),
+    [],
+  )
+
+  const {
+    handleSubmit,
+    reset,
+    register,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<EditCheckboxInputs>({
+    defaultValues: {
+      title: field.title,
+      description: field.description,
+      fieldOptions: transformCheckboxOpts.toString(field.fieldOptions),
+      required: field.required,
+    },
+  })
+
+  const watchedInputs = watch()
+
+  useEffect(() => {
+    debouncedUpdateField({
+      title: watchedInputs.title,
+      description: watchedInputs.description,
+      fieldOptions: transformCheckboxOpts.toArray(watchedInputs.fieldOptions),
+      required: watchedInputs.required,
+    })
+  }, [
+    debouncedUpdateField,
+    transformCheckboxOpts,
+    watchedInputs.description,
+    watchedInputs.fieldOptions,
+    watchedInputs.required,
+    watchedInputs.title,
+  ])
+
+  const { mutateFormField } = useMutateFormFields()
+
+  const handleUpdateField = handleSubmit(({ fieldOptions, ...inputs }) => {
+    const updatedFormField: CheckboxFieldSchema = merge({}, field, {
+      ...inputs,
+      fieldOptions: transformCheckboxOpts.toArray(fieldOptions),
+    })
+    return mutateFormField.mutate(updatedFormField, {
+      onSuccess: () => {
+        reset(inputs)
+      },
+    })
+  })
+
+  return (
+    <Stack spacing="2rem" divider={<Divider />}>
+      <FormControl
+        isRequired
+        isReadOnly={mutateFormField.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Question</FormLabel>
+        <Input autoFocus {...register('title')} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={mutateFormField.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={mutateFormField.isLoading}
+        isInvalid={!!errors.fieldOptions}
+      >
+        <FormLabel>Options</FormLabel>
+        <Textarea {...register('fieldOptions')} />
+        <FormErrorMessage>{errors?.fieldOptions?.message}</FormErrorMessage>
+      </FormControl>
+      <Toggle
+        isLoading={mutateFormField.isLoading}
+        label="Required"
+        {...register('required')}
+      />
+      <FormFieldDrawerActions
+        isLoading={mutateFormField.isLoading}
+        isDirty={isDirty}
+        handleClick={handleUpdateField}
+        handleCancel={clearActiveField}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
@@ -3,6 +3,7 @@ import { useDebounce } from 'react-use'
 import { Divider, FormControl, Stack } from '@chakra-ui/react'
 import { extend } from 'lodash'
 
+import { createBaseValidationRules } from '~utils/fieldValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
@@ -43,6 +44,21 @@ const transformToFormField = ({
     ...rest,
     fieldOptions: transformCheckboxOpts.toArray(fieldOptions),
   }
+}
+
+const requiredValidationRule = createBaseValidationRules({ required: true })
+
+const fieldOptionsValidationRule = {
+  ...requiredValidationRule,
+  validate: {
+    duplicate: (opts: string) => {
+      const optsArray = transformCheckboxOpts.toArray(opts)
+      return (
+        new Set(optsArray).size === optsArray.length ||
+        'Please remove duplicate options.'
+      )
+    },
+  },
 }
 
 export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
@@ -100,7 +116,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         isInvalid={!!errors.title}
       >
         <FormLabel>Question</FormLabel>
-        <Input autoFocus {...register('title')} />
+        <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
@@ -118,13 +134,13 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         isInvalid={!!errors.fieldOptions}
       >
         <FormLabel>Options</FormLabel>
-        <Textarea {...register('fieldOptions')} />
+        <Textarea {...register('fieldOptions', fieldOptionsValidationRule)} />
         <FormErrorMessage>{errors?.fieldOptions?.message}</FormErrorMessage>
       </FormControl>
       <Toggle
         isLoading={mutateFormField.isLoading}
         label="Required"
-        {...register('required')}
+        {...register('required', requiredValidationRule)}
       />
       <FormFieldDrawerActions
         isLoading={mutateFormField.isLoading}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
@@ -1,12 +1,22 @@
 import { useForm } from 'react-hook-form'
 import { useDebounce } from 'react-use'
-import { Divider, FormControl, Stack } from '@chakra-ui/react'
+import {
+  Box,
+  Divider,
+  FormControl,
+  Stack,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@chakra-ui/react'
 import { extend } from 'lodash'
 
 import { createBaseValidationRules } from '~utils/fieldValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
+import { Tab } from '~components/Tabs'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 import { CheckboxFieldSchema } from '~templates/Field/Checkbox/CheckboxField'
@@ -14,6 +24,7 @@ import { CheckboxFieldSchema } from '~templates/Field/Checkbox/CheckboxField'
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
 
+import { DrawerContentContainer } from './DrawerContentContainer'
 import { FormFieldDrawerActions } from './FormFieldDrawerActions'
 
 export interface EditCheckboxProps {
@@ -109,45 +120,79 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   })
 
   return (
-    <Stack spacing="2rem" divider={<Divider />}>
-      <FormControl
-        isRequired
-        isReadOnly={mutateFormField.isLoading}
-        isInvalid={!!errors.title}
+    <Tabs variant="line-light">
+      <Box
+        px="1rem"
+        pt="1.5rem"
+        borderBottom="1px solid"
+        overflow="hidden"
+        borderBottomColor="neutral.300"
       >
-        <FormLabel>Question</FormLabel>
-        <Input autoFocus {...register('title', requiredValidationRule)} />
-        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
-      </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={mutateFormField.isLoading}
-        isInvalid={!!errors.description}
-      >
-        <FormLabel>Description</FormLabel>
-        <Textarea {...register('description')} />
-        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
-      </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={mutateFormField.isLoading}
-        isInvalid={!!errors.fieldOptions}
-      >
-        <FormLabel>Options</FormLabel>
-        <Textarea {...register('fieldOptions', fieldOptionsValidationRule)} />
-        <FormErrorMessage>{errors?.fieldOptions?.message}</FormErrorMessage>
-      </FormControl>
-      <Toggle
-        isLoading={mutateFormField.isLoading}
-        label="Required"
-        {...register('required', requiredValidationRule)}
-      />
-      <FormFieldDrawerActions
-        isLoading={mutateFormField.isLoading}
-        isDirty={isDirty}
-        handleClick={handleUpdateField}
-        handleCancel={clearActiveField}
-      />
-    </Stack>
+        <TabList
+          overflowX="initial"
+          display="inline-flex"
+          w="max-content"
+          mb="-1px"
+        >
+          <Tab>General</Tab>
+          <Tab>Options</Tab>
+        </TabList>
+      </Box>
+      <DrawerContentContainer>
+        <TabPanels>
+          <TabPanel>
+            <Stack spacing="2rem" divider={<Divider />}>
+              <FormControl
+                isRequired
+                isReadOnly={mutateFormField.isLoading}
+                isInvalid={!!errors.title}
+              >
+                <FormLabel>Question</FormLabel>
+                <Input
+                  autoFocus
+                  {...register('title', requiredValidationRule)}
+                />
+                <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+              </FormControl>
+              <FormControl
+                isRequired
+                isReadOnly={mutateFormField.isLoading}
+                isInvalid={!!errors.description}
+              >
+                <FormLabel>Description</FormLabel>
+                <Textarea {...register('description')} />
+                <FormErrorMessage>
+                  {errors?.description?.message}
+                </FormErrorMessage>
+              </FormControl>
+              <FormControl
+                isRequired
+                isReadOnly={mutateFormField.isLoading}
+                isInvalid={!!errors.fieldOptions}
+              >
+                <FormLabel>Options</FormLabel>
+                <Textarea
+                  {...register('fieldOptions', fieldOptionsValidationRule)}
+                />
+                <FormErrorMessage>
+                  {errors?.fieldOptions?.message}
+                </FormErrorMessage>
+              </FormControl>
+              <Toggle
+                isLoading={mutateFormField.isLoading}
+                label="Required"
+                {...register('required', requiredValidationRule)}
+              />
+              <FormFieldDrawerActions
+                isLoading={mutateFormField.isLoading}
+                isDirty={isDirty}
+                handleClick={handleUpdateField}
+                handleCancel={clearActiveField}
+              />
+            </Stack>
+          </TabPanel>
+        </TabPanels>
+      </DrawerContentContainer>
+    </Tabs>
   )
 }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -14,6 +14,7 @@ import {
 import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
 import { transformBasicFieldToText } from '../utils'
 
+import { EditCheckbox } from './EditCheckbox'
 import { EditHeader } from './EditHeader'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
@@ -61,6 +62,8 @@ const MemoFieldDrawerContent = memo(({ field }: { field: FormFieldDto }) => {
   switch (field.fieldType) {
     case BasicField.Section:
       return <EditHeader field={field} />
+    case BasicField.Checkbox:
+      return <EditCheckbox field={field} />
     default:
       return <div>TODO: Insert field options here</div>
   }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -51,9 +51,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
         <Box m="auto">Edit {basicFieldText} field</Box>
         <BuilderDrawerCloseButton />
       </Flex>
-      <Flex flexDir="column" py="2rem" px="1.5rem">
-        <MemoFieldDrawerContent field={activeField} />
-      </Flex>
+      <MemoFieldDrawerContent field={activeField} />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -29,7 +29,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
   if (!activeField) return null
 
   return (
-    <Box>
+    <>
       <Flex
         pos="sticky"
         top={0}
@@ -52,7 +52,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
         <BuilderDrawerCloseButton />
       </Flex>
       <MemoFieldDrawerContent field={activeField} />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
@@ -14,6 +14,7 @@ import { SectionFieldSchema } from '~templates/Field/Section/SectionFieldContain
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
 
+import { DrawerContentContainer } from './DrawerContentContainer'
 import { FormFieldDrawerActions } from './FormFieldDrawerActions'
 
 export interface EditHeaderProps {
@@ -63,31 +64,33 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
   )
 
   return (
-    <Stack spacing="2rem" divider={<Divider />}>
-      <FormControl
-        isRequired
-        isReadOnly={mutateFormField.isLoading}
-        isInvalid={!!errors.title}
-      >
-        <FormLabel>Section header title</FormLabel>
-        <Input autoFocus {...register('title', requiredValidationRule)} />
-        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
-      </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={mutateFormField.isLoading}
-        isInvalid={!!errors.description}
-      >
-        <FormLabel>Description</FormLabel>
-        <Textarea {...register('description')} />
-        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
-      </FormControl>
-      <FormFieldDrawerActions
-        isLoading={mutateFormField.isLoading}
-        isDirty={isDirty}
-        handleClick={handleUpdateField}
-        handleCancel={clearActiveField}
-      />
-    </Stack>
+    <DrawerContentContainer>
+      <Stack spacing="2rem" divider={<Divider />}>
+        <FormControl
+          isRequired
+          isReadOnly={mutateFormField.isLoading}
+          isInvalid={!!errors.title}
+        >
+          <FormLabel>Section header title</FormLabel>
+          <Input autoFocus {...register('title', requiredValidationRule)} />
+          <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl
+          isRequired
+          isReadOnly={mutateFormField.isLoading}
+          isInvalid={!!errors.description}
+        >
+          <FormLabel>Description</FormLabel>
+          <Textarea {...register('description')} />
+          <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+        </FormControl>
+        <FormFieldDrawerActions
+          isLoading={mutateFormField.isLoading}
+          isDirty={isDirty}
+          handleClick={handleUpdateField}
+          handleCancel={clearActiveField}
+        />
+      </Stack>
+    </DrawerContentContainer>
   )
 }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
@@ -17,7 +17,12 @@ export const FormFieldDrawerActions = ({
   handleCancel,
 }: FormFieldDrawerActionsProps): JSX.Element => {
   return (
-    <ButtonGroup justifyContent="end" isDisabled={isLoading}>
+    <ButtonGroup
+      justifyContent="end"
+      isDisabled={isLoading}
+      pos="sticky"
+      bottom={0}
+    >
       <Button variant="outline" onClick={handleCancel}>
         Cancel
       </Button>

--- a/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
@@ -1,10 +1,12 @@
 import { memo, useCallback, useMemo } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
 import { BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
 import { Box, ButtonGroup, Collapse, Flex, Icon } from '@chakra-ui/react'
 
 import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
+import CheckboxField from '~templates/Field/Checkbox'
 
 import {
   activeFieldSelector,
@@ -23,6 +25,8 @@ export const FieldRowContainer = ({
 }: FieldRowContainerProps): JSX.Element => {
   const updateActiveField = useEditFieldStore(updateFieldSelector)
   const activeField = useEditFieldStore(activeFieldSelector)
+
+  const formMethods = useForm({ mode: 'onChange' })
 
   const isActive = useMemo(
     () => activeField?._id === field._id,
@@ -78,7 +82,9 @@ export const FieldRowContainer = ({
         }}
       />
       <Box p="1.5rem" pt={0} w="100%">
-        <MemoFieldRow field={isActive && activeField ? activeField : field} />
+        <FormProvider {...formMethods}>
+          <MemoFieldRow field={isActive && activeField ? activeField : field} />
+        </FormProvider>
       </Box>
       <Collapse in={isActive} style={{ width: '100%' }}>
         <Flex
@@ -108,6 +114,8 @@ const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
   switch (field.fieldType) {
     case BasicField.Section:
       return <SectionFieldRow field={field} />
+    case BasicField.Checkbox:
+      return <CheckboxField schema={field} />
     default:
       return <div>TODO: Add field row for {field.fieldType}</div>
   }

--- a/frontend/src/features/admin-form-builder/editFieldStore.ts
+++ b/frontend/src/features/admin-form-builder/editFieldStore.ts
@@ -1,5 +1,5 @@
 import produce from 'immer'
-import { merge } from 'lodash'
+import { extend } from 'lodash'
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
@@ -38,7 +38,7 @@ export const useEditFieldStore = create<EditFieldStoreState>(
     updateActiveField: (payload) =>
       set(
         produce<Pick<EditFieldStoreState, 'activeField'>>((draft) => {
-          draft.activeField = merge(draft.activeField, payload)
+          draft.activeField = extend(draft.activeField, payload)
         }),
       ),
   })),

--- a/frontend/src/templates/Field/Checkbox/index.ts
+++ b/frontend/src/templates/Field/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxField as default } from './CheckboxField'

--- a/frontend/src/theme/components/Tabs.ts
+++ b/frontend/src/theme/components/Tabs.ts
@@ -12,7 +12,12 @@ const sizesForLineLightDarkVariant: ComponentMultiStyleConfig<
   md: {
     tab: {
       p: '0.25rem',
-      mx: '0.75rem',
+      _notFirst: {
+        ml: '0.75rem',
+      },
+      _notLast: {
+        mr: '0.75rem',
+      },
       _selected: {
         _before: {
           width: 'calc(100% - 0.5rem)',


### PR DESCRIPTION
This PR is part of the chain for `form-v2/feat/builder` branch.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR is similar to #3130, but with a more involved CheckboxField example for future engineers (and me) to refer to.

Part of #2792


## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add EditCheckbox component to render drawer content
- feat: add DrawerContentContainer for consistent field drawer padding

**Improvements**:

- feat(Tabs): remove excess margin from first and last tab child
- feat: update layout of EditFieldDrawer to allow sticky save button
- feat: clear active field on component unmount

**Bug Fixes**:

- fix: use extend (shallow merge) instead of merge when updating field
  - it was causing removing options to be wonky, and we don't have deep nested objects anyways

## Before & After Screenshots
None... Will add :(

## Tests
<!-- What tests should be run to confirm functionality? -->
