### PR TITLE
fix: correct busboy filename extraction when utf8 filenames are used

### DIFF
--- a/src/app/modules/submission/email-submission/__tests__/email-submission.receiver.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.receiver.spec.ts
@@ -41,6 +41,10 @@ const VALID_FILENAME_2 = 'valid2.txt'
 const VALID_FILE_CONTENT_2 = readFileSync(
   `${VALID_FILE_PATH}${VALID_FILENAME_2}`,
 )
+const VALID_UTF8_FILENAME = 'utf8-with-endash – test.txt'
+const VALID_UTF8_FILE_CONTENT = readFileSync(
+  `${VALID_FILE_PATH}${VALID_UTF8_FILENAME}`,
+)
 
 describe('email-submission.receiver', () => {
   beforeEach(() => {
@@ -97,6 +101,49 @@ describe('email-submission.receiver', () => {
   })
 
   describe('configureMultipartReceiver', () => {
+    it('should correctly process and return with utf8 file names', async () => {
+      const mockResponse = pick(generateNewAttachmentResponse(), [
+        '_id',
+        'question',
+        'answer',
+        'fieldType',
+      ])
+      const mockBody = { responses: [mockResponse] }
+
+      const fileStream = createReadStream(
+        `${VALID_FILE_PATH}${VALID_UTF8_FILENAME}`,
+      )
+      const form = new FormData()
+      form.append('body', JSON.stringify(mockBody))
+      form.append(VALID_UTF8_FILENAME, fileStream, mockResponse._id)
+      const realBusboy = RealBusboy({
+        headers: {
+          'content-type': `multipart/form-data; boundary=${form.getBoundary()}`,
+        },
+      })
+      const resultPromise =
+        EmailSubmissionReceiver.configureMultipartReceiver(realBusboy)
+      form.pipe(realBusboy)
+
+      fileStream.emit('data', VALID_UTF8_FILE_CONTENT)
+      fileStream.emit('end')
+      form.emit('end')
+
+      const result = await resultPromise
+      expect(result._unsafeUnwrap()).toEqual({
+        responses: [
+          {
+            _id: mockResponse._id,
+            question: mockResponse.question,
+            answer: VALID_UTF8_FILENAME,
+            fieldType: mockResponse.fieldType,
+            filename: VALID_UTF8_FILENAME,
+            content: Buffer.concat([VALID_UTF8_FILE_CONTENT]),
+          },
+        ],
+      })
+    })
+
     it('should receive a single attachment and add it to the response', async () => {
       const mockResponse = pick(generateNewAttachmentResponse(), [
         '_id',

--- a/src/app/modules/submission/email-submission/email-submission.receiver.ts
+++ b/src/app/modules/submission/email-submission/email-submission.receiver.ts
@@ -82,6 +82,15 @@ export const configureMultipartReceiver = (
 
       busboy
         .on('file', (fieldname, file, { filename }) => {
+          // Required to convert fieldname's encoding as busboy treats all
+          // incoming fields as `latin1` encoding,
+          // but this means some file languages gets incorrectly encoded
+          // (like Chinese, Tamil, etc), e.g.
+          // `utf8-with-endash – test.txt` -> `utf8-with-endash â�� test.txt`.
+          // See https://github.com/mscdex/busboy/issues/274.
+          const utf8Fieldname = Buffer.from(fieldname, 'latin1').toString(
+            'utf8',
+          )
           if (filename) {
             const buffers: Buffer[] = []
             file.on('data', (data) => {
@@ -91,7 +100,7 @@ export const configureMultipartReceiver = (
             file.on('end', () => {
               const buffer = Buffer.concat(buffers)
               attachments.push({
-                filename: fieldname,
+                filename: utf8Fieldname,
                 content: buffer,
                 fieldId: filename,
               })

--- a/tests/unit/backend/resources/utf8-with-endash – test.txt
+++ b/tests/unit/backend/resources/utf8-with-endash – test.txt
@@ -1,0 +1,6 @@
+there are endashes in this file
+–
+–
+–
+–
+also emdashes —————— — — —


### PR DESCRIPTION
This PR fixes the file names being double/wrongly encoded when outside of latin1 encoding.

Closes #3299, since we didn't have to downgrade after all

Relevant issue where this change was suggested https://github.com/mscdex/busboy/issues/274

## Tests
- Add unit test for verifying utf8 files are not being encoded wrongly

Also tested on staging
![Screenshot 2022-01-19 at 2 34 10 PM](https://user-images.githubusercontent.com/22133008/150077025-bc1b176b-fa8e-4ea5-8d06-4d5649c6c7f7.png)
