### PR TITLE
feat: add country field backend

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -355,5 +355,7 @@ const MemoFieldRow = memo(({ field, ...rest }: MemoFieldRowProps) => {
       return <ImageField schema={field} {...rest} />
     case BasicField.Table:
       return <TableField schema={field} {...rest} />
+    default:
+      return <div>TODO: Add field row for {field.fieldType}</div>
   }
 })

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -172,5 +172,12 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
         minimumRows: 2,
       }
     }
+    case BasicField.Country: {
+      return {
+        fieldType,
+        ...baseMeta,
+        fieldOptions: [],
+      }
+    }
   }
 }

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -5,6 +5,7 @@ import {
   BiCalendarEvent,
   BiCaretDownSquare,
   BiCloudUpload,
+  BiGlobe,
   BiHash,
   BiHeading,
   BiImage,
@@ -79,6 +80,12 @@ export const BASICFIELD_TO_DRAWER_META: {
   [BasicField.Dropdown]: {
     label: 'Dropdown',
     icon: BiCaretDownSquare,
+    isSubmitted: true,
+  },
+
+  [BasicField.Country]: {
+    label: 'Country',
+    icon: BiGlobe,
     isSubmitted: true,
   },
 

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -6,6 +6,7 @@ import { FormColorTheme } from '~shared/types/form'
 import {
   AttachmentField,
   CheckboxField,
+  CountryField,
   DateField,
   DecimalField,
   DropdownField,
@@ -64,6 +65,8 @@ export const FieldFactory = memo(
         return <YesNoField schema={field} colorTheme={colorTheme} />
       case BasicField.Dropdown:
         return <DropdownField schema={field} colorTheme={colorTheme} />
+      case BasicField.Country:
+        return <CountryField schema={field} colorTheme={colorTheme} />
       case BasicField.Date:
         return <DateField schema={field} colorTheme={colorTheme} />
       case BasicField.Uen:

--- a/frontend/src/templates/Field/CountryField/CountryField.stories.tsx
+++ b/frontend/src/templates/Field/CountryField/CountryField.stories.tsx
@@ -18,7 +18,7 @@ const baseSchema: CountryFieldSchema = {
   description: 'Type or select your residential country',
   required: true,
   disabled: false,
-  fieldType: BasicField.Dropdown,
+  fieldType: BasicField.Country,
   fieldOptions: [],
   _id: 'random-id',
 }

--- a/frontend/src/templates/Field/CountryField/CountryField.tsx
+++ b/frontend/src/templates/Field/CountryField/CountryField.tsx
@@ -1,7 +1,7 @@
 import { Country } from '~shared/constants/countries'
 import {
   BasicField,
-  DropdownFieldBase,
+  CountryFieldBase,
   FormFieldWithId,
 } from '~shared/types/field'
 
@@ -9,8 +9,7 @@ import DropdownField from '~templates/Field/Dropdown'
 
 import { BaseFieldProps } from '../FieldContainer'
 
-// TODO: Change to CountryFieldBase when the new CountryField type is added in future PRs
-export type CountryFieldSchema = FormFieldWithId<DropdownFieldBase>
+export type CountryFieldSchema = FormFieldWithId<CountryFieldBase>
 export interface CountryFieldProps extends BaseFieldProps {
   schema: CountryFieldSchema
 }

--- a/frontend/src/templates/Field/CountryField/index.ts
+++ b/frontend/src/templates/Field/CountryField/index.ts
@@ -1,0 +1,1 @@
+export { CountryField as default } from './CountryField'

--- a/frontend/src/templates/Field/index.ts
+++ b/frontend/src/templates/Field/index.ts
@@ -1,5 +1,6 @@
 import AttachmentField from './Attachment'
 import CheckboxField from './Checkbox'
+import CountryField from './CountryField'
 import DateField from './Date'
 import DecimalField from './Decimal'
 import DropdownField from './Dropdown'
@@ -24,6 +25,7 @@ export * from './types'
 export {
   AttachmentField,
   CheckboxField,
+  CountryField,
   DateField,
   DecimalField,
   DropdownField,

--- a/shared/constants/field/basic.ts
+++ b/shared/constants/field/basic.ts
@@ -79,6 +79,12 @@ export const types: BasicFieldBlock[] = [
     answerArray: false,
   },
   {
+    name: BasicField.Country,
+    value: 'Country',
+    submitted: true,
+    answerArray: false,
+  },
+  {
     name: BasicField.YesNo,
     value: 'Yes/No',
     submitted: true,

--- a/shared/types/field/base.ts
+++ b/shared/types/field/base.ts
@@ -10,6 +10,7 @@ export enum BasicField {
   ShortText = 'textfield',
   LongText = 'textarea',
   Dropdown = 'dropdown',
+  Country = 'country',
   YesNo = 'yes_no',
   Checkbox = 'checkbox',
   Radio = 'radiobutton',

--- a/shared/types/field/countryField.ts
+++ b/shared/types/field/countryField.ts
@@ -1,0 +1,7 @@
+import { BasicField, MyInfoableFieldBase } from './base'
+import { Country } from '../../constants/countries'
+
+export interface CountryFieldBase extends MyInfoableFieldBase {
+  fieldType: BasicField.Country
+  fieldOptions: Country[]
+}

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -3,6 +3,7 @@ import { CheckboxFieldBase } from './checkboxField'
 import { DateFieldBase } from './dateField'
 import { DecimalFieldBase } from './decimalField'
 import { DropdownFieldBase } from './dropdownField'
+import { CountryFieldBase } from './countryField'
 import { EmailFieldBase } from './emailField'
 import { HomenoFieldBase } from './homeNoField'
 import { ImageFieldBase } from './imageField'
@@ -25,6 +26,7 @@ export * from './checkboxField'
 export * from './dateField'
 export * from './decimalField'
 export * from './dropdownField'
+export * from './countryField'
 export * from './emailField'
 export * from './homeNoField'
 export * from './imageField'
@@ -48,6 +50,7 @@ export type FormField =
   | DateFieldBase
   | DecimalFieldBase
   | DropdownFieldBase
+  | CountryFieldBase
   | EmailFieldBase
   | HomenoFieldBase
   | ImageFieldBase

--- a/shared/types/response.ts
+++ b/shared/types/response.ts
@@ -78,6 +78,11 @@ export const DropdownResponse = MyInfoableSingleResponse.extend({
 })
 export type DropdownResponse = z.infer<typeof DropdownResponse>
 
+export const CountryResponse = MyInfoableSingleResponse.extend({
+  fieldType: z.literal(BasicField.Country),
+})
+export type CountryResponse = z.infer<typeof CountryResponse>
+
 export const YesNoResponse = SingleAnswerResponse.extend({
   fieldType: z.literal(BasicField.YesNo),
 })
@@ -137,6 +142,7 @@ export type FieldResponse =
   | ShortTextResponse
   | LongTextResponse
   | DropdownResponse
+  | CountryResponse
   | YesNoResponse
   | CheckboxResponse
   | RadioResponse

--- a/src/app/models/field/countryField.ts
+++ b/src/app/models/field/countryField.ts
@@ -1,0 +1,9 @@
+import { Schema } from 'mongoose'
+
+import { ICountryFieldSchema } from '../../../types'
+
+const createCountryFieldSchema = () => {
+  return new Schema<ICountryFieldSchema>({})
+}
+
+export default createCountryFieldSchema

--- a/src/app/models/field/index.ts
+++ b/src/app/models/field/index.ts
@@ -1,6 +1,7 @@
 import createAttachmentFieldSchema from './attachmentField'
 import { BaseFieldSchema } from './baseField'
 import createCheckboxFieldSchema from './checkboxField'
+import createCountryFieldSchema from './countryField'
 import createDateFieldSchema from './dateField'
 import createDecimalFieldSchema from './decimalField'
 import createDropdownFieldSchema from './dropdownField'
@@ -26,6 +27,7 @@ export {
   createDateFieldSchema,
   createDecimalFieldSchema,
   createDropdownFieldSchema,
+  createCountryFieldSchema,
   createEmailFieldSchema,
   createHomenoFieldSchema,
   createImageFieldSchema,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -66,6 +66,7 @@ import {
   BaseFieldSchema,
   createAttachmentFieldSchema,
   createCheckboxFieldSchema,
+  createCountryFieldSchema,
   createDateFieldSchema,
   createDecimalFieldSchema,
   createDropdownFieldSchema,
@@ -441,6 +442,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     createAttachmentFieldSchema(),
   )
   FormFieldPath.discriminator(BasicField.Dropdown, createDropdownFieldSchema())
+  FormFieldPath.discriminator(BasicField.Country, createCountryFieldSchema())
   FormFieldPath.discriminator(BasicField.Radio, createRadioFieldSchema())
   FormFieldPath.discriminator(BasicField.Checkbox, createCheckboxFieldSchema())
   FormFieldPath.discriminator(

--- a/src/app/utils/field-validation/answerValidator.factory.ts
+++ b/src/app/utils/field-validation/answerValidator.factory.ts
@@ -12,6 +12,7 @@ import {
 
 import { constructAttachmentValidator } from './validators/attachmentValidator'
 import { constructCheckboxValidator } from './validators/checkboxValidator'
+import { constructCountryValidator } from './validators/countryValidator'
 import { constructDateValidator } from './validators/dateValidator'
 import { constructDecimalValidator } from './validators/decimalValidator'
 import { constructDropdownValidator } from './validators/dropdownValidator'
@@ -59,6 +60,8 @@ export const constructSingleAnswerValidator = (
       return constructDecimalValidator(formField)
     case BasicField.Dropdown:
       return constructDropdownValidator(formField)
+    case BasicField.Country:
+      return constructCountryValidator()
     case BasicField.Email:
       return constructEmailValidator(formField)
     case BasicField.Uen:

--- a/src/app/utils/field-validation/validators/__tests__/country-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/country-validation.spec.ts
@@ -1,0 +1,106 @@
+import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
+import { validateField } from 'src/app/utils/field-validation'
+
+import {
+  generateDefaultField,
+  generateNewSingleAnswerResponse,
+} from 'tests/unit/backend/helpers/generate-form-data'
+
+import { Country } from '../../../../../../shared/constants/countries'
+import { BasicField } from '../../../../../../shared/types'
+
+describe('Country validation', () => {
+  it('should allow valid option', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: Country.Singapore,
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow invalid option', () => {
+    const formField = generateDefaultField(BasicField.Dropdown, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Dropdown, {
+      answer: 'NOT A COUNTRY',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow empty answer when required', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow empty answer when not required', () => {
+    const formField = generateDefaultField(BasicField.Country, {
+      required: false,
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow empty answer when it is required but not visible', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: '',
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should disallow empty answer when it is required and visible', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: '',
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should disallow multiple answers', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: [Country.Singapore, Country.Slovak_Republic] as unknown as string,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Response has invalid shape'),
+    )
+  })
+  it('should disallow responses submitted for hidden fields', () => {
+    const formField = generateDefaultField(BasicField.Country, {})
+    const response = generateNewSingleAnswerResponse(BasicField.Country, {
+      answer: Country.Singapore,
+      isVisible: false,
+    })
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Attempted to submit response on a hidden field'),
+    )
+  })
+})

--- a/src/app/utils/field-validation/validators/countryValidator.ts
+++ b/src/app/utils/field-validation/validators/countryValidator.ts
@@ -1,0 +1,30 @@
+import { chain, left, right } from 'fp-ts/lib/Either'
+import { flow } from 'fp-ts/lib/function'
+
+import { Country } from '../../../../../shared/constants/countries'
+import { ResponseValidator } from '../../../../types/field/utils/validation'
+import { ProcessedSingleAnswerResponse } from '../../../modules/submission/submission.types'
+
+import { notEmptySingleAnswerResponse } from './common'
+import { isOneOfOptions } from './options'
+
+type CountryValidator = ResponseValidator<ProcessedSingleAnswerResponse>
+type CountryValidatorConstructor = () => CountryValidator
+
+/**
+ * Returns a validation function
+ * to check if country selection is one of the options.
+ */
+const makeCountryValidator: CountryValidatorConstructor = () => (response) => {
+  const validOptions = Object.values(Country)
+  const { answer } = response
+  return isOneOfOptions(validOptions, answer)
+    ? right(response)
+    : left(`CountryValidator:\t answer is not a valid country option`)
+}
+
+/**
+ * Returns a validation function for a country field when called.
+ */
+export const constructCountryValidator: CountryValidatorConstructor = () =>
+  flow(notEmptySingleAnswerResponse, chain(makeCountryValidator()))

--- a/src/public/modules/forms/services/form-fields.client.service.js
+++ b/src/public/modules/forms/services/form-fields.client.service.js
@@ -5,6 +5,7 @@ const get = require('lodash/get')
 const {
   types: basicTypes,
 } = require('../../../../../shared/constants/field/basic')
+const { BasicField } = require('../../../../../shared/types/field')
 const {
   types: myInfoTypes,
 } = require('../../../../../shared/constants/field/myinfo')
@@ -12,7 +13,10 @@ const {
 angular.module('forms').service('FormFields', [FormFields])
 
 function FormFields() {
-  this.basicTypes = basicTypes
+  // TODO: Unhide Country field once the frontend for Country field is done
+  this.basicTypes = basicTypes.filter(
+    (type) => type.name !== BasicField.Country,
+  )
   this.myInfoTypes = myInfoTypes
   this.customValFields = ['textarea', 'textfield', 'number']
 

--- a/src/types/field/countryField.ts
+++ b/src/types/field/countryField.ts
@@ -1,0 +1,7 @@
+import { BasicField, CountryFieldBase } from '../../../shared/types'
+
+import { IFieldSchema } from './baseField'
+
+export interface ICountryFieldSchema extends CountryFieldBase, IFieldSchema {
+  fieldType: BasicField.Country
+}

--- a/src/types/field/index.ts
+++ b/src/types/field/index.ts
@@ -3,6 +3,7 @@ import { ConditionalExcept, Merge } from 'type-fest'
 
 import { IAttachmentFieldSchema } from './attachmentField'
 import { ICheckboxFieldSchema } from './checkboxField'
+import { ICountryFieldSchema } from './countryField'
 import { IDateFieldSchema } from './dateField'
 import { IDecimalFieldSchema } from './decimalField'
 import { IDropdownFieldSchema } from './dropdownField'
@@ -28,6 +29,7 @@ export * from './checkboxField'
 export * from './dateField'
 export * from './decimalField'
 export * from './dropdownField'
+export * from './countryField'
 export * from './emailField'
 export * from './homeNoField'
 export * from './imageField'
@@ -61,6 +63,7 @@ export type FormFieldSchema =
   | IDateFieldSchema
   | IDecimalFieldSchema
   | IDropdownFieldSchema
+  | ICountryFieldSchema
   | IEmailFieldSchema
   | IHomenoFieldSchema
   | IImageFieldSchema
@@ -101,6 +104,7 @@ export type FieldValidationSchema =
   | OmitUnusedValidatorProps<IDateFieldSchema>
   | OmitUnusedValidatorProps<IDecimalFieldSchema>
   | OmitUnusedValidatorProps<IDropdownFieldSchema>
+  | OmitUnusedValidatorProps<ICountryFieldSchema>
   | OmitUnusedValidatorProps<IEmailFieldSchema>
   | OmitUnusedValidatorProps<IHomenoFieldSchema>
   | OmitUnusedValidatorProps<IImageFieldSchema>

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -13,6 +13,7 @@ import {
   IAttachmentFieldSchema,
   IAttachmentResponse,
   ICheckboxFieldSchema,
+  ICountryFieldSchema,
   IDecimalFieldSchema,
   IDropdownFieldSchema,
   IHomenoFieldSchema,
@@ -115,6 +116,12 @@ export const generateDefaultField = (
         getQuestion: () => defaultParams.title,
         ...customParams,
       } as IDropdownFieldSchema
+    case BasicField.Country:
+      return {
+        ...defaultParams,
+        getQuestion: () => defaultParams.title,
+        ...customParams,
+      } as ICountryFieldSchema
     case BasicField.Decimal:
       return {
         ...defaultParams,


### PR DESCRIPTION
## Problem

- Create country field backend

Partially solves https://github.com/opengovsg/FormSG/issues/481

## Solution

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- This PR is largely a copy of [!3015](https://github.com/opengovsg/FormSG/pull/3015)
- There is a TODO in `src/public/modules/forms/services/form-fields.client.service.js` which says `Unhide Country field once the frontend for Country field is done`.

## Before & After Screenshots

N/A

## Tests

`src/app/utils/field-validation/validators/__tests__/country-validation.spec.ts`
