### PR TITLE
feat: append new field to form on click

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -88,10 +88,10 @@ export const FieldRowContainer = ({
     return false
   }, [stateData, field])
 
-  const activeFieldRef = useRef<HTMLDivElement | null>(null)
+  const ref = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
     if (isActive) {
-      activeFieldRef.current?.scrollIntoView({
+      ref.current?.scrollIntoView({
         // Avoid sudden jump when field is clicked
         block: 'nearest',
         // Also avoid behavior: 'smooth' as scrolling may take very long
@@ -182,7 +182,7 @@ export const FieldRowContainer = ({
             align="center"
             onClick={handleFieldClick}
             onKeyDown={handleKeydown}
-            ref={isActive ? activeFieldRef : undefined}
+            ref={ref}
           >
             <Fade in={isActive}>
               <chakra.button

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { FormProvider, useForm } from 'react-hook-form'
 import {
@@ -71,6 +71,7 @@ export const FieldRowContainer = ({
         [],
       ),
     )
+
   const { handleBuilderClick } = useCreatePageSidebar()
 
   const { duplicateFieldMutation } = useDuplicateFormField()
@@ -86,6 +87,18 @@ export const FieldRowContainer = ({
     }
     return false
   }, [stateData, field])
+
+  const activeFieldRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (isActive) {
+      activeFieldRef.current?.scrollIntoView({
+        // Avoid sudden jump when field is clicked
+        block: 'nearest',
+        // Also avoid behavior: 'smooth' as scrolling may take very long
+        // on long forms
+      })
+    }
+  }, [isActive])
 
   const handleFieldClick = useCallback(() => {
     if (!isActive) {
@@ -169,6 +182,7 @@ export const FieldRowContainer = ({
             align="center"
             onClick={handleFieldClick}
             onKeyDown={handleKeydown}
+            ref={isActive ? activeFieldRef : undefined}
           >
             <Fade in={isActive}>
               <chakra.button

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
@@ -1,10 +1,17 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { Box, BoxProps, forwardRef, Icon, Stack, Text } from '@chakra-ui/react'
 
 import { BasicField } from '~shared/types/field'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
+
+import {
+  updateCreateStateSelector,
+  useBuilderAndDesignStore,
+} from '../../useBuilderAndDesignStore'
+import { useCreateTabForm } from '../../useCreateTabForm'
+import { getFieldCreationMeta } from '../../utils/fieldCreation'
 
 interface FieldOptionProps extends BoxProps {
   isActive?: boolean
@@ -62,6 +69,21 @@ export const FieldListOption = forwardRef<FieldOptionProps, 'button'>(
       () => BASICFIELD_TO_DRAWER_META[fieldType],
       [fieldType],
     )
+    const { data: form } = useCreateTabForm()
+    const numFields = useMemo(() => form?.form_fields?.length ?? 0, [form])
+
+    const newFieldMeta = useMemo(
+      () => getFieldCreationMeta(fieldType),
+      [fieldType],
+    )
+
+    const updateCreateState = useBuilderAndDesignStore(
+      updateCreateStateSelector,
+    )
+
+    const handleClick = useCallback(() => {
+      updateCreateState(newFieldMeta, numFields)
+    }, [newFieldMeta, numFields, updateCreateState])
 
     return (
       <Box
@@ -82,6 +104,7 @@ export const FieldListOption = forwardRef<FieldOptionProps, 'button'>(
         bg="white"
         {...props}
         ref={ref}
+        onClick={handleClick}
       >
         <Stack
           py="1rem"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, fields can only be added through drag and drop. We also want users to be able to simply click on fields to append them to the end of the form.

## Solution
<!-- How did you solve the problem? -->

Implement field creation on click, and also scroll the new field into view when it is created.

## Screenshots
### Before (no action on click)
![field-option-before](https://user-images.githubusercontent.com/29480346/161468542-6fa8c0b9-fe23-4e7b-8690-128cf8e0b0b1.gif)


### After
![field-option-after](https://user-images.githubusercontent.com/29480346/161468553-76006271-dbe7-441d-8ab2-cd3bf0979f0a.gif)

