### PR TITLE
feat(v2/date): correct transform ISO strings in DTOs to Date objects in certain APIs

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -22,8 +22,8 @@ export const getAdminFormView = async (
   formId: string,
 ): Promise<AdminFormDto> => {
   return ApiService.get<AdminFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
-    .then(transformAllIsoStringsToDate)
     .then(({ data }) => data.form)
+    .then(transformAllIsoStringsToDate)
 }
 
 /**
@@ -37,8 +37,8 @@ export const previewForm = async (
 ): Promise<PreviewFormViewDto> => {
   return axios
     .get<PreviewFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}/preview`)
-    .then(transformAllIsoStringsToDate)
     .then(({ data }) => data)
+    .then(transformAllIsoStringsToDate)
 }
 
 export const getFreeSmsQuota = async (formId: string) => {

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -7,6 +7,7 @@ import {
   SmsCountsDto,
 } from '~shared/types/form/form'
 
+import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
 // endpoint exported for testing
@@ -20,9 +21,9 @@ export const ADMIN_FORM_ENDPOINT = 'admin/forms'
 export const getAdminFormView = async (
   formId: string,
 ): Promise<AdminFormDto> => {
-  return ApiService.get<AdminFormViewDto>(
-    `${ADMIN_FORM_ENDPOINT}/${formId}`,
-  ).then(({ data }) => data.form)
+  return ApiService.get<AdminFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}`)
+    .then(transformAllIsoStringsToDate)
+    .then(({ data }) => data.form)
 }
 
 /**
@@ -36,6 +37,7 @@ export const previewForm = async (
 ): Promise<PreviewFormViewDto> => {
   return axios
     .get<PreviewFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}/preview`)
+    .then(transformAllIsoStringsToDate)
     .then(({ data }) => data)
 }
 

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -34,7 +34,7 @@ export const PublicFormProvider = ({
   const toastIdRef = useRef<string | number>()
 
   const getTransactionId = useCallback(async () => {
-    if (!vfnTransaction || isPast(new Date(vfnTransaction.expireAt))) {
+    if (!vfnTransaction || isPast(vfnTransaction.expireAt)) {
       const result = await createTransactionMutation.mutateAsync()
       setVfnTransaction(result)
       return result.transactionId
@@ -51,10 +51,7 @@ export const PublicFormProvider = ({
 
   const expiryInMs = useMemo(() => {
     if (!vfnTransaction?.expireAt) return null
-    return differenceInMilliseconds(
-      new Date(vfnTransaction.expireAt),
-      Date.now(),
-    )
+    return differenceInMilliseconds(vfnTransaction.expireAt, Date.now())
   }, [vfnTransaction])
 
   const generateVfnExpiryToast = useCallback(() => {

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -19,8 +19,8 @@ export const getPublicFormView = async (
   formId: string,
 ): Promise<PublicFormViewDto> => {
   return ApiService.get<PublicFormViewDto>(`${PUBLIC_FORMS_ENDPOINT}/${formId}`)
-    .then(transformAllIsoStringsToDate)
     .then(({ data }) => data)
+    .then(transformAllIsoStringsToDate)
 }
 
 /**

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -4,6 +4,7 @@ import {
 } from '~shared/types/form'
 import { FormAuthType, PublicFormViewDto } from '~shared/types/form/form'
 
+import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
 const PUBLIC_FORMS_ENDPOINT = '/forms'
@@ -17,9 +18,9 @@ const PUBLIC_FORMS_ENDPOINT = '/forms'
 export const getPublicFormView = async (
   formId: string,
 ): Promise<PublicFormViewDto> => {
-  return ApiService.get<PublicFormViewDto>(
-    `${PUBLIC_FORMS_ENDPOINT}/${formId}`,
-  ).then(({ data }) => data)
+  return ApiService.get<PublicFormViewDto>(`${PUBLIC_FORMS_ENDPOINT}/${formId}`)
+    .then(transformAllIsoStringsToDate)
+    .then(({ data }) => data)
 }
 
 /**
@@ -34,9 +35,7 @@ export const getPublicFormAuthRedirectUrl = async (
 ): Promise<PublicFormAuthRedirectDto['redirectURL']> => {
   return ApiService.get<PublicFormAuthRedirectDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/auth/redirect`,
-    {
-      params: { isPersistentLogin },
-    },
+    { params: { isPersistentLogin } },
   ).then(({ data }) => data.redirectURL)
 }
 

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -7,7 +7,9 @@ import { FormColorTheme } from '~shared/types/form'
 import {
   AttachmentField,
   CheckboxField,
+  DateField,
   DecimalField,
+  DropdownField,
   EmailField,
   HomeNoField,
   ImageField,
@@ -61,6 +63,10 @@ export const FieldFactory = memo(
         return <LongTextField schema={field} colorTheme={colorTheme} />
       case BasicField.YesNo:
         return <YesNoField schema={field} colorTheme={colorTheme} />
+      case BasicField.Dropdown:
+        return <DropdownField schema={field} colorTheme={colorTheme} />
+      case BasicField.Date:
+        return <DateField schema={field} colorTheme={colorTheme} />
       case BasicField.Uen:
         return <UenField schema={field} colorTheme={colorTheme} />
       case BasicField.Attachment:

--- a/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -27,8 +27,8 @@ export const createTransactionForForm = async (
   return ApiService.post<FetchNewTransactionResponse>(
     `${FORM_API_PREFIX}/${formId}/${VERIFICATION_ENDPOINT}`,
   )
-    .then(transformAllIsoStringsToDate)
     .then(({ data }) => data)
+    .then(transformAllIsoStringsToDate)
 }
 
 /**

--- a/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -1,5 +1,6 @@
 import { Opaque } from 'type-fest'
 
+import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
 /**
@@ -25,16 +26,18 @@ export const createTransactionForForm = async (
 ): Promise<FetchNewTransactionResponse> => {
   return ApiService.post<FetchNewTransactionResponse>(
     `${FORM_API_PREFIX}/${formId}/${VERIFICATION_ENDPOINT}`,
-  ).then(({ data }) => data)
+  )
+    .then(transformAllIsoStringsToDate)
+    .then(({ data }) => data)
 }
 
 /**
  * Sends an OTP to given answer.
- * @param formId The id of the form to generate the otp for
- * @param transactionId The generated transaction id for the form
- * @param fieldId The id of the verification field
- * @param answer The value of the verification field to verify. Usually an email or phone number
- * @param fieldType The kind of field to generate the otp for
+ * @param args
+ * @param args.formId The id of the form to generate the otp for
+ * @param args.transactionId The generated transaction id for the form
+ * @param args.fieldId The id of the verification field
+ * @param args.answer The value of the verification field to verify. Usually an email or phone number
  * @returns 201 Created status if successfully sent
  */
 export const triggerSendOtp = async ({
@@ -43,9 +46,13 @@ export const triggerSendOtp = async ({
   fieldId,
   answer,
 }: {
+  /** The id of the form to generate the otp for */
   formId: string
+  /** The generated transaction id for the form */
   transactionId: string
+  /** The id of the verification field */
   fieldId: string
+  /** The value of the verification field to verify. Usually an email or phone number */
   answer: string
 }): Promise<void> => {
   return ApiService.post(

--- a/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -1,7 +1,5 @@
 import { Opaque } from 'type-fest'
 
-import { JsonDate } from '~typings/core'
-
 import { ApiService } from '~services/ApiService'
 
 /**
@@ -9,7 +7,7 @@ import { ApiService } from '~services/ApiService'
  * current form does not have any verifiable fields.
  */
 export type FetchNewTransactionResponse =
-  | { expireAt: JsonDate; transactionId: string }
+  | { expireAt: Date; transactionId: string }
   | Record<string, never>
 
 type VerifiedFieldSignature = Opaque<string, 'VerifiedFieldSignature'>

--- a/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -1,8 +1,8 @@
 import { Opaque } from 'type-fest'
 
-import { ApiService } from '~services/ApiService'
+import { JsonDate } from '~typings/core'
 
-export type JsonDate = Opaque<string, 'JsonDate'>
+import { ApiService } from '~services/ApiService'
 
 /**
  * Response when retrieving new transaction. Can be an empty object if the

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -5,8 +5,6 @@ import { PartialDeep } from 'type-fest'
 
 import { FormId, PublicFormViewDto } from '~shared/types/form/form'
 
-import { JsonDate } from '~typings/core'
-
 import { FetchNewTransactionResponse } from '~features/verifiable-fields'
 
 import mockFormLogo from '../assets/mockFormLogo.png'
@@ -396,10 +394,7 @@ export const postVfnTransactionResponse = ({
         ctx.delay(delay),
         ctx.json<FetchNewTransactionResponse>({
           transactionId: `mock-transaction-id-${Math.random()}`,
-          expireAt: addMilliseconds(
-            new Date(),
-            expiryMsOverride,
-          ).toISOString() as JsonDate,
+          expireAt: addMilliseconds(new Date(), expiryMsOverride),
         }),
       )
     },

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -5,10 +5,9 @@ import { PartialDeep } from 'type-fest'
 
 import { FormId, PublicFormViewDto } from '~shared/types/form/form'
 
-import {
-  FetchNewTransactionResponse,
-  JsonDate,
-} from '~features/verifiable-fields'
+import { JsonDate } from '~typings/core'
+
+import { FetchNewTransactionResponse } from '~features/verifiable-fields'
 
 import mockFormLogo from '../assets/mockFormLogo.png'
 

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError } from 'axios'
 import { ApiError } from '~typings/core'
 
 import { LOCAL_STORAGE_EVENT, LOGGED_IN_KEY } from '~constants/localStorage'
+import { transformAllIsoStringsToDate } from '~utils/date'
 
 const API_BASE_URL = process.env.REACT_APP_BASE_URL ?? '/api/v3'
 export class HttpError extends Error {
@@ -46,7 +47,10 @@ export const ApiService = axios.create({
 })
 
 ApiService.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    transformAllIsoStringsToDate(response.data)
+    return response
+  },
   (error: AxiosError) => {
     if (error.response?.status === 401) {
       // Remove logged in state from localStorage

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -3,7 +3,6 @@ import axios, { AxiosError } from 'axios'
 import { ApiError } from '~typings/core'
 
 import { LOCAL_STORAGE_EVENT, LOGGED_IN_KEY } from '~constants/localStorage'
-import { transformAllIsoStringsToDate } from '~utils/date'
 
 const API_BASE_URL = process.env.REACT_APP_BASE_URL ?? '/api/v3'
 export class HttpError extends Error {
@@ -47,10 +46,7 @@ export const ApiService = axios.create({
 })
 
 ApiService.interceptors.response.use(
-  (response) => {
-    transformAllIsoStringsToDate(response.data)
-    return response
-  },
+  (response) => response,
   (error: AxiosError) => {
     if (error.response?.status === 401) {
       // Remove logged in state from localStorage

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -16,7 +16,10 @@ import FormLabel from '~components/FormControl/FormLabel'
 import { FormLabelProps } from '~components/FormControl/FormLabel/FormLabel'
 
 export type BaseFieldProps = {
-  schema: FormFieldWithId
+  schema: Pick<
+    FormFieldWithId,
+    '_id' | 'required' | 'description' | 'title' | 'disabled'
+  >
   /**
    * Color theme of form, if available. Defaults to `FormColorTheme.Blue`
    */

--- a/frontend/src/typings/core.ts
+++ b/frontend/src/typings/core.ts
@@ -1,3 +1,7 @@
+import { Opaque } from 'type-fest'
+
 import { HttpError } from '~services/ApiService'
 
 export type ApiError = HttpError | Error
+
+export type JsonDate = Opaque<string, 'JsonDate'>

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -83,9 +83,14 @@ export const isIsoDateString = (value: unknown): value is JsonDate => {
   )
 }
 
-export const transformAllIsoStringsToDate = (body: unknown) => {
+/**
+ * This function mutates given @param body, and transforms all ISO date strings
+ * in the body object to Date objects.
+ * @param body object to transform
+ */
+export const mutableTransformAllIsoStringsToDate = (body: unknown) => {
   if (body === null || body === undefined || typeof body !== 'object') {
-    return body
+    return
   }
 
   for (const key of Object.keys(body)) {
@@ -94,7 +99,18 @@ export const transformAllIsoStringsToDate = (body: unknown) => {
       // eslint-disable-next-line @typescript-eslint/no-extra-semi
       ;(body as Record<string, unknown>)[key] = parseISO(value)
     } else if (typeof value === 'object') {
-      transformAllIsoStringsToDate(value)
+      mutableTransformAllIsoStringsToDate(value)
     }
   }
+}
+
+/**
+ * Non-mutable version of `mutableTransformAllIsoStringsToDate`
+ * @param body object to transform
+ * @returns transformed object with all ISO date strings transformed to Date objects.
+ */
+export const transformAllIsoStringsToDate = <T>(body: T): T => {
+  const result = { ...body }
+  mutableTransformAllIsoStringsToDate(result)
+  return result
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,4 +1,13 @@
-import { addDays, endOfToday, isAfter, isBefore, startOfToday } from 'date-fns'
+import {
+  addDays,
+  endOfToday,
+  isAfter,
+  isBefore,
+  parseISO,
+  startOfToday,
+} from 'date-fns'
+
+import { JsonDate } from '~typings/core'
 
 /**
  * Checks whether the current date is before today
@@ -61,4 +70,27 @@ export const isDateOutOfRange = (
   }
 
   return false
+}
+
+export const ISO_DATE_FORMAT =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/
+
+export const isIsoDateString = (value: unknown): value is JsonDate => {
+  return !!value && typeof value === 'string' && ISO_DATE_FORMAT.test(value)
+}
+
+export const transformAllIsoStringsToDate = (body: unknown) => {
+  if (body === null || body === undefined || typeof body !== 'object') {
+    return body
+  }
+
+  for (const key of Object.keys(body)) {
+    const value = (body as Record<string, unknown>)[key]
+    if (isIsoDateString(value)) {
+      // eslint-disable-next-line @typescript-eslint/no-extra-semi
+      ;(body as Record<string, unknown>)[key] = parseISO(value)
+    } else if (typeof value === 'object') {
+      transformAllIsoStringsToDate(value)
+    }
+  }
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -105,12 +105,12 @@ export const mutableTransformAllIsoStringsToDate = (body: unknown) => {
 }
 
 /**
- * Non-mutable version of `mutableTransformAllIsoStringsToDate`
+ * Helper method that calls `mutableTransformAllIsoStringsToDate` internally to
+ * return the mutated @param body.
  * @param body object to transform
- * @returns transformed object with all ISO date strings transformed to Date objects.
+ * @returns mutated object with all ISO date strings transformed to Date objects.
  */
 export const transformAllIsoStringsToDate = <T>(body: T): T => {
-  const result = { ...body }
-  mutableTransformAllIsoStringsToDate(result)
-  return result
+  mutableTransformAllIsoStringsToDate(body)
+  return body
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -76,7 +76,11 @@ export const ISO_DATE_FORMAT_REGEX =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-](\d+(:\d+)?))?$/
 
 export const isIsoDateString = (value: unknown): value is JsonDate => {
-  return typeof value === 'string' && ISO_DATE_FORMAT_REGEX.test(value)
+  return (
+    typeof value === 'string' &&
+    ISO_DATE_FORMAT_REGEX.test(value) &&
+    !isNaN(new Date(value).getTime())
+  )
 }
 
 export const transformAllIsoStringsToDate = (body: unknown) => {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -72,11 +72,11 @@ export const isDateOutOfRange = (
   return false
 }
 
-export const ISO_DATE_FORMAT =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/
+export const ISO_DATE_FORMAT_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-](\d+(:\d+)?))?$/
 
 export const isIsoDateString = (value: unknown): value is JsonDate => {
-  return !!value && typeof value === 'string' && ISO_DATE_FORMAT.test(value)
+  return typeof value === 'string' && ISO_DATE_FORMAT_REGEX.test(value)
 }
 
 export const transformAllIsoStringsToDate = (body: unknown) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Dates get automatically serialized into strings (e.g. `JSON.stringify(new Date())` => ` '"2022-03-14T09:05:44.694Z"'`) when crossing the server-client divide.

~~This PR re-serializes all strings into Date objects on the client when such requests are intercepted by our `ApiService` using `axios`. This maintains type parity in the shared types and reduces the need to re-convert all ISO strings into Dates before using them.~~

This issue was found when the rendered `DateField` in public forms was working improperly due to passing a stringified ISO date into `date-fns` functions. This means that DTO types were actually not 100% correct; all `Date` types should be some serialized string `JsonDate` type instead. However, this PR will convert those serialized dates at the source where DTOs hit the client back into Date objects, so DTO types will now truly be consistent.

This PR adds client-side date utils `transformAllIsoStringsToDate` (and its mutable version `mutableTransformAllIsoStringsToDate`) to be used by various APIs that should have their Date props re-serialized. The APIs that we need to re-serialize so far are:

- get admin form `GET /api/v3/admin/forms/:formId`
- preview admin form `GET /api/v3/admin/forms/:formId/preview`
- get public form `GET /api/v3/forms/:formId`
- generate verification transaction `GET /api/v3/forms/:formId/fieldverifications`


**Pros and cons of this approach**

| Pros | Cons|
|---|---|
| Transform does not handle all requests, preventing some unknown API from transforming their date strings to Dates|No more one location to reconvert all serialized date strings back into Date objects|
|`Date` prop types in DTO are now actually consistent with their types  |~~May be too much abstraction "magic", devs may not realize that this is being performed at `ApiService`~~|

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(utils/date): add `transformAllIsoStringsToDate` util function
- use the above functions in various APIs we want dates from
- fix: render Dropdown and Date fields in public form 
