### PR TITLE
feat(v2): add initial public form authentication feature

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -5,6 +5,7 @@ import { ChakraProvider } from '@chakra-ui/react'
 
 import { theme } from '~theme/index'
 import { AuthProvider } from '~contexts/AuthContext'
+import { HttpError } from '~services/ApiService'
 
 import { AppRouter } from './AppRouter'
 
@@ -12,7 +13,14 @@ import { AppRouter } from './AppRouter'
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000, // 60 seconds
+      staleTime: 60 * 1000, // 60 seconds,
+      retry: (failureCount, error) => {
+        // Do not retry if 404.
+        if (error instanceof HttpError && error.code === 404) {
+          return false
+        }
+        return failureCount !== 3
+      },
     },
   },
 })

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
+import { FormAuthType } from '~shared/types/form'
+
 import { getPublicFormResponse } from '~/mocks/msw/handlers/public-form'
 
 import { StoryRouter } from '~utils/storybook'
@@ -29,4 +31,109 @@ export const Default = Template.bind({})
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: [getPublicFormResponse({ delay: 'infinite' })],
+}
+
+export const SingpassUnauthorized = Template.bind({})
+SingpassUnauthorized.storyName = 'Singpass/Unauthorized'
+SingpassUnauthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'Singpass login form',
+          authType: FormAuthType.SP,
+        },
+      },
+    }),
+  ],
+}
+
+export const SingpassAuthorized = Template.bind({})
+SingpassAuthorized.storyName = 'Singpass/Authorized'
+SingpassAuthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'Singpass login form',
+          authType: FormAuthType.SP,
+        },
+        spcpSession: {
+          userName: 'S1234567A',
+        },
+      },
+    }),
+  ],
+}
+
+export const CorppassUnauthorized = Template.bind({})
+CorppassUnauthorized.storyName = 'Corppass/Unauthorized'
+CorppassUnauthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'Corppass login form',
+          authType: FormAuthType.CP,
+        },
+      },
+    }),
+  ],
+}
+
+export const CorppassAuthorized = Template.bind({})
+CorppassAuthorized.storyName = 'Corppass/Authorized'
+CorppassAuthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'Corppass login form',
+          authType: FormAuthType.CP,
+        },
+        spcpSession: {
+          userName: '200000000A',
+        },
+      },
+    }),
+  ],
+}
+
+export const SgidUnauthorized = Template.bind({})
+SgidUnauthorized.storyName = 'SGID/Unauthorized'
+SgidUnauthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'SGID login form',
+          authType: FormAuthType.SGID,
+        },
+      },
+    }),
+  ],
+}
+
+export const SgidAuthorized = Template.bind({})
+SgidAuthorized.storyName = 'SGID/Authorized'
+SgidAuthorized.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'SGID login form',
+          authType: FormAuthType.SGID,
+        },
+        spcpSession: {
+          userName: 'S0000000Z',
+        },
+      },
+    }),
+  ],
 }

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -1,3 +1,4 @@
+import { PublicFormAuthRedirectDto } from '~shared/types/form'
 import { PublicFormViewDto } from '~shared/types/form/form'
 
 import { ApiService } from '~services/ApiService'
@@ -16,4 +17,22 @@ export const getPublicFormView = async (
   return ApiService.get<PublicFormViewDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}`,
   ).then(({ data }) => data)
+}
+
+/**
+ * Gets the redirect url for public form login
+ * @param formId form id of form to log in.
+ * @param isPersistentLogin whether login is persistent; affects cookie lifetime.
+ * @returns redirect url for public form login
+ */
+export const getPublicFormAuthRedirectUrl = async (
+  formId: string,
+  isPersistentLogin = false,
+): Promise<PublicFormAuthRedirectDto['redirectURL']> => {
+  return ApiService.get<PublicFormAuthRedirectDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/${formId}/auth/redirect`,
+    {
+      params: { isPersistentLogin },
+    },
+  ).then(({ data }) => data.redirectURL)
 }

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -1,5 +1,8 @@
-import { PublicFormAuthRedirectDto } from '~shared/types/form'
-import { PublicFormViewDto } from '~shared/types/form/form'
+import {
+  PublicFormAuthLogoutDto,
+  PublicFormAuthRedirectDto,
+} from '~shared/types/form'
+import { FormAuthType, PublicFormViewDto } from '~shared/types/form/form'
 
 import { ApiService } from '~services/ApiService'
 
@@ -35,4 +38,17 @@ export const getPublicFormAuthRedirectUrl = async (
       params: { isPersistentLogin },
     },
   ).then(({ data }) => data.redirectURL)
+}
+
+/**
+ * Logs out of current public form session
+ * @param authType authType of form to log out.
+ * @returns Success message
+ */
+export const logoutPublicForm = async (
+  authType: Exclude<FormAuthType, FormAuthType.NIL>,
+): Promise<PublicFormAuthLogoutDto> => {
+  return ApiService.get<PublicFormAuthLogoutDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/auth/${authType}/logout`,
+  ).then(({ data }) => data)
 }

--- a/frontend/src/features/public-form/components/FormAuth/AuthImageSvgr.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/AuthImageSvgr.tsx
@@ -1,0 +1,109 @@
+import { forwardRef, memo, Ref, SVGProps } from 'react'
+
+export const AuthImageSvgr = memo(
+  forwardRef((props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
+    <svg
+      width={118}
+      height={144}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      ref={ref}
+      {...props}
+    >
+      <path
+        d="M113.902.402h-.25v143.196h3.515V.402h-3.265Z"
+        fill="#293044"
+        stroke="#293044"
+        strokeWidth={0.5}
+      />
+      <path
+        d="M1.083.402h-.25v143.196H113.882V.402H1.083Z"
+        fill="#fff"
+        stroke="#293044"
+        strokeWidth={0.5}
+      />
+      <path d="M1.083 14.88h112.759v41.974H1.084V14.88Z" fill="#4A61C0" />
+      <path
+        d="M18.03 29.137h78.838v1.14H18.031v-1.14ZM18.03 35.322h78.838v1.14H18.03v-1.14ZM33.794 41.512h47.793v1.14H33.794v-1.14Z"
+        fill="#8998D6"
+      />
+      <rect
+        x={45.554}
+        y={48.123}
+        width={26.029}
+        height={26.029}
+        rx={3.5}
+        fill="#293044"
+        stroke="#293044"
+      />
+      <rect
+        x={43.083}
+        y={45.652}
+        width={27.029}
+        height={27.029}
+        rx={4}
+        fill="url(#a)"
+      />
+      <rect x={20.083} y={83.652} width={76} height={8} rx={4} fill="#E4E7F6" />
+      <rect x={20.083} y={99.652} width={76} height={8} rx={4} fill="#E4E7F6" />
+      <rect
+        x={20.083}
+        y={115.652}
+        width={76}
+        height={8}
+        rx={4}
+        fill="#E4E7F6"
+      />
+      <defs>
+        <pattern
+          id="a"
+          patternContentUnits="objectBoundingBox"
+          width={1}
+          height={1}
+        >
+          <use
+            xlinkHref="#b"
+            transform="matrix(.00714 0 0 .00714 -.079 -.079)"
+          />
+        </pattern>
+        <svg
+          id="b"
+          width={162}
+          height={162}
+          viewBox="0 0 180 180"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          ref={ref}
+          {...props}
+        >
+          <rect width={180} height={180} rx={22.5} fill="#F4333D" />
+          <mask
+            id="c"
+            mask-type="alpha"
+            maskUnits="userSpaceOnUse"
+            x={69}
+            y={33}
+            width={42}
+            height={113}
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M69.412 33.75h40.732v111.364H69.412V33.75Z"
+              fill="#fff"
+            />
+          </mask>
+          <g mask="url(#c)">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M69.39 145.114h40.732l-8.666-67.382c-6.5 1.95-16.9 1.95-23.4 0l-8.666 67.382Zm20.365-73.666c-10.616 0-18.85-8.233-18.85-18.849s8.234-18.85 18.85-18.85c10.617 0 18.85 8.233 18.85 18.85 0 10.616-8.233 18.85-18.85 18.85Z"
+              fill="#fff"
+            />
+          </g>
+        </svg>
+      </defs>
+    </svg>
+  )),
+)

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { BiLogInCircle } from 'react-icons/bi'
+import { Box, Stack, Text } from '@chakra-ui/react'
+
+import { FormAuthType } from '~shared/types/form'
+
+import Button from '~components/Button'
+
+import { AuthImageSvgr } from './AuthImageSvgr'
+
+export interface FormAuthProps {
+  authType: Exclude<FormAuthType, FormAuthType.NIL>
+}
+
+export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
+  const displayedInfo = useMemo(() => {
+    switch (authType) {
+      case FormAuthType.SP:
+      case FormAuthType.MyInfo:
+        return {
+          authType: 'Singpass',
+          helpText:
+            'Sign in with Singpass to access this form.\nYour Singpass ID will be included with your form submission.',
+        }
+      case FormAuthType.CP:
+        return {
+          authType: 'Singpass (Corporate)',
+          helpText:
+            'Corporate entity login is required for this form.\nYour Singpass ID and corporate Entity ID will be included with your form submission.',
+        }
+      case FormAuthType.SGID:
+        return {
+          authType: 'Singpass app',
+          helpText:
+            'Sign in with the Singpass app to access this form.\nYour Singpass ID will be included with your form submission.',
+        }
+    }
+  }, [authType])
+
+  return (
+    <Stack spacing="1.5rem" align="center">
+      <AuthImageSvgr />
+      <Box>
+        <Button rightIcon={<BiLogInCircle fontSize="1.5rem" />}>
+          Log in with {displayedInfo.authType}
+        </Button>
+      </Box>
+      <Text
+        textStyle="body-2"
+        color="secondary.500"
+        textAlign="center"
+        whiteSpace="pre-line"
+      >
+        {displayedInfo.helpText}
+      </Text>
+    </Stack>
+  )
+}

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { BiLogInCircle } from 'react-icons/bi'
-import { Box, Stack, Text } from '@chakra-ui/react'
+import { Stack, Text } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types/form'
 
@@ -44,15 +44,13 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
   return (
     <Stack spacing="1.5rem" align="center">
       <AuthImageSvgr />
-      <Box>
-        <Button
-          rightIcon={<BiLogInCircle fontSize="1.5rem" />}
-          onClick={() => handleLoginMutation.mutate()}
-          isLoading={handleLoginMutation.isLoading}
-        >
-          Log in with {displayedInfo.authType}
-        </Button>
-      </Box>
+      <Button
+        rightIcon={<BiLogInCircle fontSize="1.5rem" />}
+        onClick={() => handleLoginMutation.mutate()}
+        isLoading={handleLoginMutation.isLoading}
+      >
+        Log in with {displayedInfo.authType}
+      </Button>
       <Text
         textStyle="body-2"
         color="secondary.500"

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -6,6 +6,8 @@ import { FormAuthType } from '~shared/types/form'
 
 import Button from '~components/Button'
 
+import { usePublicAuthMutations } from '~features/public-form/mutations'
+
 import { AuthImageSvgr } from './AuthImageSvgr'
 
 export interface FormAuthProps {
@@ -37,11 +39,17 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
     }
   }, [authType])
 
+  const { handleLoginMutation } = usePublicAuthMutations()
+
   return (
     <Stack spacing="1.5rem" align="center">
       <AuthImageSvgr />
       <Box>
-        <Button rightIcon={<BiLogInCircle fontSize="1.5rem" />}>
+        <Button
+          rightIcon={<BiLogInCircle fontSize="1.5rem" />}
+          onClick={() => handleLoginMutation.mutate()}
+          isLoading={handleLoginMutation.isLoading}
+        >
           Log in with {displayedInfo.authType}
         </Button>
       </Box>

--- a/frontend/src/features/public-form/components/FormAuth/index.ts
+++ b/frontend/src/features/public-form/components/FormAuth/index.ts
@@ -1,0 +1,1 @@
+export { FormAuth } from './FormAuth'

--- a/frontend/src/features/public-form/components/FormFields/FormField.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormField.tsx
@@ -1,0 +1,37 @@
+import { Text } from '@chakra-ui/react'
+
+import { BasicField, FormFieldDto } from '~shared/types/field'
+import { FormColorTheme } from '~shared/types/form'
+
+import {
+  NricField,
+  NumberField,
+  SectionField,
+  ShortTextField,
+  UenField,
+  YesNoField,
+} from '~templates/Field'
+
+interface FormFieldProps {
+  field: FormFieldDto
+  colorTheme?: FormColorTheme
+}
+
+export const FormField = ({ field, colorTheme }: FormFieldProps) => {
+  switch (field.fieldType) {
+    case BasicField.Section:
+      return <SectionField schema={field} colorTheme={colorTheme} />
+    case BasicField.Nric:
+      return <NricField schema={field} colorTheme={colorTheme} />
+    case BasicField.Number:
+      return <NumberField schema={field} colorTheme={colorTheme} />
+    case BasicField.ShortText:
+      return <ShortTextField schema={field} colorTheme={colorTheme} />
+    case BasicField.YesNo:
+      return <YesNoField schema={field} colorTheme={colorTheme} />
+    case BasicField.Uen:
+      return <UenField schema={field} colorTheme={colorTheme} />
+    default:
+      return <Text w="100%">{JSON.stringify(field)}</Text>
+  }
+}

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,0 +1,44 @@
+import { FieldValues, FormProvider, useForm } from 'react-hook-form'
+import { Stack } from '@chakra-ui/react'
+
+import { FormFieldDto } from '~shared/types/field'
+import { FormColorTheme } from '~shared/types/form'
+
+import Button from '~components/Button'
+
+import { FormField } from './FormField'
+
+export interface FormFieldsProps {
+  formFields: FormFieldDto[]
+  colorTheme: FormColorTheme
+  onSubmit: (values: FieldValues) => void
+}
+
+export const FormFields = ({
+  formFields,
+  colorTheme,
+  onSubmit,
+}: FormFieldsProps): JSX.Element => {
+  // TODO: Inject default values if field is MyInfo, or prefilled.
+  const formMethods = useForm()
+
+  return (
+    <FormProvider {...formMethods}>
+      <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
+        <Stack spacing="2.25rem">
+          {formFields.map((field) => (
+            <FormField key={field._id} field={field} colorTheme={colorTheme} />
+          ))}
+          <Button
+            mt="1rem"
+            type="submit"
+            isLoading={formMethods.formState.isSubmitting}
+            loadingText="Submitting"
+          >
+            Submit
+          </Button>
+        </Stack>
+      </form>
+    </FormProvider>
+  )
+}

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -5,6 +5,8 @@ import { FormAuthType, FormColorTheme } from '~shared/types/form/form'
 
 import { usePublicFormView } from '~features/public-form/queries'
 
+import { FormAuth } from '../FormAuth'
+
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
 import { FormSectionsProvider } from './FormSectionsContext'
@@ -41,7 +43,7 @@ export const FormFieldsContainer = (): JSX.Element => {
     }
 
     if (data.form.authType !== FormAuthType.NIL && !data.spcpSession) {
-      return <div>NO ENTRY</div>
+      return <FormAuth authType={data.form.authType} />
     }
 
     return (

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -31,6 +31,11 @@ export const FormFieldsContainer = (): JSX.Element => {
     }
   }, [data, isLoading])
 
+  const isAuthRequired = useMemo(
+    () => data && data.form.authType !== FormAuthType.NIL && !data.spcpSession,
+    [data],
+  )
+
   const renderFields = useMemo(() => {
     // Render skeleton when no data
     if (isLoading) {
@@ -42,7 +47,8 @@ export const FormFieldsContainer = (): JSX.Element => {
       return <div>Something went wrong</div>
     }
 
-    if (data.form.authType !== FormAuthType.NIL && !data.spcpSession) {
+    // Redundant conditional for type narrowing
+    if (isAuthRequired && data.form.authType !== FormAuthType.NIL) {
       return <FormAuth authType={data.form.authType} />
     }
 
@@ -53,12 +59,12 @@ export const FormFieldsContainer = (): JSX.Element => {
         onSubmit={onSubmit}
       />
     )
-  }, [data, isLoading, onSubmit])
+  }, [data, isAuthRequired, isLoading, onSubmit])
 
   return (
     <FormSectionsProvider>
       <Flex bg={bgColour} flex={1} justify="center" p="1.5rem">
-        <SectionSidebar />
+        {isAuthRequired ? null : <SectionSidebar />}
         <Box
           bg="white"
           p="2.5rem"
@@ -69,7 +75,7 @@ export const FormFieldsContainer = (): JSX.Element => {
         >
           {renderFields}
         </Box>
-        <Spacer />
+        {isAuthRequired ? null : <Spacer />}
       </Flex>
     </FormSectionsProvider>
   )

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsSkeleton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Flex, Skeleton } from '@chakra-ui/react'
+
+export const FormFieldsSkeleton = (): JSX.Element => {
+  return (
+    <Flex flexDir="column">
+      <Skeleton height="2rem" />
+      <Skeleton height="1.5rem" mt="2.25rem" />
+      <Skeleton height="2.75rem" mt="0.75rem" />
+      <Skeleton height="1.5rem" mt="2.25rem" />
+      <Skeleton height="2.75rem" mt="0.75rem" />
+      <Skeleton height="1.5rem" mt="2.25rem" />
+      <Skeleton height="2.75rem" mt="0.75rem" />
+      <Skeleton height="1.5rem" mt="2.25rem" />
+      <Skeleton height="2.75rem" mt="0.75rem" />
+    </Flex>
+  )
+}

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.stories.tsx
@@ -42,7 +42,9 @@ NoLogo.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test title',
+        form: {
+          title: 'storybook test title',
+        },
       },
       delay: 0,
     }),
@@ -56,11 +58,13 @@ CustomLogo.parameters = {
     getCustomLogoResponse(),
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test title',
-        startPage: {
-          logo: {
-            state: FormLogoState.Custom,
-            fileId: 'mockFormLogo',
+        form: {
+          title: 'storybook test title',
+          startPage: {
+            logo: {
+              state: FormLogoState.Custom,
+              fileId: 'mockFormLogo',
+            },
           },
         },
       },
@@ -74,9 +78,11 @@ NoEstimatedTime.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook no estimated time',
-        startPage: {
-          estTimeTaken: 0,
+        form: {
+          title: 'storybook no estimated time',
+          startPage: {
+            estTimeTaken: 0,
+          },
         },
       },
       delay: 0,
@@ -89,9 +95,11 @@ ColorThemeBrown.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test brown theme',
-        startPage: {
-          colorTheme: FormColorTheme.Brown,
+        form: {
+          title: 'storybook test brown theme',
+          startPage: {
+            colorTheme: FormColorTheme.Brown,
+          },
         },
       },
       delay: 0,
@@ -103,9 +111,11 @@ ColorThemeGreen.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test green theme',
-        startPage: {
-          colorTheme: FormColorTheme.Green,
+        form: {
+          title: 'storybook test green theme',
+          startPage: {
+            colorTheme: FormColorTheme.Green,
+          },
         },
       },
       delay: 0,
@@ -118,9 +128,11 @@ ColorThemeGrey.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test grey theme',
-        startPage: {
-          colorTheme: FormColorTheme.Grey,
+        form: {
+          title: 'storybook test grey theme',
+          startPage: {
+            colorTheme: FormColorTheme.Grey,
+          },
         },
       },
       delay: 0,
@@ -133,9 +145,11 @@ ColorThemeOrange.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test orange theme',
-        startPage: {
-          colorTheme: FormColorTheme.Orange,
+        form: {
+          title: 'storybook test orange theme',
+          startPage: {
+            colorTheme: FormColorTheme.Orange,
+          },
         },
       },
       delay: 0,
@@ -148,9 +162,11 @@ ColorThemeRed.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test red theme',
-        startPage: {
-          colorTheme: FormColorTheme.Red,
+        form: {
+          title: 'storybook test red theme',
+          startPage: {
+            colorTheme: FormColorTheme.Red,
+          },
         },
       },
       delay: 0,
@@ -168,7 +184,9 @@ MiniHeader.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
-        title: 'storybook test title',
+        form: {
+          title: 'storybook test title',
+        },
       },
       delay: 0,
     }),

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -1,0 +1,30 @@
+import { useMutation } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { useToast } from '~hooks/useToast'
+
+import { getPublicFormAuthRedirectUrl } from './PublicFormService'
+
+export const usePublicAuthMutations = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  const toast = useToast({ status: 'danger', isClosable: true })
+
+  const handleLoginMutation = useMutation(
+    () => getPublicFormAuthRedirectUrl(formId),
+    {
+      onSuccess: (redirectUrl) => {
+        window.location.assign(redirectUrl)
+      },
+      onError: (error: Error) => {
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
+    },
+  )
+
+  return { handleLoginMutation }
+}

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -9,7 +9,7 @@ import { PUBLICFORM_REGEX } from '~constants/routes'
 
 import { getPublicFormView } from './PublicFormService'
 
-const publicFormKeys = {
+export const publicFormKeys = {
   // All keys map to either an array or function returning an array for
   // consistency
   base: ['publicForm'] as const,

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -28,6 +28,7 @@ export const usePublicFormView = (): UseQueryResult<
     () => getPublicFormView(formId),
     {
       enabled: PUBLICFORM_REGEX.test(formId),
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -2,7 +2,7 @@ import { merge } from 'lodash'
 import { rest } from 'msw'
 import { PartialDeep } from 'type-fest'
 
-import { PublicFormDto, PublicFormViewDto } from '~shared/types/form/form'
+import { FormId, PublicFormViewDto } from '~shared/types/form/form'
 
 import mockFormLogo from '../assets/mockFormLogo.png'
 
@@ -312,16 +312,22 @@ export const getPublicFormResponse = ({
   overrides,
 }: {
   delay?: number | 'infinite'
-  overrides?: PartialDeep<PublicFormDto>
+  overrides?: PartialDeep<PublicFormViewDto>
 } = {}) => {
   return rest.get<PublicFormViewDto>(
     '/api/v3/forms/:formId',
     (req, res, ctx) => {
       const formId = req.params.formId ?? '61540ece3d4a6e50ac0cc6ff'
 
-      const response: PublicFormViewDto = {
-        form: merge({ _id: formId }, BASE_FORM, overrides) as PublicFormDto,
-      }
+      const response = merge(
+        {
+          form: {
+            _id: formId as FormId,
+            ...BASE_FORM,
+          },
+        },
+        overrides,
+      ) as PublicFormViewDto
       return res(ctx.delay(delay), ctx.json(response))
     },
   )

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -9,6 +9,7 @@ import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
 import { FormFieldWithId } from '~shared/types/field'
+import { FormColorTheme } from '~shared/types/form'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -16,6 +17,10 @@ import { FormLabelProps } from '~components/FormControl/FormLabel/FormLabel'
 
 export type BaseFieldProps = {
   schema: FormFieldWithId
+  /**
+   * Color theme of form, if available. Defaults to `FormColorTheme.Blue`
+   */
+  colorTheme?: FormColorTheme
   questionNumber?: FormLabelProps['questionNumber']
   /**
    * Optional key of error to display in form error message.

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -1,5 +1,8 @@
+import { useMemo } from 'react'
 import { Waypoint } from 'react-waypoint'
 import { Box, Divider, forwardRef, Text } from '@chakra-ui/react'
+
+import { FormColorTheme } from '~shared/types/form'
 
 import { SectionFieldContainerProps } from './SectionFieldContainer'
 
@@ -24,7 +27,16 @@ const SectionDivider = ({ color }: { color?: string }) => (
 
 // Exported for testing.
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
-  ({ schema, dividerColor = 'secondary.100', handleSectionEnter }, ref) => {
+  ({ schema, colorTheme, handleSectionEnter }, ref) => {
+    const dividerColor = useMemo(() => {
+      switch (colorTheme) {
+        case FormColorTheme.Blue:
+          return 'secondary.100'
+        default:
+          return `theme-${colorTheme}.100`
+      }
+    }, [colorTheme])
+
     return (
       <Box>
         <SectionDivider color={dividerColor} />

--- a/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
+++ b/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
@@ -9,12 +9,11 @@ import { SectionField } from './SectionField'
 export type SectionFieldSchema = FormFieldWithId<SectionFieldBase>
 export interface SectionFieldContainerProps extends BaseFieldProps {
   schema: SectionFieldSchema
-  dividerColor?: string
 }
 
 export const SectionFieldContainer = ({
   schema,
-  dividerColor,
+  colorTheme,
 }: SectionFieldContainerProps): JSX.Element => {
   const { sectionRefs, setActiveSectionId } = useFormSections()
 
@@ -22,7 +21,7 @@ export const SectionFieldContainer = ({
     <SectionField
       ref={sectionRefs[schema._id]}
       schema={schema}
-      dividerColor={dividerColor}
+      colorTheme={colorTheme}
       handleSectionEnter={() => setActiveSectionId(schema._id)}
     />
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the public form log in feature, with a few known issues that are not resolved to be completed in future PRs

Related to #2992

## Solution
<!-- How did you solve the problem? -->

**Features**:
- feat(react-query): disable retry if error code is 404 globally
- feat: add AuthImageSvgr component
- feat: add FormAuth component and business logic to log in/log out
  - also center form field div when FormAuth component is shown
- add `usePublicAuthMutations` hook for logging in/out of public forms with spcp/sgid

**Improvements**:

- ref: add colorTheme prop to all field components
  - This will help in the future when we need to theme all (or some) form fields
- ref(SectionField): move dividerColor extrapolation to component and use colorTheme prop instead
- ref: extract all possible field render state into separate components 

**Bug Fixes**:

- fix(Button): remove auto height styling from Button
  - causing some wonky loading spinner heights
- fix(Button): remove fontWeight from baseProp in theme

## Known issues
- [ ] Does not automatically log out when JWT expires
- [ ] Does not correctly redirect to React version and insteads go to AngularJS version

## Before & After Screenshots
New stories in Storybook

## Tests
<!-- What tests should be run to confirm functionality? -->
SOON 
