### PR TITLE
feat(automation): Merge production release to develop branch

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -89,11 +89,11 @@ jobs:
             --version-label $IMAGE_TAG
 
   merge_release_to_develop:
-    if: github.ref_name == 'release'
+    if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Merge release -> develop
+      - name: Backport release into develop
         uses: devmasx/merge-branch@v1.4.0
         with:
           type: now

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -87,3 +87,16 @@ jobs:
           aws elasticbeanstalk update-environment --application-name $APP_NAME \
             --environment-name $DEPLOY_ENV \
             --version-label $IMAGE_TAG
+
+  merge_release_to_develop:
+    if: github.ref_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Merge release -> develop
+        uses: devmasx/merge-branch@v1.4.0
+        with:
+          type: now
+          from_branch: release
+          target_branch: develop
+          github_token: ${{ github.token }}


### PR DESCRIPTION
## Context
Our deployment process has clear steps with automatic deployment to production on push to the `release` branch, but every release is followed by the same steps:
- Open PR to merge `release` into `develop`
- Wait for build to succeed
- Merge

This follows a clean branch management: since releases are made from `develop`, the prior `release:HEAD` should be an ancestor to develop, to guarantee that the next release does not introduce regression by missing some code. 

This is especially important for hotfixes: a deployed hotfix **must not** be forgotten in the next release.

Opening the backport PR from `release` to `develop` is currently a manual process, which has 2 major drawbacks:
1. it wastes time for team members
2. It can be forgotten, which could have disastrous consequences

I propose to automate the backport with a github action. As soon as a release PR is merged into `release`, since it must make its way to `develop`, no further engineering involvement should be needed.

I additionally propose that a PR with approval isn't necessary. Since the release was approved to be merged and deployed, **all pushes to `release` are approved**.


## Approach
On release PR merge into the `release` branch, and **after** successful deployment to EB, the `release` branch will be merged into `develop`.

The approach works well for cases of normal releases and hotfix releases (see diagrams below). In both cases, whatever is in the `release` branch should appear in `develop` as well.

## Notes
* Automatically merging `release` into `develop` is not a right step to take in case a rollback is done by force-pushing an older commit into the `release` branch. This is not an issue because this is **not** how the form teams does rollbacks. Rollbacks are handled by reverting the EB environment to a prior version. They are not driven by github workflows.
* In the case of hotfixes, changes to `develop` since the prior release have conflicts, which will cause an automatic merge to fail. Such cases should be rare and can be handled manually.

![git_flow](https://user-images.githubusercontent.com/935223/155709005-3ab390e9-9866-4ab7-8067-983ed5087f40.png)

## Risks
Using a [third party github action](https://github.com/devmasx/merge-branch) for automatic merge can be dangerous, we might consider forking the repo or making our own action


