### PR TITLE
feat(v2): [Date1] add DateRangePicker/Input component

### DIFF
--- a/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
@@ -129,6 +129,20 @@ const useProvideCalendar = ({
     })
   }, [uuid])
 
+  const updateMonthYear = useCallback(
+    (newDate: Date) => {
+      const monthDiff = differenceInCalendarMonths(
+        newDate,
+        new Date(currYear, currMonth),
+      )
+      if (monthDiff < 0 || monthDiff > monthsToDisplay - 1) {
+        setCurrMonth(newDate.getMonth())
+        setCurrYear(newDate.getFullYear())
+      }
+    },
+    [currMonth, currYear, monthsToDisplay],
+  )
+
   /**
    * Allows user to change focus across rows/columns using arrow keys. The
    * idea is to attach a unique classname to each day, from which we can derive
@@ -152,20 +166,14 @@ const useProvideCalendar = ({
       const newDate = getNewDateFromKeyPress(focusedDate, e.key)
       if (newDate === focusedDate) return
       // If newDate is outside current displayed months, scroll to that month
-      const monthDiff = differenceInCalendarMonths(
-        newDate,
-        new Date(currYear, currMonth),
-      )
-      if (monthDiff < 0 || monthDiff > monthsToDisplay - 1) {
-        setCurrMonth(newDate.getMonth())
-        setCurrYear(newDate.getFullYear())
-      }
+      updateMonthYear(newDate)
+
       const elementToFocus = document.querySelector(
         `.${generateClassNameForDate(uuid, newDate)}`,
       ) as HTMLButtonElement | null
       elementToFocus?.focus()
     },
-    [currMonth, currYear, monthsToDisplay, uuid],
+    [updateMonthYear, uuid],
   )
   useKey((e) => ARROW_KEY_NAMES.includes(e.key), handleArrowKey)
 
@@ -173,12 +181,11 @@ const useProvideCalendar = ({
     (d: Date) => {
       if (isDateUnavailable?.(d)) return
       // Set current month/year to that of selected
-      setCurrMonth(d.getMonth())
-      setCurrYear(d.getFullYear())
+      updateMonthYear(d)
       // Call parent callback
       onSelectDate?.(d)
     },
-    [isDateUnavailable, onSelectDate],
+    [isDateUnavailable, onSelectDate, updateMonthYear],
   )
 
   const renderProps = useDayzed({

--- a/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
@@ -15,6 +15,7 @@ import {
   isSameDay,
 } from 'date-fns'
 import { Props as DayzedProps, RenderProps, useDayzed } from 'dayzed'
+import { inRange } from 'lodash'
 
 import { DatePickerProps } from '../DatePicker'
 import {
@@ -253,7 +254,10 @@ const useProvideCalendar = ({
     (d: Date) => {
       // If there is a selected date in the current month, make it
       // the only focusable date
-      if (dateToFocus && dateToFocus.getMonth() === currMonth) {
+      if (
+        dateToFocus &&
+        inRange(dateToFocus.getMonth(), currMonth, currMonth + monthsToDisplay)
+      ) {
         return isSameDay(d, dateToFocus)
       }
       // If today is in the current month, make it the only focusable date
@@ -268,7 +272,7 @@ const useProvideCalendar = ({
       // currMonth or the spillover dates for the next month will be included.
       return d.getMonth() === currMonth && isFirstDayOfMonth(d)
     },
-    [dateToFocus, currMonth],
+    [dateToFocus, currMonth, monthsToDisplay],
   )
 
   return {

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  forwardRef,
-  SimpleGrid,
-  Stack,
-  useStyles,
-  Wrap,
-} from '@chakra-ui/react'
+import { Box, forwardRef, SimpleGrid, Stack, useStyles } from '@chakra-ui/react'
 import { isSameDay } from 'date-fns'
 
 import { DAY_NAMES, generateClassNameForDate } from '../utils'
@@ -26,14 +19,14 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
     } = useCalendar()
 
     return (
-      <Wrap
-        shouldWrapChildren
+      <Stack
+        direction={{ base: 'column', md: 'row' }}
         spacing="2rem"
         sx={styles.calendarContainer}
         onMouseLeave={onMouseLeaveCalendar}
       >
         {calendars.map((calendar, i) => (
-          <Stack key={i} spacing={0}>
+          <Stack spacing={0} key={i}>
             <CalendarHeader monthOffset={i} />
             <SimpleGrid
               key={`${calendar.month}${calendar.year}`}
@@ -74,7 +67,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
             </SimpleGrid>
           </Stack>
         ))}
-      </Wrap>
+      </Stack>
     )
   },
 )

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -16,18 +16,22 @@ import { DayOfMonth } from './DayOfMonth'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const CalendarPanel = forwardRef<{}, 'button'>(
-  (_, initialFocusRef): JSX.Element => {
+  (_props, initialFocusRef): JSX.Element => {
     const styles = useStyles()
     const {
       uuid,
-      isDateUnavailable,
-      isDateFocusable,
       dateToFocus,
+      onMouseLeaveCalendar,
       renderProps: { calendars, getDateProps },
     } = useCalendar()
 
     return (
-      <Wrap shouldWrapChildren spacing="2rem" sx={styles.calendarContainer}>
+      <Wrap
+        shouldWrapChildren
+        spacing="2rem"
+        sx={styles.calendarContainer}
+        onMouseLeave={onMouseLeaveCalendar}
+      >
         {calendars.map((calendar, i) => (
           <Stack key={i} spacing={0}>
             <CalendarHeader monthOffset={i} />
@@ -44,26 +48,22 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
               {calendar.weeks.map((week, windex) =>
                 week.map((dateObj, index) => {
                   if (!dateObj) {
-                    return null
+                    return (
+                      <Box
+                        key={`${calendar.month}${calendar.year}${windex}${index}`}
+                      />
+                    )
                   }
-                  const { date, selected, today } = dateObj
                   return (
                     <DayOfMonth
                       key={`${calendar.month}${calendar.year}${windex}${index}`}
                       {...getDateProps({
                         dateObj,
                       })}
-                      date={date}
-                      isSelected={selected}
-                      isAvailable={!isDateUnavailable?.(date)}
-                      // Use the latest date for today rather than the memoised today,
-                      // since this doesn't affect offset logic
-                      isToday={today}
-                      isOutsideCurrMonth={date.getMonth() !== calendar.month}
-                      isFocusable={isDateFocusable(date)}
-                      className={generateClassNameForDate(uuid, date)}
+                      dateObj={dateObj}
+                      className={generateClassNameForDate(uuid, dateObj.date)}
                       ref={
-                        isSameDay(date, dateToFocus)
+                        isSameDay(dateObj.date, dateToFocus)
                           ? initialFocusRef
                           : undefined
                       }

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -30,7 +30,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
       <Wrap shouldWrapChildren spacing="2rem" sx={styles.calendarContainer}>
         {calendars.map((calendar, i) => (
           <Stack key={i} spacing={0}>
-            <CalendarHeader />
+            <CalendarHeader monthOffset={i} />
             <SimpleGrid
               key={`${calendar.month}${calendar.year}`}
               columns={DAY_NAMES.length}

--- a/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
+++ b/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
@@ -6,7 +6,13 @@ import {
   forwardRef,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
-import { compareAsc, format, isSameDay } from 'date-fns'
+import {
+  compareAsc,
+  format,
+  isFirstDayOfMonth,
+  isLastDayOfMonth,
+  isSameDay,
+} from 'date-fns'
 import { DateObj } from 'dayzed'
 
 import { DATE_INPUT_THEME_KEY } from '~theme/components/DateInput'
@@ -27,7 +33,12 @@ export interface DayOfMonthProps extends ButtonProps {
 
 export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
   (
-    { dateObj: { date, selected, today }, isOutsideCurrMonth, ...props },
+    {
+      dateObj: { date, selected, today },
+      isOutsideCurrMonth,
+      colorScheme = 'primary',
+      ...props
+    },
     ref,
   ) => {
     const {
@@ -60,11 +71,11 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
     const styles = useMultiStyleConfig(DATE_INPUT_THEME_KEY, {
       isSelected: selected,
       isToday: today,
-      isInRange,
       isOutsideCurrMonth,
     })
 
-    const buttonBg = useMemo(() => {
+    const buttonBoxBg = useMemo(() => {
+      const gradientColor = `var(--chakra-colors-${colorScheme}-200)`
       let gradientTo: 'left' | 'right' | undefined
       // Only style background if it is a range.
       if (Array.isArray(selectedDates)) {
@@ -85,34 +96,59 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
           gradientTo = 'right'
           // Case 4: Only one date selected, background corner should follow
           // date that is selected.
-          if (
-            hoveredDate &&
-            selectedDates.length === 1 &&
-            compareAsc(selectedDates[0], hoveredDate) === 1
-          ) {
-            gradientTo = 'left'
+          if (hoveredDate && selectedDates.length === 1) {
+            if (compareAsc(selectedDates[0], hoveredDate) === 1) {
+              gradientTo = 'left'
+            }
           }
         }
         // Case 5: Current date is the later selected date.
         if (isSameDay(selectedDates[1], date)) {
           gradientTo = 'left'
         }
+        if (
+          (isFirstDayOfMonth(date) && gradientTo === 'left') ||
+          (isLastDayOfMonth(date) && gradientTo === 'right')
+        ) {
+          return `linear-gradient(to ${gradientTo}, white 50%,${gradientColor} 50%,${gradientColor} 80%,white)`
+        }
         if (gradientTo) {
-          return `linear-gradient(to ${gradientTo}, transparent 50%,var(--chakra-colors-primary-200) 50%)`
+          return `linear-gradient(to ${gradientTo}, transparent 50%,${gradientColor} 50%)`
         }
         // Case 6: In range but none of the above criteria. Means in between range.
         if (isInRange) {
-          return 'primary.200'
+          if (isLastDayOfMonth(date)) {
+            return `linear-gradient(to right, ${gradientColor} 75%,white)`
+          }
+          if (isFirstDayOfMonth(date)) {
+            return `linear-gradient(to left, ${gradientColor} 75%,white)`
+          }
+          return `${colorScheme}.200`
         }
       }
       // Case 7. Not in a range, no background
       return
-    }, [date, hoveredDate, isInRange, selectedDates])
+    }, [colorScheme, date, hoveredDate, isInRange, selectedDates])
+
+    const boxBg = useMemo(() => {
+      if (selected) {
+        return `${colorScheme}.500`
+      }
+      if (!isInRange) return
+      if (isLastDayOfMonth(date) || isFirstDayOfMonth(date)) {
+        if (hoveredDate && isSameDay(hoveredDate, date)) {
+          return `${colorScheme}.200`
+        }
+        return 'transparent'
+      }
+      return `${colorScheme}.200`
+    }, [colorScheme, date, hoveredDate, isInRange, selected])
 
     return (
-      <Box bg={buttonBg} px="2px">
+      <Box bg={buttonBoxBg} px="2px" _focusWithin={{ zIndex: 1 }}>
         <chakra.button
           onMouseEnter={handleMouseEnter}
+          bg={boxBg}
           // Prevent form submission if this component is nested in a form.
           type="button"
           sx={styles.dayOfMonth}

--- a/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
+++ b/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
@@ -6,7 +6,7 @@ import {
   forwardRef,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
-import { compareAsc, format, isEqual } from 'date-fns'
+import { compareAsc, format, isSameDay } from 'date-fns'
 import { DateObj } from 'dayzed'
 
 import { DATE_INPUT_THEME_KEY } from '~theme/components/DateInput'
@@ -69,19 +69,19 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
       // Only style background if it is a range.
       if (Array.isArray(selectedDates)) {
         // Case 1: Both dates selected and equal, no need for background.
-        if (isEqual(selectedDates[0], selectedDates[1])) {
+        if (isSameDay(selectedDates[0], selectedDates[1])) {
           return
         }
         // Case 2: Hovered date with previously selected date.
         // Background corner should follow date that is hovered.
         if (hoveredDate && selectedDates.length === 1) {
-          if (isEqual(hoveredDate, date)) {
+          if (isSameDay(hoveredDate, date)) {
             gradientTo =
               compareAsc(hoveredDate, selectedDates[0]) === 1 ? 'left' : 'right'
           }
         }
         // Case 3: Current date is a selected date.
-        if (isEqual(selectedDates[0], date)) {
+        if (isSameDay(selectedDates[0], date)) {
           gradientTo = 'right'
           // Case 4: Only one date selected, background corner should follow
           // date that is selected.
@@ -94,7 +94,7 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
           }
         }
         // Case 5: Current date is the later selected date.
-        if (isEqual(selectedDates[1], date)) {
+        if (isSameDay(selectedDates[1], date)) {
           gradientTo = 'left'
         }
         if (gradientTo) {

--- a/frontend/src/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.tsx
@@ -30,11 +30,11 @@ export interface DatePickerProps {
 }
 
 export const DatePicker = forwardRef<DatePickerProps, 'input'>(
-  (props, initialFocusRef) => {
+  ({ date, ...props }, initialFocusRef) => {
     const styles = useMultiStyleConfig(DATE_INPUT_THEME_KEY, {})
 
     return (
-      <CalendarProvider {...props}>
+      <CalendarProvider {...props} selectedDates={date}>
         <StylesProvider value={styles}>
           {/* Overall container */}
           <Box sx={styles.container}>

--- a/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
@@ -8,13 +8,18 @@ import {
 } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
+import { mockDateDecorator } from '~utils/storybook'
+
 import { DateRangeInput, DateRangeInputProps } from './DateRangeInput'
 import { DateRangePicker, DateRangePickerProps } from './DateRangePicker'
 
 export default {
   title: 'Components/Date/DateRangeInput',
   component: DateRangeInput,
-  decorators: [],
+  decorators: [mockDateDecorator],
+  parameters: {
+    mockdate: new Date('2021-12-25T06:22:27.219Z'),
+  },
 } as Meta
 
 const PickerOnlyTemplate: Story<DateRangePickerProps> = (args) => {

--- a/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
@@ -93,7 +93,7 @@ PickerOnly.args = {}
 
 export const PickerWithDate = PickerOnlyTemplate.bind({})
 PickerWithDate.args = {
-  selectedDates: [new Date('2001-01-01'), new Date('2001-01-08')],
+  selectedDates: [new Date('2001-01-01'), new Date('2001-02-08')],
 }
 
 const PlaygroundTemplate: Story<DateRangeInputProps> = (args) => {

--- a/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+} from '@chakra-ui/react'
+import { Meta, Story } from '@storybook/react'
+
+import { DateRangeInput, DateRangeInputProps } from './DateRangeInput'
+import { DateRangePicker } from './DateRangePicker'
+
+export default {
+  title: 'Components/Date/DateRangeInput',
+  component: DateRangeInput,
+  decorators: [],
+} as Meta
+
+const PickerOnlyTemplate: Story = () => {
+  const [selectedDates, setSelectedDates] = useState<Date[]>([])
+  const [hoveredDate, setHoveredDate] = useState<Date | null>(null)
+
+  const handleOnDateSelected = (date: Date) => {
+    const newDates = [...selectedDates]
+    if (selectedDates.length) {
+      if (selectedDates.length === 1) {
+        const firstTime = selectedDates[0]
+        if (firstTime < date) {
+          newDates.push(date)
+        } else {
+          newDates.unshift(date)
+        }
+        setSelectedDates(newDates)
+      } else if (newDates.length === 2) {
+        setSelectedDates([date])
+      }
+    } else {
+      newDates.push(date)
+      setSelectedDates(newDates)
+    }
+  }
+
+  const isDateInRange = useCallback(
+    (date: Date) => {
+      if (!selectedDates?.length) {
+        return false
+      }
+      const firstSelected = selectedDates[0]
+      if (selectedDates.length === 2) {
+        const secondSelected = selectedDates[1]
+        return firstSelected < date && secondSelected > date
+      } else {
+        return (
+          hoveredDate &&
+          ((firstSelected < date && hoveredDate >= date) ||
+            (date < firstSelected && date >= hoveredDate))
+        )
+      }
+    },
+    [hoveredDate, selectedDates],
+  )
+
+  const onMouseEnterHighlight = useCallback(
+    (date: Date) => {
+      if (!selectedDates?.length) {
+        return
+      }
+      setHoveredDate(date)
+    },
+    [selectedDates?.length],
+  )
+
+  const onMouseLeaveCalendar = useCallback(() => {
+    setHoveredDate(null)
+  }, [])
+
+  return (
+    <DateRangePicker
+      onMouseEnterHighlight={onMouseEnterHighlight}
+      onMouseLeaveCalendar={onMouseLeaveCalendar}
+      isDateInRange={isDateInRange}
+      selectedDates={selectedDates}
+      hoveredDate={hoveredDate}
+      onSelectDate={handleOnDateSelected}
+    />
+  )
+}
+export const PickerOnly = PickerOnlyTemplate.bind({})
+PickerOnly.args = {}
+
+const PlaygroundTemplate: Story<DateRangeInputProps> = (args) => {
+  const name = 'Date'
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    watch,
+  } = useForm()
+
+  const onSubmit = useCallback((data: unknown) => {
+    alert(JSON.stringify(data))
+  }, [])
+
+  const val = watch(name)
+  useEffect(() => console.log('val', val), [val])
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <FormControl isRequired isInvalid={!!errors[name]}>
+        <FormLabel>Date</FormLabel>
+        <Controller
+          control={control}
+          name={name}
+          rules={{
+            required: 'Date is required',
+          }}
+          render={({ field }) => <DateRangeInput {...field} />}
+        />
+        <FormErrorMessage>{errors[name]?.message}</FormErrorMessage>
+      </FormControl>
+      <Button type="submit">Submit</Button>
+    </form>
+  )
+}
+
+export const Playground = PlaygroundTemplate.bind({})

--- a/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { Meta, Story } from '@storybook/react'
 
 import { DateRangeInput, DateRangeInputProps } from './DateRangeInput'
-import { DateRangePicker } from './DateRangePicker'
+import { DateRangePicker, DateRangePickerProps } from './DateRangePicker'
 
 export default {
   title: 'Components/Date/DateRangeInput',
@@ -17,8 +17,10 @@ export default {
   decorators: [],
 } as Meta
 
-const PickerOnlyTemplate: Story = () => {
-  const [selectedDates, setSelectedDates] = useState<Date[]>([])
+const PickerOnlyTemplate: Story<DateRangePickerProps> = (args) => {
+  const [selectedDates, setSelectedDates] = useState<Date[]>(
+    args.selectedDates ?? [],
+  )
   const [hoveredDate, setHoveredDate] = useState<Date | null>(null)
 
   const handleOnDateSelected = (date: Date) => {
@@ -88,6 +90,11 @@ const PickerOnlyTemplate: Story = () => {
 }
 export const PickerOnly = PickerOnlyTemplate.bind({})
 PickerOnly.args = {}
+
+export const PickerWithDate = PickerOnlyTemplate.bind({})
+PickerWithDate.args = {
+  selectedDates: [new Date('2001-01-01'), new Date('2001-01-08')],
+}
 
 const PlaygroundTemplate: Story<DateRangeInputProps> = (args) => {
   const name = 'Date'

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -1,5 +1,14 @@
-import { useCallback, useRef, useState } from 'react'
 import {
+  ChangeEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {
+  Box,
+  chakra,
+  CSSObject,
   Flex,
   forwardRef,
   Popover,
@@ -10,57 +19,63 @@ import {
   PopoverTrigger,
   Portal,
   Text,
+  useMultiStyleConfig,
 } from '@chakra-ui/react'
+import { compareAsc, format } from 'date-fns'
 
 import { BxCalendar } from '~assets/icons'
 import IconButton from '~components/IconButton'
 
-import Input, { InputProps } from '../Input'
-
 import { DateRangePicker } from './DateRangePicker'
 
-export interface DateRangeInputProps
-  extends Omit<InputProps, 'value' | 'onChange'> {
-  name: string
-  value?: string
-  onChange?: (val: string) => void
+export interface DateRangeInputProps {
+  value?: Date[]
+  onChange?: (val: Date[]) => void
 }
 
 export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
-  ({ onChange, value = '', ...props }, ref) => {
+  ({ onChange, value = [] }, ref) => {
     const initialFocusRef = useRef<HTMLInputElement>(null)
 
-    const [selectedDates, setSelectedDates] = useState<Date[]>([])
     const [hoveredDate, setHoveredDate] = useState<Date | null>(null)
 
-    const handleOnDateSelected = (date: Date) => {
-      const newDates = [...selectedDates]
-      if (selectedDates.length) {
-        if (selectedDates.length === 1) {
-          const firstTime = selectedDates[0]
-          if (firstTime < date) {
-            newDates.push(date)
-          } else {
-            newDates.unshift(date)
+    const inputStyles = useMultiStyleConfig('Input', {})
+
+    /**
+     * Handles date selection in calendar panel.
+     * Calls onChange prop (if provided) with sorted dates.
+     * @param date the new date selected
+     */
+    const handleOnDateSelected = useCallback(
+      (date: Date) => {
+        let newDates = value.slice()
+        if (value.length) {
+          if (value.length === 1) {
+            const firstTime = value[0]
+            if (firstTime < date) {
+              newDates.push(date)
+            } else {
+              newDates.unshift(date)
+            }
+          } else if (newDates.length === 2) {
+            newDates = [date]
           }
-          setSelectedDates(newDates)
-        } else if (newDates.length === 2) {
-          setSelectedDates([date])
+        } else {
+          newDates.push(date)
         }
-      } else {
-        newDates.push(date)
-        setSelectedDates(newDates)
-      }
-    }
+        onChange?.(newDates.sort(compareAsc))
+      },
+      [onChange, value],
+    )
 
     const isDateInRange = useCallback(
       (date: Date) => {
-        if (!selectedDates?.length) {
+        if (!value?.length) {
           return false
         }
-        const firstSelected = selectedDates[0]
-        if (selectedDates.length === 2) {
-          const secondSelected = selectedDates[1]
+        const firstSelected = value[0]
+        if (value.length === 2) {
+          const secondSelected = value[1]
           return firstSelected < date && secondSelected > date
         } else {
           return (
@@ -70,40 +85,109 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
           )
         }
       },
-      [hoveredDate, selectedDates],
+      [hoveredDate, value],
     )
 
     const onMouseEnterHighlight = useCallback(
       (date: Date) => {
-        if (!selectedDates?.length) {
+        if (!value?.length) {
           return
         }
         setHoveredDate(date)
       },
-      [selectedDates?.length],
+      [value?.length],
     )
 
     const onMouseLeaveCalendar = useCallback(() => {
       setHoveredDate(null)
     }, [])
 
+    const handleStartDateChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      const dateFromValue = new Date(e.target.value)
+      let clonedValue = value.slice()
+
+      if (isNaN(dateFromValue.getTime())) {
+        if (clonedValue.length > 0) {
+          clonedValue = []
+        }
+      } else {
+        clonedValue[0] = dateFromValue
+      }
+
+      onChange?.(clonedValue)
+    }
+
+    const startDateRenderedValue = useMemo(() => {
+      return value[0] ? format(value[0], 'yyyy-MM-dd') ?? '' : ''
+    }, [value])
+
+    const handleEndDateChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      const dateFromValue = new Date(e.target.value)
+      const clonedValue = value.slice()
+      if (isNaN(dateFromValue.getTime())) {
+        if (clonedValue.length === 2) {
+          clonedValue.pop()
+        }
+      } else {
+        clonedValue[1] = dateFromValue
+      }
+
+      onChange?.(clonedValue)
+    }
+
+    const endDateRenderedValue = useMemo(() => {
+      return value[1] ? format(value[1], 'yyyy-MM-dd') ?? '' : ''
+    }, [value])
+
     return (
       <Flex>
-        <Input
-          type="date"
-          sx={{
-            borderRadius: '4px 0 0 4px',
-            // Chrome displays a default calendar icon, which we want to hide
-            // so all browsers display our icon consistently.
-            '::-webkit-calendar-picker-indicator': {
-              display: 'none',
-            },
-          }}
-          onChange={(e) => onChange?.(e.target.value)}
-          ref={ref}
-          value={value}
-          {...props}
-        />
+        <Box
+          alignItems="center"
+          display="flex"
+          __css={inputStyles.field}
+          borderEndRadius={0}
+          _focusWithin={
+            (inputStyles.field as Record<string, CSSObject>)?._focus
+          }
+        >
+          <chakra.input
+            aria-label="Start date"
+            type="date"
+            sx={{
+              // Chrome displays a default calendar icon, which we want to hide
+              // so all browsers display our icon consistently.
+              '::-webkit-calendar-picker-indicator': {
+                display: 'none',
+              },
+            }}
+            onChange={handleStartDateChange}
+            value={startDateRenderedValue}
+            ref={ref}
+          />
+          <Text textStyle="body-1" color="secondary.400" pr="1.5rem">
+            to
+          </Text>
+          <chakra.input
+            aria-label="End date"
+            type="date"
+            _disabled={{
+              opacity: 0.5,
+              bg: 'transparent',
+              cursor: 'not-allowed',
+            }}
+            sx={{
+              // Chrome displays a default calendar icon, which we want to hide
+              // so all browsers display our icon consistently.
+              '::-webkit-calendar-picker-indicator': {
+                display: 'none',
+              },
+            }}
+            disabled={!startDateRenderedValue}
+            onChange={handleEndDateChange}
+            value={endDateRenderedValue}
+            ref={ref}
+          />
+        </Box>
         <Popover
           placement="bottom-end"
           initialFocusRef={initialFocusRef}
@@ -130,14 +214,14 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                   <PopoverHeader py="1rem" px="1.5rem">
                     <Flex justifyContent="space-between" alignItems="center">
                       <Text textStyle="subhead-2" color="secondary.500">
-                        Select a date
+                        Select date range
                       </Text>
                       <PopoverCloseButton position="static" />
                     </Flex>
                   </PopoverHeader>
                   <PopoverBody p={0}>
                     <DateRangePicker
-                      selectedDates={selectedDates}
+                      selectedDates={value}
                       hoveredDate={hoveredDate}
                       isDateInRange={isDateInRange}
                       onMouseEnterHighlight={onMouseEnterHighlight}

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   ChangeEventHandler,
   useCallback,
@@ -7,10 +8,10 @@ import {
 } from 'react'
 import {
   Box,
-  chakra,
   CSSObject,
   Flex,
   forwardRef,
+  HStack,
   Popover,
   PopoverBody,
   PopoverCloseButton,
@@ -20,26 +21,26 @@ import {
   Portal,
   Text,
   useMultiStyleConfig,
+  Wrap,
 } from '@chakra-ui/react'
 import { compareAsc, format } from 'date-fns'
 
 import { BxCalendar } from '~assets/icons'
 import IconButton from '~components/IconButton'
+import Input, { InputProps } from '~components/Input'
 
 import { DateRangePicker } from './DateRangePicker'
 
-export interface DateRangeInputProps {
+export interface DateRangeInputProps extends InputProps {
   value?: Date[]
   onChange?: (val: Date[]) => void
 }
 
 export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
-  ({ onChange, value = [] }, ref) => {
+  ({ onChange, value = [], ...props }, ref) => {
     const initialFocusRef = useRef<HTMLInputElement>(null)
 
     const [hoveredDate, setHoveredDate] = useState<Date | null>(null)
-
-    const inputStyles = useMultiStyleConfig('Input', {})
 
     /**
      * Handles date selection in calendar panel.
@@ -140,19 +141,13 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
     }, [value])
 
     return (
-      <Flex>
-        <Box
-          alignItems="center"
-          display="flex"
-          __css={inputStyles.field}
-          borderEndRadius={0}
-          _focusWithin={
-            (inputStyles.field as Record<string, CSSObject>)?._focus
-          }
-        >
-          <chakra.input
+      <Wrap shouldWrapChildren spacing="0.25rem">
+        <Wrap shouldWrapChildren spacing="0.5rem" align="center">
+          <Input
             aria-label="Start date"
+            id={`${props.name}-start-date`}
             type="date"
+            w="fit-content"
             sx={{
               // Chrome displays a default calendar icon, which we want to hide
               // so all browsers display our icon consistently.
@@ -163,18 +158,16 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
             onChange={handleStartDateChange}
             value={startDateRenderedValue}
             ref={ref}
+            {...props}
           />
-          <Text textStyle="body-1" color="secondary.400" pr="1.5rem">
+          <Text textStyle="body-1" color="secondary.400" px="0.5rem">
             to
           </Text>
-          <chakra.input
+          <Input
             aria-label="End date"
+            id={`${props.name}-end-date`}
             type="date"
-            _disabled={{
-              opacity: 0.5,
-              bg: 'transparent',
-              cursor: 'not-allowed',
-            }}
+            w="fit-content"
             sx={{
               // Chrome displays a default calendar icon, which we want to hide
               // so all browsers display our icon consistently.
@@ -182,12 +175,12 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                 display: 'none',
               },
             }}
-            disabled={!startDateRenderedValue}
+            isDisabled={!startDateRenderedValue}
             onChange={handleEndDateChange}
             value={endDateRenderedValue}
-            ref={ref}
+            {...props}
           />
-        </Box>
+        </Wrap>
         <Popover
           placement="bottom-end"
           initialFocusRef={initialFocusRef}
@@ -235,7 +228,7 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
             </>
           )}
         </Popover>
-      </Flex>
+      </Wrap>
     )
   },
 )

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -225,9 +225,19 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                 />
               </PopoverTrigger>
               <Portal>
-                <PopoverContent borderRadius="4px" w="unset" maxW="100vw">
-                  <PopoverHeader py="1rem" px="1.5rem">
-                    <Flex justifyContent="space-between" alignItems="center">
+                <PopoverContent
+                  borderRadius="4px"
+                  w="unset"
+                  maxW="100vw"
+                  bg="white"
+                >
+                  <PopoverHeader>
+                    <Flex
+                      h="3.5rem"
+                      mx={{ base: '1rem', md: '1.5rem' }}
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
                       <Text textStyle="subhead-2" color="secondary.500">
                         Select date range
                       </Text>

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -1,5 +1,6 @@
 import {
   ChangeEventHandler,
+  KeyboardEventHandler,
   useCallback,
   useMemo,
   useRef,
@@ -127,6 +128,16 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
       onChange?.(clonedValue)
     }
 
+    /**
+     * Disable spacebar from opening native calendar
+     */
+    const handlePreventOpenNativeCalendar: KeyboardEventHandler<HTMLInputElement> =
+      useCallback((e) => {
+        if (e.key === ' ') {
+          e.preventDefault()
+        }
+      }, [])
+
     const startDateRenderedValue = useMemo(() => {
       return value[0] ?? ''
     }, [value])
@@ -155,6 +166,7 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
           <Input
             aria-label="Start date"
             id={`${props.name}-start-date`}
+            onKeyDown={handlePreventOpenNativeCalendar}
             type="date"
             w="fit-content"
             sx={{
@@ -175,6 +187,7 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
           <Input
             aria-label="End date"
             id={`${props.name}-end-date`}
+            onKeyDown={handlePreventOpenNativeCalendar}
             type="date"
             w="fit-content"
             sx={{

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  Flex,
+  forwardRef,
+  Popover,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  Portal,
+  Text,
+} from '@chakra-ui/react'
+
+import { BxCalendar } from '~assets/icons'
+import IconButton from '~components/IconButton'
+
+import Input, { InputProps } from '../Input'
+
+import { DateRangePicker } from './DateRangePicker'
+
+export interface DateRangeInputProps
+  extends Omit<InputProps, 'value' | 'onChange'> {
+  name: string
+  value?: string
+  onChange?: (val: string) => void
+}
+
+export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
+  ({ onChange, value = '', ...props }, ref) => {
+    const initialFocusRef = useRef<HTMLInputElement>(null)
+
+    const [selectedDates, setSelectedDates] = useState<Date[]>([])
+    const [hoveredDate, setHoveredDate] = useState<Date | null>(null)
+
+    const handleOnDateSelected = (date: Date) => {
+      const newDates = [...selectedDates]
+      if (selectedDates.length) {
+        if (selectedDates.length === 1) {
+          const firstTime = selectedDates[0]
+          if (firstTime < date) {
+            newDates.push(date)
+          } else {
+            newDates.unshift(date)
+          }
+          setSelectedDates(newDates)
+        } else if (newDates.length === 2) {
+          setSelectedDates([date])
+        }
+      } else {
+        newDates.push(date)
+        setSelectedDates(newDates)
+      }
+    }
+
+    const isDateInRange = useCallback(
+      (date: Date) => {
+        if (!selectedDates?.length) {
+          return false
+        }
+        const firstSelected = selectedDates[0]
+        if (selectedDates.length === 2) {
+          const secondSelected = selectedDates[1]
+          return firstSelected < date && secondSelected > date
+        } else {
+          return (
+            hoveredDate &&
+            ((firstSelected < date && hoveredDate >= date) ||
+              (date < firstSelected && date >= hoveredDate))
+          )
+        }
+      },
+      [hoveredDate, selectedDates],
+    )
+
+    const onMouseEnterHighlight = useCallback(
+      (date: Date) => {
+        if (!selectedDates?.length) {
+          return
+        }
+        setHoveredDate(date)
+      },
+      [selectedDates?.length],
+    )
+
+    const onMouseLeaveCalendar = useCallback(() => {
+      setHoveredDate(null)
+    }, [])
+
+    return (
+      <Flex>
+        <Input
+          type="date"
+          sx={{
+            borderRadius: '4px 0 0 4px',
+            // Chrome displays a default calendar icon, which we want to hide
+            // so all browsers display our icon consistently.
+            '::-webkit-calendar-picker-indicator': {
+              display: 'none',
+            },
+          }}
+          onChange={(e) => onChange?.(e.target.value)}
+          ref={ref}
+          value={value}
+          {...props}
+        />
+        <Popover
+          placement="bottom-end"
+          initialFocusRef={initialFocusRef}
+          isLazy
+        >
+          {({ isOpen }) => (
+            <>
+              <PopoverTrigger>
+                <IconButton
+                  aria-label="Open calendar"
+                  icon={<BxCalendar />}
+                  isActive={isOpen}
+                  fontSize="1.25rem"
+                  variant="outline"
+                  color="secondary.500"
+                  borderColor="neutral.400"
+                  borderRadius="0"
+                  // Avoid double border with input
+                  ml="-1px"
+                />
+              </PopoverTrigger>
+              <Portal>
+                <PopoverContent borderRadius="4px" w="unset" maxW="100vw">
+                  <PopoverHeader py="1rem" px="1.5rem">
+                    <Flex justifyContent="space-between" alignItems="center">
+                      <Text textStyle="subhead-2" color="secondary.500">
+                        Select a date
+                      </Text>
+                      <PopoverCloseButton position="static" />
+                    </Flex>
+                  </PopoverHeader>
+                  <PopoverBody p={0}>
+                    <DateRangePicker
+                      selectedDates={selectedDates}
+                      hoveredDate={hoveredDate}
+                      isDateInRange={isDateInRange}
+                      onMouseEnterHighlight={onMouseEnterHighlight}
+                      onMouseLeaveCalendar={onMouseLeaveCalendar}
+                      onSelectDate={handleOnDateSelected}
+                      ref={initialFocusRef}
+                    />
+                  </PopoverBody>
+                </PopoverContent>
+              </Portal>
+            </>
+          )}
+        </Popover>
+      </Flex>
+    )
+  },
+)

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   ChangeEventHandler,
   useCallback,
@@ -7,11 +6,8 @@ import {
   useState,
 } from 'react'
 import {
-  Box,
-  CSSObject,
   Flex,
   forwardRef,
-  HStack,
   Popover,
   PopoverBody,
   PopoverCloseButton,
@@ -20,7 +16,6 @@ import {
   PopoverTrigger,
   Portal,
   Text,
-  useMultiStyleConfig,
   Wrap,
 } from '@chakra-ui/react'
 import { compareAsc, format } from 'date-fns'
@@ -31,7 +26,8 @@ import Input, { InputProps } from '~components/Input'
 
 import { DateRangePicker } from './DateRangePicker'
 
-export interface DateRangeInputProps extends InputProps {
+export interface DateRangeInputProps
+  extends Omit<InputProps, 'value' | 'onChange'> {
   value?: Date[]
   onChange?: (val: Date[]) => void
 }

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -241,7 +241,11 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                       <Text textStyle="subhead-2" color="secondary.500">
                         Select date range
                       </Text>
-                      <PopoverCloseButton position="static" />
+                      <PopoverCloseButton
+                        variant="clear"
+                        colorScheme="secondary"
+                        position="static"
+                      />
                     </Flex>
                   </PopoverHeader>
                   <PopoverBody p={0}>

--- a/frontend/src/components/DatePicker/DateRangePicker.tsx
+++ b/frontend/src/components/DatePicker/DateRangePicker.tsx
@@ -1,0 +1,67 @@
+import {
+  Box,
+  forwardRef,
+  StylesProvider,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
+
+import { DATE_INPUT_THEME_KEY } from '~theme/components/DateInput'
+
+import {
+  CalendarPanel,
+  CalendarProvider,
+  CalendarTodayButton,
+} from './Calendar'
+
+export interface DateRangePickerProps {
+  /**
+   * Selected date range pair. Undefined if no date is selected.
+   */
+  selectedDates?: Date[]
+
+  /**
+   * Handler for when date is selected.
+   */
+  onSelectDate: (d: Date) => void
+
+  /**
+   * Function to determine whether a date should be made
+   * unavailable.
+   */
+  isDateUnavailable?: (d: Date) => boolean
+
+  /**
+   * Function to be passed to CalendarPanel to determine range styling.
+   */
+  isDateInRange: (d: Date) => boolean | null
+
+  /**
+   * Function to be passed to CalendarPanel to determine range styling.
+   * Called when a date is selected and a mouseover is detected over a date.
+   */
+  onMouseEnterHighlight: (date: Date) => void
+
+  /**
+   * Function to be passed to CalendarPanel to determine range styling.
+   * Called when mouse leaves the calendar.
+   */
+  onMouseLeaveCalendar: () => void
+}
+
+export const DateRangePicker = forwardRef<DateRangePickerProps, 'input'>(
+  (props, initialFocusRef) => {
+    const styles = useMultiStyleConfig(DATE_INPUT_THEME_KEY, {})
+
+    return (
+      <CalendarProvider monthsToDisplay={2} {...props}>
+        <StylesProvider value={styles}>
+          {/* Overall container */}
+          <Box sx={styles.container}>
+            <CalendarPanel ref={initialFocusRef} />
+            <CalendarTodayButton />
+          </Box>
+        </StylesProvider>
+      </CalendarProvider>
+    )
+  },
+)

--- a/frontend/src/components/DatePicker/utils.ts
+++ b/frontend/src/components/DatePicker/utils.ts
@@ -1,11 +1,16 @@
 import {
   addDays,
   differenceInCalendarMonths,
+  format,
   startOfDay,
   subDays,
 } from 'date-fns'
 import range from 'lodash/range'
+import { Opaque } from 'type-fest'
 import { v4 as uuidv4 } from 'uuid'
+
+// Format yyyy-MM-dd
+export type IsoDateString = Opaque<string, 'IsoDateString'>
 
 /**
  * Full names of calendar months
@@ -113,4 +118,8 @@ export const generateValidUuidClass = (): string => {
   // Ensure className starts with alphabet and has no hyphens
   // followed by digits
   return `a${uuidv4().replaceAll('-', '_')}`
+}
+
+export const convertToDateString = (date: Date): IsoDateString => {
+  return format(date, 'yyyy-MM-dd') as IsoDateString
 }

--- a/frontend/src/theme/components/DateInput.ts
+++ b/frontend/src/theme/components/DateInput.ts
@@ -1,4 +1,4 @@
-import { anatomy, getColor } from '@chakra-ui/theme-tools'
+import { anatomy, getColor, SystemStyleFunction } from '@chakra-ui/theme-tools'
 
 import { ComponentMultiStyleConfig } from '~theme/types'
 
@@ -16,15 +16,67 @@ const parts = anatomy('dateinput').parts(
   'todayLinkContainer', // container for "Today" link
 )
 
+const baseDayOfMonthStyles: SystemStyleFunction = ({
+  isToday,
+  isOutsideCurrMonth,
+  isInRange,
+  isSelected,
+  colorScheme: c,
+  theme,
+}) => {
+  const bgColor = isSelected
+    ? `${c}.500`
+    : isInRange
+    ? `${c}.200`
+    : 'transparent'
+
+  return {
+    display: 'inline-block',
+    textStyle: 'body-1',
+    borderRadius: '1.5rem',
+    color: isSelected
+      ? 'white'
+      : isOutsideCurrMonth
+      ? 'secondary.300'
+      : 'secondary.500',
+    p: {
+      base: 0,
+      md: 0.75,
+    },
+    outline: 'none',
+    border: '1px solid',
+    borderColor: isToday
+      ? isOutsideCurrMonth
+        ? 'secondary.300'
+        : `${c}.500`
+      : 'transparent',
+    bg: bgColor,
+    _hover: {
+      bg: isSelected ? `${c}.500` : `${c}.200`,
+    },
+    _focus: {
+      boxShadow: `0 0 0 4px ${getColor(theme, `${c}.300`)}`,
+    },
+    _disabled: {
+      color: 'secondary.300',
+      cursor: 'not-allowed',
+      bg: 'transparent',
+      textDecor: 'line-through',
+    },
+    w: {
+      base: '2rem',
+      md: '3rem',
+    },
+    h: {
+      base: '2rem',
+      md: '3rem',
+    },
+  }
+}
+
 export const DateInput: ComponentMultiStyleConfig<typeof parts> = {
   parts: parts.keys,
-  baseStyle: ({
-    isToday,
-    isOutsideCurrMonth,
-    isSelected,
-    colorScheme: c,
-    theme,
-  }) => {
+  baseStyle: (props) => {
     return {
       container: {
         display: 'inline-block',
@@ -51,7 +103,6 @@ export const DateInput: ComponentMultiStyleConfig<typeof parts> = {
       },
       monthGrid: {
         rowGap: '0.5rem',
-        columnGap: '0.25rem',
         display: 'inline-grid',
         justifyItems: 'left',
       },
@@ -70,49 +121,7 @@ export const DateInput: ComponentMultiStyleConfig<typeof parts> = {
           md: '3rem',
         },
       },
-      dayOfMonth: {
-        transitionDuration: 'normal',
-        display: 'inline-block',
-        textStyle: 'body-1',
-        borderRadius: '1.5rem',
-        color: isSelected
-          ? 'white'
-          : isOutsideCurrMonth
-          ? 'secondary.300'
-          : 'secondary.500',
-        p: {
-          base: 0,
-          md: 0.75,
-        },
-        outline: 'none',
-        border: '1px solid',
-        borderColor: isToday
-          ? isOutsideCurrMonth
-            ? 'secondary.300'
-            : `${c}.500`
-          : 'transparent',
-        bg: isSelected ? `${c}.500` : 'transparent',
-        _hover: {
-          bg: isSelected ? `${c}.500` : `${c}.200`,
-        },
-        _focus: {
-          boxShadow: `0 0 0 4px ${getColor(theme, `${c}.300`)}`,
-        },
-        _disabled: {
-          color: 'secondary.300',
-          cursor: 'not-allowed',
-          bg: 'transparent',
-          textDecor: 'line-through',
-        },
-        w: {
-          base: '2rem',
-          md: '3rem',
-        },
-        h: {
-          base: '2rem',
-          md: '3rem',
-        },
-      },
+      dayOfMonth: baseDayOfMonthStyles(props),
       todayLinkContainer: {
         textAlign: 'center',
         py: '0.75rem',

--- a/frontend/src/theme/components/DateInput.ts
+++ b/frontend/src/theme/components/DateInput.ts
@@ -19,17 +19,10 @@ const parts = anatomy('dateinput').parts(
 const baseDayOfMonthStyles: SystemStyleFunction = ({
   isToday,
   isOutsideCurrMonth,
-  isInRange,
   isSelected,
   colorScheme: c,
   theme,
 }) => {
-  const bgColor = isSelected
-    ? `${c}.500`
-    : isInRange
-    ? `${c}.200`
-    : 'transparent'
-
   return {
     display: 'inline-block',
     textStyle: 'body-1',
@@ -50,7 +43,6 @@ const baseDayOfMonthStyles: SystemStyleFunction = ({
         ? 'secondary.300'
         : `${c}.500`
       : 'transparent',
-    bg: bgColor,
     _hover: {
       bg: isSelected ? `${c}.500` : `${c}.200`,
     },

--- a/frontend/src/theme/components/Input.ts
+++ b/frontend/src/theme/components/Input.ts
@@ -12,6 +12,7 @@ const size = {
   },
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const outlineVariant = (props: StyleFunctionProps) => {
   const {
     theme,
@@ -24,43 +25,18 @@ const outlineVariant = (props: StyleFunctionProps) => {
   return {
     field: {
       bg: isPrefilled ? 'warning.100' : 'white',
+      textStyle: 'body-1',
       border: '1px solid',
       borderColor: isSuccess ? 'success.700' : 'neutral.400',
+      _placeholder: {
+        color: 'neutral.500',
+      },
       _hover: {
         borderColor: isSuccess ? 'success.700' : 'neutral.400',
       },
       _disabled: {
-        borderColor: 'neutral.400',
-      },
-      _invalid: {
-        // Remove extra 1px of outline.
-        borderColor: getColor(theme, ec),
-        boxShadow: 'none',
-      },
-      _focus: {
-        borderColor: getColor(theme, fc),
-        _hover: {
-          borderColor: getColor(theme, fc),
-        },
-        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
-      },
-    },
-  }
-}
-
-// Additional success part.
-const parts = inputAnatomy.extend('success')
-
-export const Input = {
-  parts: parts.keys,
-  baseStyle: {
-    field: {
-      textStyle: 'body-1',
-      _placeholder: {
-        color: 'neutral.500',
-      },
-      _disabled: {
         bg: 'neutral.200',
+        borderColor: 'neutral.400',
         color: 'neutral.500',
         cursor: 'not-allowed',
         opacity: 1,
@@ -71,13 +47,29 @@ export const Input = {
           bg: 'neutral.200',
         },
       },
+      _invalid: {
+        // Remove extra 1px of outline.
+        borderColor: getColor(theme, ec),
+        boxShadow: 'none',
+      },
+      _focus: {
+        borderColor: getColor(theme, fc),
+        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
+      },
     },
     success: {
       pointerEvents: 'none',
       fontSize: '1.25rem',
       color: 'success.700',
     },
-  },
+  }
+}
+
+// Additional success part.
+const parts = inputAnatomy.extend('success')
+
+export const Input = {
+  parts: parts.keys,
   variants: {
     outline: outlineVariant,
   },

--- a/frontend/src/theme/components/Input.ts
+++ b/frontend/src/theme/components/Input.ts
@@ -12,7 +12,6 @@ const size = {
   },
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const outlineVariant = (props: StyleFunctionProps) => {
   const {
     theme,
@@ -25,18 +24,43 @@ const outlineVariant = (props: StyleFunctionProps) => {
   return {
     field: {
       bg: isPrefilled ? 'warning.100' : 'white',
-      textStyle: 'body-1',
       border: '1px solid',
       borderColor: isSuccess ? 'success.700' : 'neutral.400',
-      _placeholder: {
-        color: 'neutral.500',
-      },
       _hover: {
         borderColor: isSuccess ? 'success.700' : 'neutral.400',
       },
       _disabled: {
-        bg: 'neutral.200',
         borderColor: 'neutral.400',
+      },
+      _invalid: {
+        // Remove extra 1px of outline.
+        borderColor: getColor(theme, ec),
+        boxShadow: 'none',
+      },
+      _focus: {
+        borderColor: getColor(theme, fc),
+        _hover: {
+          borderColor: getColor(theme, fc),
+        },
+        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
+      },
+    },
+  }
+}
+
+// Additional success part.
+const parts = inputAnatomy.extend('success')
+
+export const Input = {
+  parts: parts.keys,
+  baseStyle: {
+    field: {
+      textStyle: 'body-1',
+      _placeholder: {
+        color: 'neutral.500',
+      },
+      _disabled: {
+        bg: 'neutral.200',
         color: 'neutral.500',
         cursor: 'not-allowed',
         opacity: 1,
@@ -47,29 +71,13 @@ const outlineVariant = (props: StyleFunctionProps) => {
           bg: 'neutral.200',
         },
       },
-      _invalid: {
-        // Remove extra 1px of outline.
-        borderColor: getColor(theme, ec),
-        boxShadow: 'none',
-      },
-      _focus: {
-        borderColor: getColor(theme, fc),
-        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
-      },
     },
     success: {
       pointerEvents: 'none',
       fontSize: '1.25rem',
       color: 'success.700',
     },
-  }
-}
-
-// Additional success part.
-const parts = inputAnatomy.extend('success')
-
-export const Input = {
-  parts: parts.keys,
+  },
   variants: {
     outline: outlineVariant,
   },


### PR DESCRIPTION
> This PR builds upon #3185

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a DateRangePicker component with the appropriate multi-month calendar popover.

Related to #2006 

## Solution
<!-- How did you solve the problem? -->

**Features**:

- render multiple months correctly in multi-cal display
- add DateRangePicker component
- add initial DateRangeInput component
- style: add gradient styling when range is across months 

**Bug Fixes**:

- fix: prevent spacebar from opening native date picker

## Before & After Screenshots
New DateRangeInput stories have been added

## Tests
<!-- What tests should be run to confirm functionality? -->
SORRY

