### PR TITLE
feat: enable M series FIN validation

### DIFF
--- a/src/app/utils/field-validation/validators/nricValidator.ts
+++ b/src/app/utils/field-validation/validators/nricValidator.ts
@@ -1,7 +1,10 @@
 import { chain, left, right } from 'fp-ts/lib/Either'
 import { flow } from 'fp-ts/lib/function'
 
-import { isNricValid } from '../../../../../shared/utils/nric-validation'
+import {
+  isMFinSeriesValid,
+  isNricValid,
+} from '../../../../../shared/utils/nric-validation'
 import { ResponseValidator } from '../../../../types/field/utils/validation'
 import { ProcessedSingleAnswerResponse } from '../../../modules/submission/submission.types'
 
@@ -15,7 +18,7 @@ type NricValidatorConstructor = () => NricValidator
  * format is correct.
  */
 const nricValidator: NricValidator = (response) => {
-  return isNricValid(response.answer)
+  return isNricValid(response.answer) || isMFinSeriesValid(response.answer)
     ? right(response)
     : left(`NricValidator:\tanswer is not a valid NRIC`)
 }

--- a/src/public/modules/forms/base/directives/validate-nric.client.directive.js
+++ b/src/public/modules/forms/base/directives/validate-nric.client.directive.js
@@ -2,6 +2,7 @@
 
 const {
   isNricValid,
+  isMFinSeriesValid,
 } = require('../../../../../../shared/utils/nric-validation')
 
 angular.module('forms').directive('validateNric', validateNric)
@@ -12,7 +13,9 @@ function validateNric() {
     require: 'ngModel',
     link: function (_scope, _elem, _attrs, ctrl) {
       ctrl.$validators.nricValidator = function (modelValue) {
-        return ctrl.$isEmpty(modelValue) ? true : isNricValid(modelValue)
+        return ctrl.$isEmpty(modelValue)
+          ? true
+          : isNricValid(modelValue) || isMFinSeriesValid(modelValue)
       }
     },
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, M series FIN/NRIC validation has been implemented but is not being used.

Closes #3155


## Manual Tests
- Create a NRIC field on a form
- Type in M1234567K (or any other valid M series FIN value), there should be no warning displayed in the browser
- Submit a response to the form with M1234567K as the value in the NRIC field, no error should occur


