### PR TITLE
fix: ensure clicking field opens to field editor

### DIFF
--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -51,9 +51,11 @@ export const useCreatePageSidebarContext =
     )
     const setFieldsToInactive = useBuilderAndDesignStore(setToInactiveSelector)
 
-    // Set state to inactive whenever active tab changes
+    // Set state to inactive whenever active tab is not builder
     useEffect(() => {
-      setFieldsToInactive()
+      if (activeTab !== DrawerTabs.Builder) {
+        setFieldsToInactive()
+      }
     }, [activeTab, setFieldsToInactive])
 
     const handleBuilderClick = useCallback(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Previously, when the builder drawer was closed, clicking on a
form field would open the drawer to the field list instead of
directly to the editing page for that field. This was because
of a useEffect which set fields to inactive whenever the active
tab changed.

Instead, we want to set the fields to inactive only when the active
tab is not the builder.

## Solution
<!-- How did you solve the problem? -->

Check that the currently active tab isn't the Build tab before setting
fields to inactive.

## Before
![fix_drawer_before](https://user-images.githubusercontent.com/29480346/158535897-d3310c75-dff5-44ba-ad73-c23788b83055.gif)

## After
![fix_drawer_after](https://user-images.githubusercontent.com/29480346/158535912-7338ebc8-b2aa-4bf9-b5d1-82efec4e508e.gif)

