### PR TITLE
fix(v2): centre toasts used in app

### DIFF
--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -28,11 +28,19 @@ export type UseToastReturn = {
   update: ReturnType<typeof useChakraToast>['update']
 }
 
+const DEFAULT_CONTAINER_STYLE = {
+  maxWidth: '100%',
+}
+
 export const useToast = ({
   status: initialStatus = 'success',
+  containerStyle: initialContainerStyle = DEFAULT_CONTAINER_STYLE,
   ...initialProps
 }: UseToastProps = {}): UseToastReturn => {
-  const toast = useChakraToast(initialProps)
+  const toast = useChakraToast({
+    ...initialProps,
+    containerStyle: initialContainerStyle,
+  })
 
   const customToastImpl = useMemo(() => {
     const impl = ({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The ChakraUI `Toast` component had a bug on larger screens where they will pop up off-center if the width of the screen is too much. This has been fixed upstream in https://github.com/chakra-ui/chakra-ui/pull/4922 and now fixed for the usage in this app

