### PR TITLE
fix(v2): Recaptcha double submission loading loop, single checkbox error bugfixes

### DIFF
--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -190,6 +190,8 @@ export const useRecaptcha = ({
    */
   const getCaptchaResponse = useCallback(async () => {
     if (!grecaptcha || widgetId === undefined) return Promise.resolve(null)
+    // Always reset before verifying again, or execute will never return.
+    grecaptcha.reset(widgetId)
 
     setIsVfnInProgress(true)
 

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -89,6 +89,17 @@ export const CheckboxField = ({
           {o}
         </Checkbox>
       ))}
+      {schema.fieldOptions.length === 1 ? (
+        // React-hook-form quirk where the value will not be set in an array if there is only a single checkbox option.
+        // This is a workaround to set the value in an array by registering a hidden checkbox with the same id.
+        // See https://github.com/react-hook-form/react-hook-form/issues/7834#issuecomment-1040735711.
+        <input
+          type="checkbox"
+          hidden
+          value=""
+          {...register(checkboxInputName)}
+        />
+      ) : null}
       {schema.othersRadioButton ? (
         <Checkbox.OthersWrapper colorScheme={fieldColorScheme}>
           <FormControl


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR fixes two bugs:

1. When submission fails for any reason, triggering recaptcha again results in an infinite loop. This is due to execute never returning (as the current recaptcha widget has reached the end of its lifecycle).  \
\
This is fixed by resetting the captcha widget prior to every form submission so the execution can go through (and any current response can be discarded)

3. `react-hook-form` has an interesting bug(?) where a single checkbox will not be casted to an array and instead be set directly as the value, even when the input is of a `checkbox` type. Might be due to the values being in yet another nested object. See https://github.com/react-hook-form/react-hook-form/issues/7834#issuecomment-1040735711 \
\
Fixed by adding a hidden secret checkbox with the same name to let rhf "know" about the checkbox and setting the values directly in an array
