### PR TITLE
fix(ci/deploy): truncate deploy description to 180 chars

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -72,7 +72,7 @@ jobs:
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           APP_NAME: ${{ secrets.APP_NAME }}
         run: |
-          TRUNCATED_DESC=$(echo "${{github.event.head_commit.message}}" | cut -b1-180)
+          TRUNCATED_DESC=$(echo "${{github.event.head_commit.message}}" | head -c 180)
           aws elasticbeanstalk create-application-version --application-name $APP_NAME \
           --version-label $IMAGE_TAG \
           --source-bundle S3Bucket=$BUCKET_NAME,S3Key=$IMAGE_TAG.zip \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Elastic Beanstalk application versions have a character limit of 200 for descriptions. Our deploy pipeline contains a line to grab the latest commit message and truncate it to 180 characters (#3147) but it uses the `cut` command which only cuts the specified number of bytes for each line. This means there can still be [deploy failures](https://github.com/opengovsg/FormSG/runs/5353731644?check_suite_focus=true) if the total number of characters across lines exceeds 200.

## Solution
<!-- How did you solve the problem? -->

Change to `head -c 180` which gets the first 180 characters from the specified text.