### PR TITLE
fix: DNS resolution error causes 5xx on form deletion

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2098,6 +2098,56 @@ describe('Form Model', () => {
         // Assert
         expect(actual.status).toEqual(FormStatus.Archived)
       })
+
+      it('should allow archive if form has valid webhook url', async () => {
+        // Arrange
+        const form = await Form.create({
+          admin: populatedAdmin._id,
+          publicKey: 'any public key',
+          responseMode: FormResponseMode.Encrypt,
+          title: 'mock encrypt form',
+          status: FormStatus.Public,
+          webhook: {
+            url: 'https://www.form.gov.sg',
+          },
+        })
+        expect(form).toBeDefined()
+
+        // Act
+        const actual = await form.archive()
+
+        // Assert
+        expect(actual.status).toEqual(FormStatus.Archived)
+      })
+
+      it('should prevent archive and return validation error if form has invalid webhook url', async () => {
+        // Arrange
+        const form = await Form.create({
+          admin: populatedAdmin._id,
+          publicKey: 'any public key',
+          responseMode: FormResponseMode.Encrypt,
+          title: 'mock encrypt form',
+          status: FormStatus.Public,
+          webhook: {
+            url: 'https://www.form.gov.sg',
+          },
+        })
+
+        if (form?.webhook?.url) {
+          form.webhook.url = 'https://wwwww.form.gov.sg' // Inject invalid webhook url
+        }
+
+        expect(form).toBeDefined()
+        // Act
+
+        const actual = await form.archive().catch((err) => err)
+
+        // Assert
+        expect(actual).toBeInstanceOf(mongoose.Error.ValidationError)
+        expect(actual.message).toEqual(
+          expect.stringContaining('Error encountered during DNS resolution'),
+        )
+      })
     })
 
     describe('getDashboardView', () => {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -885,8 +885,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     // Webhooks only allowed if encrypt mode
     if (
       this.responseMode !== FormResponseMode.Encrypt &&
-      this.webhook?.url &&
-      this.webhook.url.length > 0
+      this.webhook?.url?.length > 0
     ) {
       const validationError = this.invalidate(
         'webhook',

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -885,7 +885,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     // Webhooks only allowed if encrypt mode
     if (
       this.responseMode !== FormResponseMode.Encrypt &&
-      this.webhook?.url?.length > 0
+      (this.webhook?.url?.length ?? 0) > 0
     ) {
       const validationError = this.invalidate(
         'webhook',

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -397,7 +397,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       },
 
       webhook: {
-        // TODO: URL validation, encrypt mode validation
         url: {
           type: String,
           default: '',
@@ -881,6 +880,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       const err = new Error('Form size exceeded.')
       err.name = 'FormSizeError'
       return next(err)
+    }
+
+    // Webhooks only allowed if encrypt mode
+    if (
+      this.responseMode !== FormResponseMode.Encrypt &&
+      this.webhook?.url &&
+      this.webhook.url.length > 0
+    ) {
+      const validationError = this.invalidate(
+        'webhook',
+        'Webhook only allowed on storage mode form',
+      ) as mongoose.Error.ValidationError
+      return next(validationError)
     }
 
     // Validate that admin exists before form is created.

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -271,7 +271,13 @@ export const extractMyInfoFieldIds = (
  */
 export const archiveForm = (
   form: IPopulatedForm,
-): ResultAsync<true, DatabaseError> => {
+): ResultAsync<
+  true,
+  | DatabaseError
+  | DatabaseValidationError
+  | DatabaseConflictError
+  | DatabasePayloadSizeError
+> => {
   return ResultAsync.fromPromise(form.archive(), (error) => {
     logger.error({
       message: 'Database error encountered when archiving form',
@@ -282,7 +288,7 @@ export const archiveForm = (
       error,
     })
 
-    return new DatabaseError(getMongoErrorMessage(error))
+    return transformMongoError(error)
     // On success, return true
   }).map(() => true)
 }

--- a/src/app/modules/webhook/__tests__/webhook.validation.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.validation.spec.ts
@@ -38,7 +38,7 @@ describe('Webhook URL validation', () => {
     MockDns.resolve.mockRejectedValueOnce([])
     await expect(validateWebhookUrl(MOCK_WEBHOOK_URL)).rejects.toStrictEqual(
       new WebhookValidationError(
-        `Error encountered during DNS resolution for ${MOCK_WEBHOOK_URL}. Check that the URL is correct.`,
+        `Error encountered during DNS resolution for webhook URL: ${MOCK_WEBHOOK_URL}. Check that the URL is correct or delete the webhook before proceeding.`,
       ),
     )
   })

--- a/src/app/modules/webhook/webhook.validation.ts
+++ b/src/app/modules/webhook/webhook.validation.ts
@@ -53,8 +53,8 @@ export const validateWebhookUrl = (webhookUrl: string): Promise<void> => {
       .catch(() => {
         return reject(
           new WebhookValidationError(
-            `Error encountered during DNS resolution for ${webhookUrl}.` +
-              ` Check that the URL is correct.`,
+            `Error encountered during DNS resolution for webhook URL: ${webhookUrl}.` +
+              ` Check that the URL is correct or delete the webhook before proceeding.`,
           ),
         )
       })

--- a/src/public/modules/forms/admin/controllers/delete-form-modal.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/delete-form-modal.client.controller.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const get = require('lodash/get')
+
 angular
   .module('forms')
   .controller('DeleteFormModalController', [
     '$uibModalInstance',
     'externalScope',
     'FormApi',
+    'Toastr',
     '$q',
     DeleteFormModalController,
   ])
@@ -14,6 +17,7 @@ function DeleteFormModalController(
   $uibModalInstance,
   externalScope,
   FormApi,
+  Toastr,
   $q,
 ) {
   const vm = this
@@ -40,7 +44,8 @@ function DeleteFormModalController(
         vm.cancel()
       },
       function (error) {
-        console.error(error)
+        const errorMessage = get(error, 'response.data.message')
+        Toastr.error(errorMessage)
       },
     )
   }

--- a/src/public/services/UpdateFormService.ts
+++ b/src/public/services/UpdateFormService.ts
@@ -275,7 +275,9 @@ export const submitStorageModeFormPreview = async ({
  * @param formId formId of form to delete
  */
 export const deleteForm = async (formId: string): Promise<void> => {
-  return axios.delete(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+  return axios
+    .delete(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+    .then(({ data }) => data)
 }
 
 /**


### PR DESCRIPTION
## Problem
- Webhook url validation is done as part of the form model. This includes form archiving. As described in #3380, this means that if the webhook URL is invalid (i.e. DNS resolution fails), the document update cannot be saved - this is expected behavior
- However, for form archiving failure, previously the errors were not correctly mapped, resulting in a default `500` being returned from the server (instead of `422` in this case). The frontend also failed silently without any prompt to the admin

Closes #3380

## Solution
- I considered if we should simply skip model validation for DELETE form endpoint. However, Delete does not remove the document permanently, it simply updates the `status` field, and the form could be revived in future. Therefore, model validation should continue to be applied as this is a document update, as a safeguard to prevent the DB from entering into an invalid state 
- The remedy taken is 
  - Fix the error routing so that the correct errors are returned when form archiving fails
  - Display error message on the frontend so admin knows what to do to resolve the issue
- Note that the same issue does not occur for other endpoints (e.g. create / update form field, create form logic) which  trigger form validation as the errors are correctly mapped

- Separately, this PR adds in pre save validation to ensure only storage mode forms can have webhook url (resolves a TODO in the codebase) 
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Screenshot

<img width="485" alt="Screenshot 2022-02-08 at 12 19 46 PM" src="https://user-images.githubusercontent.com/63710093/152917526-71326e1c-48a0-4509-99a6-6283de92061d.png">


## Tests
- Create storage mode form. Enter valid webhook url.
- In the DB, change the webhook url to an invalid one
- Attempt to delete form. Toastr should show up telling user to update the url. In network tab, check that the status code is `422`