### PR TITLE
feat(v2/submit-8): add prefilling of data when user logs in with MyInfo on public forms

### DIFF
--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -10,6 +10,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
   Text,
+  useFormControlProps,
 } from '@chakra-ui/react'
 import { ComponentWithAs, forwardRef } from '@chakra-ui/system'
 import { format } from 'date-fns'
@@ -34,7 +35,18 @@ type DateInputWithSubcomponents = ComponentWithAs<'input', DateInputProps> & {
 }
 
 export const DateInput = forwardRef<DateInputProps, 'input'>(
-  ({ onChange, value = '', isDateUnavailable, ...props }, ref) => {
+  (
+    {
+      onChange,
+      value = '',
+      isDateUnavailable,
+      isDisabled: isDisabledProp,
+      ...props
+    },
+    ref,
+  ) => {
+    const { isDisabled } = useFormControlProps({ isDisabled: isDisabledProp })
+
     const initialFocusRef = useRef<HTMLInputElement>(null)
 
     const handleDatepickerSelection = useCallback(
@@ -92,6 +104,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   onChange={(e) => onChange?.(e.target.value)}
                   ref={ref}
                   value={value}
+                  isDisabled={isDisabled}
                   {...props}
                 />
               </PopoverAnchor>
@@ -102,6 +115,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   variant="inputAttached"
                   borderRadius={0}
                   isActive={isOpen}
+                  isDisabled={isDisabled}
                 />
               </PopoverTrigger>
               <PopoverContent

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -41,11 +41,19 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
       value = '',
       isDateUnavailable,
       isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+      isInvalid: isInvalidProp,
       ...props
     },
     ref,
   ) => {
-    const { isDisabled } = useFormControlProps({ isDisabled: isDisabledProp })
+    const fcProps = useFormControlProps({
+      isInvalid: isInvalidProp,
+      isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+    })
 
     const initialFocusRef = useRef<HTMLInputElement>(null)
 
@@ -104,8 +112,8 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   onChange={(e) => onChange?.(e.target.value)}
                   ref={ref}
                   value={value}
-                  isDisabled={isDisabled}
                   {...props}
+                  {...fcProps}
                 />
               </PopoverAnchor>
               <PopoverTrigger>
@@ -115,7 +123,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   variant="inputAttached"
                   borderRadius={0}
                   isActive={isOpen}
-                  isDisabled={isDisabled}
+                  isDisabled={fcProps.isDisabled || fcProps.isReadOnly}
                 />
               </PopoverTrigger>
               <PopoverContent

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { FormControlOptions, useMultiStyleConfig } from '@chakra-ui/react'
+import {
+  FormControlOptions,
+  useFormControlProps,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
 import { useCombobox, UseComboboxProps } from 'downshift'
 
 import { useItems } from '../hooks/useItems'
@@ -41,16 +45,25 @@ export const SingleSelectProvider = ({
   isClearable = true,
   isSearchable = true,
   initialIsOpen,
-  isInvalid,
-  isReadOnly,
-  isDisabled,
-  isRequired,
+  isInvalid: isInvalidProp,
+  isReadOnly: isReadOnlyProp,
+  isDisabled: isDisabledProp,
+  isRequired: isRequiredProp,
   children,
   inputAria: inputAriaProp,
   comboboxProps = {},
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
+
+  const { isInvalid, isDisabled, isReadOnly, isRequired } = useFormControlProps(
+    {
+      isInvalid: isInvalidProp,
+      isDisabled: isDisabledProp,
+      isReadOnly: isReadOnlyProp,
+      isRequired: isRequiredProp,
+    },
+  )
 
   const placeholder = useMemo(() => {
     if (placeholderProp === null) return ''

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
@@ -8,6 +8,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
   const {
     isClearable,
     isDisabled,
+    isReadOnly,
     clearButtonLabel,
     selectItem,
     styles,
@@ -23,7 +24,7 @@ export const ComboboxClearButton = (): JSX.Element | null => {
     <chakra.button
       // Prevent form submission from triggering this button.
       type="button"
-      disabled={isDisabled}
+      disabled={isDisabled || isReadOnly}
       aria-label={clearButtonLabel}
       onClick={handleClearSelection}
       __css={styles.clearbutton}

--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -79,7 +79,11 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            <Text textStyle="body-1" isTruncated>
+            <Text
+              textStyle="body-1"
+              isTruncated
+              color={isDisabled ? 'neutral.500' : undefined}
+            >
               {selectedItemMeta.label}
             </Text>
           </Stack>

--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react'
+import { forwardRef, useCallback, useMemo } from 'react'
 import {
   Flex,
   Icon,
@@ -44,6 +44,11 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       }),
       [selectedItem],
     )
+
+    const handleToggleMenu = useCallback(() => {
+      if (isReadOnly || isDisabled) return
+      return toggleMenu()
+    }, [isDisabled, isReadOnly, toggleMenu])
 
     return (
       <Flex>
@@ -94,7 +99,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             placeholder={selectedItem ? undefined : placeholder}
             sx={styles.field}
             {...getInputProps({
-              onClick: toggleMenu,
+              onClick: handleToggleMenu,
               onBlur: () => !isOpen && resetInputValue(),
               ref,
               'aria-describedby': inputAria.id,

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -6,15 +6,17 @@ import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
 import { useSelectContext } from '../../SelectContext'
 
 export const ToggleChevron = (): JSX.Element => {
-  const { isOpen, getToggleButtonProps, isDisabled, styles } =
+  const { isOpen, getToggleButtonProps, isDisabled, isReadOnly, styles } =
     useSelectContext()
 
   return (
-    <InputRightElement {...getToggleButtonProps({ disabled: isDisabled })}>
+    <InputRightElement
+      {...getToggleButtonProps({ disabled: isDisabled || isReadOnly })}
+    >
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-disabled={isDisabled}
+        aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>
   )

--- a/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
+++ b/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
@@ -1,0 +1,24 @@
+import { keyBy } from 'lodash'
+
+import { types as myInfoTypeArray } from '~shared/constants/field/myinfo'
+import { BasicField, FormFieldDto, MyInfoFormField } from '~shared/types/field'
+
+const MAP_ATTR_TO_NAME = keyBy(myInfoTypeArray, 'name')
+
+// Making a copy by destructuring so original object does not get affected.
+export const augmentWithMyInfo = ({
+  ...field
+}: FormFieldDto): MyInfoFormField => {
+  // Only dropdown fields have augmented options for now.
+  switch (field.fieldType) {
+    case BasicField.Dropdown: {
+      // No need to augment if no MyInfo attribute
+      if (!field.myInfo?.attr) return field
+      const myInfoBlock = MAP_ATTR_TO_NAME[field.myInfo.attr]
+      field.fieldOptions = myInfoBlock.fieldOptions ?? []
+      return field
+    }
+    default:
+      return field
+  }
+}

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -9,6 +9,8 @@ import { FormColorTheme, LogicDto } from '~shared/types/form'
 import Button from '~components/Button'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
+import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
+
 import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
@@ -24,10 +26,18 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-  // TODO: Cleanup messy code
-  // TODO: Inject default values if field is MyInfo, or prefilled.
+  // TODO: Inject default values is field is also prefilled.
+  const augmentedFormFields = useMemo(
+    () => formFields.map(augmentWithMyInfo),
+    [formFields],
+  )
+
   const defaultFormValues = useMemo(() => {
-    return formFields.reduce<FieldValues>((acc, field) => {
+    return augmentedFormFields.reduce<FieldValues>((acc, field) => {
+      if (field.fieldValue !== undefined) {
+        acc[field._id] = field.fieldValue
+        return acc
+      }
       switch (field.fieldType) {
         // Required so table column fields will render due to useFieldArray usage.
         // See https://react-hook-form.com/api/usefieldarray
@@ -38,7 +48,7 @@ export const FormFields = ({
 
       return acc
     }, {})
-  }, [formFields])
+  }, [augmentedFormFields])
 
   const formMethods = useForm({
     defaultValues: defaultFormValues,
@@ -53,7 +63,7 @@ export const FormFields = ({
           <VisibleFormFields
             colorTheme={colorTheme}
             control={formMethods.control}
-            formFields={formFields}
+            formFields={augmentedFormFields}
             formLogics={formLogics}
           />
           <Button

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -71,7 +71,7 @@ export type FormFieldWithId<T extends FormField = FormField> =
         _id: string
       }
 
-export type PossiblyPrefilledFormField<T extends FormField = FormField> =
+export type MyInfoFormField<T extends FormField = FormField> =
   FormFieldWithId<T> & {
     fieldValue?: string
   }
@@ -80,7 +80,7 @@ export type PossiblyPrefilledFormField<T extends FormField = FormField> =
  * Form field POJO with id
  */
 export type FormFieldDto<T extends FormField = FormField> =
-  | PossiblyPrefilledFormField<T>
+  | MyInfoFormField<T>
   | FormFieldWithId<T>
 
 export type FieldCreateDto = FormField


### PR DESCRIPTION
> Builds upon the ever growing chain of PRs related to submission epic tracked by https://github.com/opengovsg/FormSG/issues/3570.

> Note that I am unable to test this without mocking API shapes yet due to hardcoded MyInfo routes, and I have not updated the redirect URLs to go back to the React application.
> Code has been tested with `msw` mocks where the expected MyInfo prefilled shapes are returned.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This PR prefills form fields with values retrieved from MyInfo when server returns us fields with pre-filled values.
Also fixed a bug where Date and Dropdown fields were not correctly disabled when field itself is marked as disabled.

Closes #3602.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:

- feat(myinfo): add augmentWithMyInfo fn to inject MyInfo field options
- feat(FormFields): augment form fields with MyInfo dropdown options

**Improvements**:

- feat: add readOnly styling to Date and Dropdown fields

**Bug Fixes**:

- fix: correctly disable Dropdown and Date fields when field is disabled

