### PR TITLE
feat(v2): add and render form footer in PublicFormPage

### DIFF
--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -18,6 +18,8 @@ export interface PublicFormContextProps
    * The expiry time of current transaction, if it exists.
    * Is `null` if no transaction has been generated yet. */
   expiryInMs: number | null
+  /** Color of background based on form's colorTheme */
+  formBgColor: string
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import FormFields from './components/FormFields'
+import { FormFooter } from './components/FormFooter'
 import FormStartPage from './components/FormStartPage'
 import { PublicFormProvider } from './PublicFormProvider'
 
@@ -14,6 +15,7 @@ export const PublicFormPage = (): JSX.Element => {
       <Flex flexDir="column" h="100%" minH="100vh">
         <FormStartPage />
         <FormFields />
+        <FormFooter />
       </Flex>
     </PublicFormProvider>
   )

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { Box, Flex, Spacer } from '@chakra-ui/react'
 
-import { FormAuthType, FormColorTheme } from '~shared/types/form/form'
+import { FormAuthType } from '~shared/types/form/form'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
@@ -13,23 +13,11 @@ import { FormSectionsProvider } from './FormSectionsContext'
 import { SectionSidebar } from './SectionSidebar'
 
 export const FormFieldsContainer = (): JSX.Element => {
-  const { form, spcpSession, isLoading } = usePublicFormContext()
+  const { form, spcpSession, isLoading, formBgColor } = usePublicFormContext()
 
   const onSubmit = useCallback((values: Record<string, string>) => {
     console.log(values)
   }, [])
-
-  const bgColour = useMemo(() => {
-    if (isLoading) return 'neutral.100'
-    if (!form) return ''
-    const { colorTheme } = form.startPage
-    switch (colorTheme) {
-      case FormColorTheme.Blue:
-        return 'secondary.100'
-      default:
-        return `theme-${colorTheme}.100`
-    }
-  }, [form, isLoading])
 
   const isAuthRequired = useMemo(
     () => form && form.authType !== FormAuthType.NIL && !spcpSession,
@@ -63,7 +51,7 @@ export const FormFieldsContainer = (): JSX.Element => {
 
   return (
     <FormSectionsProvider form={form}>
-      <Flex bg={bgColour} flex={1} justify="center" p="1.5rem">
+      <Flex bg={formBgColor} flex={1} justify="center" p="1.5rem">
         {isAuthRequired ? null : <SectionSidebar />}
         <Box
           bg="white"

--- a/frontend/src/features/public-form/components/FormFields/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/FormFields/SectionSidebar.tsx
@@ -25,7 +25,7 @@ export const SectionSidebar = (): JSX.Element => {
   }, [miniHeaderRef?.current?.clientHeight])
 
   const scrollData = useMemo(() => {
-    if (!form) return
+    if (!form) return []
     const sections: SidebarSectionMeta[] = []
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
@@ -39,7 +39,11 @@ export const SectionSidebar = (): JSX.Element => {
   }, [form])
 
   return (
-    <Box flex={1} d={{ base: 'none', md: 'initial' }} minW="20%">
+    <Box
+      flex={1}
+      d={{ base: 'none', md: 'initial' }}
+      minW={scrollData.length > 0 ? '20%' : undefined}
+    >
       <VStack
         pos="sticky"
         top={sectionTopOffset}

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -1,0 +1,41 @@
+import { chakra, Divider, Flex, Link, Stack, Text } from '@chakra-ui/react'
+
+import { ReactComponent as BrandLogoSvg } from '~assets/svgs/brand/brand-hort-colour.svg'
+
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
+const BrandLogo = chakra(BrandLogoSvg, {
+  baseStyle: {
+    h: '1.5rem',
+    mt: '1rem',
+  },
+})
+
+/**
+ * @precondition Must be nested inside `PublicFormProvider`
+ */
+export const FormFooter = (): JSX.Element => {
+  const { formBgColor } = usePublicFormContext()
+
+  return (
+    <Stack
+      bg={formBgColor}
+      direction="column"
+      spacing="1.5rem"
+      align="center"
+      pb="1.5rem"
+    >
+      <Divider w="15rem" />
+      <Flex flexDir="column" align="center">
+        <Text textStyle="caption-1" color="secondary.400">
+          Created with
+        </Text>
+        <BrandLogo />
+      </Flex>
+      <Stack direction="row" spacing="1.5rem">
+        <Link textStyle="body-2">Terms of Use</Link>
+        <Link textStyle="body-2">Privacy Policy</Link>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/features/public-form/components/FormFooter/index.ts
+++ b/frontend/src/features/public-form/components/FormFooter/index.ts
@@ -1,0 +1,1 @@
+export { FormFooter } from './FormFooter'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the missing form footer in public form pages. Prerequisite for captcha PR.

## Solution
<!-- How did you solve the problem? -->
**Features**:

- add and render FormFooter component in PublicFormPage component

**Improvements**:

- feat: remove minimum widths on left spacer when displaying form if there are no section fields
  - It was causing form display to be lopsided when there are no sections to jump to
- feat: pass down formBgColor prop from PublicFormContext
  - so it can be reused by form footer too

**Known issues**:
Links to Terms of Use and Privacy Policy does not work yet. Will be in a separate PR.
EDIT: Now tracked in #3656  and #3657 

## Before & After Screenshots
PublicFormPage should now display form footer.
