### PR TITLE
chore: attempt adding explicit branch to run PR actions on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-  pull_request_target:
-    types: [opened, reopened]
   pull_request:
+    branches: [develop]
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Adding `pull_request_target` didn't work... now trying to add an explicit branch to run PR requests on similar to our CodeQL github action (that runs properly on forked PRs).

