### PR TITLE
feat(v2): update form mode display in settings to conform to design

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,17 +1,17 @@
 import { Divider } from '@chakra-ui/react'
 
-import { CategoryHeader } from './components/CategoryHeader'
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormDetailsSection } from './components/FormDetailsSection'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import { FormStatusToggle } from './components/FormStatusToggle'
+import { GeneralTabHeader } from './components/GeneralTabHeader'
 import { SubcategoryHeader } from './components/SubcategoryHeader'
 
 export const SettingsGeneralPage = (): JSX.Element => {
   return (
     <>
-      <CategoryHeader>Respondent access</CategoryHeader>
+      <GeneralTabHeader />
       <FormStatusToggle />
       <Divider my="2.5rem" />
       <SubcategoryHeader>Scheduling</SubcategoryHeader>

--- a/frontend/src/features/admin-form/settings/components/CategoryHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/CategoryHeader.tsx
@@ -1,14 +1,15 @@
-import { Text } from '@chakra-ui/react'
+import { Text, TextProps } from '@chakra-ui/react'
 
-export interface CategoryHeaderProps {
+export interface CategoryHeaderProps extends TextProps {
   children: React.ReactNode
 }
 
 export const CategoryHeader = ({
   children,
+  ...props
 }: CategoryHeaderProps): JSX.Element => {
   return (
-    <Text as="h2" textStyle="h2" color="secondary.500" mb="2.5rem">
+    <Text as="h2" textStyle="h2" color="secondary.500" mb="2.5rem" {...props}>
       {children}
     </Text>
   )

--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEventHandler, useCallback, useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { FormControl, Skeleton, Stack, Text, Wrap } from '@chakra-ui/react'
+import { FormControl, Skeleton, Stack } from '@chakra-ui/react'
 import { get, isEmpty } from 'lodash'
 
 import { FormResponseMode } from '~shared/types/form/form'
@@ -18,15 +18,6 @@ export const FormDetailsSection = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
-  const readableFormResponseMode = useMemo(() => {
-    switch (settings?.responseMode) {
-      case FormResponseMode.Email:
-        return 'Email'
-      case FormResponseMode.Encrypt:
-        return 'Storage'
-    }
-  }, [settings?.responseMode])
-
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!settings}>
       <Stack spacing="2rem">
@@ -34,10 +25,6 @@ export const FormDetailsSection = (): JSX.Element => {
         {settings?.responseMode === FormResponseMode.Email ? (
           <EmailFormSection settings={settings} />
         ) : null}
-        <Wrap shouldWrapChildren justify="space-between" textStyle="subhead-1">
-          <Text>Mode for receiving responses</Text>
-          <Text>{readableFormResponseMode}</Text>
-        </Wrap>
       </Stack>
     </Skeleton>
   )

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -64,6 +64,7 @@ export const FormStatusToggle = (): JSX.Element => {
           responses
         </Text>
         <Switch
+          aria-label="Toggle form status"
           aria-describedby="form-status"
           isLoading={mutateFormStatus.isLoading}
           isChecked={isFormPublic}

--- a/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import { Skeleton, Wrap } from '@chakra-ui/react'
+
+import { FormResponseMode } from '~shared/types/form'
+
+import Badge from '~components/Badge'
+
+import { useAdminFormSettings } from '../queries'
+
+import { CategoryHeader } from './CategoryHeader'
+
+export const GeneralTabHeader = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const readableFormResponseMode = useMemo(() => {
+    switch (settings?.responseMode) {
+      case FormResponseMode.Email:
+        return 'Email mode'
+      case FormResponseMode.Encrypt:
+        return 'Storage mode'
+    }
+    return 'Loading...'
+  }, [settings?.responseMode])
+  return (
+    <Wrap
+      shouldWrapChildren
+      spacing="0.5rem"
+      justify="space-between"
+      mb="2.5rem"
+    >
+      <CategoryHeader mb={0}>Respondent access</CategoryHeader>
+      <Skeleton isLoaded={!isLoadingSettings}>
+        <Badge variant="subtle" colorScheme="primary" color="secondary.500">
+          {readableFormResponseMode}
+        </Badge>
+      </Skeleton>
+    </Wrap>
+  )
+}

--- a/frontend/src/theme/components/Badge.ts
+++ b/frontend/src/theme/components/Badge.ts
@@ -14,7 +14,7 @@ export const Badge: ComponentStyleConfig = {
       const textColor = c === 'secondary' ? 'white' : 'secondary.700'
 
       return {
-        textColor: textColor,
+        color: textColor,
         bgColor: `${c}.400`,
       }
     },
@@ -25,7 +25,7 @@ export const Badge: ComponentStyleConfig = {
 
       return {
         bgColor: `${c}.100`,
-        textColor,
+        color: textColor,
       }
     },
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Design updated display of form mode to be shown on a badge beside the first header instead of being nested deeply in a subcategory. This PR updates SettingsGeneralPage to conform to the new design. 

Also fixes some a11y issues in `FormStatusToggle` component

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add and use `GeneralTabHeader` component that displays form mode badge
- feat(FormDetailsSection): remove response mode display from component 

**Improvements**:

- ref(Badge): use color instead of textColor prop in theme 

**Bug Fixes**:

- fix: add aria-label to form status toggle for better a11y

## Before & After Screenshots
should be captured in Chromatic snapshot
