### PR TITLE
feat(v2): warn public form filler when form has changed on server-side

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Text } from '@chakra-ui/react'
 import { differenceInMilliseconds, isPast } from 'date-fns'
 import { isEqual } from 'lodash'
 import get from 'lodash/get'
@@ -10,6 +11,7 @@ import { PUBLICFORM_REGEX } from '~constants/routes'
 import { useTimeout } from '~hooks/useTimeout'
 import { useToast } from '~hooks/useToast'
 import { HttpError } from '~services/ApiService'
+import Link from '~components/Link'
 
 import {
   FetchNewTransactionResponse,
@@ -47,8 +49,16 @@ export const PublicFormProvider = ({
       } else if (!desyncToastIdRef.current && !isEqual(data, form)) {
         desyncToastIdRef.current = toast({
           status: 'warning',
-          description:
-            'Form may have been changed and submission may fail. Refresh for the latest version of the form.',
+          title: (
+            <Text textStyle="subhead-1">
+              The form has been modified and your submission may fail.
+            </Text>
+          ),
+          description: (
+            <Text as="span">
+              <Link href="">Refresh</Link> for the latest version of the form.
+            </Text>
+          ),
           duration: null,
         })
       }

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -48,7 +48,7 @@ export const FormSectionsProvider = ({
    */
   useEffect(() => {
     if (isFirstLoad && orderedSectionFields) {
-      setActiveSectionId(orderedSectionFields[0]._id)
+      setActiveSectionId(orderedSectionFields[0]?._id)
       isFirstLoad.current = false
     }
   }, [orderedSectionFields])

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -23,7 +23,6 @@ export const usePublicFormView = (
     () => getPublicFormView(formId),
     {
       enabled: PUBLICFORM_REGEX.test(formId),
-      refetchOnWindowFocus: false,
     },
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
As originally raised by @mantariksh in https://github.com/opengovsg/FormSG/pull/3457#discussion_r816424658, we should not refresh the public form when the server state has changed. This may cause users to lose their currently filled in form fields. Instead, we should display a warning that form state has changed and the submission may fail due to such changes.

This PR implements that warning and prevents server side form changes from refreshing the current loaded form. 
This is done by storing the initially fetched form and never changing it, whilst displaying a toast if the newly fetched form does change.

### Possible future enhancements
The current methodology does a deep comparison between the current "cached" form and the form retrieved from the server, which may be inefficient. I don't think it will negatively impact responsiveness though, since the effect will not cause any rerenders -- even if a toast is shown a rerender is not triggered.

In the future, we may consider returning the `_v` prop when we retrieve the public form, a prop MongoDB exposes that declares the current version of the form, and compare that against the "cached" version for a simpler check.

## Screenshots
![Screenshot 2022-03-09 at 4 53 25 PM](https://user-images.githubusercontent.com/22133008/158113629-7888d5eb-2541-47de-b71c-2d921d3830e3.png)

