### PR TITLE
feat: disable field creation on useAdminForm error

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignDrawer/CreateFieldDrawer/CreateFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/components/BuilderAndDesignDrawer/CreateFieldDrawer/CreateFieldDrawer.tsx
@@ -55,7 +55,7 @@ export const CreateFieldDrawer = (): JSX.Element => {
 }
 
 const BasicFieldPanelContent = () => {
-  const { isLoading } = useAdminForm()
+  const { isSuccess } = useAdminForm()
 
   return (
     <>
@@ -66,7 +66,7 @@ const BasicFieldPanelContent = () => {
               {CREATE_PAGE_FIELDS_ORDERED.map((fieldType, index) => (
                 <DraggableCreateFieldOption
                   index={index}
-                  isDisabled={isLoading}
+                  isDisabled={!isSuccess}
                   key={index}
                   fieldType={fieldType}
                 />
@@ -83,7 +83,7 @@ const BasicFieldPanelContent = () => {
               {CREATE_FIELD_FIELDS_ORDERED.map((fieldType, index) => (
                 <DraggableCreateFieldOption
                   index={index}
-                  isDisabled={isLoading}
+                  isDisabled={!isSuccess}
                   key={index}
                   fieldType={fieldType}
                 />


### PR DESCRIPTION
Currently, fields in the field creation drawer are disabled only as long as the admin form is still loading. This means that if there is an error while loading the admin form, the fields can be dragged. We should only let the form be editable if it has already loaded successfully.