### PR TITLE
feat(v2): [Date2] add a11y improvements to DatePicker components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18461,20 +18461,11 @@
       }
     },
     "focus-lock": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.8.1.tgz",
-      "integrity": "sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==",
-      "dev": true,
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.10.1.tgz",
+      "integrity": "sha512-b9yUklCi4fTu2GXn7dnaVf4hiLVVBp7xTiZarAHMODV2To6Bitf6F/UI67RmKbdgJQeVwI1UO0d9HYNbXt3GkA==",
       "requires": {
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
+        "tslib": "^2.0.3"
       }
     },
     "focus-visible": {
@@ -29160,17 +29151,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",
-      "integrity": "sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==",
-      "dev": true,
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.7.1.tgz",
+      "integrity": "sha512-ImSeVmcrLKNMqzUsIdqOkXwTVltj79OPu43oT8tVun7eIckA4VdM7UmYUFo3H/UC2nRVgagMZGFnAOQEDiDYcA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.8.1",
+        "focus-lock": "^0.10.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       }
     },
     "react-helmet-async": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.4.2",
+    "react-focus-lock": "^2.7.1",
     "react-hook-form": "^7.21.2",
     "react-icons": "^4.3.1",
     "react-markdown": "^7.1.1",

--- a/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
@@ -92,6 +92,7 @@ const SelectableMonthYear = memo(() => {
         Currently displaying {MONTH_NAMES[currMonth].fullName} {currYear}
       </VisuallyHidden>
       <MonthYearSelect
+        tabIndex={1}
         value={currMonth}
         onChange={handleMonthChange}
         aria-label="Change displayed month"
@@ -101,6 +102,7 @@ const SelectableMonthYear = memo(() => {
         {memoizedMonthOptions}
       </MonthYearSelect>
       <MonthYearSelect
+        tabIndex={1}
         value={currYear}
         onChange={handleYearChange}
         aria-label="Change displayed year"
@@ -162,6 +164,7 @@ export const CalendarHeader = memo(
         {calendars.length - 1 === monthOffset ? (
           <Flex sx={styles.monthArrowContainer}>
             <IconButton
+              tabIndex={1}
               variant="clear"
               colorScheme="secondary"
               icon={<BxChevronLeft />}
@@ -170,6 +173,7 @@ export const CalendarHeader = memo(
               {...getBackProps({ calendars })}
             />
             <IconButton
+              tabIndex={1}
               variant="clear"
               colorScheme="secondary"
               icon={<BxChevronRight />}

--- a/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   useBreakpointValue,
   useStyles,
+  VisuallyHidden,
 } from '@chakra-ui/react'
 import { addMonths } from 'date-fns/esm'
 
@@ -87,6 +88,9 @@ const SelectableMonthYear = memo(() => {
 
   return (
     <HStack>
+      <VisuallyHidden aria-live="polite" aria-atomic>
+        Currently displaying {MONTH_NAMES[currMonth].fullName} {currYear}
+      </VisuallyHidden>
       <MonthYearSelect
         value={currMonth}
         onChange={handleMonthChange}

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -97,11 +97,11 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
                 })}
               </chakra.tbody>
             </chakra.table>
+            <VisuallyHidden aria-live="polite">
+              Cursor keys can navigate dates when a date is being focused.
+            </VisuallyHidden>
           </Stack>
         ))}
-        <VisuallyHidden aria-live="polite">
-          Cursor keys can navigate dates when a date is being focused.
-        </VisuallyHidden>
       </Stack>
     )
   },

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, forwardRef, SimpleGrid, Stack, useStyles } from '@chakra-ui/react'
+import { chakra, forwardRef, Stack, Td, useStyles } from '@chakra-ui/react'
 import { isSameDay } from 'date-fns'
 
 import { DAY_NAMES, generateClassNameForDate } from '../utils'
@@ -28,43 +28,65 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
         {calendars.map((calendar, i) => (
           <Stack spacing={0} key={i}>
             <CalendarHeader monthOffset={i} />
-            <SimpleGrid
+            <chakra.table
               key={`${calendar.month}${calendar.year}`}
-              columns={DAY_NAMES.length}
               sx={styles.monthGrid}
             >
-              {DAY_NAMES.map((dayName, index) => (
-                <Box key={index} sx={styles.dayNamesContainer}>
-                  {dayName}
-                </Box>
-              ))}
-              {calendar.weeks.map((week, windex) =>
-                week.map((dateObj, index) => {
-                  if (!dateObj) {
-                    return (
-                      <Box
-                        key={`${calendar.month}${calendar.year}${windex}${index}`}
-                      />
-                    )
-                  }
+              <chakra.thead>
+                <chakra.tr>
+                  {DAY_NAMES.map(({ fullName, shortName }, index) => (
+                    <chakra.th
+                      key={index}
+                      abbr={fullName}
+                      sx={styles.dayNamesContainer}
+                    >
+                      {shortName}
+                    </chakra.th>
+                  ))}
+                </chakra.tr>
+              </chakra.thead>
+              <chakra.tbody>
+                {calendar.weeks.map((week, windex) => {
                   return (
-                    <DayOfMonth
-                      key={`${calendar.month}${calendar.year}${windex}${index}`}
-                      {...getDateProps({
-                        dateObj,
+                    <chakra.tr key={windex}>
+                      {week.map((dateObj, index) => {
+                        if (!dateObj) {
+                          return (
+                            <Td
+                              key={`${calendar.month}${calendar.year}${windex}${index}`}
+                            />
+                          )
+                        }
+                        return (
+                          <chakra.td
+                            key={`${calendar.month}${calendar.year}${windex}${index}`}
+                          >
+                            <DayOfMonth
+                              {...getDateProps({
+                                dateObj,
+                              })}
+                              dateObj={dateObj}
+                              isOutsideCurrMonth={
+                                dateObj.date.getMonth() !== calendar.month
+                              }
+                              className={generateClassNameForDate(
+                                uuid,
+                                dateObj.date,
+                              )}
+                              ref={
+                                isSameDay(dateObj.date, dateToFocus)
+                                  ? initialFocusRef
+                                  : undefined
+                              }
+                            />
+                          </chakra.td>
+                        )
                       })}
-                      dateObj={dateObj}
-                      className={generateClassNameForDate(uuid, dateObj.date)}
-                      ref={
-                        isSameDay(dateObj.date, dateToFocus)
-                          ? initialFocusRef
-                          : undefined
-                      }
-                    />
+                    </chakra.tr>
                   )
-                }),
-              )}
-            </SimpleGrid>
+                })}
+              </chakra.tbody>
+            </chakra.table>
           </Stack>
         ))}
       </Stack>

--- a/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarPanel.tsx
@@ -1,7 +1,14 @@
-import { chakra, forwardRef, Stack, Td, useStyles } from '@chakra-ui/react'
+import {
+  chakra,
+  forwardRef,
+  Stack,
+  Td,
+  useStyles,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 import { isSameDay } from 'date-fns'
 
-import { DAY_NAMES, generateClassNameForDate } from '../utils'
+import { DAY_NAMES, generateClassNameForDate, MONTH_NAMES } from '../utils'
 
 import { useCalendar } from './CalendarContext'
 import { CalendarHeader } from './CalendarHeader'
@@ -29,6 +36,9 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
           <Stack spacing={0} key={i}>
             <CalendarHeader monthOffset={i} />
             <chakra.table
+              aria-label={`${MONTH_NAMES[calendar.month].fullName} ${
+                calendar.year
+              }`}
               key={`${calendar.month}${calendar.year}`}
               sx={styles.monthGrid}
             >
@@ -89,6 +99,9 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
             </chakra.table>
           </Stack>
         ))}
+        <VisuallyHidden aria-live="polite">
+          Cursor keys can navigate dates when a date is being focused.
+        </VisuallyHidden>
       </Stack>
     )
   },

--- a/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
@@ -10,6 +10,7 @@ export const CalendarTodayButton = (): JSX.Element => {
   return (
     <Box sx={styles.todayLinkContainer}>
       <Button
+        aria-label="Focus on today's date"
         variant="link"
         type="button"
         onClick={handleTodayClick}

--- a/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
@@ -14,7 +14,6 @@ export const CalendarTodayButton = (): JSX.Element => {
         variant="link"
         type="button"
         onClick={handleTodayClick}
-        tabIndex={0}
       >
         Today
       </Button>

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -51,6 +51,14 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
       return isNaN(dateFromValue.getTime()) ? undefined : dateFromValue
     }, [value])
 
+    const calendarButtonAria = useMemo(() => {
+      let ariaLabel = 'Choose date. '
+      if (value.length === 1) {
+        ariaLabel += `Selected date is ${new Date(value[0]).toDateString()}.`
+      }
+      return ariaLabel
+    }, [value])
+
     /**
      * Disable spacebar from opening native calendar
      */
@@ -91,7 +99,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
             <>
               <PopoverTrigger>
                 <IconButton
-                  aria-label="Open calendar"
+                  aria-label={calendarButtonAria}
                   icon={<BxCalendar />}
                   isActive={isOpen}
                   fontSize="1.25rem"

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -10,6 +10,7 @@ import {
   PopoverTrigger,
   Portal,
   Text,
+  VisuallyHidden,
 } from '@chakra-ui/react'
 import { ComponentWithAs, forwardRef } from '@chakra-ui/system'
 import { format } from 'date-fns'
@@ -119,7 +120,12 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   maxW="100vw"
                   bg="white"
                 >
-                  <FocusLock returnFocus persistentFocus={false}>
+                  <FocusLock returnFocus>
+                    {/* Having this extra guard here allows for tab rotation instead of closing the 
+                    calendar on certain tab key presses.
+                    data-focus-guard is required to work with FocusLock
+                    NFI why this is necessary, just that it works. Such is the life of a software engineer. */}
+                    <VisuallyHidden data-focus-guard tabIndex={2} />
                     <PopoverHeader p={0}>
                       <Flex
                         h="3.5rem"

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -3,12 +3,12 @@ import FocusLock from 'react-focus-lock'
 import {
   Flex,
   Popover,
+  PopoverAnchor,
   PopoverBody,
   PopoverCloseButton,
   PopoverContent,
   PopoverHeader,
   PopoverTrigger,
-  Portal,
   Text,
   VisuallyHidden,
 } from '@chakra-ui/react'
@@ -73,24 +73,8 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
 
     return (
       <Flex>
-        <Input
-          type="date"
-          onKeyDown={handlePreventOpenNativeCalendar}
-          sx={{
-            borderRadius: '4px 0 0 4px',
-            // Chrome displays a default calendar icon, which we want to hide
-            // so all browsers display our icon consistently.
-            '::-webkit-calendar-picker-indicator': {
-              display: 'none',
-            },
-          }}
-          onChange={(e) => onChange?.(e.target.value)}
-          ref={ref}
-          value={value}
-          {...props}
-        />
         <Popover
-          placement="bottom-end"
+          placement="bottom-start"
           initialFocusRef={initialFocusRef}
           // Prevent mobile taps to close popover when doing something like
           // changing months in the selector.
@@ -99,6 +83,24 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
         >
           {({ isOpen }) => (
             <>
+              <PopoverAnchor>
+                <Input
+                  type="date"
+                  onKeyDown={handlePreventOpenNativeCalendar}
+                  sx={{
+                    borderRadius: '4px 0 0 4px',
+                    // Chrome displays a default calendar icon, which we want to hide
+                    // so all browsers display our icon consistently.
+                    '::-webkit-calendar-picker-indicator': {
+                      display: 'none',
+                    },
+                  }}
+                  onChange={(e) => onChange?.(e.target.value)}
+                  ref={ref}
+                  value={value}
+                  {...props}
+                />
+              </PopoverAnchor>
               <PopoverTrigger>
                 <IconButton
                   aria-label={calendarButtonAria}
@@ -113,47 +115,45 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   ml="-1px"
                 />
               </PopoverTrigger>
-              <Portal>
-                <PopoverContent
-                  borderRadius="4px"
-                  w="unset"
-                  maxW="100vw"
-                  bg="white"
-                >
-                  <FocusLock returnFocus>
-                    {/* Having this extra guard here allows for tab rotation instead of closing the 
+              <PopoverContent
+                borderRadius="4px"
+                w="unset"
+                maxW="100vw"
+                bg="white"
+              >
+                <FocusLock returnFocus>
+                  {/* Having this extra guard here allows for tab rotation instead of closing the 
                     calendar on certain tab key presses.
                     data-focus-guard is required to work with FocusLock
                     NFI why this is necessary, just that it works. Such is the life of a software engineer. */}
-                    <VisuallyHidden data-focus-guard tabIndex={2} />
-                    <PopoverHeader p={0}>
-                      <Flex
-                        h="3.5rem"
-                        mx={{ base: '1rem', md: '1.5rem' }}
-                        justifyContent="space-between"
-                        alignItems="center"
-                      >
-                        <Text textStyle="subhead-2" color="secondary.500">
-                          Select a date
-                        </Text>
-                        <PopoverCloseButton
-                          position="static"
-                          variant="clear"
-                          colorScheme="secondary"
-                        />
-                      </Flex>
-                    </PopoverHeader>
-                    <PopoverBody p={0}>
-                      <DateInput.DatePicker
-                        date={datePickerDate}
-                        isDateUnavailable={isDateUnavailable}
-                        onSelectDate={handleDatepickerSelection}
-                        ref={initialFocusRef}
+                  <VisuallyHidden data-focus-guard tabIndex={2} />
+                  <PopoverHeader p={0}>
+                    <Flex
+                      h="3.5rem"
+                      mx={{ base: '1rem', md: '1.5rem' }}
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
+                      <Text textStyle="subhead-2" color="secondary.500">
+                        Select a date
+                      </Text>
+                      <PopoverCloseButton
+                        position="static"
+                        variant="clear"
+                        colorScheme="secondary"
                       />
-                    </PopoverBody>
-                  </FocusLock>
-                </PopoverContent>
-              </Portal>
+                    </Flex>
+                  </PopoverHeader>
+                  <PopoverBody p={0}>
+                    <DateInput.DatePicker
+                      date={datePickerDate}
+                      isDateUnavailable={isDateUnavailable}
+                      onSelectDate={handleDatepickerSelection}
+                      ref={initialFocusRef}
+                    />
+                  </PopoverBody>
+                </FocusLock>
+              </PopoverContent>
             </>
           )}
         </Popover>

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -1,4 +1,5 @@
 import { KeyboardEventHandler, useCallback, useMemo, useRef } from 'react'
+import FocusLock from 'react-focus-lock'
 import {
   Flex,
   Popover,
@@ -118,31 +119,33 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   maxW="100vw"
                   bg="white"
                 >
-                  <PopoverHeader p={0}>
-                    <Flex
-                      h="3.5rem"
-                      mx={{ base: '1rem', md: '1.5rem' }}
-                      justifyContent="space-between"
-                      alignItems="center"
-                    >
-                      <Text textStyle="subhead-2" color="secondary.500">
-                        Select a date
-                      </Text>
-                      <PopoverCloseButton
-                        position="static"
-                        variant="clear"
-                        colorScheme="secondary"
+                  <FocusLock returnFocus persistentFocus={false}>
+                    <PopoverHeader p={0}>
+                      <Flex
+                        h="3.5rem"
+                        mx={{ base: '1rem', md: '1.5rem' }}
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Text textStyle="subhead-2" color="secondary.500">
+                          Select a date
+                        </Text>
+                        <PopoverCloseButton
+                          position="static"
+                          variant="clear"
+                          colorScheme="secondary"
+                        />
+                      </Flex>
+                    </PopoverHeader>
+                    <PopoverBody p={0}>
+                      <DateInput.DatePicker
+                        date={datePickerDate}
+                        isDateUnavailable={isDateUnavailable}
+                        onSelectDate={handleDatepickerSelection}
+                        ref={initialFocusRef}
                       />
-                    </Flex>
-                  </PopoverHeader>
-                  <PopoverBody p={0}>
-                    <DateInput.DatePicker
-                      date={datePickerDate}
-                      isDateUnavailable={isDateUnavailable}
-                      onSelectDate={handleDatepickerSelection}
-                      ref={initialFocusRef}
-                    />
-                  </PopoverBody>
+                    </PopoverBody>
+                  </FocusLock>
                 </PopoverContent>
               </Portal>
             </>

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -160,6 +160,18 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
       return value[1] ?? ''
     }, [value])
 
+    const calendarButtonAria = useMemo(() => {
+      let ariaLabel = 'Choose date. '
+      if (value.length === 1) {
+        ariaLabel += `Selected date is ${new Date(value[0]).toDateString()}.`
+      } else if (value.length === 2) {
+        ariaLabel += `Selected date range is ${new Date(
+          value[0],
+        ).toDateString()} to ${new Date(value[1]).toDateString()}.`
+      }
+      return ariaLabel
+    }, [value])
+
     return (
       <Wrap shouldWrapChildren spacing="0.25rem">
         <Wrap shouldWrapChildren spacing="0.5rem" align="center">
@@ -212,7 +224,7 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
             <>
               <PopoverTrigger>
                 <IconButton
-                  aria-label="Open calendar"
+                  aria-label={calendarButtonAria}
                   icon={<BxCalendar />}
                   isActive={isOpen}
                   fontSize="1.25rem"

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import FocusLock from 'react-focus-lock'
 import {
   Flex,
   forwardRef,
@@ -243,34 +244,36 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                   maxW="100vw"
                   bg="white"
                 >
-                  <PopoverHeader>
-                    <Flex
-                      h="3.5rem"
-                      mx={{ base: '1rem', md: '1.5rem' }}
-                      justifyContent="space-between"
-                      alignItems="center"
-                    >
-                      <Text textStyle="subhead-2" color="secondary.500">
-                        Select date range
-                      </Text>
-                      <PopoverCloseButton
-                        variant="clear"
-                        colorScheme="secondary"
-                        position="static"
+                  <FocusLock returnFocus persistentFocus={false}>
+                    <PopoverHeader>
+                      <Flex
+                        h="3.5rem"
+                        mx={{ base: '1rem', md: '1.5rem' }}
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Text textStyle="subhead-2" color="secondary.500">
+                          Select date range
+                        </Text>
+                        <PopoverCloseButton
+                          variant="clear"
+                          colorScheme="secondary"
+                          position="static"
+                        />
+                      </Flex>
+                    </PopoverHeader>
+                    <PopoverBody p={0}>
+                      <DateRangePicker
+                        selectedDates={datePickerDates}
+                        hoveredDate={hoveredDate}
+                        isDateInRange={isDateInRange}
+                        onMouseEnterHighlight={onMouseEnterHighlight}
+                        onMouseLeaveCalendar={onMouseLeaveCalendar}
+                        onSelectDate={handleOnDateSelected}
+                        ref={initialFocusRef}
                       />
-                    </Flex>
-                  </PopoverHeader>
-                  <PopoverBody p={0}>
-                    <DateRangePicker
-                      selectedDates={datePickerDates}
-                      hoveredDate={hoveredDate}
-                      isDateInRange={isDateInRange}
-                      onMouseEnterHighlight={onMouseEnterHighlight}
-                      onMouseLeaveCalendar={onMouseLeaveCalendar}
-                      onSelectDate={handleOnDateSelected}
-                      ref={initialFocusRef}
-                    />
-                  </PopoverBody>
+                    </PopoverBody>
+                  </FocusLock>
                 </PopoverContent>
               </Portal>
             </>

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
   Portal,
   Text,
+  VisuallyHidden,
   Wrap,
 } from '@chakra-ui/react'
 import { compareAsc } from 'date-fns'
@@ -244,8 +245,13 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                   maxW="100vw"
                   bg="white"
                 >
-                  <FocusLock returnFocus persistentFocus={false}>
-                    <PopoverHeader>
+                  <FocusLock returnFocus>
+                    {/* Having this extra guard here allows for tab rotation instead of closing the 
+                    calendar on certain tab key presses.
+                    data-focus-guard is required to work with FocusLock
+                    NFI why this is necessary, just that it works. Such is the life of a software engineer. */}
+                    <VisuallyHidden data-focus-guard tabIndex={2} />
+                    <PopoverHeader p={0}>
                       <Flex
                         h="3.5rem"
                         mx={{ base: '1rem', md: '1.5rem' }}

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -11,6 +11,7 @@ import {
   Flex,
   forwardRef,
   Popover,
+  PopoverAnchor,
   PopoverBody,
   PopoverCloseButton,
   PopoverContent,
@@ -176,54 +177,56 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
 
     return (
       <Wrap shouldWrapChildren spacing="0.25rem">
-        <Wrap shouldWrapChildren spacing="0.5rem" align="center">
-          <Input
-            aria-label="Start date"
-            id={`${props.name}-start-date`}
-            onKeyDown={handlePreventOpenNativeCalendar}
-            type="date"
-            w="fit-content"
-            sx={{
-              // Chrome displays a default calendar icon, which we want to hide
-              // so all browsers display our icon consistently.
-              '::-webkit-calendar-picker-indicator': {
-                display: 'none',
-              },
-            }}
-            onChange={handleStartDateChange}
-            value={startDateRenderedValue}
-            ref={ref}
-            {...props}
-          />
-          <Text textStyle="body-1" color="secondary.400" px="0.5rem">
-            to
-          </Text>
-          <Input
-            aria-label="End date"
-            id={`${props.name}-end-date`}
-            onKeyDown={handlePreventOpenNativeCalendar}
-            type="date"
-            w="fit-content"
-            sx={{
-              // Chrome displays a default calendar icon, which we want to hide
-              // so all browsers display our icon consistently.
-              '::-webkit-calendar-picker-indicator': {
-                display: 'none',
-              },
-            }}
-            isDisabled={!startDateRenderedValue}
-            onChange={handleEndDateChange}
-            value={endDateRenderedValue}
-            {...props}
-          />
-        </Wrap>
         <Popover
-          placement="bottom-end"
+          placement="bottom-start"
           initialFocusRef={initialFocusRef}
           isLazy
         >
           {({ isOpen }) => (
             <>
+              <PopoverAnchor>
+                <Wrap shouldWrapChildren spacing="0.5rem" align="center">
+                  <Input
+                    aria-label="Start date"
+                    id={`${props.name}-start-date`}
+                    onKeyDown={handlePreventOpenNativeCalendar}
+                    type="date"
+                    w="fit-content"
+                    sx={{
+                      // Chrome displays a default calendar icon, which we want to hide
+                      // so all browsers display our icon consistently.
+                      '::-webkit-calendar-picker-indicator': {
+                        display: 'none',
+                      },
+                    }}
+                    onChange={handleStartDateChange}
+                    value={startDateRenderedValue}
+                    ref={ref}
+                    {...props}
+                  />
+                  <Text textStyle="body-1" color="secondary.400" px="0.5rem">
+                    to
+                  </Text>
+                  <Input
+                    aria-label="End date"
+                    id={`${props.name}-end-date`}
+                    onKeyDown={handlePreventOpenNativeCalendar}
+                    type="date"
+                    w="fit-content"
+                    sx={{
+                      // Chrome displays a default calendar icon, which we want to hide
+                      // so all browsers display our icon consistently.
+                      '::-webkit-calendar-picker-indicator': {
+                        display: 'none',
+                      },
+                    }}
+                    isDisabled={!startDateRenderedValue}
+                    onChange={handleEndDateChange}
+                    value={endDateRenderedValue}
+                    {...props}
+                  />
+                </Wrap>
+              </PopoverAnchor>
               <PopoverTrigger>
                 <IconButton
                   aria-label={calendarButtonAria}

--- a/frontend/src/components/DatePicker/utils.ts
+++ b/frontend/src/components/DatePicker/utils.ts
@@ -33,7 +33,15 @@ export const MONTH_NAMES: { shortName: string; fullName: string }[] = [
 /**
  * Names of days to display at top of calendar columns
  */
-export const DAY_NAMES = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+export const DAY_NAMES: { shortName: string; fullName: string }[] = [
+  { shortName: 'Su', fullName: 'Sunday' },
+  { shortName: 'Mo', fullName: 'Monday' },
+  { shortName: 'Tu', fullName: 'Tuesday' },
+  { shortName: 'We', fullName: 'Wednesday' },
+  { shortName: 'Th', fullName: 'Thursday' },
+  { shortName: 'Fr', fullName: 'Friday' },
+  { shortName: 'Sa', fullName: 'Saturday' },
+]
 
 /**
  * Generates array of years which are options in the year dropdown.

--- a/frontend/src/theme/components/DateInput.ts
+++ b/frontend/src/theme/components/DateInput.ts
@@ -94,7 +94,6 @@ export const DateInput: ComponentMultiStyleConfig<typeof parts> = {
         borderColor: 'neutral.300',
       },
       monthGrid: {
-        rowGap: '0.5rem',
         display: 'inline-grid',
         justifyItems: 'left',
       },
@@ -106,7 +105,7 @@ export const DateInput: ComponentMultiStyleConfig<typeof parts> = {
         justifyContent: 'center',
         w: {
           base: '2rem',
-          md: '3rem',
+          md: '3.25rem',
         },
         h: {
           base: '2rem',

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -9,8 +9,22 @@ import { textStyles } from './textStyles'
 export const theme = extendTheme({
   styles: {
     global: {
+      '*': {
+        margin: 0,
+      },
+      html: {
+        height: '100%',
+      },
+      'th, td': {
+        padding: 0,
+      },
       body: {
+        height: '100%',
         fontFeatureSettings: "'tnum' on, 'cv05' on",
+        '-webkit-font-smoothing': 'antialiased',
+      },
+      '#root, #__next': {
+        isolation: 'isolate',
       },
       /**
        * This will hide the focus indicator if the element receives focus via


### PR DESCRIPTION
> Note that this PR builds on #3199 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the missing a11y alerts/tab indices to the DatePicker components
Closes #2006 

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add aria labels wherever necessary for elaboration
- feat: add correct tabbing pattern outlined in design
- feat: use IconButton for calendar popover close


**Improvements**:

- feat: use table instead of grid for more semantic a11y
- style: add global reset styles

**Bug Fixes**:

- fix: remove extra margin due to wrap in CalendarPanel

## Before & After Screenshots
Stories should be automatically updated

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->


**New dependencies**:
- `react-focus-lock`: lock focus inside calendar
