### PR TITLE
feat: add a priority UI selector cookie for react rollout QA

### DIFF
--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -315,6 +315,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 'v2-admin-ui',
       env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME',
     },
+    qaCookieName: {
+      doc: 'Priority cookie to select react/angular during QA.',
+      format: String,
+      default: 'v2-qa-ui',
+      env: 'REACT_MIGRATION_QA_COOKIE_NAME',
+    },
   },
 }
 

--- a/src/app/loaders/express/logging.ts
+++ b/src/app/loaders/express/logging.ts
@@ -17,6 +17,7 @@ type LogMeta = {
   reactMigration?: {
     respRolloutAuth: number
     respRolloutNoAuth: number
+    qaCookie: string | undefined
     adminCookie: string | undefined
     respCookie: string | undefined
   }
@@ -71,11 +72,13 @@ const loggingMiddleware = () => {
       // Temporary: cookies are blacklisted, but we to track the state of the rollout for this particular request
       if (
         req.cookies?.[config.reactMigration.adminCookieName] ||
-        req.cookies?.[config.reactMigration.respondentCookieName]
+        req.cookies?.[config.reactMigration.respondentCookieName] ||
+        req.cookies?.[config.reactMigration.qaCookieName]
       ) {
         meta.reactMigration = {
           respRolloutAuth: config.reactMigration.respondentRolloutAuth,
           respRolloutNoAuth: config.reactMigration.respondentRolloutNoAuth,
+          qaCookie: req.cookies?.[config.reactMigration.qaCookieName],
           adminCookie: req.cookies?.[config.reactMigration.adminCookieName],
           respCookie: req.cookies?.[config.reactMigration.respondentCookieName],
         }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -10,8 +10,8 @@ import { RedirectParams } from '../form/public-form/public-form.types'
 import * as HomeController from '../home/home.controller'
 
 export enum UiCookieValues {
-  react = 'react',
-  angular = 'angular',
+  React = 'react',
+  Angular = 'angular',
 }
 
 export type SetEnvironmentParams = {
@@ -81,7 +81,7 @@ export const serveForm: ControllerHandler<
 
   if (config.reactMigration.qaCookieName in req.cookies) {
     showReact =
-      req.cookies[config.reactMigration.qaCookieName] === UiCookieValues.react
+      req.cookies[config.reactMigration.qaCookieName] === UiCookieValues.React
   } else if (threshold <= 0) {
     // Check the rollout value first, if it's 0, react is DISABLED
     // And we ignore cookies entirely!
@@ -92,14 +92,14 @@ export const serveForm: ControllerHandler<
       // also applies to the forms they need to fill themselves
       showReact =
         req.cookies[config.reactMigration.adminCookieName] ===
-        UiCookieValues.react
+        UiCookieValues.React
     } else if (config.reactMigration.respondentCookieName in req.cookies) {
       // Note: the respondent cookie is for the whole session, not for a specific form.
       // That means that within a session, a respondent will see the same environment
       // for all the forms he/she fills.
       showReact =
         req.cookies[config.reactMigration.respondentCookieName] ===
-        UiCookieValues.react
+        UiCookieValues.React
     }
   }
 
@@ -120,7 +120,7 @@ export const serveForm: ControllerHandler<
 
     res.cookie(
       config.reactMigration.respondentCookieName,
-      showReact ? UiCookieValues.react : UiCookieValues.angular,
+      showReact ? UiCookieValues.React : UiCookieValues.Angular,
       RESPONDENT_COOKIE_OPTIONS,
     )
   }
@@ -147,7 +147,7 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
   // only admin who chose react should see react, everybody else is plain angular
   if (
     req.cookies?.[config.reactMigration.adminCookieName] ===
-    UiCookieValues.react
+    UiCookieValues.React
   ) {
     // react
     return serveFormReact(req, res, next)
@@ -165,9 +165,9 @@ export const adminChooseEnvironment: ControllerHandler<
   Record<string, string>
 > = (req, res) => {
   const ui =
-    req.params.ui === UiCookieValues.react
-      ? UiCookieValues.react
-      : UiCookieValues.angular
+    req.params.ui === UiCookieValues.React
+      ? UiCookieValues.React
+      : UiCookieValues.Angular
   res.cookie(config.reactMigration.adminCookieName, ui, ADMIN_COOKIE_OPTIONS)
   return res.json({ ui })
 }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -9,8 +9,13 @@ import * as PublicFormController from '../form/public-form/public-form.controlle
 import { RedirectParams } from '../form/public-form/public-form.types'
 import * as HomeController from '../home/home.controller'
 
+export enum UiCookieValues {
+  react = 'react',
+  angular = 'angular',
+}
+
 export type SetEnvironmentParams = {
-  ui: 'react' | 'angular'
+  ui: UiCookieValues
 }
 
 export const RESPONDENT_COOKIE_OPTIONS = {
@@ -75,7 +80,8 @@ export const serveForm: ControllerHandler<
     : config.reactMigration.respondentRolloutNoAuth
 
   if (config.reactMigration.qaCookieName in req.cookies) {
-    showReact = req.cookies[config.reactMigration.qaCookieName] === 'react'
+    showReact =
+      req.cookies[config.reactMigration.qaCookieName] === UiCookieValues.react
   } else if (threshold <= 0) {
     // Check the rollout value first, if it's 0, react is DISABLED
     // And we ignore cookies entirely!
@@ -84,13 +90,16 @@ export const serveForm: ControllerHandler<
     if (config.reactMigration.adminCookieName in req.cookies) {
       // Admins are dogfooders, the choice they made for the admin environment
       // also applies to the forms they need to fill themselves
-      showReact = req.cookies[config.reactMigration.adminCookieName] === 'react'
+      showReact =
+        req.cookies[config.reactMigration.adminCookieName] ===
+        UiCookieValues.react
     } else if (config.reactMigration.respondentCookieName in req.cookies) {
       // Note: the respondent cookie is for the whole session, not for a specific form.
       // That means that within a session, a respondent will see the same environment
       // for all the forms he/she fills.
       showReact =
-        req.cookies[config.reactMigration.respondentCookieName] === 'react'
+        req.cookies[config.reactMigration.respondentCookieName] ===
+        UiCookieValues.react
     }
   }
 
@@ -111,7 +120,7 @@ export const serveForm: ControllerHandler<
 
     res.cookie(
       config.reactMigration.respondentCookieName,
-      showReact ? 'react' : 'angular',
+      showReact ? UiCookieValues.react : UiCookieValues.angular,
       RESPONDENT_COOKIE_OPTIONS,
     )
   }
@@ -136,7 +145,10 @@ export const serveForm: ControllerHandler<
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
   // only admin who chose react should see react, everybody else is plain angular
-  if (req.cookies?.[config.reactMigration.adminCookieName] === 'react') {
+  if (
+    req.cookies?.[config.reactMigration.adminCookieName] ===
+    UiCookieValues.react
+  ) {
     // react
     return serveFormReact(req, res, next)
   } else {
@@ -152,7 +164,10 @@ export const adminChooseEnvironment: ControllerHandler<
   unknown,
   Record<string, string>
 > = (req, res) => {
-  const ui = req.params.ui === 'react' ? 'react' : 'angular'
+  const ui =
+    req.params.ui === UiCookieValues.react
+      ? UiCookieValues.react
+      : UiCookieValues.angular
   res.cookie(config.reactMigration.adminCookieName, ui, ADMIN_COOKIE_OPTIONS)
   return res.json({ ui })
 }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -74,7 +74,9 @@ export const serveForm: ControllerHandler<
     ? config.reactMigration.respondentRolloutAuth
     : config.reactMigration.respondentRolloutNoAuth
 
-  if (threshold <= 0) {
+  if (config.reactMigration.qaCookieName in req.cookies) {
+    showReact = req.cookies[config.reactMigration.qaCookieName] === 'react'
+  } else if (threshold <= 0) {
     // Check the rollout value first, if it's 0, react is DISABLED
     // And we ignore cookies entirely!
     showReact = false

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -161,6 +161,7 @@ export interface IOptionalVarsSchema {
     respondentRolloutAuth: number
     respondentCookieName: string
     adminCookieName: string
+    qaCookieName: string
   }
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -57,6 +57,7 @@ export type ReactMigrationConfig = {
   respondentRolloutAuth: number
   respondentCookieName: string
   adminCookieName: string
+  qaCookieName: string
 }
 
 export type Config = {


### PR DESCRIPTION
## Problem
We need the ability to rollback from angular to react if we detect something really wrong. 

One mechanism in place to do that is to make sure the router serves angular if the rollout rate is 0 (fastest way to release).

BUT rollout also has a QA phase, where we need the rollout rate to be ZERO for public while we (OGP) are still able to access forms internally.

## Solution
This PR introduces an additional priority cookie for QA that will allow us (formSG dev team) to access the react UI for forms in production, while members of the public will still 100% be on react.

Note: this adds some complexity to the dev team, the QA cookie will always takes priority if it is present, so it might confuse product ops and devs, when they try to load the UI.



