### PR TITLE
Fix/twilio webhook

### DIFF
--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -1,9 +1,8 @@
+import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
-import Twilio from 'twilio'
 
 import { ITwilioSmsWebhookBody } from 'src/types/twilio'
 
-import { isDev } from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
 
@@ -11,8 +10,26 @@ const logger = createLoggerWithLabel(module)
 
 /**
  * Middleware which validates that a request came from Twilio Webhook
+ * by checking the presence of X-Twilio-Sgnature in request header and
+ * sms delivery status request body parameters
  */
-const validateTwilioWebhook = Twilio.webhook({ validate: !isDev })
+const validateTwilioWebhook = celebrate({
+  [Segments.HEADERS]: Joi.object({
+    'x-twilio-signature': Joi.string().required(),
+  }).unknown(),
+  [Segments.BODY]: Joi.object().keys({
+    SmsSid: Joi.string().required(),
+    SmsStatus: Joi.string().required(),
+    MessageStatus: Joi.string().required(),
+    To: Joi.string().required(),
+    MessageSid: Joi.string().required(),
+    AccountSid: Joi.string().required(),
+    From: Joi.string().required(),
+    ApiVersion: Joi.string().required(),
+    ErrorCode: Joi.number(), //Unable to find any official documentation stating the ErrorCode type but should be a number
+    ErrorMessage: Joi.string(),
+  }),
+})
 
 /**
  * Logs all incoming Webhook requests from Twilio in AWS

--- a/src/app/routes/api/v3/notifications/__tests__/notifications.routes.spec.ts
+++ b/src/app/routes/api/v3/notifications/__tests__/notifications.routes.spec.ts
@@ -45,11 +45,15 @@ describe('notifications.routes', () => {
     ErrorMessage: 'Twilio is down!',
   }
 
+  const TWILIO_SIGNATURE_HEADER_KEY = 'x-twilio-signature'
+  const MOCK_TWILIO_SIGNATURE = 'mockSignature'
+
   describe('POST notifications/twilio', () => {
     it('should return 200 on sending successful delivery status message', async () => {
       const response = await request
         .post('/notifications/twilio')
         .send(MOCK_SUCCESSFUL_MESSAGE)
+        .set(TWILIO_SIGNATURE_HEADER_KEY, MOCK_TWILIO_SIGNATURE)
 
       expect(response.status).toEqual(200)
       expect(response.body).toBeEmpty()
@@ -59,9 +63,18 @@ describe('notifications.routes', () => {
       const response = await request
         .post('/notifications/twilio')
         .send(MOCK_FAILED_MESSAGE)
+        .set(TWILIO_SIGNATURE_HEADER_KEY, MOCK_TWILIO_SIGNATURE)
 
       expect(response.status).toEqual(200)
       expect(response.body).toBeEmpty()
+    })
+
+    it('should return 400 on sending successful delivery status message without wilio signature', async () => {
+      const response = await request
+        .post('/notifications/twilio')
+        .send(MOCK_SUCCESSFUL_MESSAGE)
+
+      expect(response.status).toEqual(400)
     })
   })
 })

--- a/src/app/routes/api/v3/notifications/notifications.routes.ts
+++ b/src/app/routes/api/v3/notifications/notifications.routes.ts
@@ -9,10 +9,7 @@ export const NotificationsRouter = Router()
 NotificationsRouter.use('/bounces', BouncesRouter)
 
 /**
- * Receives SMS delivery status updates from Twilio webhook
- *
- * Logs any errors or failures in SMS delivery while ignoring succesful
- * status updates
+ * Receives and logs all SMS delivery status updates from Twilio webhook
  *
  * Path here is required to be synced with statusCallbackRoute under
  * sms.service#sendSms
@@ -20,7 +17,6 @@ NotificationsRouter.use('/bounces', BouncesRouter)
  * @route POST /api/v3/notifications/twilio
  *
  * @returns 200 when message succesfully received and logged
- * @returns 400 when request is not coming from Twilio
- * @returns 403 when twilio request validation failed
+ * @returns 400 when request is not coming from Twilio or request body s invalid
  */
 NotificationsRouter.post('/twilio', handleTwilioSmsUpdates)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Current, twilio webhook endpoint to receive sms delivery status updates returns 403 in new release 5.37.0. 

This is because during the validation step, the auth token used by the twilio validation middleware is different from the auth token used to send sms (users own token).

Closes #3154

# Solution

Switch to validate Twilio webhook requests by using `celebrate` to check for the presence of twilio request headers and request body parameters 