### PR TITLE
feat(v2/submit-6): show question numbers in public form fields

### DIFF
--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -9,7 +9,13 @@ import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 
 export const CreatePage = (): JSX.Element => {
   return (
-    <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
+    <Flex
+      h="100%"
+      w="100%"
+      overflow="auto"
+      bg="neutral.200"
+      direction={{ base: 'column', md: 'row' }}
+    >
       <CreatePageSidebarProvider>
         <CreatePageSidebar />
         <CreatePageContent />

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicBlock/FieldLogicBadge.tsx
@@ -4,13 +4,12 @@ import { Icon, Stack, Text } from '@chakra-ui/react'
 import Tooltip from '~components/Tooltip'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
-
-import { FormFieldWithQuestionNumber } from '../../../types'
+import { FormFieldWithQuestionNo } from '~features/form/types'
 
 import { LogicBadge } from './LogicBadge'
 
 interface FieldLogicBadgeProps {
-  field: FormFieldWithQuestionNumber
+  field: FormFieldWithQuestionNo
 }
 
 /**
@@ -32,7 +31,7 @@ export const FieldLogicBadge = ({ field }: FieldLogicBadgeProps) => {
         >
           <Icon as={fieldMeta.icon} fontSize="1rem" />
         </Tooltip>
-        <Text>{field.questionNumber}.</Text>
+        {field.questionNumber ? <Text>{field.questionNumber}.</Text> : null}
         <Text isTruncated>{field.title}</Text>
       </Stack>
     </LogicBadge>

--- a/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
+++ b/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
@@ -1,10 +1,8 @@
 import { useMemo } from 'react'
-
-import { FormFieldDto } from '~shared/types/field'
+import { keyBy } from 'lodash'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
-
-import { FormFieldWithQuestionNumber } from '../types'
+import { augmentWithQuestionNo } from '~features/form/utils/augmentWithQuestionNo'
 
 export const useAdminFormLogic = () => {
   const { data: form, isLoading } = useAdminForm()
@@ -12,10 +10,8 @@ export const useAdminFormLogic = () => {
   const mapIdToField = useMemo(() => {
     if (!form) return null
 
-    return form.form_fields.reduce((acc, field, index) => {
-      acc[field._id] = { ...field, questionNumber: index + 1 }
-      return acc
-    }, {} as Record<FormFieldDto['_id'], FormFieldWithQuestionNumber>)
+    const augmentedFormFields = augmentWithQuestionNo(form.form_fields)
+    return keyBy(augmentedFormFields, '_id')
   }, [form])
 
   return {

--- a/frontend/src/features/admin-form/create/logic/types.ts
+++ b/frontend/src/features/admin-form/create/logic/types.ts
@@ -1,9 +1,3 @@
-import { FormFieldDto } from '~shared/types/field'
-
-export type FormFieldWithQuestionNumber = FormFieldDto & {
-  questionNumber: number
-}
-
 export enum AdminEditLogicState {
   CreatingLogic,
   EditingLogic,

--- a/frontend/src/features/form/types.ts
+++ b/frontend/src/features/form/types.ts
@@ -1,0 +1,10 @@
+import { FormField, FormFieldDto } from '~shared/types/field'
+
+/**
+ * Partial question number, depends on field type. Some field types do not
+ * require a question number
+ */
+export type FormFieldWithQuestionNo<T extends FormField = FormField> =
+  FormFieldDto<T> & {
+    questionNumber?: number
+  }

--- a/frontend/src/features/form/utils/augmentWithQuestionNo.ts
+++ b/frontend/src/features/form/utils/augmentWithQuestionNo.ts
@@ -1,0 +1,34 @@
+import { BasicField, FormFieldDto } from '~shared/types/field'
+
+import { FormFieldWithQuestionNo } from '../types'
+
+type AugmentedFieldAccumulator = {
+  fields: FormFieldWithQuestionNo[]
+  nonResponseFieldsCount: number
+}
+
+const NON_RESPONSE_FIELD_SET = new Set([
+  BasicField.Section,
+  BasicField.Statement,
+  BasicField.Image,
+])
+
+export const augmentWithQuestionNo = (formFields: FormFieldDto[]) => {
+  const { fields } = formFields.reduce<AugmentedFieldAccumulator>(
+    (acc, field, index) => {
+      if (NON_RESPONSE_FIELD_SET.has(field.fieldType)) {
+        acc.nonResponseFieldsCount += 1
+        acc.fields.push(field)
+      } else {
+        acc.fields.push({
+          ...field,
+          questionNumber: index + 1 - acc.nonResponseFieldsCount,
+        })
+      }
+      return acc
+    },
+    { fields: [], nonResponseFieldsCount: 0 },
+  )
+
+  return fields
+}

--- a/frontend/src/features/form/utils/index.ts
+++ b/frontend/src/features/form/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './augmentWithQuestionNo'

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react'
-import { Text } from '@chakra-ui/react'
 
-import { BasicField, FormFieldDto } from '~shared/types/field'
+import { BasicField } from '~shared/types/field'
 import { FormColorTheme } from '~shared/types/form'
 
 import {
@@ -27,6 +26,7 @@ import {
   YesNoField,
 } from '~templates/Field'
 
+import { FormFieldWithQuestionNo } from '~features/form/types'
 import {
   VerifiableEmailField,
   VerifiableEmailFieldSchema,
@@ -37,7 +37,7 @@ import {
 } from '~features/verifiable-fields/Mobile'
 
 interface FieldFactoryProps {
-  field: FormFieldDto
+  field: FormFieldWithQuestionNo
   colorTheme?: FormColorTheme
 }
 
@@ -99,10 +99,10 @@ export const FieldFactory = memo(
       case BasicField.Image:
         return <ImageField schema={field} colorTheme={colorTheme} />
       case BasicField.Table:
-        return <TableField schema={field} />
-      default:
-        return <Text w="100%">{JSON.stringify(field)}</Text>
+        return <TableField schema={field} colorTheme={colorTheme} />
     }
   },
-  (prevProps, nextProps) => prevProps.field._id === nextProps.field._id,
+  (prevProps, nextProps) =>
+    prevProps.field._id === nextProps.field._id &&
+    prevProps.field.questionNumber === nextProps.field.questionNumber,
 )

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useState } from 'react'
 import { Control, FieldValues, useWatch } from 'react-hook-form'
 
-import { FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, LogicDto } from '~shared/types/form'
 
+import { FormFieldWithQuestionNo } from '~features/form/types'
+import { augmentWithQuestionNo } from '~features/form/utils'
 import { getVisibleFieldIds } from '~features/logic/utils'
 
 import { FieldFactory } from './FieldFactory'
 
 interface VisibleFormFieldsProps {
   control: Control<FieldValues>
-  formFields: FormFieldDto[]
+  formFields: FormFieldWithQuestionNo[]
   formLogics: LogicDto[]
   colorTheme: FormColorTheme
 }
@@ -36,7 +37,8 @@ export const VisibleFormFields = ({
     const visibleFields = formFields.filter((field) =>
       visibleFieldIds.has(field._id),
     )
-    setVisibleFormFields(visibleFields)
+    const visibleFieldsWithQuestionNo = augmentWithQuestionNo(visibleFields)
+    setVisibleFormFields(visibleFieldsWithQuestionNo)
   }, [formFields, formLogics, watchedValues])
 
   return (

--- a/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
+++ b/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
@@ -24,7 +24,6 @@ export interface VerifiableFieldContainerProps
  */
 export const VerifiableFieldContainer = ({
   schema,
-  questionNumber,
   children,
 }: VerifiableFieldContainerProps): JSX.Element => {
   const {
@@ -38,7 +37,7 @@ export const VerifiableFieldContainer = ({
 
   return (
     <Box>
-      <FieldContainer schema={schema} questionNumber={questionNumber}>
+      <FieldContainer schema={schema}>
         <Stack spacing="0.5rem" direction={{ base: 'column', md: 'row' }}>
           {children}
           <Box>

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -19,7 +19,6 @@ export interface AttachmentFieldProps extends BaseFieldProps {
  */
 export const AttachmentField = ({
   schema,
-  questionNumber,
 }: AttachmentFieldProps): JSX.Element => {
   const fieldName = schema._id
   const validationRules = useMemo(
@@ -42,7 +41,7 @@ export const AttachmentField = ({
   )
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         render={({ field: { onChange, ...rest } }) => (

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -26,10 +26,7 @@ export interface CheckboxFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const CheckboxField = ({
-  schema,
-  questionNumber,
-}: CheckboxFieldProps): JSX.Element => {
+export const CheckboxField = ({ schema }: CheckboxFieldProps): JSX.Element => {
   const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {})
 
   const othersInputName = useMemo(
@@ -69,11 +66,7 @@ export const CheckboxField = ({
   )
 
   return (
-    <FieldContainer
-      schema={schema}
-      questionNumber={questionNumber}
-      errorKey={checkboxInputName}
-    >
+    <FieldContainer schema={schema} errorKey={checkboxInputName}>
       {schema.fieldOptions.map((o, idx) => (
         <Checkbox
           key={idx}

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -21,10 +21,7 @@ export interface DateFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const DateField = ({
-  schema,
-  questionNumber,
-}: DateFieldProps): JSX.Element => {
+export const DateField = ({ schema }: DateFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDateValidationRules(schema),
     [schema],
@@ -55,7 +52,7 @@ export const DateField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         name={schema._id}

--- a/frontend/src/templates/Field/Decimal/DecimalField.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.tsx
@@ -14,10 +14,7 @@ export interface DecimalFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const DecimalField = ({
-  schema,
-  questionNumber,
-}: DecimalFieldProps): JSX.Element => {
+export const DecimalField = ({ schema }: DecimalFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDecimalValidationRules(schema),
     [schema],
@@ -26,7 +23,7 @@ export const DecimalField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/Dropdown/DropdownField.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.tsx
@@ -14,10 +14,7 @@ export interface DropdownFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const DropdownField = ({
-  schema,
-  questionNumber,
-}: DropdownFieldProps): JSX.Element => {
+export const DropdownField = ({ schema }: DropdownFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDropdownValidationRules(schema),
     [schema],
@@ -26,7 +23,7 @@ export const DropdownField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/Email/EmailField.tsx
+++ b/frontend/src/templates/Field/Email/EmailField.tsx
@@ -10,12 +10,9 @@ export interface EmailFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const EmailField = ({
-  schema,
-  questionNumber,
-}: EmailFieldProps): JSX.Element => {
+export const EmailField = ({ schema }: EmailFieldProps): JSX.Element => {
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <EmailFieldInput schema={schema} />
     </FieldContainer>
   )

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -8,23 +8,22 @@ import { FieldError, useFormState } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
-import { FormFieldWithId } from '~shared/types/field'
 import { FormColorTheme } from '~shared/types/form'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
-import { FormLabelProps } from '~components/FormControl/FormLabel/FormLabel'
+
+import { FormFieldWithQuestionNo } from '~features/form/types'
 
 export type BaseFieldProps = {
   schema: Pick<
-    FormFieldWithId,
-    '_id' | 'required' | 'description' | 'title' | 'disabled'
+    FormFieldWithQuestionNo,
+    '_id' | 'required' | 'description' | 'title' | 'disabled' | 'questionNumber'
   >
   /**
    * Color theme of form, if available. Defaults to `FormColorTheme.Blue`
    */
   colorTheme?: FormColorTheme
-  questionNumber?: FormLabelProps['questionNumber']
   /**
    * Optional key of error to display in form error message.
    * If not provided, will default to given `schema._id`.
@@ -38,7 +37,6 @@ export interface FieldContainerProps extends BaseFieldProps {
 
 export const FieldContainer = ({
   schema,
-  questionNumber,
   children,
   errorKey,
 }: FieldContainerProps): JSX.Element => {
@@ -55,7 +53,9 @@ export const FieldContainer = ({
       id={schema._id}
     >
       <FormLabel
-        questionNumber={questionNumber}
+        questionNumber={
+          schema.questionNumber ? String(schema.questionNumber) : undefined
+        }
         description={schema.description}
       >
         {schema.title}

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -54,7 +54,7 @@ export const FieldContainer = ({
     >
       <FormLabel
         questionNumber={
-          schema.questionNumber ? String(schema.questionNumber) : undefined
+          schema.questionNumber ? `${schema.questionNumber}.` : undefined
         }
         description={schema.description}
       >

--- a/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
@@ -12,10 +12,7 @@ export interface HomeNoFieldProps extends BaseFieldProps {
   schema: HomeNoFieldSchema
 }
 
-export const HomeNoField = ({
-  schema,
-  questionNumber,
-}: HomeNoFieldProps): JSX.Element => {
+export const HomeNoField = ({ schema }: HomeNoFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createHomeNoValidationRules(schema),
     [schema],
@@ -24,7 +21,7 @@ export const HomeNoField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/LongText/LongTextField.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.tsx
@@ -14,10 +14,7 @@ export interface LongTextFieldProps extends BaseFieldProps {
   schema: LongTextFieldSchema
 }
 
-export const LongTextField = ({
-  schema,
-  questionNumber,
-}: LongTextFieldProps): JSX.Element => {
+export const LongTextField = ({ schema }: LongTextFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createTextValidationRules(schema),
     [schema],
@@ -26,7 +23,7 @@ export const LongTextField = ({
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Textarea
         aria-label={schema.title}
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -14,10 +14,7 @@ export interface NricFieldProps extends BaseFieldProps {
   schema: NricFieldSchema
 }
 
-export const NricField = ({
-  schema,
-  questionNumber,
-}: NricFieldProps): JSX.Element => {
+export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createNricValidationRules(schema),
     [schema],
@@ -26,7 +23,7 @@ export const NricField = ({
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Input
         aria-label={schema.title}
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -11,10 +11,7 @@ export interface NumberFieldProps extends BaseFieldProps {
   schema: NumberFieldSchema
 }
 
-export const NumberField = ({
-  schema,
-  questionNumber,
-}: NumberFieldProps): JSX.Element => {
+export const NumberField = ({ schema }: NumberFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createNumberValidationRules(schema),
     [schema],
@@ -23,7 +20,7 @@ export const NumberField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -21,10 +21,7 @@ export interface RadioFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const RadioField = ({
-  schema,
-  questionNumber,
-}: RadioFieldProps): JSX.Element => {
+export const RadioField = ({ schema }: RadioFieldProps): JSX.Element => {
   const styles = useMultiStyleConfig(RADIO_THEME_KEY, {})
 
   const othersInputName = useMemo(
@@ -61,11 +58,7 @@ export const RadioField = ({
   )
 
   return (
-    <FieldContainer
-      schema={schema}
-      questionNumber={questionNumber}
-      errorKey={radioInputName}
-    >
+    <FieldContainer schema={schema} errorKey={radioInputName}>
       <Controller
         name={radioInputName}
         rules={validationRules}

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -25,10 +25,7 @@ const transform = {
   toNumber: (value: string) => Number(value),
 }
 
-export const RatingField = ({
-  schema,
-  questionNumber,
-}: RatingFieldProps): JSX.Element => {
+export const RatingField = ({ schema }: RatingFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createRatingValidationRules(schema),
     [schema],
@@ -46,7 +43,7 @@ export const RatingField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         rules={validationRules}
         control={control}

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -16,7 +16,6 @@ export interface ShortTextFieldProps extends BaseFieldProps {
 
 export const ShortTextField = ({
   schema,
-  questionNumber,
 }: ShortTextFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createTextValidationRules(schema),
@@ -26,7 +25,7 @@ export const ShortTextField = ({
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Input
         aria-label={schema.title}
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -24,10 +24,7 @@ export interface TableFieldProps extends BaseFieldProps {
  * @precondition This component uses `react-hook-form#useFieldArray`, and will require defaultValues to be populated in the parent `useForm` hook.
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const TableField = ({
-  schema,
-  questionNumber,
-}: TableFieldProps): JSX.Element => {
+export const TableField = ({ schema }: TableFieldProps): JSX.Element => {
   const columnsData = useMemo(() => {
     return schema.columns.map((c) => ({
       Header: (
@@ -64,7 +61,7 @@ export const TableField = ({
   )
 
   return (
-    <TableFieldContainer schema={schema} questionNumber={questionNumber}>
+    <TableFieldContainer schema={schema}>
       <Box d="block" w="100%" overflowX="auto">
         <Table
           {...getTableProps()}

--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -2,13 +2,11 @@ import { useFormState } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 
 import FormLabel from '~components/FormControl/FormLabel'
-import { FormLabelProps } from '~components/FormControl/FormLabel/FormLabel'
 
 import { TableFieldSchema } from '../types'
 
 export type BaseTableFieldProps = {
   schema: TableFieldSchema
-  questionNumber?: FormLabelProps['questionNumber']
 }
 
 export interface TableFieldContainerProps extends BaseTableFieldProps {
@@ -21,7 +19,6 @@ export interface TableFieldContainerProps extends BaseTableFieldProps {
  */
 export const TableFieldContainer = ({
   schema,
-  questionNumber,
   children,
 }: TableFieldContainerProps): JSX.Element => {
   const { isSubmitting, isValid, errors } = useFormState({ name: schema._id })
@@ -34,7 +31,9 @@ export const TableFieldContainer = ({
       isInvalid={!!errors[schema._id]}
     >
       <FormLabel
-        questionNumber={questionNumber}
+        questionNumber={
+          schema.questionNumber ? String(schema.questionNumber) : undefined
+        }
         description={schema.description}
       >
         {schema.title}

--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -32,7 +32,7 @@ export const TableFieldContainer = ({
     >
       <FormLabel
         questionNumber={
-          schema.questionNumber ? String(schema.questionNumber) : undefined
+          schema.questionNumber ? `${schema.questionNumber}.` : undefined
         }
         description={schema.description}
       >

--- a/frontend/src/templates/Field/Uen/UenField.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.tsx
@@ -17,10 +17,7 @@ export interface UenFieldProps extends BaseFieldProps {
   schema: UenFieldSchema
 }
 
-export const UenField = ({
-  schema,
-  questionNumber,
-}: UenFieldProps): JSX.Element => {
+export const UenField = ({ schema }: UenFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createUenValidationRules(schema),
     [schema],
@@ -29,7 +26,7 @@ export const UenField = ({
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Input
         aria-label={schema.title}
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/YesNo/YesNoField.tsx
+++ b/frontend/src/templates/Field/YesNo/YesNoField.tsx
@@ -23,10 +23,7 @@ const transform = {
   inputToField: (value: 'yes' | 'no') => (value === 'yes' ? 'Yes' : 'No'),
 }
 
-export const YesNoField = ({
-  schema,
-  questionNumber,
-}: YesNoFieldProps): JSX.Element => {
+export const YesNoField = ({ schema }: YesNoFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createBaseValidationRules(schema),
     [schema],
@@ -35,7 +32,7 @@ export const YesNoField = ({
   const { control } = useFormContext<YesNoFieldInput>()
 
   return (
-    <FieldContainer schema={schema} questionNumber={questionNumber}>
+    <FieldContainer schema={schema}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/types.ts
+++ b/frontend/src/templates/Field/types.ts
@@ -29,6 +29,8 @@ import {
   VerifiableResponseBase,
 } from '~shared/types/response'
 
+import { FormFieldWithQuestionNo } from '~features/form/types'
+
 // Form field types to be composed by various fields
 export type BaseFieldOutput<FF extends FormFieldDto> = {
   _id: FF['_id']
@@ -83,23 +85,25 @@ export type VerifiableAnswerOutput<F extends FormFieldDto> = Merge<
 >
 
 // Various schemas used by different fields
-export type AttachmentFieldSchema = FormFieldWithId<AttachmentFieldBase>
-export type CheckboxFieldSchema = FormFieldWithId<CheckboxFieldBase>
-export type DateFieldSchema = FormFieldWithId<DateFieldBase>
-export type DecimalFieldSchema = FormFieldWithId<DecimalFieldBase>
-export type DropdownFieldSchema = FormFieldWithId<DropdownFieldBase>
-export type EmailFieldSchema = FormFieldWithId<EmailFieldBase>
-export type HomeNoFieldSchema = FormFieldWithId<HomenoFieldBase>
-export type ImageFieldSchema = FormFieldWithId<ImageFieldBase>
-export type LongTextFieldSchema = FormFieldWithId<LongTextFieldBase>
-export type MobileFieldSchema = FormFieldWithId<MobileFieldBase>
-export type NricFieldSchema = FormFieldWithId<NricFieldBase>
-export type NumberFieldSchema = FormFieldWithId<NumberFieldBase>
-export type ParagraphFieldSchema = FormFieldWithId<StatementFieldBase>
-export type RadioFieldSchema = FormFieldWithId<RadioFieldBase>
-export type RatingFieldSchema = FormFieldWithId<RatingFieldBase>
 export type SectionFieldSchema = FormFieldWithId<SectionFieldBase>
-export type ShortTextFieldSchema = FormFieldWithId<ShortTextFieldBase>
-export type TableFieldSchema = FormFieldWithId<TableFieldBase>
-export type UenFieldSchema = FormFieldWithId<UenFieldBase>
-export type YesNoFieldSchema = FormFieldWithId<YesNoFieldBase>
+export type ParagraphFieldSchema = FormFieldWithId<StatementFieldBase>
+export type ImageFieldSchema = FormFieldWithId<ImageFieldBase>
+
+// With question number
+export type AttachmentFieldSchema = FormFieldWithQuestionNo<AttachmentFieldBase>
+export type CheckboxFieldSchema = FormFieldWithQuestionNo<CheckboxFieldBase>
+export type DateFieldSchema = FormFieldWithQuestionNo<DateFieldBase>
+export type DecimalFieldSchema = FormFieldWithQuestionNo<DecimalFieldBase>
+export type DropdownFieldSchema = FormFieldWithQuestionNo<DropdownFieldBase>
+export type EmailFieldSchema = FormFieldWithQuestionNo<EmailFieldBase>
+export type HomeNoFieldSchema = FormFieldWithQuestionNo<HomenoFieldBase>
+export type LongTextFieldSchema = FormFieldWithQuestionNo<LongTextFieldBase>
+export type MobileFieldSchema = FormFieldWithQuestionNo<MobileFieldBase>
+export type NricFieldSchema = FormFieldWithQuestionNo<NricFieldBase>
+export type NumberFieldSchema = FormFieldWithQuestionNo<NumberFieldBase>
+export type RadioFieldSchema = FormFieldWithQuestionNo<RadioFieldBase>
+export type RatingFieldSchema = FormFieldWithQuestionNo<RatingFieldBase>
+export type ShortTextFieldSchema = FormFieldWithQuestionNo<ShortTextFieldBase>
+export type TableFieldSchema = FormFieldWithQuestionNo<TableFieldBase>
+export type UenFieldSchema = FormFieldWithQuestionNo<UenFieldBase>
+export type YesNoFieldSchema = FormFieldWithQuestionNo<YesNoFieldBase>


### PR DESCRIPTION
> This chain is getting long... Sorzzz

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds question numbers to form fields that can take in a response. The only fields that do not have question numbers are the Image, Section, and Statement fields.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: extract augmentWithQuestionNo function
- feat: use FormFieldWithQuestionNo type across form render components
- feat(FormFields): render question number in form fields

**Bug Fixes**:
- fix(logic/hooks): correctly augment logic field's question number
  - Was assigning question numbers to every single field, even those that do not actually accept a response

## Before & After Screenshots
Public form fields should now show a question number if the field accepts inputs.

