### PR TITLE
feat(v2): i18n - add storage of user preferred language and test string interpolations

### DIFF
--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -211,7 +211,7 @@ export const LoginPage = (): JSX.Element => {
                   color="secondary.500"
                   display={{ base: 'initial', lg: 'none' }}
                 >
-                  Build secure government forms in minutes
+                  {t('general.slogan')}
                 </Text>
               </Flex>
               {!email ? (
@@ -228,7 +228,7 @@ export const LoginPage = (): JSX.Element => {
 
           <DesktopCopyGridArea>
             <Text textStyle="caption-2" color="white">
-              © {currentYear} Open Government Products, GovTech Singapore
+              {t('general.copyright', { currentYear })}
             </Text>
           </DesktopCopyGridArea>
           <DesktopLinksGridArea>

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { FormControl, Stack, useBreakpointValue } from '@chakra-ui/react'
 import isEmail from 'validator/lib/isEmail'
 
@@ -20,6 +21,8 @@ interface LoginFormProps {
 }
 
 export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
+  const { t } = useTranslation()
+
   const { handleSubmit, register, formState, setError } =
     useForm<LoginFormInputs>()
 
@@ -45,16 +48,16 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
         <FormLabel
           isRequired
           htmlFor="email"
-          description="Only available for use by public officers with a gov.sg email"
+          description={t('loginPage.onlyAvailableForPublicOfficers')}
         >
-          Email
+          {t('loginPage.email')}
         </FormLabel>
         <Input
           autoComplete="email"
           autoFocus
           placeholder="e.g. jane@data.gov.sg"
           {...register('email', {
-            required: 'Please enter an email address',
+            required: t('loginPage.emailEmptyErrorMsg'),
             validate: validateEmail,
           })}
         />
@@ -72,10 +75,10 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
           isLoading={formState.isSubmitting}
           type="submit"
         >
-          Log in
+          {t('loginPage.login')}
         </Button>
         <Link isExternal variant="standalone" href={FORM_GUIDE}>
-          Have a question?
+          {t('loginPage.haveAQuestion')}
         </Link>
       </Stack>
     </form>

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -7,7 +7,7 @@ import { locales } from './locales'
 
 i18n
   .use(ICU)
-  .use(LanguageDetector)
+  .use(new LanguageDetector(null, { lookupLocalStorage: 'formsg-language' }))
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
     resources: locales,

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -4,6 +4,15 @@ export const enSG: Translation = {
   translation: {
     general: {
       slogan: 'Build secure government forms in minutes',
+      copyright: '© {currentYear} Open Government Products, GovTech Singapore',
+    },
+    loginPage: {
+      onlyAvailableForPublicOfficers:
+        'Only available for use by public officers with a gov.sg email',
+      email: 'Email',
+      emailEmptyErrorMsg: 'Please enter an email address',
+      login: 'Log in',
+      haveAQuestion: 'Have a question?',
     },
   },
 }

--- a/frontend/src/i18n/locales/index.ts
+++ b/frontend/src/i18n/locales/index.ts
@@ -1,7 +1,9 @@
 import { ResourceLanguage } from 'i18next'
 
 import { enSG } from './en-sg'
+import { zhSG } from './zh-sg'
 
 export const locales = {
   'en-SG': enSG as unknown as ResourceLanguage,
+  'zh-SG': zhSG as unknown as ResourceLanguage,
 }

--- a/frontend/src/i18n/locales/types.ts
+++ b/frontend/src/i18n/locales/types.ts
@@ -2,6 +2,14 @@ interface Translation {
   translation: {
     general: {
       slogan: string
+      copyright: string
+    }
+    loginPage: {
+      onlyAvailableForPublicOfficers: string
+      email: string
+      emailEmptyErrorMsg: string
+      login: string
+      haveAQuestion: string
     }
   }
 }

--- a/frontend/src/i18n/locales/zh-sg.ts
+++ b/frontend/src/i18n/locales/zh-sg.ts
@@ -1,0 +1,17 @@
+import Translation from './types'
+
+export const zhSG: Translation = {
+  translation: {
+    general: {
+      slogan: '在几分钟内创建安全的政府表格',
+      copyright: '© {currentYear} 政府开源科技部, 新加坡政府科技局',
+    },
+    loginPage: {
+      onlyAvailableForPublicOfficers: '只供拥有 gov.sg 电子邮件的公职人员使用',
+      email: '电子邮件地址',
+      emailEmptyErrorMsg: '请输入电子邮件地址',
+      login: '登录',
+      haveAQuestion: '有问题？',
+    },
+  },
+}


### PR DESCRIPTION
## Problem
Part of #3792

## Solution
This adds support for detecting languages from a user's localStorage (key is `formsg-language`), and also adds some Chinese translations and an interpolated string to test out those functionalities.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

**Features**:

- Adds user preferred language detector (via configuring the `i18next-browser-languagedetector` package)
- Adds some Chinese translations
- Adds an interpolated string to translate

## Screenshots

![image](https://user-images.githubusercontent.com/691628/168731760-be1ff8f2-1aa2-4412-b355-f6e3f9d3a75c.png)
