### PR TITLE
refactor(theme): use apply keyword in theme instead of spreading

### DIFF
--- a/frontend/src/theme/components/Badge.ts
+++ b/frontend/src/theme/components/Badge.ts
@@ -6,12 +6,10 @@ import {
 
 import { meetsWcagAaRatio } from '~theme/utils/contrast'
 
-import { textStyles } from '../textStyles'
-
 export type BadgeVariants = 'solid' | 'subtle'
 
 const baseStyle: SystemStyleObject = {
-  ...textStyles['caption-1'],
+  apply: 'textStyles.caption-1',
   textTransform: 'initial',
 }
 

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -5,8 +5,6 @@ import {
 } from '@chakra-ui/theme-tools'
 import merge from 'lodash/merge'
 
-import { textStyles } from '../textStyles'
-
 import { Link } from './Link'
 
 export type ThemeButtonVariant =
@@ -224,7 +222,7 @@ const variantInputAttached: SystemStyleFunction = (props) => {
 
 export const Button = {
   baseStyle: {
-    ...textStyles['subhead-1'],
+    apply: 'textStyles.subhead-1',
     whiteSpace: 'pre-wrap',
     borderRadius: '0.25rem',
     border: '1px solid',

--- a/frontend/src/theme/components/FormLabel.ts
+++ b/frontend/src/theme/components/FormLabel.ts
@@ -1,10 +1,8 @@
 import { ComponentStyleConfig } from '~theme/types'
 
-import { textStyles } from '../textStyles'
-
 export const FormLabel: ComponentStyleConfig = {
   baseStyle: {
-    ...textStyles['subhead-1'],
+    apply: 'textStyles.subhead-1',
     mb: '0.75rem',
   },
 }

--- a/frontend/src/theme/components/Modal.ts
+++ b/frontend/src/theme/components/Modal.ts
@@ -8,8 +8,6 @@ import {
 
 import { ComponentMultiStyleConfig } from '~theme/types'
 
-import { textStyles } from '../textStyles'
-
 const baseStyleOverlay: SystemStyleObject = {
   bg: 'rgba(0, 0, 0, 0.65)',
 }
@@ -45,7 +43,7 @@ const getSize = (value: string): PartsStyleObject<typeof parts> => {
           pt: '2rem',
           pb: '1.5rem',
           px: '1.5rem',
-          ...textStyles['h3'],
+          apply: 'textStyles.h3',
         },
         body: {
           flex: 'initial',
@@ -63,7 +61,7 @@ const getSize = (value: string): PartsStyleObject<typeof parts> => {
         },
         dialog: fullDialogStyle,
         header: {
-          ...textStyles['h2'],
+          apply: 'textStyles.h2',
           p: '1.5rem',
         },
         closeButton: {
@@ -75,7 +73,7 @@ const getSize = (value: string): PartsStyleObject<typeof parts> => {
       return {
         dialog: { maxW: '42.5rem' },
         header: {
-          ...textStyles['h2'],
+          apply: 'textStyles.h2',
           pt: '2rem',
           pb: '1rem',
           px: '2rem',

--- a/frontend/src/theme/components/Table.ts
+++ b/frontend/src/theme/components/Table.ts
@@ -3,8 +3,6 @@ import { PartsStyleFunction } from '@chakra-ui/theme-tools'
 
 import { ComponentMultiStyleConfig } from '~theme/types'
 
-import { textStyles } from '../textStyles'
-
 const variantColumnStripe: PartsStyleFunction<typeof parts> = ({
   colorScheme: c,
 }) => {
@@ -24,7 +22,7 @@ const variantColumnStripe: PartsStyleFunction<typeof parts> = ({
     th: {
       textAlign: 'center',
       textTransform: 'initial',
-      ...textStyles['subhead-2'],
+      apply: 'textStyles.subhead-2',
       color: 'secondary.500',
       bg: { base: 'transparent', md: 'white' },
       '&:nth-of-type(odd)': {
@@ -44,14 +42,14 @@ const variantColumnStripe: PartsStyleFunction<typeof parts> = ({
 const variantSolid: PartsStyleFunction<typeof parts> = ({ colorScheme: c }) => {
   return {
     th: {
-      ...textStyles['subhead-2'],
+      apply: 'textStyles.subhead-2',
       color: 'white',
       bg: `${c}.500`,
       px: '1rem',
       textTransform: 'none',
     },
     td: {
-      ...textStyles['body-2'],
+      apply: 'textStyles.body-2',
       py: '0.625rem',
       px: '1rem',
       borderBottom: '1px solid',
@@ -63,7 +61,6 @@ const variantSolid: PartsStyleFunction<typeof parts> = ({ colorScheme: c }) => {
 const sizes: ComponentMultiStyleConfig<typeof parts>['sizes'] = {
   sm: {
     th: {
-      fontSize: textStyles['subhead-2']['fontSize'],
       py: '0.5rem',
       px: '0.5rem',
     },

--- a/frontend/src/theme/components/Tabs.ts
+++ b/frontend/src/theme/components/Tabs.ts
@@ -4,8 +4,6 @@ import merge from 'lodash/merge'
 
 import { ComponentMultiStyleConfig } from '~theme/types'
 
-import { textStyles } from '../textStyles'
-
 const sizesForLineLightDarkVariant: ComponentMultiStyleConfig<
   typeof parts
 >['sizes'] = {
@@ -45,7 +43,7 @@ const variantLineColor: PartsStyleFunction<typeof parts> = () => ({
     mt: '-2px',
   },
   tab: {
-    ...textStyles['subhead-3'],
+    apply: 'textStyles.subhead-3',
     position: 'relative',
     borderRadius: '0.25rem',
     _selected: {

--- a/frontend/src/theme/components/Tag.ts
+++ b/frontend/src/theme/components/Tag.ts
@@ -8,14 +8,12 @@ import {
 
 import { meetsWcagAaRatio } from '~theme/utils/contrast'
 
-import { textStyles } from '../textStyles'
-
 import { Badge } from './Badge'
 
 const parts = tagAnatomy.extend('icon')
 
 const baseStyleContainer: SystemStyleObject = {
-  ...textStyles['body-2'],
+  apply: 'textStyles.body-2',
   transitionProperty: 'common',
   transitionDuration: 'normal',
 }

--- a/frontend/src/theme/components/Tooltip.ts
+++ b/frontend/src/theme/components/Tooltip.ts
@@ -1,7 +1,5 @@
 import { ComponentStyleConfig } from '~theme/types'
 
-import { textStyles } from '../textStyles'
-
 export const Tooltip: ComponentStyleConfig = {
   baseStyle: {
     // overriding --tooltip-bg since Chakra UI does it this way -
@@ -15,8 +13,6 @@ export const Tooltip: ComponentStyleConfig = {
     textAlign: 'left',
     margin: '0.25rem',
     maxWidth: '19.5rem',
-    // For some reason textStyle prop is not accepted, so just
-    // pass all required styles
-    ...textStyles['body-2'],
+    apply: 'textStyles.body-2',
   },
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Recently discovered the `apply` keyword in Chakra theme props, which allows for spreading of theme properties without having to import the property itself.
