### PR TITLE
perf(v2): improve responsiveness of public form when filling inputs (again)

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -6,15 +6,12 @@ import { times } from 'lodash'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, LogicDto } from '~shared/types/form'
 
-import { useIsMobile } from '~hooks/useIsMobile'
-import Button from '~components/Button'
-import InlineMessage from '~components/InlineMessage'
 import { FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
-import { getLogicUnitPreventingSubmit } from '~features/logic/utils'
 import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
+import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
@@ -30,9 +27,7 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-  const isMobile = useIsMobile()
-
-  // TODO: Inject default values is field is also prefilled.
+  // TODO: Inject default values if field is also prefilled.
   const augmentedFormFields = useMemo(
     () => formFields.map(augmentWithMyInfo),
     [formFields],
@@ -61,16 +56,6 @@ export const FormFields = ({
     shouldUnregister: true,
   })
 
-  const allInputs = formMethods.watch()
-
-  const preventSubmissionLogic = useMemo(() => {
-    return getLogicUnitPreventingSubmit({
-      formInputs: allInputs,
-      formFields: augmentedFormFields,
-      formLogics,
-    })
-  }, [allInputs, augmentedFormFields, formLogics])
-
   return (
     <FormProvider {...formMethods}>
       <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
@@ -84,24 +69,11 @@ export const FormFields = ({
             />
           </Stack>
         </Box>
-        <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
-          <Button
-            isFullWidth={isMobile}
-            w="100%"
-            colorScheme={`theme-${colorTheme}`}
-            type="submit"
-            isLoading={formMethods.formState.isSubmitting}
-            isDisabled={!!preventSubmissionLogic}
-            loadingText="Submitting"
-          >
-            {preventSubmissionLogic ? 'Submission disabled' : 'Submit now'}
-          </Button>
-          {preventSubmissionLogic ? (
-            <InlineMessage variant="warning">
-              {preventSubmissionLogic.preventSubmitMessage}
-            </InlineMessage>
-          ) : null}
-        </Stack>
+        <PublicFormSubmitButton
+          formFields={augmentedFormFields}
+          formLogics={formLogics}
+          colorTheme={colorTheme}
+        />
       </form>
     </FormProvider>
   )

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -28,17 +28,16 @@ export const PublicFormSubmitButton = ({
   colorTheme,
 }: PublicFormSubmitButtonProps): JSX.Element => {
   const isMobile = useIsMobile()
-  const { control } = useFormContext<FormFieldValues>()
   const { isSubmitting } = useFormState()
-  const allInputs = useWatch({ control })
+  const formInputs = useWatch<FormFieldValues>({})
 
   const preventSubmissionLogic = useMemo(() => {
     return getLogicUnitPreventingSubmit({
-      formInputs: allInputs,
+      formInputs,
       formFields,
       formLogics,
     })
-  }, [allInputs, formFields, formLogics])
+  }, [formInputs, formFields, formLogics])
 
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react'
+import { useFormContext, useFormState, useWatch } from 'react-hook-form'
+import { Stack } from '@chakra-ui/react'
+
+import { FormField, LogicDto, MyInfoFormField } from '~shared/types'
+
+import { ThemeColorScheme } from '~theme/foundations/colours'
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
+import InlineMessage from '~components/InlineMessage'
+import { FormFieldValues } from '~templates/Field'
+
+import { getLogicUnitPreventingSubmit } from '~features/logic/utils'
+
+interface PublicFormSubmitButtonProps {
+  formFields: MyInfoFormField<FormField>[]
+  formLogics: LogicDto[]
+  colorTheme: string
+}
+
+/**
+ * This component is split up so that input changes will not rerender the
+ * entire FormFields component leading to terrible performance.
+ */
+export const PublicFormSubmitButton = ({
+  formFields,
+  formLogics,
+  colorTheme,
+}: PublicFormSubmitButtonProps): JSX.Element => {
+  const isMobile = useIsMobile()
+  const { control } = useFormContext<FormFieldValues>()
+  const { isSubmitting } = useFormState()
+  const allInputs = useWatch({ control })
+
+  const preventSubmissionLogic = useMemo(() => {
+    return getLogicUnitPreventingSubmit({
+      formInputs: allInputs,
+      formFields,
+      formLogics,
+    })
+  }, [allInputs, formFields, formLogics])
+
+  return (
+    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
+      <Button
+        isFullWidth={isMobile}
+        w="100%"
+        colorScheme={`theme-${colorTheme}` as ThemeColorScheme}
+        type="submit"
+        isLoading={isSubmitting}
+        isDisabled={!!preventSubmissionLogic}
+        loadingText="Submitting"
+      >
+        {preventSubmissionLogic ? 'Submission disabled' : 'Submit now'}
+      </Button>
+      {preventSubmissionLogic ? (
+        <InlineMessage variant="warning">
+          {preventSubmissionLogic.preventSubmitMessage}
+        </InlineMessage>
+      ) : null}
+    </Stack>
+  )
+}


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR moves the form input watcher into PublicFormSubmitButton subcomponent so that input changes will not rerender the entire FormFields component leading to terrible performance.

This perf degradation was introduced in #3813.

Oddy reminiscent of #3576 

## Solution
<!-- How did you solve the problem? -->

**Bug Fixes**:

- perf: move form input watcher into PublicFormSubmitButton subcomponent

## Before & After Screenshots

**BEFORE**:
![Recording 2022-05-27 at 01 10 40](https://user-images.githubusercontent.com/22133008/170539520-65d9300d-56d4-4c03-972f-4845f88642a9.gif)

**AFTER**:
![Recording 2022-05-27 at 01 06 06](https://user-images.githubusercontent.com/22133008/170539186-ffe1fbf4-c89a-4a22-81d9-8b71ca075a48.gif)

