### PR TITLE
fix: update ports for maildev to 1080 and 1025

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - SECRET_ENV=development
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60
-      - SES_PORT=25
+      - SES_PORT=1025
       - SES_HOST=maildev
       - WEBHOOK_SQS_URL=http://localhost:4566/000000000000/local-webhooks-sqs-main
       - INTRANET_IP_LIST_PATH
@@ -135,9 +135,9 @@ services:
       driver: none
 
   maildev:
-    image: maildev/maildev:1.1.0
+    image: maildev/maildev
     ports:
-      - '1080:80'
+      - '1080:1080'
 
 volumes:
   mongodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       driver: none
 
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:1.1.0
     ports:
       - '1080:80'
 


### PR DESCRIPTION
## Context
[maildev](https://hub.docker.com/r/maildev/maildev) has released a new docker image on 2022-03-30, which changed the internal app ports.

The smtp server now runs on port 1025 (was 25), the web interface runs in port 1080 (was 80). This was done on purpose in [this PR](https://github.com/maildev/maildev/pull/281).

This change in port causes the docker setup for FormSG to break since the app can't connect to the mail server, and so the ports need to be updated.

## Approach

Update both the web app and smtp port for maildev.

The PR targets branch `develop`, and we can merge `develop` into `form-v2/develop` later.