### PR TITLE
refactor(v2/submit-4): add storage mode form submission

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3968,6 +3968,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
     "@storybook/addon-a11y": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.3.12.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
     "@opengovsg/formsg-sdk": "^0.9.0",
+    "@stablelib/base64": "^1.0.1",
     "axios": "^0.24.0",
     "comlink": "^4.3.1",
     "country-flag-icons": "^1.4.19",

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -46,7 +46,8 @@ export const PublicFormProvider = ({
   const [cachedDto, setCachedDto] = useState<PublicFormViewDto>()
 
   const { createTransactionMutation } = useTransactionMutations(formId)
-  const { submitEmailModeFormMutation } = usePublicFormMutations(formId)
+  const { submitEmailModeFormMutation, submitStorageModeFormMutation } =
+    usePublicFormMutations(formId)
   const toast = useToast()
   const vfnToastIdRef = useRef<string | number>()
   const desyncToastIdRef = useRef<string | number>()
@@ -147,9 +148,32 @@ export const PublicFormProvider = ({
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
               .catch(showErrorToast)
           )
+        case FormResponseMode.Encrypt:
+          // Using mutateAsync so react-hook-form goes into loading state.
+          return (
+            submitStorageModeFormMutation
+              .mutateAsync(
+                {
+                  formFields: form.form_fields,
+                  formInputs,
+                  publicKey: form.publicKey,
+                },
+                {
+                  onSuccess: ({ submissionId }) =>
+                    setSubmissionId(submissionId),
+                },
+              )
+              // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
+              .catch(showErrorToast)
+          )
       }
     },
-    [cachedDto, showErrorToast, submitEmailModeFormMutation],
+    [
+      cachedDto,
+      showErrorToast,
+      submitEmailModeFormMutation,
+      submitStorageModeFormMutation,
+    ],
   )
 
   return (

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -119,36 +119,37 @@ export const PublicFormProvider = ({
 
   useTimeout(generateVfnExpiryToast, expiryInMs)
 
+  const showErrorToast = useCallback(() => {
+    toast({
+      status: 'danger',
+      description:
+        'An error occurred whilst processing your submission. Please refresh and try again.',
+    })
+  }, [toast])
+
   const handleSubmitForm = useCallback(
     async (formInputs: Record<FormFieldDto['_id'], unknown>) => {
       const { form } = cachedDto ?? {}
       if (!form) return
+
       switch (form.responseMode) {
         case FormResponseMode.Email:
           // Using mutateAsync so react-hook-form goes into loading state.
-          return submitEmailModeFormMutation
-            .mutateAsync(
-              {
-                formFields: form.form_fields,
-                formInputs,
-              },
-              {
-                onSuccess: ({ submissionId }) => setSubmissionId(submissionId),
-              },
-            )
-            .catch(() => {
+          return (
+            submitEmailModeFormMutation
+              .mutateAsync(
+                { formFields: form.form_fields, formInputs },
+                {
+                  onSuccess: ({ submissionId }) =>
+                    setSubmissionId(submissionId),
+                },
+              )
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
-              toast({
-                status: 'danger',
-                description:
-                  'An error occurred whilst processing your submission. Please refresh and try again.',
-              })
-            })
-        case FormResponseMode.Encrypt:
-          return console.log('encrypt mode TODO')
+              .catch(showErrorToast)
+          )
       }
     },
-    [cachedDto, submitEmailModeFormMutation, toast],
+    [cachedDto, showErrorToast, submitEmailModeFormMutation],
   )
 
   return (

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -56,7 +56,7 @@ export const logoutPublicForm = async (
   ).then(({ data }) => data)
 }
 
-export type SubmitEmailModeFormArgs = {
+export type SubmitPublicFormArgs = {
   formId: string
   captchaResponse?: string | null
   formFields: FormFieldDto[]
@@ -68,7 +68,7 @@ export const submitEmailModeForm = async ({
   formInputs,
   formId,
   captchaResponse = null,
-}: SubmitEmailModeFormArgs): Promise<SubmissionResponseDto> => {
+}: SubmitPublicFormArgs): Promise<SubmissionResponseDto> => {
   const formData = createEmailSubmissionFormData(formFields, formInputs)
 
   return ApiService.post<SubmissionResponseDto>(

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -9,7 +9,10 @@ import { SubmissionResponseDto } from '~shared/types/submission'
 import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
-import { createEmailSubmissionFormData } from './utils/createSubmission'
+import {
+  createEmailSubmissionFormData,
+  createEncryptedSubmissionData,
+} from './utils/createSubmission'
 
 const PUBLIC_FORMS_ENDPOINT = '/forms'
 
@@ -74,6 +77,29 @@ export const submitEmailModeForm = async ({
   return ApiService.post<SubmissionResponseDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email`,
     formData,
+    {
+      params: {
+        captchaResponse: String(captchaResponse),
+      },
+    },
+  ).then(({ data }) => data)
+}
+
+export const submitEncryptModeForm = async ({
+  formFields,
+  formInputs,
+  captchaResponse,
+  formId,
+  publicKey,
+}: SubmitPublicFormArgs & { publicKey: string }) => {
+  const submissionContent = createEncryptedSubmissionData(
+    formFields,
+    formInputs,
+    publicKey,
+  )
+  return ApiService.post<SubmissionResponseDto>(
+    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt`,
+    submissionContent,
     {
       params: {
         captchaResponse: String(captchaResponse),

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -87,18 +87,19 @@ export const submitEmailModeForm = async ({
   ).then(({ data }) => data)
 }
 
-export const submitEncryptModeForm = async ({
+export const submitStorageModeForm = async ({
   formFields,
   formInputs,
   captchaResponse,
   formId,
   publicKey,
 }: SubmitStorageFormArgs) => {
-  const submissionContent = createEncryptedSubmissionData(
+  const submissionContent = await createEncryptedSubmissionData(
     formFields,
     formInputs,
     publicKey,
   )
+
   return ApiService.post<SubmissionResponseDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt`,
     submissionContent,

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -59,19 +59,21 @@ export const logoutPublicForm = async (
   ).then(({ data }) => data)
 }
 
-export type SubmitPublicFormArgs = {
+export type SubmitEmailFormArgs = {
   formId: string
   captchaResponse?: string | null
   formFields: FormFieldDto[]
   formInputs: Record<string, unknown>
 }
 
+export type SubmitStorageFormArgs = SubmitEmailFormArgs & { publicKey: string }
+
 export const submitEmailModeForm = async ({
   formFields,
   formInputs,
   formId,
   captchaResponse = null,
-}: SubmitPublicFormArgs): Promise<SubmissionResponseDto> => {
+}: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
   const formData = createEmailSubmissionFormData(formFields, formInputs)
 
   return ApiService.post<SubmissionResponseDto>(
@@ -91,7 +93,7 @@ export const submitEncryptModeForm = async ({
   captchaResponse,
   formId,
   publicKey,
-}: SubmitPublicFormArgs & { publicKey: string }) => {
+}: SubmitStorageFormArgs) => {
   const submissionContent = createEncryptedSubmissionData(
     formFields,
     formInputs,

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -90,9 +90,9 @@ export const submitEmailModeForm = async ({
 export const submitStorageModeForm = async ({
   formFields,
   formInputs,
-  captchaResponse,
   formId,
   publicKey,
+  captchaResponse = null,
 }: SubmitStorageFormArgs) => {
   const submissionContent = await createEncryptedSubmissionData(
     formFields,

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -7,8 +7,8 @@ import { useToast } from '~hooks/useToast'
 import {
   getPublicFormAuthRedirectUrl,
   logoutPublicForm,
+  SubmitEmailFormArgs,
   submitEmailModeForm,
-  SubmitPublicFormArgs,
 } from './PublicFormService'
 import { publicFormKeys } from './queries'
 
@@ -53,7 +53,7 @@ export const usePublicAuthMutations = (formId: string) => {
 
 export const usePublicFormMutations = (formId: string) => {
   const submitEmailModeFormMutation = useMutation(
-    (args: Omit<SubmitPublicFormArgs, 'formId'>) => {
+    (args: Omit<SubmitEmailFormArgs, 'formId'>) => {
       return submitEmailModeForm({ ...args, formId })
     },
   )

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -8,7 +8,7 @@ import {
   getPublicFormAuthRedirectUrl,
   logoutPublicForm,
   submitEmailModeForm,
-  SubmitEmailModeFormArgs,
+  SubmitPublicFormArgs,
 } from './PublicFormService'
 import { publicFormKeys } from './queries'
 
@@ -53,7 +53,7 @@ export const usePublicAuthMutations = (formId: string) => {
 
 export const usePublicFormMutations = (formId: string) => {
   const submitEmailModeFormMutation = useMutation(
-    (args: Omit<SubmitEmailModeFormArgs, 'formId'>) => {
+    (args: Omit<SubmitPublicFormArgs, 'formId'>) => {
       return submitEmailModeForm({ ...args, formId })
     },
   )

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -9,6 +9,8 @@ import {
   logoutPublicForm,
   SubmitEmailFormArgs,
   submitEmailModeForm,
+  SubmitStorageFormArgs,
+  submitStorageModeForm,
 } from './PublicFormService'
 import { publicFormKeys } from './queries'
 
@@ -58,5 +60,11 @@ export const usePublicFormMutations = (formId: string) => {
     },
   )
 
-  return { submitEmailModeFormMutation }
+  const submitStorageModeFormMutation = useMutation(
+    (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
+      return submitStorageModeForm({ ...args, formId })
+    },
+  )
+
+  return { submitEmailModeFormMutation, submitStorageModeFormMutation }
 }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -1,12 +1,51 @@
-import { forOwn, isEmpty } from 'lodash'
+import { encode as encodeBase64 } from '@stablelib/base64'
+import { chain, forOwn, isEmpty, omit } from 'lodash'
 
 import { BasicField, FormFieldDto } from '~shared/types/field'
-import { FieldResponse } from '~shared/types/response'
+import { EmailResponse, FieldResponse } from '~shared/types/response'
+import {
+  StorageModeAttachment,
+  StorageModeAttachmentsMap,
+  StorageModeSubmissionContentDto,
+} from '~shared/types/submission'
 
+import formsgSdk from '~utils/formSdk'
 import { AttachmentFieldSchema } from '~templates/Field'
 
 import { transformInputsToOutputs } from './inputTransformation'
 import { validateAttachmentInput } from './inputValidation'
+
+// The current encrypt version to assign to the encrypted submission.
+// This is needed if we ever break backwards compatibility with
+// end-to-end encryption
+const ENCRYPT_VERSION = 1
+
+export const createEncryptedSubmissionData = async (
+  formFields: FormFieldDto[],
+  formInputs: Record<string, unknown>,
+  publicKey: string,
+): Promise<StorageModeSubmissionContentDto> => {
+  const responses = createResponsesArray(formFields, formInputs)
+  const encryptedContent = formsgSdk.crypto.encrypt(responses, publicKey)
+  // Edge case: We still send email fields to the server in plaintext
+  // even with end-to-end encryption in order to support email autoreplies
+  const filteredResponses = filterEmailResponsesWithAutoreply(
+    formFields,
+    responses,
+  )
+  const attachments = await getEncryptedAttachmentsMap(
+    formFields,
+    formInputs,
+    publicKey,
+  )
+
+  return {
+    attachments,
+    responses: filteredResponses,
+    encryptedContent,
+    version: ENCRYPT_VERSION,
+  }
+}
 
 export const createEmailSubmissionFormData = (
   formFields: FormFieldDto[],
@@ -39,6 +78,28 @@ const createResponsesArray = (
     .filter((output): output is FieldResponse => output !== undefined)
 }
 
+const getEncryptedAttachmentsMap = async (
+  formFields: FormFieldDto[],
+  formInputs: Record<string, unknown>,
+  publicKey: string,
+): Promise<StorageModeAttachmentsMap> => {
+  const attachmentsMap = getAttachmentsMap(formFields, formInputs)
+
+  const attachmentPromises = Object.keys(attachmentsMap).map((id) =>
+    encryptAttachment(attachmentsMap[id], { id, publicKey }),
+  )
+
+  return Promise.all(attachmentPromises).then((encryptedAttachmentsMeta) => {
+    return (
+      chain(encryptedAttachmentsMeta)
+        .keyBy('id')
+        // Remove id from object.
+        .mapValues((v) => omit(v, 'id'))
+        .value()
+    )
+  })
+}
+
 const getAttachmentsMap = (
   formFields: FormFieldDto[],
   formInputs: Record<string, unknown>,
@@ -54,4 +115,39 @@ const getAttachmentsMap = (
   })
 
   return attachmentsMap
+}
+const filterEmailResponsesWithAutoreply = (
+  formFields: FormFieldDto[],
+  responses: FieldResponse[],
+) => {
+  return responses
+    .filter((r): r is EmailResponse => {
+      const isEmailResponse = r.fieldType === BasicField.Email
+      if (!isEmailResponse) return false
+      const field = formFields.find((ff) => ff._id === r._id)
+      if (field?.fieldType !== BasicField.Email) return false
+      // Only filter out fields with auto reply set to true
+      return field.autoReplyOptions.hasAutoReply
+    })
+    .map((r) =>
+      chain(r).pick(['fieldType', '_id', 'answer', 'signature']).value(),
+    )
+}
+const encryptAttachment = async (
+  attachment: File,
+  { id, publicKey }: { id: string; publicKey: string },
+): Promise<StorageModeAttachment & { id: string }> => {
+  const fileArrayBuffer = await attachment.arrayBuffer()
+  const fileContentsView = new Uint8Array(fileArrayBuffer)
+
+  const encryptedAttachment = await formsgSdk.crypto.encryptFile(
+    fileContentsView,
+    publicKey,
+  )
+  const encodedEncryptedAttachment = {
+    ...encryptedAttachment,
+    binary: encodeBase64(encryptedAttachment.binary),
+  }
+
+  return { id, encryptedFile: encodedEncryptedAttachment }
 }

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -3,7 +3,7 @@ import { ErrorDto } from './core'
 import { FormFieldDto, MyInfoAttribute } from './field'
 import { FormAuthType, FormDto } from './form/form'
 import { DateString } from './generic'
-import { FieldResponse } from './response'
+import { EmailResponse, FieldResponse } from './response'
 
 export type SubmissionId = Opaque<string, 'SubmissionId'>
 
@@ -95,14 +95,12 @@ export type FormSubmissionMetadataQueryDto = RequireAtLeastOne<
   'page' | 'submissionId'
 >
 
-type SubmissionContentBase = {
-  responses: FieldResponse[]
-}
-
 /**
  * Shape of email form submissions
  */
-export type EmailModeSubmissionContentDto = SubmissionContentBase
+export type EmailModeSubmissionContentDto = {
+  responses: FieldResponse[]
+}
 
 export type StorageModeAttachment = {
   encryptedFile?: {
@@ -117,7 +115,9 @@ export type StorageModeAttachmentsMap = Record<
   StorageModeAttachment
 >
 
-export type StorageModeSubmissionContentDto = SubmissionContentBase & {
+export type StorageModeSubmissionContentDto = {
+  // Storage mode only allows email responses in order to support email replies.
+  responses: Pick<EmailResponse, 'fieldType' | '_id' | 'answer' | 'signature'>[]
   encryptedContent: string
   attachments?: StorageModeAttachmentsMap
   version: number


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the submit storage mode form submission feature. The necessary functions to transform form field inputs to expected outputs have been written.

Related to #3570, closes #3598

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat(shared/submission): update `StorageModeSubmissionContentDto` **to only allow autoreplyable email fields** in the responses prop
- feat(utils/createSubmission): add storage mode form related fns
  - encrypt content
  - filter autoreplyable email field responses 
  - encrypt attachments
- feat(PublicFormService): add submitEncryptModeForm service function
- feat: add and use submitStorageModeFormMutation

**Improvements**:

- ref: extract and memoize error handler 

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:
- `@stablelib/base64`: used for encoding attachments in storage mode form submissions

