### PR TITLE
feat(v2): add field deletion, duplication, set inactive functionality

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, Story } from '@storybook/react'
 
 import {
   createSingleField,
+  deleteField,
   duplicateField,
   getAdminFormResponse,
   reorderField,
@@ -44,6 +45,7 @@ export default {
       updateSingleField(),
       reorderField(),
       duplicateField(),
+      deleteField(),
     ],
   },
 } as Meta

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, Story } from '@storybook/react'
 
 import {
   createSingleField,
+  duplicateField,
   getAdminFormResponse,
   reorderField,
   updateSingleField,
@@ -42,6 +43,7 @@ export default {
       createSingleField(),
       updateSingleField(),
       reorderField(),
+      duplicateField(),
     ],
   },
 } as Meta

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -99,8 +99,12 @@ export const FieldRowContainer = ({
   )
 
   const handleDuplicateClick = useCallback(() => {
-    duplicateFieldMutation.mutate(field._id)
-  }, [field._id, duplicateFieldMutation])
+    // Duplicate button should be hidden if field
+    // is not yet created, but guard here just in case
+    if (stateData.state !== BuildFieldState.CreatingField) {
+      duplicateFieldMutation.mutate(field._id)
+    }
+  }, [stateData.state, duplicateFieldMutation, field._id])
 
   const handleDeleteClick = useCallback(() => {
     if (stateData.state === BuildFieldState.CreatingField) {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,7 +1,13 @@
 import { memo, useCallback, useMemo } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { FormProvider, useForm } from 'react-hook-form'
-import { BiDuplicate, BiEdit, BiGridHorizontal, BiTrash } from 'react-icons/bi'
+import {
+  BiCog,
+  BiDuplicate,
+  BiEdit,
+  BiGridHorizontal,
+  BiTrash,
+} from 'react-icons/bi'
 import { useIsMutating } from 'react-query'
 import {
   Box,
@@ -25,6 +31,7 @@ import { useCreatePageSidebar } from '~features/admin-form/create/common/CreateP
 import { PENDING_CREATE_FIELD_ID } from '../../constants'
 import {
   BuildFieldState,
+  setToInactiveSelector,
   stateDataSelector,
   updateEditStateSelector,
   useBuilderAndDesignStore,
@@ -45,8 +52,17 @@ export const FieldRowContainer = ({
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
-  const updateEditState = useBuilderAndDesignStore(updateEditStateSelector)
+  const { stateData, setToInactive, updateEditState } =
+    useBuilderAndDesignStore(
+      useCallback(
+        (state) => ({
+          stateData: stateDataSelector(state),
+          setToInactive: setToInactiveSelector(state),
+          updateEditState: updateEditStateSelector(state),
+        }),
+        [],
+      ),
+    )
   const { handleBuilderClick } = useCreatePageSidebar()
 
   const formMethods = useForm({ mode: 'onChange' })
@@ -176,6 +192,11 @@ export const FieldRowContainer = ({
                   colorScheme="secondary"
                   spacing={0}
                 >
+                  <IconButton
+                    aria-label="Close field settings"
+                    icon={<BiCog fontSize="1.25rem" />}
+                    onClick={setToInactive}
+                  />
                   <IconButton
                     aria-label="Duplicate field"
                     icon={<BiDuplicate fontSize="1.25rem" />}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -29,6 +29,7 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
 
 import { PENDING_CREATE_FIELD_ID } from '../../constants'
+import { useDeleteFormField } from '../../mutations/useDeleteFormField'
 import { useDuplicateFormField } from '../../mutations/useDuplicateFormField'
 import {
   BuildFieldState,
@@ -67,6 +68,7 @@ export const FieldRowContainer = ({
   const { handleBuilderClick } = useCreatePageSidebar()
 
   const { duplicateFieldMutation } = useDuplicateFormField()
+  const { deleteFieldMutation } = useDeleteFormField()
 
   const formMethods = useForm({ mode: 'onChange' })
 
@@ -99,6 +101,19 @@ export const FieldRowContainer = ({
   const handleDuplicateClick = useCallback(() => {
     duplicateFieldMutation.mutate(field._id)
   }, [field._id, duplicateFieldMutation])
+
+  const handleDeleteClick = useCallback(() => {
+    if (stateData.state === BuildFieldState.CreatingField) {
+      setToInactive()
+    } else if (stateData.state === BuildFieldState.EditingField) {
+      deleteFieldMutation.mutate(field._id)
+    }
+  }, [field._id, deleteFieldMutation, setToInactive, stateData.state])
+
+  const isAnyMutationLoading = useMemo(
+    () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
+    [duplicateFieldMutation, deleteFieldMutation],
+  )
 
   return (
     <Draggable
@@ -208,7 +223,8 @@ export const FieldRowContainer = ({
                     aria-label="Duplicate field"
                     // Fields which are not yet created cannot be duplicated
                     isDisabled={
-                      stateData.state === BuildFieldState.CreatingField
+                      stateData.state === BuildFieldState.CreatingField ||
+                      isAnyMutationLoading
                     }
                     onClick={handleDuplicateClick}
                     isLoading={duplicateFieldMutation.isLoading}
@@ -218,6 +234,9 @@ export const FieldRowContainer = ({
                     colorScheme="danger"
                     aria-label="Delete field"
                     icon={<BiTrash fontSize="1.25rem" />}
+                    onClick={handleDeleteClick}
+                    isLoading={deleteFieldMutation.isLoading}
+                    isDisabled={isAnyMutationLoading}
                   />
                 </ButtonGroup>
               </Flex>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -29,6 +29,7 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
 
 import { PENDING_CREATE_FIELD_ID } from '../../constants'
+import { useDuplicateFormField } from '../../mutations/useDuplicateFormField'
 import {
   BuildFieldState,
   setToInactiveSelector,
@@ -65,6 +66,8 @@ export const FieldRowContainer = ({
     )
   const { handleBuilderClick } = useCreatePageSidebar()
 
+  const { duplicateFieldMutation } = useDuplicateFormField()
+
   const formMethods = useForm({ mode: 'onChange' })
 
   const isActive = useMemo(() => {
@@ -92,6 +95,10 @@ export const FieldRowContainer = ({
     },
     [handleFieldClick],
   )
+
+  const handleDuplicateClick = useCallback(() => {
+    duplicateFieldMutation.mutate(field._id)
+  }, [field._id, duplicateFieldMutation])
 
   return (
     <Draggable
@@ -203,6 +210,8 @@ export const FieldRowContainer = ({
                     isDisabled={
                       stateData.state === BuildFieldState.CreatingField
                     }
+                    onClick={handleDuplicateClick}
+                    isLoading={duplicateFieldMutation.isLoading}
                     icon={<BiDuplicate fontSize="1.25rem" />}
                   />
                   <IconButton

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -222,6 +222,7 @@ export const FieldRowContainer = ({
                     aria-label="Close field settings"
                     icon={<BiCog fontSize="1.25rem" />}
                     onClick={setToInactive}
+                    isDisabled={isAnyMutationLoading}
                   />
                   {
                     // Fields which are not yet created cannot be duplicated

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -199,6 +199,10 @@ export const FieldRowContainer = ({
                   />
                   <IconButton
                     aria-label="Duplicate field"
+                    // Fields which are not yet created cannot be duplicated
+                    isDisabled={
+                      stateData.state === BuildFieldState.CreatingField
+                    }
                     icon={<BiDuplicate fontSize="1.25rem" />}
                   />
                   <IconButton

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -219,17 +219,18 @@ export const FieldRowContainer = ({
                     icon={<BiCog fontSize="1.25rem" />}
                     onClick={setToInactive}
                   />
-                  <IconButton
-                    aria-label="Duplicate field"
+                  {
                     // Fields which are not yet created cannot be duplicated
-                    isDisabled={
-                      stateData.state === BuildFieldState.CreatingField ||
-                      isAnyMutationLoading
-                    }
-                    onClick={handleDuplicateClick}
-                    isLoading={duplicateFieldMutation.isLoading}
-                    icon={<BiDuplicate fontSize="1.25rem" />}
-                  />
+                    stateData.state !== BuildFieldState.CreatingField && (
+                      <IconButton
+                        aria-label="Duplicate field"
+                        isDisabled={isAnyMutationLoading}
+                        onClick={handleDuplicateClick}
+                        isLoading={duplicateFieldMutation.isLoading}
+                        icon={<BiDuplicate fontSize="1.25rem" />}
+                      />
+                    )
+                  }
                   <IconButton
                     colorScheme="danger"
                     aria-label="Delete field"

--- a/frontend/src/features/admin-form/create/builder-and-design/UpdateFormFieldService.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/UpdateFormFieldService.ts
@@ -81,3 +81,19 @@ export const duplicateSingleFormField = async ({
     `${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}/duplicate`,
   ).then(({ data }) => data)
 }
+
+/**
+ * Delete a single form field by its id in given form
+ * @param formId the id of the form to delete the field from
+ * @param fieldId the id of the field to delete
+ * @returns void on success
+ */
+export const deleteSingleFormField = async ({
+  formId,
+  fieldId,
+}: {
+  formId: string
+  fieldId: string
+}): Promise<void> => {
+  return ApiService.delete(`${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}`)
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/UpdateFormFieldService.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/UpdateFormFieldService.ts
@@ -62,3 +62,22 @@ export const reorderSingleFormField = async ({
     { params: { to: newPosition } },
   ).then(({ data }) => data)
 }
+
+/**
+ * Duplicates a field, adding the new field as the last field in
+ * the form.
+ * @param formId the id of the form
+ * @param fieldId the id of the field to duplicate
+ * @returns the newly created field
+ */
+export const duplicateSingleFormField = async ({
+  formId,
+  fieldId,
+}: {
+  formId: string
+  fieldId: string
+}): Promise<FormFieldDto> => {
+  return ApiService.post<FormFieldDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/fields/${fieldId}/duplicate`,
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
@@ -31,7 +31,7 @@ export const useCreateFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (!stateData || stateData.state !== BuildFieldState.CreatingField) {
+      if (stateData.state !== BuildFieldState.CreatingField) {
         toast({
           status: 'warning',
           description:

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
@@ -1,0 +1,88 @@
+import { useCallback } from 'react'
+import { useMutation, useQueryClient } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { AdminFormDto } from '~shared/types/form'
+
+import { useToast } from '~hooks/useToast'
+
+import { adminFormKeys } from '~features/admin-form/common/queries'
+
+import { deleteSingleFormField } from '../UpdateFormFieldService'
+import {
+  BuildFieldState,
+  setToInactiveSelector,
+  stateDataSelector,
+  useBuilderAndDesignStore,
+} from '../useBuilderAndDesignStore'
+
+export const useDeleteFormField = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  const setToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+  const stateData = useBuilderAndDesignStore(stateDataSelector)
+
+  const queryClient = useQueryClient()
+  const toast = useToast({ status: 'success', isClosable: true })
+  const adminFormKey = adminFormKeys.id(formId)
+
+  const handleSuccess = useCallback(() => {
+    toast.closeAll()
+    if (stateData.state !== BuildFieldState.EditingField) {
+      toast({
+        status: 'warning',
+        description:
+          'Something went wrong when deleting your field. Please refresh and try again.',
+      })
+      return
+    }
+    toast({
+      description: `Field "${stateData.field.title}" deleted`,
+    })
+    queryClient.setQueryData<AdminFormDto>(adminFormKey, (oldForm) => {
+      // Should not happen, should not be able to update field if there is no
+      // existing data.
+      if (!oldForm) throw new Error('Query should have been set')
+      const deletedFieldIndex = oldForm.form_fields.findIndex(
+        (ff) => ff._id === stateData.field._id,
+      )
+      if (deletedFieldIndex < 0) {
+        toast({
+          status: 'warning',
+          description:
+            'Something went wrong when deleting your field. Please refresh and try again.',
+        })
+      } else {
+        oldForm.form_fields.splice(deletedFieldIndex, 1)
+      }
+      return oldForm
+    })
+    setToInactive()
+  }, [adminFormKey, stateData, queryClient, setToInactive, toast])
+
+  const handleError = useCallback(
+    (error: Error) => {
+      toast.closeAll()
+      toast({
+        description: error.message,
+        status: 'danger',
+      })
+    },
+    [toast],
+  )
+
+  return {
+    deleteFieldMutation: useMutation(
+      (fieldId: string) =>
+        deleteSingleFormField({
+          formId,
+          fieldId,
+        }),
+      {
+        onSuccess: handleSuccess,
+        onError: handleError,
+      },
+    ),
+  }
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
@@ -1,0 +1,82 @@
+import { useCallback } from 'react'
+import { useMutation, useQueryClient } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { FormFieldDto } from '~shared/types/field'
+import { AdminFormDto } from '~shared/types/form'
+
+import { useToast } from '~hooks/useToast'
+
+import { adminFormKeys } from '~features/admin-form/common/queries'
+
+import { duplicateSingleFormField } from '../UpdateFormFieldService'
+import {
+  BuildFieldState,
+  stateDataSelector,
+  updateEditStateSelector,
+  useBuilderAndDesignStore,
+} from '../useBuilderAndDesignStore'
+
+export const useDuplicateFormField = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  const updateEditState = useBuilderAndDesignStore(updateEditStateSelector)
+  const stateData = useBuilderAndDesignStore(stateDataSelector)
+
+  const queryClient = useQueryClient()
+  const toast = useToast({ status: 'success', isClosable: true })
+  const adminFormKey = adminFormKeys.id(formId)
+
+  const handleSuccess = useCallback(
+    (newField: FormFieldDto) => {
+      toast.closeAll()
+      if (stateData.state !== BuildFieldState.EditingField) {
+        toast({
+          status: 'warning',
+          description:
+            'Something went wrong when creating your field. Please refresh and try again.',
+        })
+        return
+      }
+      toast({
+        description: `Field "${newField.title}" created`,
+      })
+      queryClient.setQueryData<AdminFormDto>(adminFormKey, (oldForm) => {
+        // Should not happen, should not be able to update field if there is no
+        // existing data.
+        if (!oldForm) throw new Error('Query should have been set')
+        oldForm.form_fields.push(newField)
+        return oldForm
+      })
+      // Switch to editing new field
+      updateEditState(newField)
+    },
+    [adminFormKey, stateData, queryClient, updateEditState, toast],
+  )
+
+  const handleError = useCallback(
+    (error: Error) => {
+      toast.closeAll()
+      toast({
+        description: error.message,
+        status: 'danger',
+      })
+    },
+    [toast],
+  )
+
+  return {
+    duplicateFieldMutation: useMutation(
+      (fieldId: string) =>
+        duplicateSingleFormField({
+          formId,
+          fieldId,
+        }),
+      {
+        onSuccess: handleSuccess,
+        onError: handleError,
+      },
+    ),
+  }
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
@@ -29,7 +29,7 @@ export const useEditFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (!stateData || stateData.state !== BuildFieldState.EditingField) {
+      if (stateData.state !== BuildFieldState.EditingField) {
         toast({
           status: 'warning',
           description:

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -138,3 +138,24 @@ export const reorderField = (delay = 500) => {
     return res(ctx.delay(delay), ctx.status(200), ctx.json(formFields))
   })
 }
+
+export const duplicateField = (delay = 500) => {
+  return rest.post<
+    Record<string, never>,
+    { formId: string; fieldId: string },
+    FormFieldDto
+  >(
+    '/api/v3/admin/forms/:formId/fields/:fieldId/duplicate',
+    (req, res, ctx) => {
+      const fieldToCopyIndex = formFields.findIndex(
+        (field) => field._id === req.params.fieldId,
+      )
+      const newField = {
+        ...formFields[fieldToCopyIndex],
+        _id: `random-id-${formFields.length}`,
+      }
+      formFields.push(newField)
+      return res(ctx.delay(delay), ctx.status(200), ctx.json(newField))
+    },
+  )
+}

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -159,3 +159,17 @@ export const duplicateField = (delay = 500) => {
     },
   )
 }
+
+export const deleteField = (delay = 500) => {
+  return rest.delete<
+    Record<string, never>,
+    { formId: string; fieldId: string },
+    FormFieldDto
+  >('/api/v3/admin/forms/:formId/fields/:fieldId', (req, res, ctx) => {
+    const fieldToDeleteIndex = formFields.findIndex(
+      (field) => field._id === req.params.fieldId,
+    )
+    formFields.splice(fieldToDeleteIndex, 1)
+    return res(ctx.delay(delay), ctx.status(200))
+  })
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Field deletion and duplication buttons currently don't do anything, and the `BiCog` icon to set the field to inactive is missing.

## Solution
- Add `BiCog` icon which sets field to inactive
- Add duplication and deletion functionality

## Screenshots

### Set to inactive
![field_inactive](https://user-images.githubusercontent.com/29480346/158545597-090554b5-836c-4b1c-a941-7f3cadf4ac69.gif)

### Duplicate
![field_dup](https://user-images.githubusercontent.com/29480346/158545642-ab3b8bfd-9e51-4115-bed3-faf5d7f82313.gif)

### Delete
![field_delete](https://user-images.githubusercontent.com/29480346/158545663-67e34432-41ac-4f2b-820b-e116fb85b544.gif)

