### PR TITLE
chore: allow forked PRs to run our github action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+  pull_request_target:
+    types: [opened, reopened]
   pull_request:
     types: [opened, reopened]
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Forked PRs (see #2819) seem to not be able to run our Github Action workflows due to missing trigger conditions.
This results in a bad experience for any open source contributors and should be fixed.

This PR adds a new `pull_request_target` workflow trigger to our CI workflow config.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
New `pull_request_target` trigger on our `CI` Github workflow.