### PR TITLE
feat(v2/submit-7): add reCAPTCHA support in public form submissions

### DIFF
--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -10,6 +10,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
   Text,
+  useFormControlProps,
 } from '@chakra-ui/react'
 import { ComponentWithAs, forwardRef } from '@chakra-ui/system'
 import { format } from 'date-fns'
@@ -34,7 +35,26 @@ type DateInputWithSubcomponents = ComponentWithAs<'input', DateInputProps> & {
 }
 
 export const DateInput = forwardRef<DateInputProps, 'input'>(
-  ({ onChange, value = '', isDateUnavailable, ...props }, ref) => {
+  (
+    {
+      onChange,
+      value = '',
+      isDateUnavailable,
+      isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+      isInvalid: isInvalidProp,
+      ...props
+    },
+    ref,
+  ) => {
+    const fcProps = useFormControlProps({
+      isInvalid: isInvalidProp,
+      isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+    })
+
     const initialFocusRef = useRef<HTMLInputElement>(null)
 
     const handleDatepickerSelection = useCallback(
@@ -93,6 +113,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   ref={ref}
                   value={value}
                   {...props}
+                  {...fcProps}
                 />
               </PopoverAnchor>
               <PopoverTrigger>
@@ -102,6 +123,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   variant="inputAttached"
                   borderRadius={0}
                   isActive={isOpen}
+                  isDisabled={fcProps.isDisabled || fcProps.isReadOnly}
                 />
               </PopoverTrigger>
               <PopoverContent

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { FormControlOptions, useMultiStyleConfig } from '@chakra-ui/react'
+import {
+  FormControlOptions,
+  useFormControlProps,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
 import { useCombobox, UseComboboxProps } from 'downshift'
 
 import { useItems } from '../hooks/useItems'
@@ -41,16 +45,25 @@ export const SingleSelectProvider = ({
   isClearable = true,
   isSearchable = true,
   initialIsOpen,
-  isInvalid,
-  isReadOnly,
-  isDisabled,
-  isRequired,
+  isInvalid: isInvalidProp,
+  isReadOnly: isReadOnlyProp,
+  isDisabled: isDisabledProp,
+  isRequired: isRequiredProp,
   children,
   inputAria: inputAriaProp,
   comboboxProps = {},
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
+
+  const { isInvalid, isDisabled, isReadOnly, isRequired } = useFormControlProps(
+    {
+      isInvalid: isInvalidProp,
+      isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+    },
+  )
 
   const placeholder = useMemo(() => {
     if (placeholderProp === null) return ''

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
@@ -8,6 +8,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
   const {
     isClearable,
     isDisabled,
+    isReadOnly,
     clearButtonLabel,
     selectItem,
     styles,
@@ -23,7 +24,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
     <chakra.button
       // Prevent form submission from triggering this button.
       type="button"
-      disabled={isDisabled}
+      disabled={isDisabled || isReadOnly}
       aria-label={clearButtonLabel}
       onClick={handleClearSelection}
       __css={styles.clearbutton}

--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react'
+import { forwardRef, useCallback, useMemo } from 'react'
 import {
   Flex,
   Icon,
@@ -45,6 +45,11 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       [selectedItem],
     )
 
+    const handleToggleMenu = useCallback(() => {
+      if (isReadOnly || isDisabled) return
+      return toggleMenu()
+    }, [isDisabled, isReadOnly, toggleMenu])
+
     return (
       <Flex>
         <VisuallyHidden id={inputAria.id}>{inputAria.label}</VisuallyHidden>
@@ -79,7 +84,11 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            <Text textStyle="body-1" isTruncated>
+            <Text
+              textStyle="body-1"
+              isTruncated
+              color={isDisabled ? 'neutral.500' : undefined}
+            >
               {selectedItemMeta.label}
             </Text>
           </Stack>
@@ -90,7 +99,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             placeholder={selectedItem ? undefined : placeholder}
             sx={styles.field}
             {...getInputProps({
-              onClick: toggleMenu,
+              onClick: handleToggleMenu,
               onBlur: () => !isOpen && resetInputValue(),
               ref,
               'aria-describedby': inputAria.id,

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -6,15 +6,17 @@ import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
 import { useSelectContext } from '../../SelectContext'
 
 export const ToggleChevron = (): JSX.Element => {
-  const { isOpen, getToggleButtonProps, isDisabled, styles } =
+  const { isOpen, getToggleButtonProps, isDisabled, isReadOnly, styles } =
     useSelectContext()
 
   return (
-    <InputRightElement {...getToggleButtonProps({ disabled: isDisabled })}>
+    <InputRightElement
+      {...getToggleButtonProps({ disabled: isDisabled || isReadOnly })}
+    >
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-disabled={isDisabled}
+        aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>
   )

--- a/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
+++ b/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
@@ -1,0 +1,24 @@
+import { keyBy } from 'lodash'
+
+import { types as myInfoTypeArray } from '~shared/constants/field/myinfo'
+import { BasicField, FormFieldDto, MyInfoFormField } from '~shared/types/field'
+
+const MAP_ATTR_TO_NAME = keyBy(myInfoTypeArray, 'name')
+
+// Making a copy by destructuring so original object does not get affected.
+export const augmentWithMyInfo = ({
+  ...field
+}: FormFieldDto): MyInfoFormField => {
+  // Only dropdown fields have augmented options for now.
+  switch (field.fieldType) {
+    case BasicField.Dropdown: {
+      // No need to augment if no MyInfo attribute
+      if (!field.myInfo?.attr) return field
+      const myInfoBlock = MAP_ATTR_TO_NAME[field.myInfo.attr]
+      field.fieldOptions = myInfoBlock.fieldOptions ?? []
+      return field
+    }
+    default:
+      return field
+  }
+}

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -22,6 +22,8 @@ export interface PublicFormContextProps
   handleSubmitForm: (formInputs: any) => void
   /** If form is submitted, submissionId will be defined. */
   submissionId: string | undefined
+  /** Color of background based on form's colorTheme */
+  formBgColor: string
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -24,6 +24,8 @@ export interface PublicFormContextProps
   submissionId: string | undefined
   /** Color of background based on form's colorTheme */
   formBgColor: string
+  /** id of container to render captcha in  */
+  captchaContainerId: string
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { BasicField } from '~shared/types/field'
 import { FormAuthType } from '~shared/types/form'
 
+import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   getPublicFormResponse,
   postGenerateVfnOtpResponse,
@@ -15,6 +16,7 @@ import { StoryRouter } from '~utils/storybook'
 import PublicFormPage from './PublicFormPage'
 
 const DEFAULT_MSW_HANDLERS = [
+  ...envHandlers,
   getPublicFormResponse(),
   postVfnTransactionResponse(),
   postGenerateVfnOtpResponse(),
@@ -43,13 +45,14 @@ export const Default = Template.bind({})
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: [getPublicFormResponse({ delay: 'infinite' })],
+  msw: [...envHandlers, getPublicFormResponse({ delay: 'infinite' })],
 }
 
 export const SingpassUnauthorized = Template.bind({})
 SingpassUnauthorized.storyName = 'Singpass/Unauthorized'
 SingpassUnauthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {
@@ -66,6 +69,7 @@ export const SingpassAuthorized = Template.bind({})
 SingpassAuthorized.storyName = 'Singpass/Authorized'
 SingpassAuthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {
@@ -85,6 +89,7 @@ export const CorppassUnauthorized = Template.bind({})
 CorppassUnauthorized.storyName = 'Corppass/Unauthorized'
 CorppassUnauthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {
@@ -101,6 +106,7 @@ export const CorppassAuthorized = Template.bind({})
 CorppassAuthorized.storyName = 'Corppass/Authorized'
 CorppassAuthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {
@@ -120,6 +126,7 @@ export const SgidUnauthorized = Template.bind({})
 SgidUnauthorized.storyName = 'SGID/Unauthorized'
 SgidUnauthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {
@@ -136,6 +143,7 @@ export const SgidAuthorized = Template.bind({})
 SgidAuthorized.storyName = 'SGID/Authorized'
 SgidAuthorized.parameters = {
   msw: [
+    ...envHandlers,
     getPublicFormResponse({
       delay: 0,
       overrides: {

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import FormFields from './components/FormFields'
+import { FormFooter } from './components/FormFooter'
 import FormStartPage from './components/FormStartPage'
 import { PublicFormProvider } from './PublicFormProvider'
 
@@ -14,6 +15,7 @@ export const PublicFormPage = (): JSX.Element => {
       <Flex flexDir="column" h="100%" minH="100vh">
         <FormStartPage />
         <FormFields />
+        <FormFooter />
       </Flex>
     </PublicFormProvider>
   )

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -155,13 +155,20 @@ export const PublicFormProvider = ({
       const { form } = cachedDto ?? {}
       if (!form) return
 
+      let captchaResponse: string | null
+      try {
+        captchaResponse = await getCaptchaResponse()
+      } catch {
+        return showErrorToast()
+      }
+
       switch (form.responseMode) {
         case FormResponseMode.Email:
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitEmailModeFormMutation
               .mutateAsync(
-                { formFields: form.form_fields, formInputs },
+                { formFields: form.form_fields, formInputs, captchaResponse },
                 {
                   onSuccess: ({ submissionId }) =>
                     setSubmissionId(submissionId),
@@ -179,6 +186,7 @@ export const PublicFormProvider = ({
                   formFields: form.form_fields,
                   formInputs,
                   publicKey: form.publicKey,
+                  captchaResponse,
                 },
                 {
                   onSuccess: ({ submissionId }) =>
@@ -192,6 +200,7 @@ export const PublicFormProvider = ({
     },
     [
       cachedDto,
+      getCaptchaResponse,
       showErrorToast,
       submitEmailModeFormMutation,
       submitStorageModeFormMutation,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -6,7 +6,11 @@ import get from 'lodash/get'
 import simplur from 'simplur'
 
 import { FormFieldDto } from '~shared/types/field'
-import { FormResponseMode, PublicFormViewDto } from '~shared/types/form'
+import {
+  FormColorTheme,
+  FormResponseMode,
+  PublicFormViewDto,
+} from '~shared/types/form'
 
 import { PUBLICFORM_REGEX } from '~constants/routes'
 import { useTimeout } from '~hooks/useTimeout'
@@ -37,7 +41,7 @@ export const PublicFormProvider = ({
   const [vfnTransaction, setVfnTransaction] =
     useState<FetchNewTransactionResponse>()
   const miniHeaderRef = useRef<HTMLDivElement>(null)
-  const { data, error, ...rest } = usePublicFormView(
+  const { data, isLoading, error, ...rest } = usePublicFormView(
     formId,
     // Stop querying once submissionId is present.
     /* enabled= */ !submissionId,
@@ -51,6 +55,18 @@ export const PublicFormProvider = ({
   const toast = useToast()
   const vfnToastIdRef = useRef<string | number>()
   const desyncToastIdRef = useRef<string | number>()
+
+  const formBgColor = useMemo(() => {
+    if (isLoading) return 'neutral.100'
+    if (!cachedDto) return ''
+    const { colorTheme } = cachedDto.form.startPage
+    switch (colorTheme) {
+      case FormColorTheme.Blue:
+        return 'secondary.100'
+      default:
+        return `theme-${colorTheme}.100`
+    }
+  }, [cachedDto, isLoading])
 
   useEffect(() => {
     if (data) {
@@ -186,6 +202,8 @@ export const PublicFormProvider = ({
         getTransactionId,
         expiryInMs,
         submissionId,
+        formBgColor,
+        isLoading,
         ...cachedDto,
         ...rest,
       }}

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -18,6 +18,8 @@ import { useToast } from '~hooks/useToast'
 import { HttpError } from '~services/ApiService'
 import Link from '~components/Link'
 
+import { useEnv } from '~features/env/queries'
+import { useRecaptcha } from '~features/recaptcha/useRecaptcha'
 import {
   FetchNewTransactionResponse,
   useTransactionMutations,
@@ -46,6 +48,10 @@ export const PublicFormProvider = ({
     // Stop querying once submissionId is present.
     /* enabled= */ !submissionId,
   )
+  const { data: { captchaPublicKey } = {} } = useEnv(!!data?.form.hasCaptcha)
+  const { hasLoaded, getCaptchaResponse, containerId } = useRecaptcha({
+    sitekey: captchaPublicKey,
+  })
 
   const [cachedDto, setCachedDto] = useState<PublicFormViewDto>()
 
@@ -203,7 +209,8 @@ export const PublicFormProvider = ({
         expiryInMs,
         submissionId,
         formBgColor,
-        isLoading,
+        captchaContainerId: containerId,
+        isLoading: isLoading || (!!cachedDto?.form.hasCaptcha && !hasLoaded),
         ...cachedDto,
         ...rest,
       }}

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -48,7 +48,9 @@ export const PublicFormProvider = ({
     // Stop querying once submissionId is present.
     /* enabled= */ !submissionId,
   )
-  const { data: { captchaPublicKey } = {} } = useEnv(!!data?.form.hasCaptcha)
+  const { data: { captchaPublicKey } = {} } = useEnv(
+    /* enabled= */ !!data?.form.hasCaptcha,
+  )
   const { hasLoaded, getCaptchaResponse, containerId } = useRecaptcha({
     sitekey: captchaPublicKey,
   })

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -9,6 +9,8 @@ import { FormColorTheme, LogicDto } from '~shared/types/form'
 import Button from '~components/Button'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
+import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
+
 import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
@@ -24,10 +26,18 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-  // TODO: Cleanup messy code
-  // TODO: Inject default values if field is MyInfo, or prefilled.
+  // TODO: Inject default values is field is also prefilled.
+  const augmentedFormFields = useMemo(
+    () => formFields.map(augmentWithMyInfo),
+    [formFields],
+  )
+
   const defaultFormValues = useMemo(() => {
-    return formFields.reduce<FieldValues>((acc, field) => {
+    return augmentedFormFields.reduce<FieldValues>((acc, field) => {
+      if (field.fieldValue !== undefined) {
+        acc[field._id] = field.fieldValue
+        return acc
+      }
       switch (field.fieldType) {
         // Required so table column fields will render due to useFieldArray usage.
         // See https://react-hook-form.com/api/usefieldarray
@@ -38,7 +48,7 @@ export const FormFields = ({
 
       return acc
     }, {})
-  }, [formFields])
+  }, [augmentedFormFields])
 
   const formMethods = useForm({
     defaultValues: defaultFormValues,
@@ -53,7 +63,7 @@ export const FormFields = ({
           <VisibleFormFields
             colorTheme={colorTheme}
             control={formMethods.control}
-            formFields={formFields}
+            formFields={augmentedFormFields}
             formLogics={formLogics}
           />
           <Button

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Box, Flex, Spacer } from '@chakra-ui/react'
 
-import { FormAuthType, FormColorTheme } from '~shared/types/form/form'
+import { FormAuthType } from '~shared/types/form/form'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
@@ -13,20 +13,14 @@ import { FormSectionsProvider } from './FormSectionsContext'
 import { SectionSidebar } from './SectionSidebar'
 
 export const FormFieldsContainer = (): JSX.Element => {
-  const { form, spcpSession, isLoading, handleSubmitForm, submissionId } =
-    usePublicFormContext()
-
-  const bgColour = useMemo(() => {
-    if (isLoading) return 'neutral.100'
-    if (!form) return ''
-    const { colorTheme } = form.startPage
-    switch (colorTheme) {
-      case FormColorTheme.Blue:
-        return 'secondary.100'
-      default:
-        return `theme-${colorTheme}.100`
-    }
-  }, [form, isLoading])
+  const {
+    form,
+    spcpSession,
+    isLoading,
+    handleSubmitForm,
+    submissionId,
+    formBgColor,
+  } = usePublicFormContext()
 
   const isAuthRequired = useMemo(
     () => form && form.authType !== FormAuthType.NIL && !spcpSession,
@@ -65,7 +59,7 @@ export const FormFieldsContainer = (): JSX.Element => {
 
   return (
     <FormSectionsProvider form={form}>
-      <Flex bg={bgColour} flex={1} justify="center" p="1.5rem">
+      <Flex bg={formBgColor} flex={1} justify="center" p="1.5rem">
         {isAuthRequired ? null : <SectionSidebar />}
         <Box
           bg="white"

--- a/frontend/src/features/public-form/components/FormFields/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/FormFields/SectionSidebar.tsx
@@ -25,7 +25,7 @@ export const SectionSidebar = (): JSX.Element => {
   }, [miniHeaderRef?.current?.clientHeight])
 
   const scrollData = useMemo(() => {
-    if (!form) return
+    if (!form) return []
     const sections: SidebarSectionMeta[] = []
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
@@ -39,7 +39,11 @@ export const SectionSidebar = (): JSX.Element => {
   }, [form])
 
   return (
-    <Box flex={1} d={{ base: 'none', md: 'initial' }} minW="20%">
+    <Box
+      flex={1}
+      d={{ base: 'none', md: 'initial' }}
+      minW={scrollData.length > 0 ? '20%' : undefined}
+    >
       <VStack
         pos="sticky"
         top={sectionTopOffset}

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -1,0 +1,41 @@
+import { chakra, Divider, Flex, Link, Stack, Text } from '@chakra-ui/react'
+
+import { ReactComponent as BrandLogoSvg } from '~assets/svgs/brand/brand-hort-colour.svg'
+
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
+const BrandLogo = chakra(BrandLogoSvg, {
+  baseStyle: {
+    h: '1.5rem',
+    mt: '1rem',
+  },
+})
+
+/**
+ * @precondition Must be nested inside `PublicFormProvider`
+ */
+export const FormFooter = (): JSX.Element => {
+  const { formBgColor } = usePublicFormContext()
+
+  return (
+    <Stack
+      bg={formBgColor}
+      direction="column"
+      spacing="1.5rem"
+      align="center"
+      pb="1.5rem"
+    >
+      <Divider w="15rem" />
+      <Flex flexDir="column" align="center">
+        <Text textStyle="caption-1" color="secondary.400">
+          Created with
+        </Text>
+        <BrandLogo />
+      </Flex>
+      <Stack direction="row" spacing="1.5rem">
+        <Link textStyle="body-2">Terms of Use</Link>
+        <Link textStyle="body-2">Privacy Policy</Link>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -1,4 +1,4 @@
-import { chakra, Divider, Flex, Link, Stack, Text } from '@chakra-ui/react'
+import { Box, chakra, Divider, Flex, Link, Stack, Text } from '@chakra-ui/react'
 
 import { ReactComponent as BrandLogoSvg } from '~assets/svgs/brand/brand-hort-colour.svg'
 
@@ -15,7 +15,7 @@ const BrandLogo = chakra(BrandLogoSvg, {
  * @precondition Must be nested inside `PublicFormProvider`
  */
 export const FormFooter = (): JSX.Element => {
-  const { formBgColor } = usePublicFormContext()
+  const { formBgColor, captchaContainerId } = usePublicFormContext()
 
   return (
     <Stack
@@ -36,6 +36,7 @@ export const FormFooter = (): JSX.Element => {
         <Link textStyle="body-2">Terms of Use</Link>
         <Link textStyle="body-2">Privacy Policy</Link>
       </Stack>
+      <Box id={captchaContainerId} />
     </Stack>
   )
 }

--- a/frontend/src/features/public-form/components/FormFooter/index.ts
+++ b/frontend/src/features/public-form/components/FormFooter/index.ts
@@ -1,0 +1,1 @@
+export { FormFooter } from './FormFooter'

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -23,9 +23,6 @@ interface UseRecaptchaProps extends RecaptchaBaseConfig {
   id?: string
   useRecaptchaNet?: boolean
   useEnterprise?: boolean
-  onChange?: (response: string | null) => void
-  onExpiry?: () => void
-  onError?: () => void
 }
 
 type RecaptchaConfig = RecaptchaBaseConfig & {
@@ -73,9 +70,6 @@ export const useRecaptcha = ({
   id: containerId = DEFAULT_CONTAINER_ID,
   sitekey,
   theme,
-  onChange,
-  onExpiry,
-  onError,
   useEnterprise = true,
   badge = 'inline',
   size = 'invisible',
@@ -102,33 +96,24 @@ export const useRecaptcha = ({
     !sitekey || hasLoaded ? null : 500,
   )
 
-  const handleChange = useCallback(
-    (response: string | null) => {
-      onChange?.(response)
-      if (executionPromise.current.resolve) {
-        executionPromise.current.resolve(response)
-        executionPromise.current = {}
-      }
-    },
-    [onChange],
-  )
+  const handleChange = useCallback((response: string | null) => {
+    if (executionPromise.current.resolve) {
+      executionPromise.current.resolve(response)
+      executionPromise.current = {}
+    }
+  }, [])
 
   const handleError = useCallback(() => {
-    onError?.()
     if (executionPromise.current?.reject) {
       executionPromise.current.reject()
       executionPromise.current = {}
     }
-  }, [onError])
+  }, [])
 
   const handleExpiry = useCallback(() => {
     grecaptcha?.reset(widgetId)
-    if (onExpiry) {
-      onExpiry()
-    } else {
-      handleChange(null)
-    }
-  }, [grecaptcha, handleChange, onExpiry, widgetId])
+    handleChange(null)
+  }, [grecaptcha, handleChange, widgetId])
 
   useEffect(() => {
     if (sitekey && hasLoaded && widgetId === undefined) {

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -131,7 +131,7 @@ export const useRecaptcha = ({
   }, [grecaptcha, handleChange, onExpiry, widgetId])
 
   useEffect(() => {
-    if (hasLoaded && widgetId === undefined) {
+    if (sitekey && hasLoaded && widgetId === undefined) {
       const renderProps = {
         sitekey,
         size,

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -1,0 +1,180 @@
+// Hook to load the reCAPTCHA script.
+// No other package works for our enterprise use case, so this hook is written with reference from
+// https://github.com/tomliangg/react-hook-recaptcha,
+// https://github.com/sarneeh/reaptcha, and
+// https://github.com/dozoisch/react-google-recaptcha.
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useInterval } from '@chakra-ui/react'
+
+import { useScript } from '~hooks/useScript'
+
+type RecaptchaBaseConfig = {
+  sitekey?: string
+  theme?: 'light' | 'dark'
+  size?: 'compact' | 'normal' | 'invisible'
+  badge?: 'bottomright' | 'bottomleft' | 'inline'
+  tabindex?: number
+  hl?: string
+  isolated?: boolean
+}
+
+interface UseRecaptchaProps extends RecaptchaBaseConfig {
+  /** id of container to load reCaptcha in. If not provided, one will be generated */
+  id?: string
+  useRecaptchaNet?: boolean
+  useEnterprise?: boolean
+  onChange?: (response: string | null) => void
+  onExpiry?: () => void
+  onError?: () => void
+}
+
+type RecaptchaConfig = RecaptchaBaseConfig & {
+  callback?: (response: string) => void
+  'expired-callback'?: () => void
+  'error-callback'?: () => void
+}
+
+type GrecaptchaCallbacks = {
+  ready: (callback: () => void) => void
+  render: (container?: string, config?: RecaptchaConfig) => number
+  reset: (id?: number) => void
+  execute: (id?: number) => void
+  getResponse: (id?: number) => string
+}
+
+export type Grecaptcha = GrecaptchaCallbacks & {
+  enterprise: GrecaptchaCallbacks
+}
+
+declare global {
+  interface Window {
+    grecaptcha?: Grecaptcha
+  }
+}
+
+const getRecaptchaUrl = ({
+  useEnterprise,
+  useRecaptchaNet,
+}: Pick<UseRecaptchaProps, 'useEnterprise' | 'useRecaptchaNet'>) => {
+  const hostname = useRecaptchaNet ? 'recaptcha.net' : 'www.google.com'
+  return `https://${hostname}/recaptcha/${
+    useEnterprise ? 'enterprise' : 'api'
+  }.js?render=explicit`
+}
+
+type GreptchaExecutionCallback = {
+  resolve?: (response: string | null) => void
+  reject?: (reason?: unknown) => void
+}
+
+const DEFAULT_CONTAINER_ID = 'recaptcha-container'
+
+export const useRecaptcha = ({
+  id: containerId = DEFAULT_CONTAINER_ID,
+  sitekey,
+  theme,
+  onChange,
+  onExpiry,
+  onError,
+  useEnterprise = true,
+  badge = 'inline',
+  size = 'invisible',
+  useRecaptchaNet,
+}: UseRecaptchaProps) => {
+  useScript(getRecaptchaUrl({ useEnterprise, useRecaptchaNet }))
+
+  const grecaptcha: GrecaptchaCallbacks | undefined = useEnterprise
+    ? window.grecaptcha?.enterprise
+    : window.grecaptcha
+
+  const [hasLoaded, setHasLoaded] = useState(grecaptcha?.render ? true : false)
+  const [widgetId, setWidgetId] = useState<number>()
+
+  const executionPromise = useRef<GreptchaExecutionCallback>({})
+
+  useInterval(
+    () => {
+      if (grecaptcha?.render) {
+        setHasLoaded(true)
+      }
+    },
+    // Do not even start if sitekey is not provided
+    !sitekey || hasLoaded ? null : 500,
+  )
+
+  const handleChange = useCallback(
+    (response: string | null) => {
+      onChange?.(response)
+      if (executionPromise.current.resolve) {
+        executionPromise.current.resolve(response)
+        executionPromise.current = {}
+      }
+    },
+    [onChange],
+  )
+
+  const handleError = useCallback(() => {
+    onError?.()
+    if (executionPromise.current?.reject) {
+      executionPromise.current.reject()
+      executionPromise.current = {}
+    }
+  }, [onError])
+
+  const handleExpiry = useCallback(() => {
+    grecaptcha?.reset(widgetId)
+    if (onExpiry) {
+      onExpiry()
+    } else {
+      handleChange(null)
+    }
+  }, [grecaptcha, handleChange, onExpiry, widgetId])
+
+  useEffect(() => {
+    if (hasLoaded && widgetId === undefined) {
+      const renderProps = {
+        sitekey,
+        size,
+        theme,
+        badge,
+        callback: handleChange,
+        'expired-callback': handleExpiry,
+        'error-callback': handleError,
+      }
+      const widget = grecaptcha?.render(containerId, renderProps)
+      setWidgetId(widget)
+    }
+  }, [
+    hasLoaded,
+    widgetId,
+    containerId,
+    sitekey,
+    size,
+    theme,
+    badge,
+    handleChange,
+    handleExpiry,
+    handleError,
+    useEnterprise,
+    grecaptcha,
+  ])
+
+  /**
+   * Executes reCAPTCHA asynchronously.
+   * @returns captcha response if available, null if not instantiated.
+   */
+  const getCaptchaResponse = useCallback(async () => {
+    if (!grecaptcha || widgetId === undefined) return Promise.resolve(null)
+
+    return new Promise<string | null>((resolve, reject) => {
+      executionPromise.current = { resolve, reject }
+      return grecaptcha.execute(widgetId)
+    })
+  }, [grecaptcha, widgetId])
+
+  return {
+    hasLoaded,
+    getCaptchaResponse,
+    containerId,
+  }
+}

--- a/frontend/src/hooks/useScript.ts
+++ b/frontend/src/hooks/useScript.ts
@@ -1,0 +1,74 @@
+// Dynamically load an external script in one line with this React hook.
+// This can be useful to integrate a third party library like Google Analytics or Stripe.
+// This avoids loading this script in the <head> </head> on all your pages if it is not necessary.
+// Retrieved from https://usehooks-ts.com/react-hook/use-script.
+
+import { useEffect, useState } from 'react'
+
+type Status = 'idle' | 'loading' | 'ready' | 'error'
+
+export const useScript = (src?: string): Status => {
+  const [status, setStatus] = useState<Status>(src ? 'loading' : 'idle')
+
+  useEffect(
+    () => {
+      if (!src) {
+        setStatus('idle')
+        return
+      }
+
+      // Fetch existing script element by src
+      // It may have been added by another instance of this hook
+      let script: HTMLScriptElement | null = document.querySelector(
+        `script[src="${src}"]`,
+      )
+
+      if (!script) {
+        // Create script
+        script = document.createElement('script')
+        script.src = src
+        script.async = true
+        script.setAttribute('data-status', 'loading')
+        // Add script to document body
+        document.body.appendChild(script)
+
+        // Store status in attribute on script
+        // This can be read by other instances of this hook
+        const setAttributeFromEvent = (event: Event) => {
+          script?.setAttribute(
+            'data-status',
+            event.type === 'load' ? 'ready' : 'error',
+          )
+        }
+
+        script.addEventListener('load', setAttributeFromEvent)
+        script.addEventListener('error', setAttributeFromEvent)
+      } else {
+        // Grab existing script status from attribute and set to state.
+        setStatus(script.getAttribute('data-status') as Status)
+      }
+
+      // Script event handler to update status in state
+      // Note: Even if the script already exists we still need to add
+      // event handlers to update the state for *this* hook instance.
+      const setStateFromEvent = (event: Event) => {
+        setStatus(event.type === 'load' ? 'ready' : 'error')
+      }
+
+      // Add event listeners
+      script.addEventListener('load', setStateFromEvent)
+      script.addEventListener('error', setStateFromEvent)
+
+      // Remove event listeners on cleanup
+      return () => {
+        if (script) {
+          script.removeEventListener('load', setStateFromEvent)
+          script.removeEventListener('error', setStateFromEvent)
+        }
+      }
+    },
+    [src], // Only re-run effect if script src changes
+  )
+
+  return status
+}

--- a/frontend/src/mocks/msw/handlers/env.ts
+++ b/frontend/src/mocks/msw/handlers/env.ts
@@ -4,7 +4,7 @@ import { ClientEnvVars } from '~shared/types/core'
 
 export const MOCK_ENVS: Partial<ClientEnvVars> = {
   logoBucketUrl: 'local-logo-bucket',
-  captchaPublicKey: 'mock-ga-tracking-id',
+  captchaPublicKey: 'mock-captcha-public-key',
 }
 
 export const envHandlers = [

--- a/frontend/src/mocks/msw/handlers/env.ts
+++ b/frontend/src/mocks/msw/handlers/env.ts
@@ -2,8 +2,9 @@ import { rest } from 'msw'
 
 import { ClientEnvVars } from '~shared/types/core'
 
-export const MOCK_ENVS = {
+export const MOCK_ENVS: Partial<ClientEnvVars> = {
   logoBucketUrl: 'local-logo-bucket',
+  captchaPublicKey: 'mock-ga-tracking-id',
 }
 
 export const envHandlers = [

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -329,7 +329,7 @@ const BASE_FORM = {
       ],
     },
   ],
-  hasCaptcha: true,
+  hasCaptcha: false,
   startPage: {
     colorTheme: 'blue',
     logo: { state: 'NONE' },

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -71,7 +71,7 @@ export type FormFieldWithId<T extends FormField = FormField> =
         _id: string
       }
 
-export type PossiblyPrefilledFormField<T extends FormField = FormField> =
+export type MyInfoFormField<T extends FormField = FormField> =
   FormFieldWithId<T> & {
     fieldValue?: string
   }
@@ -80,7 +80,7 @@ export type PossiblyPrefilledFormField<T extends FormField = FormField> =
  * Form field POJO with id
  */
 export type FormFieldDto<T extends FormField = FormField> =
-  | PossiblyPrefilledFormField<T>
+  | MyInfoFormField<T>
   | FormFieldWithId<T>
 
 export type FieldCreateDto = FormField


### PR DESCRIPTION
> Builds upon the ever growing chain of PRs related to submission epic tracked by #3570.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds reCAPTCHA support in public form submissions. 

**We are still using reCAPTCHA v2 instead of v3** since mo' version doesn't mean mo' better -- v2 validation returns a true/false score whilst v3 returns a continuous value for us to take action. v3 will require server changes and I don't think we need the supposed benefits v3 gives us (variable range of actions instead of true/false).

Closes #3434 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:

- feat: add useRecaptcha custom hook
- feat: set up recaptcha in PublicFormProvider and render recaptcha container in FormFooter
- feat: retrieve captcha response from captcha before submitting

**Improvements**:

- feat: pass down formBgColor prop from PublicFormContext so bg colour can be shared across public form components.
- feat: add FormFooter component (note that this is cherry picked from #3609)
- feat: remove public form section min-width if there are no sections (also cherry picked from #3609)

## Before & After Screenshots
FormFooter is now displayed in PublicFormPage. Otherwise no additional changes.
