### PR TITLE
feat: handle old style urls in react (redirects)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <base href="/" />
     <!--favicon.ico: 32x32-->
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -22,6 +22,7 @@ import {
 } from '~features/admin-form/responses'
 import { SettingsPage } from '~features/admin-form/settings/SettingsPage'
 
+import { HashRouterElement } from './HashRouterElement'
 import { PrivateElement } from './PrivateElement'
 import { PublicElement } from './PublicElement'
 
@@ -38,12 +39,13 @@ const WithSuspense = ({ children }: { children: React.ReactNode }) => (
 )
 
 export const AppRouter = (): JSX.Element => {
+  // code here?
   return (
     <WithSuspense>
       <Routes>
         <Route
           path={ROOT_ROUTE}
-          element={<PrivateElement element={<WorkspacePage />} />}
+          element={<HashRouterElement element={<WorkspacePage />} />}
         />
         <Route
           path={LOGIN_ROUTE}

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,0 +1,58 @@
+import { Navigate, NavigateProps, useLocation } from 'react-router-dom'
+
+import { useAuth } from '~contexts/AuthContext'
+import { LOGIN_ROUTE } from '~constants/routes'
+
+interface HashRouterElementProps {
+  /**
+   * Route to redirect to when user is not authenticated. Defaults to
+   * `LOGIN_ROUTE` if not provided.
+   */
+  redirectTo?: NavigateProps['to']
+  element: React.ReactElement
+}
+
+const hashRouteMapper = [
+  {
+    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})$/,
+    getTarget: (m: RegExpMatchArray) => `/${m.groups.formid}`,
+  },
+  {
+    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
+    getTarget: (m: RegExpMatchArray) => `/admin/${m.groups.formid}`,
+  },
+  {
+    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
+    getTarget: (m: RegExpMatchArray) => `/admin/${m.groups.formid}/preview`,
+  },
+  {
+    regex: /^#!\/examples$/,
+    getTarget: (m: RegExpMatchArray) => `/admin`,
+  },
+]
+
+export const HashRouterElement = ({
+  element,
+  redirectTo = LOGIN_ROUTE,
+}: HashRouterElementProps): React.ReactElement => {
+  const location = useLocation()
+  const { isAuthenticated } = useAuth()
+
+  // Retire this custom routing after July 2024
+  if (location.hash.startsWith('#!/')) {
+    // angular routes that need to be mapped
+    for (const { regex, getTarget } of hashRouteMapper) {
+      const match = location.hash.match(regex)
+      if (match) {
+        redirectTo = getTarget(match)
+        return <Navigate replace to={redirectTo} state={{ from: location }} />
+      }
+    }
+  }
+
+  return isAuthenticated ? (
+    element
+  ) : (
+    <Navigate replace to={redirectTo} state={{ from: location }} />
+  )
+}

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -25,11 +25,12 @@ const hashRouteMapper = [
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
-    getTarget: (m: FormRegExpMatchArray) => `/admin/${m.groups.formid}`,
+    getTarget: (m: FormRegExpMatchArray) => `/admin/form/${m.groups.formid}`,
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
-    getTarget: (m: FormRegExpMatchArray) => `/admin/${m.groups.formid}/preview`,
+    getTarget: (m: FormRegExpMatchArray) =>
+      `/admin/form/${m.groups.formid}/preview`,
   },
   {
     regex: /^#!\/examples$/,

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -12,22 +12,28 @@ interface HashRouterElementProps {
   element: React.ReactElement
 }
 
+type FormRegExpMatchArray = RegExpMatchArray & {
+  groups: {
+    formid?: string
+  }
+}
+
 const hashRouteMapper = [
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})$/,
-    getTarget: (m: RegExpMatchArray) => `/${m.groups.formid}`,
+    getTarget: (m: FormRegExpMatchArray) => `/${m.groups.formid}`,
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
-    getTarget: (m: RegExpMatchArray) => `/admin/${m.groups.formid}`,
+    getTarget: (m: FormRegExpMatchArray) => `/admin/${m.groups.formid}`,
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
-    getTarget: (m: RegExpMatchArray) => `/admin/${m.groups.formid}/preview`,
+    getTarget: (m: FormRegExpMatchArray) => `/admin/${m.groups.formid}/preview`,
   },
   {
     regex: /^#!\/examples$/,
-    getTarget: (m: RegExpMatchArray) => `/admin`,
+    getTarget: (m: FormRegExpMatchArray) => `/admin`,
   },
 ]
 
@@ -44,7 +50,7 @@ export const HashRouterElement = ({
     for (const { regex, getTarget } of hashRouteMapper) {
       const match = location.hash.match(regex)
       if (match) {
-        redirectTo = getTarget(match)
+        redirectTo = getTarget(match as FormRegExpMatchArray)
         return <Navigate replace to={redirectTo} state={{ from: location }} />
       }
     }


### PR DESCRIPTION
## Problem

People may have bookmarked URLS into forms.

Angular JS uses Hash based routing (e.g. path like `/#!/examples`), where the URL hash is NOT sent to the server. 

Because the server doesn't get to see the URL, the frontend needs to be able to identify the old URLs and redirect to the new URL scheme.

For example:

`/#!/:formid/admin` -> `/admin/forms/:formid`

## Solution
Implement a router in react that will check the hash on the base route and redirect as needed.
