### PR TITLE
perf(v2): massively optimize public form filling responsiveness

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29274,9 +29274,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.21.2.tgz",
-      "integrity": "sha512-G2qcUsZSoVolLMZi83nRcZR3VquUWI8lgAfMUyL2teL7vAFPKKwPMfKv2+tXFZjBMzNXHb+HxARdUGcETo8IqQ=="
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.28.0.tgz",
+      "integrity": "sha512-mmLpT86BkMGPr0r6ca8zxV0WH4Y1FW5MKs7Rq1+uHLVeeg5pSWbF5Z/qLCnM5vPVblHNM6lRBRRotnfEAf0ALA=="
     },
     "react-hotkeys": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "react-dropzone": "^11.4.2",
     "react-focus-lock": "^2.7.1",
     "react-highlight-words": "^0.17.0",
-    "react-hook-form": "^7.21.2",
+    "react-hook-form": "^7.28.0",
     "react-icons": "^4.3.1",
     "react-markdown": "^7.1.1",
     "react-query": "^3.34.2",

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -68,7 +68,7 @@ export const EmailFormSection = ({
 }
 
 interface AdminEmailRecipientsInputProps {
-  onSubmit: (params: { emails: [] }) => void
+  onSubmit: (params: { emails: string[] }) => void
 }
 
 const AdminEmailRecipientsInput = ({

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -7,7 +7,9 @@ import { FormColorTheme } from '~shared/types/form'
 import {
   AttachmentField,
   CheckboxField,
+  DateField,
   DecimalField,
+  DropdownField,
   EmailField,
   HomeNoField,
   ImageField,
@@ -61,6 +63,10 @@ export const FieldFactory = memo(
         return <LongTextField schema={field} colorTheme={colorTheme} />
       case BasicField.YesNo:
         return <YesNoField schema={field} colorTheme={colorTheme} />
+      case BasicField.Dropdown:
+        return <DropdownField schema={field} colorTheme={colorTheme} />
+      case BasicField.Date:
+        return <DateField schema={field} colorTheme={colorTheme} />
       case BasicField.Uen:
         return <UenField schema={field} colorTheme={colorTheme} />
       case BasicField.Attachment:

--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.stories.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.stories.tsx
@@ -97,7 +97,9 @@ const Template: Story<StoryEmailFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (
+    values: Record<string, VerifiableFieldInput | undefined>,
+  ) => {
     setSubmitValues(
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',
     )

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.stories.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.stories.tsx
@@ -89,7 +89,9 @@ const Template: Story<StoryMobileFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (
+    values: Record<string, VerifiableFieldInput | undefined>,
+  ) => {
     setSubmitValues(
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',
     )

--- a/frontend/src/templates/Field/Attachment/AttachmentField.stories.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.stories.tsx
@@ -55,8 +55,8 @@ const Template: Story<StoryAttachmentFieldProps> = ({
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, File>) => {
-    const stringifyFile = (obj: File) => {
+  const onSubmit = (values: Record<string, File | undefined>) => {
+    const stringifyFile = (obj?: File) => {
       const replacer = []
       for (const key in obj) {
         replacer.push(key)

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.stories.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.stories.tsx
@@ -62,7 +62,7 @@ const Template: Story<StoryCheckboxFieldProps> = ({
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',
     )

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { FieldError, useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -44,11 +44,15 @@ export const CheckboxField = ({
   }, [othersInputName, schema])
 
   const {
-    watch,
     register,
+    control,
     formState: { isValid, isSubmitting, errors },
   } = useFormContext()
-  const checkboxValues = watch(checkboxInputName, [])
+  const checkboxValues = useWatch({
+    name: checkboxInputName,
+    defaultValue: [],
+    control,
+  })
   const isOthersSelected = useMemo(
     () =>
       Array.isArray(checkboxValues) &&
@@ -68,8 +72,6 @@ export const CheckboxField = ({
     }),
     [isOthersSelected],
   )
-
-  const othersInputError: FieldError | undefined = get(errors, othersInputName)
 
   return (
     <FieldContainer
@@ -92,7 +94,7 @@ export const CheckboxField = ({
             isRequired={schema.required}
             isDisabled={schema.disabled}
             isReadOnly={isValid && isSubmitting}
-            isInvalid={!!othersInputError}
+            isInvalid={!!get(errors, othersInputName)}
           >
             <Checkbox.OthersCheckbox
               value={CHECKBOX_OTHERS_INPUT_VALUE}
@@ -103,7 +105,7 @@ export const CheckboxField = ({
               {...register(othersInputName, othersValidationRules)}
             />
             <FormErrorMessage ml={styles.othersInput?.ml as string} mb={0}>
-              {othersInputError?.message}
+              {get(errors, `${othersInputName}.message`)}
             </FormErrorMessage>
           </FormControl>
         </Checkbox.OthersWrapper>

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useFormContext, useWatch } from 'react-hook-form'
+import { useFormContext, useFormState, useWatch } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -43,11 +43,9 @@ export const CheckboxField = ({
     }
   }, [othersInputName, schema])
 
-  const {
-    register,
-    control,
-    formState: { isValid, isSubmitting, errors },
-  } = useFormContext()
+  const { register, control } = useFormContext()
+  const { isValid, isSubmitting, errors } = useFormState({ name: schema._id })
+
   const checkboxValues = useWatch({
     name: checkboxInputName,
     defaultValue: [],

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -1,7 +1,11 @@
-import { useMemo } from 'react'
-import { useFormContext, useFormState, useWatch } from 'react-hook-form'
+import { forwardRef, useMemo } from 'react'
+import {
+  get,
+  useFormContext,
+  UseFormRegisterReturn,
+  useFormState,
+} from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
-import { get } from 'lodash'
 
 import { CheckboxFieldBase, FormFieldWithId } from '~shared/types/field'
 
@@ -34,41 +38,33 @@ export const CheckboxField = ({
     () => `${schema._id}.${CHECKBOX_OTHERS_INPUT_KEY}`,
     [schema._id],
   )
-  const checkboxInputName = `${schema._id}.value`
+  const checkboxInputName = useMemo(() => `${schema._id}.value`, [schema._id])
 
-  const validationRules = useMemo(() => {
-    return {
-      ...createCheckboxValidationRules(schema),
-      deps: [othersInputName],
-    }
-  }, [othersInputName, schema])
-
-  const { register, control } = useFormContext()
-  const { isValid, isSubmitting, errors } = useFormState({ name: schema._id })
-
-  const checkboxValues = useWatch({
-    name: checkboxInputName,
-    defaultValue: [],
-    control,
-  })
-  const isOthersSelected = useMemo(
-    () =>
-      Array.isArray(checkboxValues) &&
-      checkboxValues.includes(CHECKBOX_OTHERS_INPUT_VALUE),
-    [checkboxValues],
+  const validationRules = useMemo(
+    () => createCheckboxValidationRules(schema),
+    [schema],
   )
+
+  const { register, getValues, trigger } = useFormContext()
+  const { isValid, isSubmitting, errors } = useFormState({
+    name: schema._id,
+  })
 
   const othersValidationRules = useMemo(
     () => ({
       validate: (value: string) => {
+        const currCheckedVals = getValues(checkboxInputName)
         return (
-          !isOthersSelected ||
+          !(
+            Array.isArray(currCheckedVals) &&
+            currCheckedVals.includes(CHECKBOX_OTHERS_INPUT_VALUE)
+          ) ||
           !!value ||
           'Please specify a value for the "others" option'
         )
       },
     }),
-    [isOthersSelected],
+    [checkboxInputName, getValues],
   )
 
   return (
@@ -94,8 +90,9 @@ export const CheckboxField = ({
             isReadOnly={isValid && isSubmitting}
             isInvalid={!!get(errors, othersInputName)}
           >
-            <Checkbox.OthersCheckbox
+            <OtherCheckboxField
               value={CHECKBOX_OTHERS_INPUT_VALUE}
+              triggerOthersInputValidation={() => trigger(othersInputName)}
               {...register(checkboxInputName, validationRules)}
             />
             <Checkbox.OthersInput
@@ -111,3 +108,19 @@ export const CheckboxField = ({
     </FieldContainer>
   )
 }
+
+interface OtherCheckboxFieldProps extends UseFormRegisterReturn {
+  value: string
+  triggerOthersInputValidation: () => void
+}
+const OtherCheckboxField = forwardRef<
+  HTMLInputElement,
+  OtherCheckboxFieldProps
+>(({ onChange, triggerOthersInputValidation, ...rest }, ref) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event)
+    triggerOthersInputValidation()
+  }
+
+  return <Checkbox.OthersCheckbox onChange={handleChange} {...rest} ref={ref} />
+})

--- a/frontend/src/templates/Field/Date/DateField.stories.tsx
+++ b/frontend/src/templates/Field/Date/DateField.stories.tsx
@@ -65,7 +65,7 @@ const Template: Story<StoryDateFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Decimal/DecimalField.stories.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.stories.tsx
@@ -56,7 +56,7 @@ const Template: Story<StoryDecimalFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
@@ -62,7 +62,7 @@ const Template: Story<StoryDropdownFieldProps> = ({
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Email/EmailField.stories.tsx
+++ b/frontend/src/templates/Field/Email/EmailField.stories.tsx
@@ -64,7 +64,9 @@ const Template: Story<StoryEmailFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, VerifiableFieldInput>) => {
+  const onSubmit = (
+    values: Record<string, VerifiableFieldInput | undefined>,
+  ) => {
     setSubmitValues(values[args.schema._id]?.value || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -4,7 +4,7 @@
  * component as this component relies on methods the FormProvider component
  * provides.
  */
-import { FieldError, useFormContext, useFormState } from 'react-hook-form'
+import { FieldError, useFormState } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -39,7 +39,7 @@ export const FieldContainer = ({
   children,
   errorKey,
 }: FieldContainerProps): JSX.Element => {
-  const { errors, isSubmitting, isValid } = useFormState()
+  const { errors, isSubmitting, isValid } = useFormState({ name: schema._id })
 
   const error: FieldError | undefined = get(errors, errorKey ?? schema._id)
 

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -4,7 +4,7 @@
  * component as this component relies on methods the FormProvider component
  * provides.
  */
-import { FieldError, useFormContext } from 'react-hook-form'
+import { FieldError, useFormContext, useFormState } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -39,9 +39,7 @@ export const FieldContainer = ({
   children,
   errorKey,
 }: FieldContainerProps): JSX.Element => {
-  const {
-    formState: { errors, isSubmitting, isValid },
-  } = useFormContext()
+  const { errors, isSubmitting, isValid } = useFormState()
 
   const error: FieldError | undefined = get(errors, errorKey ?? schema._id)
 

--- a/frontend/src/templates/Field/HomeNo/HomeNoField.stories.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.stories.tsx
@@ -52,7 +52,7 @@ const Template: Story<StoryHomeNoFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/LongText/LongTextField.stories.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.stories.tsx
@@ -58,7 +58,7 @@ const Template: Story<StoryLongTextFieldProps> = ({
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Mobile/MobileField.stories.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileField.stories.tsx
@@ -56,7 +56,9 @@ const Template: Story<StoryMobileFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, { value?: string }>) => {
+  const onSubmit = (
+    values: Record<string, { value?: string | undefined } | undefined>,
+  ) => {
     setSubmitValues(values[args.schema._id]?.value || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Nric/NricField.stories.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.stories.tsx
@@ -51,7 +51,7 @@ const Template: Story<StoryNricFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Number/NumberField.stories.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.stories.tsx
@@ -55,7 +55,7 @@ const Template: Story<StoryNumberFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Radio/RadioField.stories.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
@@ -41,16 +41,8 @@ const baseSchema: RadioFieldSchema = {
   _id: '611b94dfbb9e300012f702a7',
 }
 
-interface StoryRadioFieldProps extends RadioFieldProps {
-  defaultValue?: string
-}
-
-const Template: Story<StoryRadioFieldProps> = ({ defaultValue, ...args }) => {
-  const formMethods = useForm({
-    defaultValues: {
-      [args.schema._id]: {},
-    },
-  })
+const Template: Story<RadioFieldProps> = (args) => {
+  const formMethods = useForm()
 
   const [submitValues, setSubmitValues] = useState<string>()
 
@@ -59,12 +51,6 @@ const Template: Story<StoryRadioFieldProps> = ({ defaultValue, ...args }) => {
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',
     )
   }
-
-  useEffect(() => {
-    if (defaultValue) {
-      formMethods.trigger()
-    }
-  }, [])
 
   return (
     <FormProvider {...formMethods}>

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -1,10 +1,5 @@
 import { useMemo } from 'react'
-import {
-  Controller,
-  useFormContext,
-  useFormState,
-  useWatch,
-} from 'react-hook-form'
+import { Controller, useFormContext, useFormState } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react'
-import { Controller, useFormContext, useWatch } from 'react-hook-form'
+import {
+  Controller,
+  useFormContext,
+  useFormState,
+  useWatch,
+} from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -42,11 +47,8 @@ export const RadioField = ({
     }
   }, [othersInputName, schema])
 
-  const {
-    register,
-    control,
-    formState: { isValid, isSubmitting, errors },
-  } = useFormContext()
+  const { register, control } = useFormContext()
+  const { isValid, isSubmitting, errors } = useFormState({ name: schema._id })
   const radioValue = useWatch({ name: radioInputName, control })
 
   const isOthersSelected = useMemo(

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Controller, FieldError, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 
@@ -43,11 +43,11 @@ export const RadioField = ({
   }, [othersInputName, schema])
 
   const {
-    watch,
     register,
+    control,
     formState: { isValid, isSubmitting, errors },
   } = useFormContext()
-  const radioValue = watch(radioInputName)
+  const radioValue = useWatch({ name: radioInputName, control })
 
   const isOthersSelected = useMemo(
     () => schema.othersRadioButton && radioValue === RADIO_OTHERS_INPUT_VALUE,
@@ -66,8 +66,6 @@ export const RadioField = ({
     }),
     [isOthersSelected],
   )
-
-  const othersInputError: FieldError | undefined = get(errors, othersInputName)
 
   return (
     <FieldContainer
@@ -93,7 +91,7 @@ export const RadioField = ({
                   isRequired={schema.required}
                   isDisabled={schema.disabled}
                   isReadOnly={isValid && isSubmitting}
-                  isInvalid={!!othersInputError}
+                  isInvalid={!!get(errors, othersInputName)}
                 >
                   <OthersInput
                     aria-label='Enter value for "Others" option'
@@ -103,7 +101,7 @@ export const RadioField = ({
                     ml={styles.othersInput?.ml as string}
                     mb={0}
                   >
-                    {othersInputError?.message}
+                    {get(errors, `${othersInputName}.message`)}
                   </FormErrorMessage>
                 </FormControl>
               </Radio.OthersWrapper>

--- a/frontend/src/templates/Field/ShortText/ShortTextField.stories.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.stories.tsx
@@ -58,7 +58,7 @@ const Template: Story<StoryShortTextFieldProps> = ({
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Controller, FieldError, useFormContext } from 'react-hook-form'
+import { Controller, useFormState } from 'react-hook-form'
 import { UseTableCellProps } from 'react-table'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
@@ -48,16 +48,12 @@ export const ColumnCell = ({
   column,
   columnSchema,
 }: ColumnCellProps): JSX.Element => {
-  const {
-    formState: { errors },
-  } = useFormContext()
+  const { errors } = useFormState()
 
   const inputName = useMemo(
     () => `${schemaId}.${row.index}.${column.id}`,
     [column.id, row.index, schemaId],
   )
-
-  const cellError: FieldError | undefined = get(errors, inputName)
 
   const renderedColumnCell = useMemo(() => {
     switch (columnSchema.columnType) {
@@ -71,12 +67,15 @@ export const ColumnCell = ({
   }, [columnSchema, inputName])
 
   return (
-    <FormControl isRequired={columnSchema.required} isInvalid={!!cellError}>
+    <FormControl
+      isRequired={columnSchema.required}
+      isInvalid={!!get(errors, inputName)}
+    >
       <FormLabel display={{ base: 'flex', md: 'none' }} color="secondary.700">
         {columnSchema.title}
       </FormLabel>
       {renderedColumnCell}
-      <FormErrorMessage>{cellError?.message}</FormErrorMessage>
+      <FormErrorMessage>{get(errors, `${inputName}.message`)}</FormErrorMessage>
     </FormControl>
   )
 }

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -48,7 +48,7 @@ export const ColumnCell = ({
   column,
   columnSchema,
 }: ColumnCellProps): JSX.Element => {
-  const { errors } = useFormState()
+  const { errors } = useFormState({ name: schemaId })
 
   const inputName = useMemo(
     () => `${schemaId}.${row.index}.${column.id}`,

--- a/frontend/src/templates/Field/Table/TableField.stories.tsx
+++ b/frontend/src/templates/Field/Table/TableField.stories.tsx
@@ -128,7 +128,7 @@ const Template: Story<StoryTableFieldProps> = ({ defaultValue, ...args }) => {
     }
   }, [])
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, any>) => {
     console.log(values)
     setSubmitValues(
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',

--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -1,4 +1,4 @@
-import { get, useFormContext } from 'react-hook-form'
+import { useFormState } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 
 import FormLabel from '~components/FormControl/FormLabel'
@@ -24,16 +24,14 @@ export const TableFieldContainer = ({
   questionNumber,
   children,
 }: TableFieldContainerProps): JSX.Element => {
-  const {
-    formState: { isSubmitting, isValid, errors },
-  } = useFormContext()
+  const { isSubmitting, isValid, errors } = useFormState()
 
   return (
     <FormControl
       isRequired={schema.required}
       isDisabled={schema.disabled}
       isReadOnly={isValid && isSubmitting}
-      isInvalid={!!get(errors, schema._id)}
+      isInvalid={!!errors[schema._id]}
     >
       <FormLabel
         questionNumber={questionNumber}

--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -24,7 +24,7 @@ export const TableFieldContainer = ({
   questionNumber,
   children,
 }: TableFieldContainerProps): JSX.Element => {
-  const { isSubmitting, isValid, errors } = useFormState()
+  const { isSubmitting, isValid, errors } = useFormState({ name: schema._id })
 
   return (
     <FormControl

--- a/frontend/src/templates/Field/Uen/UenField.stories.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.stories.tsx
@@ -51,7 +51,7 @@ const Template: Story<StoryUenFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, string>) => {
+  const onSubmit = (values: Record<string, string | undefined>) => {
     setSubmitValues(values[args.schema._id] || 'Nothing was selected')
   }
 

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -320,7 +320,7 @@ export const createCheckboxValidationRules: ValidationRuleFn<
         ValidationOptions: { customMin, customMax },
         validateByValue,
       } = schema
-      if (!val || !validateByValue) return true
+      if (!val || val.length === 0 || !validateByValue) return true
 
       if (
         customMin &&


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Perf was HORRENDOUS due to global formState mutating on literally every single error, causing each keystroke to render every single field again.

This PR updates the performance by only monitoring a subslice of the form state, so each field does not rerender from other field changes.

Also adds rendering for Dropdown and Date fields in public form view, must have been removed again due to merge conflicts.

See the comparison videos below for the massive responsiveness boost.

## Solution
<!-- How did you solve the problem? -->

**Improvements**:

- perf: use `useFormState` and `useWatch` over contextual counterparts
- perf: remove `dep` in validation, only trigger on OtherCheckbox/OtherRadio option change

**Bug Fixes**:

- fix(checkboxValidation): do not run length validation if empty value

## Before & After Screenshots

**BEFORE**:
![horrendous public form rendering perf](https://user-images.githubusercontent.com/22133008/158253339-a3733dbb-3e64-4093-bcfc-714e8ba63f8f.gif)


**AFTER**:
<!-- [insert screenshot here] -->
![Recording 2022-03-15 at 04 07 48](https://user-images.githubusercontent.com/22133008/158253390-c7e75d48-6e65-4ec0-8968-fc1e27c93ec2.gif)

## Tests
<!-- What tests should be run to confirm functionality? -->
Should have no changes in tests

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- fix(deps): update react-hook-form to v7.28.0
  - needed to use the new `useFormState` hook, which allows monitoring substates of form state to gain the much better rendering speeds.

