### PR TITLE
feat: export shared types for use in client/backend, update user route error to return new status code, update SettingsDto return

### DIFF
--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -20,6 +20,7 @@ export const STORAGE_PUBLIC_FORM_FIELDS = <const>[
 ]
 
 const FORM_SETTINGS_FIELDS = <const>[
+  'responseMode',
   'authType',
   'esrvcId',
   'hasCaptcha',

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -35,7 +35,10 @@ export const EMAIL_FORM_SETTINGS_FIELDS = <const>[
   ...FORM_SETTINGS_FIELDS,
   'emails',
 ]
-export const STORAGE_FORM_SETTINGS_FIELDS = FORM_SETTINGS_FIELDS
+export const STORAGE_FORM_SETTINGS_FIELDS = <const>[
+  ...FORM_SETTINGS_FIELDS,
+  'publicKey',
+]
 
 export const ADMIN_FORM_META_FIELDS = <const>[
   'admin',

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -123,7 +123,9 @@ export type EmailFormDto = Merge<EmailFormBase, FormDtoBase>
 
 export type FormDto = StorageFormDto | EmailFormDto
 
-export type AdminFormDto = Merge<FormDto, { admin: UserDto }>
+export type AdminFormDto =
+  | Merge<StorageFormDto, { admin: UserDto }>
+  | Merge<EmailFormDto, { admin: UserDto }>
 
 type PublicFormBase = {
   admin: PublicUserDto

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -37,5 +37,16 @@ export const UserDto = UserBase.extend({
 export type UserDto = z.infer<typeof UserDto>
 
 export type PublicUserDto = {
-  agency: PublicAgencyDto | AgencyDto['_id']
+  agency: PublicAgencyDto
+}
+
+export type SendUserContactOtpDto = {
+  contact: string
+  userId: string
+}
+
+export type VerifyUserContactOtpDto = {
+  userId: string
+  otp: string
+  contact: string
 }

--- a/shared/utils/file-validation.ts
+++ b/shared/utils/file-validation.ts
@@ -2,7 +2,7 @@ import JSZip from 'jszip'
 import flattenDeep from 'lodash/flattenDeep'
 import uniq from 'lodash/uniq'
 
-const VALID_EXTENSIONS = [
+export const VALID_EXTENSIONS = [
   '.asc',
   '.avi',
   '.bmp',

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -298,7 +298,7 @@ describe('user.controller', () => {
       expect(MockUserService.updateUserContact).toHaveBeenCalledTimes(1)
     })
 
-    it('should return 401 when verifying contact returns InvalidOtpError', async () => {
+    it('should return 404 when verifying contact returns InvalidOtpError', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
       const expectedError = new InvalidOtpError('mock error')
@@ -312,7 +312,7 @@ describe('user.controller', () => {
       await UserController._handleContactVerifyOtp(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
-      expect(mockRes.status).toBeCalledWith(401)
+      expect(mockRes.status).toBeCalledWith(404)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
       expect(MockUserService.verifyContactOtp).toHaveBeenCalledTimes(1)
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()

--- a/src/app/modules/user/__tests__/user.routes.spec.ts
+++ b/src/app/modules/user/__tests__/user.routes.spec.ts
@@ -350,7 +350,7 @@ describe('user.routes', () => {
       expect(response.body).toEqual('User is unauthorized.')
     })
 
-    it('should return 401 when hashes does not exist for current contact', async () => {
+    it('should return 404 when hashes does not exist for current contact', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
 
@@ -362,13 +362,13 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'OTP has expired. Please request for a new OTP.',
       )
     })
 
-    it('should return 401 when given otp does not match hashed otp', async () => {
+    it('should return 404 when given otp does not match hashed otp', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -381,11 +381,11 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual('OTP is invalid. Please try again.')
     })
 
-    it('should return 401 when given contact does not match hashed contact', async () => {
+    it('should return 404 when given contact does not match hashed contact', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -399,13 +399,13 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'Contact number given does not match the number the OTP is sent to. Please try again with the correct contact number.',
       )
     })
 
-    it('should return 401 when otp has been attempted too many times', async () => {
+    it('should return 404 when otp has been attempted too many times', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -429,7 +429,7 @@ describe('user.routes', () => {
       // Should be all invalid OTP responses.
       expect(results).toEqual(
         Array(UserService.MAX_OTP_ATTEMPTS).fill({
-          status: 401,
+          status: 404,
           body: 'OTP is invalid. Please try again.',
         }),
       )
@@ -443,7 +443,7 @@ describe('user.routes', () => {
 
       // Assert
       // Should still reject with max OTP attempts error.
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'You have hit the max number of attempts. Please request for a new OTP.',
       )

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -1,5 +1,9 @@
 import { StatusCodes } from 'http-status-codes'
 
+import {
+  SendUserContactOtpDto,
+  VerifyUserContactOtpDto,
+} from '../../../../shared/types'
 import { IPopulatedUser } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import { SmsFactory } from '../../services/sms/sms.factory'
@@ -24,7 +28,7 @@ const logger = createLoggerWithLabel(module)
 export const _handleContactSendOtp: ControllerHandler<
   unknown,
   string,
-  { contact: string; userId: string }
+  SendUserContactOtpDto
 > = async (req, res) => {
   // Joi validation ensures existence.
   const { contact, userId } = req.body
@@ -103,11 +107,7 @@ export const handleContactSendOtp = [
 export const _handleContactVerifyOtp: ControllerHandler<
   unknown,
   string | IPopulatedUser,
-  {
-    userId: string
-    otp: string
-    contact: string
-  }
+  VerifyUserContactOtpDto
 > = async (req, res) => {
   // Joi validation ensures existence.
   const { userId, otp, contact } = req.body

--- a/src/app/modules/user/user.utils.ts
+++ b/src/app/modules/user/user.utils.ts
@@ -24,7 +24,7 @@ export const mapRouteError = (
   switch (error.constructor) {
     case UserErrors.InvalidOtpError:
       return {
-        statusCode: StatusCodes.UNAUTHORIZED,
+        statusCode: StatusCodes.NOT_FOUND,
         errorMessage: error.message,
       }
     case UserErrors.MissingUserError:

--- a/src/app/routes/api/v3/user/__tests__/user.routes.spec.ts
+++ b/src/app/routes/api/v3/user/__tests__/user.routes.spec.ts
@@ -349,7 +349,7 @@ describe('user.routes', () => {
       expect(response.body).toEqual('User is unauthorized.')
     })
 
-    it('should return 401 when hashes does not exist for current contact', async () => {
+    it('should return 404 when hashes does not exist for current contact', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
 
@@ -361,13 +361,13 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'OTP has expired. Please request for a new OTP.',
       )
     })
 
-    it('should return 401 when given otp does not match hashed otp', async () => {
+    it('should return 404 when given otp does not match hashed otp', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -380,11 +380,11 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual('OTP is invalid. Please try again.')
     })
 
-    it('should return 401 when given contact does not match hashed contact', async () => {
+    it('should return 404 when given contact does not match hashed contact', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -398,13 +398,13 @@ describe('user.routes', () => {
       })
 
       // Assert
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'Contact number given does not match the number the OTP is sent to. Please try again with the correct contact number.',
       )
     })
 
-    it('should return 401 when otp has been attempted too many times', async () => {
+    it('should return 404 when otp has been attempted too many times', async () => {
       // Arrange
       const session = await createAuthedSession(defaultUser.email, request)
       await requestForContactOtp(defaultUser, VALID_CONTACT, session)
@@ -428,7 +428,7 @@ describe('user.routes', () => {
       // Should be all invalid OTP responses.
       expect(results).toEqual(
         Array(UserService.MAX_OTP_ATTEMPTS).fill({
-          status: 401,
+          status: 404,
           body: 'OTP is invalid. Please try again.',
         }),
       )
@@ -442,7 +442,7 @@ describe('user.routes', () => {
 
       // Assert
       // Should still reject with max OTP attempts error.
-      expect(response.status).toEqual(401)
+      expect(response.status).toEqual(404)
       expect(response.body).toEqual(
         'You have hit the max number of attempts. Please request for a new OTP.',
       )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR is part of #3472, where types that can be shared with client/server are exported.
In addition, update user route's `InvalidOtpError` to return `404` instead of `401` status code, due to React app logging user out automatically when 401 is retrieved.

Also also updates the fields SettingsDto returns to:
- Include `responseMode` in returned JSON
- include `publicKey` field in storage mode forms