### PR TITLE
feat(v2): add editors for Yes/No, NRIC, UEN

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -23,6 +23,7 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
+import { YesNoField } from '~templates/Field'
 import CheckboxField from '~templates/Field/Checkbox'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
@@ -260,6 +261,8 @@ const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
       return <SectionFieldRow field={field} />
     case BasicField.Checkbox:
       return <CheckboxField schema={field} />
+    case BasicField.YesNo:
+      return <YesNoField schema={field} />
     default:
       return <div>TODO: Add field row for {field.fieldType}</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -23,8 +23,7 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
-import { YesNoField } from '~templates/Field'
-import CheckboxField from '~templates/Field/Checkbox'
+import { CheckboxField, NricField, YesNoField } from '~templates/Field'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
@@ -263,6 +262,8 @@ const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
       return <CheckboxField schema={field} />
     case BasicField.YesNo:
       return <YesNoField schema={field} />
+    case BasicField.Nric:
+      return <NricField schema={field} />
     default:
       return <div>TODO: Add field row for {field.fieldType}</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -23,7 +23,12 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
-import { CheckboxField, NricField, YesNoField } from '~templates/Field'
+import {
+  CheckboxField,
+  NricField,
+  UenField,
+  YesNoField,
+} from '~templates/Field'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
@@ -256,14 +261,16 @@ export const FieldRowContainer = ({
 
 const MemoFieldRow = memo(({ field }: { field: FormFieldDto }) => {
   switch (field.fieldType) {
-    case BasicField.Section:
-      return <SectionFieldRow field={field} />
     case BasicField.Checkbox:
       return <CheckboxField schema={field} />
-    case BasicField.YesNo:
-      return <YesNoField schema={field} />
     case BasicField.Nric:
       return <NricField schema={field} />
+    case BasicField.Section:
+      return <SectionFieldRow field={field} />
+    case BasicField.Uen:
+      return <UenField schema={field} />
+    case BasicField.YesNo:
+      return <YesNoField schema={field} />
     default:
       return <div>TODO: Add field row for {field.fieldType}</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -22,7 +22,13 @@ import {
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 import { FieldMutateOptions } from './edit-fieldtype/common/types'
-import { EditCheckbox, EditHeader, EditNric, EditYesNo } from './edit-fieldtype'
+import {
+  EditCheckbox,
+  EditHeader,
+  EditNric,
+  EditUen,
+  EditYesNo,
+} from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =
@@ -157,6 +163,8 @@ const MemoFieldDrawerContent = memo((props: MemoFieldDrawerContentProps) => {
       return <EditNric {...props} field={field} />
     case BasicField.Section:
       return <EditHeader {...props} field={field} />
+    case BasicField.Uen:
+      return <EditUen {...props} field={field} />
     case BasicField.YesNo:
       return <EditYesNo {...props} field={field} />
     default:

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -22,7 +22,7 @@ import {
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 import { FieldMutateOptions } from './edit-fieldtype/common/types'
-import { EditCheckbox, EditHeader } from './edit-fieldtype'
+import { EditCheckbox, EditHeader, EditYesNo } from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =
@@ -155,6 +155,8 @@ const MemoFieldDrawerContent = memo((props: MemoFieldDrawerContentProps) => {
       return <EditHeader {...props} field={field} />
     case BasicField.Checkbox:
       return <EditCheckbox {...props} field={field} />
+    case BasicField.YesNo:
+      return <EditYesNo {...props} field={field} />
     default:
       return <div>TODO: Insert field options here</div>
   }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -22,7 +22,7 @@ import {
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 import { FieldMutateOptions } from './edit-fieldtype/common/types'
-import { EditCheckbox, EditHeader, EditYesNo } from './edit-fieldtype'
+import { EditCheckbox, EditHeader, EditNric, EditYesNo } from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =
@@ -151,10 +151,12 @@ const MemoFieldDrawerContent = memo((props: MemoFieldDrawerContentProps) => {
   // Extract field variable just to get field.fieldType types to cooperate
   const field = useMemo(() => props.field, [props.field])
   switch (field.fieldType) {
-    case BasicField.Section:
-      return <EditHeader {...props} field={field} />
     case BasicField.Checkbox:
       return <EditCheckbox {...props} field={field} />
+    case BasicField.Nric:
+      return <EditNric {...props} field={field} />
+    case BasicField.Section:
+      return <EditHeader {...props} field={field} />
     case BasicField.YesNo:
       return <EditYesNo {...props} field={field} />
     default:

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react'
+import { FormControl } from '@chakra-ui/react'
+import { extend, pick } from 'lodash'
+
+import { NricFieldBase } from '~shared/types/field'
+
+import { createBaseValidationRules } from '~utils/fieldValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+
+import { DrawerContentContainer } from './common/DrawerContentContainer'
+import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
+import { EditFieldProps } from './common/types'
+import { useEditFieldForm } from './common/useEditFieldForm'
+
+type EditNricProps = EditFieldProps<NricFieldBase>
+
+type EditNricInputs = Pick<NricFieldBase, 'title' | 'description' | 'required'>
+
+export const EditNric = (props: EditNricProps): JSX.Element => {
+  const {
+    register,
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+  } = useEditFieldForm<EditNricInputs, NricFieldBase>({
+    ...props,
+    transform: {
+      input: (inputField) =>
+        pick(inputField, ['title', 'description', 'required']),
+      output: (formOutput, originalField) =>
+        extend({}, originalField, formOutput),
+    },
+  })
+
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
+  return (
+    <DrawerContentContainer>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Section header</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('required')} label="Required" />
+      </FormControl>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
+    </DrawerContentContainer>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
@@ -49,7 +49,7 @@ export const EditNric = (props: EditNricProps): JSX.Element => {
         isReadOnly={props.isLoading}
         isInvalid={!!errors.title}
       >
-        <FormLabel>Section header</FormLabel>
+        <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
@@ -49,7 +49,7 @@ export const EditUen = (props: EditUenProps): JSX.Element => {
         isReadOnly={props.isLoading}
         isInvalid={!!errors.title}
       >
-        <FormLabel>Section header</FormLabel>
+        <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react'
+import { FormControl } from '@chakra-ui/react'
+import { extend, pick } from 'lodash'
+
+import { UenFieldBase } from '~shared/types/field'
+
+import { createBaseValidationRules } from '~utils/fieldValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+
+import { DrawerContentContainer } from './common/DrawerContentContainer'
+import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
+import { EditFieldProps } from './common/types'
+import { useEditFieldForm } from './common/useEditFieldForm'
+
+type EditUenProps = EditFieldProps<UenFieldBase>
+
+type EditUenInputs = Pick<UenFieldBase, 'title' | 'description' | 'required'>
+
+export const EditUen = (props: EditUenProps): JSX.Element => {
+  const {
+    register,
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+  } = useEditFieldForm<EditUenInputs, UenFieldBase>({
+    ...props,
+    transform: {
+      input: (inputField) =>
+        pick(inputField, ['title', 'description', 'required']),
+      output: (formOutput, originalField) =>
+        extend({}, originalField, formOutput),
+    },
+  })
+
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
+  return (
+    <DrawerContentContainer>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Section header</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('required')} label="Required" />
+      </FormControl>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
+    </DrawerContentContainer>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
@@ -52,7 +52,7 @@ export const EditYesNo = (props: EditYesNoProps): JSX.Element => {
         isReadOnly={props.isLoading}
         isInvalid={!!errors.title}
       >
-        <FormLabel>Section header</FormLabel>
+        <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react'
+import { FormControl } from '@chakra-ui/react'
+import { extend, pick } from 'lodash'
+
+import { YesNoFieldBase } from '~shared/types/field'
+
+import { createBaseValidationRules } from '~utils/fieldValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+import Textarea from '~components/Textarea'
+import Toggle from '~components/Toggle'
+
+import { DrawerContentContainer } from './common/DrawerContentContainer'
+import { FormFieldDrawerActions } from './common/FormFieldDrawerActions'
+import { EditFieldProps } from './common/types'
+import { useEditFieldForm } from './common/useEditFieldForm'
+
+type EditYesNoProps = EditFieldProps<YesNoFieldBase>
+
+type EditYesNoInputs = Pick<
+  YesNoFieldBase,
+  'title' | 'description' | 'required'
+>
+
+export const EditYesNo = (props: EditYesNoProps): JSX.Element => {
+  const {
+    register,
+    formState: { errors },
+    isSaveEnabled,
+    buttonText,
+    handleUpdateField,
+  } = useEditFieldForm<EditYesNoInputs, YesNoFieldBase>({
+    ...props,
+    transform: {
+      input: (inputField) =>
+        pick(inputField, ['title', 'description', 'required']),
+      output: (formOutput, originalField) =>
+        extend({}, originalField, formOutput),
+    },
+  })
+
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
+  return (
+    <DrawerContentContainer>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.title}
+      >
+        <FormLabel>Section header</FormLabel>
+        <Input autoFocus {...register('title', requiredValidationRule)} />
+        <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isRequired
+        isReadOnly={props.isLoading}
+        isInvalid={!!errors.description}
+      >
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
+        <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl isReadOnly={props.isLoading}>
+        <Toggle {...register('required')} label="Required" />
+      </FormControl>
+      <FormFieldDrawerActions
+        isLoading={props.isLoading}
+        isSaveEnabled={isSaveEnabled}
+        buttonText={buttonText}
+        handleClick={handleUpdateField}
+        handleCancel={props.handleCancel}
+      />
+    </DrawerContentContainer>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,2 +1,3 @@
 export * from './EditCheckbox'
 export * from './EditHeader'
+export * from './EditYesNo'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,4 +1,5 @@
 export * from './EditCheckbox'
 export * from './EditHeader'
 export * from './EditNric'
+export * from './EditUen'
 export * from './EditYesNo'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/index.ts
@@ -1,3 +1,4 @@
 export * from './EditCheckbox'
 export * from './EditHeader'
+export * from './EditNric'
 export * from './EditYesNo'

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -18,6 +18,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
   }
 
   switch (fieldType) {
+    case BasicField.YesNo:
     case BasicField.Section: {
       return {
         fieldType,

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -19,6 +19,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
 
   switch (fieldType) {
     case BasicField.YesNo:
+    case BasicField.Nric:
     case BasicField.Section: {
       return {
         fieldType,

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -20,6 +20,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
   switch (fieldType) {
     case BasicField.YesNo:
     case BasicField.Nric:
+    case BasicField.Uen:
     case BasicField.Section: {
       return {
         fieldType,


### PR DESCRIPTION
Adds edit drawers for Yes/No, NRIC and UEN fields. These fields were all done at the same time as they require no additional configuration other than setting the "Required" toggle, so the UI is exactly the same for all 3.

I chose to copy-paste the code instead of having a common component for all 3 as this allows the types to be tighter, i.e. tied to each `fieldType`. 

Depends on #3581 