### PR TITLE
feat(v2/PublicForm): add handling of form color theme, update design

### DIFF
--- a/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
@@ -128,7 +128,7 @@ const useProvideCalendar = ({
   onMouseLeaveCalendar,
   isDateInRange,
   hoveredDate,
-  colorScheme,
+  colorScheme = 'primary',
 }: UseProvideCalendarProps) => {
   // Ensure that calculations are always made based on date of initial render,
   // so component state doesn't suddenly jump at midnight

--- a/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarContext.tsx
@@ -17,6 +17,8 @@ import {
 import { Props as DayzedProps, RenderProps, useDayzed } from 'dayzed'
 import { inRange } from 'lodash'
 
+import { ThemeColorScheme } from '~theme/foundations/colours'
+
 import { DatePickerProps } from '../DatePicker'
 import {
   generateClassNameForDate,
@@ -64,6 +66,10 @@ type PassthroughProps = {
    * Date currently being hovered, if any.
    */
   hoveredDate?: Date
+  /**
+   * Color scheme of date input
+   */
+  colorScheme?: ThemeColorScheme
 }
 export type UseProvideCalendarProps = Pick<DayzedProps, 'monthsToDisplay'> &
   PassthroughProps
@@ -122,6 +128,7 @@ const useProvideCalendar = ({
   onMouseLeaveCalendar,
   isDateInRange,
   hoveredDate,
+  colorScheme,
 }: UseProvideCalendarProps) => {
   // Ensure that calculations are always made based on date of initial render,
   // so component state doesn't suddenly jump at midnight
@@ -293,5 +300,6 @@ const useProvideCalendar = ({
     onMouseLeaveCalendar,
     isDateInRange,
     hoveredDate,
+    colorScheme,
   }
 }

--- a/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
+++ b/frontend/src/components/DatePicker/Calendar/CalendarTodayButton.tsx
@@ -6,11 +6,12 @@ import { useCalendar } from './CalendarContext'
 
 export const CalendarTodayButton = (): JSX.Element => {
   const styles = useStyles()
-  const { handleTodayClick } = useCalendar()
+  const { handleTodayClick, colorScheme } = useCalendar()
   return (
     <Box sx={styles.todayLinkContainer}>
       <Button
         aria-label="Focus on today's date"
+        colorScheme={colorScheme}
         variant="link"
         type="button"
         onClick={handleTodayClick}

--- a/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
+++ b/frontend/src/components/DatePicker/Calendar/DayOfMonth.tsx
@@ -33,12 +33,7 @@ export interface DayOfMonthProps extends ButtonProps {
 
 export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
   (
-    {
-      dateObj: { date, selected, today },
-      isOutsideCurrMonth,
-      colorScheme = 'primary',
-      ...props
-    },
+    { dateObj: { date, selected, today }, isOutsideCurrMonth, ...props },
     ref,
   ) => {
     const {
@@ -48,6 +43,7 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
       isDateInRange,
       selectedDates,
       hoveredDate,
+      colorScheme,
     } = useCalendar()
 
     const isAvailable = useMemo(
@@ -72,6 +68,7 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
       isSelected: selected,
       isToday: today,
       isOutsideCurrMonth,
+      colorScheme,
     })
 
     const buttonBoxBg = useMemo(() => {

--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -23,8 +23,8 @@ import Input, { InputProps } from '../Input'
 import { DatePicker, DatePickerProps } from './DatePicker'
 
 export interface DateInputProps
-  extends Omit<InputProps, 'value' | 'onChange'>,
-    Pick<DatePickerProps, 'isDateUnavailable'> {
+  extends Omit<InputProps, 'value' | 'onChange' | 'colorScheme'>,
+    Pick<DatePickerProps, 'isDateUnavailable' | 'colorScheme'> {
   name: string
   value?: string
   onChange?: (val: string) => void
@@ -44,6 +44,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
       isReadOnly: isReadOnlyProp,
       isRequired: isRequiredProp,
       isInvalid: isInvalidProp,
+      colorScheme,
       ...props
     },
     ref,
@@ -118,6 +119,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
               </PopoverAnchor>
               <PopoverTrigger>
                 <IconButton
+                  colorScheme={colorScheme}
                   aria-label={calendarButtonAria}
                   icon={<BxCalendar />}
                   variant="inputAttached"
@@ -152,6 +154,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                   </PopoverHeader>
                   <PopoverBody p={0}>
                     <DateInput.DatePicker
+                      colorScheme={colorScheme}
                       date={datePickerDate}
                       isDateUnavailable={isDateUnavailable}
                       onSelectDate={handleDatepickerSelection}

--- a/frontend/src/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.tsx
@@ -6,6 +6,7 @@ import {
 } from '@chakra-ui/react'
 
 import { DATE_INPUT_THEME_KEY } from '~theme/components/DateInput'
+import { ThemeColorScheme } from '~theme/foundations/colours'
 
 import {
   CalendarPanel,
@@ -27,11 +28,15 @@ export interface DatePickerProps {
    * unavailable.
    */
   isDateUnavailable?: (d: Date) => boolean
+  /**
+   * Color scheme for date picker component
+   */
+  colorScheme?: ThemeColorScheme
 }
 
 export const DatePicker = forwardRef<DatePickerProps, 'input'>(
   ({ date, ...props }, initialFocusRef) => {
-    const styles = useMultiStyleConfig(DATE_INPUT_THEME_KEY, {})
+    const styles = useMultiStyleConfig(DATE_INPUT_THEME_KEY, props)
 
     return (
       <CalendarProvider {...props} selectedDates={date}>

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -6,6 +6,8 @@ import {
 } from '@chakra-ui/react'
 import { useCombobox, UseComboboxProps } from 'downshift'
 
+import { ThemeColorScheme } from '~theme/foundations/colours'
+
 import { useItems } from '../hooks/useItems'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
 import { ComboboxItem } from '../types'
@@ -32,6 +34,8 @@ export interface SingleSelectProviderProps<
     label: string
   }
   children: React.ReactNode
+  /** Color scheme of component */
+  colorScheme?: ThemeColorScheme
 }
 export const SingleSelectProvider = ({
   items: rawItems,
@@ -51,6 +55,7 @@ export const SingleSelectProvider = ({
   isRequired: isRequiredProp,
   children,
   inputAria: inputAriaProp,
+  colorScheme,
   comboboxProps = {},
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
@@ -178,6 +183,7 @@ export const SingleSelectProvider = ({
 
   const styles = useMultiStyleConfig('SingleSelect', {
     isClearable,
+    colorScheme,
   })
 
   const inputAria = useMemo(() => {

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -14,6 +14,7 @@ import omit from 'lodash/omit'
 import simplur from 'simplur'
 
 import { ATTACHMENT_THEME_KEY } from '~theme/components/Field/Attachment'
+import { ThemeColorScheme } from '~theme/foundations/colours'
 
 import { AttachmentDropzone } from './AttachmentDropzone'
 import { AttachmentFileInfo } from './AttachmentFileInfo'
@@ -56,11 +57,26 @@ export interface AttachmentProps extends UseFormControlProps<HTMLElement> {
    * input.
    */
   showFileSize?: boolean
+
+  /**
+   * Color scheme of the component.
+   */
+  colorScheme?: ThemeColorScheme
 }
 
 export const Attachment = forwardRef<AttachmentProps, 'div'>(
   (
-    { onChange, onError, maxSize, showFileSize, accept, value, name, ...props },
+    {
+      onChange,
+      onError,
+      maxSize,
+      showFileSize,
+      accept,
+      value,
+      name,
+      colorScheme,
+      ...props
+    },
     ref,
   ) => {
     // Merge given props with any form control props, if they exist.
@@ -179,6 +195,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
 
     const styles = useMultiStyleConfig(ATTACHMENT_THEME_KEY, {
       isDragActive,
+      colorScheme,
     })
 
     const handleRemoveFile = useCallback(() => {

--- a/frontend/src/components/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/NumberInput/NumberInput.tsx
@@ -12,6 +12,8 @@ import {
   useNumberInput,
 } from '@chakra-ui/react'
 
+import { ThemeColorScheme } from '~theme/foundations/colours'
+
 import IconButton from '../IconButton'
 
 export interface NumberInputProps extends ChakraNumberInputProps {
@@ -27,6 +29,11 @@ export interface NumberInputProps extends ChakraNumberInputProps {
    * Whether to show the increment and decrement steppers. Defaults to true.
    */
   showSteppers?: boolean
+
+  /**
+   * Color scheme of number input.
+   */
+  colorScheme?: ThemeColorScheme
 }
 
 export const NumberInput = forwardRef<NumberInputProps, 'input'>(
@@ -93,6 +100,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
           <Box __css={styles.stepperWrapper} ref={stepperWrapperRef}>
             <IconButton
               sx={styles.stepperButton}
+              colorScheme={props.colorScheme}
               aria-hidden
               aria-label="Decrement number"
               variant="clear"
@@ -102,6 +110,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
             <Divider __css={styles.stepperDivider} orientation="vertical" />
             <IconButton
               sx={styles.stepperButton}
+              colorScheme={props.colorScheme}
               aria-hidden
               aria-label="Increment number"
               variant="clear"

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -106,6 +106,9 @@ SingpassUnauthorized.parameters = {
         form: {
           title: 'Singpass login form',
           authType: FormAuthType.SP,
+          startPage: {
+            colorTheme: FormColorTheme.Grey,
+          },
         },
       },
     }),

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -12,7 +12,7 @@ import {
   SHOW_FIELDS_ON_YES_LOGIC,
 } from '~/mocks/msw/handlers/public-form'
 
-import { StoryRouter } from '~utils/storybook'
+import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import PublicFormPage from './PublicFormPage'
 
@@ -62,6 +62,9 @@ export default {
 const Template: Story = () => <PublicFormPage />
 export const Default = Template.bind({})
 
+export const Mobile = Template.bind({})
+Mobile.parameters = getMobileViewParameters()
+
 export const ColorThemeGreen = Template.bind({})
 ColorThemeGreen.parameters = {
   msw: generateMswHandlersForColorTheme(FormColorTheme.Green),
@@ -107,6 +110,12 @@ SingpassUnauthorized.parameters = {
       },
     }),
   ],
+}
+
+export const UnauthedMobile = Template.bind({})
+UnauthedMobile.parameters = {
+  ...SingpassUnauthorized.parameters,
+  ...getMobileViewParameters(),
 }
 
 export const SingpassAuthorized = Template.bind({})

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
 import { BasicField } from '~shared/types/field'
-import { FormAuthType } from '~shared/types/form'
+import { FormAuthType, FormColorTheme } from '~shared/types/form'
 
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
@@ -24,6 +24,24 @@ const DEFAULT_MSW_HANDLERS = [
   postVerifyVfnOtpResponse(),
 ]
 
+const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
+  return [
+    ...envHandlers,
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          startPage: {
+            colorTheme,
+          },
+        },
+      },
+    }),
+    postVfnTransactionResponse(),
+    postGenerateVfnOtpResponse(),
+    postVerifyVfnOtpResponse(),
+  ]
+}
+
 export default {
   title: 'Pages/PublicFormPage',
   component: PublicFormPage,
@@ -43,6 +61,31 @@ export default {
 
 const Template: Story = () => <PublicFormPage />
 export const Default = Template.bind({})
+
+export const ColorThemeGreen = Template.bind({})
+ColorThemeGreen.parameters = {
+  msw: generateMswHandlersForColorTheme(FormColorTheme.Green),
+}
+
+export const ColorThemeGrey = Template.bind({})
+ColorThemeGrey.parameters = {
+  msw: generateMswHandlersForColorTheme(FormColorTheme.Grey),
+}
+
+export const ColorThemeBrown = Template.bind({})
+ColorThemeBrown.parameters = {
+  msw: generateMswHandlersForColorTheme(FormColorTheme.Brown),
+}
+
+export const ColorThemeRed = Template.bind({})
+ColorThemeRed.parameters = {
+  msw: generateMswHandlersForColorTheme(FormColorTheme.Red),
+}
+
+export const ColorThemeOrange = Template.bind({})
+ColorThemeOrange.parameters = {
+  msw: generateMswHandlersForColorTheme(FormColorTheme.Orange),
+}
 
 export const Loading = Template.bind({})
 Loading.parameters = {

--- a/frontend/src/features/public-form/components/FormAuth/AuthImageSvgr.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/AuthImageSvgr.tsx
@@ -3,7 +3,7 @@ import { forwardRef, memo, Ref, SVGProps } from 'react'
 export const AuthImageSvgr = memo(
   forwardRef((props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     <svg
-      width={118}
+      width={117}
       height={144}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -12,48 +12,67 @@ export const AuthImageSvgr = memo(
       {...props}
     >
       <path
-        d="M113.902.402h-.25v143.196h3.515V.402h-3.265Z"
+        d="M113.401.402h-.25v143.196h3.515V.402h-3.265Z"
         fill="#293044"
         stroke="#293044"
         strokeWidth={0.5}
       />
       <path
-        d="M1.083.402h-.25v143.196H113.882V.402H1.083Z"
+        d="M.583.402h-.25v143.196H113.382V.402H.583Z"
         fill="#fff"
         stroke="#293044"
         strokeWidth={0.5}
       />
-      <path d="M1.083 14.88h112.759v41.974H1.084V14.88Z" fill="#4A61C0" />
+      <path d="M.583 14.88h112.758v41.974H.583V14.881Z" fill="#4A61C0" />
       <path
-        d="M18.03 29.137h78.838v1.14H18.031v-1.14ZM18.03 35.322h78.838v1.14H18.03v-1.14ZM33.794 41.512h47.793v1.14H33.794v-1.14Z"
+        d="M17.53 29.138h78.838v1.14H17.53v-1.14ZM17.53 35.322h78.838v1.14H17.53v-1.14ZM33.294 41.513h47.793v1.14H33.294v-1.14Z"
         fill="#8998D6"
       />
+      <rect x={19.583} y={83.652} width={76} height={8} rx={4} fill="#E4E7F6" />
+      <rect x={19.583} y={99.652} width={76} height={8} rx={4} fill="#E4E7F6" />
       <rect
-        x={45.554}
-        y={48.123}
-        width={26.029}
-        height={26.029}
-        rx={3.5}
-        fill="#293044"
-        stroke="#293044"
-      />
-      <rect
-        x={43.083}
-        y={45.652}
-        width={27.029}
-        height={27.029}
-        rx={4}
-        fill="url(#a)"
-      />
-      <rect x={20.083} y={83.652} width={76} height={8} rx={4} fill="#E4E7F6" />
-      <rect x={20.083} y={99.652} width={76} height={8} rx={4} fill="#E4E7F6" />
-      <rect
-        x={20.083}
+        x={19.583}
         y={115.652}
         width={76}
         height={8}
         rx={4}
         fill="#E4E7F6"
+      />
+      <rect
+        x={42.374}
+        y={47.875}
+        width={19.821}
+        height={19.821}
+        rx={2.625}
+        fill="#293044"
+        stroke="#293044"
+        strokeWidth={0.75}
+      />
+      <rect
+        x={40.499}
+        y={46}
+        width={20.571}
+        height={20.571}
+        rx={3}
+        fill="url(#a)"
+      />
+      <rect
+        x={55.874}
+        y={61.375}
+        width={19.821}
+        height={19.821}
+        rx={2.625}
+        fill="#293044"
+        stroke="#293044"
+        strokeWidth={0.75}
+      />
+      <rect
+        x={53.999}
+        y={59.5}
+        width={20.571}
+        height={20.571}
+        rx={3}
+        fill="url(#b)"
       />
       <defs>
         <pattern
@@ -63,46 +82,30 @@ export const AuthImageSvgr = memo(
           height={1}
         >
           <use
-            xlinkHref="#b"
+            xlinkHref="#c"
             transform="matrix(.00714 0 0 .00714 -.079 -.079)"
           />
         </pattern>
-        <svg
+        <pattern
           id="b"
+          patternContentUnits="objectBoundingBox"
+          width={1}
+          height={1}
+        >
+          <use xlinkHref="#d" transform="matrix(.00515 0 0 .00515 -.08 -.08)" />
+        </pattern>
+        <image
+          id="c"
           width={162}
           height={162}
-          viewBox="0 0 180 180"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          ref={ref}
-          {...props}
-        >
-          <rect width={180} height={180} rx={22.5} fill="#F4333D" />
-          <mask
-            id="c"
-            mask-type="alpha"
-            maskUnits="userSpaceOnUse"
-            x={69}
-            y={33}
-            width={42}
-            height={113}
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M69.412 33.75h40.732v111.364H69.412V33.75Z"
-              fill="#fff"
-            />
-          </mask>
-          <g mask="url(#c)">
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M69.39 145.114h40.732l-8.666-67.382c-6.5 1.95-16.9 1.95-23.4 0l-8.666 67.382Zm20.365-73.666c-10.616 0-18.85-8.233-18.85-18.849s8.234-18.85 18.85-18.85c10.617 0 18.85 8.233 18.85 18.85 0 10.616-8.233 18.85-18.85 18.85Z"
-              fill="#fff"
-            />
-          </g>
-        </svg>
+          xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKIAAACiCAYAAADC8hYbAAALIElEQVR4Ae2dv4skxxXH+3/acNhNlmGCTSSMAyUHTiScXHIIwwUCg3FyDg6DkwtOwYHBGGNwoECgwGBwIFBgDEKBUCYEdiDB7k17527LfGu2dntqurqru6u6r7c/BUtP9/aP6lefeq9+vH5VmInTzW5nbn78ydx8+515849/muuXr0z57Pnx35On5vWjD83Vxc/M5ckpfw0ykIy2v/ilKZ88PZbjs+dWxpK1ZG5lv9tNTIExxWg52JYHsL1+/DEwNcA0RWVTmUgROEjNthwNj6wg3vznv2b317+Zq/c/ALp3DLpY0F///JHZffa51Zw5qcwC4tt//duahtiX5bx5NDVk7lW2OVI6ELelrTmX5xdov5lqv2iFcH6x15IJ25ZJQHzz5VfmavMeAD50AL33U5mr7FOkYSBuS9uTja5J3otw3TxMcls5aTRjaMemN4hvv/7GXK7WaEEq156B1dqIib6pF4jXf3gBgABYy4DY6JM6g1h+8pvaDLSpb/7/MMxwTDluf/3bzixGg6gZEI3Ux2SEc5YDXaisxYqYiU3RIAIhcIWgCx0XM7EpCkTMMRCGYGs7HmumW0G8fvEp5piOySAGNH/dlhpBtEM0FMKgQmjTGEv5f9vQThjEbck4IZUwXSVcrRsHvYMgaoJ7KbWV9xynDdzUeakFUR4WFM44hbM0OYe8d2pBxIEBCHNVELFVl45AlBNkrkxwXwAXA2LMT0cg4sgALNkVhjouXjoAkbYhEGaH8HYkwm8rHoAov7KxMsJzlg299WGsaMU7EG++/wEIGTcclQEx59IdiHRSlq2hprBQb774u+Pw/rtmBrABcWwY9R21S1Yjym9s7EzwPMAXA85ncQ8i7UMq4kTtY9dOtCDKVqOh0FBTMODaiRZEOS9OkQmeCfzOcdaCSIQtgJhKKYg9JQviVJnguVQAMbAHUQ6wEzVUeS4gWhC3pSmYUQGGqRWCGCz4LgUQpwZRDBaKDjp1Rnj+siuDGCwU0RUQlg3C1OUvP4di98c/AyKdtUkZEIMFkb3QhlNrRDFYMKsCiFODKAYLlpnoAOJqbSOiqV2tnp6bsL9bJ+bLr4xqN57uHWR6cmrKX31iCvwQI4R2trHrj3QJz6vFdKjkEbI9ObUrUABiS0dFMEnj9U12eOxsM2lnYGrT2/Z8KcNCC7q0nbjU/6vt4hw3+4Ko66QdCVoQ1o5isMDzpl5AarekTHYqFc1Yq/TEICDWmGZ1NlJoQh9kvhuvr/QWxEtq6VEt1RqCudL/fvf7o+cttenj3nsPYo1GcCcscdt3eYZYcNXxofJ7mvFsY4olwtb0zkN6yLEwMpvlgXhyCohVKLcfPY5ladB5tBUBsbF9psn3sRLm+RBGTHOljZxqpc0YmKV9q9p46b8BsQJiW+T7GMBiz2HtGjRiUBM5J4ZYmIacR4cFEMMgfvvdELY6Xct4IiAGQZSDwlhJU4hLbxdW3582YqWNKD/DsRI+i2jEoCZK7egQgtrOrlQqQFUzLPU3GrEKxNkmxE7S40TnPdSGqnyAWAXx5NSM0U7EcxsQg2bZmUQ5aeZwAXMqVYPm7lls74FEI3oaUXBc/+kvjpvkWzzi7+GrVkRArAFRAvIXpElBpFbnrAqf3/dQAmIAxMvzC/utSQoAdQ9mUu6hq6uAgBgCUcfPNmaoI4TamwxeN0MoMAGxCcTb/1mv7W3ZWTnKvDNw3Q4hIEZAeGdGzi/M9YtP2831tjSKlE97MA5AJ180YhcYb8/Vxz4aC9R3z9KWcmCQ+SVqRjf4HIRoxB4QVoXH7/7g+bJDIwLjOzGkBIiACIi+emY/nambmyzRiC0aUU4Q6gWrU+I6JOqs1Bb0am00hacPo2xH5uUrO0PD9yntFQwQW0BMEX5Ewz614LY8e0nXAGILDJ1HsWsuwP8QjThIE129/0ENVt0PEdkBEAeBqEHrFEnmfUlmts+7YpobTHP57HkKDu09+hTOkq4BxAYQr1++SgaizPySwOr6roDYAKKGbVIlvlNpbicCYgOIKWPhyMx31RJLOh8QG0BMGbRTZn5JYHV9V0AMgbhap7LK9j4y810LZ0nnA2IARE3VpUwy80sCq+u7AmIARHlYp0yEGaGz0ksTyes6dbpcrXvlpat2meP5aMSARswRT5uP68NaERADIOaIgcMHVYDY2SRqIcfUiSixgNgZxC5rM8cCK3M/x/bbGHnGNNeZ5vOLWLY6ncdYIhqxkyZSdIYcSeZ+DO0yx2egEWs0YrYQxtsSEGvkrYoDiDWCsbFucqhEY4yijM1RY+XOMyDWgZgzUOejDwGxRuaAWCOUHGOITsESoq6+wwKINSDmGEN0IMrs5zZzc7w/INaBuNs5bpJvFZ97jqDkzjMgeiAqikPOJLOfu1DneH9A9EBUjMOcibFE2ohRmkhxanImxdSeo8bKnWc0oqcRFacmd7ravAeMntwB0ROI4tTkToQ4PjbPgOiBOHQ5ixiICVMHiK0m8eb7H2JYGnQOYeoAsRXEQYRFXqwFynM3/ud2f0xzxTSnCkPXxiMrlKIRGzWRQg6PkWT+56axcucXjVjRiIp7PVbKXbBzuz8gVkBMGYauDehgQPhKfuYG05D8AmKl4McYQ3SAqhkwpOAe2rWAWAExx2LhDjx/q2bAQ4NpyPsAYgXElGHofPD8fcLUHfacAdGBmDgMnQ+ev8+SF4BYaxJTh6HzwfP3WfKiAuLZxhSXZ5vaghli7+d4baqlLHzgQvsseXEPokYQCoYR9gJJuZRFCD7/+BwrbI48A6JrH56cmhxh6Hzw/H38EvdKwIJIzL69MFIuZeEDF9pH9nvZSw4FTpp7YeT8hDQEIoPae9mLwQJh3IL4408hXrId52P7WxA/emwKhLEXRo5GOPeMk60YLJhqihMWUOWTkxgsCIGRT8DAGydbMVgw5xknLKDKJycNnRXMeeYTMPDGyVYMFnw/EScsoMonJzFYEIsln4CBN062YrBg8j1OWECVT05isNB6Igg5n5CRbbtsxWChaQOE1S4sZJRPRmLQgsjkez4hA3CzbF08Sgsig9rNwgKmfPIRe3cakXC6+QQNxM2ydSs4WI1ICIxmYQFTPvm46Gt7EAmnS4et4q0+ZsVTKOc706wfOMjmq/VjFuycnuU6KgcgMucMiGNDLOZcsqZZO8ywAOLYIFYja9yBKBi1TvHYmeF5y6wA/prYByASfWCZUEyhDPyAVwcgSitertZoxYl6kFMAMckzzy9c0/BuewSivGUnyRyFvxi5K5i9n45A1AlEIMBE51JGYqsu1YJIWxEQc4Hotw0dlLUg6p8McANjahirA9gOQLcNgmgdZum4LKbdlhq6o/ut1sZN5zn4qtswiMaYt19/Q0HQiUrCgFhqSo0g6kJ8FTHRR9qtY+WMWTakFUTBSFgSYOwLY+xC7FEgCsbyydMkKrrvC3Hd/CqDmIlN0SCqoclc9PxgmKoCi5WmzokPaDSI7kLMNDC2wR1rjh1T2nYGURex8DUwhmB0H0NVIYv53QtE3dgO7TDOSLvZ9aBXa8tEDHR15/QG0d5sW9JudAWx4K31LdyWdXxFHxsG4u1jFM0JR4nlmWuVuco+RUoCosuIlojAn3EBQK7WJvVyIElBdEDKwwKniYcHpMo05D3jyr7vNguILjP6IEtLi4V6WByfB6wqQ5VlzpQVxIOMb0ujgIwKMaG5Ry3CCIjvFogqE5WNysgugDSwA3JQ/i0744EYyIhG3/VZYRVS1cCjvydPrblnEct2eCUj9WQ1xXYkx2fP7bqDDjYr+9toC4EiGuXw/wEDYnf4Qxd4QQAAAABJRU5ErkJggg=="
+        />
+        <image
+          id="d"
+          width={225}
+          height={225}
+          xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAYAAAA+s9J6AAAYc0lEQVR4Ae2dz6slRxXH+x9xI4IgKIIgiqgoZjazGFezCTIrcaGSjRAhZGE2gbgZCC5GyCYgARchCwlEAhIXCiIouAlEIhFE3IiQN/PmRyYtn35zXur163739r3VXadOfQvu3Pvm3XdvdZ3vp+rUqVPVXV9huf+g7z88+bj/578e93/520f9H/70Uf/W7x71r73+sP/lqw/6l16+3z//4mn/zHOn/Q9+cq//3g/v9Te/f6+/cetuf/3pu/1TN88e3/juSc/jK9cvPr507aTXY502GLe12cBsgn2wE/bCbtgPO2JP7Ip9sTP2xu7YHx2gB3RRY+k8V5qG/fs/Hvdvv/Oof+VXDwZDYBgM94Vvn/Sf/upJ/6kvfzg8eP2Zr530n/36Sf+5b570n//W2YP38fjidz55CLB1AMvRrqmdzHZmS+yKfbHz2Pa8F12gD4BFL+gG/aAjz8UVhP/938dD7/aLVx4MPSCNSqMbYBjBgMphcH2GXxgPsQ0Aow90YqCiH3TEiIquGD3RmadSHEJciVd//aC/9eN7w2gFcDQcvR+Neogx9Ddqt1QD6Ag9WYfOz+gN3aG/0qUIhLgHv/nto8F1wJ2k1xJ0AicFZ83XBiW6Q3/MP9FjKbd1UwhxA/DVcQ8Y8QBvzcbWZ6t999EALix6RJfoc2t3dRMI7532Q1SLyBi9j9xMwbEPHFu/B12iT3TK/HGraOvqEDLM05iCT+BtDdWh32cw8vfod+2yGoSEhgkX43Nr5BOAhwJR8u/QLfoliPPue+sFcFaBkKgTYWIeJRtR3632z6EBdExkFV2vUbJCyISW9RgmuRr9BEAOALx8BnpG1+g7d+AmG4SkD9FgGv0Enxdw1qiH6Ru95ypZICSPj16CUO8aF67PVLt60oAtaeQK2hwNIX6y3E9B4gmSLepi7mmOeeJREN6+cwbgFhet7xDoHjXAAAQHx5SDIeSLCd96bBjVScBuqQE4OAbEgyA0F3TLC9V3CSzPGmBEPNQ1XQwhk1G+0HODqG6yTwkNwAVByqVlEYSEZfkirQFK5CVE7v07LVizdPlibwhZoKQRtAwhAL3DULJ+xseSBf29ISRTwBYqS16kvludgHcNwAm87Fv2glCBGAnfu/C91W9JoGYnhGSPk7yqeaBA9CZ0z/WBF0ZEdhPtKjshZBuH3FAB6FnwXusGN/Czq1wJIcsRWpAXgF5FXkO94GdXjukshGzt5yLlhgrCGsTutY7GD0e8zJVZCDljgyMpvF6c6iXb1KIBOOLk8LkyCSFrHBx2YxTXcrGqp8D0qAE4gqe5tcNJCDn2TaOgBO1R0LXWCZ7gaqpcgpADUDl/UaOgIKxV8B7rDU9wNXXA8CUIlaAt+DyKOEKdWMCfipRegpAjwS3/LcKF6xrUqXjRAFxxDOi4XICQm2NoXVCi9SLaiPWAr/FNaC5ASI6oAjKCMKL4vVwTfI03/16AkBQb3aRFEHoRbMR6wNfYJT2HkDUMIjiKigrCiOL3ck3GWLpmeA4hdzAleuOlsqqHbBFVA3AGb1bOISRNjS1LUS9c1yXbetEAnMGblXMI2Qms+aCE6kWokesBZ+nO+wFCZckIvsii93Zt4+yZAUJ2/8oVFYjexBq5PvBmu+4HCN9+R2eJRja4rs1fB0twBu4oA4TaNeHPSAIntk3SXRUDhM+/eKpzZK7FNrqg9mVfzp+Bu/ORkBV8JW37MpKgiW2PNJm74ywZ7R+MbXAB7c++FiGFv47lCY2C/owkcOLbBO7gr2NbhdLV4htcUPuzMdzBX8cdZLSH0J+BBE18m8Ad/HUkkgrC+AYX1P5sDHfw1+lMGX/GETBt2AR3lJuKdq+9/lC76bVGqN0zBTTAgj38dZwMrLzRNnpejbC+7Ax38Ne99PJ9ZcsU6AUFhC8gStiDrBn460id0T5CCaKECFv/TriDv+6Z5wRhTWKwM0rmnmu6ltbrCoTw17HDVxkzvkZC7IGrwsSdMDYPImk2d+fmIqQaPnXz7vDgNQ/+H8PyXh7p3/H/gNu68D1dP3aGv07J22WFiSGAy2DjZ05B/9nP7w/nU7LnjAVdMis4oYs0J+51R87h+MHveM+///Nxz23OWYN6482H/e07D/of/fR0ANW+B8AFZnnbw1+HwdVDbmcM2ppRjpEK4G7cujtMzn//xzPQhr0tK/4DpEDNAbT0woygAElHQH08jRTR64IW4K9DBIJwffEZeLiMz75wOizSMmKVLoyeQMnpXwgCIHlIE+trgjaGv+7604JwrR6XRjZRMwFntEsPfS0N4Pj7cW9xYwGSERLXFZd1rfZp/XPRB/x1TO5bb4zc149bh7vJqMfRIR5GvDFwu34GSDoNbo3AtTCSa3TM3yHBnyDMuFBv8OFiTN2Hbpfwvf7+/Q8eD+tZQGgR2twdV6ufN0CI29FqA+S6bsSJ68acimgmo0jEQoSWDA9cbEbGXO3X8ufAXycIjxOTuZ2RRr5dHQgjI0sedDyKqB6nnwFC5i0t90SHXjsBC0YEghhRR75dMP75rx8NgQU6Is0XD+MI/jpBuKzxEBuiI2BhJyjvEmv037MTAPdUkdRlWmIAEIQLgzK4Xox+4zutRodsn+tjacPWGQ/1Llr8O0G4AEKigjQYYlOZbgHcctLtmCvKPd1vVBwgbLH3WXrNuJ9kubQ695tGbv5/ObIBr0Hu6X4gdksF2dL7bf7HgrvKshbAY2ANTEsZu0EUhDMuqQHY0tLDMsx2v5sUPeaJWuC/GkRBOAGhuVLpfcV3S07vmGoBXHgiyQS0WvKillyrIBxBaIvP7CxQydMCgEgCu0Cc7ogEYQIhLiiukyKgeeBLPwUQybIRiJdBFIRPILQ5oFzQFJ28rwFRc0RBODsvYRnCbl+cV3r6tLQFOJqDXSaKmn4Co0bCa2dpaMqCSVFZ9zW7MUhctvn3kiBGxPc2DyFzFBbiVbZtAZK/8T4iQrX0mpqGkIwOFpSZq6hs3wJ4H6S4LRVttPc3CyGBGNwh9saplGsBli5aX8xvFkJcIe6Io1K2BciqaX1+2CSEROY4c1PFRwsQlW55ftgkhARjajwBzQcy69SC4FiryxbNQUiPq10R64B0zKfilgIhc/VogZdd19MUhARiFA09BpV1/5bOsUW3tCkICYfXmBXDKMG6GiF97mfHrgSyTji9mQevubEIkUYOnuIaa3S3WSpqMUjTDISsCSLeWgoQEb0l15LOgwdzWVw2roVRffzgd4T77f0IGihrOpCKXfmtjYbNQIhha0jOZgcHox0wUWdA2zWnmPs98yvABUpGSo61914YDRnZj7nuufbw+v9NQIhBGVE8F/IpDb41Fq8ZPYGadvDeGXGaQUujYRMQMhJ4ngvidgLeGvCNe3+Dkb19zDU9FpsbthIpDQ8hhuRYOY+FeR/zVDqJrQXH/BEPwauL2lKkNDyEuDUe1wWZ+xE4AYbxaLXVz4BP+3CCtrfCKN2KSxoeQlw8b+F6lhsYhbwEHxiJObTXW2HJpWQntVVnGBpCDIghPRUApGPwAqAJzSOItBX1sjpGfQ4NIe4M605eCut1uIDeADRxI3jWFb2UVgI0YSG0gIyXCCBnq5AyR3TSRO/x2VvHxU1Jt4gal7RFWAgRu6ftSuwSqEFMdF6e5tGsaUYP0ISFkEwRL5t2WXyuaW7DXJoMGw8FT4YlJjqHkqPVmt8dGkIPOZOIqMakZEafN970cfIAHo13N/4YSENCSK+J8JnYly4EOhiVjzFSib8leEQbfnhSPquGdcwaXPlD7RQSQi/zQUZBxFyrK8Vo6OE8VpYqIs8LQ0LIyOMhS+b2nTpHQevR6TyYj5UeDenM5I4mN00xA3l+JghSeqcArnDNo6DZl7b0cI9GXONaPQpry7nnkCMhwmFrUMnCro2aIqJzAqEj8bANLHJwJiSEuC6lgzKR8h7pTErn30ZetA8HIS4LmSklC3OoSGtbHpYrWC6JGpwJByGjYOmzZLjLb43LEnMuKYv3pW+awxw/gns/1cbhIEQwHBNRspCpE6nXZl7IqW4lC/svBWElEVIWdVkaKFnYm0dnMNXr1fh/FpUsOS8k0CYIK4HQwxphxEgenRujUanCWmEk7yLtjMO5oxiqZOI2UVlC+rhwaUPX/pp2JXOlVGErmCCsZCTEUCUTj4GQ6Ky5cLXDZ/WnXUueWEe7Rs0fDTkSloSQHjtidgcQlsycAcKoqWuCMLN/JQgzN+iTjwPCSMEu8zB4FoSZNSN3NHODJhDKHa1oTqjATP6gEO6oAjP52zXkSOhhiYIj5qPNXxiFSp5UoCWKSkZBehXEUnqxPlqysUV6AaFU0WJ9RRAqbS2/y6S0tfxtGjow4yGBm8ySaAncpfNxuXGN0tYqGQ29bGWKtFZYeo0QFzhaUnzokZCLwyVlqaBkibapt+R8EDtGm2eHhxC3pfTxFlHcJ9x7DwcBR0yKNxDDLdZzYUDo4eaX1MUii9bgtT3TliVzRs2bieTejzUQEkKCIh5ufFn73WaJipKMXtq1Zx9j1JQ1gAwJIS4U7kvpwlkzjIS1joYEZEpmH5n9ot8UJiSEiJ6Dlkr34IiIE6wR89gF8f6zrQ16aENuJRA1bzTsSMiFIfySO8GtF2dXBeez1LbJl/bzMBekHTm4K1oaYNoJhxwJuUDmhR7uo4CIanOnmH+R/+qhsDQS6fjIFD57HRZCL/NCEzKHP9XgluLKA2HpdUFrN6LcNbSbAXXIc1gILRhS8oQwE5I9c/aM9ygfgi99Hw9rL56jnVw3BWlYCLlYBFXySIZUTLymQ2C9y+v8hvby4sLTXsyno7ui6DQ0hIjdy9zGgCRYRMN7C9SwKF96C5i1kT1HPnU7HRFDQ8iFEqApncJmorLn9z84A9HDiIjb7hFA2ooO1Lv7nsJ06OsmIPSQPWMA2jMdw41bd4tueWI0Zv3Nw4K8tYs9ExiiczhU2DX9XXgILUBjxvX0TEYN+/QQm9VzK/HgIZCSxs1rPBY6Tuq4VXuU/J7wENK4iPyt3z3yqLWhToThGZW2EB0uMO1B1JHAh8dClk7khO0x8E1AiMBx/TwXhEd6FtHAsZFy/Uw7MM8qeWDTPjaIfC/CKVs2ASEXTvjdSxrWVUJc8z4WjLRe3U9rk1rT/Kbg2vf/moEQN8zDvddNbFPPrCOuOTckCOMxSJW2RWujIKA2A6GNhp7nhozUjNj79qBL30dH5GGLVwpd+rq1uaDZrykIGWWY8HsNSKx9jgrXz5zTS15oCiCvmROv2QmZ6L09NwUhjY+RMbbHsuZ80ITH9Zc8zn6u3XHFI+8ZtPafem4OQhqBAIW3LBpGpy1EyLVz7Ia3Eul0uinQrvq/JiFkbsRGUU9lq9PZPM4LSbJv0Q01MJuEkIvH6J5GhLXng2Zwi76SreOh4Ia2sFPC2n/quVkIESPJwR6OwAAGUshYTJ8yUu7/I2PGy3ohHkkLSdpX2bBZCGkURE+0tPRhRlsnK3uZF7JmSYdwlUBb+F3TEGJggiGl9xxuNR80QdP5lE5c2Pqa7do9PjcPIUYpvWyx1XwwFSCjYSkPgNxV6mLz07ReLb4WhE/uNgWIpEyVKFusD47FXWpeiOvN/Jco7bhOrf4sCJ9ASK8MiFsneRMd3Cogk4q8xLyQkZfdLK0HYlI78FoQJvddBERGiC0zSpgbAf/YMGv/vPVaKamC3N1pi4SEtdsu9+cLwgRCGhcQGZm2OvaPw5VKCJPrZH1ui/VCvoOliBLXmRuYNT5PEI4gNBARzBauKaNDCXeU68QlXXu9kBGQOa8AnPd2ujV3cq/Ra2z1meaarnkIUqn5oLXh2vNCro91WM0B5wGEP0E4MRKaSHlmjrjWeZyl5oN2fcwL11ojZV6NwBQFnQcQOwjCHQCaWAmcsBk29z68UvNBuy5Ge0aq3PNCvAdGv1Jutl1fDc+CcE8IMSaiosFyzqFKrA+OhUkHk+uamP89+0KZIxzH11XLzwOE9IS1VLh0PenZcU/ZFHxstgmjKnOy0teUa16I+4mWFIBZZlParBOEyxoNaBg9WHQ+ZgTxcp8F5mzHnDuDK0vaHW0i93O5lgYISSEq3RvX+P2Il1EEAR4ypyo9H7Q2Z17I45CRnSUc9ONhRLfrqe2Z9usE4fLeKzU07hci5pZiS4TMSOpl5FiaR8oeTOaz/J2Xa0htUstrdDNAyP3U+aGWinusJ+2HO4ZrQRL4rtPcmA96mjvtOy8EPs6CAT4tPRzPDLqBv44eWRAe36B0DowKwEjDEqafc1OZD/I+Lx0KQF115g5zX9YTgVUL7/nsBnfw1+FWCMJ8DZvCSPiZud/4ZDcv80HrBLA/j9Sd5jUHMKEPwZdXH2m7075dydxFq0zUZ4SN24n7Ro+Hq0oql8c2Z2RmmYFRj9u1Wb0151sHQDRP26KFjvC0Gnq9hrYOxlxV7+4cMHqvo7Vp7c9oAv46JtqaZK8PYe2CUf3zawTu4K/D9RCE+RtYolWb7tIA3MFfx2Kz3A8JZpdg9Pv8GoE7+Os4+9HTmpWMnd/YalOfbQp38NexnqW0I59GEjyx7QJ38Ne1fjMOCT220D3bl0g0N63tvGTze24s1U2grqEB1o/hr2Nxlh/W+BJ9psQrDcxrAO7gryOlylMeo4w2bzS1Tay2gTv460gyVsZMLOMK1jrsyToh/HUk6rIFR0ncdRhOgMWwE7zBHfx13ADFY0KxxBZDbLLjtB3xPuGOMkBI6oyyZqYbSyJSu6yhAXiDu3MIuXe7FuwltjXEps+c1hW8wd05hBzYowjpdGNJRGqXNTQAb3avk8Ed5c6pyh+V2NYQmz5zWlfwBnfnIyFhUkVIpxtLIlK75NaARUbtDKJhJIRGdvhqX6EEl1tw+rzLmoKz9MDlcwg52l0u6eUGk4jUJrk1AGfwZuUcQm/H8OW+cH2eYPKiAYIy8GblHEIOpMVXVeaMxOpFrBHrYYylt9k7hxAqWcHXvFAQRhS/l2uCr/FByxcg5H4KWrQXhF4EG7Ee8AVnabkAIdsqtLdQEEYUv5drgq/xiewXIDSXVFubBKIX0UaqB1xx7P24XIJQZ84IwEjC93QtREXha1wuQajsGUHoSbhR6jLOkklBvAQhv9SuCoEYRfxeriPdNZECyOtJCFnD4LZeWjMUjF5EXHM94Aie0rXBFMRJCHkDJwNruUIQ1ix+L3WHozRNLQVwdiTkF9zymYvQaCgQvYi5xnoYP+kNWPeGkDcSydG6oSCsUfxe6gw/UxHRFMRZd9TeRIqNzp8RiF5EXVM94GacomZcpc87IWT3Lx9mw2pNjaC6qvMopQF4YcvSu++d7Z5PoRu/3gkhf0Cum86gkaBLCbrG74WXcY7oGD77eS8IeTM7geWWCsQagdi6znCS7pw32Oae94aQNQ4uRnmlAnFrUdf0fcbH3JrgFIh7Q8gfcwcZhlnNDwViTWBsVVe4gA84WVIWQcgHK8FbAG4l6tq+BwC56efSshhCvkCBGoFYGyBr13dJIGYM6UEQ8iG37zzQQv41wbi2uGv4fBbk4eHQcjCEBiI9QA0NpTrKTmtoAP0fAyAcHQUhH2CuqYI1EvkaIvf6mRaE2Xct8KpR8mgI+XAmo/QIFp712nCqlzqKHBpA5+h9V07oVeClv8sCIR9IWJYL1IK+hJ5D6F4/w/S9dBkihW78OhuEfDALlGQK0EvIPRWMXkE6pF7mfqLvJQvxY+Cmfs4KoX0BfjLJq9ZrHHLR+htB7EUD6JhHjvmfMZI+rwIhX0D2ONs4CN9qVBRQXoBaUg90i345md7uJZjCk+v1ahBaBZm8cuFs8ReMgnEJBKXei07taJdcwRfjYep5dQj5Urb2c8YGh90IRoFYCq5d32vwoVPOWOKIly3KJhDahTCh5ThF7gqsJQ3BuAuKrX7PTVrQI7pEn7kDL6b/uedNIbRKcMAwwzy+Nj43oyMNIXdVYG4BHjpDb+jO5nzo0W5fbTrd6rkIhOnFcXOM115/OARxaBx6JCKrglJA5gLSoENXtnzGAEC0c3xzllSbW70uDmF6obgB3MGU+SPrMbgHhIZpOHotXpOtoBFTgE4Bii7QBzpBL+iG1+gIPaEr9LW1u5lqfOq1KwjHFcQ9eP+Dx/3b7zwafPXnXzwdXFga1VKHcCd4GKi2PslIyoP3GbgYyR5TRtT/lYfb7GNAYTuzJUBhXwMstT3vQxeMcOiEuR26YWmhlJs51vPcz64hnKs00VYaFleC9CF6N/JXcWuJar308v3BEM88dzr0gBiGW1LduHW3v/703f6pm2cPjMaDaFj6EIzrwZi2M6/NBmYT7IOdsBd2YwTDjoCFXbEvdmYOh92xPzpAD1cdsDunJQ///3+Z6+pDuM6rIAAAAABJRU5ErkJggg=="
+        />
       </defs>
     </svg>
   )),

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react'
 import { BiLogInCircle } from 'react-icons/bi'
-import { Stack, Text } from '@chakra-ui/react'
+import { Box, Stack, Text } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types/form'
 
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 
 import { usePublicAuthMutations } from '~features/public-form/mutations'
@@ -17,6 +18,9 @@ export interface FormAuthProps {
 
 export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
   const { formId } = usePublicFormContext()
+
+  const isMobile = useIsMobile()
+
   const displayedInfo = useMemo(() => {
     switch (authType) {
       case FormAuthType.SP:
@@ -44,23 +48,32 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
   const { handleLoginMutation } = usePublicAuthMutations(formId)
 
   return (
-    <Stack spacing="1.5rem" align="center">
-      <AuthImageSvgr />
-      <Button
-        rightIcon={<BiLogInCircle fontSize="1.5rem" />}
-        onClick={() => handleLoginMutation.mutate()}
-        isLoading={handleLoginMutation.isLoading}
-      >
-        Log in with {displayedInfo.authType}
-      </Button>
-      <Text
-        textStyle="body-2"
-        color="secondary.500"
-        textAlign="center"
-        whiteSpace="pre-line"
-      >
-        {displayedInfo.helpText}
-      </Text>
-    </Stack>
+    <Box
+      bg="white"
+      mt={{ base: '1.5rem', md: 0 }}
+      mb="1.5rem"
+      py="4rem"
+      px="2.5rem"
+    >
+      <Stack spacing="1.5rem" align="center">
+        <AuthImageSvgr />
+        <Button
+          isFullWidth={isMobile}
+          rightIcon={<BiLogInCircle fontSize="1.5rem" />}
+          onClick={() => handleLoginMutation.mutate()}
+          isLoading={handleLoginMutation.isLoading}
+        >
+          Log in with {displayedInfo.authType}
+        </Button>
+        <Text
+          textStyle="body-2"
+          color="secondary.500"
+          textAlign="center"
+          whiteSpace="pre-line"
+        >
+          {displayedInfo.helpText}
+        </Text>
+      </Stack>
+    </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -17,7 +17,12 @@ export interface FormAuthProps {
 }
 
 export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
-  const { formId } = usePublicFormContext()
+  const { formId, form } = usePublicFormContext()
+
+  const buttonColorScheme = useMemo(() => {
+    if (!form) return
+    return `theme-${form.startPage.colorTheme}` as const
+  }, [form])
 
   const isMobile = useIsMobile()
 
@@ -58,6 +63,7 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
       <Stack spacing="1.5rem" align="center">
         <AuthImageSvgr />
         <Button
+          colorScheme={buttonColorScheme}
           isFullWidth={isMobile}
           rightIcon={<BiLogInCircle fontSize="1.5rem" />}
           onClick={() => handleLoginMutation.mutate()}

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -58,14 +58,14 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
       mt={{ base: '1.5rem', md: 0 }}
       mb="1.5rem"
       py="4rem"
-      px="2.5rem"
+      px={{ base: '1.5rem', md: '2.5rem' }}
     >
       <Stack spacing="1.5rem" align="center">
         <AuthImageSvgr />
         <Button
           colorScheme={buttonColorScheme}
           isFullWidth={isMobile}
-          rightIcon={<BiLogInCircle fontSize="1.5rem" />}
+          rightIcon={isMobile ? undefined : <BiLogInCircle fontSize="1.5rem" />}
           onClick={() => handleLoginMutation.mutate()}
           isLoading={handleLoginMutation.isLoading}
         >

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
+import { FormColorTheme } from '~shared/types'
+
 import { getMobileViewParameters } from '~utils/storybook'
 
 import { FormEndPage, FormEndPageProps } from './FormEndPage'
@@ -31,6 +33,36 @@ Default.args = {
   },
   formTitle: 'Test Form',
   handleSubmitFeedback: (inputs) => console.log(inputs),
+}
+
+export const ColorThemeGreen = Template.bind({})
+ColorThemeGreen.args = {
+  ...Default.args,
+  colorTheme: FormColorTheme.Green,
+}
+
+export const ColorThemeGrey = Template.bind({})
+ColorThemeGrey.args = {
+  ...Default.args,
+  colorTheme: FormColorTheme.Grey,
+}
+
+export const ColorThemeBrown = Template.bind({})
+ColorThemeBrown.args = {
+  ...Default.args,
+  colorTheme: FormColorTheme.Brown,
+}
+
+export const ColorThemeRed = Template.bind({})
+ColorThemeRed.args = {
+  ...Default.args,
+  colorTheme: FormColorTheme.Red,
+}
+
+export const ColorThemeOrange = Template.bind({})
+ColorThemeOrange.args = {
+  ...Default.args,
+  colorTheme: FormColorTheme.Orange,
 }
 
 export const FeedbackSubmitted = Template.bind({})

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
@@ -1,6 +1,6 @@
 import { Container, Flex, Stack, StackDivider } from '@chakra-ui/react'
 
-import { FormDto } from '~shared/types/form'
+import { FormColorTheme, FormDto } from '~shared/types/form'
 
 import { SubmissionData } from '~features/public-form/PublicFormContext'
 
@@ -15,11 +15,13 @@ export interface FormEndPageProps {
   submissionData: SubmissionData
   handleSubmitFeedback: (inputs: FeedbackFormInput) => void
   isFeedbackSubmitted: boolean
+  colorTheme: FormColorTheme
 }
 
 export const FormEndPage = ({
   handleSubmitFeedback,
   isFeedbackSubmitted,
+  colorTheme,
   ...endPageProps
 }: FormEndPageProps): JSX.Element => {
   return (
@@ -34,9 +36,12 @@ export const FormEndPage = ({
           w="100%"
           divider={<StackDivider />}
         >
-          <EndPageBlock {...endPageProps} />
+          <EndPageBlock {...endPageProps} colorTheme={colorTheme} />
           {isFeedbackSubmitted ? null : (
-            <FeedbackBlock onSubmit={handleSubmitFeedback} />
+            <FeedbackBlock
+              colorTheme={colorTheme}
+              onSubmit={handleSubmitFeedback}
+            />
           )}
         </Stack>
       </Flex>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -31,6 +31,7 @@ export const FormEndPageContainer = (): JSX.Element | null => {
   return (
     <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
       <FormEndPage
+        colorTheme={form.startPage.colorTheme}
         submissionData={submissionData}
         formTitle={form.title}
         endPage={form.endPage}

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -38,13 +38,7 @@ export const EndPageBlock = ({
 
   return (
     <Flex flexDir="column">
-      <Accordion
-        allowToggle
-        m="-1rem"
-        flex={1}
-        variant="medium"
-        colorScheme={`theme-${colorTheme}`}
-      >
+      <Accordion allowToggle m="-1rem" flex={1} variant="medium">
         <AccordionItem color="secondary.500" border="none">
           <AccordionButton>
             <Stack

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { format } from 'date-fns'
 
-import { FormDto } from '~shared/types/form'
+import { FormColorTheme, FormDto } from '~shared/types/form'
 
 import Button from '~components/Button'
 
@@ -23,12 +23,14 @@ export interface EndPageBlockProps {
   formTitle: string
   endPage: FormDto['endPage']
   submissionData: SubmissionData
+  colorTheme?: FormColorTheme
 }
 
 export const EndPageBlock = ({
   formTitle,
   endPage,
   submissionData,
+  colorTheme = FormColorTheme.Blue,
 }: EndPageBlockProps): JSX.Element => {
   const prettifiedDateString = useMemo(() => {
     return format(new Date(submissionData.timeInEpochMs), 'dd MMM yyyy, h:mm a')
@@ -36,7 +38,13 @@ export const EndPageBlock = ({
 
   return (
     <Flex flexDir="column">
-      <Accordion allowToggle m="-1rem" flex={1} variant="medium">
+      <Accordion
+        allowToggle
+        m="-1rem"
+        flex={1}
+        variant="medium"
+        colorScheme={`theme-${colorTheme}`}
+      >
         <AccordionItem color="secondary.500" border="none">
           <AccordionButton>
             <Stack
@@ -74,7 +82,7 @@ export const EndPageBlock = ({
           as="a"
           href={endPage.buttonLink ?? ''}
           variant="solid"
-          colorScheme="primary"
+          colorScheme={`theme-${colorTheme}`}
         >
           {endPage.buttonText}
         </Button>

--- a/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
@@ -1,5 +1,8 @@
+import { useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { chakra, Flex, FormControl } from '@chakra-ui/react'
+
+import { FormColorTheme } from '~shared/types/form'
 
 import Button from '~components/Button'
 import Rating from '~components/Field/Rating'
@@ -14,10 +17,12 @@ export type FeedbackFormInput = {
 
 export interface FeedbackBlockProps {
   onSubmit: (input: FeedbackFormInput) => void
+  colorTheme?: FormColorTheme
 }
 
 export const FeedbackBlock = ({
   onSubmit,
+  colorTheme = FormColorTheme.Blue,
 }: FeedbackBlockProps): JSX.Element => {
   const {
     control,
@@ -27,6 +32,10 @@ export const FeedbackBlock = ({
   } = useForm<FeedbackFormInput>()
 
   const handleFormSubmit = handleSubmit((inputs) => onSubmit(inputs))
+
+  const colorScheme = useMemo(() => {
+    return `theme-${colorTheme}` as const
+  }, [colorTheme])
 
   return (
     <Flex justify="center">
@@ -45,7 +54,12 @@ export const FeedbackBlock = ({
             control={control}
             name="rating"
             render={({ field }) => (
-              <Rating numberOfRatings={5} variant="star" {...field} />
+              <Rating
+                colorScheme={colorScheme}
+                numberOfRatings={5}
+                variant="star"
+                {...field}
+              />
             )}
           />
           <FormErrorMessage>{errors.rating?.message}</FormErrorMessage>
@@ -61,6 +75,7 @@ export const FeedbackBlock = ({
           mt="1.5rem"
           variant="outline"
           type="submit"
+          colorScheme={colorScheme}
           isLoading={isSubmitting}
         >
           Submit feedback

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -67,6 +67,7 @@ export const FormFields = ({
             formLogics={formLogics}
           />
           <Button
+            colorScheme={`theme-${colorTheme}`}
             mt="1rem"
             type="submit"
             isLoading={formMethods.formState.isSubmitting}

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
-import { Stack } from '@chakra-ui/react'
+import { Box, Stack } from '@chakra-ui/react'
 import { times } from 'lodash'
 
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, LogicDto } from '~shared/types/form'
 
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import { FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
@@ -27,6 +28,8 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
+  const isMobile = useIsMobile()
+
   // TODO: Inject default values is field is also prefilled.
   const augmentedFormFields = useMemo(
     () => formFields.map(augmentWithMyInfo),
@@ -59,23 +62,28 @@ export const FormFields = ({
   return (
     <FormProvider {...formMethods}>
       <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
-        <Stack spacing="2.25rem">
-          <VisibleFormFields
-            colorTheme={colorTheme}
-            control={formMethods.control}
-            formFields={augmentedFormFields}
-            formLogics={formLogics}
-          />
+        <Box bg="white" py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
+          <Stack spacing="2.25rem">
+            <VisibleFormFields
+              colorTheme={colorTheme}
+              control={formMethods.control}
+              formFields={augmentedFormFields}
+              formLogics={formLogics}
+            />
+          </Stack>
+        </Box>
+        <Box px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
           <Button
+            isFullWidth={isMobile}
+            w="100%"
             colorScheme={`theme-${colorTheme}`}
-            mt="1rem"
             type="submit"
             isLoading={formMethods.formState.isSubmitting}
             loadingText="Submitting"
           >
-            Submit
+            Submit now
           </Button>
-        </Stack>
+        </Box>
       </form>
     </FormProvider>
   )

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -53,15 +53,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     <FormSectionsProvider form={form}>
       <Flex flex={1} justify="center">
         {isAuthRequired ? null : <SectionSidebar />}
-        <Box
-          bg="white"
-          py="2.5rem"
-          px={{ base: '1rem', md: '2.5rem' }}
-          w="100%"
-          minW={0}
-          h="fit-content"
-          maxW="57rem"
-        >
+        <Box w="100%" minW={0} h="fit-content" maxW="57rem">
           {renderFields}
         </Box>
         {isAuthRequired ? null : <Spacer />}

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -55,7 +55,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
         {isAuthRequired ? null : <SectionSidebar />}
         <Box
           bg="white"
-          p="2.5rem"
+          py="2.5rem"
+          px={{ base: '1rem', md: '2.5rem' }}
           w="100%"
           minW={0}
           h="fit-content"

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -123,7 +123,12 @@ export const FormHeader = (): JSX.Element | null => {
   return (
     <>
       <MiniHeader isOpen={isOpen} />
-      <Flex p="3rem" justify="center" bg={titleBg}>
+      <Flex
+        px={{ base: '1.5rem', md: '3rem' }}
+        py={{ base: '2rem', md: '3rem' }}
+        justify="center"
+        bg={titleBg}
+      >
         <Flex
           maxW="32.5rem"
           flexDir="column"
@@ -131,14 +136,20 @@ export const FormHeader = (): JSX.Element | null => {
           color={titleColour}
         >
           <Skeleton isLoaded={!!title}>
-            <Text as="h1" textStyle="h1" textAlign="center">
+            <Text
+              as="h1"
+              textStyle="h1"
+              textAlign={{ base: 'start', md: 'center' }}
+            >
               {title ?? 'Loading title'}
             </Text>
           </Skeleton>
           {estTimeString && (
-            <Flex align="center" justify="center" mt="1rem">
+            <Flex align="flex-start" justify="center" mt="0.875rem">
               <Icon as={BxsTimeFive} fontSize="1.5rem" mr="0.5rem" />
-              <Text textStyle="body-2">{estTimeString}</Text>
+              <Text textStyle="body-2" mt="0.125rem">
+                {estTimeString}
+              </Text>
             </Flex>
           )}
           {loggedInId ? (

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -130,9 +130,9 @@ export const FormHeader = (): JSX.Element | null => {
         bg={titleBg}
       >
         <Flex
-          maxW="32.5rem"
+          maxW="57rem"
           flexDir="column"
-          align="center"
+          align={{ base: 'start', md: 'center' }}
           color={titleColour}
         >
           <Skeleton isLoaded={!!title}>

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -22,7 +22,13 @@ export const PublicFormWrapper = ({
   }, [form, isLoading])
 
   return (
-    <Flex bg={bgColour} p="1.5rem" flex={1} justify="center" flexDir="column">
+    <Flex
+      bg={bgColour}
+      p={{ base: 0, md: '1.5rem' }}
+      flex={1}
+      justify="center"
+      flexDir="column"
+    >
       {children}
     </Flex>
   )

--- a/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
+++ b/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
@@ -1,6 +1,7 @@
 import { BiCheck } from 'react-icons/bi'
 import { Box, Stack } from '@chakra-ui/react'
 
+import { FormColorTheme } from '~shared/types'
 import { FormFieldWithId } from '~shared/types/field'
 
 import Button from '~components/Button'
@@ -24,6 +25,7 @@ export interface VerifiableFieldContainerProps
  */
 export const VerifiableFieldContainer = ({
   schema,
+  colorTheme = FormColorTheme.Blue,
   children,
 }: VerifiableFieldContainerProps): JSX.Element => {
   const {
@@ -48,6 +50,7 @@ export const VerifiableFieldContainer = ({
               isDisabled={isVfnBoxOpen || hasSignature}
               isLoading={isSendingOtp}
               onClick={handleVfnButtonClick}
+              colorScheme={`theme-${colorTheme}`}
               leftIcon={
                 hasSignature ? <BiCheck fontSize="1.5rem" /> : undefined
               }

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
 import { MB } from '~shared/constants/file'
+import { FormColorTheme } from '~shared/types'
 import { VALID_EXTENSIONS } from '~shared/utils/file-validation'
 
 import { createAttachmentValidationRules } from '~utils/fieldValidation'
@@ -19,6 +20,7 @@ export interface AttachmentFieldProps extends BaseFieldProps {
  */
 export const AttachmentField = ({
   schema,
+  colorTheme = FormColorTheme.Blue,
 }: AttachmentFieldProps): JSX.Element => {
   const fieldName = schema._id
   const validationRules = useMemo(
@@ -47,6 +49,7 @@ export const AttachmentField = ({
         render={({ field: { onChange, ...rest } }) => (
           <Attachment
             {...rest}
+            colorScheme={`theme-${colorTheme}`}
             maxSize={maxSizeInBytes}
             accept={VALID_EXTENSIONS}
             showFileSize

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -7,6 +7,8 @@ import {
 } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 
+import { FormColorTheme } from '~shared/types'
+
 import { CHECKBOX_THEME_KEY } from '~theme/components/Checkbox'
 import { createCheckboxValidationRules } from '~utils/fieldValidation'
 import Checkbox from '~components/Checkbox'
@@ -27,8 +29,17 @@ export interface CheckboxFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const CheckboxField = ({ schema }: CheckboxFieldProps): JSX.Element => {
-  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {})
+export const CheckboxField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: CheckboxFieldProps): JSX.Element => {
+  const fieldColorScheme = useMemo(
+    () => `theme-${colorTheme}` as const,
+    [colorTheme],
+  )
+  const styles = useMultiStyleConfig(CHECKBOX_THEME_KEY, {
+    colorScheme: fieldColorScheme,
+  })
 
   const othersInputName = useMemo(
     () => `${schema._id}.${CHECKBOX_OTHERS_INPUT_KEY}` as const,
@@ -70,6 +81,7 @@ export const CheckboxField = ({ schema }: CheckboxFieldProps): JSX.Element => {
     <FieldContainer schema={schema} errorKey={checkboxInputName}>
       {schema.fieldOptions.map((o, idx) => (
         <Checkbox
+          colorScheme={fieldColorScheme}
           key={idx}
           value={o}
           {...register(checkboxInputName, validationRules)}
@@ -78,7 +90,7 @@ export const CheckboxField = ({ schema }: CheckboxFieldProps): JSX.Element => {
         </Checkbox>
       ))}
       {schema.othersRadioButton ? (
-        <Checkbox.OthersWrapper>
+        <Checkbox.OthersWrapper colorScheme={fieldColorScheme}>
           <FormControl
             isRequired={schema.required}
             isDisabled={schema.disabled}
@@ -86,12 +98,14 @@ export const CheckboxField = ({ schema }: CheckboxFieldProps): JSX.Element => {
             isInvalid={!!get(errors, othersInputName)}
           >
             <OtherCheckboxField
+              colorScheme={fieldColorScheme}
               value={CHECKBOX_OTHERS_INPUT_VALUE}
               isInvalid={!!get(errors, checkboxInputName)}
               triggerOthersInputValidation={() => trigger(othersInputName)}
               {...register(checkboxInputName, validationRules)}
             />
             <Checkbox.OthersInput
+              colorScheme={fieldColorScheme}
               aria-label='Enter value for "Others" option'
               {...register(othersInputName, othersValidationRules)}
             />

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FormColorTheme } from '~shared/types'
 import { DateSelectedValidation } from '~shared/types/field'
 
 import {
@@ -21,7 +22,10 @@ export interface DateFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const DateField = ({ schema }: DateFieldProps): JSX.Element => {
+export const DateField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: DateFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDateValidationRules(schema),
     [schema],
@@ -58,7 +62,11 @@ export const DateField = ({ schema }: DateFieldProps): JSX.Element => {
         name={schema._id}
         rules={validationRules}
         render={({ field }) => (
-          <DateInput {...field} isDateUnavailable={isDateUnavailable} />
+          <DateInput
+            colorScheme={`theme-${colorTheme}`}
+            {...field}
+            isDateUnavailable={isDateUnavailable}
+          />
         )}
       />
     </FieldContainer>

--- a/frontend/src/templates/Field/Dropdown/DropdownField.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FormColorTheme } from '~shared/types'
+
 import { createDropdownValidationRules } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown/SingleSelect'
 
@@ -14,7 +16,10 @@ export interface DropdownFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const DropdownField = ({ schema }: DropdownFieldProps): JSX.Element => {
+export const DropdownField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: DropdownFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDropdownValidationRules(schema),
     [schema],
@@ -30,7 +35,11 @@ export const DropdownField = ({ schema }: DropdownFieldProps): JSX.Element => {
         name={schema._id}
         defaultValue=""
         render={({ field }) => (
-          <SingleSelect items={schema.fieldOptions} {...field} />
+          <SingleSelect
+            colorScheme={`theme-${colorTheme}`}
+            items={schema.fieldOptions}
+            {...field}
+          />
         )}
       />
     </FieldContainer>

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FormColorTheme } from '~shared/types'
+
 import { createNumberValidationRules } from '~utils/fieldValidation'
 import NumberInput from '~components/NumberInput'
 
@@ -11,7 +13,10 @@ export interface NumberFieldProps extends BaseFieldProps {
   schema: NumberFieldSchema
 }
 
-export const NumberField = ({ schema }: NumberFieldProps): JSX.Element => {
+export const NumberField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: NumberFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createNumberValidationRules(schema),
     [schema],
@@ -29,6 +34,7 @@ export const NumberField = ({ schema }: NumberFieldProps): JSX.Element => {
           <NumberInput
             min={0}
             inputMode="numeric"
+            colorScheme={`theme-${colorTheme}`}
             aria-label={schema.title}
             allowMouseWheel
             precision={0}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -3,6 +3,8 @@ import { Controller, useFormContext, useFormState } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
 
+import { FormColorTheme } from '~shared/types'
+
 import { RADIO_THEME_KEY } from '~theme/components/Radio'
 import { createRadioValidationRules } from '~utils/fieldValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -21,8 +23,17 @@ export interface RadioFieldProps extends BaseFieldProps {
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const RadioField = ({ schema }: RadioFieldProps): JSX.Element => {
-  const styles = useMultiStyleConfig(RADIO_THEME_KEY, {})
+export const RadioField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: RadioFieldProps): JSX.Element => {
+  const fieldColorScheme = useMemo(
+    () => `theme-${colorTheme}` as const,
+    [colorTheme],
+  )
+  const styles = useMultiStyleConfig(RADIO_THEME_KEY, {
+    colorScheme: fieldColorScheme,
+  })
 
   const othersInputName = useMemo(
     () => `${schema._id}.${RADIO_OTHERS_INPUT_KEY}` as const,
@@ -66,6 +77,7 @@ export const RadioField = ({ schema }: RadioFieldProps): JSX.Element => {
         // radio themselves get the ref.
         render={({ field: { ref, onChange, value, ...rest } }) => (
           <Radio.RadioGroup
+            colorScheme={fieldColorScheme}
             {...rest}
             value={value}
             onChange={(nextValue) => {
@@ -86,7 +98,10 @@ export const RadioField = ({ schema }: RadioFieldProps): JSX.Element => {
               </Radio>
             ))}
             {schema.othersRadioButton ? (
-              <Radio.OthersWrapper value={RADIO_OTHERS_INPUT_VALUE}>
+              <Radio.OthersWrapper
+                colorScheme={fieldColorScheme}
+                value={RADIO_OTHERS_INPUT_VALUE}
+              >
                 <FormControl
                   isRequired={schema.required}
                   isDisabled={schema.disabled}

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -4,6 +4,7 @@
 import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FormColorTheme } from '~shared/types'
 import { RatingShape } from '~shared/types/field'
 
 import { createRatingValidationRules } from '~utils/fieldValidation'
@@ -25,7 +26,10 @@ const transform = {
   toNumber: (value: string) => Number(value),
 }
 
-export const RatingField = ({ schema }: RatingFieldProps): JSX.Element => {
+export const RatingField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: RatingFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createRatingValidationRules(schema),
     [schema],
@@ -50,6 +54,7 @@ export const RatingField = ({ schema }: RatingFieldProps): JSX.Element => {
         name={schema._id}
         render={({ field: { value, onChange, ...rest } }) => (
           <Rating
+            colorScheme={`theme-${colorTheme}`}
             numberOfRatings={schema.ratingOptions.steps}
             variant={ratingVariant}
             value={transform.toNumber(value)}

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -1,6 +1,8 @@
 import { Waypoint } from 'react-waypoint'
 import { Box, forwardRef, Text } from '@chakra-ui/react'
 
+import { FormColorTheme } from '~shared/types'
+
 import { SectionFieldContainerProps } from './SectionFieldContainer'
 
 export interface SectionFieldProps extends SectionFieldContainerProps {
@@ -13,7 +15,7 @@ export interface SectionFieldProps extends SectionFieldContainerProps {
 
 // Used by SectionFieldContainer
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
-  ({ schema, colorTheme, handleSectionEnter }, ref) => {
+  ({ schema, colorTheme = FormColorTheme.Blue, handleSectionEnter }, ref) => {
     return (
       <Box
         _notFirst={{

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Waypoint } from 'react-waypoint'
 import { Box, forwardRef, Text } from '@chakra-ui/react'
 
@@ -16,6 +17,16 @@ export interface SectionFieldProps extends SectionFieldContainerProps {
 // Used by SectionFieldContainer
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
   ({ schema, colorTheme = FormColorTheme.Blue, handleSectionEnter }, ref) => {
+    const sectionColor = useMemo(() => {
+      switch (colorTheme) {
+        case FormColorTheme.Orange:
+        case FormColorTheme.Red:
+          return `theme-${colorTheme}.600` as const
+        default:
+          return `theme-${colorTheme}.500` as const
+      }
+    }, [])
+
     return (
       <Box
         _notFirst={{
@@ -24,7 +35,7 @@ export const SectionField = forwardRef<SectionFieldProps, 'div'>(
       >
         {/* id given so app can scrolled to this section */}
         <Box id={schema._id} ref={ref}>
-          <Text textStyle="h2" color={`theme-${colorTheme}.500`}>
+          <Text textStyle="h2" color={sectionColor}>
             {schema.title}
           </Text>
           <Text textStyle="body-1" color="secondary.700" mt="1rem">

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -13,7 +13,7 @@ export interface SectionFieldProps extends SectionFieldContainerProps {
 
 // Used by SectionFieldContainer
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
-  ({ schema, handleSectionEnter }, ref) => {
+  ({ schema, colorTheme, handleSectionEnter }, ref) => {
     return (
       <Box
         _notFirst={{
@@ -22,7 +22,7 @@ export const SectionField = forwardRef<SectionFieldProps, 'div'>(
       >
         {/* id given so app can scrolled to this section */}
         <Box id={schema._id} ref={ref}>
-          <Text textStyle="h2" color="primary.500">
+          <Text textStyle="h2" color={`theme-${colorTheme}.500`}>
             {schema.title}
           </Text>
           <Text textStyle="body-1" color="secondary.700" mt="1rem">

--- a/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
+++ b/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
@@ -11,6 +11,7 @@ export interface SectionFieldContainerProps extends BaseFieldProps {
 
 export const SectionFieldContainer = ({
   schema,
+  colorTheme,
 }: SectionFieldContainerProps): JSX.Element => {
   const { sectionRefs, setActiveSectionId } = useFormSections()
 
@@ -18,6 +19,7 @@ export const SectionFieldContainer = ({
     <SectionField
       ref={sectionRefs[schema._id]}
       schema={schema}
+      colorTheme={colorTheme}
       handleSectionEnter={() => setActiveSectionId(schema._id)}
     />
   )

--- a/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
+++ b/frontend/src/templates/Field/Section/SectionFieldContainer.tsx
@@ -1,3 +1,5 @@
+import { FormColorTheme } from '~shared/types'
+
 import { useFormSections } from '~features/public-form/components/FormFields/FormSectionsContext'
 
 import { BaseFieldProps } from '../FieldContainer'
@@ -11,7 +13,7 @@ export interface SectionFieldContainerProps extends BaseFieldProps {
 
 export const SectionFieldContainer = ({
   schema,
-  colorTheme,
+  colorTheme = FormColorTheme.Blue,
 }: SectionFieldContainerProps): JSX.Element => {
   const { sectionRefs, setActiveSectionId } = useFormSections()
 

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -4,6 +4,7 @@ import { UseTableCellProps } from 'react-table'
 import { FormControl } from '@chakra-ui/react'
 import { get } from 'lodash'
 
+import { FormColorTheme } from '~shared/types'
 import {
   BasicField,
   Column,
@@ -28,17 +29,20 @@ export interface ColumnCellProps
   extends UseTableCellProps<TableFieldInputs, string> {
   schemaId: string
   columnSchema: ColumnDto
+  colorTheme: FormColorTheme
 }
 
 export interface FieldColumnCellProps<T extends Column = Column> {
   schema: ColumnDto<T>
   /** Represents `{schemaId}.{rowIndex}.{columnId}` */
   inputName: `${string}.${number}.${string}`
+  colorTheme: FormColorTheme
 }
 
 const ShortTextColumnCell = ({
   schema,
   inputName,
+  colorTheme,
 }: FieldColumnCellProps<ShortTextColumnBase>) => {
   const rules = useMemo(() => createTextValidationRules(schema), [schema])
 
@@ -49,7 +53,13 @@ const ShortTextColumnCell = ({
       control={control}
       name={inputName}
       rules={rules}
-      render={({ field }) => <Input aria-labelledby={schema._id} {...field} />}
+      render={({ field }) => (
+        <Input
+          colorScheme={`theme-${colorTheme}`}
+          aria-labelledby={schema._id}
+          {...field}
+        />
+      )}
     />
   )
 }
@@ -57,6 +67,7 @@ const ShortTextColumnCell = ({
 const DropdownColumnCell = ({
   schema,
   inputName,
+  colorTheme,
 }: FieldColumnCellProps<DropdownColumnBase>) => {
   const rules = useMemo(() => createDropdownValidationRules(schema), [schema])
 
@@ -66,7 +77,11 @@ const DropdownColumnCell = ({
       rules={rules}
       defaultValue=""
       render={({ field }) => (
-        <SingleSelect items={schema.fieldOptions} {...field} />
+        <SingleSelect
+          colorScheme={`theme-${colorTheme}`}
+          items={schema.fieldOptions}
+          {...field}
+        />
       )}
     />
   )
@@ -80,6 +95,7 @@ export const ColumnCell = ({
   row,
   column,
   columnSchema,
+  colorTheme,
 }: ColumnCellProps): JSX.Element => {
   const isMobile = useIsMobile()
   const { errors } = useFormState<TableFieldInputs>({ name: schemaId })
@@ -93,16 +109,24 @@ export const ColumnCell = ({
     switch (columnSchema.columnType) {
       case BasicField.ShortText:
         return (
-          <ShortTextColumnCell schema={columnSchema} inputName={inputName} />
+          <ShortTextColumnCell
+            colorTheme={colorTheme}
+            schema={columnSchema}
+            inputName={inputName}
+          />
         )
       case BasicField.Dropdown:
         return (
-          <DropdownColumnCell schema={columnSchema} inputName={inputName} />
+          <DropdownColumnCell
+            colorTheme={colorTheme}
+            schema={columnSchema}
+            inputName={inputName}
+          />
         )
       default:
         return null
     }
-  }, [columnSchema, inputName])
+  }, [colorTheme, columnSchema, inputName])
 
   return (
     <FormControl

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -5,6 +5,8 @@ import { useTable } from 'react-table'
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
 import { get, head, uniq } from 'lodash'
 
+import { FormColorTheme } from '~shared/types'
+
 import { useIsMobile } from '~hooks/useIsMobile'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import IconButton from '~components/IconButton'
@@ -27,7 +29,10 @@ export interface TableFieldProps extends BaseFieldProps {
  * @precondition This component uses `react-hook-form#useFieldArray`, and will require defaultValues to be populated in the parent `useForm` hook.
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-export const TableField = ({ schema }: TableFieldProps): JSX.Element => {
+export const TableField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: TableFieldProps): JSX.Element => {
   const isMobile = useIsMobile()
 
   const columnsData = useMemo(() => {
@@ -85,7 +90,7 @@ export const TableField = ({ schema }: TableFieldProps): JSX.Element => {
           {...getTableProps()}
           variant="column-stripe"
           size="sm"
-          colorScheme="primary"
+          colorScheme={`theme-${colorTheme}`}
         >
           <Thead display={{ base: 'none', md: 'table-header-group' }}>
             {headerGroups.map((headerGroup) => (
@@ -117,6 +122,7 @@ export const TableField = ({ schema }: TableFieldProps): JSX.Element => {
                       {cell.render('Cell', {
                         schemaId: schema._id,
                         columnSchema: schema.columns[j],
+                        colorTheme,
                       })}
                     </Td>
                   ))}

--- a/frontend/src/templates/Field/YesNo/YesNoField.tsx
+++ b/frontend/src/templates/Field/YesNo/YesNoField.tsx
@@ -4,6 +4,8 @@
 import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FormColorTheme } from '~shared/types'
+
 import { createBaseValidationRules } from '~/utils/fieldValidation'
 
 import YesNo from '~components/Field/YesNo'
@@ -15,7 +17,10 @@ export interface YesNoFieldProps extends BaseFieldProps {
   schema: YesNoFieldSchema
 }
 
-export const YesNoField = ({ schema }: YesNoFieldProps): JSX.Element => {
+export const YesNoField = ({
+  schema,
+  colorTheme = FormColorTheme.Blue,
+}: YesNoFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createBaseValidationRules(schema),
     [schema],
@@ -29,7 +34,9 @@ export const YesNoField = ({ schema }: YesNoFieldProps): JSX.Element => {
         control={control}
         rules={validationRules}
         name={schema._id}
-        render={({ field }) => <YesNo {...field} />}
+        render={({ field }) => (
+          <YesNo colorScheme={`theme-${colorTheme}`} {...field} />
+        )}
       />
     </FieldContainer>
   )

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -1,4 +1,8 @@
-import { getColor, SystemStyleFunction } from '@chakra-ui/theme-tools'
+import {
+  getColor,
+  StyleFunctionProps,
+  SystemStyleFunction,
+} from '@chakra-ui/theme-tools'
 import merge from 'lodash/merge'
 
 import { textStyles } from '../textStyles'
@@ -41,6 +45,28 @@ const genVariantSolidColours = (c: string) => {
     }
     default: {
       return defaultBackgrounds
+    }
+  }
+}
+
+const genVariantOutlineColours = ({
+  colorScheme: c,
+  theme,
+}: StyleFunctionProps) => {
+  switch (c) {
+    case 'theme-red':
+    case 'theme-orange':
+    case 'theme-yellow': {
+      return {
+        borderColor: `${c}.600` as const,
+        focusBorderColor: getColor(theme, `${c}.400`),
+      }
+    }
+    default: {
+      return {
+        borderColor: `${c}.500` as const,
+        focusBorderColor: getColor(theme, `${c}.300`),
+      }
     }
   }
 }
@@ -114,15 +140,16 @@ const variantClear: SystemStyleFunction = (props) => {
 
 const variantOutlineReverse: SystemStyleFunction = (props) => {
   const { colorScheme: c, variant } = props
+  const { borderColor, focusBorderColor } = genVariantOutlineColours(props)
   const showBorder = variant === 'outline'
 
   return {
     bg: 'white',
     px: '15px',
-    borderColor: showBorder ? `${c}.500` : 'white',
-    color: `${c}.500`,
+    borderColor: showBorder ? borderColor : 'white',
+    color: borderColor,
     _focus: {
-      boxShadow: `0 0 0 4px var(--chakra-colors-${c}-300)`,
+      boxShadow: `0 0 0 4px ${focusBorderColor}`,
     },
     _disabled: {
       color: `${c}.300`,
@@ -132,7 +159,7 @@ const variantOutlineReverse: SystemStyleFunction = (props) => {
     },
     _active: {
       bg: `${c}.200`,
-      borderColor: showBorder ? `${c}.500` : `${c}.200`,
+      borderColor: showBorder ? borderColor : `${c}.200`,
       _disabled: {
         bg: 'white',
         borderColor: showBorder ? `${c}.300` : 'white',
@@ -140,7 +167,7 @@ const variantOutlineReverse: SystemStyleFunction = (props) => {
     },
     _hover: {
       bg: `${c}.100`,
-      borderColor: showBorder ? `${c}.500` : `${c}.100`,
+      borderColor: showBorder ? borderColor : `${c}.100`,
       _disabled: {
         bg: 'white',
         borderColor: showBorder ? `${c}.300` : 'white',

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -13,19 +13,41 @@ export type ThemeButtonVariant =
   | 'link'
   | 'inputAttached'
 
+const genVariantSolidColours = (c: string) => {
+  const defaultBackgrounds = {
+    bg: `${c}.500`,
+    activeBg: `${c}.700`,
+    hoverBg: `${c}.600`,
+    focusBoxShadow: `0 0 0 4px var(--chakra-colors-${c}-300)`,
+  }
+  switch (c) {
+    case 'success': {
+      return {
+        bg: `${c}.700`,
+        activeBg: `${c}.800`,
+        hoverBg: `${c}.800`,
+        focusBoxShadow: `0 0 0 4px var(--chakra-colors-${c}-400)`,
+      }
+    }
+    case 'theme-red':
+    case 'theme-orange':
+    case 'theme-yellow': {
+      return {
+        ...defaultBackgrounds,
+        bg: `${c}.600`,
+        activeBg: `${c}.800`,
+        hoverBg: `${c}.700`,
+      }
+    }
+    default: {
+      return defaultBackgrounds
+    }
+  }
+}
+
 const variantSolid: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
-  let bg = `${c}.500`
-  let activeBg = `${c}.700`
-  let hoverBg = `${c}.600`
-  let focusBoxShadow = `0 0 0 4px var(--chakra-colors-${c}-300)`
-
-  if (c === 'success') {
-    bg = `${c}.700`
-    activeBg = `${c}.800`
-    hoverBg = `${c}.800`
-    focusBoxShadow = `0 0 0 4px var(--chakra-colors-${c}-400)`
-  }
+  const { bg, hoverBg, activeBg, focusBoxShadow } = genVariantSolidColours(c)
 
   return {
     bg,

--- a/frontend/src/theme/components/Checkbox.ts
+++ b/frontend/src/theme/components/Checkbox.ts
@@ -24,6 +24,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = ({
 }) => ({
   // Control is the box containing the check icon
   control: {
+    bg: 'white',
     borderRadius: '0.25rem',
     border: '0.125rem solid',
     borderColor: `${c}.500`,

--- a/frontend/src/theme/components/Field/Attachment.ts
+++ b/frontend/src/theme/components/Field/Attachment.ts
@@ -34,6 +34,7 @@ export const Attachment: ComponentMultiStyleConfig<typeof parts> = {
         isDragActive,
         focusBorderColor: fc,
         errorBorderColor: ec,
+        colorScheme: c,
         theme,
       } = props
 
@@ -49,9 +50,9 @@ export const Attachment: ComponentMultiStyleConfig<typeof parts> = {
           justifyContent: 'center',
           cursor: 'pointer',
           border: '1px dashed',
-          borderColor: 'primary.700',
+          borderColor: `${c}.700`,
           borderRadius: '0.25rem',
-          bg: isDragActive ? 'primary.200' : 'neutral.100',
+          bg: isDragActive ? `${c}.200` : 'neutral.100',
           _invalid: {
             // Remove extra 1px of outline.
             borderColor: getColor(theme, ec),
@@ -66,10 +67,10 @@ export const Attachment: ComponentMultiStyleConfig<typeof parts> = {
             ...inputStyle._disabled,
           },
           _hover: {
-            bg: 'primary.100',
+            bg: `${c}.100`,
           },
           _active: {
-            bg: 'primary.200',
+            bg: `${c}.200`,
           },
         },
       }
@@ -77,5 +78,6 @@ export const Attachment: ComponentMultiStyleConfig<typeof parts> = {
   },
   defaultProps: {
     ...Input.defaultProps,
+    colorScheme: 'primary',
   },
 }

--- a/frontend/src/theme/components/Field/Rating.ts
+++ b/frontend/src/theme/components/Field/Rating.ts
@@ -10,7 +10,7 @@ const getOptionThemeColor = (colorScheme: string) => {
     case 'theme-red':
     case 'theme-orange':
     case 'theme-yellow':
-      return `${colorScheme}.700`
+      return `${colorScheme}.600`
     default:
       return `${colorScheme}.500`
   }

--- a/frontend/src/theme/components/Menu.ts
+++ b/frontend/src/theme/components/Menu.ts
@@ -27,18 +27,18 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
       fontWeight: '400',
       color: 'secondary.700',
       _hover: {
-        bg: 'primary.100',
+        bg: `${c}.100`,
         borderWidth: '0rem',
       },
       _focus: {
-        bg: 'primary.100',
+        bg: `${c}.100`,
         boxShadow: `0 0 0 2px ${getColor(theme, fc)}`,
         _active: {
-          bg: 'primary.200',
+          bg: `${c}.200`,
         },
       },
       _active: {
-        bg: 'primary.200',
+        bg: `${c}.200`,
         fontWeight: 500,
       },
       _disabled: {

--- a/frontend/src/theme/foundations/colours.ts
+++ b/frontend/src/theme/foundations/colours.ts
@@ -22,6 +22,7 @@ export type ThemeColorScheme =
 export type FieldColorScheme = Extract<
   ThemeColorScheme,
   | 'primary'
+  | 'theme-blue'
   | 'theme-green'
   | 'theme-teal'
   | 'theme-purple'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements handling of the current form's color theme and updates components to render their expected color theme. A couple of components have also been updated to accept theming of color.

Also update mobile and desktop styling to better fit design, most notably padding and the display of submission button.

Stories have been added for the various color themes and mobile views and snapshots should reflect those changes.
