### PR TITLE
feat: inject DataDog config variable at build time

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
+          REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
+          REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
+          REACT_APP_DD_RUM_ENV: ${{ secrets.DEPLOY_ENV }}
         run: |
           npm ci
           set -e
@@ -59,11 +62,14 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REPOSITORY: ${{ secrets.ECR_REPO }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_ENV: ${{ secrets.DEPLOY_ENV }}
         run: |
           docker build -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
           docker push -a $ECR_REPOSITORY
-          sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json 
+          sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json
+          sed -i -e "s/@DD_API_KEY/$DD_API_KEY/g" -e "s/@DD_ENV/$DEPLOY_ENV/g" .ebextensions/99datadog-amazon-linux-2.config
           zip -r "$IMAGE_TAG.zip" .ebextensions Dockerrun.aws.json
 
       - name: Copy to S3


### PR DESCRIPTION
## Problem
We need to be able to inject some variables at build time when deploying. for RUM monitoring, we need to have the monitors ready as soon as the app starts.

## Solution
I have added new secrets in our project repo, and this PR activates substitutions. 

The substitutions are currently no-ops, because there is no template `@DD_API_KEY` `@DD_ENV` in code. These will be tested in in feature branches for staging deployments.
