### PR TITLE
feat(v2): update Tile and Badge styling to better fit design 

### DIFF
--- a/frontend/src/components/Tile/Tile.stories.tsx
+++ b/frontend/src/components/Tile/Tile.stories.tsx
@@ -6,14 +6,7 @@ import { values } from 'lodash'
 
 import Badge from '~components/Badge'
 
-import {
-  Tile,
-  TileListItem,
-  TileProps,
-  TileSubtitle,
-  TileText,
-  TileTitle,
-} from './Tile'
+import { Tile, TileProps } from './Tile'
 
 export default {
   title: 'Components/Tiles',
@@ -29,12 +22,12 @@ const List = ({
   listItems: string[]
 }) => (
   <>
-    <TileText textStyle="subhead-2">{listTitle}</TileText>
+    <Tile.Text textStyle="subhead-2">{listTitle}</Tile.Text>
     <UnorderedList>
       {listItems.map((text) => (
-        <TileListItem textStyle="body-2" textAlign="left">
+        <Tile.ListItem textStyle="body-2" textAlign="left">
           {text}
-        </TileListItem>
+        </Tile.ListItem>
       ))}
     </UnorderedList>
   </>
@@ -62,8 +55,8 @@ const Template: Story<TileTemplateProps> = ({
       onClick={() => setIsClicked(!isClicked)}
       isActive={isClicked}
     >
-      <TileTitle>{title}</TileTitle>
-      <TileSubtitle>{subtitle}</TileSubtitle>
+      <Tile.Title>{title}</Tile.Title>
+      <Tile.Subtitle>{subtitle}</Tile.Subtitle>
       {hasDescription && (
         <List listTitle={listTitle} listItems={values(listItems)} />
       )}
@@ -127,8 +120,8 @@ const EmailTile = ({ onClick, isActive }: StoryTileProps) => (
     onClick={onClick}
     isFullWidth
   >
-    <TileTitle>Email Mode</TileTitle>
-    <TileSubtitle>Receive responses in your inbox</TileSubtitle>
+    <Tile.Title>Email Mode</Tile.Title>
+    <Tile.Subtitle>Receive responses in your inbox</Tile.Subtitle>
     <List
       listTitle="Who is it for:"
       listItems={['Emailed copy of response', 'MyInfo fields']}
@@ -145,8 +138,8 @@ const StorageTile = ({ onClick, isActive }: StoryTileProps) => (
     onClick={onClick}
     isFullWidth
   >
-    <TileTitle>Storage Mode</TileTitle>
-    <TileSubtitle>Receive responses in Form</TileSubtitle>
+    <Tile.Title>Storage Mode</Tile.Title>
+    <Tile.Subtitle>Receive responses in Form</Tile.Subtitle>
     <List
       listTitle="Who is it for:"
       listItems={['High-volume forms', 'End to end encryption needs']}

--- a/frontend/src/components/Tile/Tile.stories.tsx
+++ b/frontend/src/components/Tile/Tile.stories.tsx
@@ -24,8 +24,8 @@ const List = ({
   <>
     <Tile.Text textStyle="subhead-2">{listTitle}</Tile.Text>
     <UnorderedList>
-      {listItems.map((text) => (
-        <Tile.ListItem textStyle="body-2" textAlign="left">
+      {listItems.map((text, i) => (
+        <Tile.ListItem textStyle="body-2" textAlign="left" key={i}>
           {text}
         </Tile.ListItem>
       ))}
@@ -118,7 +118,7 @@ const EmailTile = ({ onClick, isActive }: StoryTileProps) => (
     icon={BiMailSend}
     isActive={isActive}
     onClick={onClick}
-    isFullWidth
+    flex={1}
   >
     <Tile.Title>Email Mode</Tile.Title>
     <Tile.Subtitle>Receive responses in your inbox</Tile.Subtitle>
@@ -136,7 +136,7 @@ const StorageTile = ({ onClick, isActive }: StoryTileProps) => (
     badge={<Badge colorScheme="success">recommended</Badge>}
     isActive={isActive}
     onClick={onClick}
-    isFullWidth
+    flex={1}
   >
     <Tile.Title>Storage Mode</Tile.Title>
     <Tile.Subtitle>Receive responses in Form</Tile.Subtitle>

--- a/frontend/src/components/Tile/Tile.tsx
+++ b/frontend/src/components/Tile/Tile.tsx
@@ -58,14 +58,14 @@ type TileWithParts = ComponentWithAs<'button', TileProps> & {
 }
 
 export const Tile = forwardRef<TileProps, 'button'>(
-  ({ badge, icon, variant = 'simple', children, isActive, ...props }, ref) => {
-    const styles = useMultiStyleConfig('Tile', { variant, isActive })
+  ({ badge, icon, children, ...props }, ref) => {
+    const styles = useMultiStyleConfig('Tile', props)
     return (
       // Ref passed into the component as a whole so that it can be focused
       <StylesProvider value={styles}>
         <Button sx={styles.container} ref={ref} {...props}>
           <HStack spacing="1rem">
-            <Icon sx={styles.icon} as={icon}></Icon>
+            <Icon __css={styles.icon} as={icon} />
             {badge}
           </HStack>
           {children}

--- a/frontend/src/components/Tile/Tile.tsx
+++ b/frontend/src/components/Tile/Tile.tsx
@@ -2,6 +2,7 @@ import { IconType } from 'react-icons/lib'
 import {
   Button,
   ButtonProps,
+  ComponentWithAs,
   forwardRef,
   HStack,
   Icon,
@@ -46,10 +47,16 @@ export interface TileProps
    * The variant of the tile - whether it is complex (many elements) or simple (title and subtitle only).
    * Defaults to simple.
    */
-  variant: TileVariant
+  variant: 'complex' | 'simple'
 }
 
-type TileVariant = 'complex' | 'simple'
+type TileWithParts = ComponentWithAs<'button', TileProps> & {
+  Subtitle: typeof TileSubtitle
+  Title: typeof TileTitle
+  Text: typeof TileText
+  ListItem: typeof TileListItem
+}
+
 export const Tile = forwardRef<TileProps, 'button'>(
   ({ badge, icon, variant = 'simple', children, isActive, ...props }, ref) => {
     const styles = useMultiStyleConfig('Tile', { variant, isActive })
@@ -66,28 +73,33 @@ export const Tile = forwardRef<TileProps, 'button'>(
       </StylesProvider>
     )
   },
-)
+) as TileWithParts
 
-export const TileTitle = (props: TextProps): JSX.Element => {
+const TileTitle = (props: TextProps): JSX.Element => {
   const styles = useStyles()
   // Allow consumers to override default style props with their own styling
   return <Text sx={styles.title} {...props} />
 }
 
-export const TileSubtitle = (props: TextProps): JSX.Element => {
+const TileSubtitle = (props: TextProps): JSX.Element => {
   const styles = useStyles()
   // Allow consumers to override default style props with their own styling
   return <Text sx={styles.subtitle} {...props} />
 }
 
-export const TileText = (props: TextProps): JSX.Element => {
+const TileText = (props: TextProps): JSX.Element => {
   return <Text color="secondary.400" {...props} />
 }
 
-export const TileListItem = (props: TextProps): JSX.Element => {
+const TileListItem = (props: TextProps): JSX.Element => {
   return (
     <ListItem>
       <TileText textStyle="body-2" textAlign="left" {...props} />
     </ListItem>
   )
 }
+
+Tile.Title = TileTitle
+Tile.Subtitle = TileSubtitle
+Tile.ListItem = TileListItem
+Tile.Text = TileText

--- a/frontend/src/theme/components/Badge.ts
+++ b/frontend/src/theme/components/Badge.ts
@@ -31,8 +31,9 @@ export const Badge: ComponentStyleConfig = {
   },
   sizes: {
     md: {
-      p: '0.25rem',
-      borderRadius: '0.25rem',
+      py: '0.25rem',
+      px: '0.5rem',
+      borderRadius: '4px',
     },
   },
   defaultProps: {

--- a/frontend/src/theme/components/Tile.ts
+++ b/frontend/src/theme/components/Tile.ts
@@ -1,50 +1,48 @@
-import { anatomy, SystemStyleObject } from '@chakra-ui/theme-tools'
+import { anatomy } from '@chakra-ui/theme-tools'
 
 import { ComponentMultiStyleConfig } from '~theme/types'
 
 const parts = anatomy('tile').parts('container', 'title', 'icon', 'subtitle')
 
-const activeContainerStyle: SystemStyleObject = {
-  bgColor: 'primary.200',
-  borderColor: 'transparent',
-  // NOTE: For the boxShadow styling, due to conflicts with the focus-visible package,
-  // the !important is required to display the boxShadow styling correctly.
-  boxShadow: '0 0 0 3px var(--chakra-colors-primary-500) !important',
-  _hover: {
-    bgColor: 'primary.200',
-  },
-}
-
-const baseContainerStyle: SystemStyleObject = {
-  color: 'inherit',
-  borderRadius: '0.25rem',
-  padding: '1.5rem',
-  _hover: {
-    bgColor: 'primary.100',
-  },
-  _focus: {
-    borderColor: 'transparent',
-    // NOTE: For the boxShadow styling, due to conflicts with the focus-visible package,
-    // the !important is required to display the boxShadow styling correctly.
-    boxShadow: '0 0 0 2px var(--chakra-colors-primary-500) !important',
-  },
-  _active: activeContainerStyle,
-  bgColor: 'white',
-  border: '1px solid',
-  borderColor: 'neutral.300',
-  whiteSpace: 'pre-line',
-  flexDir: 'column',
-  alignItems: 'flex-start',
-  maxWidth: 'inherit',
-  textAlign: 'left',
-}
-
 export const Tile: ComponentMultiStyleConfig<typeof parts> = {
   parts: parts.keys,
-  baseStyle: ({ isActive }) => ({
-    container: isActive
-      ? { ...baseContainerStyle, ...activeContainerStyle }
-      : baseContainerStyle,
+  baseStyle: {
+    container: {
+      transitionProperty: 'common',
+      transitionDuration: 'normal',
+      color: 'inherit',
+      borderRadius: '0.25rem',
+      padding: '1.5rem',
+      _hover: {
+        bgColor: 'primary.100',
+      },
+      _focus: {
+        borderColor: 'transparent',
+        // NOTE: For the boxShadow styling, due to conflicts with the focus-visible package,
+        // the !important is required to display the boxShadow styling correctly.
+        boxShadow: '0 0 0 2px var(--chakra-colors-primary-500) !important',
+      },
+      _active: {
+        bgColor: 'primary.200',
+        // borderColor: 'transparent',
+        boxShadow: '0 0 0 3px var(--chakra-colors-primary-400)',
+        _focus: {
+          // NOTE: For the boxShadow styling, due to conflicts with the focus-visible package,
+          // the !important is required to display the boxShadow styling correctly.
+          boxShadow: '0 0 0 3px var(--chakra-colors-primary-500) !important',
+        },
+      },
+      bgColor: 'white',
+      border: '1px solid',
+      borderColor: 'neutral.300',
+      whiteSpace: 'pre-line',
+      flexDir: 'column',
+      alignItems: 'flex-start',
+      maxWidth: 'inherit',
+      textAlign: 'left',
+      alignSelf: 'stretch',
+      justifyContent: 'stretch',
+    },
     title: {
       color: 'secondary.700',
       textStyle: 'h4',
@@ -58,7 +56,7 @@ export const Tile: ComponentMultiStyleConfig<typeof parts> = {
       color: 'secondary.500',
       textStyle: 'body-2',
     },
-  }),
+  },
   variants: {
     complex: {
       title: {
@@ -71,5 +69,8 @@ export const Tile: ComponentMultiStyleConfig<typeof parts> = {
     simple: {
       title: { mb: '1rem' },
     },
+  },
+  defaultProps: {
+    variant: 'simple',
   },
 }

--- a/frontend/src/theme/components/Tile.ts
+++ b/frontend/src/theme/components/Tile.ts
@@ -52,6 +52,7 @@ export const Tile: ComponentMultiStyleConfig<typeof parts> = {
     },
     icon: {
       boxSize: '2.5rem',
+      color: 'secondary.500',
     },
     subtitle: {
       color: 'secondary.500',


### PR DESCRIPTION
> Cherry picked commits from #3048 into its own smaller PR.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Our Tile and Badge components are not fully compliant with the design. This PR attempts to correct that variance.

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- ref: reexport Tile subcomponents in Tile instead their own components
- style(Tile): add default color for tile icon
- style(Tile): simplify styles
- style(Badge): update styles according to design
