### PR TITLE
fix(ci/deploy): set truncated description during ELB deployment

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -76,7 +76,7 @@ jobs:
           aws elasticbeanstalk create-application-version --application-name $APP_NAME \
           --version-label $IMAGE_TAG \
           --source-bundle S3Bucket=$BUCKET_NAME,S3Key=$IMAGE_TAG.zip \
-          --description $TRUNCATED_DESC
+          --description "$TRUNCATED_DESC"
 
       - name: Update EB environment
         id: update-eb-1

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -72,7 +72,7 @@ jobs:
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           APP_NAME: ${{ secrets.APP_NAME }}
         run: |
-          TRUNCATED_DESC=$(echo ${{github.event.head_commit.message}} | cut -d -200)
+          TRUNCATED_DESC=$(echo "${{github.event.head_commit.message}}" | cut -b1-180)
           aws elasticbeanstalk create-application-version --application-name $APP_NAME \
           --version-label $IMAGE_TAG \
           --source-bundle S3Bucket=$BUCKET_NAME,S3Key=$IMAGE_TAG.zip \

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -72,10 +72,11 @@ jobs:
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           APP_NAME: ${{ secrets.APP_NAME }}
         run: |
+          TRUNCATED_DESC=$(echo ${{github.event.head_commit.message}} | cut -d -200)
           aws elasticbeanstalk create-application-version --application-name $APP_NAME \
           --version-label $IMAGE_TAG \
           --source-bundle S3Bucket=$BUCKET_NAME,S3Key=$IMAGE_TAG.zip \
-          --description "${{ github.event.head_commit.message }}"
+          --description $TRUNCATED_DESC
 
       - name: Update EB environment
         id: update-eb-1


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We use git commit messages as the description for our ELB deployment.
AWS has a hard limit of 200 characters, which may exceed when a commit message is longer (like this) and throw an error. This commit attempts to fix that by truncating the commit message if it is longer than 200 characters.

