### PR TITLE
feat: track Twilio metrics to DataDog

### DIFF
--- a/src/app/config/datadog-statsd-client.ts
+++ b/src/app/config/datadog-statsd-client.ts
@@ -1,0 +1,3 @@
+import { StatsD } from 'hot-shots'
+
+export const statsdClient = new StatsD({ useDefaultRoute: true })

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -55,7 +55,7 @@ export const twilioSmsUpdates: ControllerHandler<
    */
 
   const ddTags = {
-    // msgsrvcsid: req.body.MessagingServiceSid,
+    // msgSrvcSid not included to limit tag cardinality (for now?)
     smsstatus: req.body.SmsStatus,
     errorcode: '0',
   }

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -3,14 +3,12 @@ import { StatusCodes } from 'http-status-codes'
 
 import { ITwilioSmsWebhookBody } from 'src/types/twilio'
 
-import { statsdClient } from '../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
 
+import { twilioStatsdClient } from './twilio.statsd-client'
+
 const logger = createLoggerWithLabel(module)
-const ddClient = statsdClient.childClient({
-  prefix: 'vendor.twilio.',
-})
 
 /**
  * Middleware which validates that a request came from Twilio Webhook
@@ -84,7 +82,7 @@ export const twilioSmsUpdates: ControllerHandler<
     })
   }
 
-  ddClient.increment('sms.update', 1, 1, ddTags)
+  twilioStatsdClient.increment('sms.update', 1, 1, ddTags)
 
   return res.sendStatus(StatusCodes.OK)
 }

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -1,7 +1,7 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 
-import { ITwilioSmsWebhookBody } from 'src/types/twilio'
+import { ITwilioSmsWebhookBody, TwilioSmsStatsdTags } from 'src/types/twilio'
 
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
@@ -54,7 +54,7 @@ export const twilioSmsUpdates: ControllerHandler<
    * Example: https://www.twilio.com/docs/usage/webhooks/sms-webhooks.
    */
 
-  const ddTags = {
+  const ddTags: TwilioSmsStatsdTags = {
     // msgSrvcSid not included to limit tag cardinality (for now?)
     smsstatus: req.body.SmsStatus,
     errorcode: '0',

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -56,7 +56,6 @@ export const twilioSmsUpdates: ControllerHandler<
    * Example: https://www.twilio.com/docs/usage/webhooks/sms-webhooks.
    */
 
-  // should we add
   const ddTags = {
     // msgsrvcsid: req.body.MessagingServiceSid,
     smsstatus: req.body.SmsStatus,

--- a/src/app/modules/twilio/twilio.statsd-client.ts
+++ b/src/app/modules/twilio/twilio.statsd-client.ts
@@ -1,0 +1,5 @@
+import { statsdClient } from '../../config/datadog-statsd-client'
+
+export const twilioStatsdClient = statsdClient.childClient({
+  prefix: 'vendor.twilio.',
+})

--- a/src/app/routes/api/v3/notifications/__tests__/notifications.routes.spec.ts
+++ b/src/app/routes/api/v3/notifications/__tests__/notifications.routes.spec.ts
@@ -29,6 +29,7 @@ describe('notifications.routes', () => {
     To: '+12345678',
     MessageSid: 'SM212312',
     AccountSid: 'AC123456',
+    MessagingServiceSid: 'MG123456',
     From: '+12345678',
     ApiVersion: '2011-11-01',
   }
@@ -40,6 +41,7 @@ describe('notifications.routes', () => {
     To: '+12345678',
     MessageSid: 'SM212312',
     AccountSid: 'AC123456',
+    MessagingServiceSid: 'MG123456',
     From: '+12345678',
     ApiVersion: '2011-11-01',
     ErrorCode: 30001,

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -4,6 +4,8 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import NodeCache from 'node-cache'
 import Twilio from 'twilio'
 
+import { TwilioSmsStatsdTags } from 'src/types/twilio'
+
 import { isPhoneNumber } from '../../../../shared/utils/phone-num-validation'
 import { AdminContactOtpData, FormOtpData } from '../../../types'
 import config from '../../config/config'
@@ -213,7 +215,7 @@ const sendSms = (
     },
   )
     .andThen(({ status, sid, errorCode, errorMessage }) => {
-      const ddTags = {
+      const ddTags: TwilioSmsStatsdTags = {
         // msgSrvcSid not included to limit tag cardinality (for now?)
         smsstatus: status,
         errorcode: '0',

--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -214,7 +214,7 @@ const sendSms = (
   )
     .andThen(({ status, sid, errorCode, errorMessage }) => {
       const ddTags = {
-        // msgsrvcsid: msgSrvcSid,
+        // msgSrvcSid not included to limit tag cardinality (for now?)
         smsstatus: status,
         errorcode: '0',
       }

--- a/src/types/twilio.ts
+++ b/src/types/twilio.ts
@@ -6,6 +6,7 @@ export interface ITwilioSmsWebhookBody {
   To: string
   MessageSid: string
   AccountSid: string
+  MessagingServiceSid: string
   From: string
   ApiVersion: string
   ErrorCode?: number // Only filled when it is 'failed' or 'undelivered'

--- a/src/types/twilio.ts
+++ b/src/types/twilio.ts
@@ -12,3 +12,8 @@ export interface ITwilioSmsWebhookBody {
   ErrorCode?: number // Only filled when it is 'failed' or 'undelivered'
   ErrorMessage?: string // Only filled when it is 'failed' or 'undelivered'
 }
+
+export type TwilioSmsStatsdTags = {
+  errorcode: string
+  smsstatus: string
+}


### PR DESCRIPTION
## Problem
We need to be able to diagnose Twilio errors early by having a clear view into Twilio API usage, callbacks, and success/errors in both cases.

## Solution
Report real time counters of Twilio stats under the metrics:
* `vendor.twilio.sms.send`
* `vendor.twilio.sms.update`

Note that this is a PR for develop to be released to production asap.