### PR TITLE
feat(v2/collab): Add transfer ownership feature

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -63,3 +63,19 @@ export const updateFormCollaborators = async (
     collaborators,
   ).then(({ data }) => data)
 }
+
+/**
+ * Transfers ownership of form to another user with the given email.
+ * @param formId formId of the form to transfer ownership for
+ * @param newOwnerEmail Email of new owner
+ * @returns Updated form with new ownership.
+ */
+export const transferFormOwner = async (
+  formId: string,
+  newOwnerEmail: string,
+): Promise<AdminFormViewDto> => {
+  return ApiService.post<AdminFormViewDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators/transfer-owner`,
+    { email: newOwnerEmail },
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
@@ -22,8 +22,13 @@ export type AddCollaboratorInputs = {
 }
 
 const useAddCollaboratorInput = () => {
-  const { formMethods, handleListSubmit, isMutationLoading, formAdminEmail } =
-    useCollaboratorWizard()
+  const {
+    formMethods,
+    handleListSubmit,
+    isMutationLoading,
+    formAdminEmail,
+    isFormAdmin,
+  } = useCollaboratorWizard()
   const { isLoading, data: collaborators } = useAdminFormCollaborators({
     enabled: !!formAdminEmail,
   })
@@ -63,6 +68,7 @@ const useAddCollaboratorInput = () => {
     isQueryLoading: isLoading,
     isMutationLoading,
     isTransferOwnershipSelected,
+    isFormAdmin,
     formMethods,
     isFullWidth: isMobile,
     validationRules,
@@ -80,6 +86,7 @@ export const AddCollaboratorInput = (): JSX.Element => {
     isFullWidth,
     isQueryLoading,
     isTransferOwnershipSelected,
+    isFormAdmin,
     isMutationLoading,
     validationRules,
     handleListSubmit,
@@ -107,6 +114,7 @@ export const AddCollaboratorInput = (): JSX.Element => {
               control={control}
               render={({ field: { value, onChange } }) => (
                 <PermissionDropdown
+                  allowTransferOwnership={isFormAdmin}
                   isLoading={isQueryLoading || isMutationLoading}
                   value={value}
                   onChange={onChange}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -50,7 +50,7 @@ const CollaboratorRow = ({
       direction={{ base: 'column', md: 'row' }}
       justify="space-between"
       align={{ base: 'flex-start', md: 'center' }}
-      spacing={{ base: '0.75rem', md: '0.5rem' }}
+      spacing={{ base: '0.75rem', md: '2rem' }}
       {...props}
     >
       {children}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -96,7 +96,8 @@ export const CollaboratorList = (): JSX.Element => {
         <Skeleton isLoaded={!!collaborators} flex={1}>
           <Stack
             direction="row"
-            align="baseline" // Required to allow flex to shrink
+            align="baseline"
+            // Required to allow flex to shrink
             minW={0}
           >
             <CollaboratorText>{form?.admin.email}</CollaboratorText>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -11,6 +11,7 @@ import {
 
 import { FormPermission } from '~shared/types/form/form'
 
+import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
 
 import { useMutateCollaborators } from '../../../mutations'
@@ -59,6 +60,7 @@ const CollaboratorRow = ({
 }
 
 export const CollaboratorList = (): JSX.Element => {
+  const isMobile = useIsMobile()
   // Admin form data required for checking for duplicate emails.
   const { handleForwardToTransferOwnership } = useCollaboratorWizard()
   const { collaborators, user, isFormAdmin, form, isLoading } =
@@ -165,7 +167,14 @@ export const CollaboratorList = (): JSX.Element => {
   }
 
   return (
-    <Stack spacing={0} align="flex-start" flex={1} divider={<StackDivider />}>
+    <Stack
+      spacing={0}
+      align="flex-start"
+      flex={1}
+      divider={isMobile ? undefined : <StackDivider />}
+      mt="2.5rem"
+      borderY={{ md: '1px solid var(--chakra-colors-neutral-300)' }}
+    >
       {ownerRow}
       {list.map((row, index) => (
         <CollaboratorRow

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -15,12 +15,12 @@ import IconButton from '~components/IconButton'
 
 import { useUser } from '~features/user/queries'
 
-import { useMutateCollaborators } from '../../mutations'
-import { useAdminForm, useAdminFormCollaborators } from '../../queries'
+import { useMutateCollaborators } from '../../../mutations'
+import { useAdminForm, useAdminFormCollaborators } from '../../../queries'
+import { DropdownRole } from '../constants'
+import { permissionsToRole, roleToPermission } from '../utils'
 
-import { DropdownRole } from './AddCollaboratorInput'
 import { PermissionDropdown } from './PermissionDropdown'
-import { permissionsToRole, roleToPermission } from './utils'
 
 type CollaboratorRowMeta = {
   email: string

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -62,7 +62,8 @@ const CollaboratorRow = ({
 
 export const CollaboratorList = (): JSX.Element => {
   // Admin form data required for checking for duplicate emails.
-  const { formAdminEmail, isFormAdmin } = useCollaboratorWizard()
+  const { formAdminEmail, isFormAdmin, handleForwardToTransferOwnership } =
+    useCollaboratorWizard()
   const { user } = useUser()
   const { data: collaborators } = useAdminFormCollaborators({
     enabled: !!formAdminEmail,
@@ -128,6 +129,11 @@ export const CollaboratorList = (): JSX.Element => {
       // collaborators being loaded, but guarding just in case.
       // Or when role to update is already the current role.
       if (!collaborators || row.role === newRole) return
+
+      if (newRole === DropdownRole.Owner) {
+        return handleForwardToTransferOwnership(row.email)
+      }
+
       const permissionToUpdate: FormPermission = {
         email: row.email,
         ...roleToPermission(newRole),

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -16,7 +16,8 @@ import IconButton from '~components/IconButton'
 import { useUser } from '~features/user/queries'
 
 import { useMutateCollaborators } from '../../../mutations'
-import { useAdminForm, useAdminFormCollaborators } from '../../../queries'
+import { useAdminFormCollaborators } from '../../../queries'
+import { useCollaboratorWizard } from '../CollaboratorWizardContext'
 import { DropdownRole } from '../constants'
 import { permissionsToRole, roleToPermission } from '../utils'
 
@@ -61,10 +62,10 @@ const CollaboratorRow = ({
 
 export const CollaboratorList = (): JSX.Element => {
   // Admin form data required for checking for duplicate emails.
-  const { data: form } = useAdminForm()
+  const { formAdminEmail, isFormAdmin } = useCollaboratorWizard()
   const { user } = useUser()
   const { data: collaborators } = useAdminFormCollaborators({
-    enabled: !!form,
+    enabled: !!formAdminEmail,
   })
 
   const { mutateUpdateCollaborator, mutateRemoveCollaborator } =
@@ -100,8 +101,8 @@ export const CollaboratorList = (): JSX.Element => {
             // Required to allow flex to shrink
             minW={0}
           >
-            <CollaboratorText>{form?.admin.email}</CollaboratorText>
-            {createCurrentUserHint({ email: form?.admin.email ?? '' })}
+            <CollaboratorText>{formAdminEmail}</CollaboratorText>
+            {createCurrentUserHint({ email: formAdminEmail ?? '' })}
           </Stack>
         </Skeleton>
         <Skeleton isLoaded={!!collaborators}>
@@ -119,7 +120,7 @@ export const CollaboratorList = (): JSX.Element => {
         </Skeleton>
       </CollaboratorRow>
     )
-  }, [collaborators, form?.admin.email, createCurrentUserHint])
+  }, [collaborators, formAdminEmail, createCurrentUserHint])
 
   const handleUpdateRole =
     (row: typeof list[number]) => (newRole: DropdownRole) => {
@@ -180,6 +181,7 @@ export const CollaboratorList = (): JSX.Element => {
             <PermissionDropdown
               buttonVariant="clear"
               value={row.role}
+              allowTransferOwnership={isFormAdmin}
               isLoading={
                 mutateUpdateCollaborator.isLoading ||
                 mutateRemoveCollaborator.isLoading

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
@@ -1,0 +1,17 @@
+import { Divider, ModalBody, ModalHeader } from '@chakra-ui/react'
+
+import { AddCollaboratorInput } from './AddCollaboratorInput'
+import { CollaboratorList } from './CollaboratorList'
+
+export const CollaboratorListScreen = (): JSX.Element => {
+  return (
+    <>
+      <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
+      <ModalBody whiteSpace="pre-line" pb="3.25rem">
+        <AddCollaboratorInput />
+        <Divider mt="2.5rem" />
+        <CollaboratorList />
+      </ModalBody>
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
@@ -7,10 +7,11 @@ export const CollaboratorListScreen = (): JSX.Element => {
   return (
     <>
       <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
-      <ModalBody whiteSpace="pre-line" pb="3.25rem">
+      <ModalBody whiteSpace="pre-line" pb="2rem">
         <AddCollaboratorInput />
         <Divider mt="2.5rem" />
         <CollaboratorList />
+        <Divider />
       </ModalBody>
     </>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
@@ -1,4 +1,4 @@
-import { Divider, ModalBody, ModalHeader } from '@chakra-ui/react'
+import { ModalBody, ModalHeader } from '@chakra-ui/react'
 
 import { AddCollaboratorInput } from './AddCollaboratorInput'
 import { CollaboratorList } from './CollaboratorList'
@@ -9,9 +9,7 @@ export const CollaboratorListScreen = (): JSX.Element => {
       <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
       <ModalBody whiteSpace="pre-line" pb="2rem">
         <AddCollaboratorInput />
-        <Divider mt="2.5rem" />
         <CollaboratorList />
-        <Divider />
       </ModalBody>
     </>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/PermissionDropdown.tsx
@@ -2,7 +2,7 @@ import { Text } from '@chakra-ui/react'
 
 import Menu from '~components/Menu'
 
-import { DropdownRole } from './AddCollaboratorInput'
+import { DropdownRole } from '../constants'
 
 export interface PermissionDropdownProps {
   value: DropdownRole

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/PermissionDropdown.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/PermissionDropdown.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Text } from '@chakra-ui/react'
 
 import Menu from '~components/Menu'
@@ -8,7 +9,7 @@ export interface PermissionDropdownProps {
   value: DropdownRole
   onChange: (role: DropdownRole) => void
   isLoading: boolean
-
+  allowTransferOwnership: boolean
   buttonVariant?: 'outline' | 'clear'
 }
 
@@ -16,8 +17,16 @@ export const PermissionDropdown = ({
   value,
   onChange,
   isLoading,
+  allowTransferOwnership,
   buttonVariant = 'outline',
 }: PermissionDropdownProps): JSX.Element => {
+  const availableRoles = useMemo(() => {
+    return Object.values(DropdownRole).filter((role) => {
+      // Either not owner role, or owner role and allowTransferOwnership is true.
+      return role !== DropdownRole.Owner || allowTransferOwnership
+    })
+  }, [allowTransferOwnership])
+
   return (
     <Menu>
       {({ isOpen }) => (
@@ -33,7 +42,7 @@ export const PermissionDropdown = ({
             {value}
           </Menu.Button>
           <Menu.List defaultValue={value}>
-            {Object.values(DropdownRole).map((role) => (
+            {availableRoles.map((role) => (
               <Menu.Item key={role} onClick={() => onChange(role)}>
                 <Text
                   // Styling to hint to user the current active choice

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/index.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/index.ts
@@ -1,0 +1,1 @@
+export { CollaboratorListScreen } from './CollaboratorListScreen'

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -27,7 +27,10 @@ export const CollaboratorModal = ({
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent
+        // Prevent motion box content from escaping modal
+        overflowX="hidden"
+      >
         <ModalCloseButton />
         {isOpen && (
           <CollaboratorWizardProvider>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -1,17 +1,14 @@
 import {
-  Divider,
   Modal,
-  ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   useBreakpointValue,
 } from '@chakra-ui/react'
 
 import { ModalCloseButton } from '~components/Modal'
 
-import { AddCollaboratorInput } from './AddCollaboratorInput'
-import { CollaboratorList } from './CollaboratorList'
+import { CollaboratorModalContent } from './CollaboratorModalContent'
+import { CollaboratorWizardProvider } from './CollaboratorWizardContext'
 
 interface CollaboratorModalProps {
   isOpen: boolean
@@ -32,12 +29,11 @@ export const CollaboratorModal = ({
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />
-        <ModalHeader color="secondary.700">Manage collaborators</ModalHeader>
-        <ModalBody whiteSpace="pre-line" pb="3.25rem">
-          <AddCollaboratorInput />
-          <Divider mt="2.5rem" />
-          <CollaboratorList />
-        </ModalBody>
+        {isOpen && (
+          <CollaboratorWizardProvider>
+            <CollaboratorModalContent />
+          </CollaboratorWizardProvider>
+        )}
       </ModalContent>
     </Modal>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
@@ -1,7 +1,4 @@
-import { FC, useEffect, useState } from 'react'
-import { Box, BoxProps } from '@chakra-ui/react'
-import { HTMLMotionProps, motion } from 'framer-motion'
-import { Merge } from 'type-fest'
+import { XMotionBox } from '~templates/MotionBox'
 
 import { CollaboratorListScreen } from './CollaboratorListScreen'
 import {
@@ -10,55 +7,21 @@ import {
 } from './CollaboratorWizardContext'
 import { TransferOwnershipScreen } from './TransferOwnershipScreen'
 
-const SCREEN_ANIMATION_VARIANT = {
-  enter: (direction: number) => {
-    return {
-      x: direction > 0 ? 1000 : -1000,
-      opacity: 0,
-    }
-  },
-  center: {
-    x: 0,
-    opacity: 1,
-  },
-}
-
-type MotionBoxProps = Merge<BoxProps, HTMLMotionProps<'div'>>
-const MotionBox: FC<MotionBoxProps> = motion(Box)
-
 /**
  * @preconditions Requires CollaboratorWizardProvider parent
  * Display screen content depending on the current step (with animation).
  */
 export const CollaboratorModalContent = () => {
   const { direction, currentStep } = useCollaboratorWizard()
-  const [isFirstLoad, setIsFirstLoad] = useState(true)
-
-  // So animation does not run on first load.
-  useEffect(() => {
-    if (isFirstLoad) {
-      setIsFirstLoad(false)
-    }
-  }, [isFirstLoad])
 
   return (
-    <MotionBox
-      key={currentStep}
-      custom={direction}
-      variants={SCREEN_ANIMATION_VARIANT}
-      initial={isFirstLoad ? 'center' : 'enter'}
-      animate="center"
-      transition={{
-        x: { type: 'spring', stiffness: 300, damping: 30 },
-        opacity: { duration: 0.2 },
-      }}
-    >
+    <XMotionBox keyProp={currentStep} direction={direction}>
       {currentStep === CollaboratorFlowStates.List && (
         <CollaboratorListScreen />
       )}
       {currentStep === CollaboratorFlowStates.TransferOwner && (
         <TransferOwnershipScreen />
       )}
-    </MotionBox>
+    </XMotionBox>
   )
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
@@ -1,0 +1,64 @@
+import { FC, useEffect, useState } from 'react'
+import { Box, BoxProps } from '@chakra-ui/react'
+import { HTMLMotionProps, motion } from 'framer-motion'
+import { Merge } from 'type-fest'
+
+import { CollaboratorListScreen } from './CollaboratorListScreen'
+import {
+  CollaboratorFlowStates,
+  useCollaboratorWizard,
+} from './CollaboratorWizardContext'
+import { TransferOwnershipScreen } from './TransferOwnershipScreen'
+
+const SCREEN_ANIMATION_VARIANT = {
+  enter: (direction: number) => {
+    return {
+      x: direction > 0 ? 1000 : -1000,
+      opacity: 0,
+    }
+  },
+  center: {
+    x: 0,
+    opacity: 1,
+  },
+}
+
+type MotionBoxProps = Merge<BoxProps, HTMLMotionProps<'div'>>
+const MotionBox: FC<MotionBoxProps> = motion(Box)
+
+/**
+ * @preconditions Requires CollaboratorWizardProvider parent
+ * Display screen content depending on the current step (with animation).
+ */
+export const CollaboratorModalContent = () => {
+  const { direction, currentStep } = useCollaboratorWizard()
+  const [isFirstLoad, setIsFirstLoad] = useState(true)
+
+  // So animation does not run on first load.
+  useEffect(() => {
+    if (isFirstLoad) {
+      setIsFirstLoad(false)
+    }
+  }, [isFirstLoad])
+
+  return (
+    <MotionBox
+      key={currentStep}
+      custom={direction}
+      variants={SCREEN_ANIMATION_VARIANT}
+      initial={isFirstLoad ? 'center' : 'enter'}
+      animate="center"
+      transition={{
+        x: { type: 'spring', stiffness: 300, damping: 30 },
+        opacity: { duration: 0.2 },
+      }}
+    >
+      {currentStep === CollaboratorFlowStates.List && (
+        <CollaboratorListScreen />
+      )}
+      {currentStep === CollaboratorFlowStates.TransferOwner && (
+        <TransferOwnershipScreen />
+      )}
+    </MotionBox>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -1,0 +1,128 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+import { useForm, UseFormHandleSubmit, UseFormReturn } from 'react-hook-form'
+
+import { FormPermission } from '~shared/types'
+
+import { useMutateCollaborators } from '../../mutations'
+import { useAdminForm } from '../../queries'
+
+import { DropdownRole } from './constants'
+import { roleToPermission } from './utils'
+
+export enum CollaboratorFlowStates {
+  List = 'list',
+  TransferOwner = 'transferOwner',
+}
+
+type CollaboratorWizardContextReturn = {
+  currentStep: CollaboratorFlowStates
+  direction: number
+  /** So wizard screens can keep track of the current form state */
+  formMethods: UseFormReturn<AddCollaboratorInputs>
+  handleBackToList: () => void
+  handleListSubmit: ReturnType<UseFormHandleSubmit<AddCollaboratorInputs>>
+  isMutationLoading: boolean
+  formAdminEmail?: string
+}
+
+export type AddCollaboratorInputs = {
+  email: string
+  role: DropdownRole
+}
+
+const CollaboratorWizardContext = createContext<
+  CollaboratorWizardContextReturn | undefined
+>(undefined)
+
+const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
+  CollaboratorFlowStates.List,
+  0 | 1 | -1,
+]
+
+const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
+  const { data: form } = useAdminForm()
+  const { mutateAddCollaborator } = useMutateCollaborators()
+
+  const [[currentStep, direction], setCurrentStep] =
+    useState(INITIAL_STEP_STATE)
+
+  const formMethods = useForm<AddCollaboratorInputs>({
+    defaultValues: {
+      email: '',
+      role: DropdownRole.Editor,
+    },
+  })
+
+  const handleBackToList = useCallback(() => {
+    setCurrentStep([CollaboratorFlowStates.List, -1])
+  }, [])
+
+  const handleForwardToTransferOwnership = useCallback(() => {
+    setCurrentStep([CollaboratorFlowStates.TransferOwner, 1])
+  }, [])
+
+  const handleAddCollaborator = useCallback(
+    (inputs: AddCollaboratorInputs) => {
+      if (!form?.permissionList) return
+
+      const newPermission: FormPermission = {
+        ...roleToPermission(inputs.role),
+        email: inputs.email,
+      }
+      return mutateAddCollaborator.mutate(
+        {
+          newPermission,
+          currentPermissions: form.permissionList,
+        },
+        {
+          onSuccess: () => formMethods.reset(),
+        },
+      )
+    },
+    [form?.permissionList, formMethods, mutateAddCollaborator],
+  )
+
+  const handleListSubmit = formMethods.handleSubmit((inputs) => {
+    if (!form?.permissionList) return
+
+    // Handle transfer form ownership instead of granting admin rights.
+    if (inputs.role === DropdownRole.Owner) {
+      return handleForwardToTransferOwnership()
+    }
+
+    return handleAddCollaborator(inputs)
+  })
+
+  return {
+    currentStep,
+    direction,
+    handleBackToList,
+    formMethods,
+    formAdminEmail: form?.admin.email,
+    handleListSubmit,
+    isMutationLoading: mutateAddCollaborator.isLoading,
+  }
+}
+
+export const CollaboratorWizardProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => {
+  const values = useCollaboratorWizardContext()
+  return (
+    <CollaboratorWizardContext.Provider value={values}>
+      {children}
+    </CollaboratorWizardContext.Provider>
+  )
+}
+
+export const useCollaboratorWizard = (): CollaboratorWizardContextReturn => {
+  const context = useContext(CollaboratorWizardContext)
+  if (!context) {
+    throw new Error(
+      `useCollaboratorWizard must be used within a CollaboratorWizardProvider component`,
+    )
+  }
+  return context
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -1,7 +1,15 @@
-import { createContext, useCallback, useContext, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
 import { useForm, UseFormHandleSubmit, UseFormReturn } from 'react-hook-form'
 
 import { FormPermission } from '~shared/types'
+
+import { useUser } from '~features/user/queries'
 
 import { useMutateCollaborators } from '../../mutations'
 import { useAdminForm } from '../../queries'
@@ -26,6 +34,7 @@ type CollaboratorWizardContextReturn = {
   >
   isMutationLoading: boolean
   formAdminEmail?: string
+  isFormAdmin: boolean
 }
 
 export type AddCollaboratorInputs = {
@@ -44,6 +53,7 @@ const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
 
 const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
   const { data: form } = useAdminForm()
+  const { user } = useUser()
   const { mutateAddCollaborator, mutateTransferFormOwnership } =
     useMutateCollaborators()
 
@@ -56,6 +66,11 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
       role: DropdownRole.Editor,
     },
   })
+
+  const isFormAdmin = useMemo(
+    () => !!user && !!form && user.email === form.admin.email,
+    [form, user],
+  )
 
   const handleBackToList = useCallback(() => {
     setCurrentStep([CollaboratorFlowStates.List, -1])
@@ -113,6 +128,7 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     handleBackToList,
     formMethods,
     formAdminEmail: form?.admin.email,
+    isFormAdmin,
     handleListSubmit,
     handleTransferOwnershipSubmit,
     isMutationLoading:

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -21,6 +21,9 @@ type CollaboratorWizardContextReturn = {
   formMethods: UseFormReturn<AddCollaboratorInputs>
   handleBackToList: () => void
   handleListSubmit: ReturnType<UseFormHandleSubmit<AddCollaboratorInputs>>
+  handleTransferOwnershipSubmit: ReturnType<
+    UseFormHandleSubmit<AddCollaboratorInputs>
+  >
   isMutationLoading: boolean
   formAdminEmail?: string
 }
@@ -41,7 +44,8 @@ const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
 
 const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
   const { data: form } = useAdminForm()
-  const { mutateAddCollaborator } = useMutateCollaborators()
+  const { mutateAddCollaborator, mutateTransferFormOwnership } =
+    useMutateCollaborators()
 
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
@@ -93,6 +97,16 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     return handleAddCollaborator(inputs)
   })
 
+  const handleTransferOwnershipSubmit = formMethods.handleSubmit((inputs) => {
+    if (!form?.permissionList || inputs.role !== DropdownRole.Owner) return
+    return mutateTransferFormOwnership.mutate(inputs.email, {
+      onSuccess: () => {
+        handleBackToList()
+        formMethods.reset()
+      },
+    })
+  })
+
   return {
     currentStep,
     direction,
@@ -100,7 +114,9 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     formMethods,
     formAdminEmail: form?.admin.email,
     handleListSubmit,
-    isMutationLoading: mutateAddCollaborator.isLoading,
+    handleTransferOwnershipSubmit,
+    isMutationLoading:
+      mutateAddCollaborator.isLoading || mutateTransferFormOwnership.isLoading,
   }
 }
 

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -1,3 +1,48 @@
+import {
+  ButtonGroup,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Text,
+} from '@chakra-ui/react'
+
+import Button from '~components/Button'
+
+import { useCollaboratorWizard } from '../CollaboratorWizardContext'
+
 export const TransferOwnershipScreen = (): JSX.Element => {
-  return <div>Hello transfer ownership</div>
+  const {
+    handleBackToList,
+    formMethods: { watch },
+  } = useCollaboratorWizard()
+
+  const transferEmail = watch('email')
+
+  return (
+    <>
+      <ModalHeader color="secondary.700">Transfer form ownership</ModalHeader>
+      <ModalBody whiteSpace="pre-line" pb="3.25rem">
+        <Text>
+          You are transferring this form to{' '}
+          <Text color="danger.500" as="span" fontWeight={700}>
+            {transferEmail}
+          </Text>
+          . You will lose form ownership and the right to delete this form. You
+          will still have Editor rights.
+        </Text>
+      </ModalBody>
+      <ModalFooter>
+        <ButtonGroup>
+          <Button
+            variant="clear"
+            colorScheme="secondary"
+            onClick={handleBackToList}
+          >
+            Cancel
+          </Button>
+          <Button colorScheme="danger">Yes, transfer form</Button>
+        </ButtonGroup>
+      </ModalFooter>
+    </>
+  )
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -1,0 +1,3 @@
+export const TransferOwnershipScreen = (): JSX.Element => {
+  return <div>Hello transfer ownership</div>
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import {
   ModalBody,
   ModalFooter,
@@ -9,16 +10,23 @@ import {
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 
+import { useMutateCollaborators } from '~features/admin-form/common/mutations'
+
 import { useCollaboratorWizard } from '../CollaboratorWizardContext'
 
-export const TransferOwnershipScreen = (): JSX.Element => {
+export const TransferOwnershipScreen = (): JSX.Element | null => {
   const isMobile = useIsMobile()
-  const {
-    handleBackToList,
-    emailToTransfer,
-    handleTransferOwnership,
-    isMutationLoading,
-  } = useCollaboratorWizard()
+  const { mutateTransferFormOwnership } = useMutateCollaborators()
+  const { handleBackToList, emailToTransfer } = useCollaboratorWizard()
+
+  const handleTransferOwnership = useCallback(() => {
+    if (!emailToTransfer) return
+    return mutateTransferFormOwnership.mutate(emailToTransfer, {
+      onSuccess: () => handleBackToList(),
+    })
+  }, [emailToTransfer, handleBackToList, mutateTransferFormOwnership])
+
+  if (!emailToTransfer) return null
 
   return (
     <>
@@ -41,7 +49,7 @@ export const TransferOwnershipScreen = (): JSX.Element => {
         >
           <Button
             isFullWidth={isMobile}
-            isLoading={isMutationLoading}
+            isLoading={mutateTransferFormOwnership.isLoading}
             colorScheme="danger"
             onClick={handleTransferOwnership}
           >
@@ -49,7 +57,7 @@ export const TransferOwnershipScreen = (): JSX.Element => {
           </Button>
           <Button
             isFullWidth={isMobile}
-            isDisabled={isMutationLoading}
+            isDisabled={mutateTransferFormOwnership.isLoading}
             variant="clear"
             colorScheme="secondary"
             onClick={handleBackToList}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -1,16 +1,18 @@
 import {
-  ButtonGroup,
   ModalBody,
   ModalFooter,
   ModalHeader,
+  Stack,
   Text,
 } from '@chakra-ui/react'
 
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 
 import { useCollaboratorWizard } from '../CollaboratorWizardContext'
 
 export const TransferOwnershipScreen = (): JSX.Element => {
+  const isMobile = useIsMobile()
   const {
     handleBackToList,
     formMethods: { watch },
@@ -21,7 +23,7 @@ export const TransferOwnershipScreen = (): JSX.Element => {
   return (
     <>
       <ModalHeader color="secondary.700">Transfer form ownership</ModalHeader>
-      <ModalBody whiteSpace="pre-line" pb="3.25rem">
+      <ModalBody whiteSpace="pre-line">
         <Text>
           You are transferring this form to{' '}
           <Text color="danger.500" as="span" fontWeight={700}>
@@ -32,16 +34,23 @@ export const TransferOwnershipScreen = (): JSX.Element => {
         </Text>
       </ModalBody>
       <ModalFooter>
-        <ButtonGroup>
+        <Stack
+          flex={1}
+          spacing="1rem"
+          direction={{ base: 'column', md: 'row-reverse' }}
+        >
+          <Button isFullWidth={isMobile} colorScheme="danger">
+            Yes, transfer form
+          </Button>
           <Button
+            isFullWidth={isMobile}
             variant="clear"
             colorScheme="secondary"
             onClick={handleBackToList}
           >
             Cancel
           </Button>
-          <Button colorScheme="danger">Yes, transfer form</Button>
-        </ButtonGroup>
+        </Stack>
       </ModalFooter>
     </>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -15,12 +15,10 @@ export const TransferOwnershipScreen = (): JSX.Element => {
   const isMobile = useIsMobile()
   const {
     handleBackToList,
-    handleTransferOwnershipSubmit,
+    emailToTransfer,
+    handleTransferOwnership,
     isMutationLoading,
-    formMethods: { watch },
   } = useCollaboratorWizard()
-
-  const transferEmail = watch('email')
 
   return (
     <>
@@ -29,7 +27,7 @@ export const TransferOwnershipScreen = (): JSX.Element => {
         <Text>
           You are transferring this form to{' '}
           <Text color="danger.500" as="span" fontWeight={700}>
-            {transferEmail}
+            {emailToTransfer}
           </Text>
           . You will lose form ownership and the right to delete this form. You
           will still have Editor rights.
@@ -45,7 +43,7 @@ export const TransferOwnershipScreen = (): JSX.Element => {
             isFullWidth={isMobile}
             isLoading={isMutationLoading}
             colorScheme="danger"
-            onClick={handleTransferOwnershipSubmit}
+            onClick={handleTransferOwnership}
           >
             Yes, transfer form
           </Button>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -15,6 +15,8 @@ export const TransferOwnershipScreen = (): JSX.Element => {
   const isMobile = useIsMobile()
   const {
     handleBackToList,
+    handleTransferOwnershipSubmit,
+    isMutationLoading,
     formMethods: { watch },
   } = useCollaboratorWizard()
 
@@ -39,11 +41,17 @@ export const TransferOwnershipScreen = (): JSX.Element => {
           spacing="1rem"
           direction={{ base: 'column', md: 'row-reverse' }}
         >
-          <Button isFullWidth={isMobile} colorScheme="danger">
+          <Button
+            isFullWidth={isMobile}
+            isLoading={isMutationLoading}
+            colorScheme="danger"
+            onClick={handleTransferOwnershipSubmit}
+          >
             Yes, transfer form
           </Button>
           <Button
             isFullWidth={isMobile}
+            isDisabled={isMutationLoading}
             variant="clear"
             colorScheme="secondary"
             onClick={handleBackToList}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/index.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/index.ts
@@ -1,0 +1,1 @@
+export { TransferOwnershipScreen } from './TransferOwnershipScreen'

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/constants.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/constants.ts
@@ -1,0 +1,5 @@
+export enum DropdownRole {
+  Owner = 'Owner',
+  Editor = 'Editor',
+  Viewer = 'Viewer',
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/utils.ts
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/utils.ts
@@ -1,6 +1,6 @@
 import { FormPermission } from '~shared/types/form/form'
 
-import { DropdownRole } from './AddCollaboratorInput'
+import { DropdownRole } from './constants'
 
 export const permissionsToRole = (permission: FormPermission): DropdownRole => {
   return permission.write ? DropdownRole.Editor : DropdownRole.Viewer
@@ -10,7 +10,7 @@ export const roleToPermission = (
   role: DropdownRole,
 ): Omit<FormPermission, 'email'> => {
   switch (role) {
-    case DropdownRole.Admin:
+    case DropdownRole.Owner:
     case DropdownRole.Editor:
       return { write: true }
     case DropdownRole.Viewer:

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -17,6 +17,16 @@ import {
 } from './AdminViewFormService'
 import { adminFormKeys } from './queries'
 
+export type MutateAddCollaboratorArgs = {
+  newPermission: FormPermission
+  currentPermissions: FormPermissionsDto
+}
+
+export type MutateRemoveCollaboratorArgs = {
+  permissionToRemove: FormPermission
+  currentPermissions: FormPermissionsDto
+}
+
 export const useMutateCollaborators = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
@@ -105,13 +115,7 @@ export const useMutateCollaborators = () => {
   )
 
   const mutateAddCollaborator = useMutation(
-    ({
-      newPermission,
-      currentPermissions,
-    }: {
-      newPermission: FormPermission
-      currentPermissions: FormPermissionsDto
-    }) => {
+    ({ newPermission, currentPermissions }: MutateAddCollaboratorArgs) => {
       const rebuiltPermissions = [newPermission].concat(currentPermissions)
       return updateFormCollaborators(formId, rebuiltPermissions)
     },
@@ -130,10 +134,7 @@ export const useMutateCollaborators = () => {
     ({
       permissionToRemove,
       currentPermissions,
-    }: {
-      permissionToRemove: FormPermission
-      currentPermissions: FormPermissionsDto
-    }) => {
+    }: MutateRemoveCollaboratorArgs) => {
       const filteredList = currentPermissions.filter(
         (c) => c.email !== permissionToRemove.email,
       )

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -11,7 +11,10 @@ import {
 import { useToast } from '~hooks/useToast'
 
 import { permissionsToRole } from './components/CollaboratorModal/utils'
-import { updateFormCollaborators } from './AdminViewFormService'
+import {
+  transferFormOwner,
+  updateFormCollaborators,
+} from './AdminViewFormService'
 import { adminFormKeys } from './queries'
 
 export const useMutateCollaborators = () => {
@@ -146,9 +149,34 @@ export const useMutateCollaborators = () => {
     },
   )
 
+  const mutateTransferFormOwnership = useMutation(
+    (newOwnerEmail: string) => transferFormOwner(formId, newOwnerEmail),
+    {
+      onSuccess: (newData) => {
+        toast.closeAll()
+        // Show toast on success.
+        toast({
+          description: `${newData.form.admin.email} is now the owner of this form`,
+        })
+
+        // Update cached data.
+        queryClient.setQueryData(
+          adminFormKeys.collaborators(formId),
+          newData.form.permissionList,
+        )
+        queryClient.setQueryData<AdminFormDto | undefined>(
+          adminFormKeys.id(formId),
+          newData.form,
+        )
+      },
+      onError: handleError,
+    },
+  )
+
   return {
     mutateAddCollaborator,
     mutateUpdateCollaborator,
     mutateRemoveCollaborator,
+    mutateTransferFormOwnership,
   }
 }

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -1,7 +1,4 @@
-import { FC, useEffect, useState } from 'react'
-import { Box, BoxProps } from '@chakra-ui/react'
-import { HTMLMotionProps, motion } from 'framer-motion'
-import { Merge } from 'type-fest'
+import { XMotionBox } from '~templates/MotionBox'
 
 import {
   CreateFormFlowStates,
@@ -11,53 +8,19 @@ import {
 import { CreateFormDetailsScreen } from './CreateFormDetailsScreen'
 import { SaveSecretKeyScreen } from './SaveSecretKeyScreen'
 
-const SCREEN_ANIMATION_VARIANT = {
-  enter: (direction: number) => {
-    return {
-      x: direction > 0 ? 1000 : -1000,
-      opacity: 0,
-    }
-  },
-  center: {
-    x: 0,
-    opacity: 1,
-  },
-}
-
-type MotionBoxProps = Merge<BoxProps, HTMLMotionProps<'div'>>
-const MotionBox: FC<MotionBoxProps> = motion(Box)
-
 /**
  * @preconditions Requires CreateFormWizardProvider parent
  * Display screen content depending on the current step (with animation).
  */
 export const CreateFormModalContent = () => {
   const { direction, currentStep } = useCreateFormWizard()
-  const [isFirstLoad, setIsFirstLoad] = useState(true)
-
-  // So animation does not run on first load.
-  useEffect(() => {
-    if (isFirstLoad) {
-      setIsFirstLoad(false)
-    }
-  }, [isFirstLoad])
 
   return (
-    <MotionBox
-      key={currentStep}
-      custom={direction}
-      variants={SCREEN_ANIMATION_VARIANT}
-      initial={isFirstLoad ? 'center' : 'enter'}
-      animate="center"
-      transition={{
-        x: { type: 'spring', stiffness: 300, damping: 30 },
-        opacity: { duration: 0.2 },
-      }}
-    >
+    <XMotionBox keyProp={currentStep} custom={direction}>
       {currentStep === CreateFormFlowStates.Details && (
         <CreateFormDetailsScreen />
       )}
       {currentStep === CreateFormFlowStates.Landing && <SaveSecretKeyScreen />}
-    </MotionBox>
+    </XMotionBox>
   )
 }

--- a/frontend/src/templates/MotionBox/MotionBox.tsx
+++ b/frontend/src/templates/MotionBox/MotionBox.tsx
@@ -1,0 +1,7 @@
+import { FC } from 'react'
+import { Box, BoxProps } from '@chakra-ui/react'
+import { HTMLMotionProps, motion } from 'framer-motion'
+import { Merge } from 'type-fest'
+
+export type MotionBoxProps = Merge<BoxProps, HTMLMotionProps<'div'>>
+export const MotionBox: FC<MotionBoxProps> = motion(Box)

--- a/frontend/src/templates/MotionBox/XMotionBox.tsx
+++ b/frontend/src/templates/MotionBox/XMotionBox.tsx
@@ -1,0 +1,55 @@
+/** MotionBox that slides with the x-axis */
+
+import { Key, useLayoutEffect, useState } from 'react'
+
+import { MotionBox, MotionBoxProps } from './MotionBox'
+
+interface XMotionBoxProps extends MotionBoxProps {
+  /** To be passed to inner MotionBox component for rerendering */
+  keyProp?: Key | null
+  direction?: number
+  animateFirstLoad?: boolean
+}
+
+const SCREEN_ANIMATION_VARIANT = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 1000 : -1000,
+    opacity: 0,
+  }),
+  center: {
+    x: 0,
+    opacity: 1,
+  },
+}
+
+export const XMotionBox = ({
+  keyProp,
+  animateFirstLoad,
+  direction,
+  variants = SCREEN_ANIMATION_VARIANT,
+  ...props
+}: XMotionBoxProps) => {
+  const [isFirstRender, setIsFirstRender] = useState(!animateFirstLoad)
+
+  useLayoutEffect(() => {
+    if (isFirstRender) {
+      setIsFirstRender(false)
+    }
+  }, [isFirstRender])
+
+  return (
+    <MotionBox
+      // Required to force a rerender on direction change
+      key={keyProp}
+      custom={direction}
+      variants={variants}
+      initial={isFirstRender ? 'center' : 'enter'}
+      animate="center"
+      transition={{
+        x: { type: 'spring', stiffness: 300, damping: 30 },
+        opacity: { duration: 0.2 },
+      }}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/templates/MotionBox/index.ts
+++ b/frontend/src/templates/MotionBox/index.ts
@@ -1,0 +1,2 @@
+export * from './MotionBox'
+export * from './XMotionBox'


### PR DESCRIPTION
> Note that this PR builds on top of #3771.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements the ability for form owners to transfer ownership of their forms.

Same caveats as the base PR apply, no client-side guards if a user with view-only rights attempts to transfer permissions (backend will correctly block the action).

Related to #2487

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add TransferOwnershipScreen component
- feat(PermissionDropdown): only allow transfer owner option if current logged in user is the form owner

**Improvements**:

- feat: move current modal into CollabatorListScreen so there can be a distinction between transfer ownership and default list view.
- feat: extract MotionBox and XMotionBox template components
  - duplicate code, also used in CreateFormModal
- feat(CollaboratorListScreen): add bottom divider and fix padding


## Before & After Screenshots
Stories for collaborator modal should have been updated to also include the transfer ownership feature.
Will add more stories if I have time...
