### PR TITLE
Conditional React Routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - SECRET_ENV=development
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60
-      - SES_PORT=25
+      - SES_PORT=1025
       - SES_HOST=maildev
       - WEBHOOK_SQS_URL=http://localhost:4566/000000000000/local-webhooks-sqs-main
       - INTRANET_IP_LIST_PATH
@@ -134,9 +134,9 @@ services:
       driver: none
 
   maildev:
-    image: maildev/maildev:1.1.0
+    image: maildev/maildev
     ports:
-      - '1080:80'
+      - '1080:1080'
 
 volumes:
   mongodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       driver: none
 
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:1.1.0
     ports:
       - '1080:80'
 

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -224,6 +224,7 @@ const config: Config = {
   siteBannerContent: basicVars.banner.siteBannerContent,
   adminBannerContent: basicVars.banner.adminBannerContent,
   rateLimitConfig: basicVars.rateLimit,
+  reactMigrationConfig: basicVars.reactMigration,
   configureAws,
   secretEnv: basicVars.core.secretEnv,
 }

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -291,11 +291,17 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
     },
   },
   reactMigration: {
-    respondentRollout: {
-      doc: 'Percentage threshold to serve React for respondents',
+    respondentRolloutNoSPCP: {
+      doc: 'Percentage threshold to serve React for respondents for Phase 1 (NO SP/CP/MyInfo)',
       format: 'int',
       default: 0,
-      env: 'REACT_MIGRATION_RESPONDENT_ROLLOUT',
+      env: 'REACT_MIGRATION_RESP_ROLLOUT_NO_SPCP',
+    },
+    respondentRolloutSPCP: {
+      doc: 'Percentage threshold to serve React for respondents for Phase 2 (WITH SP/CP/MyInfo)',
+      format: 'int',
+      default: 0,
+      env: 'REACT_MIGRATION_RESP_ROLLOUT_SPCP',
     },
     adminRollout: {
       doc: 'Percentage threshold to serve React for admins',

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -292,13 +292,13 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
   },
   reactMigration: {
     respondentRollout: {
-      doc: 'Percentage threshold to to serve React for respondents',
+      doc: 'Percentage threshold to serve React for respondents',
       format: 'int',
       default: 0,
       env: 'REACT_MIGRATION_RESPONDENT_ROLLOUT',
     },
     adminRollout: {
-      doc: 'Percentage threshold to to serve React for respondents',
+      doc: 'Percentage threshold to serve React for admins',
       format: 'int',
       default: 0,
       env: 'REACT_MIGRATION_ADMIN_ROLLOUT',

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -290,6 +290,20 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       env: 'SEND_AUTH_OTP_RATE_LIMIT',
     },
   },
+  reactMigration: {
+    respondentRollout: {
+      doc: 'Percentage threshold to to serve React for respondents',
+      format: 'int',
+      default: 0,
+      env: 'REACT_MIGRATION_RESPONDENT_ROLLOUT',
+    },
+    adminRollout: {
+      doc: 'Percentage threshold to to serve React for respondents',
+      format: 'int',
+      default: 0,
+      env: 'REACT_MIGRATION_ADMIN_ROLLOUT',
+    },
+  },
 }
 
 export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {
@@ -330,10 +344,10 @@ export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {
           database: 'formsg',
           hosts: [ { host: 'database', port: 27017 } ]
         }
-        e.g. https://form.gov.sg will be parsed into: 
-        { 
-          scheme: 'https', 
-          hosts: [ { host: 'form.gov.sg' } ] 
+        e.g. https://form.gov.sg will be parsed into:
+        {
+          scheme: 'https',
+          hosts: [ { host: 'form.gov.sg' } ]
         }
       */
       if (uriObject.scheme !== 'mongodb') {

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -8,7 +8,6 @@ import { Connection } from 'mongoose'
 import path from 'path'
 import url from 'url'
 
-import { Environment } from '../../../types'
 import config from '../../config/config'
 import { AnalyticsRouter } from '../../modules/analytics/analytics.routes'
 import { AuthRouter } from '../../modules/auth/auth.routes'
@@ -161,11 +160,9 @@ const loadExpressApp = async (connection: Connection) => {
   app.use('/public', express.static(path.resolve('dist/angularjs')))
   app.get('/old/', HomeController.home)
 
-  console.log('setting up migration router')
-  app.use(ReactMigrationRouter)
+  app.use('/', ReactMigrationRouter)
 
   app.use(sentryMiddlewares())
-
   app.use(errorHandlerMiddlewares())
 
   const server = http.createServer(app)

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -151,7 +151,7 @@ const loadExpressApp = async (connection: Connection) => {
   // Use constant for registered routes with MyInfo servers
   app.use(MYINFO_ROUTER_PREFIX, MyInfoRouter)
 
-  app.user(ReactMigrationRouter)
+  app.use(ReactMigrationRouter)
 
   app.use(AdminFormsRouter)
   app.use(PublicFormRouter)

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -156,7 +156,7 @@ const loadExpressApp = async (connection: Connection) => {
   // New routes in preparation for API refactor.
   app.use('/api', ApiRouter)
 
-  app.use(express.static(path.resolve('dist/frontend')))
+  app.use(express.static(path.resolve('dist/frontend'), { index: false }))
   app.use('/public', express.static(path.resolve('dist/angularjs')))
   app.get('/old/', HomeController.home)
 

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -151,34 +151,18 @@ const loadExpressApp = async (connection: Connection) => {
   // Use constant for registered routes with MyInfo servers
   app.use(MYINFO_ROUTER_PREFIX, MyInfoRouter)
 
-  app.use(ReactMigrationRouter)
-
   app.use(AdminFormsRouter)
   app.use(PublicFormRouter)
 
   // New routes in preparation for API refactor.
   app.use('/api', ApiRouter)
 
-  // Serve static client files only in prod
-  // This block must be after all our routes, since the React application is
-  // served in a catchall route.
-  if (config.nodeEnv === Environment.Prod) {
-    const frontendPath = path.resolve('dist/frontend')
-    app.use(express.static(frontendPath))
+  app.use(express.static(path.resolve('dist/frontend')))
+  app.use('/public', express.static(path.resolve('dist/angularjs')))
+  app.get('/old/', HomeController.home)
 
-    app.get('*', (_req, res) => {
-      res.sendFile(path.join(frontendPath, 'index.html'))
-    })
-  }
-
-  if (config.nodeEnv === Environment.Dev) {
-    app.use(
-      '/public/fonts',
-      express.static(path.resolve('./dist/angularjs/fonts')),
-    )
-    app.use('/public', express.static(path.resolve('./dist/angularjs')))
-    app.get('/old/', HomeController.home)
-  }
+  console.log('setting up migration router')
+  app.use(ReactMigrationRouter)
 
   app.use(sentryMiddlewares())
 

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -21,6 +21,7 @@ import { FrontendRouter } from '../../modules/frontend/frontend.routes'
 import * as HomeController from '../../modules/home/home.controller'
 import { MYINFO_ROUTER_PREFIX } from '../../modules/myinfo/myinfo.constants'
 import { MyInfoRouter } from '../../modules/myinfo/myinfo.routes'
+import { ReactMigrationRouter } from '../../modules/react-migration/react-migration.routes'
 import { SgidRouter } from '../../modules/sgid/sgid.routes'
 import {
   CorppassLoginRouter,
@@ -149,6 +150,9 @@ const loadExpressApp = async (connection: Connection) => {
   app.use('/sgid', SgidRouter)
   // Use constant for registered routes with MyInfo servers
   app.use(MYINFO_ROUTER_PREFIX, MyInfoRouter)
+
+  app.user(ReactMigrationRouter)
+
   app.use(AdminFormsRouter)
   app.use(PublicFormRouter)
 

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -171,7 +171,6 @@ export const handleRedirect: ControllerHandler<
   unknown,
   Record<string, string>
 > = async (req, res) => {
-  console.log('handleRedirect')
   const { state, formId } = req.params
 
   let redirectPath = state ? `${formId}/${state}` : formId

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -171,9 +171,10 @@ export const handleRedirect: ControllerHandler<
   unknown,
   Record<string, string>
 > = async (req, res) => {
-  const { state, Id } = req.params
+  console.log('handleRedirect')
+  const { state, formId } = req.params
 
-  let redirectPath = state ? `${Id}/${state}` : Id
+  let redirectPath = state ? `${formId}/${state}` : formId
   const queryString = querystring.stringify(req.query)
   if (queryString.length > 0) {
     redirectPath = redirectPath + '?' + encodeURIComponent(queryString)
@@ -183,7 +184,7 @@ export const handleRedirect: ControllerHandler<
   const appUrl = baseUrl + req.originalUrl
 
   const createMetatagsResult = await PublicFormService.createMetatags({
-    formId: Id,
+    formId,
     appUrl,
     imageBaseUrl: baseUrl,
   })

--- a/src/app/modules/form/public-form/public-form.routes.ts
+++ b/src/app/modules/form/public-form/public-form.routes.ts
@@ -43,7 +43,7 @@ PublicFormRouter.get(
  * through the main index, with the form ID specified as a hashbang path
  */
 PublicFormRouter.get(
-  '/:formId([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
+  '/:formId([a-fA-F0-9]{24})/:state(preview|template|use-template)',
   PublicFormController.handleRedirect,
 )
 

--- a/src/app/modules/form/public-form/public-form.routes.ts
+++ b/src/app/modules/form/public-form/public-form.routes.ts
@@ -43,22 +43,22 @@ PublicFormRouter.get(
  * through the main index, with the form ID specified as a hashbang path
  */
 PublicFormRouter.get(
-  '/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
+  '/:formId([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
   PublicFormController.handleRedirect,
 )
 
 PublicFormRouter.get(
-  '/:Id([a-fA-F0-9]{24})/embed',
+  '/:formId([a-fA-F0-9]{24})/embed',
   PublicFormController.handleRedirect,
 )
 
 PublicFormRouter.get(
-  '/forms/:agency/:Id([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
+  '/forms/:agency/:formId([a-fA-F0-9]{24})/:state(preview|template|use-template)?',
   PublicFormController.handleRedirect,
 )
 
 PublicFormRouter.get(
-  '/forms/:agency/:Id([a-fA-F0-9]{24})/embed',
+  '/forms/:agency/:formId([a-fA-F0-9]{24})/embed',
   PublicFormController.handleRedirect,
 )
 

--- a/src/app/modules/form/public-form/public-form.types.ts
+++ b/src/app/modules/form/public-form/public-form.types.ts
@@ -9,5 +9,5 @@ export type Metatags = {
 export type RedirectParams = {
   state?: 'preview' | 'template' | 'use-template'
   // TODO(#144): Rename Id to formId after all routes have been updated.
-  Id: string
+  formId: string
 }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -16,7 +16,6 @@ export const RESPONDENT_COOKIE_OPTIONS = {
 }
 
 const serveFormReact: ControllerHandler = (_req, res) => {
-  console.log('serveFormReact 2')
   const reactFrontendPath = path.resolve('dist/frontend')
   res.sendFile(path.join(reactFrontendPath, 'index.html'))
 }
@@ -36,9 +35,6 @@ export const serveForm: ControllerHandler<
   unknown,
   Record<string, string>
 > = (req, res, next) => {
-  console.log('conditional routing 2')
-
-  // check cookies
   let showReact: boolean | undefined = undefined
 
   if (config.reactMigrationConfig.respondentRollout <= 0) {
@@ -72,7 +68,6 @@ export const serveForm: ControllerHandler<
 }
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
-  console.log('serveDefault')
   // only admin who chose react should see react, everybody else is plain angular
   if (req.cookies?.[ADMIN_COOKIE_NAME] === 'react') {
     // react

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -9,8 +9,19 @@ import * as HomeController from '../home/home.controller'
 const RESPONDENT_COOKIE_NAME = 'v2-respondent-ui'
 const ADMIN_COOKIE_NAME = 'v2-admin-ui'
 
+export type SetEnvironmentParams = {
+  ui: 'react' | 'angular'
+}
+
 export const RESPONDENT_COOKIE_OPTIONS = {
   httpOnly: true,
+  sameSite: 'strict' as const,
+  secure: !config.isDev,
+}
+
+export const ADMIN_COOKIE_OPTIONS = {
+  httpOnly: true,
+  maxAge: 365 * 24 * 60 * 60, // 1 year
   sameSite: 'strict' as const,
   secure: !config.isDev,
 }
@@ -76,4 +87,16 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     // angular
     HomeController.home(req, res, next)
   }
+}
+
+// Note: frontend is expected to refresh after executing this
+export const adminChooseEnvironment: ControllerHandler<
+  SetEnvironmentParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res) => {
+  const ui = req.params.ui === 'react' ? 'react' : 'angular'
+  res.cookie(ADMIN_COOKIE_NAME, ui, ADMIN_COOKIE_OPTIONS)
+  res.json({ ui })
 }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+
+import config from '../../config/config'
+import { ControllerHandler } from '../core/core.types'
+import * as PublicFormController from '../form/public-form/public-form.controller'
+import { RedirectParams } from '../form/public-form/public-form.types'
+// import * as HomeController from '../home/home.controller'
+
+const RESPONDENT_COOKIE_NAME = 'v2-respondent-ui'
+const ADMIN_COOKIE_NAME = 'v2-admin-ui'
+
+const REACT_ROLLOUT_THRESHOLD = 20 / 100
+
+export const RESPONDENT_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'strict' as const,
+  secure: !config.isDev,
+}
+
+const serveFormReact: ControllerHandler = (_req, res) => {
+  console.log('serveFormReact 2')
+  const reactFrontendPath = path.resolve('dist/frontend')
+  res.sendFile(path.join(reactFrontendPath, 'index.html'))
+}
+
+const serveFormAngular: ControllerHandler<
+  RedirectParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res, next) => {
+  PublicFormController.handleRedirect(req, res, next)
+}
+
+export const serveForm: ControllerHandler<
+  RedirectParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res, next) => {
+  console.log('conditional routing 2')
+
+  // check cookies
+  let showReact
+
+  if (req.cookies) {
+    if (ADMIN_COOKIE_NAME in req.cookies) {
+      showReact = req.cookies[ADMIN_COOKIE_NAME] === 'react'
+    } else if (RESPONDENT_COOKIE_NAME in req.cookies) {
+      showReact = req.cookies[RESPONDENT_COOKIE_NAME] === 'react'
+    }
+  }
+
+  if (showReact === undefined) {
+    const rand = Math.random()
+    showReact = rand < REACT_ROLLOUT_THRESHOLD
+
+    console.log('random assignment', rand, showReact)
+
+    res.cookie(
+      RESPONDENT_COOKIE_NAME,
+      showReact ? 'react' : 'angular',
+      RESPONDENT_COOKIE_OPTIONS,
+    )
+  }
+
+  if (showReact) {
+    serveFormReact(req, res, next)
+  } else {
+    serveFormAngular(req, res, next)
+  }
+}
+
+export const serveDefault: ControllerHandler = (req, res, next) => {
+  // only admin who chose react should see react, everybody else is plain angular
+  if (req.cookies?.[ADMIN_COOKIE_NAME] === 'react') {
+    // react
+  } else {
+    // angular
+  }
+}

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -41,7 +41,11 @@ export const serveForm: ControllerHandler<
   // check cookies
   let showReact: boolean | undefined = undefined
 
-  if (req.cookies) {
+  if (config.reactMigrationConfig.respondentRollout <= 0) {
+    // Check the rollout value first, if it's 0, react is DISABLED
+    // And we ignore cookies entirely!
+    showReact = false
+  } else if (req.cookies) {
     if (ADMIN_COOKIE_NAME in req.cookies) {
       showReact = req.cookies[ADMIN_COOKIE_NAME] === 'react'
     } else if (RESPONDENT_COOKIE_NAME in req.cookies) {
@@ -52,8 +56,6 @@ export const serveForm: ControllerHandler<
   if (showReact === undefined) {
     const rand = Math.random() * 100
     showReact = rand <= config.reactMigrationConfig.respondentRollout
-
-    console.log('random assignment', rand, showReact)
 
     res.cookie(
       RESPONDENT_COOKIE_NAME,

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -39,7 +39,7 @@ export const serveForm: ControllerHandler<
   console.log('conditional routing 2')
 
   // check cookies
-  let showReact
+  let showReact: boolean | undefined = undefined
 
   if (req.cookies) {
     if (ADMIN_COOKIE_NAME in req.cookies) {

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -4,12 +4,10 @@ import config from '../../config/config'
 import { ControllerHandler } from '../core/core.types'
 import * as PublicFormController from '../form/public-form/public-form.controller'
 import { RedirectParams } from '../form/public-form/public-form.types'
-// import * as HomeController from '../home/home.controller'
+import * as HomeController from '../home/home.controller'
 
 const RESPONDENT_COOKIE_NAME = 'v2-respondent-ui'
 const ADMIN_COOKIE_NAME = 'v2-admin-ui'
-
-const REACT_ROLLOUT_THRESHOLD = 20 / 100
 
 export const RESPONDENT_COOKIE_OPTIONS = {
   httpOnly: true,
@@ -52,8 +50,8 @@ export const serveForm: ControllerHandler<
   }
 
   if (showReact === undefined) {
-    const rand = Math.random()
-    showReact = rand < REACT_ROLLOUT_THRESHOLD
+    const rand = Math.random() * 100
+    showReact = rand <= config.reactMigrationConfig.respondentRollout
 
     console.log('random assignment', rand, showReact)
 
@@ -72,10 +70,13 @@ export const serveForm: ControllerHandler<
 }
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
+  console.log('serveDefault')
   // only admin who chose react should see react, everybody else is plain angular
   if (req.cookies?.[ADMIN_COOKIE_NAME] === 'react') {
     // react
+    serveFormReact(req, res, next)
   } else {
     // angular
+    HomeController.home(req, res, next)
   }
 }

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -1,86 +1,12 @@
 import { Router } from 'express'
-import {
-  NextFunction,
-  ParamsDictionary,
-  Request,
-  Response,
-} from 'express-serve-static-core'
-import path from 'path'
-import { ParsedQs } from 'qs'
 
-import config from '../../config/config'
-import { ControllerHandler } from '../core/core.types'
-import * as PublicFormController from '../form/public-form/public-form.controller'
-import { RedirectParams } from '../form/public-form/public-form.types'
-import * as HomeController from '../home/home.controller'
+import * as ReactMigrationController from './react-migration.controller'
 
 export const ReactMigrationRouter = Router()
 
-const RESPONDENT_COOKIE_NAME = 'v2-respondent-ui'
-const ADMIN_COOKIE_NAME = 'v2-admin-ui'
+ReactMigrationRouter.get(
+  '/:formId([a-fA-F0-9]{24})',
+  ReactMigrationController.serveForm,
+)
 
-const REACT_ROLLOUT_THRESHOLD = 20 / 100
-
-export const RESPONDENT_COOKIE_OPTIONS = {
-  httpOnly: true,
-  sameSite: 'strict' as const,
-  secure: !config.isDev,
-}
-
-function serveReact(_req: Request, res: Response) {
-  console.log('serveReact')
-  const reactFrontendPath = path.resolve('dist/frontend')
-  res.sendFile(path.join(reactFrontendPath, 'index.html'))
-}
-
-const serveAngular: ControllerHandler<
-  RedirectParams,
-  unknown,
-  unknown,
-  Record<string, string>
-> = (req, res) => {
-  PublicFormController.handleRedirect(req, res)
-}
-
-ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res) => {
-  console.log('conditional routing 2')
-
-  // check cookies
-  let showReact
-
-  if (req.cookies) {
-    if (ADMIN_COOKIE_NAME in req.cookies) {
-      showReact = req.cookies[ADMIN_COOKIE_NAME] === 'react'
-    } else if (RESPONDENT_COOKIE_NAME in req.cookies) {
-      showReact = req.cookies[RESPONDENT_COOKIE_NAME] === 'react'
-    }
-  }
-
-  if (showReact === undefined) {
-    const rand = Math.random()
-    showReact = rand < REACT_ROLLOUT_THRESHOLD
-
-    console.log('random assignment', rand, showReact)
-
-    res.cookie(
-      RESPONDENT_COOKIE_NAME,
-      showReact ? 'react' : 'angular',
-      RESPONDENT_COOKIE_OPTIONS,
-    )
-  }
-
-  if (showReact) {
-    serveReact(req, res)
-  } else {
-    serveAngular(req, res)
-  }
-})
-
-ReactMigrationRouter.get('*', (req, res) => {
-  // only admin who chose react should see react, everybody else is plain angular
-  if (req.cookies?.[ADMIN_COOKIE_NAME] === 'react') {
-    serveReact(req, res)
-  } else {
-    serveAngular(req, res)
-  }
-})
+ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -5,9 +5,12 @@ import * as HomeController from '../home/home.controller'
 
 export const ReactMigrationRouter = Router()
 
+const RESPONDENT_COOKIE_NAME = 'v2-respondent-ui'
+const ADMIN_COOKIE_NAME = 'v2-admin-ui'
+
 const REACT_ROLLOUT_THRESHOLD = 20 / 100
 
-export const SESSION_COOKIE_OPTIONS = {
+export const RESPONDENT_COOKIE_OPTIONS = {
   httpOnly: true,
   sameSite: 'lax' as const,
   secure: !config.isDev,
@@ -19,21 +22,27 @@ ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res, next) => {
   // check cookies
   let serveReact
 
-  if (req.cookies && 'frontend' in req.cookies) {
-    serveReact = req.cookies.frontend === 'react'
-  } else {
-    serveReact = Math.random() < REACT_ROLLOUT_THRESHOLD
+  if (req.cookies) {
+    if (ADMIN_COOKIE_NAME in req.cookies) {
+      serveReact = req.cookies[ADMIN_COOKIE_NAME] === 'react'
+    } else if (RESPONDENT_COOKIE_NAME in req.cookies) {
+      serveReact = req.cookies[RESPONDENT_COOKIE_NAME] === 'react'
+    }
   }
 
-  res.cookie(
-    'frontend',
-    serveReact ? 'react' : 'angular',
-    SESSION_COOKIE_OPTIONS,
-  )
+  if (serveReact === undefined) {
+    serveReact = Math.random() < REACT_ROLLOUT_THRESHOLD
+
+    res.cookie(
+      RESPONDENT_COOKIE_NAME,
+      serveReact ? 'react' : 'angular',
+      RESPONDENT_COOKIE_OPTIONS,
+    )
+  }
 
   if (serveReact) {
     // serve react
   } else {
-    return HomeController.home(req, res, next)
+    // return HomeController.home(req, res, next)
   }
 })

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -13,4 +13,4 @@ ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
   res.redirect(`/${req.params.formId}`)
 })
 
-ReactMigrationRouter.get('/', ReactMigrationController.serveDefault)
+ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -1,7 +1,17 @@
 import { Router } from 'express'
+import {
+  NextFunction,
+  ParamsDictionary,
+  Request,
+  Response,
+} from 'express-serve-static-core'
 import path from 'path'
+import { ParsedQs } from 'qs'
 
 import config from '../../config/config'
+import { ControllerHandler } from '../core/core.types'
+import * as PublicFormController from '../form/public-form/public-form.controller'
+import { RedirectParams } from '../form/public-form/public-form.types'
 import * as HomeController from '../home/home.controller'
 
 export const ReactMigrationRouter = Router()
@@ -13,18 +23,26 @@ const REACT_ROLLOUT_THRESHOLD = 20 / 100
 
 export const RESPONDENT_COOKIE_OPTIONS = {
   httpOnly: true,
-  sameSite: 'lax' as const,
+  sameSite: 'strict' as const,
   secure: !config.isDev,
 }
 
-function serveReact(req, res, next) {
+function serveReact(_req: Request, res: Response) {
+  console.log('serveReact')
   const reactFrontendPath = path.resolve('dist/frontend')
   res.sendFile(path.join(reactFrontendPath, 'index.html'))
 }
 
-function serveAngular(req, res, next) {}
+const serveAngular: ControllerHandler<
+  RedirectParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res) => {
+  PublicFormController.handleRedirect(req, res)
+}
 
-ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res, next) => {
+ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res) => {
   console.log('conditional routing 2')
 
   // check cookies
@@ -39,7 +57,10 @@ ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res, next) => {
   }
 
   if (showReact === undefined) {
-    showReact = Math.random() < REACT_ROLLOUT_THRESHOLD
+    const rand = Math.random()
+    showReact = rand < REACT_ROLLOUT_THRESHOLD
+
+    console.log('random assignment', rand, showReact)
 
     res.cookie(
       RESPONDENT_COOKIE_NAME,
@@ -49,17 +70,17 @@ ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res, next) => {
   }
 
   if (showReact) {
-    serveReact(req, res, next)
+    serveReact(req, res)
   } else {
-    serveAngular(req, res, next)
+    serveAngular(req, res)
   }
 })
 
-ReactMigrationRouter.get('*', (req, res, next) => {
+ReactMigrationRouter.get('*', (req, res) => {
   // only admin who chose react should see react, everybody else is plain angular
   if (req.cookies?.[ADMIN_COOKIE_NAME] === 'react') {
-    serveReact(req, res, next)
+    serveReact(req, res)
   } else {
-    serveAngular(req, res, next)
+    serveAngular(req, res)
   }
 })

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express'
+
+export const ReactMigrationRouter = Router()
+
+const reactRolloutThreshold = 20 / 100
+
+ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res) => {
+  // check cookies
+  let serveReact
+
+  if (req.cookies && 'frontend' in req.cookies) {
+    serveReact = req.cookies.frontend === 'react'
+  } else {
+    serveReact = Math.random() < reactRolloutThreshold
+  }
+
+  res.cookie('frontend', serveReact ? 'react' : 'angular')
+
+  if (serveReact) {
+    // serve react
+  } else {
+    // serve angular
+  }
+})

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -9,4 +9,8 @@ ReactMigrationRouter.get(
   ReactMigrationController.serveForm,
 )
 
+ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
+  res.redirect(`/${req.params.formId}`)
+})
+
 ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -1,24 +1,39 @@
 import { Router } from 'express'
 
+import config from '../../config/config'
+import * as HomeController from '../home/home.controller'
+
 export const ReactMigrationRouter = Router()
 
-const reactRolloutThreshold = 20 / 100
+const REACT_ROLLOUT_THRESHOLD = 20 / 100
 
-ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res) => {
+export const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: !config.isDev,
+}
+
+ReactMigrationRouter.get('/:formId([a-fA-F0-9]{24})', (req, res, next) => {
+  console.log('conditional routing')
+
   // check cookies
   let serveReact
 
   if (req.cookies && 'frontend' in req.cookies) {
     serveReact = req.cookies.frontend === 'react'
   } else {
-    serveReact = Math.random() < reactRolloutThreshold
+    serveReact = Math.random() < REACT_ROLLOUT_THRESHOLD
   }
 
-  res.cookie('frontend', serveReact ? 'react' : 'angular')
+  res.cookie(
+    'frontend',
+    serveReact ? 'react' : 'angular',
+    SESSION_COOKIE_OPTIONS,
+  )
 
   if (serveReact) {
     // serve react
   } else {
-    // serve angular
+    return HomeController.home(req, res, next)
   }
 })

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -13,4 +13,4 @@ ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
   res.redirect(`/${req.params.formId}`)
 })
 
-ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)
+ReactMigrationRouter.get('/', ReactMigrationController.serveDefault)

--- a/src/app/routes/api/v3/admin/admin.routes.ts
+++ b/src/app/routes/api/v3/admin/admin.routes.ts
@@ -1,7 +1,15 @@
 import { Router } from 'express'
 
+import * as ReactMigrationController from '../../../../modules/react-migration/react-migration.controller'
+
 import { AdminFormsRouter } from './forms'
 
 export const AdminRouter = Router()
 
 AdminRouter.use('/forms', AdminFormsRouter)
+
+// This endpoint doesn't reaaaallly need to be a verified admin to be used
+AdminRouter.get(
+  '/environment/:env(react|angular)',
+  ReactMigrationController.adminChooseEnvironment,
+)

--- a/src/public/modules/core/resources/landing-examples.js
+++ b/src/public/modules/core/resources/landing-examples.js
@@ -3,37 +3,37 @@ const examples = [
     img: '/public/modules/core/img/landing/restricted__1-MOM.png',
     agency: 'MOM',
     title: 'Report an Employment Act violation',
-    formLink: 'https://form.gov.sg/#!/5a0ae8bb66545d85005daf6f',
+    formLink: 'https://form.gov.sg/5a0ae8bb66545d85005daf6f',
   },
   {
     img: '/public/modules/core/img/landing/restricted__3-NEA.png',
     agency: 'NEA',
     title: 'Update particulars of deceased next-of-kin',
-    formLink: 'https://form.gov.sg/#!/5a9e53d0b3a3b6006e6e0b74',
+    formLink: 'https://form.gov.sg/5a9e53d0b3a3b6006e6e0b74',
   },
   {
     img: '/public/modules/core/img/landing/restricted__7-MFA.png',
     agency: 'MFA',
     title: 'Scholarship Mailing List',
-    formLink: 'https://form.gov.sg/#!/5a9f3906b3a3b6006e6ee595',
+    formLink: 'https://form.gov.sg/5a9f3906b3a3b6006e6ee595',
   },
   {
     img: '/public/modules/core/img/landing/restricted__8-IPOS.png',
     agency: 'IPOS',
     title: 'FinTech Fast Track Initiative Registration',
-    formLink: 'https://form.gov.sg/#!/5ac6cced5eaf2b0030597aaa',
+    formLink: 'https://form.gov.sg/5ac6cced5eaf2b0030597aaa',
   },
   {
     img: '/public/modules/core/img/landing/restricted__9-SCB.png',
     agency: 'SCB',
     title: 'National Science Challenge Registration',
-    formLink: 'https://form.gov.sg/#!/5a813986c860b96e00a3026d',
+    formLink: 'https://form.gov.sg/5a813986c860b96e00a3026d',
   },
   {
     img: '/public/modules/core/img/landing/restricted__2-MOE.png',
     agency: 'MOE',
     title: 'School placement for returning Singaporeans',
-    formLink: 'https://form.gov.sg/#!/5aa5e5b1dcff52006dfd5f86',
+    formLink: 'https://form.gov.sg/5aa5e5b1dcff52006dfd5f86',
   },
 ]
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -53,7 +53,8 @@ export type RateLimitConfig = {
 }
 
 export type ReactMigrationConfig = {
-  respondentRollout: number
+  respondentRolloutNoSPCP: number
+  respondentRolloutSPCP: number
   adminRollout: number
 }
 
@@ -155,7 +156,8 @@ export interface IOptionalVarsSchema {
     sendAuthOtp: number
   }
   reactMigration: {
-    respondentRollout: number
+    respondentRolloutNoSPCP: number
+    respondentRolloutSPCP: number
     adminRollout: number
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -52,6 +52,11 @@ export type RateLimitConfig = {
   sendAuthOtp: number
 }
 
+export type ReactMigrationConfig = {
+  respondentRollout: number
+  adminRollout: number
+}
+
 export type Config = {
   app: AppConfig
   db: DbConfig
@@ -75,6 +80,7 @@ export type Config = {
   siteBannerContent: string
   adminBannerContent: string
   rateLimitConfig: RateLimitConfig
+  reactMigrationConfig: ReactMigrationConfig
   secretEnv: string
 
   // Functions
@@ -147,6 +153,10 @@ export interface IOptionalVarsSchema {
   rateLimit: {
     submissions: number
     sendAuthOtp: number
+  }
+  reactMigration: {
+    respondentRollout: number
+    adminRollout: number
   }
 }
 


### PR DESCRIPTION
## Context

We need a way to control rollout of React (and stop it if needed). 

We have several constraints:
* We should have an illegibility criteria where some form are excluded from the react rollout
* Domain must stay constants as `form.gov.sg`
* Form URLs must be constant, so whatever URLs were shared before, during, and after rollout will work without us having to maintain deprecated custom routes
* Respondent taking SP/CP/MyInfo forms should have the same environment before and after login, so they are not confused
* Admin can chose an environment (react/angular) and have it served consistently across multiple sessions

We considered several approach to do routing in infra, but the constraints above make it hard to do this outside application (which can have knowledge on admin/respondent and eligibility criteria based on form definitions.

## Approach
* Update old routes to have a consistent param `formId` in URL
* Conditional routing is done in app code with a new controller `reactMigrationController`
    * new config block `reactMigration populated from new env vars
    * static assets are loaded first so the react controller can catch all urls later
* Admins choice is saved in a cookie with 1 year expiry
    * new API endpoint `/api/v3/admin/environment/(react|angular)` to allow setting of the cookie (only needed if `http-only`)
* Respondent choice of react/angular is saved in a session cookie. Same user may get different ui for forms during the rollout period, but a single interaction with a form, including refreshes should be consistent within one ui.


## TODOs / TODISCUSS
- [ ] Add Eligibility criteria (forms with SP/CP/MyInfo) are excluded from first phase of rollout
- [ ] Test for all common cases (pairing session wearing hacker hats -> can we break it?)
- [ ] Build UI in BOTH angular and React to allow switching the environment (simple api call to set cookie and redirect)
- [ ] Discuss whether frontend needs access to the environment cookies to take decisions (cookies do not contain secure data and do not necessarily need to be `http-only`

## Deploy Notes

**New environment variables**:
-  `REACT_MIGRATION_RESPONDENT_ROLLOUT`: number between 0 and 100
-  `REACT_MIGRATION_ADMIN_ROLLOUT`: number between 0 and 100
