### PR TITLE
feat(builder): add radio field preview when editing field in form builder

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -26,6 +26,7 @@ import IconButton from '~components/IconButton'
 import {
   CheckboxField,
   NricField,
+  RadioField,
   UenField,
   YesNoField,
 } from '~templates/Field'
@@ -271,6 +272,8 @@ const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
       return <UenField schema={field} />
     case BasicField.YesNo:
       return <YesNoField schema={field} />
+    case BasicField.Radio:
+      return <RadioField schema={field} />
     default:
       return <div>TODO: Add field row for {field.fieldType}</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -26,6 +26,7 @@ import {
   EditCheckbox,
   EditHeader,
   EditNric,
+  EditRadio,
   EditUen,
   EditYesNo,
 } from './edit-fieldtype'
@@ -167,6 +168,8 @@ const MemoFieldDrawerContent = memo((props: MemoFieldDrawerContentProps) => {
       return <EditUen {...props} field={field} />
     case BasicField.YesNo:
       return <EditYesNo {...props} field={field} />
+    case BasicField.Radio:
+      return <EditRadio {...props} field={field} />
     default:
       return <div>TODO: Insert field options here</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react'
+import { FormControl } from '@chakra-ui/react'
+import { extend, pick } from 'lodash'
+
+import { RadioFieldBase } from '~shared/types/field'
+
+import { createBaseValidationRules } from '~utils/fieldValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+
+import { DrawerContentContainer } from './common/DrawerContentContainer'
+import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
+import { EditFieldProps } from './common/types'
+import { useEditFieldForm } from './common/useEditFieldForm'
+import {
+  SPLIT_TEXTAREA_TRANSFORM,
+  SPLIT_TEXTAREA_VALIDATION,
+} from './common/utils'
+
+type EditRadioProps = EditFieldProps<RadioFieldBase>
+
+const EDIT_RADIO_FIELD_KEYS = [
+  'title',
+  'description',
+  'required',
+  'othersRadioButton',
+] as const
+
+type EditRadioKeys = typeof EDIT_RADIO_FIELD_KEYS[number]
+
+type EditRadioInputs = Pick<RadioFieldBase, EditRadioKeys> & {
+  fieldOptionsString: string // Differs from fieldOptions in RadioFieldBase because input is a string. Will be converted to array using SPLIT_TEXTAREA_TRANSFORM
+}
+
+const transformRadioFieldToEditForm = (
+  field: RadioFieldBase,
+): EditRadioInputs => {
+  return {
+    ...pick(field, EDIT_RADIO_FIELD_KEYS),
+    fieldOptionsString: SPLIT_TEXTAREA_TRANSFORM.input(field.fieldOptions),
+  }
+}
+
+const transformRadioEditFormToField = (
+  form: EditRadioInputs,
+  originalField: RadioFieldBase,
+): RadioFieldBase => {
+  return extend({}, originalField, form, {
+    fieldOptions: SPLIT_TEXTAREA_TRANSFORM.output(form.fieldOptionsString),
+  })
+}
+
+export const EditRadio = (props: EditRadioProps): JSX.Element => {
+  const {
+    register,
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+  } = useEditFieldForm<EditRadioInputs, RadioFieldBase>({
+    ...props,
+    transform: {
+      input: transformRadioFieldToEditForm,
+      output: transformRadioEditFormToField,
+    },
+  })
+
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
+  return (
+    <DrawerContentContainer>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Question</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('required')} label="Required" />
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('othersRadioButton')} label="Others" />
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.fieldOptionsString}
+      >
+        <FormLabel>Options</FormLabel>
+        <Textarea
+          {...register('fieldOptionsString', {
+            validate: SPLIT_TEXTAREA_VALIDATION,
+          })}
+        />
+        <FormErrorMessage>
+          {errors?.fieldOptionsString?.message}
+        </FormErrorMessage>
+      </FormControl>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
+    </DrawerContentContainer>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,5 +1,6 @@
 export * from './EditCheckbox'
 export * from './EditHeader'
 export * from './EditNric'
+export * from './EditRadio'
 export * from './EditUen'
 export * from './EditYesNo'

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -40,6 +40,14 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
         othersRadioButton: false,
       }
     }
+    case BasicField.Radio: {
+      return {
+        fieldType,
+        ...baseMeta,
+        fieldOptions: ['Option 1'],
+        othersRadioButton: false,
+      }
+    }
     default: {
       return {
         fieldType: BasicField.Section,


### PR DESCRIPTION
This PR is part of the chain for `form-v2/feat/builder` branch.

Part of #2792

Closes #3409 

## Solution
**Features**:

- feat: add EditRadio component to render drawer content

**Bug Fixes**:

- fixed drawer width which did not resize when screen was smaller