### PR TITLE
chore: Update README file for Mac OS Monterey and Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The current product roadmap includes:
 
 Install [docker and docker-compose](https://docs.docker.com/get-docker/).
 
+### First Setup
+
+Run the following shell command to install relevant npm packages.
+
+```bash
+npm install
+```
+
 ### Running Locally
 
 Run the following shell command to build the Docker image from scratch. This will usually take 10 or so minutes.
@@ -61,7 +69,7 @@ Run the following shell command to build the Docker image from scratch. This wil
 npm run dev
 ```
 
-After the Docker image has finished building, the application can be accessed at [localhost:5000](localhost:5000).
+After the Docker image has finished building, the React application can be accessed at [localhost:3000](localhost:3000). The backend API server can be accessed at [localhost:5000](localhost:5000).
 
 If there have been no dependency changes in `package.json` or changes in the
 `src/app/server.ts` file, you can run

--- a/package-lock.json
+++ b/package-lock.json
@@ -18015,9 +18015,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanoid": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "mongodb-uri": "^0.9.7",
     "mongoose": "^5.13.2",
     "multiparty": ">=4.2.2",
+    "nan": "^2.15.0",
     "neverthrow": "^4.2.2",
     "ng-infinite-scroll": "^1.3.0",
     "ng-table": "^3.0.1",


### PR DESCRIPTION
## Problem
README documentation is not updated for Apple Silicon Macs on Mac OS Monterey for the v2 branch.

## Solution
Update README file in the FormV2 branch for Mac OS Monterey and Apple Silicon. Also updates the `nan` package to 2.15 to resolve a build error on Apple Silicon.