### PR TITLE
chore: fix secrets check

### DIFF
--- a/secrets-check.sh
+++ b/secrets-check.sh
@@ -7,7 +7,9 @@ exec 1>&2
 
 # Check changed files for an AWS keys
 KEY_ID=$(git diff --cached --name-only -z $against | xargs -0 cat | perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])}')
-KEY=$(git diff --cached --name-only -z $against | xargs -0 cat | perl -nle'print $& if m{(?<![^A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![^A-Za-z0-9/+=])}')
+KEY=$(git diff --cached --name-only -z $against | xargs -0 cat | perl -nle'print $& if m{(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}')
+
+# Regex for secret check can be found here: https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
 
 if [ "$KEY_ID" != "" -o "$KEY" != "" ]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
## Problem
- Fixes a typo in the secret check regex introduced in #3287 (additional caret `^` led to wrong patterns being matched)

Reference: Regex can be found here: https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/

## Tests

- [x] Add the following to a file in the repo and try to commit. Pre-commit hook should catch
Access Key ID: AKIAIOSFODNN7EXAMPLE
Secret Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY