### PR TITLE
feat(v2): create droppable empty form placeholder

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -5,6 +5,7 @@ import { Meta, Story } from '@storybook/react'
 import {
   createSingleField,
   getAdminFormResponse,
+  updateSingleField,
 } from '~/mocks/msw/handlers/admin-form'
 
 import { viewports } from '~utils/storybook'
@@ -35,7 +36,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true },
     layout: 'fullscreen',
-    msw: [getAdminFormResponse(), createSingleField()],
+    msw: [getAdminFormResponse(), createSingleField(), updateSingleField()],
   },
 } as Meta
 

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -2,7 +2,10 @@ import { MemoryRouter, Route } from 'react-router'
 import { Routes } from 'react-router-dom'
 import { Meta, Story } from '@storybook/react'
 
-import { getAdminFormResponse } from '~/mocks/msw/handlers/admin-form'
+import {
+  createSingleField,
+  getAdminFormResponse,
+} from '~/mocks/msw/handlers/admin-form'
 
 import { viewports } from '~utils/storybook'
 
@@ -32,7 +35,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true },
     layout: 'fullscreen',
-    msw: [getAdminFormResponse()],
+    msw: [getAdminFormResponse(), createSingleField()],
   },
 } as Meta
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
@@ -4,7 +4,7 @@ import { Box, Flex } from '@chakra-ui/react'
 
 import { AdminFormDto } from '~shared/types/form'
 
-import { BuilderAndDesignPlaceholder } from './components/BuilderAndDesignPlaceholder'
+import BuilderAndDesignPlaceholder from './components/BuilderAndDesignPlaceholder'
 import FieldRow from './components/FieldRow'
 import { FIELD_LIST_DROP_ID } from './constants'
 import { useEditFieldStore } from './editFieldStore'
@@ -64,11 +64,10 @@ export const BuilderAndDesignContent = ({
               >
                 <BuilderFields fields={builderFields} />
                 {provided.placeholder}
-                {snapshot.isDraggingOver ? (
-                  <BuilderAndDesignPlaceholder
-                    placeholderProps={placeholderProps}
-                  />
-                ) : null}
+                <BuilderAndDesignPlaceholder
+                  placeholderProps={placeholderProps}
+                  isDraggingOver={snapshot.isDraggingOver}
+                />
               </Box>
             )}
           </Droppable>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
@@ -5,6 +5,7 @@ import { Box, Flex } from '@chakra-ui/react'
 import { AdminFormDto } from '~shared/types/form'
 
 import BuilderAndDesignPlaceholder from './components/BuilderAndDesignPlaceholder'
+import { EmptyFormPlaceholder } from './components/BuilderAndDesignPlaceholder/EmptyFormPlaceholder'
 import FieldRow from './components/FieldRow'
 import { FIELD_LIST_DROP_ID } from './constants'
 import { useEditFieldStore } from './editFieldStore'
@@ -56,20 +57,28 @@ export const BuilderAndDesignContent = ({
           flexDir="column"
         >
           <Droppable droppableId={FIELD_LIST_DROP_ID}>
-            {(provided, snapshot) => (
-              <Box
-                pos="relative"
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
-                <BuilderFields fields={builderFields} />
-                {provided.placeholder}
-                <BuilderAndDesignPlaceholder
-                  placeholderProps={placeholderProps}
+            {(provided, snapshot) =>
+              builderFields?.length ? (
+                <Box
+                  pos="relative"
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                >
+                  <BuilderFields fields={builderFields} />
+                  {provided.placeholder}
+                  <BuilderAndDesignPlaceholder
+                    placeholderProps={placeholderProps}
+                    isDraggingOver={snapshot.isDraggingOver}
+                  />
+                </Box>
+              ) : (
+                <EmptyFormPlaceholder
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
                   isDraggingOver={snapshot.isDraggingOver}
                 />
-              </Box>
-            )}
+              )
+            }
           </Droppable>
         </Flex>
       </Flex>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent.tsx
@@ -64,7 +64,10 @@ export const BuilderAndDesignContent = ({
                   ref={provided.innerRef}
                   {...provided.droppableProps}
                 >
-                  <BuilderFields fields={builderFields} />
+                  <BuilderFields
+                    fields={builderFields}
+                    isDraggingOver={snapshot.isDraggingOver}
+                  />
                   {provided.placeholder}
                   <BuilderAndDesignPlaceholder
                     placeholderProps={placeholderProps}
@@ -86,8 +89,13 @@ export const BuilderAndDesignContent = ({
   )
 }
 
+interface BuilderFieldsProps {
+  fields: AdminFormDto['form_fields']
+  isDraggingOver: boolean
+}
+
 const BuilderFields = memo(
-  ({ fields }: { fields: AdminFormDto['form_fields'] | undefined }) => {
+  ({ fields, isDraggingOver }: BuilderFieldsProps) => {
     if (!fields) {
       return <div>Loading...</div>
     }
@@ -95,10 +103,16 @@ const BuilderFields = memo(
     return (
       <>
         {fields.map((f, i) => (
-          <FieldRow index={i} key={f._id} field={f} />
+          <FieldRow
+            index={i}
+            key={f._id}
+            field={f}
+            isDraggingOver={isDraggingOver}
+          />
         ))}
       </>
     )
   },
-  (prev, next) => prev.fields === next.fields,
+  (prev, next) =>
+    prev.fields === next.fields && prev.isDraggingOver === next.isDraggingOver,
 )

--- a/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
@@ -2,15 +2,17 @@ import { useMemo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 
-import { FIELD_LIST_DROP_ID } from '../constants'
-import { DndPlaceholderProps } from '../types'
+import { FIELD_LIST_DROP_ID } from '../../constants'
+import { DndPlaceholderProps } from '../../types'
 
 export interface BuilderDesignPlaceholderProps {
   placeholderProps: DndPlaceholderProps
+  isDraggingOver: boolean
 }
 
 export const BuilderAndDesignPlaceholder = ({
   placeholderProps,
+  isDraggingOver,
 }: BuilderDesignPlaceholderProps): JSX.Element | null => {
   const renderedContents = useMemo(() => {
     switch (placeholderProps.droppableId) {
@@ -40,7 +42,7 @@ export const BuilderAndDesignPlaceholder = ({
     }
   }, [placeholderProps.droppableId])
 
-  if (isEmpty(placeholderProps)) return null
+  if (isEmpty(placeholderProps) || !isDraggingOver) return null
 
   return (
     <Box

--- a/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -1,0 +1,34 @@
+import { BoxProps, Center, forwardRef, Icon, Text } from '@chakra-ui/react'
+
+import { BxsWidget } from '~assets/icons/BxsWidget'
+
+interface EmptyFormPlaceholderProps extends BoxProps {
+  isDraggingOver: boolean
+}
+
+export const EmptyFormPlaceholder = forwardRef<
+  EmptyFormPlaceholderProps,
+  'div'
+>(({ isDraggingOver, ...props }, ref): JSX.Element => {
+  return (
+    <Center
+      h="13.75rem"
+      border="1px dashed"
+      borderColor={isDraggingOver ? 'primary.700' : 'secondary.300'}
+      borderRadius="4px"
+      bgColor={isDraggingOver ? 'primary.200' : 'neutral.100'}
+      {...props}
+      ref={ref}
+    >
+      <Center flexDir="column" gap={'0.75rem'}>
+        <Icon
+          as={BxsWidget}
+          __css={{ color: 'secondary.500', fontSize: '1.5rem' }}
+        />
+        <Text textStyle="subhead-2" color="secondary.500">
+          Drag a field from the Builder on the left to start
+        </Text>
+      </Center>
+    </Center>
+  )
+})

--- a/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignPlaceholder/index.ts
@@ -1,0 +1,1 @@
+export { BuilderAndDesignPlaceholder as default } from './BuilderAndDesignPlaceholder'

--- a/frontend/src/features/admin-form/create/builder-and-design/components/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/components/FieldRow/FieldRowContainer.tsx
@@ -30,11 +30,13 @@ import { SectionFieldRow } from './SectionFieldRow'
 export interface FieldRowContainerProps {
   field: FormFieldDto
   index: number
+  isDraggingOver: boolean
 }
 
 export const FieldRowContainer = ({
   field,
   index,
+  isDraggingOver,
 }: FieldRowContainerProps): JSX.Element => {
   const updateActiveField = useEditFieldStore(updateFieldSelector)
   const activeField = useEditFieldStore(activeFieldSelector)
@@ -87,7 +89,7 @@ export const FieldRowContainer = ({
             cursor={isActive ? 'initial' : 'pointer'}
             bg="white"
             transition="background 0.2s ease"
-            _hover={{ bg: 'secondary.100' }}
+            _hover={{ bg: isDraggingOver ? 'white' : 'secondary.100' }}
             borderRadius="4px"
             outline="none"
             {...(isActive ? { 'data-active': true } : {})}

--- a/frontend/src/features/admin-form/create/builder-and-design/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils.ts
@@ -42,6 +42,19 @@ export const getFieldCreationMeta = (
         ...baseMeta,
       }
     }
+    case BasicField.Checkbox: {
+      return {
+        fieldType,
+        ...baseMeta,
+        ValidationOptions: {
+          customMax: null,
+          customMin: null,
+        },
+        validateByValue: false,
+        fieldOptions: ['Option 1'],
+        othersRadioButton: false,
+      }
+    }
     default: {
       return {
         fieldType: BasicField.Section,

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -71,7 +71,7 @@ export const createMockForm = (
 export const getAdminFormResponse = (
   props: Partial<AdminFormDto> = {},
   delay = 0,
-): ReturnType<typeof rest['post']> => {
+): ReturnType<typeof rest['get']> => {
   return rest.get<AdminFormViewDto>(
     '/api/v3/admin/forms/:formId',
     (req, res, ctx) => {

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -90,9 +90,7 @@ export const getAdminFormResponse = (
   )
 }
 
-export const createSingleField = (
-  delay = 0,
-): ReturnType<typeof rest['post']> => {
+export const createSingleField = (delay = 500) => {
   return rest.post<FieldCreateDto, { to: string }, FormFieldDto>(
     '/api/v3/admin/forms/:formId/fields',
     (req, res, ctx) => {
@@ -105,6 +103,19 @@ export const createSingleField = (
       )
       formFields = insertAt(formFields, newIndex, newField)
       return res(ctx.delay(delay), ctx.status(200), ctx.json(newField))
+    },
+  )
+}
+
+export const updateSingleField = (delay = 500) => {
+  return rest.put<FormFieldDto, Record<string, never>, FormFieldDto>(
+    '/api/v3/admin/forms/:formId/fields/:fieldId',
+    (req, res, ctx) => {
+      const index = formFields.findIndex(
+        (field) => field._id === req.params.fieldId,
+      )
+      formFields.splice(index, 1, req.body)
+      return res(ctx.delay(delay), ctx.status(200), ctx.json(req.body))
     },
   )
 }

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -2,6 +2,7 @@ import { merge } from 'lodash'
 import { rest } from 'msw'
 
 import { AgencyId } from '~shared/types/agency'
+import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
 import {
   AdminFormDto,
   AdminFormViewDto,
@@ -14,6 +15,9 @@ import {
 import { FormLogoState } from '~shared/types/form/form_logo'
 import { DateString } from '~shared/types/generic'
 import { UserDto } from '~shared/types/user'
+import { insertAt } from '~shared/utils/immutable-array-fns'
+
+let formFields: FormFieldDto[] = []
 
 export const createMockForm = (
   props: Partial<AdminFormDto> = {},
@@ -40,7 +44,7 @@ export const createMockForm = (
         inactiveMessage:
           'If you think this is a mistake, please contact the agency that gave you the form link!',
         submissionLimit: null,
-        form_fields: [],
+        form_fields: formFields,
         form_logics: [],
         permissionList: [],
         title: 'Test form title',
@@ -82,6 +86,25 @@ export const getAdminFormResponse = (
           createMockForm({ _id: req.params.formId as FormId, ...props }),
         ),
       )
+    },
+  )
+}
+
+export const createSingleField = (
+  delay = 0,
+): ReturnType<typeof rest['post']> => {
+  return rest.post<FieldCreateDto, { to: string }, FormFieldDto>(
+    '/api/v3/admin/forms/:formId/fields',
+    (req, res, ctx) => {
+      const newField = {
+        ...req.body,
+        _id: `random-id-${formFields.length}`,
+      }
+      const newIndex = parseInt(
+        req.url.searchParams.get('to') ?? `${formFields.length}`,
+      )
+      formFields = insertAt(formFields, newIndex, newField)
+      return res(ctx.delay(delay), ctx.status(200), ctx.json(newField))
     },
   )
 }


### PR DESCRIPTION
Currently the form builder renders an empty page when the form has no fields. This PR adds the placeholder for fields to be dragged in when the form is empty:
![empty-form-placeholder](https://user-images.githubusercontent.com/29480346/155462012-c51d71e4-02ec-4f02-bccc-23b2f8a7f07b.gif)

Moreover, previously, background colour of existing fields would change to `neutral.100` when a new field was being dragged over, even though they are not responsive to new fields being dropped over them. This is inconsistent with the [design system](https://www.figma.com/file/9oE4ECjdeZQ1RBpwZVtnB3/Form-Design-Master?node-id=2584%3A107188). This PR fixes the issue by preventing the background colour of existing fields from changing when new fields are being dragged over.

## Other improvements
- Mocks added for POST request to create field and PUT request to update field

## Known bugs
These will be fixed in a future PR:
- After creating a new field, the `onSuccess` handler in the `Edit*` component does not fire, because the component unmounts and re-mounts due to its `key` in the parent changing.
- After updating a field and exiting the edit field drawer, the field reverts back to its previous state. When attempting to create a new field, the field flips into the new state again.
