### PR TITLE
feat: add positional argument to create form field API 

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2513,6 +2513,46 @@ describe('Form Model', () => {
         expect(actual?.form_fields.toObject()).toEqual([expectedField])
       })
 
+      it('should return updated document with inserted form field with positional argument', async () => {
+        // Arrange
+        const shouldBeSecondField = generateDefaultField(BasicField.Checkbox)
+        const shouldBeFirstField = generateDefaultField(BasicField.Statement)
+        const expectedSecondField = {
+          ...omit(shouldBeSecondField, 'getQuestion'),
+          _id: new ObjectId(shouldBeSecondField._id),
+        }
+        const expectedFirstField = {
+          ...omit(shouldBeFirstField, 'getQuestion'),
+          _id: new ObjectId(shouldBeFirstField._id),
+        }
+        const formWithField = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Email,
+          title: 'mock email form',
+          emails: [populatedAdmin.email],
+          form_fields: [shouldBeSecondField],
+        })
+        // @ts-ignore
+        expect(formWithField.form_fields.toObject()).toEqual([
+          expectedSecondField,
+        ])
+
+        // Act
+        // Inserting new field but at the beginning.
+        const actual = await formWithField.insertFormField(
+          shouldBeFirstField,
+          0,
+        )
+
+        // Assert
+        // @ts-ignore
+        expect(actual?.form_fields.toObject()).toEqual([
+          // Should be expected order even though first field was inserted later.
+          expectedFirstField,
+          expectedSecondField,
+        ])
+      })
+
       it('should return validation error if model validation fails whilst creating field', async () => {
         // Arrange
         const newField = {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -627,9 +627,16 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return this.save()
   }
 
-  FormDocumentSchema.methods.insertFormField = function (newField: FormField) {
-    // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;(this.form_fields as Types.DocumentArray<IFieldSchema>).push(newField)
+  FormDocumentSchema.methods.insertFormField = function (
+    newField: FormField,
+    to?: number,
+  ) {
+    const formFields = this.form_fields as Types.DocumentArray<IFieldSchema>
+    if (to) {
+      formFields.splice(to, 0, newField as any) // Typings are not complete for splice.
+    } else {
+      formFields.push(newField)
+    }
     return this.save()
   }
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -632,7 +632,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     to?: number,
   ) {
     const formFields = this.form_fields as Types.DocumentArray<IFieldSchema>
-    if (to) {
+    // Must use undefined check since number can be 0; i.e. falsey.
+    if (to !== undefined) {
       formFields.splice(to, 0, newField as any) // Typings are not complete for splice.
     } else {
       formFields.push(newField)

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -7128,6 +7128,43 @@ describe('admin-form.controller', () => {
       )
     })
 
+    it('should return 200 with created form field when passing in positional argument', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const expectedPosition = 100
+      const mockReqWithPosQuery = expressHandler.mockRequest({
+        session: {
+          user: {
+            _id: MOCK_USER_ID,
+          },
+        },
+        params: {
+          formId: String(MOCK_FORM_ID),
+        },
+        body: MOCK_CREATE_FIELD_BODY,
+        query: {
+          to: expectedPosition,
+        },
+      })
+
+      // Act
+      await AdminFormController._handleCreateFormField(
+        mockReqWithPosQuery,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_RETURNED_FIELD)
+      expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_CREATE_FIELD_BODY,
+        // Should pass in position query
+        expectedPosition,
+      )
+    })
+
     it('should return 403 when current user does not have permissions to create a form field', async () => {
       // Arrange
       const expectedErrorString = 'no permissions pls'

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -4500,7 +4500,7 @@ describe('admin-form.controller', () => {
 
     it('should return 200 with updated settings successfully', async () => {
       // Arrange
-      const mockUpdatedSettings: FormSettings = {
+      const mockUpdatedSettings = {
         authType: FormAuthType.NIL,
         hasCaptcha: false,
         inactiveMessage: 'some inactive message',
@@ -4511,7 +4511,7 @@ describe('admin-form.controller', () => {
           isRetryEnabled: true,
           url: '',
         },
-      }
+      } as FormSettings
       const mockRes = expressHandler.mockResponse()
       // Mock various services to return expected results.
       MockUserService.getPopulatedUserById.mockReturnValueOnce(
@@ -4846,7 +4846,7 @@ describe('admin-form.controller', () => {
   })
 
   describe('handleGetSettings', () => {
-    const MOCK_FORM_SETTINGS: FormSettings = {
+    const MOCK_FORM_SETTINGS = {
       authType: FormAuthType.NIL,
       hasCaptcha: false,
       inactiveMessage: 'some inactive message',
@@ -4857,7 +4857,7 @@ describe('admin-form.controller', () => {
         isRetryEnabled: true,
         url: '',
       },
-    }
+    } as FormSettings
     const MOCK_USER_ID = new ObjectId().toHexString()
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
@@ -7124,6 +7124,7 @@ describe('admin-form.controller', () => {
       expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_CREATE_FIELD_BODY,
+        undefined,
       )
     })
 
@@ -7242,6 +7243,7 @@ describe('admin-form.controller', () => {
       expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_CREATE_FIELD_BODY,
+        undefined,
       )
     })
 
@@ -7268,6 +7270,7 @@ describe('admin-form.controller', () => {
       expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_CREATE_FIELD_BODY,
+        undefined,
       )
     })
 
@@ -7373,6 +7376,7 @@ describe('admin-form.controller', () => {
       expect(MockAdminFormService.createFormField).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_CREATE_FIELD_BODY,
+        undefined,
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1102,7 +1102,7 @@ describe('admin-form.service', () => {
   })
 
   describe('updateFormSettings', () => {
-    const MOCK_UPDATED_SETTINGS: FormSettings = {
+    const MOCK_UPDATED_SETTINGS = {
       authType: FormAuthType.NIL,
       hasCaptcha: false,
       inactiveMessage: 'some inactive message',
@@ -1113,7 +1113,7 @@ describe('admin-form.service', () => {
         url: '',
         isRetryEnabled: false,
       },
-    }
+    } as FormSettings
 
     const MOCK_UPDATED_FORM = {
       ...MOCK_UPDATED_SETTINGS,
@@ -1351,6 +1351,43 @@ describe('admin-form.service', () => {
 
       // Assert
       // Should return last element in form_field
+      expect(actual._unsafeUnwrap()).toEqual(expectedCreatedField)
+    })
+
+    it('should return created form field when passing in positional argument', async () => {
+      // Arrange
+      const initialFields = [
+        generateDefaultField(BasicField.Mobile),
+        generateDefaultField(BasicField.Image),
+      ]
+      const expectedCreatedField = generateDefaultField(BasicField.Nric, {
+        title: 'some nric title',
+      })
+      const mockUpdatedForm = {
+        title: 'some mock form',
+        // Prefix created field to start of form_fields.
+        form_fields: [expectedCreatedField, ...initialFields],
+      }
+      const mockForm = {
+        title: 'some mock form',
+        form_fields: initialFields,
+        insertFormField: jest.fn().mockResolvedValue(mockUpdatedForm),
+      } as unknown as IPopulatedForm
+      const formCreateParams = pick(expectedCreatedField, [
+        'title',
+        'fieldType',
+      ]) as FieldCreateDto
+
+      // Act
+      const actual = await AdminFormService.createFormField(
+        mockForm,
+        formCreateParams,
+        // Insert at beginning.
+        0,
+      )
+
+      // Assert
+      // Should return first element in form_field
       expect(actual._unsafeUnwrap()).toEqual(expectedCreatedField)
     })
 

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1714,9 +1714,11 @@ export const handleUpdateFormField = [
 export const _handleCreateFormField: ControllerHandler<
   { formId: string },
   FormFieldDto | ErrorDto,
-  FieldCreateDto
+  FieldCreateDto,
+  { to?: number }
 > = (req, res) => {
   const { formId } = req.params
+  const { to } = req.query
   const formFieldToCreate = req.body
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
@@ -1737,7 +1739,7 @@ export const _handleCreateFormField: ControllerHandler<
       )
       // Step 4: User has permissions, proceed to create form field with provided body.
       .andThen((form) =>
-        AdminFormService.createFormField(form, formFieldToCreate),
+        AdminFormService.createFormField(form, formFieldToCreate, to),
       )
       .map((createdFormField) =>
         res.status(StatusCodes.OK).json(createdFormField as FormFieldDto),
@@ -1936,6 +1938,10 @@ export const handleCreateFormField = [
       // Allow other field related key-values to be provided and let the model
       // layer handle the validation.
     }).unknown(true),
+    [Segments.QUERY]: {
+      // Optional index to insert the field at.
+      to: Joi.number().min(0),
+    },
   }),
   _handleCreateFormField,
 ]

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -588,8 +588,9 @@ export const createFormField = (
     }
     let indexToRetrieve = updatedForm.form_fields.length - 1
     // Must use undefined check since number can be 0; i.e. falsey.
-    if (to !== undefined && to < indexToRetrieve) {
-      indexToRetrieve = to
+    if (to !== undefined) {
+      // Bound indexToRetrieve to 0 and length - 1.
+      indexToRetrieve = Math.min(Math.max(to, 0), indexToRetrieve)
     }
     const updatedField = updatedForm.form_fields[indexToRetrieve]
     return updatedField

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -587,7 +587,8 @@ export const createFormField = (
       return errAsync(new FormNotFoundError())
     }
     let indexToRetrieve = updatedForm.form_fields.length - 1
-    if (to && to < indexToRetrieve) {
+    // Must use undefined check since number can be 0; i.e. falsey.
+    if (to !== undefined && to < indexToRetrieve) {
       indexToRetrieve = to
     }
     const updatedField = updatedForm.form_fields[indexToRetrieve]

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -555,33 +555,42 @@ export const duplicateFormField = (
  * Inserts a new form field into given form's fields with the field provided
  * @param form the form to insert the new field into
  * @param newField the new field to insert
+ * @param to optional index to insert the new field at
  * @returns ok(created form field)
  * @returns err(PossibleDatabaseError) when database errors arise
  */
 export const createFormField = (
   form: IPopulatedForm,
   newField: FieldCreateDto,
+  to?: number,
 ): ResultAsync<
   FormFieldSchema,
   PossibleDatabaseError | FormNotFoundError | FieldNotFoundError
 > => {
-  return ResultAsync.fromPromise(form.insertFormField(newField), (error) => {
-    logger.error({
-      message: 'Error encountered while inserting new form field',
-      meta: {
-        action: 'createFormField',
-        formId: form._id,
-        newField,
-      },
-      error,
-    })
+  return ResultAsync.fromPromise(
+    form.insertFormField(newField, to),
+    (error) => {
+      logger.error({
+        message: 'Error encountered while inserting new form field',
+        meta: {
+          action: 'createFormField',
+          formId: form._id,
+          newField,
+        },
+        error,
+      })
 
-    return transformMongoError(error)
-  }).andThen((updatedForm) => {
+      return transformMongoError(error)
+    },
+  ).andThen((updatedForm) => {
     if (!updatedForm) {
       return errAsync(new FormNotFoundError())
     }
-    const updatedField = last(updatedForm.form_fields)
+    let indexToRetrieve = updatedForm.form_fields.length - 1
+    if (to && to < indexToRetrieve) {
+      indexToRetrieve = to
+    }
+    const updatedField = updatedForm.form_fields[indexToRetrieve]
     return updatedField
       ? okAsync(updatedField)
       : errAsync(new FieldNotFoundError())

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -150,10 +150,15 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   /**
    * Inserts a form field into the form
    * @param newField the new field to insert
+   * @param to Optional position to insert the field at. If not provided, field will be inserted at the end.
    * @returns updated form after the insertion if field insertion is successful
    * @throws validation error on invalid updates
    */
-  insertFormField<T>(this: T, newField: FormField): Promise<T | null>
+  insertFormField<T>(
+    this: T,
+    newField: FormField,
+    to?: number,
+  ): Promise<T | null>
 
   /**
    * Returns the dashboard form view of the form.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a positional argument to create form field API at `POST /form/:formId/fields`, to allow for drag and drop field creation feature coming in React.

Part of #3472
Closes #1841

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
  - Positional argument is optional; if not given will default to insertion at end of form field array.

**Features**:

- feat(Form): allow optional positional arg for inserting form field 

## Before & After Screenshots
No changes in client -- will continue to call API without positional argument. Positional argument will be used in the React variant.

## Tests
<!-- What tests should be run to confirm functionality? -->
Tests have been added for this new feature. 


New unit tests have been added to 
- admin.form.service.spec
- admin-form.controller.spec
- form.server.model

New integration tests have been added to
- admin-forms.form.routes.spec
