### PR TITLE
chore: enable dependabot for /shared directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/shared' # Location of package manifests
+    schedule:
+      interval: 'daily'
+      time: '03:00'
+      timezone: 'Asia/Singapore'
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'


### PR DESCRIPTION
Dependabot has not been running on the `/shared` directory ever since it was shared out. This PR adds that in