### PR TITLE
feat: pre-fill to support myinfo forms

### DIFF
--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -427,6 +427,7 @@ export const _handleFormAuthRedirect: ControllerHandler<
               formEsrvcId: form.esrvcId,
               formId,
               requestedAttributes: form.getUniqueMyInfoAttrs(),
+              encodedQuery,
             }),
           )
         case FormAuthType.SP:

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -196,9 +196,20 @@ export const loginToMyInfo: ControllerHandler<
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
   const { formId, cookieDuration, encodedQuery } = parseStateResult.value
-  const redirectDestination = encodedQuery
-    ? `/${formId}?${Buffer.from(encodedQuery, 'base64').toString('utf8')}`
-    : `/${formId}`
+
+  let redirectDestination = `/${formId}`
+
+  if (encodedQuery) {
+    try {
+      redirectDestination = `/${formId}?${Buffer.from(
+        encodedQuery,
+        'base64',
+      ).toString('utf8')}`
+    } catch {
+      // Buffer.from might throw an error if there is a badly encoded
+      // string, in which case we will fall back to the default.
+    }
+  }
 
   // Ensure form exists
   const formResult = await FormService.retrieveFullFormById(formId)

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -202,10 +202,11 @@ export class MyInfoServiceClass {
     formId,
     formEsrvcId,
     requestedAttributes,
+    encodedQuery,
   }: IMyInfoRedirectURLArgs): Result<string, never> {
     const redirectURL = this.#myInfoGovClient.createRedirectURL({
       purpose: MYINFO_CONSENT_PAGE_PURPOSE,
-      relayState: createRelayState(formId),
+      relayState: createRelayState(formId, encodedQuery),
       // Always request consent for NRIC/FIN
       requestedAttributes: internalAttrListToScopes(requestedAttributes),
       singpassEserviceId: formEsrvcId,
@@ -241,6 +242,7 @@ export class MyInfoServiceClass {
         return ok({
           uuid: parsed.uuid,
           formId: parsed.formId,
+          encodedQuery: parsed.encodedQuery,
           // Cookie duration is currently not derived from the relay state
           // but may be in future, e.g. if rememberMe is implemented
           cookieDuration: this.#spCookieMaxAge,

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -13,6 +13,7 @@ export interface IMyInfoRedirectURLArgs {
   formId: string
   formEsrvcId: string
   requestedAttributes: MyInfoAttribute[]
+  encodedQuery?: string
 }
 
 export type MyInfoHashPromises = Partial<
@@ -48,6 +49,7 @@ export type MyInfoCookiePayload =
 export type MyInfoRelayState = {
   uuid: string
   formId: string
+  encodedQuery?: string
 }
 
 /**

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -272,10 +272,14 @@ export const getMyInfoFieldOptions = (
  * Creates state which MyInfo should forward back once user has logged in.
  * @param formId ID of form which user is logging into
  */
-export const createRelayState = (formId: string): string =>
+export const createRelayState = (
+  formId: string,
+  encodedQuery?: string,
+): string =>
   JSON.stringify({
     uuid: uuidv4(),
     formId,
+    encodedQuery,
   })
 
 /**
@@ -411,4 +415,6 @@ export const isMyInfoRelayState = (obj: unknown): obj is MyInfoRelayState =>
   mongoose.Types.ObjectId.isValid(obj.formId) &&
   hasProp(obj, 'uuid') &&
   typeof obj.uuid === 'string' &&
-  validateUUID(obj.uuid)
+  validateUUID(obj.uuid) &&
+  ((hasProp(obj, 'encodedQuery') && typeof obj.encodedQuery === 'string') ||
+    !hasProp(obj, 'encodedQuery'))


### PR DESCRIPTION
## Problem
Adds the relevant routes to pass relayState through to MyInfo forms.

Closes #3183 

## Solution
Added handling for `encodedQuery` into the MyInfo controllers.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

**Features**:
- Adds support for prefilled text for MyInfo forms.

## Tests
Create a MyInfo form with a pre-fill textbox and ensure that the pre-fill text is carried over when the user logs in.