### PR TITLE
chore(ci): add lint and build stages to GA CI, update mergify CI

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - title~=bump [^\s]+ from ([\d]+)\..+ to \1\.
-      - check-success~=install
+      - check-success~=build
       - check-success~=test-frontend
       - check-success~=test-backend
       - check-success~=test-e2e
@@ -23,7 +23,7 @@ pull_request_rules:
     conditions:
       - author=snyk-bot
       - title~=\[Snyk\] Security upgrade [^\s]+ from ([\d]+)\..+ to \1\.
-      - check-success~=install
+      - check-success~=build
       - check-success~=test-frontend
       - check-success~=test-backend
       - check-success~=test-e2e

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,6 @@ pull_request_rules:
       - check-success~=CodeQL # CodeQL code scanning results
       - check-success~=GitGuardian
       - check-success~=Semantic Pull Request
-      - check-success~=build_deploy_application
       - check-success~=coverage/coveralls
       - check-success~=license/snyk
       - check-success~=security/snyk
@@ -32,7 +31,6 @@ pull_request_rules:
       - check-success~=CodeQL # CodeQL code scanning results
       - check-success~=GitGuardian
       - check-success~=Semantic Pull Request
-      - check-success~=build_deploy_application
       - check-success~=coverage/coveralls
       - check-success~=license/snyk
       - check-success~=security/snyk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   install:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -25,11 +24,45 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - run: npm ci
-
-  test-e2e:
+  lint:
     needs: install
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run lint-ci
 
+  build:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run build
+
+  test-e2e:
+    needs: lint
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -46,9 +79,8 @@ jobs:
       - run: npm run test-e2e
 
   test-frontend:
-    needs: install
+    needs: lint
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -65,9 +97,8 @@ jobs:
       - run: npm run test-frontend
 
   test-backend:
-    needs: install
+    needs: lint
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Mergify CI stopped auto-approving due to the need of deployment checks introduced in #3120. This PR fixes that, whilst simultaneously fixing the lack of lint and build checks due to the removal of Travis CI in that same PR.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- chore(ci): add lint, build stages to github actions CI workflow 
- chore(ci): update mergify to ignore build_deploy_application, and check for new `build` workflow success instead of `build_deploy_application` workflow that will only be triggered on release branches.

