### PR TITLE
feat(ci/chromatic): fix node to v14 for turbosnap to work correctly

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,6 +26,10 @@ jobs:
     # Job steps
     steps:
       - uses: actions/checkout@v1
+      - name: Use Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
       - name: Install dependencies
         run: npm i
         # 👇 Adds Chromatic as a step in the workflow

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -44,4 +44,3 @@ jobs:
           autoAcceptChanges: form-v2/develop
           exitOnceUploaded: true
           onlyChanged: true
-          untraced: '*/package-lock.json'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -40,3 +40,4 @@ jobs:
           autoAcceptChanges: form-v2/develop
           exitOnceUploaded: true
           onlyChanged: true
+          untraced: '*/package-lock.json'


### PR DESCRIPTION
Chromatic is detecting package-lock changes and rerunning every single test instead of only running snapshot tests for changed stories due to `npm install` using `npm@7`, resulting in diffs between the lockfileVersion of the repository's package-lock.json and the resulting package-lock.json in the workflow, triggering Turbosnap.

This is causing the costs to balloon with every push. This PR adds a node version setting step to the workflow (to v14) so npm@6 is used to prevent any unnecessary lockfileVersion changes.

