### PR TITLE
fix(v2/CalendarHeader): use non-esm variant of date-fns function

### DIFF
--- a/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarHeader.tsx
@@ -8,7 +8,7 @@ import {
   useBreakpointValue,
   useStyles,
 } from '@chakra-ui/react'
-import { addMonths } from 'date-fns/esm'
+import { addMonths } from 'date-fns'
 
 import { BxChevronLeft, BxChevronRight } from '~assets/icons'
 import IconButton from '~components/IconButton'


### PR DESCRIPTION
This PR changes an accidental esm import of date-fns to use the non-esm variant