### PR TITLE
chore(v2/eslint): update unused vars rule to warn instead of error

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -8,7 +8,7 @@
       "extends": ["react-app", "plugin:@typescript-eslint/recommended"],
       "parser": "@typescript-eslint/parser",
       "rules": {
-        "@typescript-eslint/no-unused-vars": "error"
+        "@typescript-eslint/no-unused-vars": "warn"
       }
     },
     {


### PR DESCRIPTION
TOO DAMN ANNOYING

TODOs in the future could be to only be an error during a precommit hook (to prevent commits if there are unused vars). This could still allow for a faster and more experimental local developer experience without adding unused variables during review.
