### PR TITLE
feat(builder/4): add form field creation feature in form builder, extend create field API with positional arg

### DIFF
--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -8,7 +8,7 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
 import { BuilderContentPlaceholder } from './BuilderContentPlaceholder'
-import { FIELD_LIST_DROPPABLE_ID } from './constants'
+import { FIELD_LIST_DROP_ID } from './constants'
 import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
 import { DndPlaceholderProps } from './FormBuilderPage'
 
@@ -46,7 +46,7 @@ export const BuilderContent = ({
           w="100%"
           flexDir="column"
         >
-          <Droppable droppableId={FIELD_LIST_DROPPABLE_ID}>
+          <Droppable droppableId={FIELD_LIST_DROP_ID}>
             {(provided, snapshot) => (
               <Box
                 pos="relative"

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -1,13 +1,13 @@
 import { memo, useEffect } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
 import { Box, Flex } from '@chakra-ui/react'
-import { isEmpty } from 'lodash'
 
 import { AdminFormDto } from '~shared/types/form'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
+import { BuilderContentPlaceholder } from './BuilderContentPlaceholder'
 import { FIELD_LIST_DROPPABLE_ID } from './constants'
 import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
 import { DndPlaceholderProps } from './FormBuilderPage'
@@ -55,24 +55,11 @@ export const BuilderContent = ({
               >
                 <BuilderFields fields={data?.form_fields} />
                 {provided.placeholder}
-                {!isEmpty(placeholderProps) && snapshot.isDraggingOver && (
-                  <Box
-                    style={{
-                      top: placeholderProps.clientY,
-                      left: placeholderProps.clientX,
-                      height: placeholderProps.clientHeight,
-                      width: placeholderProps.clientWidth,
-                    }}
-                    py={
-                      placeholderProps.droppableId === FIELD_LIST_DROPPABLE_ID
-                        ? '1.25rem'
-                        : 0
-                    }
-                    pos="absolute"
-                  >
-                    <Box h="100%" bg="primary.200" border="dashed 1px blue" />
-                  </Box>
-                )}
+                {snapshot.isDraggingOver ? (
+                  <BuilderContentPlaceholder
+                    placeholderProps={placeholderProps}
+                  />
+                ) : null}
               </Box>
             )}
           </Droppable>

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -1,15 +1,24 @@
 import { memo, useEffect } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
-import { Flex, Stack } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
+import { isEmpty } from 'lodash'
 
 import { AdminFormDto } from '~shared/types/form'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
+import { FIELD_LIST_DROPPABLE_ID } from './constants'
 import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
+import { DndPlaceholderProps } from './FormBuilderPage'
 
-export const BuilderContent = (): JSX.Element => {
+interface BuilderContentProps {
+  placeholderProps: DndPlaceholderProps
+}
+
+export const BuilderContent = ({
+  placeholderProps,
+}: BuilderContentProps): JSX.Element => {
   const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
   const { data } = useAdminForm()
 
@@ -37,16 +46,34 @@ export const BuilderContent = (): JSX.Element => {
           w="100%"
           flexDir="column"
         >
-          <Droppable droppableId="formFieldList">
-            {(provided) => (
-              <Stack
-                spacing="2.25rem"
+          <Droppable droppableId={FIELD_LIST_DROPPABLE_ID}>
+            {(provided, snapshot) => (
+              <Box
+                pos="relative"
                 ref={provided.innerRef}
                 {...provided.droppableProps}
               >
                 <BuilderFields fields={data?.form_fields} />
                 {provided.placeholder}
-              </Stack>
+                {!isEmpty(placeholderProps) && snapshot.isDraggingOver && (
+                  <Box
+                    style={{
+                      top: placeholderProps.clientY,
+                      left: placeholderProps.clientX,
+                      height: placeholderProps.clientHeight,
+                      width: placeholderProps.clientWidth,
+                    }}
+                    py={
+                      placeholderProps.droppableId === FIELD_LIST_DROPPABLE_ID
+                        ? '1.25rem'
+                        : 0
+                    }
+                    pos="absolute"
+                  >
+                    <Box h="100%" bg="primary.200" border="dashed 1px blue" />
+                  </Box>
+                )}
+              </Box>
             )}
           </Droppable>
         </Flex>

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -1,5 +1,5 @@
-import { memo, useCallback, useEffect } from 'react'
-import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd'
+import { memo, useEffect } from 'react'
+import { Droppable } from 'react-beautiful-dnd'
 import { Flex, Stack } from '@chakra-ui/react'
 
 import { AdminFormDto } from '~shared/types/form'
@@ -8,38 +8,10 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
 import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
-import { useMutateFormFields } from './mutations'
 
 export const BuilderContent = (): JSX.Element => {
   const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
   const { data } = useAdminForm()
-  const { mutateReorderField } = useMutateFormFields()
-
-  const onBeforeCapture = useCallback(() => {
-    /*...*/
-  }, [])
-  const onBeforeDragStart = useCallback(() => {
-    /*...*/
-  }, [])
-  const onDragStart = useCallback(() => {
-    /*...*/
-  }, [])
-  const onDragUpdate = useCallback(() => {
-    /*...*/
-  }, [])
-  const onDragEnd = useCallback(
-    ({ source, destination }: DropResult) => {
-      if (!data || !destination || destination.index === source.index) {
-        return
-      }
-      return mutateReorderField.mutate({
-        fields: data.form_fields,
-        from: source.index,
-        to: destination.index,
-      })
-    },
-    [data, mutateReorderField],
-  )
 
   useEffect(() => {
     // Clear field on component unmount.
@@ -65,26 +37,18 @@ export const BuilderContent = (): JSX.Element => {
           w="100%"
           flexDir="column"
         >
-          <DragDropContext
-            onBeforeCapture={onBeforeCapture}
-            onBeforeDragStart={onBeforeDragStart}
-            onDragStart={onDragStart}
-            onDragUpdate={onDragUpdate}
-            onDragEnd={onDragEnd}
-          >
-            <Droppable droppableId="formFieldList">
-              {(provided) => (
-                <Stack
-                  spacing="2.25rem"
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                >
-                  <BuilderFields fields={data?.form_fields} />
-                  {provided.placeholder}
-                </Stack>
-              )}
-            </Droppable>
-          </DragDropContext>
+          <Droppable droppableId="formFieldList">
+            {(provided) => (
+              <Stack
+                spacing="2.25rem"
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
+                <BuilderFields fields={data?.form_fields} />
+                {provided.placeholder}
+              </Stack>
+            )}
+          </Droppable>
         </Flex>
       </Flex>
     </Flex>

--- a/frontend/src/features/admin-form-builder/BuilderContent.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContent.tsx
@@ -1,16 +1,15 @@
-import { memo, useEffect } from 'react'
+import { memo, useCallback, useEffect } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
 import { Box, Flex } from '@chakra-ui/react'
 
 import { AdminFormDto } from '~shared/types/form'
 
-import { useAdminForm } from '~features/admin-form/common/queries'
-
 import { FieldRowContainer } from './FieldRow/FieldRowContainer'
 import { BuilderContentPlaceholder } from './BuilderContentPlaceholder'
 import { FIELD_LIST_DROP_ID } from './constants'
-import { clearActiveFieldSelector, useEditFieldStore } from './editFieldStore'
+import { useEditFieldStore } from './editFieldStore'
 import { DndPlaceholderProps } from './FormBuilderPage'
+import { useBuilderFormFields } from './useBuilderFormFields'
 
 interface BuilderContentProps {
   placeholderProps: DndPlaceholderProps
@@ -19,13 +18,23 @@ interface BuilderContentProps {
 export const BuilderContent = ({
   placeholderProps,
 }: BuilderContentProps): JSX.Element => {
-  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
-  const { data } = useAdminForm()
+  const { clearActiveField, clearFieldToCreate } = useEditFieldStore(
+    useCallback((state) => {
+      return {
+        clearActiveField: state.clearActiveField,
+        clearFieldToCreate: state.clearFieldToCreate,
+      }
+    }, []),
+  )
+  const { builderFields } = useBuilderFormFields()
 
   useEffect(() => {
     // Clear field on component unmount.
-    return () => clearActiveField()
-  }, [clearActiveField])
+    return () => {
+      clearActiveField()
+      clearFieldToCreate()
+    }
+  }, [clearActiveField, clearFieldToCreate])
 
   return (
     <Flex flex={1} bg="neutral.200">
@@ -53,7 +62,7 @@ export const BuilderContent = ({
                 ref={provided.innerRef}
                 {...provided.droppableProps}
               >
-                <BuilderFields fields={data?.form_fields} />
+                <BuilderFields fields={builderFields} />
                 {provided.placeholder}
                 {snapshot.isDraggingOver ? (
                   <BuilderContentPlaceholder

--- a/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
@@ -15,7 +15,14 @@ export const BuilderContentPlaceholder = ({
   const renderedContents = useMemo(() => {
     switch (placeholderProps.droppableId) {
       case FIELD_LIST_DROPPABLE_ID:
-        return <Box h="100%" bg="danger.200" border="dashed 1px blue" />
+        return (
+          <Box
+            h="100%"
+            bg="primary.200"
+            opacity="0.5"
+            border="dashed 1px blue"
+          />
+        )
       default:
         return (
           <Flex

--- a/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 
-import { FIELD_LIST_DROPPABLE_ID } from './constants'
+import { FIELD_LIST_DROP_ID } from './constants'
 import { DndPlaceholderProps } from './FormBuilderPage'
 
 export interface BuilderContentPlaceholderProps {
@@ -14,7 +14,7 @@ export const BuilderContentPlaceholder = ({
 }: BuilderContentPlaceholderProps): JSX.Element | null => {
   const renderedContents = useMemo(() => {
     switch (placeholderProps.droppableId) {
-      case FIELD_LIST_DROPPABLE_ID:
+      case FIELD_LIST_DROP_ID:
         return (
           <Box
             h="100%"
@@ -50,9 +50,7 @@ export const BuilderContentPlaceholder = ({
         height: placeholderProps.clientHeight,
         width: placeholderProps.clientWidth,
       }}
-      py={
-        placeholderProps.droppableId === FIELD_LIST_DROPPABLE_ID ? '1.25rem' : 0
-      }
+      py={placeholderProps.droppableId === FIELD_LIST_DROP_ID ? '1.25rem' : 0}
       pos="absolute"
     >
       {renderedContents}

--- a/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderContentPlaceholder.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react'
+import { Box, Flex, Text } from '@chakra-ui/react'
+import { isEmpty } from 'lodash'
+
+import { FIELD_LIST_DROPPABLE_ID } from './constants'
+import { DndPlaceholderProps } from './FormBuilderPage'
+
+export interface BuilderContentPlaceholderProps {
+  placeholderProps: DndPlaceholderProps
+}
+
+export const BuilderContentPlaceholder = ({
+  placeholderProps,
+}: BuilderContentPlaceholderProps): JSX.Element | null => {
+  const renderedContents = useMemo(() => {
+    switch (placeholderProps.droppableId) {
+      case FIELD_LIST_DROPPABLE_ID:
+        return <Box h="100%" bg="danger.200" border="dashed 1px blue" />
+      default:
+        return (
+          <Flex
+            h="100%"
+            bg="primary.200"
+            border="1px solid"
+            borderColor="primary.500"
+            color="primary.400"
+            justify="center"
+            align="center"
+          >
+            <Text textStyle="subhead-2">Drop your field here</Text>
+          </Flex>
+        )
+    }
+  }, [placeholderProps.droppableId])
+
+  if (isEmpty(placeholderProps)) return null
+
+  return (
+    <Box
+      style={{
+        top: placeholderProps.clientY,
+        left: placeholderProps.clientX,
+        height: placeholderProps.clientHeight,
+        width: placeholderProps.clientWidth,
+      }}
+      py={
+        placeholderProps.droppableId === FIELD_LIST_DROPPABLE_ID ? '1.25rem' : 0
+      }
+      pos="absolute"
+    >
+      {renderedContents}
+    </Box>
+  )
+}

--- a/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawer.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 import { AnimatePresence } from 'framer-motion'
 
 import { MotionBox } from '~components/motion'
 
 import { EditFieldDrawer } from './EditFieldDrawer/EditFieldDrawer'
-import { useBuilderDrawer } from './BuilderDrawerContext'
+import { DrawerTabs, useBuilderDrawer } from './BuilderDrawerContext'
+import { CreateFieldDrawer } from './CreateFieldDrawer'
+import { activeFieldSelector, useEditFieldStore } from './editFieldStore'
 
 const DRAWER_MOTION_PROPS = {
   initial: { width: 0 },
@@ -26,11 +29,27 @@ const DRAWER_MOTION_PROPS = {
 }
 
 export const BuilderDrawer = (): JSX.Element => {
-  const { isShowDrawer } = useBuilderDrawer()
+  const { isShowDrawer, activeTab } = useBuilderDrawer()
+  const activeField = useEditFieldStore(activeFieldSelector)
+
+  const renderDrawerContent = useMemo(() => {
+    switch (activeTab) {
+      case DrawerTabs.Builder: {
+        if (activeField) {
+          return <EditFieldDrawer />
+        }
+        return <CreateFieldDrawer />
+      }
+      case DrawerTabs.Design:
+        return <div>TODO: Design drawer contents</div>
+      case DrawerTabs.Logic:
+        return <div>TODO: Logic drawer contents</div>
+    }
+  }, [activeField, activeTab])
 
   return (
     <AnimatePresence>
-      {isShowDrawer && (
+      {isShowDrawer ? (
         <MotionBox
           bg="white"
           key="sidebar"
@@ -40,10 +59,10 @@ export const BuilderDrawer = (): JSX.Element => {
           {...DRAWER_MOTION_PROPS}
         >
           <Flex w="100%" h="100%" minW="max-content" flexDir="column">
-            <EditFieldDrawer />
+            {renderDrawerContent}
           </Flex>
         </MotionBox>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
@@ -68,12 +68,9 @@ const editFieldStoreSelector = (state: EditFieldStoreState) => {
 
 const useProvideDrawerContext = (): BuilderDrawerContextProps => {
   const [activeTab, setActiveTab] = useState<DrawerTabs | null>(null)
-  const {
-    hasActiveField,
-    hasFieldToCreate,
-    clearActiveField,
-    clearFieldToCreate,
-  } = useEditFieldStore(editFieldStoreSelector)
+  const { hasActiveField, clearActiveField } = useEditFieldStore(
+    editFieldStoreSelector,
+  )
 
   useEffect(() => {
     if (hasActiveField) {
@@ -88,9 +85,6 @@ const useProvideDrawerContext = (): BuilderDrawerContextProps => {
 
   const handleClose = useCallback(
     (clearActiveTab = true) => {
-      if (hasFieldToCreate) {
-        clearFieldToCreate()
-      }
       if (hasActiveField) {
         clearActiveField()
       }
@@ -98,7 +92,7 @@ const useProvideDrawerContext = (): BuilderDrawerContextProps => {
         setActiveTab(null)
       }
     },
-    [clearActiveField, clearFieldToCreate, hasActiveField, hasFieldToCreate],
+    [clearActiveField, hasActiveField],
   )
 
   const handleBuilderClick = () => setActiveTab(DrawerTabs.Builder)

--- a/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
@@ -7,12 +7,9 @@ import {
   useMemo,
   useState,
 } from 'react'
+import { isEmpty } from 'lodash'
 
-import {
-  activeFieldSelector,
-  clearActiveFieldSelector,
-  useEditFieldStore,
-} from './editFieldStore'
+import { EditFieldStoreState, useEditFieldStore } from './editFieldStore'
 
 export enum DrawerTabs {
   Builder,
@@ -23,7 +20,7 @@ export enum DrawerTabs {
 type BuilderDrawerContextProps = {
   activeTab: DrawerTabs | null
   isShowDrawer: boolean
-  handleClose: () => void
+  handleClose: (clearActiveTab?: boolean) => void
   handleBuilderClick: () => void
   handleDesignClick: () => void
   handleLogicClick: () => void
@@ -60,31 +57,49 @@ export const useBuilderDrawer = (): BuilderDrawerContextProps => {
   return context
 }
 
+const editFieldStoreSelector = (state: EditFieldStoreState) => {
+  return {
+    hasActiveField: !!state.activeField,
+    hasFieldToCreate: !isEmpty(state.fieldToCreate),
+    clearActiveField: state.clearActiveField,
+    clearFieldToCreate: state.clearFieldToCreate,
+  }
+}
+
 const useProvideDrawerContext = (): BuilderDrawerContextProps => {
   const [activeTab, setActiveTab] = useState<DrawerTabs | null>(null)
-  const activeField = useEditFieldStore(activeFieldSelector)
-  const hasActiveField = useEditFieldStore(
-    useCallback((state) => !!state.activeField, []),
-  )
-  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+  const {
+    hasActiveField,
+    hasFieldToCreate,
+    clearActiveField,
+    clearFieldToCreate,
+  } = useEditFieldStore(editFieldStoreSelector)
 
   useEffect(() => {
-    if (activeField) {
+    if (hasActiveField) {
       setActiveTab(DrawerTabs.Builder)
     }
-  }, [activeField])
+  }, [hasActiveField])
 
   const isShowDrawer = useMemo(
     () => activeTab !== null && activeTab !== DrawerTabs.Logic,
     [activeTab],
   )
 
-  const handleClose = useCallback(() => {
-    if (hasActiveField) {
-      clearActiveField()
-    }
-    setActiveTab(null)
-  }, [clearActiveField, hasActiveField])
+  const handleClose = useCallback(
+    (clearActiveTab = true) => {
+      if (hasFieldToCreate) {
+        clearFieldToCreate()
+      }
+      if (hasActiveField) {
+        clearActiveField()
+      }
+      if (clearActiveTab) {
+        setActiveTab(null)
+      }
+    },
+    [clearActiveField, clearFieldToCreate, hasActiveField, hasFieldToCreate],
+  )
 
   const handleBuilderClick = () => setActiveTab(DrawerTabs.Builder)
   const handleDesignClick = () => {

--- a/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
+++ b/frontend/src/features/admin-form-builder/BuilderDrawerContext.tsx
@@ -87,8 +87,14 @@ const useProvideDrawerContext = (): BuilderDrawerContextProps => {
   }, [clearActiveField, hasActiveField])
 
   const handleBuilderClick = () => setActiveTab(DrawerTabs.Builder)
-  const handleDesignClick = () => setActiveTab(DrawerTabs.Design)
-  const handleLogicClick = () => setActiveTab(DrawerTabs.Logic)
+  const handleDesignClick = () => {
+    clearActiveField()
+    setActiveTab(DrawerTabs.Design)
+  }
+  const handleLogicClick = () => {
+    clearActiveField()
+    setActiveTab(DrawerTabs.Logic)
+  }
 
   return {
     activeTab,

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
 import {
   Box,
@@ -19,7 +18,12 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
 
-import { ALL_FIELDS_ORDERED } from './constants'
+import {
+  CREATE_FIELD_DROP_ID,
+  CREATE_FIELD_FIELDS_ORDERED,
+  CREATE_PAGE_DROP_ID,
+  CREATE_PAGE_FIELDS_ORDERED,
+} from './constants'
 import { DraggableCreateFieldOption } from './CreateFieldOption'
 
 export const CreateFieldDrawer = (): JSX.Element => {
@@ -53,16 +57,13 @@ export const CreateFieldDrawer = (): JSX.Element => {
 const BasicFieldPanelContent = () => {
   const { isLoading } = useAdminForm()
 
-  const pageFieldOptions = useMemo(() => ALL_FIELDS_ORDERED.slice(0, 3), [])
-  const fieldFieldOptions = useMemo(() => ALL_FIELDS_ORDERED.slice(3), [])
-
   return (
     <>
-      <Droppable isDropDisabled droppableId="create-fields-page">
+      <Droppable isDropDisabled droppableId={CREATE_PAGE_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
             <FieldSection label="Page">
-              {pageFieldOptions.map((fieldType, index) => (
+              {CREATE_PAGE_FIELDS_ORDERED.map((fieldType, index) => (
                 <DraggableCreateFieldOption
                   index={index}
                   isDisabled={isLoading}
@@ -75,11 +76,11 @@ const BasicFieldPanelContent = () => {
           </Box>
         )}
       </Droppable>
-      <Droppable isDropDisabled droppableId="create-fields-fields">
+      <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
             <FieldSection label="Fields">
-              {fieldFieldOptions.map((fieldType, index) => (
+              {CREATE_FIELD_FIELDS_ORDERED.map((fieldType, index) => (
                 <DraggableCreateFieldOption
                   index={index}
                   isDisabled={isLoading}

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
@@ -1,3 +1,109 @@
+import { useMemo } from 'react'
+import {
+  Box,
+  Divider,
+  Flex,
+  Stack,
+  StackDivider,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+} from '@chakra-ui/react'
+
+import { Tab } from '~components/Tabs'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+
+import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
+
+import { ALL_FIELDS_ORDERED } from './constants'
+import { CreateFieldOption } from './CreateFieldOption'
+
 export const CreateFieldDrawer = (): JSX.Element => {
-  return <div>TODO: Create field drawer content</div>
+  const { isLoading } = useAdminForm()
+
+  return (
+    <Tabs pos="relative" h="100%" display="flex" flexDir="column">
+      <Box pt="1rem" px="1.5rem" bg="white">
+        <Flex justify="space-between">
+          <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
+            Builder
+          </Text>
+          <BuilderDrawerCloseButton />
+        </Flex>
+        <TabList mx="-1rem" w="100%">
+          <Tab isDisabled={isLoading}>Basic</Tab>
+          <Tab isDisabled={isLoading}>MyInfo</Tab>
+        </TabList>
+        <Divider w="auto" mx="-1.5rem" />
+      </Box>
+      <TabPanels pb="1rem" flex={1} overflowY="auto">
+        <TabPanel>
+          <BasicFieldPanelContent />
+        </TabPanel>
+        <TabPanel>MyInfo</TabPanel>
+      </TabPanels>
+    </Tabs>
+  )
+}
+
+const BasicFieldPanelContent = () => {
+  const { isLoading } = useAdminForm()
+
+  const pageFieldOptions = useMemo(() => ALL_FIELDS_ORDERED.slice(0, 3), [])
+  const fieldFieldOptions = useMemo(() => ALL_FIELDS_ORDERED.slice(3), [])
+
+  return (
+    <Box>
+      <FieldSection label="Page">
+        {pageFieldOptions.map((fieldType, index) => (
+          <CreateFieldOption
+            isDisabled={isLoading}
+            key={index}
+            fieldType={fieldType}
+          />
+        ))}
+      </FieldSection>
+      <FieldSection label="Fields">
+        {fieldFieldOptions.map((fieldType, index) => (
+          <CreateFieldOption
+            isDisabled={isLoading}
+            key={index}
+            fieldType={fieldType}
+          />
+        ))}
+      </FieldSection>
+    </Box>
+  )
+}
+
+const FieldSection = ({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) => {
+  return (
+    <Box mb="0.5rem">
+      <Text
+        px="1.5rem"
+        pt="1rem"
+        pb="0.75rem"
+        textStyle="subhead-2"
+        color="secondary.500"
+        pos="sticky"
+        top={0}
+        bg="white"
+        zIndex="docked"
+      >
+        {label}
+      </Text>
+      <Stack divider={<StackDivider />} spacing={0}>
+        {children}
+      </Stack>
+    </Box>
+  )
 }

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
@@ -1,0 +1,3 @@
+export const CreateFieldDrawer = (): JSX.Element => {
+  return <div>TODO: Create field drawer content</div>
+}

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldDrawer.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Droppable } from 'react-beautiful-dnd'
 import {
   Box,
   Divider,
@@ -19,7 +20,7 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
 
 import { ALL_FIELDS_ORDERED } from './constants'
-import { CreateFieldOption } from './CreateFieldOption'
+import { DraggableCreateFieldOption } from './CreateFieldOption'
 
 export const CreateFieldDrawer = (): JSX.Element => {
   const { isLoading } = useAdminForm()
@@ -56,26 +57,42 @@ const BasicFieldPanelContent = () => {
   const fieldFieldOptions = useMemo(() => ALL_FIELDS_ORDERED.slice(3), [])
 
   return (
-    <Box>
-      <FieldSection label="Page">
-        {pageFieldOptions.map((fieldType, index) => (
-          <CreateFieldOption
-            isDisabled={isLoading}
-            key={index}
-            fieldType={fieldType}
-          />
-        ))}
-      </FieldSection>
-      <FieldSection label="Fields">
-        {fieldFieldOptions.map((fieldType, index) => (
-          <CreateFieldOption
-            isDisabled={isLoading}
-            key={index}
-            fieldType={fieldType}
-          />
-        ))}
-      </FieldSection>
-    </Box>
+    <>
+      <Droppable isDropDisabled droppableId="create-fields-page">
+        {(provided) => (
+          <Box ref={provided.innerRef} {...provided.droppableProps}>
+            <FieldSection label="Page">
+              {pageFieldOptions.map((fieldType, index) => (
+                <DraggableCreateFieldOption
+                  index={index}
+                  isDisabled={isLoading}
+                  key={index}
+                  fieldType={fieldType}
+                />
+              ))}
+            </FieldSection>
+            <Box display="none">{provided.placeholder}</Box>
+          </Box>
+        )}
+      </Droppable>
+      <Droppable isDropDisabled droppableId="create-fields-fields">
+        {(provided) => (
+          <Box ref={provided.innerRef} {...provided.droppableProps}>
+            <FieldSection label="Fields">
+              {fieldFieldOptions.map((fieldType, index) => (
+                <DraggableCreateFieldOption
+                  index={index}
+                  isDisabled={isLoading}
+                  key={index}
+                  fieldType={fieldType}
+                />
+              ))}
+            </FieldSection>
+            <Box display="none">{provided.placeholder}</Box>
+          </Box>
+        )}
+      </Droppable>
+    </>
   )
 }
 

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
@@ -74,8 +74,8 @@ export const CreateFieldOption = forwardRef<FieldOptionProps, 'button'>(
           _focus: { bg: 'white' },
         }}
         _hover={{ bg: 'primary.100' }}
-        _focus={{ bg: 'primary.200' }}
-        _active={{ bg: 'primary.200' }}
+        _focus={{ bg: 'primary.100' }}
+        _active={{ bg: 'primary.100' }}
         bg="white"
         {...props}
         ref={ref}

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react'
+import {
+  ButtonProps,
+  chakra,
+  forwardRef,
+  Icon,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+
+import { BasicField } from '~shared/types/field'
+
+import { FIELDS_TO_CREATE_META } from './constants'
+
+interface FieldOptionProps extends ButtonProps {
+  fieldType: BasicField
+}
+
+export const CreateFieldOption = forwardRef<FieldOptionProps, 'div'>(
+  ({ fieldType, isDisabled, ...props }, ref) => {
+    const meta = useMemo(() => FIELDS_TO_CREATE_META[fieldType], [fieldType])
+
+    return (
+      <chakra.button
+        px="1.5rem"
+        {...(isDisabled ? { 'data-disabled': true } : {})}
+        _disabled={{
+          opacity: 0.5,
+          cursor: 'not-allowed',
+          _hover: { bg: 'white' },
+          _focus: { bg: 'white' },
+        }}
+        _hover={{ bg: 'primary.100' }}
+        _focus={{ bg: 'primary.200' }}
+        bg="white"
+        ref={ref}
+        {...props}
+      >
+        <Stack
+          py="1rem"
+          spacing="1.5rem"
+          direction="row"
+          align="center"
+          color="secondary.500"
+        >
+          <Icon fontSize="1.5rem" as={meta.icon} />
+          <Text textStyle="body-1">{meta.label}</Text>
+        </Stack>
+      </chakra.button>
+    )
+  },
+)

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/CreateFieldOption.tsx
@@ -1,29 +1,72 @@
 import { useMemo } from 'react'
-import {
-  ButtonProps,
-  chakra,
-  forwardRef,
-  Icon,
-  Stack,
-  Text,
-} from '@chakra-ui/react'
+import { Draggable } from 'react-beautiful-dnd'
+import { Box, BoxProps, forwardRef, Icon, Stack, Text } from '@chakra-ui/react'
 
 import { BasicField } from '~shared/types/field'
 
 import { FIELDS_TO_CREATE_META } from './constants'
 
-interface FieldOptionProps extends ButtonProps {
+interface FieldOptionProps extends BoxProps {
+  isActive?: boolean
+  isDisabled?: boolean
   fieldType: BasicField
 }
 
-export const CreateFieldOption = forwardRef<FieldOptionProps, 'div'>(
-  ({ fieldType, isDisabled, ...props }, ref) => {
+interface DraggableFieldOptionProps extends Omit<FieldOptionProps, 'isActive'> {
+  index: number
+}
+
+export const DraggableCreateFieldOption = ({
+  fieldType,
+  index,
+  ...props
+}: DraggableFieldOptionProps): JSX.Element => {
+  return (
+    <Draggable
+      index={index}
+      disableInteractiveElementBlocking
+      draggableId={fieldType}
+    >
+      {(provided, snapshot) => (
+        <>
+          <CreateFieldOption
+            fieldType={fieldType}
+            {...props}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            style={{
+              ...provided.draggableProps.style,
+              transform: snapshot.isDragging
+                ? provided.draggableProps.style?.transform
+                : 'translate(0px, 0px)',
+            }}
+            ref={provided.innerRef}
+          />
+          {snapshot.isDragging && (
+            <CreateFieldOption
+              fieldType={fieldType}
+              isActive={snapshot.isDragging}
+              style={{ transform: 'none !important' }}
+              opacity={0.5}
+            />
+          )}
+        </>
+      )}
+    </Draggable>
+  )
+}
+
+export const CreateFieldOption = forwardRef<FieldOptionProps, 'button'>(
+  ({ fieldType, isDisabled, isActive, ...props }, ref) => {
     const meta = useMemo(() => FIELDS_TO_CREATE_META[fieldType], [fieldType])
 
     return (
-      <chakra.button
+      <Box
+        transition="background 0.2s ease"
         px="1.5rem"
+        // Props to trigger styling for the specific states
         {...(isDisabled ? { 'data-disabled': true } : {})}
+        {...(isActive ? { 'data-active': true } : {})}
         _disabled={{
           opacity: 0.5,
           cursor: 'not-allowed',
@@ -32,9 +75,10 @@ export const CreateFieldOption = forwardRef<FieldOptionProps, 'div'>(
         }}
         _hover={{ bg: 'primary.100' }}
         _focus={{ bg: 'primary.200' }}
+        _active={{ bg: 'primary.200' }}
         bg="white"
-        ref={ref}
         {...props}
+        ref={ref}
       >
         <Stack
           py="1rem"
@@ -46,7 +90,7 @@ export const CreateFieldOption = forwardRef<FieldOptionProps, 'div'>(
           <Icon fontSize="1.5rem" as={meta.icon} />
           <Text textStyle="body-1">{meta.label}</Text>
         </Stack>
-      </chakra.button>
+      </Box>
     )
   },
 )

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/constants.ts
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/constants.ts
@@ -1,0 +1,196 @@
+import {
+  BiAlignLeft,
+  BiBuilding,
+  BiCalculator,
+  BiCalendarEvent,
+  BiCaretDownSquare,
+  BiCloudUpload,
+  BiHash,
+  BiHeading,
+  BiImage,
+  BiMailSend,
+  BiMobile,
+  BiPhone,
+  BiRadioCircleMarked,
+  BiRename,
+  BiSelectMultiple,
+  BiStar,
+  BiTable,
+  BiText,
+  BiToggleLeft,
+  BiUser,
+} from 'react-icons/bi'
+import { As } from '@chakra-ui/react'
+
+import { BasicField } from '~shared/types/field'
+
+export const ALL_FIELDS_ORDERED = [
+  // Page section
+
+  BasicField.Section,
+
+  BasicField.Statement,
+
+  BasicField.Image,
+
+  // Fields section
+
+  BasicField.ShortText,
+
+  BasicField.LongText,
+
+  BasicField.Radio,
+
+  BasicField.Checkbox,
+
+  BasicField.Mobile,
+
+  BasicField.Email,
+
+  BasicField.HomeNo,
+
+  BasicField.Dropdown,
+
+  BasicField.YesNo,
+
+  BasicField.Rating,
+
+  BasicField.Number,
+
+  BasicField.Decimal,
+
+  BasicField.Attachment,
+
+  BasicField.Date,
+
+  BasicField.Table,
+
+  BasicField.Nric,
+
+  BasicField.Uen,
+]
+
+export const FIELDS_TO_CREATE_META: Record<
+  BasicField,
+  { label: string; icon: As }
+> = {
+  [BasicField.Image]: {
+    label: 'Image',
+
+    icon: BiImage,
+  },
+
+  [BasicField.Statement]: {
+    label: 'Paragraph',
+
+    icon: BiText,
+  },
+
+  [BasicField.Section]: {
+    label: 'Header',
+
+    icon: BiHeading,
+  },
+
+  [BasicField.Attachment]: {
+    label: 'Attachment',
+
+    icon: BiCloudUpload,
+  },
+
+  [BasicField.Checkbox]: {
+    label: 'Checkbox',
+
+    icon: BiSelectMultiple,
+  },
+
+  [BasicField.Date]: {
+    label: 'Date',
+
+    icon: BiCalendarEvent,
+  },
+
+  [BasicField.Decimal]: {
+    label: 'Decimal',
+
+    icon: BiCalculator,
+  },
+
+  [BasicField.Dropdown]: {
+    label: 'Dropdown',
+
+    icon: BiCaretDownSquare,
+  },
+
+  [BasicField.Email]: {
+    label: 'Email',
+
+    icon: BiMailSend,
+  },
+
+  [BasicField.HomeNo]: {
+    label: 'Home Number',
+
+    icon: BiPhone,
+  },
+
+  [BasicField.LongText]: {
+    label: 'Long answer',
+
+    icon: BiAlignLeft,
+  },
+
+  [BasicField.Mobile]: {
+    label: 'Mobile number',
+
+    icon: BiMobile,
+  },
+
+  [BasicField.Nric]: {
+    label: 'NRIC',
+
+    icon: BiUser,
+  },
+
+  [BasicField.Number]: {
+    label: 'Number',
+
+    icon: BiHash,
+  },
+
+  [BasicField.Radio]: {
+    label: 'Radio',
+
+    icon: BiRadioCircleMarked,
+  },
+
+  [BasicField.Rating]: {
+    label: 'Rating',
+
+    icon: BiStar,
+  },
+
+  [BasicField.ShortText]: {
+    label: 'Short answer',
+
+    icon: BiRename,
+  },
+
+  [BasicField.Table]: {
+    label: 'Table',
+
+    icon: BiTable,
+  },
+
+  [BasicField.Uen]: {
+    label: 'UEN',
+
+    icon: BiBuilding,
+  },
+
+  [BasicField.YesNo]: {
+    label: 'Yes/No',
+
+    icon: BiToggleLeft,
+  },
+}

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/constants.ts
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/constants.ts
@@ -24,7 +24,7 @@ import { As } from '@chakra-ui/react'
 
 import { BasicField } from '~shared/types/field'
 
-export const ALL_FIELDS_ORDERED = [
+const ALL_FIELDS_ORDERED = [
   // Page section
 
   BasicField.Section,
@@ -69,6 +69,12 @@ export const ALL_FIELDS_ORDERED = [
 
   BasicField.Uen,
 ]
+
+export const CREATE_PAGE_FIELDS_ORDERED = ALL_FIELDS_ORDERED.slice(0, 3)
+export const CREATE_FIELD_FIELDS_ORDERED = ALL_FIELDS_ORDERED.slice(3)
+
+export const CREATE_PAGE_DROP_ID = 'create-fields-page'
+export const CREATE_FIELD_DROP_ID = 'create-fields-field'
 
 export const FIELDS_TO_CREATE_META: Record<
   BasicField,

--- a/frontend/src/features/admin-form-builder/CreateFieldDrawer/index.ts
+++ b/frontend/src/features/admin-form-builder/CreateFieldDrawer/index.ts
@@ -1,0 +1,1 @@
+export { CreateFieldDrawer } from './CreateFieldDrawer'

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
@@ -26,9 +26,9 @@ import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 import { CheckboxFieldSchema } from '~templates/Field/Checkbox/CheckboxField'
 
-import { PENDING_CREATE_FIELD_ID } from '../constants'
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
+import { isPendingFormField } from '../utils'
 
 import { DrawerContentContainer } from './DrawerContentContainer'
 import { FormFieldDrawerActions } from './FormFieldDrawerActions'
@@ -147,8 +147,13 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   const { mutateFormField } = useMutateFormFields()
 
   const saveButtonText = useMemo(
-    () => (field._id === PENDING_CREATE_FIELD_ID ? 'Create' : 'Save'),
-    [field._id],
+    () => (isPendingFormField(field) ? 'Create' : 'Save'),
+    [field],
+  )
+
+  const isSaveDisabled = useMemo(
+    () => isDirty || isPendingFormField(field),
+    [field, isDirty],
   )
 
   const handleUpdateField = handleSubmit((inputs) => {
@@ -386,7 +391,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
 
         <FormFieldDrawerActions
           isLoading={mutateFormField.isLoading}
-          isDirty={isDirty}
+          isDirty={isSaveDisabled}
           buttonText={saveButtonText}
           handleClick={handleUpdateField}
           handleCancel={clearActiveField}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditCheckbox.tsx
@@ -26,6 +26,7 @@ import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 import { CheckboxFieldSchema } from '~templates/Field/Checkbox/CheckboxField'
 
+import { PENDING_CREATE_FIELD_ID } from '../constants'
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
 
@@ -144,6 +145,11 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   )
 
   const { mutateFormField } = useMutateFormFields()
+
+  const saveButtonText = useMemo(
+    () => (field._id === PENDING_CREATE_FIELD_ID ? 'Create' : 'Save'),
+    [field._id],
+  )
 
   const handleUpdateField = handleSubmit((inputs) => {
     const updatedField = extend({}, field, transformToFormField(inputs))
@@ -381,6 +387,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         <FormFieldDrawerActions
           isLoading={mutateFormField.isLoading}
           isDirty={isDirty}
+          buttonText={saveButtonText}
           handleClick={handleUpdateField}
           handleCancel={clearActiveField}
         />

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { BiLeftArrowAlt } from 'react-icons/bi'
 import { Box, Flex } from '@chakra-ui/react'
 
@@ -6,11 +6,8 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
 
-import {
-  activeFieldSelector,
-  clearActiveFieldSelector,
-  useEditFieldStore,
-} from '../editFieldStore'
+import { useBuilderDrawer } from '../BuilderDrawerContext'
+import { activeFieldSelector, useEditFieldStore } from '../editFieldStore'
 import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
 import { transformBasicFieldToText } from '../utils'
 
@@ -18,13 +15,17 @@ import { EditCheckbox } from './EditCheckbox'
 import { EditHeader } from './EditHeader'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
-  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
+  const { handleClose } = useBuilderDrawer()
   const activeField = useEditFieldStore(activeFieldSelector)
 
   const basicFieldText = useMemo(
     () => transformBasicFieldToText(activeField?.fieldType),
     [activeField?.fieldType],
   )
+
+  const handleBackClick = useCallback(() => {
+    handleClose(/* clearActiveTab= */ false)
+  }, [handleClose])
 
   if (!activeField) return null
 
@@ -45,7 +46,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
           aria-label="Back to field selection"
           variant="clear"
           colorScheme="secondary"
-          onClick={clearActiveField}
+          onClick={handleBackClick}
           icon={<BiLeftArrowAlt />}
         />
         <Box m="auto">Edit {basicFieldText} field</Box>

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import { BiLeftArrowAlt } from 'react-icons/bi'
 import { Box, Flex } from '@chakra-ui/react'
 
@@ -6,8 +6,11 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
 
-import { useBuilderDrawer } from '../BuilderDrawerContext'
-import { activeFieldSelector, useEditFieldStore } from '../editFieldStore'
+import {
+  activeFieldSelector,
+  clearActiveFieldSelector,
+  useEditFieldStore,
+} from '../editFieldStore'
 import { BuilderDrawerCloseButton } from '../FieldRow/BuilderDrawerCloseButton'
 import { transformBasicFieldToText } from '../utils'
 
@@ -15,17 +18,13 @@ import { EditCheckbox } from './EditCheckbox'
 import { EditHeader } from './EditHeader'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
-  const { handleClose } = useBuilderDrawer()
+  const clearActiveField = useEditFieldStore(clearActiveFieldSelector)
   const activeField = useEditFieldStore(activeFieldSelector)
 
   const basicFieldText = useMemo(
     () => transformBasicFieldToText(activeField?.fieldType),
     [activeField?.fieldType],
   )
-
-  const handleBackClick = useCallback(() => {
-    handleClose(/* clearActiveTab= */ false)
-  }, [handleClose])
 
   if (!activeField) return null
 
@@ -46,7 +45,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
           aria-label="Back to field selection"
           variant="clear"
           colorScheme="secondary"
-          onClick={handleBackClick}
+          onClick={clearActiveField}
           icon={<BiLeftArrowAlt />}
         />
         <Box m="auto">Edit {basicFieldText} field</Box>

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditFieldDrawer.tsx
@@ -51,7 +51,8 @@ export const EditFieldDrawer = (): JSX.Element | null => {
         <Box m="auto">Edit {basicFieldText} field</Box>
         <BuilderDrawerCloseButton />
       </Flex>
-      <MemoFieldDrawerContent field={activeField} />
+      {/* key required to refresh content whenever the active field changes */}
+      <MemoFieldDrawerContent key={activeField._id} field={activeField} />
     </>
   )
 }

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
@@ -11,6 +11,7 @@ import Input from '~components/Input'
 import Textarea from '~components/Textarea'
 import { SectionFieldSchema } from '~templates/Field/Section/SectionFieldContainer'
 
+import { PENDING_CREATE_FIELD_ID } from '../constants'
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
 
@@ -51,6 +52,11 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
 
   const { mutateFormField } = useMutateFormFields()
 
+  const saveButtonText = useMemo(
+    () => (field._id === PENDING_CREATE_FIELD_ID ? 'Create' : 'Save'),
+    [field._id],
+  )
+
   const handleUpdateField = handleSubmit((inputs) => {
     const updatedFormField: SectionFieldSchema = extend({}, field, inputs)
     return mutateFormField.mutate(updatedFormField, {
@@ -87,6 +93,7 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
         <FormFieldDrawerActions
           isLoading={mutateFormField.isLoading}
           isDirty={isDirty}
+          buttonText={saveButtonText}
           handleClick={handleUpdateField}
           handleCancel={clearActiveField}
         />

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/EditHeader.tsx
@@ -11,9 +11,9 @@ import Input from '~components/Input'
 import Textarea from '~components/Textarea'
 import { SectionFieldSchema } from '~templates/Field/Section/SectionFieldContainer'
 
-import { PENDING_CREATE_FIELD_ID } from '../constants'
 import { useEditFieldStore } from '../editFieldStore'
 import { useMutateFormFields } from '../mutations'
+import { isPendingFormField } from '../utils'
 
 import { DrawerContentContainer } from './DrawerContentContainer'
 import { FormFieldDrawerActions } from './FormFieldDrawerActions'
@@ -52,9 +52,14 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
 
   const { mutateFormField } = useMutateFormFields()
 
+  const isSaveDisabled = useMemo(
+    () => isDirty || isPendingFormField(field),
+    [field, isDirty],
+  )
+
   const saveButtonText = useMemo(
-    () => (field._id === PENDING_CREATE_FIELD_ID ? 'Create' : 'Save'),
-    [field._id],
+    () => (isPendingFormField(field) ? 'Create' : 'Save'),
+    [field],
   )
 
   const handleUpdateField = handleSubmit((inputs) => {
@@ -92,7 +97,7 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
         </FormControl>
         <FormFieldDrawerActions
           isLoading={mutateFormField.isLoading}
-          isDirty={isDirty}
+          isDirty={isSaveDisabled}
           buttonText={saveButtonText}
           handleClick={handleUpdateField}
           handleCancel={clearActiveField}

--- a/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form-builder/EditFieldDrawer/FormFieldDrawerActions.tsx
@@ -8,6 +8,7 @@ interface FormFieldDrawerActionsProps {
   isDirty: boolean
   handleClick: ReturnType<UseFormHandleSubmit<FieldValues>>
   handleCancel: () => void
+  buttonText: string
 }
 
 export const FormFieldDrawerActions = ({
@@ -15,6 +16,7 @@ export const FormFieldDrawerActions = ({
   isDirty,
   handleClick,
   handleCancel,
+  buttonText,
 }: FormFieldDrawerActionsProps): JSX.Element => {
   return (
     <ButtonGroup
@@ -32,7 +34,7 @@ export const FormFieldDrawerActions = ({
         isLoading={isLoading}
         onClick={handleClick}
       >
-        Save
+        {buttonText}
       </Button>
     </ButtonGroup>
   )

--- a/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/BuilderDrawerCloseButton.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { BiX } from 'react-icons/bi'
 import { CloseButton } from '@chakra-ui/react'
 
@@ -5,6 +6,10 @@ import { useBuilderDrawer } from '../BuilderDrawerContext'
 
 export const BuilderDrawerCloseButton = (): JSX.Element => {
   const { handleClose } = useBuilderDrawer()
+
+  const handleCloseDrawer = useCallback(() => {
+    handleClose(/* clearActiveTab= */ true)
+  }, [handleClose])
 
   return (
     <CloseButton
@@ -15,7 +20,7 @@ export const BuilderDrawerCloseButton = (): JSX.Element => {
       variant="clear"
       colorScheme="neutral"
       children={<BiX />}
-      onClick={handleClose}
+      onClick={handleCloseDrawer}
     />
   )
 }

--- a/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form-builder/FieldRow/FieldRowContainer.tsx
@@ -71,90 +71,104 @@ export const FieldRowContainer = ({
       draggableId={field._id}
     >
       {(provided, snapshot) => (
-        <Flex
+        <Box
+          _first={{ pt: 0 }}
+          _last={{ pb: 0 }}
+          py="1.25rem"
           {...provided.draggableProps}
           ref={provided.innerRef}
-          // Focusable
-          tabIndex={0}
-          role="button"
-          cursor={isActive ? 'initial' : 'pointer'}
-          bg="white"
-          transition="background 0.2s ease"
-          _hover={{ bg: 'secondary.100' }}
-          borderRadius="4px"
-          outline="none"
-          {...(isActive ? { 'data-active': true } : {})}
-          _focusWithin={{
-            boxShadow: snapshot.isDragging
-              ? 'md'
-              : '0 0 0 2px var(--chakra-colors-primary-500) !important',
-          }}
-          _active={{
-            bg: 'secondary.100',
-            boxShadow: snapshot.isDragging
-              ? 'md'
-              : '0 0 0 2px var(--chakra-colors-primary-500)',
-          }}
-          flexDir="column"
-          align="center"
-          onClick={handleFieldClick}
-          onKeyDown={handleKeydown}
         >
-          <Fade in={isActive}>
-            <chakra.button
-              tabIndex={isActive ? 0 : -1}
-              {...provided.dragHandleProps}
-              borderRadius="4px"
-              _focus={{
-                boxShadow: snapshot.isDragging
-                  ? undefined
-                  : '0 0 0 2px var(--chakra-colors-neutral-500)',
-              }}
-            >
-              <Icon
-                transition="color 0.2s ease"
-                _hover={{
-                  color: 'secondary.300',
-                }}
-                color={snapshot.isDragging ? 'secondary.300' : 'secondary.200'}
-                as={BiGridHorizontal}
-                fontSize="1.5rem"
-              />
-            </chakra.button>
-          </Fade>
-          <Box
-            p="1.5rem"
-            pt={0}
-            w="100%"
-            pointerEvents={isActive ? undefined : 'none'}
+          <Flex
+            // Offset for focus boxShadow
+            my="2px"
+            // Focusable
+            tabIndex={0}
+            role="button"
+            cursor={isActive ? 'initial' : 'pointer'}
+            bg="white"
+            transition="background 0.2s ease"
+            _hover={{ bg: 'secondary.100' }}
+            borderRadius="4px"
+            outline="none"
+            {...(isActive ? { 'data-active': true } : {})}
+            _focusWithin={{
+              boxShadow: snapshot.isDragging
+                ? 'md'
+                : '0 0 0 2px var(--chakra-colors-primary-500) !important',
+            }}
+            _active={{
+              bg: 'secondary.100',
+              boxShadow: snapshot.isDragging
+                ? 'md'
+                : '0 0 0 2px var(--chakra-colors-primary-500)',
+            }}
+            flexDir="column"
+            align="center"
+            onClick={handleFieldClick}
+            onKeyDown={handleKeydown}
           >
-            <FormProvider {...formMethods}>
-              <MemoFieldRow
-                field={isActive && activeField ? activeField : field}
-              />
-            </FormProvider>
-          </Box>
-          <Collapse in={isActive} style={{ width: '100%' }}>
-            <Flex
-              px="1.5rem"
-              flex={1}
-              borderTop="1px solid var(--chakra-colors-neutral-300)"
-              justify="end"
+            <Fade in={isActive}>
+              <chakra.button
+                tabIndex={isActive ? 0 : -1}
+                {...provided.dragHandleProps}
+                borderRadius="4px"
+                _focus={{
+                  boxShadow: snapshot.isDragging
+                    ? undefined
+                    : '0 0 0 2px var(--chakra-colors-neutral-500)',
+                }}
+              >
+                <Icon
+                  transition="color 0.2s ease"
+                  _hover={{
+                    color: 'secondary.300',
+                  }}
+                  color={
+                    snapshot.isDragging ? 'secondary.300' : 'secondary.200'
+                  }
+                  as={BiGridHorizontal}
+                  fontSize="1.5rem"
+                />
+              </chakra.button>
+            </Fade>
+            <Box
+              p="1.5rem"
+              pt={0}
+              w="100%"
+              pointerEvents={isActive ? undefined : 'none'}
             >
-              <ButtonGroup variant="clear" colorScheme="secondary" spacing={0}>
-                <IconButton
-                  aria-label="Duplicate field"
-                  icon={<BiDuplicate fontSize="1.25rem" />}
+              <FormProvider {...formMethods}>
+                <MemoFieldRow
+                  field={isActive && activeField ? activeField : field}
                 />
-                <IconButton
-                  colorScheme="danger"
-                  aria-label="Delete field"
-                  icon={<BiTrash fontSize="1.25rem" />}
-                />
-              </ButtonGroup>
-            </Flex>
-          </Collapse>
-        </Flex>
+              </FormProvider>
+            </Box>
+            <Collapse in={isActive} style={{ width: '100%' }}>
+              <Flex
+                px="1.5rem"
+                flex={1}
+                borderTop="1px solid var(--chakra-colors-neutral-300)"
+                justify="end"
+              >
+                <ButtonGroup
+                  variant="clear"
+                  colorScheme="secondary"
+                  spacing={0}
+                >
+                  <IconButton
+                    aria-label="Duplicate field"
+                    icon={<BiDuplicate fontSize="1.25rem" />}
+                  />
+                  <IconButton
+                    colorScheme="danger"
+                    aria-label="Delete field"
+                    icon={<BiTrash fontSize="1.25rem" />}
+                  />
+                </ButtonGroup>
+              </Flex>
+            </Collapse>
+          </Flex>
+        </Box>
       )}
     </Draggable>
   )

--- a/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
+++ b/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
@@ -13,7 +13,7 @@ import { BuilderContent } from './BuilderContent'
 import { BuilderDrawer } from './BuilderDrawer'
 import { BuilderDrawerProvider } from './BuilderDrawerContext'
 import { BuilderSidebar } from './BuilderSidebar'
-import { FIELD_LIST_DROPPABLE_ID } from './constants'
+import { FIELD_LIST_DROP_ID } from './constants'
 import { useMutateFormFields } from './mutations'
 
 const dragHandleQueryAttr = 'data-rbd-drag-handle-draggable-id'
@@ -63,7 +63,7 @@ export const FormBuilderPage = (): JSX.Element => {
   // for original code.
   const onDragStart = useCallback(({ draggableId, source }: DragStart) => {
     const draggedDOM =
-      source.droppableId === FIELD_LIST_DROPPABLE_ID
+      source.droppableId === FIELD_LIST_DROP_ID
         ? getDragDom(draggableId)
         : getDragHandleDom(draggableId)
 
@@ -101,7 +101,7 @@ export const FormBuilderPage = (): JSX.Element => {
       }
 
       const draggedDOM =
-        source.droppableId === FIELD_LIST_DROPPABLE_ID
+        source.droppableId === FIELD_LIST_DROP_ID
           ? getDragDom(draggableId)
           : getDragHandleDom(draggableId)
 
@@ -160,7 +160,7 @@ export const FormBuilderPage = (): JSX.Element => {
   const onDragEnd = useCallback(
     ({ source, destination }: DropResult) => {
       setPlaceholderProps({})
-      if (source.droppableId !== FIELD_LIST_DROPPABLE_ID) return
+      if (source.droppableId !== FIELD_LIST_DROP_ID) return
       if (!data || !destination || destination.index === source.index) {
         return
       }

--- a/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
+++ b/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
@@ -1,18 +1,61 @@
+import { useCallback } from 'react'
+import { DragDropContext, DropResult } from 'react-beautiful-dnd'
 import { Flex } from '@chakra-ui/react'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { BuilderContent } from './BuilderContent'
 import { BuilderDrawer } from './BuilderDrawer'
 import { BuilderDrawerProvider } from './BuilderDrawerContext'
 import { BuilderSidebar } from './BuilderSidebar'
+import { useMutateFormFields } from './mutations'
 
 export const FormBuilderPage = (): JSX.Element => {
+  const { data } = useAdminForm()
+  const { mutateReorderField } = useMutateFormFields()
+
+  const onBeforeCapture = useCallback(() => {
+    /*...*/
+  }, [])
+  const onBeforeDragStart = useCallback(() => {
+    /*...*/
+  }, [])
+  const onDragStart = useCallback(() => {
+    /*...*/
+  }, [])
+  const onDragUpdate = useCallback(() => {
+    /*...*/
+  }, [])
+  const onDragEnd = useCallback(
+    ({ source, destination }: DropResult) => {
+      if (source.droppableId !== 'formFieldList') return
+      if (!data || !destination || destination.index === source.index) {
+        return
+      }
+      return mutateReorderField.mutate({
+        fields: data.form_fields,
+        from: source.index,
+        to: destination.index,
+      })
+    },
+    [data, mutateReorderField],
+  )
+
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
-      <BuilderDrawerProvider>
-        <BuilderSidebar />
-        <BuilderDrawer />
-      </BuilderDrawerProvider>
-      <BuilderContent />
+      <DragDropContext
+        onBeforeCapture={onBeforeCapture}
+        onBeforeDragStart={onBeforeDragStart}
+        onDragStart={onDragStart}
+        onDragUpdate={onDragUpdate}
+        onDragEnd={onDragEnd}
+      >
+        <BuilderDrawerProvider>
+          <BuilderSidebar />
+          <BuilderDrawer />
+        </BuilderDrawerProvider>
+        <BuilderContent />
+      </DragDropContext>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
+++ b/frontend/src/features/admin-form-builder/FormBuilderPage.tsx
@@ -1,5 +1,10 @@
-import { useCallback } from 'react'
-import { DragDropContext, DropResult } from 'react-beautiful-dnd'
+import { useCallback, useState } from 'react'
+import {
+  DragDropContext,
+  DragStart,
+  DragUpdate,
+  DropResult,
+} from 'react-beautiful-dnd'
 import { Flex } from '@chakra-ui/react'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
@@ -8,27 +13,154 @@ import { BuilderContent } from './BuilderContent'
 import { BuilderDrawer } from './BuilderDrawer'
 import { BuilderDrawerProvider } from './BuilderDrawerContext'
 import { BuilderSidebar } from './BuilderSidebar'
+import { FIELD_LIST_DROPPABLE_ID } from './constants'
 import { useMutateFormFields } from './mutations'
+
+const dragHandleQueryAttr = 'data-rbd-drag-handle-draggable-id'
+const dragContainerQueryAttr = 'data-rbd-draggable-id'
+const destinationQuertAttr = 'data-rbd-droppable-id'
+
+const getDragHandleDom = (draggableId: unknown) => {
+  const domQuery = `[${dragHandleQueryAttr}='${draggableId}']`
+  const draggedDOM = document.querySelector(domQuery)
+
+  return draggedDOM
+}
+const getDragDom = (draggableId: unknown) => {
+  const domQuery = `[${dragContainerQueryAttr}='${draggableId}']`
+  const draggedDOM = document.querySelector(domQuery)
+
+  return draggedDOM
+}
+
+const getDestinationDom = (dropabbleId: unknown) => {
+  const domQuery = `[${destinationQuertAttr}='${dropabbleId}']`
+  const destinationDOM = document.querySelector(domQuery)
+  return destinationDOM
+}
+
+export type DndPlaceholderProps =
+  | {
+      droppableId: string
+      clientHeight: number
+      clientWidth: string
+      clientY: number
+      clientX: number
+    }
+  | Record<string, never>
 
 export const FormBuilderPage = (): JSX.Element => {
   const { data } = useAdminForm()
   const { mutateReorderField } = useMutateFormFields()
 
-  const onBeforeCapture = useCallback(() => {
-    /*...*/
+  const [placeholderProps, setPlaceholderProps] = useState<DndPlaceholderProps>(
+    {},
+  )
+
+  // onDrag handler functions to get props to render placeholders since
+  // react-beautiful-dnd does not natively support custom placeholders.
+  // See https://medium.com/@Dedanade/how-to-add-a-custom-placeholder-for-more-than-one-column-react-beautiful-dnd-3d59b64fe2d2
+  // for original code.
+  const onDragStart = useCallback(({ draggableId, source }: DragStart) => {
+    const draggedDOM =
+      source.droppableId === FIELD_LIST_DROPPABLE_ID
+        ? getDragDom(draggableId)
+        : getDragHandleDom(draggableId)
+
+    if (!draggedDOM?.parentElement) {
+      return
+    }
+
+    const sourceIndex = source.index
+    const clientY =
+      parseFloat(window.getComputedStyle(draggedDOM.parentElement).paddingTop) +
+      [...draggedDOM.parentElement.children]
+        .slice(0, sourceIndex)
+        .reduce((total, curr) => {
+          const style = window.getComputedStyle(curr)
+          const marginBottom = parseFloat(style.marginBottom)
+          return total + curr.clientHeight + marginBottom
+        }, 0)
+
+    const nextPlaceholderProps = {
+      droppableId: source.droppableId,
+      clientHeight: draggedDOM.clientHeight,
+      clientWidth: '100%',
+      clientY,
+      clientX: parseFloat(
+        window.getComputedStyle(draggedDOM.parentElement).paddingLeft,
+      ),
+    }
+    setPlaceholderProps(nextPlaceholderProps)
   }, [])
-  const onBeforeDragStart = useCallback(() => {
-    /*...*/
-  }, [])
-  const onDragStart = useCallback(() => {
-    /*...*/
-  }, [])
-  const onDragUpdate = useCallback(() => {
-    /*...*/
-  }, [])
+
+  const onDragUpdate = useCallback(
+    ({ source, destination, draggableId }: DragUpdate) => {
+      if (!destination) {
+        return
+      }
+
+      const draggedDOM =
+        source.droppableId === FIELD_LIST_DROPPABLE_ID
+          ? getDragDom(draggableId)
+          : getDragHandleDom(draggableId)
+
+      if (!draggedDOM?.parentElement) {
+        return
+      }
+
+      const destinationIndex = destination.index
+      const sourceIndex = source.index
+
+      const childrenArray = [...draggedDOM.parentElement.children]
+      const movedItem = childrenArray[sourceIndex]
+      childrenArray.splice(sourceIndex, 1)
+
+      const droppedDom = getDestinationDom(destination.droppableId)
+      if (!droppedDom) return
+      const destinationChildrenArray = [...droppedDom.children]
+      let updatedArray
+      if (draggedDOM.parentNode === droppedDom) {
+        updatedArray = [
+          ...childrenArray.slice(0, destinationIndex),
+          movedItem,
+          ...childrenArray.slice(destinationIndex + 1),
+        ]
+      } else {
+        updatedArray = [
+          ...destinationChildrenArray.slice(0, destinationIndex),
+          movedItem,
+          ...destinationChildrenArray.slice(destinationIndex + 1),
+        ]
+      }
+
+      const clientY =
+        parseFloat(
+          window.getComputedStyle(draggedDOM.parentElement).paddingTop,
+        ) +
+        updatedArray.slice(0, destinationIndex).reduce((total, curr) => {
+          const style = window.getComputedStyle(curr)
+          const marginBottom = parseFloat(style.marginBottom)
+          return total + curr.clientHeight + marginBottom
+        }, 0)
+
+      setPlaceholderProps({
+        droppableId: source.droppableId,
+        clientHeight: draggedDOM.clientHeight,
+        clientWidth: '100%',
+        clientY,
+        clientX: parseFloat(
+          window.getComputedStyle(draggedDOM.parentElement).paddingLeft,
+        ),
+      })
+    },
+    [],
+  )
+
   const onDragEnd = useCallback(
     ({ source, destination }: DropResult) => {
-      if (source.droppableId !== 'formFieldList') return
+      setPlaceholderProps({})
+      if (source.droppableId !== FIELD_LIST_DROPPABLE_ID) return
       if (!data || !destination || destination.index === source.index) {
         return
       }
@@ -44,8 +176,6 @@ export const FormBuilderPage = (): JSX.Element => {
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
       <DragDropContext
-        onBeforeCapture={onBeforeCapture}
-        onBeforeDragStart={onBeforeDragStart}
         onDragStart={onDragStart}
         onDragUpdate={onDragUpdate}
         onDragEnd={onDragEnd}
@@ -54,7 +184,7 @@ export const FormBuilderPage = (): JSX.Element => {
           <BuilderSidebar />
           <BuilderDrawer />
         </BuilderDrawerProvider>
-        <BuilderContent />
+        <BuilderContent placeholderProps={placeholderProps} />
       </DragDropContext>
     </Flex>
   )

--- a/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
+++ b/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
@@ -8,18 +8,22 @@ import { ADMIN_FORM_ENDPOINT } from '~features/admin-form/common/AdminViewFormSe
  * Creates a new form field in the given form
  * @param formId the form to insert a new form field for
  * @param createFieldBody the body of the new form field
+ * @param insertionIndex optional. The index to insert the new form field at
  * @returns the created form field
  */
 export const createSingleFormField = async ({
   formId,
   createFieldBody,
+  insertionIndex,
 }: {
   formId: string
   createFieldBody: FieldCreateDto
+  insertionIndex?: number
 }): Promise<FormFieldDto> => {
   return ApiService.post<FormFieldDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/fields`,
     createFieldBody,
+    { params: { to: insertionIndex } },
   ).then(({ data }) => data)
 }
 

--- a/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
+++ b/frontend/src/features/admin-form-builder/UpdateFormFieldService.ts
@@ -1,8 +1,27 @@
-import { FormFieldDto } from '~shared/types/field'
+import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
 
 import { ApiService } from '~services/ApiService'
 
 import { ADMIN_FORM_ENDPOINT } from '~features/admin-form/common/AdminViewFormService'
+
+/**
+ * Creates a new form field in the given form
+ * @param formId the form to insert a new form field for
+ * @param createFieldBody the body of the new form field
+ * @returns the created form field
+ */
+export const createSingleFormField = async ({
+  formId,
+  createFieldBody,
+}: {
+  formId: string
+  createFieldBody: FieldCreateDto
+}): Promise<FormFieldDto> => {
+  return ApiService.post<FormFieldDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/fields`,
+    createFieldBody,
+  ).then(({ data }) => data)
+}
 
 export const updateSingleFormField = async ({
   formId,

--- a/frontend/src/features/admin-form-builder/constants.ts
+++ b/frontend/src/features/admin-form-builder/constants.ts
@@ -1,0 +1,1 @@
+export const FIELD_LIST_DROPPABLE_ID = 'formFieldList'

--- a/frontend/src/features/admin-form-builder/constants.ts
+++ b/frontend/src/features/admin-form-builder/constants.ts
@@ -1,1 +1,2 @@
-export const FIELD_LIST_DROPPABLE_ID = 'formFieldList'
+export const FIELD_LIST_DROP_ID = 'formFieldList'
+export const PENDING_CREATE_FIELD_ID = 'FIELD-PENDING-CREATION'

--- a/frontend/src/features/admin-form-builder/types.ts
+++ b/frontend/src/features/admin-form-builder/types.ts
@@ -1,0 +1,9 @@
+import { FormField, FormFieldDto } from '~shared/types/field'
+
+import { PENDING_CREATE_FIELD_ID } from './constants'
+
+export type PendingFormField = FormField & {
+  _id: typeof PENDING_CREATE_FIELD_ID
+}
+
+export type BuilderContentField = FormFieldDto | PendingFormField

--- a/frontend/src/features/admin-form-builder/useBuilderFormFields.ts
+++ b/frontend/src/features/admin-form-builder/useBuilderFormFields.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+
+import { FormFieldDto } from '~shared/types/field'
+import { insertAt } from '~shared/utils/immutable-array-fns'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+
+import { EditFieldStoreState, useEditFieldStore } from './editFieldStore'
+import { BuilderContentField } from './types'
+import { getFieldCreationMeta } from './utils'
+
+const editFieldStoreSelector = (state: EditFieldStoreState) => ({
+  clearActiveField: state.clearActiveField,
+  fieldToCreate: state.fieldToCreate,
+  clearFieldToCreate: state.clearFieldToCreate,
+  updateActiveField: state.updateActiveField,
+})
+
+const getComputedFormFields = ({
+  formFields,
+  fieldToCreate,
+}: {
+  formFields?: FormFieldDto[]
+  fieldToCreate: EditFieldStoreState['fieldToCreate']
+}) => {
+  if (!formFields) {
+    return
+  }
+  if (fieldToCreate) {
+    return insertAt(
+      formFields,
+      fieldToCreate.insertionIndex,
+      getFieldCreationMeta(fieldToCreate.fieldType),
+    )
+  } else {
+    return formFields
+  }
+}
+
+export const useBuilderFormFields = () => {
+  const { fieldToCreate, updateActiveField } = useEditFieldStore(
+    editFieldStoreSelector,
+  )
+
+  const { data } = useAdminForm({
+    // Only fetch when there are no fields to create.
+    enabled: !fieldToCreate,
+  })
+
+  const [builderFields, setBuilderFields] = useState<
+    BuilderContentField[] | undefined
+  >(data?.form_fields)
+
+  // Update form fields whenever admin form changes
+  useEffect(() => {
+    const nextFormFields = getComputedFormFields({
+      fieldToCreate,
+      formFields: data?.form_fields,
+    })
+    if (nextFormFields) {
+      setBuilderFields(nextFormFields)
+      if (fieldToCreate) {
+        updateActiveField(nextFormFields[fieldToCreate.insertionIndex])
+      }
+    }
+  }, [data?.form_fields, fieldToCreate, updateActiveField])
+
+  return {
+    builderFields,
+  }
+}

--- a/frontend/src/features/admin-form-builder/utils.ts
+++ b/frontend/src/features/admin-form-builder/utils.ts
@@ -1,7 +1,7 @@
 import { BasicField } from '~shared/types/field'
 
 import { PENDING_CREATE_FIELD_ID } from './constants'
-import { PendingFormField } from './types'
+import { BuilderContentField, PendingFormField } from './types'
 
 /**
  * Maps BasicField enums to their human-readable field type string
@@ -30,6 +30,12 @@ export const transformBasicFieldToText = (basicField?: BasicField): string => {
     default:
       return basicField.charAt(0).toUpperCase() + basicField.slice(1)
   }
+}
+
+export const isPendingFormField = (
+  field: BuilderContentField,
+): field is PendingFormField => {
+  return field._id === PENDING_CREATE_FIELD_ID
 }
 
 /**

--- a/frontend/src/features/admin-form-builder/utils.ts
+++ b/frontend/src/features/admin-form-builder/utils.ts
@@ -1,5 +1,8 @@
 import { BasicField } from '~shared/types/field'
 
+import { PENDING_CREATE_FIELD_ID } from './constants'
+import { PendingFormField } from './types'
+
 /**
  * Maps BasicField enums to their human-readable field type string
  */
@@ -26,5 +29,39 @@ export const transformBasicFieldToText = (basicField?: BasicField): string => {
       return 'UEN'
     default:
       return basicField.charAt(0).toUpperCase() + basicField.slice(1)
+  }
+}
+
+/**
+ * Utility methods to create bare minimum meta required for field creation.
+ * TODO: Create one for every field type.
+ */
+export const getFieldCreationMeta = (
+  fieldType: BasicField,
+): PendingFormField => {
+  const baseMeta: Pick<
+    PendingFormField,
+    'description' | 'disabled' | 'required' | 'title' | '_id'
+  > = {
+    description: '',
+    disabled: false,
+    required: true,
+    title: transformBasicFieldToText(fieldType),
+    _id: PENDING_CREATE_FIELD_ID,
+  }
+
+  switch (fieldType) {
+    case BasicField.Section: {
+      return {
+        fieldType,
+        ...baseMeta,
+      }
+    }
+    default: {
+      return {
+        fieldType: BasicField.Section,
+        ...baseMeta,
+      }
+    }
   }
 }

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult } from 'react-query'
+import { QueryObserverOptions, useQuery, UseQueryResult } from 'react-query'
 import { useParams } from 'react-router-dom'
 
 import { AdminFormDto } from '~shared/types/form/form'
@@ -15,9 +15,21 @@ export const adminFormKeys = {
 /**
  * @precondition Must be wrapped in a Router as `useParam` is used.
  */
-export const useAdminForm = (): UseQueryResult<AdminFormDto, ApiError> => {
+export const useAdminForm = (
+  props?: QueryObserverOptions<
+    AdminFormDto,
+    ApiError,
+    AdminFormDto,
+    AdminFormDto,
+    ReturnType<typeof adminFormKeys.id>
+  >,
+): UseQueryResult<AdminFormDto, ApiError> => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  return useQuery(adminFormKeys.id(formId), () => getAdminFormView(formId))
+  return useQuery(
+    adminFormKeys.id(formId),
+    () => getAdminFormView(formId),
+    props,
+  )
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,11 +2,7 @@
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,10 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "downlevelIteration": true
   },
-  "include": [
-    "src/**/*",
-    ".storybook/**/*"
-  ]
+  "include": ["src/**/*", ".storybook/**/*"]
 }

--- a/shared/utils/immutable-array-fns.ts
+++ b/shared/utils/immutable-array-fns.ts
@@ -78,3 +78,11 @@ export const replaceAt = <T>(
   ret[index] = newValue
   return ret
 }
+
+export const insertAt = <T>(
+  array: ExtractTypeFromArray<T>[],
+  index: number,
+  valueToInsert: ExtractTypeFromArray<T>,
+): ExtractTypeFromArray<T>[] => {
+  return [...array.slice(0, index), valueToInsert, ...array.slice(index)]
+}

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -609,9 +609,23 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return this.save()
   }
 
-  FormDocumentSchema.methods.insertFormField = function (newField: FormField) {
-    // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;(this.form_fields as Types.DocumentArray<IFieldSchema>).push(newField)
+  FormDocumentSchema.methods.insertFormField = function (
+    newField: FormField,
+    to?: number,
+  ) {
+    // Insert new field in specified position if provided.
+    if (to) {
+      // eslint-disable-next-line @typescript-eslint/no-extra-semi
+      ;(this.form_fields as Types.DocumentArray<IFieldSchema>).splice(
+        to,
+        0,
+        newField as any, // Typings are not complete for splice.
+        // See https://mongoosejs.com/docs/api/array.html#mongoosearray_MongooseArray-splice
+      )
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-extra-semi
+      ;(this.form_fields as Types.DocumentArray<IFieldSchema>).push(newField)
+    }
     return this.save()
   }
 

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1696,9 +1696,11 @@ export const handleUpdateFormField = [
 export const _handleCreateFormField: ControllerHandler<
   { formId: string },
   FormFieldWithId | ErrorDto,
-  FieldCreateDto
+  FieldCreateDto,
+  { to?: number }
 > = (req, res) => {
   const { formId } = req.params
+  const { to } = req.query
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Step 1: Retrieve currently logged in user.
@@ -1713,7 +1715,7 @@ export const _handleCreateFormField: ControllerHandler<
         }),
       )
       // Step 3: User has permissions, proceed to create form field with provided body.
-      .andThen((form) => AdminFormService.createFormField(form, req.body))
+      .andThen((form) => AdminFormService.createFormField(form, req.body, to))
       .map((createdFormField) =>
         res.status(StatusCodes.OK).json(createdFormField as FormFieldWithId),
       )
@@ -1911,6 +1913,10 @@ export const handleCreateFormField = [
       // Allow other field related key-values to be provided and let the model
       // layer handle the validation.
     }).unknown(true),
+    [Segments.QUERY]: {
+      // Optional index to insert the field at.
+      to: Joi.number().min(0),
+    },
   }),
   _handleCreateFormField,
 ]

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -523,33 +523,43 @@ export const duplicateFormField = (
  * Inserts a new form field into given form's fields with the field provided
  * @param form the form to insert the new field into
  * @param newField the new field to insert
+ * @param to optional index to insert the new field at
  * @returns ok(created form field)
  * @returns err(PossibleDatabaseError) when database errors arise
  */
 export const createFormField = (
   form: IPopulatedForm,
   newField: FieldCreateDto,
+  to?: number,
 ): ResultAsync<
   FormFieldSchema,
   PossibleDatabaseError | FormNotFoundError | FieldNotFoundError
 > => {
-  return ResultAsync.fromPromise(form.insertFormField(newField), (error) => {
-    logger.error({
-      message: 'Error encountered while inserting new form field',
-      meta: {
-        action: 'createFormField',
-        formId: form._id,
-        newField,
-      },
-      error,
-    })
+  return ResultAsync.fromPromise(
+    form.insertFormField(newField, to),
+    (error) => {
+      logger.error({
+        message: 'Error encountered while inserting new form field',
+        meta: {
+          action: 'createFormField',
+          formId: form._id,
+          newField,
+          to,
+        },
+        error,
+      })
 
-    return transformMongoError(error)
-  }).andThen((updatedForm) => {
+      return transformMongoError(error)
+    },
+  ).andThen((updatedForm) => {
     if (!updatedForm) {
       return errAsync(new FormNotFoundError())
     }
-    const updatedField = last(updatedForm.form_fields)
+    let indexToRetrieve = updatedForm.form_fields.length - 1
+    if (to && to < indexToRetrieve) {
+      indexToRetrieve = to
+    }
+    const updatedField = updatedForm.form_fields[indexToRetrieve]
     return updatedField
       ? okAsync(updatedField)
       : errAsync(new FieldNotFoundError())

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -178,10 +178,15 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   /**
    * Inserts a form field into the form
    * @param newField the new field to insert
+   * @param to Optional position to insert the field at. If not provided, field will be inserted at the end.
    * @returns updated form after the insertion if field insertion is successful
    * @throws validation error on invalid updates
    */
-  insertFormField<T>(this: T, newField: FormField): Promise<T | null>
+  insertFormField<T>(
+    this: T,
+    newField: FormField,
+    to?: number,
+  ): Promise<T | null>
 
   /**
    * Returns the dashboard form view of the form.


### PR DESCRIPTION
This PR is part of the chain for `form-v2/feat/builder` branch.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR adds form field creation feature into the form builder. In addition, the create form field server API has been extended to accept a positional argument to facilitate this new feature. The API is backwards compatible as the new positional argument is optional.

Related to #3132 
Closes #1847, #3133

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
  - New API for positional create. If rolled back, new created form fields will be set to the end of the form field array

### Client updates
**Features**:
- feat: render drawer contents according to drawer tab state
- feat: add copy-on-drag create form field behaviour in CreateFieldDrawer
  - feat: set up logic and styling for drag and drop placeholder
- feat: extract BuilderContentPlaceholder component for different placeholders depending on the dragged item
- feat(shared): add immutable array insertAt function
- feat: update edit builder drawer close and back handling
- feat: add and use create form field service fn and mutation

**Improvements**:

- feat: move DragDropContext to FormBuilderPage to be shared between builder, drawer and content
- feat: use constants for field creation sections and drop ids

**Bug fixes**:
- fix: refresh field drawer content whenever active field changes 
  - Previously, if the active field is the same field type, the rendered drawer content will not refresh.

### Server updates
**Features**:
- feat(AdminFormRoutes): add positional query for create form field, (see issue #1847)

## Before & After Screenshots
SOON

## Tests
<!-- What tests should be run to confirm functionality? -->
SOON 
