### PR TITLE
feat: store prefill in frontend for spcp/myinfo forms, enable prefill for SGID forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6929,7 +6929,7 @@
     "addressparser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
-      "integrity": "sha512-aQX7AISOMM7HFE0iZ3+YnD07oIeJqWGVnJ+ZIKaBZAk03ftmVYVqsGas/rbXKR21n4D/hKCSHypvcyOkds/xzg==",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
       "dev": true
     },
     "agent-base": {
@@ -7943,7 +7943,7 @@
     "base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
       "dev": true
     },
     "base64-js": {
@@ -9925,6 +9925,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
       "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "cuint": {
       "version": "0.2.2",
@@ -22784,7 +22789,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "cookie-parser": "~1.4.6",
     "css-toggle-switch": "^4.1.0",
     "csv-string": "^4.1.0",
+    "cuid": "^2.1.8",
     "date-fns": "^2.28.0",
     "dedent-js": "~1.0.1",
     "dotenv": "^16.0.1",

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -395,7 +395,7 @@ export const handleGetPublicForm: ControllerHandler<
  * NOTE: This is exported only for testing
  * Generates redirect URL to Official SingPass/CorpPass log in page
  * @param isPersistentLogin whether the client wants to have their login information stored
- * @param encodedQuery base64 encoded querystring (usually contains prefilled form information)
+ * @param encodedQuery base64 encoded queryId for frontend to retrieve stored query params (usually contains prefilled form information)
  * @returns 200 with the redirect url when the user authenticates successfully
  * @returns 400 when there is an error on the authType of the form
  * @returns 400 when the eServiceId of the form does not exist

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -453,6 +453,7 @@ export const _handleFormAuthRedirect: ControllerHandler<
             return SgidService.createRedirectUrl(
               formId,
               Boolean(isPersistentLogin),
+              encodedQuery,
             )
           })
         default:

--- a/src/app/modules/sgid/__tests__/sgid.service.spec.ts
+++ b/src/app/modules/sgid/__tests__/sgid.service.spec.ts
@@ -91,6 +91,7 @@ describe('sgid.service', () => {
     it('should parse state', () => {
       const state = SgidService.parseState(MOCK_STATE)
       expect(state._unsafeUnwrap()).toStrictEqual({
+        decodedQuery: '',
         formId: MOCK_DESTINATION,
         rememberMe: MOCK_REMEMBER_ME,
       })

--- a/src/app/modules/sgid/sgid.controller.ts
+++ b/src/app/modules/sgid/sgid.controller.ts
@@ -33,6 +33,8 @@ export const handleLogin: ControllerHandler<
   }
 
   const { formId, rememberMe, decodedQuery } = parsedState.value
+  const target = decodedQuery ? `/${formId}${decodedQuery}` : `/${formId}`
+
   const formResult = await FormService.retrieveFullFormById(formId)
   if (formResult.isErr()) {
     logger.error({
@@ -54,7 +56,7 @@ export const handleLogin: ControllerHandler<
       },
     })
     res.cookie('isLoginError', true)
-    return res.redirect(`/${formId}${decodedQuery}`)
+    return res.redirect(target)
   }
 
   const jwtResult = await SgidService.retrieveAccessToken(code)
@@ -68,7 +70,7 @@ export const handleLogin: ControllerHandler<
       error: jwtResult.error,
     })
     res.cookie('isLoginError', true)
-    return res.redirect(`/${formId}${decodedQuery}`)
+    return res.redirect(target)
   }
 
   const { maxAge, jwt } = jwtResult.value
@@ -79,5 +81,5 @@ export const handleLogin: ControllerHandler<
     secure: !config.isDev,
     ...SgidService.getCookieSettings(),
   })
-  return res.redirect(`/${formId}${decodedQuery}`)
+  return res.redirect(target)
 }

--- a/src/app/modules/sgid/sgid.controller.ts
+++ b/src/app/modules/sgid/sgid.controller.ts
@@ -32,7 +32,7 @@ export const handleLogin: ControllerHandler<
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
 
-  const { formId, rememberMe } = parsedState.value
+  const { formId, rememberMe, decodedQuery } = parsedState.value
   const formResult = await FormService.retrieveFullFormById(formId)
   if (formResult.isErr()) {
     logger.error({
@@ -54,7 +54,7 @@ export const handleLogin: ControllerHandler<
       },
     })
     res.cookie('isLoginError', true)
-    return res.redirect(`/${formId}`)
+    return res.redirect(`/${formId}${decodedQuery}`)
   }
 
   const jwtResult = await SgidService.retrieveAccessToken(code)
@@ -68,7 +68,7 @@ export const handleLogin: ControllerHandler<
       error: jwtResult.error,
     })
     res.cookie('isLoginError', true)
-    return res.redirect(`/${formId}`)
+    return res.redirect(`/${formId}${decodedQuery}`)
   }
 
   const { maxAge, jwt } = jwtResult.value
@@ -79,5 +79,5 @@ export const handleLogin: ControllerHandler<
     secure: !config.isDev,
     ...SgidService.getCookieSettings(),
   })
-  return res.redirect(`/${formId}`)
+  return res.redirect(`/${formId}${decodedQuery}`)
 }

--- a/src/app/modules/sgid/sgid.service.ts
+++ b/src/app/modules/sgid/sgid.service.ts
@@ -60,13 +60,17 @@ export class SgidServiceClass {
    * Create a URL to sgID which is used to redirect the user for authentication
    * @param formId - the form id to redirect to after authentication
    * @param rememberMe - whether we create a JWT that remembers the user
+   * @param encodedQuery base64 encoded queryId for frontend to retrieve stored query params (usually contains prefilled form information)
    * for an extended period of time
    */
   createRedirectUrl(
     formId: string,
     rememberMe: boolean,
+    encodedQuery?: string,
   ): Result<string, SgidCreateRedirectUrlError> {
-    const state = `${formId},${rememberMe}`
+    const state = encodedQuery
+      ? `${formId},${rememberMe},${encodedQuery}`
+      : `${formId},${rememberMe}`
     const logMeta = {
       action: 'createRedirectUrl',
       state,
@@ -88,18 +92,41 @@ export class SgidServiceClass {
    * Parses the string serialization containing the form id and if the
    * user should be remembered, both needed when redirecting the user back to
    * the form post-authentication
-   * @param state - a comma-separated string of the form id and a boolean flag
-   * indicating if the user should be remembered
-   * @returns {Result<{ formId: string; rememberMe: boolean }, SgidInvalidStateError>}
-   *   the form id and whether the user should be remembered
+   * @param state - a comma-separated string of the form id, a boolean flag
+   * indicating if the user should be remembered, and an optional encodedQuery
+   * @returns {Result<{ formId: string; rememberMe: boolean; decodedQuery?: string }, SgidInvalidStateError>}
    */
   parseState(
     state: string,
-  ): Result<{ formId: string; rememberMe: boolean }, SgidInvalidStateError> {
-    const [formId, rememberMeStr] = state.split(',')
-    const rememberMe = rememberMeStr === 'true'
+  ): Result<
+    { formId: string; rememberMe: boolean; decodedQuery: string },
+    SgidInvalidStateError
+  > {
+    const payloads = state.split(',')
+    const formId = payloads[0]
+    const rememberMe = payloads[1] === 'true'
+
+    const encodedQuery = payloads.length === 3 ? payloads[2] : ''
+    let decodedQuery = ''
+
+    try {
+      decodedQuery = encodedQuery
+        ? `?${Buffer.from(encodedQuery, 'base64').toString('utf8')}`
+        : ''
+    } catch (e) {
+      logger.error({
+        message: 'Unable to decode encodedQuery',
+        meta: {
+          action: 'parseOOBParams',
+          encodedQuery,
+        },
+        error: e,
+      })
+      return err(new SgidInvalidStateError())
+    }
+
     return formId
-      ? ok({ formId, rememberMe })
+      ? ok({ formId, rememberMe, decodedQuery })
       : err(new SgidInvalidStateError())
   }
 

--- a/src/public/main.js
+++ b/src/public/main.js
@@ -727,3 +727,7 @@ angular
     },
   })
   .constant('responseModeEnum', { ENCRYPT: 'encrypt', EMAIL: 'email' })
+  .constant('prefill', {
+    QUERY_ID: 'queryId',
+    STORED_QUERY: 'storedQuery',
+  })

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -36,8 +36,11 @@ function SubmitFormController(
   )
 
   // If it is an authenticated form, read the storedQuery from local storage and append to query params
-  // Note that regardless of whether user is logged in, we should replace the queryId with the
+  // As a design decision, regardless of whether user is logged in, we should replace the queryId with the
   // stored query params
+  // queryId could exist even though user is not logged in if user initiates the login flow
+  // but does not complete it and returns to the public form view within the same session
+
   if (isSpcpSgidForm || isMyInfoForm) {
     const location = $window.location.toString().split('?')
     if (location.length > 1) {

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -11,6 +11,7 @@ angular
     '$document',
     'GTag',
     'Toastr',
+    'prefill',
     SubmitFormController,
   ])
 
@@ -21,6 +22,7 @@ function SubmitFormController(
   $document,
   GTag,
   Toastr,
+  prefill,
 ) {
   const vm = this
 
@@ -35,6 +37,7 @@ function SubmitFormController(
     FormData.spcpSession && FormData.spcpSession.userName
   )
 
+  // Handle prefills
   // If it is an authenticated form, read the storedQuery from local storage and append to query params
   // As a design decision, regardless of whether user is logged in, we should replace the queryId with the
   // stored query params
@@ -45,14 +48,16 @@ function SubmitFormController(
     const location = $window.location.toString().split('?')
     if (location.length > 1) {
       const queryParams = new URLSearchParams(location[1])
-      const queryId = queryParams.get('queryId')
+      const queryId = queryParams.get(prefill.QUERY_ID)
 
       let storedQuery
 
       try {
         // If storedQuery is not valid JSON, JSON.parse throws a SyntaxError
         // In try-catch block as this should not prevent rest of form from being loaded
-        storedQuery = JSON.parse($window.sessionStorage.getItem('storedQuery'))
+        storedQuery = JSON.parse(
+          $window.sessionStorage.getItem(prefill.STORED_QUERY),
+        )
       } catch (e) {
         console.error('Unable to parse storedQuery, not valid JSON string')
       }
@@ -64,7 +69,7 @@ function SubmitFormController(
         storedQuery.queryString
       ) {
         $window.location.href = `${location[0]}?${storedQuery.queryString}` // Replace the queryId with stored queryString
-        $window.sessionStorage.removeItem('storedQuery') // Delete after reading the stored queryString, as only needed once
+        $window.sessionStorage.removeItem(prefill.STORED_QUERY) // Delete after reading the stored queryString, as only needed once
       }
     }
   }

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -49,7 +49,7 @@ function SubmitFormController(
       try {
         // If storedQuery is not valid JSON, JSON.parse throws a SyntaxError
         // In try-catch block as this should not prevent rest of form from being loaded
-        storedQuery = JSON.parse($window.localStorage.getItem('storedQuery'))
+        storedQuery = JSON.parse($window.sessionStorage.getItem('storedQuery'))
       } catch (e) {
         console.error('Unable to parse storedQuery, not valid JSON string')
       }
@@ -61,7 +61,7 @@ function SubmitFormController(
         storedQuery.queryString
       ) {
         $window.location.href = `${location[0]}?${storedQuery.queryString}` // Replace the queryId with stored queryString
-        $window.localStorage.removeItem('storedQuery') // Delete after reading the stored queryString, as only needed once
+        $window.sessionStorage.removeItem('storedQuery') // Delete after reading the stored queryString, as only needed once
       }
     }
   }

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -41,6 +41,7 @@ angular
     '$uibModal',
     '$timeout',
     '$location',
+    'prefill',
     submitFormDirective,
   ])
 
@@ -57,6 +58,7 @@ function submitFormDirective(
   $uibModal,
   $timeout,
   $location,
+  prefill,
 ) {
   return {
     restrict: 'E',
@@ -104,7 +106,9 @@ function submitFormDirective(
         const query = $location.url().split('?')
         const queryString = query.length > 1 ? query[1] : undefined
         const queryId = queryString ? cuid() : undefined
-        const encodedQuery = queryId ? btoa(`queryId=${queryId}`) : undefined
+        const encodedQuery = queryId
+          ? btoa(`${prefill.QUERY_ID}=${queryId}`)
+          : undefined
         const queryObject = {
           _id: queryId,
           queryString,
@@ -119,7 +123,10 @@ function submitFormDirective(
             // we should only store one set of prefill params. Meanwhile, we use queryId and pass it to the
             // backend instead of simply storing the query params directly in sessionStorage, so as to
             // ensure that the stored query is loaded only for the session where it was generated
-            sessionStorage.setItem('storedQuery', JSON.stringify(queryObject))
+            sessionStorage.setItem(
+              prefill.STORED_QUERY,
+              JSON.stringify(queryObject),
+            )
           } catch (e) {
             console.error('Failed to store query string')
             // Login can proceed, since after login, user can still prefill form by accessing

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -1,7 +1,7 @@
 'use strict'
 const cloneDeep = require('lodash/cloneDeep')
 const get = require('lodash/get')
-const { ObjectId } = require('bson')
+const cuid = require('cuid')
 
 const FieldVerificationService = require('../../../../services/FieldVerificationService')
 const PublicFormAuthService = require('../../../../services/PublicFormAuthService')
@@ -103,7 +103,7 @@ function submitFormDirective(
 
         const query = $location.url().split('?')
         const queryString = query.length > 1 ? query[1] : undefined
-        const queryId = queryString ? new ObjectId() : undefined
+        const queryId = queryString ? cuid() : undefined
         const encodedQuery = queryId ? btoa(`queryId=${queryId}`) : undefined
         const queryObject = {
           _id: queryId,
@@ -114,7 +114,7 @@ function submitFormDirective(
           // Defensive - try catch block in case the storage is full
           // See https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem
           try {
-            // We use storedQuery as the sessionStorage key rather than just using the ObjectId
+            // We use storedQuery as the sessionStorage key rather than just using the queryId
             // because only one person can be logging in at a time in a given session, so
             // we should only store one set of prefill params. Meanwhile, we use queryId and pass it to the
             // backend instead of simply storing the query params directly in sessionStorage, so as to

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -114,6 +114,11 @@ function submitFormDirective(
           // Defensive - try catch block in case the storage is full
           // See https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem
           try {
+            // We use storedQuery as the sessionStorage key rather than just using the ObjectId
+            // because only one person can be logging in at a time in a given session, so
+            // we should only store one set of prefill params. Meanwhile, we use queryId and pass it to the
+            // backend instead of simply storing the query params directly in sessionStorage, so as to
+            // ensure that the stored query is loaded only for the session where it was generated
             sessionStorage.setItem('storedQuery', JSON.stringify(queryObject))
           } catch (e) {
             console.error('Failed to store query string')

--- a/src/public/modules/forms/base/directives/submit-form.directive.js
+++ b/src/public/modules/forms/base/directives/submit-form.directive.js
@@ -114,7 +114,7 @@ function submitFormDirective(
           // Defensive - try catch block in case the storage is full
           // See https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem
           try {
-            localStorage.setItem('storedQuery', JSON.stringify(queryObject))
+            sessionStorage.setItem('storedQuery', JSON.stringify(queryObject))
           } catch (e) {
             console.error('Failed to store query string')
             // Login can proceed, since after login, user can still prefill form by accessing


### PR DESCRIPTION
## Problem

- Currently, when there are prefill query parameters for an SP/CP/Myinfo form, to preserve the prefill query during the authentication flow the prefill query parameters are relayed through our backend and SPCP/Myinfo servers, before they are returned to the client in the form of a redirect after authentication is complete
- The prefilled query parameters can be arbitrarily long. With the transition to OIDC, this approach is no longer possible as NDI only accepts `state` of up to 255 characters
- In addition, prefill is a purely frontend feature for user's convenience, and ideally, prefilled form values should not pass through our servers until they have been reviewed and submitted by the user

## Solution
- The workflow has been revised as follows:
  - When user attempts to login to SP/CP/Myinfo form with prefilled query parameter, the client generates a random queryId and stores the queryId and query parameter in local storage
  - The queryId is then relayed through our servers
  - Thereafter, after authentication, the client is redirected back to the form with the queryId provided in the redirect. Using the queryId, the client can then retrieve the stored query parameters and reconstruct the original url 
- This change is backwards compatible because there is no change to the backend logic

## Others

- Separately, this PR enables prefill for SGID forms (which was somehow left out previously)

## Tests

- [ ] Create Singpass form. Open in public view with prefilled query parameters. Login to Singpass. On redirect back to the form, check that the prefill displays correctly. Check that `storedQuery` has been deleted from `sessionStorage`
- [ ] Logout. With the prefilled query parameters still in the url, click login again. Do not complete the Singpass authentication flow. Return to the form and enter a new set of prefilled query parameters. Login using this new set of query parameters and complete the authentication flow. Check that on redirect back to the form, the correct prefill is displayed and `storedQuery` has been deleted from `sessionStorage`
- [ ] Repeat above for CP, MyInfo and SGID forms
- [ ] Create normal prefill form and check that it works normally