### PR TITLE
feat: add error handling middlewares for /api namespace

### DIFF
--- a/src/app/routes/api/api.routes.ts
+++ b/src/app/routes/api/api.routes.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express'
 
+import errorHandlerMiddlewares from '../../loaders/express/error-handler'
+
 import { V3Router } from './v3'
 
 export const ApiRouter = Router()
 
 ApiRouter.use('/v3', V3Router)
+ApiRouter.use(errorHandlerMiddlewares())


### PR DESCRIPTION
## Problem
We can't have 404s for frontend (since frontends do catch all), but we should have 404s and error reporting for the `/api` namespace.


## Solution
This PR adds error middlewares to the `/api` namespace explicitely

- [X] Tested on staging:

```bash
$ curl -v https://staging.form.gov.sg/api/foobar

< HTTP/2 404
< date: Tue, 17 May 2022 07:48:04 GMT
< content-type: text/plain; charset=utf-8
< content-length: 9
< cf-ray: 70cabfa7eb4c895c-SIN
< etag: W/"9-0gXL1ngzMqISxa6S1zx3F4wtLyg"
< strict-transport-security: max-age=5184000; includeSubDomains
< vary: Accept-Encoding
< cf-cache-status: DYNAMIC
< content-security-policy: img-src 'self' data: https://www.googletagmanager.com/ https://www.google-analytics.com/ https://s3-ap-southeast-1.amazonaws.com/agency.form.sg/ https://s3.ap-southeast-1.amazonaws.com/images.staging.form.gov.sg https://s3.ap-southeast-1.amazonaws.com/logos.staging.form.gov.sg *;font-src 'self' data: https://fonts.gstatic.com/;script-src 'self' https://www.googletagmanager.com/ https://ssl.google-analytics.com/ https://www.google-analytics.com/ https://www.tagmanager.google.com/ https://www.google.com/recaptcha/ https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.cn/ https://www.google-analytics.com/;connect-src 'self' https://www.google-analytics.com/ https://ssl.google-analytics.com/ https://sentry.io/api/ https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/ https://s3.ap-southeast-1.amazonaws.com/images.staging.form.gov.sg https://s3.ap-southeast-1.amazonaws.com/logos.staging.form.gov.sg;frame-src 'self' https://www.google.com/recaptcha/ https://www.recaptcha.net/recaptcha/;style-src 'self' https://www.google.com/recaptcha/ https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.cn/ 'unsafe-inline';frame-ancestors *;report-uri https://sentry.io/api/1450778/security/?sentry_key=0783c1f1c90e4e48b3e4e20e2519931d;default-src 'self';base-uri 'self';block-all-mixed-content;form-action 'self';object-src 'none';script-src-attr 'none';upgrade-insecure-requests
< expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< x-dns-prefetch-control: off
< x-download-options: noopen
< x-request-id: e1bb1a1e-9fcd-44fd-aec9-39466e3d1d2c
< x-xss-protection: 0
< report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=RyfP2ddSab8aRKe89%2Flz28MU7a5HykUXSiSTug5cTlAdngWcO5jc4zEQYBR1RV%2BlfiaWWImsP3%2BCO30anr%2BruPXNbMkhQzuqzQWkKs3H0xTruUWUJlgUQK%2BI0rezWH7JzXqoQV4%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
<
* Connection #0 to host staging.form.gov.sg left intact

Not Found
```
