### PR TITLE
fix(v2/Dropdown): allow controlled selectedItems, render icon in MultiSelectItem

### DIFF
--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   FormControlOptions,
   useFormControlProps,
@@ -218,6 +218,11 @@ export const MultiSelectProvider = ({
     },
     ...downshiftComboboxProps,
   })
+
+  /** Effect to update filtered items whenever items prop changes. */
+  useEffect(() => {
+    setFilteredItems(getFilteredItems(inputValue))
+  }, [getFilteredItems, inputValue, items])
 
   const resetInputValue = useCallback(() => setInputValue(''), [setInputValue])
 

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -57,7 +57,7 @@ export const MultiSelectProvider = ({
   name,
   filter = defaultFilter,
   nothingFoundLabel = 'No matching results',
-  placeholder = 'Select options',
+  placeholder: placeholderProp,
   clearButtonLabel = 'Clear dropdown',
   isSearchable = true,
   defaultIsOpen,
@@ -146,10 +146,9 @@ export const MultiSelectProvider = ({
   })
 
   const dynamicPlaceholder = useMemo(() => {
-    const numSelectedItems = selectedItems.length
-    if (numSelectedItems > 0) return ''
-    return placeholder ?? 'Select options'
-  }, [placeholder, selectedItems.length])
+    if (placeholderProp === null || selectedItems.length > 0) return ''
+    return placeholderProp ?? 'Select options'
+  }, [placeholderProp, selectedItems.length])
 
   const {
     toggleMenu,

--- a/frontend/src/components/Dropdown/MultiSelect/index.ts
+++ b/frontend/src/components/Dropdown/MultiSelect/index.ts
@@ -1,0 +1,2 @@
+export type { MultiSelectProps } from './MultiSelect'
+export { MultiSelect } from './MultiSelect'

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -15,8 +15,12 @@ export interface SharedSelectContextReturnProps<
   nothingFoundLabel?: string
   /** aria-label for clear button. Defaults to "Clear dropdown" */
   clearButtonLabel?: string
-  /** Placeholder to show in the input field. Defaults to "Select an option". */
-  placeholder?: string
+  /**
+   * Placeholder to show in the input field.
+   * Defaults to "Select an option".
+   * Set to `null` to hide the placeholder.
+   */
+  placeholder?: string | null
   /** ID of input itself, for a11y purposes */
   name: string
   /** Item data used to render items in dropdown */

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelect.stories.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelect.stories.tsx
@@ -10,7 +10,7 @@ import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 
 import { ComboboxItem } from '../types'
-import { itemToLabelString, itemToValue } from '../utils/itemUtils'
+import { itemToValue } from '../utils/itemUtils'
 
 import { SingleSelect, SingleSelectProps } from './SingleSelect'
 
@@ -90,7 +90,7 @@ NotClearable.args = {
 
 export const HasValueSelected = Template.bind({})
 HasValueSelected.args = {
-  value: itemToLabelString(INITIAL_COMBOBOX_ITEMS[0]),
+  value: itemToValue(INITIAL_COMBOBOX_ITEMS[0]),
   initialIsOpen: true,
 }
 

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -36,7 +36,7 @@ export const SingleSelectProvider = ({
   name,
   filter = defaultFilter,
   nothingFoundLabel = 'No matching results',
-  placeholder = 'Select an option',
+  placeholder: placeholderProp,
   clearButtonLabel = 'Clear dropdown input',
   isClearable = true,
   isSearchable = true,
@@ -51,6 +51,11 @@ export const SingleSelectProvider = ({
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
+
+  const placeholder = useMemo(() => {
+    if (placeholderProp === null) return ''
+    return placeholderProp ?? 'Select an option'
+  }, [placeholderProp])
 
   const getFilteredItems = useCallback(
     (filterValue?: string) =>

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FormControlOptions, useMultiStyleConfig } from '@chakra-ui/react'
 import { useCombobox, UseComboboxProps } from 'downshift'
 
@@ -143,6 +143,11 @@ export const SingleSelectProvider = ({
     },
     ...comboboxProps,
   })
+
+  /** Effect to update filtered items whenever items prop changes. */
+  useEffect(() => {
+    setFilteredItems(getFilteredItems(inputValue))
+  }, [getFilteredItems, inputValue, items])
 
   const isItemSelected = useCallback(
     (item: ComboboxItem) => {

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -6,7 +6,7 @@ import { useItems } from '../hooks/useItems'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
 import { ComboboxItem } from '../types'
 import { defaultFilter } from '../utils/defaultFilter'
-import { itemToValue } from '../utils/itemUtils'
+import { itemToLabelString, itemToValue } from '../utils/itemUtils'
 
 export interface SingleSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
@@ -171,7 +171,7 @@ export const SingleSelectProvider = ({
     if (inputAriaProp) return inputAriaProp
     let label = 'No option selected'
     if (selectedItem) {
-      label = `Option ${itemToValue(selectedItem)}, selected`
+      label = `Option ${itemToLabelString(selectedItem)}, selected`
     }
     return {
       id: `${name}-current-selection`,

--- a/frontend/src/components/Dropdown/components/MultiSelectItem/MultiSelectItem.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectItem/MultiSelectItem.tsx
@@ -1,10 +1,13 @@
 import { MouseEvent, useCallback, useMemo } from 'react'
-import { TagLabel } from '@chakra-ui/react'
+import { Icon, TagLabel } from '@chakra-ui/react'
 
 import { useMultiSelectContext } from '~components/Dropdown/MultiSelectContext'
 import { useSelectContext } from '~components/Dropdown/SelectContext'
 import { ComboboxItem } from '~components/Dropdown/types'
-import { itemToLabelString } from '~components/Dropdown/utils/itemUtils'
+import {
+  itemToIcon,
+  itemToLabelString,
+} from '~components/Dropdown/utils/itemUtils'
 import { Tag, TagCloseButton } from '~components/Tag'
 
 export interface MultiSelectItemProps<
@@ -18,11 +21,16 @@ export const MultiSelectItem = ({
   item,
   index,
 }: MultiSelectItemProps): JSX.Element => {
-  const { isDisabled, isReadOnly, setIsFocused, closeMenu, isOpen } =
+  const { isDisabled, isReadOnly, setIsFocused, closeMenu, isOpen, styles } =
     useSelectContext()
   const { getSelectedItemProps, removeSelectedItem } = useMultiSelectContext()
 
-  const itemLabel = useMemo(() => itemToLabelString(item), [item])
+  const itemMeta = useMemo(() => {
+    return {
+      label: itemToLabelString(item),
+      icon: itemToIcon(item),
+    }
+  }, [item])
 
   const handleRemoveItem = useCallback(
     (e: MouseEvent) => {
@@ -51,7 +59,7 @@ export const MultiSelectItem = ({
 
   return (
     <Tag
-      title={itemLabel}
+      title={itemMeta.label}
       colorScheme="secondary"
       m="2px"
       h="2rem"
@@ -74,7 +82,17 @@ export const MultiSelectItem = ({
         onClick: handleTagClick,
       })}
     >
-      <TagLabel>{itemLabel}</TagLabel>
+      {itemMeta.icon ? (
+        <Icon
+          aria-hidden
+          sx={styles.icon}
+          ml="-0.25rem"
+          mr="0.25rem"
+          as={itemMeta.icon}
+          aria-disabled={isDisabled}
+        />
+      ) : null}
+      <TagLabel>{itemMeta.label}</TagLabel>
       <TagCloseButton
         tabIndex={-1}
         aria-hidden

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
@@ -12,6 +12,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
     selectItem,
     styles,
     inputValue,
+    selectedItem,
   } = useSelectContext()
 
   const handleClearSelection = useCallback(() => selectItem(null), [selectItem])
@@ -26,7 +27,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
       aria-label={clearButtonLabel}
       onClick={handleClearSelection}
       __css={styles.clearbutton}
-      color={inputValue ? 'secondary.500' : undefined}
+      color={inputValue || selectedItem ? 'secondary.500' : undefined}
     >
       <BiX fontSize="1.25rem" />
     </chakra.button>

--- a/frontend/src/components/Dropdown/index.ts
+++ b/frontend/src/components/Dropdown/index.ts
@@ -1,0 +1,2 @@
+export * from './MultiSelect'
+export * from './SingleSelect'

--- a/frontend/src/theme/components/MultiSelect.ts
+++ b/frontend/src/theme/components/MultiSelect.ts
@@ -39,6 +39,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
       w: 0,
       px: '2px',
       my: '2px',
+      bg: 'transparent',
       _disabled: {
         cursor: 'not-allowed',
       },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR cherry picks a bunch of `SingleSelect`/`MultiSelect` fixes that were encountered whilst working on #3556.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(Select): allow setting of empty placeholder
- feat(MultiSelectItem): show icon in tag if it exists

**Bug Fixes**:

- fix(ComboboxClearButton): show active state if item has been selected
  - Previously, the clear button will remain in inactive styling even if item has been selected
- fix(Single/MultiSelectProvider)!: allow control of selectedItem, refilter items whenever `items` prop changes
  - Instead of using `initialSelectedItem` prop, allow users of the component to pass in current value for selection.
- fix(SingleSelectProvider): use label string as aria-live announcement 
  - the value was used previously, which may cause screenreaders to read something different that what is being rendered.

## Before & After Screenshots
Most stories should not have a change. The only changes should be the ones for rendering an icon in the selected items in `MultiSelect`.

