### PR TITLE
fix(v2/CreatePage): use column flex in mobile view so content renders

### DIFF
--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -9,7 +9,13 @@ import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 
 export const CreatePage = (): JSX.Element => {
   return (
-    <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
+    <Flex
+      h="100%"
+      w="100%"
+      overflow="auto"
+      bg="neutral.200"
+      direction={{ base: 'column', md: 'row' }}
+    >
       <CreatePageSidebarProvider>
         <CreatePageSidebar />
         <CreatePageContent />


### PR DESCRIPTION
This PR fixes bug where create page's mobile view would not render content due to having the wrong flex direction