### PR TITLE
feat(v2): edit checkbox field in form builder

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -8,7 +8,6 @@ import { FIELD_LIST_DROP_ID } from '../constants'
 import { DndPlaceholderProps } from '../types'
 import {
   setToInactiveSelector,
-  stateDataSelector,
   useBuilderAndDesignStore,
 } from '../useBuilderAndDesignStore'
 
@@ -25,7 +24,6 @@ export const BuilderAndDesignContent = ({
   placeholderProps,
 }: BuilderAndDesignContentProps): JSX.Element => {
   const setFieldsToInactive = useBuilderAndDesignStore(setToInactiveSelector)
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
   const { builderFields } = useBuilderFields()
 
   useEffect(() => setFieldsToInactive, [setFieldsToInactive])

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
@@ -74,7 +74,7 @@ export const BuilderAndDesignDrawer = (): JSX.Element | null => {
           overflow="hidden"
           {...DRAWER_MOTION_PROPS}
         >
-          <Flex w="100%" h="100%" minW="max-content" flexDir="column">
+          <Flex w="100%" h="100%" flexDir="column">
             {renderDrawerContent}
           </Flex>
         </MotionBox>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -22,7 +22,7 @@ import {
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 import { FieldMutateOptions } from './edit-fieldtype/common/types'
-import { EditHeader } from './edit-fieldtype'
+import { EditCheckbox, EditHeader } from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =
@@ -153,6 +153,8 @@ const MemoFieldDrawerContent = memo((props: MemoFieldDrawerContentProps) => {
   switch (field.fieldType) {
     case BasicField.Section:
       return <EditHeader {...props} field={field} />
+    case BasicField.Checkbox:
+      return <EditCheckbox {...props} field={field} />
     default:
       return <div>TODO: Insert field options here</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -21,7 +21,7 @@ import {
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 import { FieldMutateOptions } from './edit-fieldtype/common/types'
-import { EditHeader } from './edit-fieldtype/EditHeader'
+import { EditHeader } from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -8,6 +8,7 @@ import IconButton from '~components/IconButton'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 
+import { useBuilderFields } from '../../BuilderAndDesignContent/useBuilderFields'
 import { useCreateFormField } from '../../mutations/useCreateFormField'
 import { useEditFormField } from '../../mutations/useEditFormField'
 import {
@@ -79,6 +80,26 @@ export const EditFieldDrawer = (): JSX.Element | null => {
     [stateData, updateCreateState, updateEditState],
   )
 
+  // Hacky method of determining when to rerender the drawer,
+  // i.e. when the user clicks into a different field.
+  // We pass `${fieldIndex}-${numFields}` as the key. If the
+  // user was creating a new field but clicked into an existing
+  // field, causing the new field to be discarded, then numFields
+  // changes. If the user was editing an existing field then clicked
+  // into another existing field, causing the edits to be discarded,
+  // then fieldIndex changes.
+  const { builderFields } = useBuilderFields()
+  const fieldIndex = useMemo(() => {
+    if (stateData.state === BuildFieldState.CreatingField) {
+      return stateData.insertionIndex
+    } else if (stateData.state === BuildFieldState.EditingField) {
+      return builderFields?.findIndex(
+        (field) => field._id === stateData.field._id,
+      )
+    }
+  }, [builderFields, stateData])
+  const numFields = useMemo(() => builderFields?.length, [builderFields])
+
   if (!fieldToEdit) return null
 
   return (
@@ -111,6 +132,7 @@ export const EditFieldDrawer = (): JSX.Element | null => {
         handleChange={handleChange}
         handleSave={handleSave}
         handleCancel={setToInactive}
+        key={`${fieldIndex}-${numFields}`}
       />
     </>
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -37,8 +37,8 @@ type EditCheckboxKeys = typeof EDIT_CHECKBOX_FIELD_KEYS[number]
 type EditCheckboxInputs = Pick<CheckboxFieldBase, EditCheckboxKeys> & {
   fieldOptions: string
   ValidationOptions: {
-    customMin?: number
-    customMax?: number
+    customMin?: number | string
+    customMax?: number | string
   }
 }
 
@@ -47,10 +47,10 @@ const transformCheckboxFieldToEditForm = (
 ): EditCheckboxInputs => {
   const nextValidationOptions = field.validateByValue
     ? {
-        customMin: field.ValidationOptions.customMin || undefined,
-        customMax: field.ValidationOptions.customMax || undefined,
+        customMin: field.ValidationOptions.customMin || '',
+        customMax: field.ValidationOptions.customMax || '',
       }
-    : { customMin: undefined, customMax: undefined }
+    : { customMin: '', customMax: '' }
   return {
     ...pick(field, EDIT_CHECKBOX_FIELD_KEYS),
     fieldOptions: SPLIT_TEXTAREA_TRANSFORM.input(field.fieldOptions),

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useMemo } from 'react'
+import { Controller, RegisterOptions } from 'react-hook-form'
+import { Box, FormControl, Stack } from '@chakra-ui/react'
+import { extend, isEmpty, pick } from 'lodash'
+
+import { CheckboxFieldBase } from '~shared/types/field'
+
+import { createBaseValidationRules } from '~utils/fieldValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import NumberInput from '~components/NumberInput'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+
+import { DrawerContentContainer } from './common/DrawerContentContainer'
+import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
+import { EditFieldProps } from './common/types'
+import { useEditFieldForm } from './common/useEditFieldForm'
+import {
+  SPLIT_TEXTAREA_TRANSFORM,
+  SPLIT_TEXTAREA_VALIDATION,
+} from './common/utils'
+
+type EditCheckboxProps = EditFieldProps<CheckboxFieldBase>
+
+const EDIT_CHECKBOX_FIELD_KEYS = [
+  'title',
+  'description',
+  'required',
+  'othersRadioButton',
+  'validateByValue',
+] as const
+
+type EditCheckboxKeys = typeof EDIT_CHECKBOX_FIELD_KEYS[number]
+
+type EditCheckboxInputs = Pick<CheckboxFieldBase, EditCheckboxKeys> & {
+  fieldOptions: string
+  ValidationOptions: {
+    customMin?: number
+    customMax?: number
+  }
+}
+
+const transformCheckboxFieldToEditForm = (
+  field: CheckboxFieldBase,
+): EditCheckboxInputs => {
+  const nextValidationOptions = field.validateByValue
+    ? {
+        customMin: field.ValidationOptions.customMin || undefined,
+        customMax: field.ValidationOptions.customMax || undefined,
+      }
+    : { customMin: undefined, customMax: undefined }
+  return {
+    ...pick(field, EDIT_CHECKBOX_FIELD_KEYS),
+    fieldOptions: SPLIT_TEXTAREA_TRANSFORM.input(field.fieldOptions),
+    ValidationOptions: nextValidationOptions,
+  }
+}
+
+const transformCheckboxEditFormToField = (
+  form: EditCheckboxInputs,
+  originalField: CheckboxFieldBase,
+): CheckboxFieldBase => {
+  const nextValidationOptions = form.validateByValue
+    ? {
+        customMin: form.ValidationOptions.customMin || null,
+        customMax: form.ValidationOptions.customMax || null,
+      }
+    : { customMin: null, customMax: null }
+  return extend({}, originalField, form, {
+    fieldOptions: SPLIT_TEXTAREA_TRANSFORM.output(form.fieldOptions),
+    ValidationOptions: nextValidationOptions,
+  })
+}
+
+export const EditCheckbox = (props: EditCheckboxProps): JSX.Element => {
+  const {
+    register,
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+    watch,
+    control,
+    clearErrors,
+  } = useEditFieldForm<EditCheckboxInputs, CheckboxFieldBase>({
+    ...props,
+    transform: {
+      input: transformCheckboxFieldToEditForm,
+      output: transformCheckboxEditFormToField,
+    },
+  })
+
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
+  const watchedInputs = watch()
+
+  const customMinValidationOptions: RegisterOptions = useMemo(
+    () => ({
+      required: {
+        value:
+          watchedInputs.validateByValue &&
+          !watchedInputs.ValidationOptions.customMax,
+        message: 'Please enter selection limits',
+      },
+      min: {
+        value: 1,
+        message: 'Cannot be less than 1',
+      },
+      validate: {
+        minLargerThanMax: (val) => {
+          return (
+            !val ||
+            !watchedInputs.validateByValue ||
+            !watchedInputs.ValidationOptions.customMax ||
+            Number(val) <= Number(watchedInputs.ValidationOptions.customMax) ||
+            'Minimum cannot be larger than maximum'
+          )
+        },
+        max: (val) => {
+          let numOptions = SPLIT_TEXTAREA_TRANSFORM.output(
+            watchedInputs.fieldOptions,
+          ).length
+          if (watchedInputs.othersRadioButton) {
+            numOptions += 1
+          }
+          return (
+            !val || val <= numOptions || 'Cannot be more than number of options'
+          )
+        },
+      },
+    }),
+    [watchedInputs],
+  )
+
+  const customMaxValidationOptions: RegisterOptions = useMemo(
+    () => ({
+      required: {
+        value:
+          watchedInputs.validateByValue &&
+          !watchedInputs.ValidationOptions.customMin,
+        message: 'Please enter selection limits',
+      },
+      min: {
+        value: 1,
+        message: 'Cannot be less than 1',
+      },
+      validate: {
+        maxLargerThanMin: (val) => {
+          return (
+            !val ||
+            !watchedInputs.validateByValue ||
+            !watchedInputs.ValidationOptions.customMin ||
+            Number(val) >= Number(watchedInputs.ValidationOptions.customMin) ||
+            'Maximum cannot be less than minimum'
+          )
+        },
+        max: (val) => {
+          if (!watchedInputs.validateByValue) return true
+          let numOptions = SPLIT_TEXTAREA_TRANSFORM.output(
+            watchedInputs.fieldOptions,
+          ).length
+          if (watchedInputs.othersRadioButton) {
+            numOptions += 1
+          }
+          return (
+            !val || val <= numOptions || 'Cannot be more than number of options'
+          )
+        },
+      },
+    }),
+    [watchedInputs],
+  )
+
+  // Effect to clear validation option errors when selection limit is toggled off.
+  useEffect(() => {
+    if (!watchedInputs.validateByValue) {
+      clearErrors('ValidationOptions')
+    }
+  }, [clearErrors, watchedInputs.validateByValue])
+
+  return (
+    <DrawerContentContainer>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Question</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('required')} label="Required" />
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('othersRadioButton')} label="Others" />
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.fieldOptions}
+      >
+        <FormLabel>Options</FormLabel>
+        <Textarea
+          {...register('fieldOptions', {
+            validate: SPLIT_TEXTAREA_VALIDATION,
+          })}
+        />
+        <FormErrorMessage>{errors?.fieldOptions?.message}</FormErrorMessage>
+      </FormControl>
+      <Box>
+        <Toggle
+          {...register('validateByValue')}
+          label="Selection limits"
+          description="Customise the number of options that users are allowed to select"
+        />
+        <FormControl
+          isDisabled={!watchedInputs.validateByValue}
+          isReadOnly={props.isLoading}
+          isInvalid={!isEmpty(errors.ValidationOptions)}
+        >
+          <Stack mt="0.5rem" direction="row" spacing="0.5rem">
+            <Controller
+              name="ValidationOptions.customMin"
+              control={control}
+              rules={customMinValidationOptions}
+              render={({ field }) => (
+                <NumberInput
+                  flex={1}
+                  showSteppers={false}
+                  {...field}
+                  placeholder="Minimum"
+                />
+              )}
+            />
+            <Controller
+              name="ValidationOptions.customMax"
+              control={control}
+              rules={customMaxValidationOptions}
+              render={({ field }) => (
+                <NumberInput
+                  flex={1}
+                  showSteppers={false}
+                  {...field}
+                  placeholder="Maximum"
+                />
+              )}
+            />
+          </Stack>
+          <FormErrorMessage>
+            {errors?.ValidationOptions?.customMin?.message ??
+              errors?.ValidationOptions?.customMax?.message}
+          </FormErrorMessage>
+        </FormControl>
+      </Box>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
+    </DrawerContentContainer>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -14,16 +14,9 @@ import Textarea from '~components/Textarea'
 
 import { DrawerContentContainer } from './common/DrawerContentContainer'
 import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
-import { FieldMutateOptions } from './common/types'
+import { EditFieldProps } from './common/types'
 
-export interface EditHeaderProps {
-  field: SectionFieldBase
-  isLoading: boolean
-  isPendingField: boolean
-  handleChange: (field: SectionFieldBase) => void
-  handleSave: (field: SectionFieldBase, options?: FieldMutateOptions) => void
-  handleCancel: () => void
-}
+type EditHeaderProps = EditFieldProps<SectionFieldBase>
 
 interface EditHeaderInputs {
   title: string

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -15,6 +15,7 @@ import Textarea from '~components/Textarea'
 import { DrawerContentContainer } from './common/DrawerContentContainer'
 import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
 import { EditFieldProps } from './common/types'
+import { getButtonText } from './common/utils'
 
 type EditHeaderProps = EditFieldProps<SectionFieldBase>
 
@@ -58,7 +59,7 @@ export const EditHeader = ({
   }, [field.title, field.description, setValue, getValues])
 
   const buttonText = useMemo(
-    () => (isPendingField ? 'Create' : 'Save'),
+    () => getButtonText(isPendingField),
     [isPendingField],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -18,10 +18,7 @@ import { EditFieldProps } from './common/types'
 
 type EditHeaderProps = EditFieldProps<SectionFieldBase>
 
-interface EditHeaderInputs {
-  title: string
-  description: string
-}
+type EditHeaderInputs = Pick<SectionFieldBase, 'title' | 'description'>
 
 export const EditHeader = ({
   field,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { FormControl } from '@chakra-ui/react'
+import { extend, pick } from 'lodash'
 
 import { SectionFieldBase } from '~shared/types/field'
 
@@ -27,7 +28,10 @@ export const EditHeader = (props: EditHeaderProps): JSX.Element => {
     handleUpdateField,
   } = useEditFieldForm<EditHeaderInputs, SectionFieldBase>({
     ...props,
-    fieldKeys: ['title', 'description'],
+    transform: {
+      input: (inputField) => pick(inputField, ['title', 'description']),
+      output: (formOutput) => extend({}, props.field, formOutput),
+    },
   })
 
   const requiredValidationRule = useMemo(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -1,8 +1,5 @@
-import { useEffect, useMemo } from 'react'
-import { useForm } from 'react-hook-form'
-import { useDebounce } from 'react-use'
+import { useMemo } from 'react'
 import { Divider, FormControl, Stack } from '@chakra-ui/react'
-import { extend } from 'lodash'
 
 import { SectionFieldBase } from '~shared/types/field'
 
@@ -15,76 +12,22 @@ import Textarea from '~components/Textarea'
 import { DrawerContentContainer } from './common/DrawerContentContainer'
 import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
 import { EditFieldProps } from './common/types'
-import { getButtonText } from './common/utils'
+import { useEditFieldForm } from './common/useEditFieldForm'
 
 type EditHeaderProps = EditFieldProps<SectionFieldBase>
 
 type EditHeaderInputs = Pick<SectionFieldBase, 'title' | 'description'>
 
-export const EditHeader = ({
-  field,
-  isLoading,
-  isPendingField,
-  handleChange,
-  handleSave,
-  handleCancel,
-}: EditHeaderProps): JSX.Element => {
+export const EditHeader = (props: EditHeaderProps): JSX.Element => {
   const {
-    handleSubmit,
-    watch,
     register,
-    formState: { errors, isDirty },
-    reset,
-    setValue,
-    getValues,
-  } = useForm<EditHeaderInputs>({
-    defaultValues: {
-      title: field.title,
-      description: field.description,
-    },
-  })
-
-  // Update form when field loads or changes due to external action,
-  // e.g. if user clicks on another field in the builder
-  useEffect(() => {
-    // perf: setValue causes an additional render, so call it only if
-    // the values change
-    const currentValues = getValues()
-    if (currentValues.title !== field.title) {
-      setValue('title', field.title, { shouldDirty: false })
-    }
-    if (currentValues.description !== field.description) {
-      setValue('description', field.description, { shouldDirty: false })
-    }
-  }, [field.title, field.description, setValue, getValues])
-
-  const buttonText = useMemo(
-    () => getButtonText(isPendingField),
-    [isPendingField],
-  )
-
-  const isSaveEnabled = useMemo(
-    () => isDirty || isPendingField,
-    [isDirty, isPendingField],
-  )
-
-  const watchedInputs = watch()
-
-  useDebounce(() => handleChange({ ...field, ...watchedInputs }), 300, [
-    watchedInputs.description,
-    watchedInputs.title,
-  ])
-
-  const handleUpdateField = handleSubmit((inputs) => {
-    const updatedFormField: SectionFieldBase = extend({}, field, inputs)
-    return handleSave(updatedFormField, {
-      onSuccess: (newField) => {
-        reset({
-          title: newField.title,
-          description: newField.description,
-        })
-      },
-    })
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+  } = useEditFieldForm<EditHeaderInputs, SectionFieldBase>({
+    ...props,
+    fieldKeys: ['title', 'description'],
   })
 
   const requiredValidationRule = useMemo(
@@ -97,7 +40,7 @@ export const EditHeader = ({
       <Stack spacing="2rem" divider={<Divider />}>
         <FormControl
           isRequired
-          isReadOnly={isLoading}
+          isReadOnly={props.isLoading}
           isInvalid={!!errors.title}
         >
           <FormLabel>Section header title</FormLabel>
@@ -106,7 +49,7 @@ export const EditHeader = ({
         </FormControl>
         <FormControl
           isRequired
-          isReadOnly={isLoading}
+          isReadOnly={props.isLoading}
           isInvalid={!!errors.description}
         >
           <FormLabel>Description</FormLabel>
@@ -114,11 +57,11 @@ export const EditHeader = ({
           <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
         </FormControl>
         <FormFieldDrawerActions
-          isLoading={isLoading}
+          isLoading={props.isLoading}
           isSaveEnabled={isSaveEnabled}
           buttonText={buttonText}
           handleClick={handleUpdateField}
-          handleCancel={handleCancel}
+          handleCancel={props.handleCancel}
         />
       </Stack>
     </DrawerContentContainer>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -30,7 +30,8 @@ export const EditHeader = (props: EditHeaderProps): JSX.Element => {
     ...props,
     transform: {
       input: (inputField) => pick(inputField, ['title', 'description']),
-      output: (formOutput) => extend({}, props.field, formOutput),
+      output: (formOutput, originalField) =>
+        extend({}, originalField, formOutput),
     },
   })
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Divider, FormControl, Stack } from '@chakra-ui/react'
+import { FormControl } from '@chakra-ui/react'
 
 import { SectionFieldBase } from '~shared/types/field'
 
@@ -37,33 +37,31 @@ export const EditHeader = (props: EditHeaderProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <Stack spacing="2rem" divider={<Divider />}>
-        <FormControl
-          isRequired
-          isReadOnly={props.isLoading}
-          isInvalid={!!errors.title}
-        >
-          <FormLabel>Section header</FormLabel>
-          <Input autoFocus {...register('title', requiredValidationRule)} />
-          <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
-        </FormControl>
-        <FormControl
-          isRequired
-          isReadOnly={props.isLoading}
-          isInvalid={!!errors.description}
-        >
-          <FormLabel>Description</FormLabel>
-          <Textarea {...register('description')} />
-          <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
-        </FormControl>
-        <FormFieldDrawerActions
-          isLoading={props.isLoading}
-          isSaveEnabled={isSaveEnabled}
-          buttonText={buttonText}
-          handleClick={handleUpdateField}
-          handleCancel={props.handleCancel}
-        />
-      </Stack>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Section header</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
     </DrawerContentContainer>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -43,7 +43,7 @@ export const EditHeader = (props: EditHeaderProps): JSX.Element => {
           isReadOnly={props.isLoading}
           isInvalid={!!errors.title}
         >
-          <FormLabel>Section header title</FormLabel>
+          <FormLabel>Section header</FormLabel>
           <Input autoFocus {...register('title', requiredValidationRule)} />
           <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
         </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/DrawerContentContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/DrawerContentContainer.tsx
@@ -1,6 +1,7 @@
-import { Flex, FlexProps } from '@chakra-ui/layout'
+import { Children } from 'react'
+import { Box, Divider, Stack, StackProps } from '@chakra-ui/layout'
 
-export interface DrawerContentContainerProps extends FlexProps {
+export interface DrawerContentContainerProps extends StackProps {
   children: React.ReactNode
 }
 /**
@@ -12,16 +13,19 @@ export const DrawerContentContainer = ({
   ...props
 }: DrawerContentContainerProps): JSX.Element => {
   return (
-    <Flex
+    <Stack
       py="2rem"
-      px="1.5rem"
       flexDir="column"
       flex={1}
       pos="relative"
       overflow="auto"
+      divider={<Divider />}
+      spacing="2rem"
       {...props}
     >
-      {children}
-    </Flex>
+      {Children.map(children, (child) => (
+        <Box px="1.5rem">{child}</Box>
+      ))}
+    </Stack>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/types.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/types.ts
@@ -1,6 +1,6 @@
 import { MutateOptions } from 'react-query'
 
-import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
+import { FieldBase, FieldCreateDto, FormFieldDto } from '~shared/types/field'
 
 export type FieldMutateOptions = MutateOptions<
   FormFieldDto,
@@ -8,3 +8,12 @@ export type FieldMutateOptions = MutateOptions<
   FieldCreateDto,
   unknown
 >
+
+export type EditFieldProps<T extends FieldBase> = {
+  field: T
+  isLoading: boolean
+  isPendingField: boolean
+  handleChange: (field: T) => void
+  handleSave: (field: T, options?: FieldMutateOptions) => void
+  handleCancel: () => void
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -65,6 +65,9 @@ export const useEditFieldForm = <FormShape, FieldShape extends FieldBase>({
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           transform.input(newField),
+          // react-hook-form has strange behaviour where setting a field
+          // to undefined results in the form displaying the field in
+          // a previous state. Hence don't reset the form values.
           { keepValues: true },
         )
       },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -65,10 +65,6 @@ export const useEditFieldForm = <FormShape, FieldShape extends FieldBase>({
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           transform.input(newField),
-          // react-hook-form has strange behaviour where setting a field
-          // to undefined results in the form displaying the field in
-          // a previous state. Hence don't reset the form values.
-          { keepValues: true },
         )
       },
     })

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -65,6 +65,7 @@ export const useEditFieldForm = <FormShape, FieldShape extends FieldBase>({
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           transform.input(newField),
+          { keepValues: true },
         )
       },
     })

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -18,7 +18,7 @@ type UseEditFieldFormProps<
 > = EditFieldProps<FieldShape> & {
   transform: {
     input: (field: FieldShape) => FormShape
-    output: (form: FormShape) => FieldShape
+    output: (form: FormShape, originalField: FieldShape) => FieldShape
   }
 }
 
@@ -49,13 +49,16 @@ export const useEditFieldForm = <FormShape, FieldShape extends FieldBase>({
   const watchedInputs = editForm.watch()
 
   useDebounce(
-    () => handleChange(transform.output(watchedInputs as FormShape)),
+    () => handleChange(transform.output(watchedInputs as FormShape, field)),
     300,
     Object.values(watchedInputs),
   )
 
   const handleUpdateField = editForm.handleSubmit((inputs) => {
-    const updatedFormField: FieldShape = transform.output(inputs as FormShape)
+    const updatedFormField: FieldShape = transform.output(
+      inputs as FormShape,
+      field,
+    )
     return handleSave(updatedFormField, {
       onSuccess: (newField) => {
         editForm.reset(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -1,21 +1,25 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import {
   DeepPartial,
-  Path,
   UnpackNestedValue,
   useForm,
   UseFormReturn,
 } from 'react-hook-form'
 import { useDebounce } from 'react-use'
-import { extend, get, isEqual, pick } from 'lodash'
 
 import { FieldBase } from '~shared/types/field'
 
 import { EditFieldProps } from './types'
 import { getButtonText } from './utils'
 
-type UseEditFieldFormProps<T extends FieldBase> = EditFieldProps<T> & {
-  fieldKeys: readonly Path<T>[]
+type UseEditFieldFormProps<
+  FormShape,
+  FieldShape extends FieldBase,
+> = EditFieldProps<FieldShape> & {
+  transform: {
+    input: (field: FieldShape) => FormShape
+    output: (form: FormShape) => FieldShape
+  }
 }
 
 type UseEditFieldFormReturn<U> = UseFormReturn<U> & {
@@ -24,60 +28,40 @@ type UseEditFieldFormReturn<U> = UseFormReturn<U> & {
   isSaveEnabled: boolean
 }
 
-export const useEditFieldForm = <U, T extends FieldBase>({
+export const useEditFieldForm = <FormShape, FieldShape extends FieldBase>({
   field,
-  fieldKeys,
   isPendingField,
   handleChange,
   handleSave,
-}: UseEditFieldFormProps<T>): UseEditFieldFormReturn<U> => {
-  // Destructure getValues and setValue specifically so they can
-  // be used as dependencies in the useEffect below
-  const { getValues, setValue, ...editForm } = useForm<U>({
-    defaultValues: pick(field, fieldKeys) as UnpackNestedValue<DeepPartial<U>>,
+  transform,
+}: UseEditFieldFormProps<
+  FormShape,
+  FieldShape
+>): UseEditFieldFormReturn<FormShape> => {
+  const defaultValues = useMemo(
+    () => transform.input(field) as UnpackNestedValue<DeepPartial<FormShape>>,
+    [field, transform],
+  )
+  const editForm = useForm<FormShape>({
+    defaultValues,
   })
 
   const watchedInputs = editForm.watch()
 
-  // Update form when field loads or changes due to external action,
-  // e.g. if user clicks on another field in the builder
-  useEffect(() => {
-    // perf: setValue causes an additional render, so call it only if
-    // the values change
-    const currentValues = getValues()
-    fieldKeys.forEach((key) => {
-      if (!isEqual(get(currentValues, key), get(field, key))) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        setValue(key, get(field, key), { shouldDirty: false })
-      }
-    })
-    // Not ideal to disable exhaustive deps linting, but it is
-    // necessary to ensure that this useEffect is only called
-    // after the useDebounce below runs, i.e. after the field
-    // is updated.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    ...fieldKeys.map((key) => get(field, key)),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    ...fieldKeys,
-    setValue,
-    getValues,
-  ])
-
   useDebounce(
-    () => handleChange({ ...field, ...watchedInputs }),
+    () => handleChange(transform.output(watchedInputs as FormShape)),
     300,
-    fieldKeys.map((key) => get(watchedInputs, key)),
+    Object.values(watchedInputs),
   )
 
   const handleUpdateField = editForm.handleSubmit((inputs) => {
-    const updatedFormField: T = extend({}, field, inputs)
+    const updatedFormField: FieldShape = transform.output(inputs as FormShape)
     return handleSave(updatedFormField, {
       onSuccess: (newField) => {
         editForm.reset(
-          pick(newField, fieldKeys) as UnpackNestedValue<DeepPartial<U>>,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          transform.input(newField),
         )
       },
     })
@@ -95,8 +79,6 @@ export const useEditFieldForm = <U, T extends FieldBase>({
 
   return {
     ...editForm,
-    setValue,
-    getValues,
     buttonText,
     isSaveEnabled,
     handleUpdateField,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -1,0 +1,104 @@
+import { useEffect, useMemo } from 'react'
+import {
+  DeepPartial,
+  Path,
+  UnpackNestedValue,
+  useForm,
+  UseFormReturn,
+} from 'react-hook-form'
+import { useDebounce } from 'react-use'
+import { extend, get, isEqual, pick } from 'lodash'
+
+import { FieldBase } from '~shared/types/field'
+
+import { EditFieldProps } from './types'
+import { getButtonText } from './utils'
+
+type UseEditFieldFormProps<T extends FieldBase> = EditFieldProps<T> & {
+  fieldKeys: readonly Path<T>[]
+}
+
+type UseEditFieldFormReturn<U> = UseFormReturn<U> & {
+  handleUpdateField: () => Promise<void>
+  buttonText: string
+  isSaveEnabled: boolean
+}
+
+export const useEditFieldForm = <U, T extends FieldBase>({
+  field,
+  fieldKeys,
+  isPendingField,
+  handleChange,
+  handleSave,
+}: UseEditFieldFormProps<T>): UseEditFieldFormReturn<U> => {
+  // Destructure getValues and setValue specifically so they can
+  // be used as dependencies in the useEffect below
+  const { getValues, setValue, ...editForm } = useForm<U>({
+    defaultValues: pick(field, fieldKeys) as UnpackNestedValue<DeepPartial<U>>,
+  })
+
+  const watchedInputs = editForm.watch()
+
+  // Update form when field loads or changes due to external action,
+  // e.g. if user clicks on another field in the builder
+  useEffect(() => {
+    // perf: setValue causes an additional render, so call it only if
+    // the values change
+    const currentValues = getValues()
+    fieldKeys.forEach((key) => {
+      if (!isEqual(get(currentValues, key), get(field, key))) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        setValue(key, get(field, key), { shouldDirty: false })
+      }
+    })
+    // Not ideal to disable exhaustive deps linting, but it is
+    // necessary to ensure that this useEffect is only called
+    // after the useDebounce below runs, i.e. after the field
+    // is updated.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ...fieldKeys.map((key) => get(field, key)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ...fieldKeys,
+    setValue,
+    getValues,
+  ])
+
+  useDebounce(
+    () => handleChange({ ...field, ...watchedInputs }),
+    300,
+    fieldKeys.map((key) => get(watchedInputs, key)),
+  )
+
+  const handleUpdateField = editForm.handleSubmit((inputs) => {
+    const updatedFormField: T = extend({}, field, inputs)
+    return handleSave(updatedFormField, {
+      onSuccess: (newField) => {
+        editForm.reset(
+          pick(newField, fieldKeys) as UnpackNestedValue<DeepPartial<U>>,
+        )
+      },
+    })
+  })
+
+  const buttonText = useMemo(
+    () => getButtonText(isPendingField),
+    [isPendingField],
+  )
+
+  const isSaveEnabled = useMemo(
+    () => editForm.formState.isDirty || isPendingField,
+    [editForm.formState.isDirty, isPendingField],
+  )
+
+  return {
+    ...editForm,
+    setValue,
+    getValues,
+    buttonText,
+    isSaveEnabled,
+    handleUpdateField,
+  }
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/utils.ts
@@ -1,2 +1,21 @@
 export const getButtonText = (isPendingField: boolean) =>
   isPendingField ? 'Create' : 'Save'
+
+export const SPLIT_TEXTAREA_TRANSFORM = {
+  input: (optsArr: string[]) => optsArr.filter(Boolean).join('\n'),
+  output: (optsString: string) =>
+    optsString
+      .split('\n')
+      .map((opt) => opt.trim())
+      .filter(Boolean),
+}
+
+export const SPLIT_TEXTAREA_VALIDATION = {
+  validate: (opts: string) => {
+    const optsArr = SPLIT_TEXTAREA_TRANSFORM.output(opts)
+    return (
+      new Set(optsArr).size === optsArr.length ||
+      'Please remove duplicate options.'
+    )
+  },
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/utils.ts
@@ -1,0 +1,2 @@
+export const getButtonText = (isPendingField: boolean) =>
+  isPendingField ? 'Create' : 'Save'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,0 +1,1 @@
+export * from './EditHeader'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,1 +1,2 @@
+export * from './EditCheckbox'
 export * from './EditHeader'


### PR DESCRIPTION
This PR reimplements the checkbox field editor originally implemented in #3131, with the refactors from #3547 included. There are a few significant differences from the original implementation:
- The design of the checkbox editor has changed from two tabs to a single tab containing all the fields.
- The original `ValidationOptions` validation did not allow one of `customMin` or `customMax` to be set without setting the other. This PR fixes this.

## Known issues
1. ~When the sidebar drawer is closed, clicking on a field results in the drawer opening to the field list, rather than directly to the editing page for that field. This will be addressed separately.~ fixed in #3583 

## Next steps
Field duplication and deletion will be implemented together with the relevant mocks before submitting the form builder for design review.

While design review is happening, I will concurrently work on the edit pages for the other fields.