### PR TITLE
fix(v2/shared): update type shape for TableFieldDto

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15449,6 +15449,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.24.0",
     "comlink": "^4.3.1",
     "country-flag-icons": "^1.4.19",
+    "cuid": "^2.1.8",
     "date-fns": "^2.27.0",
     "dayjs": "^1.10.7",
     "dayzed": "^3.2.2",

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
+import cuid from 'cuid'
 
-import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
+import {
+  BasicField,
+  FieldCreateDto,
+  FormFieldDto,
+  TableFieldDto,
+} from '~shared/types/field'
 import { insertAt, replaceAt } from '~shared/utils/immutable-array-fns'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
@@ -15,6 +21,17 @@ const getFormFieldsWhileCreating = (
   formFields: FormFieldDto[],
   fieldToCreate: { field: FieldCreateDto; insertionIndex: number },
 ): FormFieldDto[] => {
+  if (fieldToCreate.field.fieldType === BasicField.Table) {
+    const newField: TableFieldDto = {
+      ...fieldToCreate.field,
+      _id: PENDING_CREATE_FIELD_ID,
+      columns: fieldToCreate.field.columns.map((column) => ({
+        ...column,
+        _id: cuid(),
+      })),
+    }
+    return insertAt(formFields, fieldToCreate.insertionIndex, newField)
+  }
   return insertAt(formFields, fieldToCreate.insertionIndex, {
     ...fieldToCreate.field,
     _id: PENDING_CREATE_FIELD_ID,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo } from 'react'
 import { BiLeftArrowAlt } from 'react-icons/bi'
 import { Box, Flex } from '@chakra-ui/react'
 
-import { BasicField, FieldCreateDto } from '~shared/types/field'
+import { BasicField, FieldCreateDto, FormFieldDto } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
 
@@ -55,12 +55,12 @@ export const EditFieldDrawer = (): JSX.Element | null => {
   }, [fieldToEdit?.fieldType])
 
   const handleSave = useCallback(
-    (field: FieldCreateDto, options?: FieldMutateOptions) => {
+    (field: FieldCreateDto | FormFieldDto, options?: FieldMutateOptions) => {
       if (stateData.state === BuildFieldState.CreatingField) {
         createFieldMutation.mutate(field, options)
       } else if (stateData.state === BuildFieldState.EditingField) {
         editFieldMutation.mutate(
-          { ...field, _id: stateData.field._id },
+          { ...(field as FormFieldDto), _id: stateData.field._id },
           options,
         )
       }
@@ -69,11 +69,14 @@ export const EditFieldDrawer = (): JSX.Element | null => {
   )
 
   const handleChange = useCallback(
-    (field: FieldCreateDto) => {
+    (field: FieldCreateDto | FormFieldDto) => {
       if (stateData.state === BuildFieldState.CreatingField) {
         updateCreateState(field, stateData.insertionIndex)
       } else if (stateData.state === BuildFieldState.EditingField) {
-        updateEditState({ ...field, _id: stateData.field._id })
+        updateEditState({
+          ...(field as FormFieldDto),
+          _id: stateData.field._id,
+        })
       }
     },
     [stateData, updateCreateState, updateEditState],

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -23,7 +23,6 @@ import {
   SectionField,
   ShortTextField,
   TableField,
-  TableFieldSchema,
   UenField,
   YesNoField,
 } from '~templates/Field'
@@ -100,7 +99,7 @@ export const FieldFactory = memo(
       case BasicField.Image:
         return <ImageField schema={field} colorTheme={colorTheme} />
       case BasicField.Table:
-        return <TableField schema={field as TableFieldSchema} />
+        return <TableField schema={field} />
       default:
         return <Text w="100%">{JSON.stringify(field)}</Text>
     }

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -7,7 +7,6 @@ import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme } from '~shared/types/form'
 
 import Button from '~components/Button'
-import { TableFieldSchema } from '~templates/Field'
 
 import { FieldFactory } from './FieldFactory'
 
@@ -31,13 +30,10 @@ export const FormFields = ({
         // See https://react-hook-form.com/api/usefieldarray
         case BasicField.Table:
           acc[field._id] = times(field.minimumRows, () =>
-            (field as TableFieldSchema).columns.reduce<FieldValues>(
-              (acc, c) => {
-                acc[c._id] = ''
-                return acc
-              },
-              {},
-            ),
+            field.columns.reduce<FieldValues>((acc, c) => {
+              acc[c._id] = ''
+              return acc
+            }, {}),
           )
       }
 

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -1,8 +1,14 @@
+import cuid from 'cuid'
 import { merge } from 'lodash'
 import { rest } from 'msw'
 
 import { AgencyId } from '~shared/types/agency'
-import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
+import {
+  BasicField,
+  FieldCreateDto,
+  FormFieldDto,
+  TableFieldDto,
+} from '~shared/types/field'
 import {
   AdminFormDto,
   AdminFormViewDto,
@@ -97,6 +103,13 @@ export const createSingleField = (delay = 500) => {
       const newField = {
         ...req.body,
         _id: `random-id-${formFields.length}`,
+      } as FormFieldDto
+      if (req.body.fieldType === BasicField.Table) {
+        // eslint-disable-next-line @typescript-eslint/no-extra-semi
+        ;(newField as TableFieldDto).columns = req.body.columns.map((col) => ({
+          ...col,
+          _id: cuid(),
+        }))
       }
       const newIndex = parseInt(
         req.url.searchParams.get('to') ?? `${formFields.length}`,

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -4,23 +4,26 @@ import { UseTableCellProps } from 'react-table'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
-import { BasicField, Column, ShortTextColumnBase } from '~shared/types/field'
+import {
+  BasicField,
+  Column,
+  ColumnDto,
+  ShortTextColumnBase,
+} from '~shared/types/field'
 
 import { createTextValidationRules } from '~utils/fieldValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
 
-import { ColumnWithId } from './TableField'
-
 export interface ColumnCellProps
   extends UseTableCellProps<Record<string, unknown>, string> {
   schemaId: string
-  columnSchema: ColumnWithId
+  columnSchema: ColumnDto
 }
 
-export interface FieldColumnCellProps<T = Column> {
-  schema: ColumnWithId<T>
+export interface FieldColumnCellProps<T extends Column = Column> {
+  schema: ColumnDto<T>
   inputName: string
 }
 

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -3,9 +3,8 @@ import { useFieldArray, useFormContext } from 'react-hook-form'
 import { BiTrash } from 'react-icons/bi'
 import { useTable } from 'react-table'
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
-import { Merge, RequireAllOrNone } from 'type-fest'
 
-import { Column, FormFieldWithId, TableFieldBase } from '~shared/types/field'
+import { FormFieldWithId, TableFieldBase } from '~shared/types/field'
 
 import IconButton from '~components/IconButton'
 
@@ -16,11 +15,7 @@ import { ColumnCell } from './ColumnCell'
 import { ColumnHeader } from './ColumnHeader'
 import { TableFieldContainer } from './TableFieldContainer'
 
-export type ColumnWithId<T = Column> = T & { _id: string }
-export type TableFieldSchema = RequireAllOrNone<
-  Merge<FormFieldWithId<TableFieldBase>, { columns: ColumnWithId[] }>,
-  'addMoreRows' | 'maximumRows'
->
+export type TableFieldSchema = FormFieldWithId<TableFieldBase>
 export interface TableFieldProps extends BaseFieldProps {
   schema: TableFieldSchema
 }
@@ -144,7 +139,7 @@ export const TableField = ({
           </Tbody>
         </Table>
       </Box>
-      {schema.addMoreRows ? (
+      {schema.addMoreRows && schema.maximumRows !== undefined ? (
         <AddRowFooter
           currentRows={fields.length}
           maxRows={schema.maximumRows}

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -15,12 +15,12 @@ import { RatingFieldBase } from './ratingField'
 import { SectionFieldBase } from './sectionField'
 import { ShortTextFieldBase } from './shortTextField'
 import { StatementFieldBase } from './statementField'
-import { TableFieldBase } from './tableField'
+import { TableFieldBase, TableFieldDto } from './tableField'
 import { UenFieldBase } from './uenField'
 import { YesNoFieldBase } from './yesNoField'
 
-export * from './base'
 export * from './attachmentField'
+export * from './base'
 export * from './checkboxField'
 export * from './dateField'
 export * from './decimalField'
@@ -39,9 +39,8 @@ export * from './shortTextField'
 export * from './statementField'
 export * from './tableField'
 export * from './uenField'
-export * from './yesNoField'
-
 export * from './utils'
+export * from './yesNoField'
 
 export type FormField =
   | AttachmentFieldBase
@@ -65,9 +64,12 @@ export type FormField =
   | UenFieldBase
   | YesNoFieldBase
 
-export type FormFieldWithId<T extends FormField = FormField> = T & {
-  _id: string
-}
+export type FormFieldWithId<T extends FormField = FormField> =
+  T extends TableFieldBase
+    ? TableFieldDto
+    : T & {
+        _id: string
+      }
 
 export type PossiblyPrefilledFormField = FormFieldWithId & {
   fieldValue?: string

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -81,4 +81,4 @@ export type PossiblyPrefilledFormField = FormFieldWithId & {
 export type FormFieldDto = PossiblyPrefilledFormField | FormFieldWithId
 
 export type FieldCreateDto = FormField
-export type FieldUpdateDto = FormField & { _id: string }
+export type FieldUpdateDto = FormFieldWithId

--- a/shared/types/field/tableField.ts
+++ b/shared/types/field/tableField.ts
@@ -1,3 +1,4 @@
+import { Merge } from 'type-fest'
 import { FieldBase, BasicField } from './base'
 import { DropdownFieldBase } from './dropdownField'
 import { ShortTextFieldBase } from './shortTextField'
@@ -16,10 +17,16 @@ export interface DropdownColumnBase extends ColumnBase<DropdownFieldBase> {
 
 export type Column = ShortTextColumnBase | DropdownColumnBase
 
+export type ColumnDto<C extends Column = Column> = C & { _id: string }
+
 export interface TableFieldBase extends FieldBase {
   fieldType: BasicField.Table
   minimumRows: number
   addMoreRows?: boolean
   maximumRows?: number
   columns: Column[]
+}
+
+export type TableFieldDto = Merge<TableFieldBase, { columns: ColumnDto[] }> & {
+  _id: string
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, `TableFieldDto` was equivalent to `FormWithWithId<TableFieldBase>`, which only added the `_id` prop to table fields. However, `TableField#columns` was also a schema with an `_id`, which was not augmented by `FormFieldWithId<F>`.

> We technically had a hint of type incompatibility when I had to cast `FormFieldWithId<TableFieldBase>` with a new schema type. Just fixing it here now.

This PR updates `TableFieldDto` to include `column#_id`. Whilst doing so, `useBuilderFields` had to be updated to create a temporary object with column `_id`s populated  when attempting to create a new table field. This is done using `cuid`.

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- fix: update FormFieldWithId type to assign id to TableField columns

## Dependencies
- add cuid package to generate collision resistant ids for table field column ids.