### PR TITLE
feat(v2): add admin form collaborator modal

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -43,7 +43,7 @@ export const previewForm = async (
 export const getFreeSmsQuota = async (formId: string) => {
   return ApiService.get<SmsCountsDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/verified-sms/count/free`,
-  )
+  ).then(({ data }) => data)
 }
 
 export const getFormCollaborators = async (

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -1,8 +1,7 @@
-import axios from 'axios'
-
 import {
   AdminFormDto,
   AdminFormViewDto,
+  FormPermissionsDto,
   PreviewFormViewDto,
   SmsCountsDto,
 } from '~shared/types/form/form'
@@ -35,14 +34,21 @@ export const getAdminFormView = async (
 export const previewForm = async (
   formId: string,
 ): Promise<PreviewFormViewDto> => {
-  return axios
-    .get<PreviewFormViewDto>(`${ADMIN_FORM_ENDPOINT}/${formId}/preview`)
-    .then(({ data }) => data)
-    .then(transformAllIsoStringsToDate)
+  return ApiService.get<PreviewFormViewDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/preview`,
+  ).then(({ data }) => data)
 }
 
 export const getFreeSmsQuota = async (formId: string) => {
   return ApiService.get<SmsCountsDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/verified-sms/count/free`,
+  )
+}
+
+export const getFormCollaborators = async (
+  formId: string,
+): Promise<FormPermissionsDto> => {
+  return ApiService.get<FormPermissionsDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators`,
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -2,6 +2,7 @@ import {
   AdminFormDto,
   AdminFormViewDto,
   FormPermissionsDto,
+  PermissionsUpdateDto,
   PreviewFormViewDto,
   SmsCountsDto,
 } from '~shared/types/form/form'
@@ -50,5 +51,15 @@ export const getFormCollaborators = async (
 ): Promise<FormPermissionsDto> => {
   return ApiService.get<FormPermissionsDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators`,
+  ).then(({ data }) => data)
+}
+
+export const updateFormCollaborators = async (
+  formId: string,
+  collaborators: PermissionsUpdateDto,
+): Promise<FormPermissionsDto> => {
+  return ApiService.put<FormPermissionsDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators`,
+    collaborators,
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -10,6 +10,7 @@ import {
 } from '~constants/routes'
 
 import { useAdminForm } from '../../queries'
+import CollaboratorModal, { useCollaboratorModal } from '../CollaboratorModal'
 
 import { AdminFormNavbar } from './AdminFormNavbar'
 
@@ -46,10 +47,6 @@ const useAdminFormNavbar = () => {
     [navigate],
   )
 
-  const handleAddCollaborator = useCallback((): void => {
-    console.log('add collab button clicked')
-  }, [])
-
   const handlePreviewForm = useCallback((): void => {
     console.log('preview form button clicked')
   }, [])
@@ -67,7 +64,6 @@ const useAdminFormNavbar = () => {
     tabIndex,
     handleTabsChange,
     handleBackToDashboard,
-    handleAddCollaborator,
     handlePreviewForm,
     handleShareForm,
     form,
@@ -82,11 +78,16 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
     tabIndex,
     handleTabsChange,
     handleBackToDashboard,
-    handleAddCollaborator,
     handlePreviewForm,
     handleShareForm,
     form,
   } = useAdminFormNavbar()
+
+  const {
+    isCollaboratorModalOpen,
+    onCloseCollaboratorModal,
+    onOpenCollaboratorModal,
+  } = useCollaboratorModal()
 
   const responsiveVariant = useBreakpointValue({
     base: 'line-dark',
@@ -95,20 +96,26 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
   })
 
   return (
-    <Tabs
-      variant={responsiveVariant}
-      isLazy
-      defaultIndex={tabIndex}
-      index={tabIndex}
-      onChange={handleTabsChange}
-    >
-      <AdminFormNavbar
-        formInfo={form}
-        handleBackButtonClick={handleBackToDashboard}
-        handleAddCollabButtonClick={handleAddCollaborator}
-        handlePreviewFormButtonClick={handlePreviewForm}
-        handleShareButtonClick={handleShareForm}
+    <>
+      <CollaboratorModal
+        isOpen={isCollaboratorModalOpen}
+        onClose={onCloseCollaboratorModal}
       />
-    </Tabs>
+      <Tabs
+        variant={responsiveVariant}
+        isLazy
+        defaultIndex={tabIndex}
+        index={tabIndex}
+        onChange={handleTabsChange}
+      >
+        <AdminFormNavbar
+          formInfo={form}
+          handleBackButtonClick={handleBackToDashboard}
+          handleAddCollabButtonClick={onOpenCollaboratorModal}
+          handlePreviewFormButtonClick={handlePreviewForm}
+          handleShareButtonClick={handleShareForm}
+        />
+      </Tabs>
+    </>
   )
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
@@ -150,6 +150,7 @@ export const AddCollaboratorInput = (): JSX.Element => {
         </FormErrorMessage>
       </FormControl>
       <Button
+        isDisabled={isLoading}
         isLoading={mutateAddCollaborator.isLoading}
         isFullWidth={isFullWidth}
         mt="1rem"

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
@@ -1,0 +1,81 @@
+import { Controller, useForm } from 'react-hook-form'
+import { FormControl, Stack, useBreakpointValue } from '@chakra-ui/react'
+import { isEmpty } from 'lodash'
+import isEmail from 'validator/lib/isEmail'
+
+import Button from '~components/Button'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { PermissionDropdown } from './PermissionDropdown'
+
+export type AddCollaboratorInputs = {
+  email: string
+  role: DropdownRole
+}
+
+export enum DropdownRole {
+  Admin = 'Admin',
+  Editor = 'Editor',
+  Viewer = 'Viewer',
+}
+
+interface AddCollaboratorInputProps {
+  onSubmit: (inputs: AddCollaboratorInputs) => void
+}
+
+export const AddCollaboratorInput = ({
+  onSubmit,
+}: AddCollaboratorInputProps): JSX.Element => {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<AddCollaboratorInputs>({
+    defaultValues: {
+      role: DropdownRole.Editor,
+    },
+  })
+
+  const isFullWidth = useBreakpointValue({ base: true, xs: true, md: false })
+
+  return (
+    <form noValidate onSubmit={handleSubmit(onSubmit)}>
+      <FormControl isInvalid={!isEmpty(errors)}>
+        <FormLabel
+          isRequired
+          description="Share your secret key with users who need to access response data"
+        >
+          Add collaborators or transfer form ownership
+        </FormLabel>
+        <Stack direction={{ base: 'column', md: 'row' }}>
+          <Input
+            type="email"
+            {...register('email', {
+              required: 'Collaborator email is required',
+              validate: (value) => {
+                return !value || isEmail(value) || 'Please enter a valid email'
+              },
+            })}
+            placeholder="me@example.com"
+          />
+          <Controller
+            name="role"
+            control={control}
+            render={({ field: { value, onChange } }) => (
+              <PermissionDropdown value={value} onChange={onChange} />
+            )}
+          />
+        </Stack>
+        <FormErrorMessage>
+          {errors.email && errors.email.message}
+        </FormErrorMessage>
+      </FormControl>
+      <Button isFullWidth={isFullWidth} mt="1rem" type="submit">
+        Add collaborator
+      </Button>
+    </form>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
@@ -42,6 +42,7 @@ const useAddCollaboratorInput = () => {
 
   const formMethods = useForm<AddCollaboratorInputs>({
     defaultValues: {
+      email: '',
       role: DropdownRole.Editor,
     },
   })

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/AddCollaboratorInput.tsx
@@ -1,5 +1,10 @@
 import { Controller, useForm } from 'react-hook-form'
-import { FormControl, Stack, useBreakpointValue } from '@chakra-ui/react'
+import {
+  FormControl,
+  Skeleton,
+  Stack,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
@@ -23,10 +28,12 @@ export enum DropdownRole {
 
 interface AddCollaboratorInputProps {
   onSubmit: (inputs: AddCollaboratorInputs) => void
+  isLoading: boolean
 }
 
 export const AddCollaboratorInput = ({
   onSubmit,
+  isLoading,
 }: AddCollaboratorInputProps): JSX.Element => {
   const {
     register,
@@ -50,25 +57,34 @@ export const AddCollaboratorInput = ({
         >
           Add collaborators or transfer form ownership
         </FormLabel>
-        <Stack direction={{ base: 'column', md: 'row' }}>
-          <Input
-            type="email"
-            {...register('email', {
-              required: 'Collaborator email is required',
-              validate: (value) => {
-                return !value || isEmail(value) || 'Please enter a valid email'
-              },
-            })}
-            placeholder="me@example.com"
-          />
-          <Controller
-            name="role"
-            control={control}
-            render={({ field: { value, onChange } }) => (
-              <PermissionDropdown value={value} onChange={onChange} />
-            )}
-          />
-        </Stack>
+        <Skeleton isLoaded={!isLoading}>
+          <Stack direction={{ base: 'column', md: 'row' }}>
+            <Input
+              isDisabled={isLoading}
+              type="email"
+              {...register('email', {
+                required: 'Collaborator email is required',
+                validate: (value) => {
+                  return (
+                    !value || isEmail(value) || 'Please enter a valid email'
+                  )
+                },
+              })}
+              placeholder="me@example.com"
+            />
+            <Controller
+              name="role"
+              control={control}
+              render={({ field: { value, onChange } }) => (
+                <PermissionDropdown
+                  isLoading={isLoading}
+                  value={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          </Stack>
+        </Skeleton>
         <FormErrorMessage>
           {errors.email && errors.email.message}
         </FormErrorMessage>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -94,7 +94,11 @@ export const CollaboratorList = (): JSX.Element => {
     return (
       <CollaboratorRow bg={{ base: 'primary.100', md: 'white' }}>
         <Skeleton isLoaded={!!collaborators} flex={1}>
-          <Stack direction="row" align="baseline">
+          <Stack
+            direction="row"
+            align="baseline" // Required to allow flex to shrink
+            minW={0}
+          >
             <CollaboratorText>{form?.admin.email}</CollaboratorText>
             {createCurrentUserHint({ email: form?.admin.email ?? '' })}
           </Stack>
@@ -154,7 +158,7 @@ export const CollaboratorList = (): JSX.Element => {
           key={row.email}
           bg={{ base: index % 2 ? 'primary.100' : 'white', md: 'white' }}
         >
-          <Stack direction="row" flex={1} align="center">
+          <Stack direction="row" flex={1} align="center" w="100%">
             <CollaboratorText>{row.email}</CollaboratorText>
             {createCurrentUserHint(row)}
           </Stack>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -1,6 +1,6 @@
-import { Fragment, useMemo } from 'react'
+import { useMemo } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { Divider, Grid, Skeleton, Spacer, Text } from '@chakra-ui/react'
+import { Skeleton, Spacer, Stack, StackDivider, Text } from '@chakra-ui/react'
 
 import { FormPermission } from '~shared/types/form/form'
 
@@ -34,21 +34,24 @@ export const CollaboratorList = (): JSX.Element => {
 
   const ownerRow = useMemo(() => {
     return (
-      <>
+      <Stack
+        direction="row"
+        justify="space-between"
+        align="center"
+        minH="3.5rem"
+      >
         <Skeleton isLoaded={!!collaborators} alignSelf="center" py="0.5rem">
           <Text textStyle="body-2" color="secondary.900" isTruncated>
             {form?.admin.email}
           </Text>
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
-          <Text textStyle="body-2" color="secondary.300" px="1rem" py="0.5rem">
+          <Text textStyle="body-2" color="secondary.300" p="0.25rem">
             Owner
           </Text>
+          <Spacer />
         </Skeleton>
-        {/* Spacer required for 3 column grid layout */}
-        <Spacer />
-        <Divider gridColumn="1 / -1" />
-      </>
+      </Stack>
     )
   }, [collaborators, form?.admin.email])
 
@@ -83,10 +86,16 @@ export const CollaboratorList = (): JSX.Element => {
   }
 
   return (
-    <Grid templateColumns="1fr auto auto" overflowY="auto">
+    <Stack spacing={0} divider={<StackDivider />}>
       {ownerRow}
       {list.map((row) => (
-        <Fragment key={row.email}>
+        <Stack
+          minH="3.5rem"
+          direction="row"
+          justify="space-between"
+          align="center"
+          key={row.email}
+        >
           <Text
             textStyle="body-2"
             color="secondary.900"
@@ -95,34 +104,35 @@ export const CollaboratorList = (): JSX.Element => {
           >
             {row.email}
           </Text>
-          <PermissionDropdown
-            buttonVariant="clear"
-            value={row.role}
-            isLoading={
-              mutateUpdateCollaborator.isLoading ||
-              mutateRemoveCollaborator.isLoading
-            }
-            onChange={handleUpdateRole(row)}
-          />
-          <IconButton
-            icon={<BiTrash />}
-            isLoading={
-              mutateRemoveCollaborator.isLoading &&
-              mutateRemoveCollaborator.variables?.permissionToRemove.email ===
-                row.email
-            }
-            isDisabled={
-              mutateUpdateCollaborator.isLoading ||
-              mutateRemoveCollaborator.isLoading
-            }
-            variant="clear"
-            aria-label="Remove collaborator"
-            colorScheme="danger"
-            onClick={handleRemoveCollaborator(row)}
-          />
-          <Divider gridColumn="1 / -1" />
-        </Fragment>
+          <Stack direction="row" align="center">
+            <PermissionDropdown
+              buttonVariant="clear"
+              value={row.role}
+              isLoading={
+                mutateUpdateCollaborator.isLoading ||
+                mutateRemoveCollaborator.isLoading
+              }
+              onChange={handleUpdateRole(row)}
+            />
+            <IconButton
+              icon={<BiTrash />}
+              isLoading={
+                mutateRemoveCollaborator.isLoading &&
+                mutateRemoveCollaborator.variables?.permissionToRemove.email ===
+                  row.email
+              }
+              isDisabled={
+                mutateUpdateCollaborator.isLoading ||
+                mutateRemoveCollaborator.isLoading
+              }
+              variant="clear"
+              aria-label="Remove collaborator"
+              colorScheme="danger"
+              onClick={handleRemoveCollaborator(row)}
+            />
+          </Stack>
+        </Stack>
       ))}
-    </Grid>
+    </Stack>
   )
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -70,7 +70,7 @@ export const CollaboratorList = (): JSX.Element => {
   const { mutateUpdateCollaborator, mutateRemoveCollaborator } =
     useMutateCollaborators()
 
-  const isCurrentUserHint = useCallback(
+  const createCurrentUserHint = useCallback(
     (row: Pick<CollaboratorRowMeta, 'email'>) => {
       return row.email === user?.email ? (
         <Text as="span" textStyle="caption-1" color="neutral.600">
@@ -96,7 +96,7 @@ export const CollaboratorList = (): JSX.Element => {
         <Skeleton isLoaded={!!collaborators} w="100%">
           <Stack direction="row" align="baseline">
             <CollaboratorText>{form?.admin.email}</CollaboratorText>
-            {isCurrentUserHint({ email: form?.admin.email ?? '' })}
+            {createCurrentUserHint({ email: form?.admin.email ?? '' })}
           </Stack>
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
@@ -115,7 +115,7 @@ export const CollaboratorList = (): JSX.Element => {
         </Skeleton>
       </CollaboratorRow>
     )
-  }, [collaborators, form?.admin.email, isCurrentUserHint])
+  }, [collaborators, form?.admin.email, createCurrentUserHint])
 
   const handleUpdateRole =
     (row: typeof list[number]) => (newRole: DropdownRole) => {
@@ -157,7 +157,7 @@ export const CollaboratorList = (): JSX.Element => {
         >
           <Stack direction="row" w="100%" align="center">
             <CollaboratorText>{row.email}</CollaboratorText>
-            {isCurrentUserHint(row)}
+            {createCurrentUserHint(row)}
           </Stack>
           <Stack
             w="100%"

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -158,7 +158,14 @@ export const CollaboratorList = (): JSX.Element => {
           key={row.email}
           bg={{ base: index % 2 ? 'primary.100' : 'white', md: 'white' }}
         >
-          <Stack direction="row" flex={1} align="center" w="100%">
+          <Stack
+            direction="row"
+            flex={1}
+            align="center"
+            w="100%"
+            // Required to allow flex to shrink
+            minW={0}
+          >
             <CollaboratorText>{row.email}</CollaboratorText>
             {createCurrentUserHint(row)}
           </Stack>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -11,6 +11,7 @@ import { useAdminForm, useAdminFormCollaborators } from '../../queries'
 
 import { DropdownRole } from './AddCollaboratorInput'
 import { PermissionDropdown } from './PermissionDropdown'
+import { permissionsToRole } from './utils'
 
 export const CollaboratorList = (): JSX.Element => {
   // Admin form data required for checking for duplicate emails.
@@ -18,10 +19,6 @@ export const CollaboratorList = (): JSX.Element => {
   const { isLoading, data: collaborators } = useAdminFormCollaborators({
     enabled: !!form,
   })
-
-  const permissionsToRole = (permission: FormPermission) => {
-    return permission.write ? DropdownRole.Editor : DropdownRole.Viewer
-  }
 
   const list = useMemo(() => {
     return (
@@ -54,7 +51,7 @@ export const CollaboratorList = (): JSX.Element => {
   }, [form?.admin.email])
 
   return (
-    <Grid templateColumns="1fr auto auto">
+    <Grid templateColumns="1fr auto auto" maxH="12.5rem" overflowY="auto">
       {ownerRow}
       {list.map((row) => (
         <Fragment key={row.email}>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -1,6 +1,13 @@
 import { useMemo } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { Skeleton, Spacer, Stack, StackDivider, Text } from '@chakra-ui/react'
+import {
+  Skeleton,
+  Spacer,
+  Stack,
+  StackDivider,
+  StackProps,
+  Text,
+} from '@chakra-ui/react'
 
 import { FormPermission } from '~shared/types/form/form'
 
@@ -12,6 +19,39 @@ import { useAdminForm, useAdminFormCollaborators } from '../../queries'
 import { DropdownRole } from './AddCollaboratorInput'
 import { PermissionDropdown } from './PermissionDropdown'
 import { permissionsToRole, roleToPermission } from './utils'
+
+const CollaboratorText = ({ children }: { children?: string }) => {
+  return (
+    <Text
+      textStyle={{ base: 'subhead-1', md: 'body-2' }}
+      color={{ base: 'secondary.700', md: 'secondary.900' }}
+      isTruncated
+      w="100%"
+    >
+      {children}
+    </Text>
+  )
+}
+
+const CollaboratorRow = ({
+  children,
+  ...props
+}: { children: React.ReactNode } & StackProps) => {
+  return (
+    <Stack
+      p={{ base: '1.5rem', md: 0 }}
+      w="100%"
+      minH="3.5rem"
+      direction={{ base: 'column', md: 'row' }}
+      justify="space-between"
+      align={{ base: 'flex-start', md: 'center' }}
+      spacing={{ base: '0.75rem', md: '0.5rem' }}
+      {...props}
+    >
+      {children}
+    </Stack>
+  )
+}
 
 export const CollaboratorList = (): JSX.Element => {
   // Admin form data required for checking for duplicate emails.
@@ -34,24 +74,17 @@ export const CollaboratorList = (): JSX.Element => {
 
   const ownerRow = useMemo(() => {
     return (
-      <Stack
-        direction="row"
-        justify="space-between"
-        align="center"
-        minH="3.5rem"
-      >
-        <Skeleton isLoaded={!!collaborators} alignSelf="center" py="0.5rem">
-          <Text textStyle="body-2" color="secondary.900" isTruncated>
-            {form?.admin.email}
-          </Text>
+      <CollaboratorRow bg={{ base: 'primary.100', md: 'white' }}>
+        <Skeleton isLoaded={!!collaborators} py="0.5rem">
+          <CollaboratorText>{form?.admin.email}</CollaboratorText>
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
-          <Text textStyle="body-2" color="secondary.300" p="0.25rem">
+          <Text textStyle="subhead-1" color="secondary.500">
             Owner
           </Text>
           <Spacer />
         </Skeleton>
-      </Stack>
+      </CollaboratorRow>
     )
   }, [collaborators, form?.admin.email])
 
@@ -86,25 +119,21 @@ export const CollaboratorList = (): JSX.Element => {
   }
 
   return (
-    <Stack spacing={0} divider={<StackDivider />}>
+    <Stack spacing={0} align="flex-start" w="100%" divider={<StackDivider />}>
       {ownerRow}
-      {list.map((row) => (
-        <Stack
-          minH="3.5rem"
-          direction="row"
-          justify="space-between"
-          align="center"
+      {list.map((row, index) => (
+        <CollaboratorRow
           key={row.email}
+          bg={{ base: index % 2 ? 'primary.100' : 'white', md: 'white' }}
         >
-          <Text
-            textStyle="body-2"
-            color="secondary.900"
-            alignSelf="center"
-            isTruncated
+          <CollaboratorText>{row.email}</CollaboratorText>
+          <Stack
+            w="100%"
+            direction="row"
+            justify="space-between"
+            flex={0}
+            align="center"
           >
-            {row.email}
-          </Text>
-          <Stack direction="row" align="center">
             <PermissionDropdown
               buttonVariant="clear"
               value={row.role}
@@ -131,7 +160,7 @@ export const CollaboratorList = (): JSX.Element => {
               onClick={handleRemoveCollaborator(row)}
             />
           </Stack>
-        </Stack>
+        </CollaboratorRow>
       ))}
     </Stack>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -100,10 +100,18 @@ export const CollaboratorList = (): JSX.Element => {
           </Stack>
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
-          <Text textStyle="subhead-1" color="secondary.500">
-            Owner
-          </Text>
-          <Spacer />
+          <Stack
+            w="100%"
+            direction="row"
+            justify="space-between"
+            flex={0}
+            align="center"
+          >
+            <Text textStyle="subhead-1" color="secondary.500">
+              Owner
+            </Text>
+            <Spacer w={collaborators?.length ? '5.75rem' : 0} />
+          </Stack>
         </Skeleton>
       </CollaboratorRow>
     )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -93,7 +93,7 @@ export const CollaboratorList = (): JSX.Element => {
   const ownerRow = useMemo(() => {
     return (
       <CollaboratorRow bg={{ base: 'primary.100', md: 'white' }}>
-        <Skeleton isLoaded={!!collaborators} py="0.5rem" w="100%">
+        <Skeleton isLoaded={!!collaborators} w="100%">
           <Stack direction="row" align="baseline">
             <CollaboratorText>{form?.admin.email}</CollaboratorText>
             {isCurrentUserHint({ email: form?.admin.email ?? '' })}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Fragment, useMemo } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { Divider, Flex, Grid, Spacer, Stack, Text } from '@chakra-ui/react'
+import {
+  Divider,
+  Flex,
+  Grid,
+  Skeleton,
+  Spacer,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 
 import { FormPermission } from '~shared/types/form/form'
 
@@ -32,26 +40,25 @@ export const CollaboratorList = (): JSX.Element => {
   const ownerRow = useMemo(() => {
     return (
       <>
-        <Text
-          textStyle="body-2"
-          color="secondary.900"
-          alignSelf="center"
-          isTruncated
-        >
-          {form?.admin.email}
-        </Text>
-        <Text textStyle="body-2" color="secondary.300" px="1rem" py="0.5rem">
-          Owner
-        </Text>
+        <Skeleton isLoaded={!!collaborators} alignSelf="center" py="0.5rem">
+          <Text textStyle="body-2" color="secondary.900" isTruncated>
+            {form?.admin.email}
+          </Text>
+        </Skeleton>
+        <Skeleton isLoaded={!!collaborators}>
+          <Text textStyle="body-2" color="secondary.300" px="1rem" py="0.5rem">
+            Owner
+          </Text>
+        </Skeleton>
         {/* Spacer required for 3 column grid layout */}
         <Spacer />
         <Divider gridColumn="1 / -1" />
       </>
     )
-  }, [form?.admin.email])
+  }, [collaborators, form?.admin.email])
 
   return (
-    <Grid templateColumns="1fr auto auto" maxH="12.5rem" overflowY="auto">
+    <Grid templateColumns="1fr auto auto" overflowY="auto">
       {ownerRow}
       {list.map((row) => (
         <Fragment key={row.email}>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Fragment, useMemo } from 'react'
+import { BiTrash } from 'react-icons/bi'
+import { Divider, Flex, Grid, Spacer, Stack, Text } from '@chakra-ui/react'
+
+import { FormPermission } from '~shared/types/form/form'
+
+import IconButton from '~components/IconButton'
+
+import { useAdminForm, useAdminFormCollaborators } from '../../queries'
+
+import { DropdownRole } from './AddCollaboratorInput'
+import { PermissionDropdown } from './PermissionDropdown'
+
+export const CollaboratorList = (): JSX.Element => {
+  // Admin form data required for checking for duplicate emails.
+  const { data: form } = useAdminForm()
+  const { isLoading, data: collaborators } = useAdminFormCollaborators({
+    enabled: !!form,
+  })
+
+  const permissionsToRole = (permission: FormPermission) => {
+    return permission.write ? DropdownRole.Editor : DropdownRole.Viewer
+  }
+
+  const list = useMemo(() => {
+    return (
+      collaborators?.map((c) => ({
+        email: c.email,
+        role: permissionsToRole(c),
+      })) ?? []
+    )
+  }, [collaborators])
+
+  const ownerRow = useMemo(() => {
+    return (
+      <>
+        <Text
+          textStyle="body-2"
+          color="secondary.900"
+          alignSelf="center"
+          isTruncated
+        >
+          {form?.admin.email}
+        </Text>
+        <Text textStyle="body-2" color="secondary.300" px="1rem" py="0.5rem">
+          Owner
+        </Text>
+        {/* Spacer required for 3 column grid layout */}
+        <Spacer />
+        <Divider gridColumn="1 / -1" />
+      </>
+    )
+  }, [form?.admin.email])
+
+  return (
+    <Grid templateColumns="1fr auto auto">
+      {ownerRow}
+      {list.map((row) => (
+        <Fragment key={row.email}>
+          <Text
+            textStyle="body-2"
+            color="secondary.900"
+            alignSelf="center"
+            isTruncated
+          >
+            {row.email}
+          </Text>
+          <PermissionDropdown
+            buttonVariant="clear"
+            value={row.role}
+            isLoading={false}
+            onChange={(e) => console.log(e)}
+          />
+          <IconButton
+            icon={<BiTrash />}
+            variant="clear"
+            aria-label="Remove collaborator"
+            colorScheme="danger"
+          />
+          <Divider gridColumn="1 / -1" />
+        </Fragment>
+      ))}
+    </Grid>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorList.tsx
@@ -31,7 +31,7 @@ const CollaboratorText = ({ children }: { children: React.ReactNode }) => {
   return (
     <Text
       textStyle={{ base: 'subhead-1', md: 'body-2' }}
-      color={{ base: 'secondary.700', md: 'secondary.900' }}
+      color={{ base: 'secondary.700', md: 'secondary.500' }}
       isTruncated
     >
       {children}
@@ -93,7 +93,7 @@ export const CollaboratorList = (): JSX.Element => {
   const ownerRow = useMemo(() => {
     return (
       <CollaboratorRow bg={{ base: 'primary.100', md: 'white' }}>
-        <Skeleton isLoaded={!!collaborators} w="100%">
+        <Skeleton isLoaded={!!collaborators} flex={1}>
           <Stack direction="row" align="baseline">
             <CollaboratorText>{form?.admin.email}</CollaboratorText>
             {createCurrentUserHint({ email: form?.admin.email ?? '' })}
@@ -101,16 +101,15 @@ export const CollaboratorList = (): JSX.Element => {
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
           <Stack
-            w="100%"
             direction="row"
             justify="space-between"
             flex={0}
             align="center"
           >
-            <Text textStyle="subhead-1" color="secondary.500">
+            <Text minW="6.25rem" textStyle="body-2" color="secondary.500">
               Owner
             </Text>
-            <Spacer w={collaborators?.length ? '5.75rem' : 0} />
+            <Spacer w={collaborators?.length ? '2.75rem' : 0} />
           </Stack>
         </Skeleton>
       </CollaboratorRow>
@@ -148,14 +147,14 @@ export const CollaboratorList = (): JSX.Element => {
   }
 
   return (
-    <Stack spacing={0} align="flex-start" w="100%" divider={<StackDivider />}>
+    <Stack spacing={0} align="flex-start" flex={1} divider={<StackDivider />}>
       {ownerRow}
       {list.map((row, index) => (
         <CollaboratorRow
           key={row.email}
           bg={{ base: index % 2 ? 'primary.100' : 'white', md: 'white' }}
         >
-          <Stack direction="row" w="100%" align="center">
+          <Stack direction="row" flex={1} align="center">
             <CollaboratorText>{row.email}</CollaboratorText>
             {createCurrentUserHint(row)}
           </Stack>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -3,7 +3,10 @@ import ReactDOM from 'react-dom'
 import { useDisclosure } from '@chakra-ui/hooks'
 import { Meta, Story } from '@storybook/react'
 
-import { getAdminFormCollaborators } from '~/mocks/msw/handlers/admin-form'
+import {
+  getAdminFormCollaborators,
+  getAdminFormResponse,
+} from '~/mocks/msw/handlers/admin-form'
 
 import {
   fullScreenDecorator,
@@ -13,6 +16,8 @@ import {
 } from '~utils/storybook'
 
 import { CollaboratorModal } from './CollaboratorModal'
+
+const baseMswRoutes = [getAdminFormResponse(), getAdminFormCollaborators()]
 
 export default {
   title: 'Features/AdminForm/CollaboratorModal',
@@ -26,7 +31,7 @@ export default {
     layout: 'fullscreen',
     // Prevent flaky tests due to modal animating in.
     chromatic: { pauseAnimationAtEnd: true },
-    msw: [getAdminFormCollaborators()],
+    msw: baseMswRoutes,
   },
 } as Meta
 
@@ -58,7 +63,7 @@ export const Default = Template.bind({})
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: [getAdminFormCollaborators({ delay: 'infinite' })],
+  msw: [getAdminFormCollaborators({ delay: 'infinite' }), ...baseMswRoutes],
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -3,9 +3,12 @@ import ReactDOM from 'react-dom'
 import { useDisclosure } from '@chakra-ui/hooks'
 import { Meta, Story } from '@storybook/react'
 
+import { getAdminFormCollaborators } from '~/mocks/msw/handlers/admin-form'
+
 import {
   fullScreenDecorator,
   LoggedInDecorator,
+  StoryRouter,
   viewports,
 } from '~utils/storybook'
 
@@ -14,11 +17,16 @@ import { CollaboratorModal } from './CollaboratorModal'
 export default {
   title: 'Features/AdminForm/CollaboratorModal',
   component: CollaboratorModal,
-  decorators: [fullScreenDecorator, LoggedInDecorator],
+  decorators: [
+    fullScreenDecorator,
+    LoggedInDecorator,
+    StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
+  ],
   parameters: {
     layout: 'fullscreen',
     // Prevent flaky tests due to modal animating in.
     chromatic: { pauseAnimationAtEnd: true },
+    msw: [getAdminFormCollaborators()],
   },
 } as Meta
 
@@ -49,6 +57,9 @@ const Template: Story = () => {
 export const Default = Template.bind({})
 
 export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: [getAdminFormCollaborators({ delay: 'infinite' })],
+}
 
 export const Mobile = Template.bind({})
 Mobile.parameters = {

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -66,6 +66,26 @@ const Template: Story = () => {
 }
 export const Default = Template.bind({})
 
+export const WithCollaborators = Template.bind({})
+WithCollaborators.parameters = {
+  msw: [
+    getAdminFormCollaborators({
+      delay: 0,
+      overrides: [
+        {
+          email: 'viewer@example.com',
+          write: false,
+        },
+        {
+          email: 'editor@example.com',
+          write: true,
+        },
+      ],
+    }),
+    ...baseMswRoutes,
+  ],
+}
+
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: [getAdminFormCollaborators({ delay: 'infinite' }), ...baseMswRoutes],
@@ -77,4 +97,20 @@ Mobile.parameters = {
     defaultViewport: 'mobile1',
   },
   chromatic: { viewports: [viewports.xs] },
+  msw: [
+    getAdminFormCollaborators({
+      delay: 0,
+      overrides: [
+        {
+          email: 'viewer@example.com',
+          write: false,
+        },
+        {
+          email: 'editor@example.com',
+          write: true,
+        },
+      ],
+    }),
+    ...baseMswRoutes,
+  ],
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -80,6 +80,11 @@ WithCollaborators.parameters = {
           email: 'editor@example.com',
           write: true,
         },
+        {
+          email:
+            'super-duper-long-email-the-quick-brown-fox-jumps-over-the-lazy-dog@example.com',
+          write: true,
+        },
       ],
     }),
     ...baseMswRoutes,

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import { useDisclosure } from '@chakra-ui/hooks'
+import { Meta, Story } from '@storybook/react'
+
+import {
+  fullScreenDecorator,
+  LoggedInDecorator,
+  viewports,
+} from '~utils/storybook'
+
+import { CollaboratorModal } from './CollaboratorModal'
+
+export default {
+  title: 'Features/AdminForm/CollaboratorModal',
+  component: CollaboratorModal,
+  decorators: [fullScreenDecorator, LoggedInDecorator],
+  parameters: {
+    layout: 'fullscreen',
+    // Prevent flaky tests due to modal animating in.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
+} as Meta
+
+const modalRoot = document.createElement('div')
+document.body.appendChild(modalRoot)
+
+const Template: Story = () => {
+  const modalProps = useDisclosure({ defaultIsOpen: true })
+
+  const el = document.createElement('div')
+
+  useEffect(() => {
+    modalRoot.appendChild(el)
+
+    return () => {
+      modalRoot.removeChild(el)
+    }
+  })
+
+  return ReactDOM.createPortal(
+    <CollaboratorModal
+      {...modalProps}
+      onClose={() => console.log('close modal')}
+    />,
+    el,
+  )
+}
+export const Default = Template.bind({})
+
+export const Loading = Template.bind({})
+
+export const Mobile = Template.bind({})
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -19,7 +19,7 @@ import {
 import { CollaboratorModal } from './CollaboratorModal'
 
 const baseMswRoutes = [
-  createFormBuilderMocks({}, 0),
+  ...createFormBuilderMocks({}, 0),
   getAdminFormCollaborators(),
   getUser({ delay: 0 }),
 ]

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -4,8 +4,8 @@ import { useDisclosure } from '@chakra-ui/hooks'
 import { Meta, Story } from '@storybook/react'
 
 import {
+  createFormBuilderMocks,
   getAdminFormCollaborators,
-  getAdminFormResponse,
 } from '~/mocks/msw/handlers/admin-form'
 
 import {
@@ -17,7 +17,10 @@ import {
 
 import { CollaboratorModal } from './CollaboratorModal'
 
-const baseMswRoutes = [getAdminFormResponse(), getAdminFormCollaborators()]
+const baseMswRoutes = [
+  createFormBuilderMocks({}, 0),
+  getAdminFormCollaborators(),
+]
 
 export default {
   title: 'Features/AdminForm/CollaboratorModal',

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -7,6 +7,7 @@ import {
   createFormBuilderMocks,
   getAdminFormCollaborators,
 } from '~/mocks/msw/handlers/admin-form'
+import { getUser } from '~/mocks/msw/handlers/user'
 
 import {
   fullScreenDecorator,
@@ -20,6 +21,7 @@ import { CollaboratorModal } from './CollaboratorModal'
 const baseMswRoutes = [
   createFormBuilderMocks({}, 0),
   getAdminFormCollaborators(),
+  getUser({ delay: 0 }),
 ]
 
 export default {

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -1,0 +1,39 @@
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useBreakpointValue,
+} from '@chakra-ui/react'
+
+import { ModalCloseButton } from '~components/Modal'
+
+interface CollaboratorModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const CollaboratorModal = ({
+  isOpen,
+  onClose,
+}: CollaboratorModalProps): JSX.Element => {
+  const modalSize = useBreakpointValue({
+    base: 'mobile',
+    xs: 'mobile',
+    md: 'md',
+  })
+
+  return (
+    <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
+        <ModalBody whiteSpace="pre-line" pb="3.25rem">
+          Placeholder content
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -27,12 +27,6 @@ export const CollaboratorModal = ({
     xs: 'mobile',
     md: 'md',
   })
-
-  const handleAddCollaborators = (inputs: AddCollaboratorInputs) => {
-    const permission = roleToPermission(inputs.role)
-    console.log({ permission, email: inputs.email })
-  }
-
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -40,7 +34,7 @@ export const CollaboratorModal = ({
         <ModalCloseButton />
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
-          <AddCollaboratorInput onSubmit={handleAddCollaborators} />
+          <AddCollaboratorInput />
           <Divider mt="2.5rem" mb="2rem" />
           <CollaboratorList />
         </ModalBody>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -17,6 +17,7 @@ import {
   AddCollaboratorInputs,
   DropdownRole,
 } from './AddCollaboratorInput'
+import { CollaboratorList } from './CollaboratorList'
 
 interface CollaboratorModalProps {
   isOpen: boolean
@@ -59,6 +60,7 @@ export const CollaboratorModal = ({
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
           <AddCollaboratorInput onSubmit={handleAddCollaborators} />
           <Divider mt="2.5rem" mb="2rem" />
+          <CollaboratorList />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -8,15 +8,9 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react'
 
-import { FormPermission } from '~shared/types/form/form'
-
 import { ModalCloseButton } from '~components/Modal'
 
-import {
-  AddCollaboratorInput,
-  AddCollaboratorInputs,
-  DropdownRole,
-} from './AddCollaboratorInput'
+import { AddCollaboratorInput } from './AddCollaboratorInput'
 import { CollaboratorList } from './CollaboratorList'
 
 interface CollaboratorModalProps {
@@ -33,18 +27,6 @@ export const CollaboratorModal = ({
     xs: 'mobile',
     md: 'md',
   })
-
-  const roleToPermission = (
-    role: DropdownRole,
-  ): Omit<FormPermission, 'email'> => {
-    switch (role) {
-      case DropdownRole.Admin:
-      case DropdownRole.Editor:
-        return { write: true }
-      case DropdownRole.Viewer:
-        return { write: false }
-    }
-  }
 
   const handleAddCollaborators = (inputs: AddCollaboratorInputs) => {
     const permission = roleToPermission(inputs.role)

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -35,7 +35,7 @@ export const CollaboratorModal = ({
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
           <AddCollaboratorInput />
-          <Divider mt="2.5rem" mb="2rem" />
+          <Divider mt="2.5rem" />
           <CollaboratorList />
         </ModalBody>
       </ModalContent>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -7,7 +7,15 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react'
 
+import { FormPermission } from '~shared/types/form/form'
+
 import { ModalCloseButton } from '~components/Modal'
+
+import {
+  AddCollaboratorInput,
+  AddCollaboratorInputs,
+  DropdownRole,
+} from './AddCollaboratorInput'
 
 interface CollaboratorModalProps {
   isOpen: boolean
@@ -24,6 +32,23 @@ export const CollaboratorModal = ({
     md: 'md',
   })
 
+  const roleToPermission = (
+    role: DropdownRole,
+  ): Omit<FormPermission, 'email'> => {
+    switch (role) {
+      case DropdownRole.Admin:
+      case DropdownRole.Editor:
+        return { write: true }
+      case DropdownRole.Viewer:
+        return { write: false }
+    }
+  }
+
+  const handleAddCollaborators = (inputs: AddCollaboratorInputs) => {
+    const permission = roleToPermission(inputs.role)
+    console.log({ permission, email: inputs.email })
+  }
+
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -31,7 +56,7 @@ export const CollaboratorModal = ({
         <ModalCloseButton />
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
-          Placeholder content
+          <AddCollaboratorInput onSubmit={handleAddCollaborators} />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Divider,
   Modal,
   ModalBody,
   ModalContent,
@@ -10,6 +11,8 @@ import {
 import { FormPermission } from '~shared/types/form/form'
 
 import { ModalCloseButton } from '~components/Modal'
+
+import { useAdminFormCollaborators } from '../../queries'
 
 import {
   AddCollaboratorInput,
@@ -26,6 +29,8 @@ export const CollaboratorModal = ({
   isOpen,
   onClose,
 }: CollaboratorModalProps): JSX.Element => {
+  const { data: collaborators } = useAdminFormCollaborators({ enabled: isOpen })
+
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -57,9 +62,10 @@ export const CollaboratorModal = ({
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
           <AddCollaboratorInput
-            isLoading={false}
+            isLoading={!collaborators}
             onSubmit={handleAddCollaborators}
           />
+          <Divider mt="2.5rem" mb="2rem" />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -56,7 +56,10 @@ export const CollaboratorModal = ({
         <ModalCloseButton />
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
-          <AddCollaboratorInput onSubmit={handleAddCollaborators} />
+          <AddCollaboratorInput
+            isLoading={false}
+            onSubmit={handleAddCollaborators}
+          />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -12,8 +12,6 @@ import { FormPermission } from '~shared/types/form/form'
 
 import { ModalCloseButton } from '~components/Modal'
 
-import { useAdminFormCollaborators } from '../../queries'
-
 import {
   AddCollaboratorInput,
   AddCollaboratorInputs,
@@ -29,8 +27,6 @@ export const CollaboratorModal = ({
   isOpen,
   onClose,
 }: CollaboratorModalProps): JSX.Element => {
-  const { data: collaborators } = useAdminFormCollaborators({ enabled: isOpen })
-
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -61,10 +57,7 @@ export const CollaboratorModal = ({
         <ModalCloseButton />
         <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
         <ModalBody whiteSpace="pre-line" pb="3.25rem">
-          <AddCollaboratorInput
-            isLoading={!collaborators}
-            onSubmit={handleAddCollaborators}
-          />
+          <AddCollaboratorInput onSubmit={handleAddCollaborators} />
           <Divider mt="2.5rem" mb="2rem" />
         </ModalBody>
       </ModalContent>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -23,6 +23,7 @@ export const PermissionDropdown = ({
       {({ isOpen }) => (
         <>
           <Menu.Button
+            minW="6.5rem"
             ml={{ base: '-0.25rem', md: 0 }}
             isDisabled={isLoading}
             variant={buttonVariant}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Text } from '@chakra-ui/react'
 
 import Menu from '~components/Menu'
 
@@ -22,18 +22,14 @@ export const PermissionDropdown = ({
     <Menu>
       {({ isOpen }) => (
         <>
-          <Box>
-            <Menu.Button
-              isDisabled={isLoading}
-              w="100%"
-              minW="8rem"
-              variant={buttonVariant}
-              colorScheme="secondary"
-              isActive={isOpen}
-            >
-              {value}
-            </Menu.Button>
-          </Box>
+          <Menu.Button
+            isDisabled={isLoading}
+            variant={buttonVariant}
+            colorScheme="secondary"
+            isActive={isOpen}
+          >
+            {value}
+          </Menu.Button>
           <Menu.List defaultValue={value}>
             {Object.values(DropdownRole).map((role) => (
               <Menu.Item key={role} onClick={() => onChange(role)}>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -7,11 +7,13 @@ import { DropdownRole } from './AddCollaboratorInput'
 export interface PermissionDropdownProps {
   value: DropdownRole
   onChange: (role: DropdownRole) => void
+  isLoading: boolean
 }
 
 export const PermissionDropdown = ({
   value,
   onChange,
+  isLoading,
 }: PermissionDropdownProps): JSX.Element => {
   return (
     <Menu>
@@ -19,6 +21,7 @@ export const PermissionDropdown = ({
         <>
           <Box>
             <Menu.Button
+              isDisabled={isLoading}
               w="100%"
               minW="8rem"
               variant="outline"

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -8,12 +8,15 @@ export interface PermissionDropdownProps {
   value: DropdownRole
   onChange: (role: DropdownRole) => void
   isLoading: boolean
+
+  buttonVariant?: 'outline' | 'clear'
 }
 
 export const PermissionDropdown = ({
   value,
   onChange,
   isLoading,
+  buttonVariant = 'outline',
 }: PermissionDropdownProps): JSX.Element => {
   return (
     <Menu>
@@ -24,7 +27,7 @@ export const PermissionDropdown = ({
               isDisabled={isLoading}
               w="100%"
               minW="8rem"
-              variant="outline"
+              variant={buttonVariant}
               colorScheme="secondary"
               isActive={isOpen}
             >

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -1,0 +1,47 @@
+import { Box, Text } from '@chakra-ui/react'
+
+import Menu from '~components/Menu'
+
+import { DropdownRole } from './AddCollaboratorInput'
+
+export interface PermissionDropdownProps {
+  value: DropdownRole
+  onChange: (role: DropdownRole) => void
+}
+
+export const PermissionDropdown = ({
+  value,
+  onChange,
+}: PermissionDropdownProps): JSX.Element => {
+  return (
+    <Menu>
+      {({ isOpen }) => (
+        <>
+          <Box>
+            <Menu.Button
+              w="100%"
+              minW="8rem"
+              variant="outline"
+              colorScheme="secondary"
+              isActive={isOpen}
+            >
+              {value}
+            </Menu.Button>
+          </Box>
+          <Menu.List defaultValue={value}>
+            {Object.values(DropdownRole).map((role) => (
+              <Menu.Item key={role} onClick={() => onChange(role)}>
+                <Text
+                  // Styling to hint to user the current active choice
+                  fontWeight={role === value ? 500 : 400}
+                >
+                  {role}
+                </Text>
+              </Menu.Item>
+            ))}
+          </Menu.List>
+        </>
+      )}
+    </Menu>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/PermissionDropdown.tsx
@@ -23,6 +23,7 @@ export const PermissionDropdown = ({
       {({ isOpen }) => (
         <>
           <Menu.Button
+            ml={{ base: '-0.25rem', md: 0 }}
             isDisabled={isLoading}
             variant={buttonVariant}
             colorScheme="secondary"

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/index.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/index.ts
@@ -1,0 +1,2 @@
+export { CollaboratorModal as default } from './CollaboratorModal'
+export { useCollaboratorModal } from './useCollaboratorModal'

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/useCollaboratorModal.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/useCollaboratorModal.ts
@@ -1,0 +1,17 @@
+import { useDisclosure } from '@chakra-ui/react'
+
+type UseCollaboratorModalReturn = {
+  isCollaboratorModalOpen: boolean
+  onOpenCollaboratorModal: () => void
+  onCloseCollaboratorModal: () => void
+}
+
+export const useCollaboratorModal = (): UseCollaboratorModalReturn => {
+  const { onOpen, onClose, isOpen } = useDisclosure()
+
+  return {
+    onOpenCollaboratorModal: onOpen,
+    onCloseCollaboratorModal: onClose,
+    isCollaboratorModalOpen: isOpen,
+  }
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/utils.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/utils.ts
@@ -1,0 +1,19 @@
+import { FormPermission } from '~shared/types/form/form'
+
+import { DropdownRole } from './AddCollaboratorInput'
+
+export const permissionsToRole = (permission: FormPermission): DropdownRole => {
+  return permission.write ? DropdownRole.Editor : DropdownRole.Viewer
+}
+
+export const roleToPermission = (
+  role: DropdownRole,
+): Omit<FormPermission, 'email'> => {
+  switch (role) {
+    case DropdownRole.Admin:
+    case DropdownRole.Editor:
+      return { write: true }
+    case DropdownRole.Viewer:
+      return { write: false }
+  }
+}

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -1,0 +1,78 @@
+import { useCallback } from 'react'
+import { useMutation, useQueryClient } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import {
+  AdminFormDto,
+  FormPermission,
+  FormPermissionsDto,
+} from '~shared/types/form/form'
+
+import { useToast } from '~hooks/useToast'
+
+import { permissionsToRole } from './components/CollaboratorModal/utils'
+import { updateFormCollaborators } from './AdminViewFormService'
+import { adminFormKeys } from './queries'
+
+export const useMutateCollaborators = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  const queryClient = useQueryClient()
+  const toast = useToast({ status: 'success', isClosable: true })
+
+  const updateFormData = useCallback(
+    (newData: FormPermissionsDto) => {
+      queryClient.setQueryData(adminFormKeys.collaborators(formId), newData)
+      // Only update adminForm if it already has prior data.
+      queryClient.setQueryData<AdminFormDto | undefined>(
+        adminFormKeys.id(formId),
+        (oldData) =>
+          oldData
+            ? {
+                ...oldData,
+                permissionList: newData,
+              }
+            : undefined,
+      )
+    },
+    [formId, queryClient],
+  )
+
+  const mutateAddCollaborator = useMutation(
+    ({
+      newPermission,
+      currentPermissions,
+    }: {
+      newPermission: FormPermission
+      currentPermissions: FormPermissionsDto
+    }) => {
+      const rebuiltPermissions = [newPermission].concat(currentPermissions)
+      return updateFormCollaborators(formId, rebuiltPermissions)
+    },
+    {
+      onSuccess: (newData, { newPermission }) => {
+        toast.closeAll()
+        updateFormData(newData)
+
+        // Show toast on success.
+        toast({
+          description: `${
+            newPermission.email
+          } has been added as a ${permissionsToRole(newPermission)}`,
+        })
+      },
+      onError: (error: Error) => {
+        toast.closeAll()
+        toast({
+          description: error.message,
+          status: 'danger',
+        })
+      },
+    },
+  )
+
+  return {
+    mutateAddCollaborator,
+  }
+}

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -45,7 +45,7 @@ export const useMutateCollaborators = () => {
       toastDescription,
     }: {
       newData: FormPermissionsDto
-      toastDescription: string
+      toastDescription: React.ReactNode
     }) => {
       toast.closeAll()
       updateFormData(newData)
@@ -123,8 +123,32 @@ export const useMutateCollaborators = () => {
     },
   )
 
+  const mutateRemoveCollaborator = useMutation(
+    ({
+      permissionToRemove,
+      currentPermissions,
+    }: {
+      permissionToRemove: FormPermission
+      currentPermissions: FormPermissionsDto
+    }) => {
+      const filteredList = currentPermissions.filter(
+        (c) => c.email !== permissionToRemove.email,
+      )
+      return updateFormCollaborators(formId, filteredList)
+    },
+    {
+      onSuccess: (newData, { permissionToRemove }) => {
+        // TODO: Decide if we want to allow redo (via readding permission)
+        const toastDescription = `${permissionToRemove.email} has been removed as a collaborator`
+        handleSuccess({ newData, toastDescription })
+      },
+      onError: handleError,
+    },
+  )
+
   return {
     mutateAddCollaborator,
     mutateUpdateCollaborator,
+    mutateRemoveCollaborator,
   }
 }

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -1,27 +1,32 @@
-import { QueryObserverOptions, useQuery, UseQueryResult } from 'react-query'
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query'
 import { useParams } from 'react-router-dom'
 
-import { AdminFormDto } from '~shared/types/form/form'
+import { AdminFormDto, FormPermissionsDto } from '~shared/types/form/form'
 
 import { ApiError } from '~typings/core'
 
-import { getAdminFormView, getFreeSmsQuota } from './AdminViewFormService'
+import {
+  getAdminFormView,
+  getFormCollaborators,
+  getFreeSmsQuota,
+} from './AdminViewFormService'
 
 export const adminFormKeys = {
   base: ['adminForm'] as const,
   id: (id: string) => ['adminForm', id] as const,
   freeSmsCount: (id: string) =>
     [...adminFormKeys.id(id), 'freeSmsCount'] as const,
+  collaborators: (id: string) =>
+    [...adminFormKeys.id(id), 'collaborators'] as const,
 }
 
 /**
  * @precondition Must be wrapped in a Router as `useParam` is used.
  */
 export const useAdminForm = (
-  props?: QueryObserverOptions<
+  props?: UseQueryOptions<
     AdminFormDto,
     ApiError,
-    AdminFormDto,
     AdminFormDto,
     ReturnType<typeof adminFormKeys.id>
   >,
@@ -42,5 +47,23 @@ export const useFreeSmsQuota = () => {
 
   return useQuery(adminFormKeys.freeSmsCount(formId), () =>
     getFreeSmsQuota(formId),
+  )
+}
+
+export const useAdminFormCollaborators = (
+  props: UseQueryOptions<
+    FormPermissionsDto,
+    ApiError,
+    FormPermissionsDto,
+    ReturnType<typeof adminFormKeys.collaborators>
+  >,
+): UseQueryResult<FormPermissionsDto, ApiError> => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  return useQuery(
+    adminFormKeys.collaborators(formId),
+    () => getFormCollaborators(formId),
+    { ...props },
   )
 }

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -51,7 +51,7 @@ export const useFreeSmsQuota = () => {
 }
 
 export const useAdminFormCollaborators = (
-  props: UseQueryOptions<
+  props?: UseQueryOptions<
     FormPermissionsDto,
     ApiError,
     FormPermissionsDto,

--- a/frontend/src/mocks/msw/handlers/admin-form/collaborators.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/collaborators.ts
@@ -1,0 +1,18 @@
+import { rest } from 'msw'
+
+import { FormPermissionsDto } from '~shared/types/form/form'
+
+export const getAdminFormCollaborators = ({
+  overrides,
+  delay = 0,
+}: {
+  overrides?: FormPermissionsDto
+  delay?: number | 'infinite'
+} = {}): ReturnType<typeof rest['post']> => {
+  return rest.get<FormPermissionsDto>(
+    '/api/v3/admin/forms/:formId/collaborators',
+    (req, res, ctx) => {
+      return res(ctx.delay(delay), ctx.status(200), ctx.json(overrides ?? []))
+    },
+  )
+}

--- a/frontend/src/mocks/msw/handlers/admin-form/index.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/index.ts
@@ -1,3 +1,4 @@
+export * from './collaborators'
 export * from './form'
 export * from './settings'
 export * from './submissions'

--- a/frontend/src/mocks/msw/handlers/user.ts
+++ b/frontend/src/mocks/msw/handlers/user.ts
@@ -11,7 +11,7 @@ import { DefaultRequestReturn, WithDelayProps } from './types'
 
 export const MOCK_USER = {
   _id: 'mock_id' as UserId,
-  email: 'test@example.com',
+  email: 'admin@example.com',
   agency: {
     emailDomain: ['example.com'],
     _id: '59bb6d4ef06ef18400109733' as AgencyId,

--- a/frontend/src/theme/components/Menu.ts
+++ b/frontend/src/theme/components/Menu.ts
@@ -11,11 +11,9 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
       textAlign: 'left',
       justifyContent: 'space-between',
       _hover: {
-        bg: 'white',
         color: `${c}.900`,
       },
       _active: {
-        bg: 'white',
         color: `${c}.500`,
         _hover: {
           color: `${c}.900`,

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -228,4 +228,5 @@ export type CreateFormBodyDto =
 
 export type EndPageUpdateDto = FormEndPage
 export type StartPageUpdateDto = FormStartPage
+export type FormPermissionsDto = FormPermission[]
 export type PermissionsUpdateDto = FormPermission[]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the initial admin form collaboration feature, where admins can add/remove collaborators.

Note that there is still no transfer ownership feature, or viewer-only modal. Those will come in later PRs.
Meaning there are no client-side guards if a user with view-only rights attempts to modify collaborator permissions (backend will correctly block the action).

Related to #2487 

## Solution
<!-- How did you solve the problem? -->

**Features**:

- add CollaboratorModal component and stories, and use in admin nav bar
  - includes `useCollaboratorModal` hook to control modal open close
  - add various skeleton states

## Before & After Screenshots
New stories in storybook
