### PR TITLE
feat(v2/collab): allow removal of self from form collaborators

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -79,3 +79,11 @@ export const transferFormOwner = async (
     { email: newOwnerEmail },
   ).then(({ data }) => data)
 }
+
+export const removeSelfFromFormCollaborators = async (
+  formId: string,
+): Promise<void> => {
+  return ApiService.delete(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/collaborators/self`,
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -39,7 +39,8 @@ const RemoveCollaboratorButton = (
 export const CollaboratorList = (): JSX.Element => {
   const isMobile = useIsMobile()
   // Admin form data required for checking for duplicate emails.
-  const { handleForwardToTransferOwnership } = useCollaboratorWizard()
+  const { handleForwardToTransferOwnership, handleForwardToRemoveSelf } =
+    useCollaboratorWizard()
   const {
     collaborators,
     user,
@@ -98,6 +99,11 @@ export const CollaboratorList = (): JSX.Element => {
   const handleRemoveCollaborator = useCallback(
     (row: typeof list[number]) => () => {
       if (!collaborators || areMutationsLoading) return
+
+      if (row.email === user?.email) {
+        return handleForwardToRemoveSelf()
+      }
+
       // May seem redundant since we already have the email, but this may prevent
       // issues arising from desync between `list` and `collaborators`.
       const permissionToRemove: FormPermission = {
@@ -109,7 +115,13 @@ export const CollaboratorList = (): JSX.Element => {
         currentPermissions: collaborators,
       })
     },
-    [areMutationsLoading, collaborators, mutateRemoveCollaborator],
+    [
+      areMutationsLoading,
+      collaborators,
+      handleForwardToRemoveSelf,
+      mutateRemoveCollaborator,
+      user?.email,
+    ],
   )
 
   return (
@@ -163,7 +175,6 @@ export const CollaboratorList = (): JSX.Element => {
                       .email === row.email
                   }
                   isDisabled={areMutationsLoading}
-                  // TODO: Add handling for removing self as collaborator.
                   onClick={handleRemoveCollaborator(row)}
                 />
               </Stack>
@@ -172,7 +183,7 @@ export const CollaboratorList = (): JSX.Element => {
                 {isCurrentUser ? (
                   <RemoveCollaboratorButton
                     isDisabled={areMutationsLoading}
-                    // TODO: Add handling for removing self as collaborator.
+                    onClick={handleForwardToRemoveSelf}
                   />
                 ) : (
                   <Spacer w="2.75rem" />

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
@@ -22,6 +22,9 @@ export const CollaboratorModalContent = () => {
       {currentStep === CollaboratorFlowStates.TransferOwner && (
         <TransferOwnershipScreen />
       )}
+      {currentStep === CollaboratorFlowStates.RemoveSelf && (
+        <div>Remove self</div>
+      )}
     </XMotionBox>
   )
 }

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModalContent.tsx
@@ -1,5 +1,6 @@
 import { XMotionBox } from '~templates/MotionBox'
 
+import { RemoveSelfScreen } from './RemoveSelfScreen/RemoveSelfScreen'
 import { CollaboratorListScreen } from './CollaboratorListScreen'
 import {
   CollaboratorFlowStates,
@@ -23,7 +24,7 @@ export const CollaboratorModalContent = () => {
         <TransferOwnershipScreen />
       )}
       {currentStep === CollaboratorFlowStates.RemoveSelf && (
-        <div>Remove self</div>
+        <RemoveSelfScreen />
       )}
     </XMotionBox>
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useCallback, useContext, useState } from 'react'
 export enum CollaboratorFlowStates {
   List = 'list',
   TransferOwner = 'transferOwner',
+  RemoveSelf = 'removeSelf',
 }
 
 type CollaboratorWizardContextReturn = {
@@ -11,6 +12,7 @@ type CollaboratorWizardContextReturn = {
   handleBackToList: () => void
   emailToTransfer: string | null
   handleForwardToTransferOwnership: (emailToTransfer: string) => void
+  handleForwardToRemoveSelf: () => void
 }
 
 const CollaboratorWizardContext = createContext<
@@ -40,12 +42,17 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     [],
   )
 
+  const handleForwardToRemoveSelf = useCallback(() => {
+    setCurrentStep([CollaboratorFlowStates.RemoveSelf, 1])
+  }, [])
+
   return {
     currentStep,
     direction,
     handleBackToList,
     emailToTransfer,
     handleForwardToTransferOwnership,
+    handleForwardToRemoveSelf,
   }
 }
 

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
@@ -28,7 +28,7 @@ export const RemoveSelfScreen = (): JSX.Element | null => {
       <ModalHeader color="secondary.700">
         Remove myself as collaborator
       </ModalHeader>
-      <ModalBody whiteSpace="pre-line">
+      <ModalBody whiteSpace="pre-line" color="secondary.500">
         <Text>
           You are removing yourself as a collaborator and will lose all access
           to this form. This action cannot be undone.

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react'
+import {
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
+
+import { useMutateCollaborators } from '~features/admin-form/common/mutations'
+
+import { useCollaboratorWizard } from '../CollaboratorWizardContext'
+
+export const RemoveSelfScreen = (): JSX.Element | null => {
+  const isMobile = useIsMobile()
+  const { mutateRemoveSelf } = useMutateCollaborators()
+  const { handleBackToList } = useCollaboratorWizard()
+
+  const handleRemoveSelf = useCallback(() => {
+    return mutateRemoveSelf.mutate()
+  }, [mutateRemoveSelf])
+
+  return (
+    <>
+      <ModalHeader color="secondary.700">
+        Remove myself as collaborator
+      </ModalHeader>
+      <ModalBody whiteSpace="pre-line">
+        <Text>
+          You are removing yourself as a collaborator and will lose all access
+          to this form. This action cannot be undone.
+        </Text>
+      </ModalBody>
+      <ModalFooter>
+        <Stack
+          flex={1}
+          spacing="1rem"
+          direction={{ base: 'column', md: 'row-reverse' }}
+        >
+          <Button
+            isFullWidth={isMobile}
+            isLoading={mutateRemoveSelf.isLoading}
+            colorScheme="danger"
+            onClick={handleRemoveSelf}
+          >
+            Yes, remove myself
+          </Button>
+          <Button
+            isFullWidth={isMobile}
+            isDisabled={mutateRemoveSelf.isLoading}
+            variant="clear"
+            colorScheme="secondary"
+            onClick={handleBackToList}
+          >
+            Cancel
+          </Button>
+        </Stack>
+      </ModalFooter>
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/TransferOwnershipScreen/TransferOwnershipScreen.tsx
@@ -31,7 +31,7 @@ export const TransferOwnershipScreen = (): JSX.Element | null => {
   return (
     <>
       <ModalHeader color="secondary.700">Transfer form ownership</ModalHeader>
-      <ModalBody whiteSpace="pre-line">
+      <ModalBody whiteSpace="pre-line" color="secondary.500">
         <Text>
           You are transferring this form to{' '}
           <Text color="danger.500" as="span" fontWeight={700}>


### PR DESCRIPTION
> This PR builds on top of #3793 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the ability for form collaborators (not the owners themselves) to removes themselves as a collaborator on the form. 

Related to #2487, will close when this entire chain is merged in.

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add ability to remove self from collaborator list

**Improvements**:

- style(Collab): use secondary.500 color in collaborator modal text


## Before & After Screenshots
No new stories, though can be tested in the Viewer-only stories.
