### PR TITLE
fix: server to randomize image and logo filenames before generating presigned url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6929,7 +6929,7 @@
     "addressparser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
-      "integrity": "sha512-aQX7AISOMM7HFE0iZ3+YnD07oIeJqWGVnJ+ZIKaBZAk03ftmVYVqsGas/rbXKR21n4D/hKCSHypvcyOkds/xzg==",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
       "dev": true
     },
     "agent-base": {
@@ -7943,7 +7943,7 @@
     "base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
       "dev": true
     },
     "base64-js": {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -952,6 +952,7 @@ describe('admin-form.controller', () => {
         fileId: 'any file id',
         fileMd5Hash: 'any hash',
         fileType: 'any type',
+        isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
       },
     })
 
@@ -979,6 +980,55 @@ describe('admin-form.controller', () => {
       // Act
       await AdminFormController.createPresignedPostUrlForImages(
         MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
+    })
+
+    it('should return 200 with presigned POST URL object when successful for old clients', async () => {
+      // TODO (#128): Test to be removed after isNewClient flag has been removed
+      // Arrange
+      const MOCK_REQ_OLD = expressHandler.mockRequest({
+        params: {
+          formId: MOCK_FORM_ID,
+        },
+        session: {
+          user: {
+            _id: MOCK_USER_ID,
+          },
+        },
+        body: {
+          fileId: 'any file id',
+          fileMd5Hash: 'any hash',
+          fileType: 'any type',
+        },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+      const expectedPresignedPost: PresignedPost = {
+        fields: {
+          'X-Amz-Signature': 'some-amz-signature',
+          Policy: 'some policy',
+        },
+        url: 'some url',
+      }
+      MockAdminFormService.createPresignedPostUrlForImages.mockReturnValueOnce(
+        okAsync(expectedPresignedPost),
+      )
+
+      // Act
+      await AdminFormController.createPresignedPostUrlForImages(
+        MOCK_REQ_OLD,
         mockRes,
         jest.fn(),
       )
@@ -1187,6 +1237,7 @@ describe('admin-form.controller', () => {
         fileId: 'any file id',
         fileMd5Hash: 'any hash',
         fileType: 'any type',
+        isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
       },
     })
 
@@ -1214,6 +1265,55 @@ describe('admin-form.controller', () => {
       // Act
       await AdminFormController.createPresignedPostUrlForLogos(
         MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
+    })
+
+    it('should return 200 with presigned POST URL object when successful for old clients', async () => {
+      // TODO (#128): Test to be removed after isNewClient flag has been removed
+      // Arrange
+      const MOCK_REQ_OLD = expressHandler.mockRequest({
+        params: {
+          formId: MOCK_FORM_ID,
+        },
+        session: {
+          user: {
+            _id: MOCK_USER_ID,
+          },
+        },
+        body: {
+          fileId: 'any file id',
+          fileMd5Hash: 'any hash',
+          fileType: 'any type',
+        },
+      })
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      // Mock various services to return expected results.
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+      const expectedPresignedPost: PresignedPost = {
+        fields: {
+          'X-Amz-Signature': 'some-amz-signature',
+          Policy: 'some policy',
+        },
+        url: 'some url',
+      }
+      MockAdminFormService.createPresignedPostUrlForLogos.mockReturnValueOnce(
+        okAsync(expectedPresignedPost),
+      )
+
+      // Act
+      await AdminFormController.createPresignedPostUrlForLogos(
+        MOCK_REQ_OLD,
         mockRes,
         jest.fn(),
       )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -4906,9 +4906,17 @@ describe('admin-form.routes', () => {
       fileId: 'some file id',
       fileMd5Hash: SparkMD5.hash('test file name'),
       fileType: VALID_UPLOAD_FILE_TYPES[0],
+      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
-    it('should return 200 with presigned POST URL object', async () => {
+    const DEFAULT_POST_PARAMS_OLD_CLIENT = {
+      // TODO (#128): Clean up tests after isNewClient flag has been removed.
+      fileId: 'some other file id',
+      fileMd5Hash: SparkMD5.hash('test file name again'),
+      fileType: VALID_UPLOAD_FILE_TYPES[2],
+    }
+
+    it('should return 200 with presigned POST URL object and append an objectId to the key', async () => {
       // Arrange
       const form = await EncryptFormModel.create({
         title: 'form',
@@ -4929,7 +4937,43 @@ describe('admin-form.routes', () => {
         fields: expect.objectContaining({
           'Content-MD5': DEFAULT_POST_PARAMS.fileMd5Hash,
           'Content-Type': DEFAULT_POST_PARAMS.fileType,
-          key: DEFAULT_POST_PARAMS.fileId,
+          key: expect.any(String),
+          // Should have correct permissions.
+          acl: 'public-read',
+          bucket: expect.any(String),
+        }),
+      })
+      expect(response.body.fields.key).toEqual(
+        expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
+      )
+      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
+        response.body.fields.key.length,
+      )
+    })
+
+    it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {
+      // TODO (#128): Test to be removed after isNewClient flag has been removed.
+      // Arrange
+      const form = await EncryptFormModel.create({
+        title: 'form',
+        admin: defaultUser._id,
+        publicKey: 'does not matter',
+      })
+
+      // Act
+      const response = await request
+        .post(`/${form._id}/adminform/logos`)
+        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Should equal mocked result.
+      expect(response.body).toEqual({
+        url: expect.any(String),
+        fields: expect.objectContaining({
+          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
+          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
+          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
           // Should have correct permissions.
           acl: 'public-read',
           bucket: expect.any(String),
@@ -5144,9 +5188,17 @@ describe('admin-form.routes', () => {
       fileId: 'some other file id',
       fileMd5Hash: SparkMD5.hash('test file name again'),
       fileType: VALID_UPLOAD_FILE_TYPES[2],
+      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
-    it('should return 200 with presigned POST URL object', async () => {
+    const DEFAULT_POST_PARAMS_OLD_CLIENT = {
+      // TODO (#128): Clean up tests after isNewClient flag has been removed.
+      fileId: 'some other file id',
+      fileMd5Hash: SparkMD5.hash('test file name again'),
+      fileType: VALID_UPLOAD_FILE_TYPES[2],
+    }
+
+    it('should return 200 with presigned POST URL object and append an objectId to the key', async () => {
       // Arrange
       const form = await EncryptFormModel.create({
         title: 'form',
@@ -5167,7 +5219,43 @@ describe('admin-form.routes', () => {
         fields: expect.objectContaining({
           'Content-MD5': DEFAULT_POST_PARAMS.fileMd5Hash,
           'Content-Type': DEFAULT_POST_PARAMS.fileType,
-          key: DEFAULT_POST_PARAMS.fileId,
+          key: expect.any(String),
+          // Should have correct permissions.
+          acl: 'public-read',
+          bucket: expect.any(String),
+        }),
+      })
+      expect(response.body.fields.key).toEqual(
+        expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
+      )
+      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
+        response.body.fields.key.length,
+      )
+    })
+
+    it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {
+      // TODO (#128): Test to be removed after isNewClient flag has been removed.
+      // Arrange
+      const form = await EncryptFormModel.create({
+        title: 'form',
+        admin: defaultUser._id,
+        publicKey: 'does not matter',
+      })
+
+      // Act
+      const response = await request
+        .post(`/${form._id}/adminform/logos`)
+        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Should equal mocked result.
+      expect(response.body).toEqual({
+        url: expect.any(String),
+        fields: expect.objectContaining({
+          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
+          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
+          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
           // Should have correct permissions.
           acl: 'public-read',
           bucket: expect.any(String),

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -4946,9 +4946,11 @@ describe('admin-form.routes', () => {
       expect(response.body.fields.key).toEqual(
         expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
       )
-      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
-        response.body.fields.key.length,
+      expect(DEFAULT_POST_PARAMS.fileId.length).toEqual(
+        response.body.fields.key.length - 25,
       )
+
+      expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
     })
 
     it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {
@@ -5228,9 +5230,11 @@ describe('admin-form.routes', () => {
       expect(response.body.fields.key).toEqual(
         expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
       )
-      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
-        response.body.fields.key.length,
+      expect(DEFAULT_POST_PARAMS.fileId.length).toEqual(
+        response.body.fields.key.length - 25,
       )
+
+      expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
     })
 
     it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
@@ -92,9 +92,11 @@ describe('admin-form.presign.routes', () => {
       expect(response.body.fields.key).toEqual(
         expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
       )
-      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
-        response.body.fields.key.length,
+      expect(DEFAULT_POST_PARAMS.fileId.length).toEqual(
+        response.body.fields.key.length - 25,
       )
+
+      expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
     })
 
     it('should return 200 with presigned POST URL object for old client', async () => {
@@ -374,9 +376,11 @@ describe('admin-form.presign.routes', () => {
       expect(response.body.fields.key).toEqual(
         expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
       )
-      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
-        response.body.fields.key.length,
+      expect(DEFAULT_POST_PARAMS.fileId.length).toEqual(
+        response.body.fields.key.length - 25,
       )
+
+      expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
     })
 
     it('should return 200 with presigned POST URL object for old client', async () => {

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
@@ -59,6 +59,7 @@ describe('admin-form.presign.routes', () => {
       fileId: 'some file id',
       fileMd5Hash: SparkMD5.hash('test file name'),
       fileType: VALID_UPLOAD_FILE_TYPES[0],
+      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
     it('should return 200 with presigned POST URL object', async () => {
@@ -82,7 +83,49 @@ describe('admin-form.presign.routes', () => {
         fields: expect.objectContaining({
           'Content-MD5': DEFAULT_POST_PARAMS.fileMd5Hash,
           'Content-Type': DEFAULT_POST_PARAMS.fileType,
-          key: DEFAULT_POST_PARAMS.fileId,
+          key: expect.any(String),
+          // Should have correct permissions.
+          acl: 'public-read',
+          bucket: expect.any(String),
+        }),
+      })
+      expect(response.body.fields.key).toEqual(
+        expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
+      )
+      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
+        response.body.fields.key.length,
+      )
+    })
+
+    it('should return 200 with presigned POST URL object for old client', async () => {
+      // Arrange
+
+      const DEFAULT_POST_PARAMS_OLD_CLIENT = {
+        fileId: 'some file id',
+        fileMd5Hash: SparkMD5.hash('test file name'),
+        fileType: VALID_UPLOAD_FILE_TYPES[0],
+      }
+
+      const form = await EncryptFormModel.create({
+        title: 'form',
+        admin: defaultUser._id,
+        publicKey: 'does not matter',
+      })
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${form._id}/images/presign`)
+        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Should equal mocked result.
+      expect(response.body).toEqual({
+        url: expect.any(String),
+        fields: expect.objectContaining({
+          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
+          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
+          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
           // Should have correct permissions.
           acl: 'public-read',
           bucket: expect.any(String),
@@ -297,6 +340,7 @@ describe('admin-form.presign.routes', () => {
       fileId: 'some other file id',
       fileMd5Hash: SparkMD5.hash('test file name again'),
       fileType: VALID_UPLOAD_FILE_TYPES[2],
+      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
     it('should return 200 with presigned POST URL object', async () => {
@@ -320,7 +364,50 @@ describe('admin-form.presign.routes', () => {
         fields: expect.objectContaining({
           'Content-MD5': DEFAULT_POST_PARAMS.fileMd5Hash,
           'Content-Type': DEFAULT_POST_PARAMS.fileType,
-          key: DEFAULT_POST_PARAMS.fileId,
+          key: expect.any(String),
+          // Should have correct permissions.
+          acl: 'public-read',
+          bucket: expect.any(String),
+        }),
+      })
+
+      expect(response.body.fields.key).toEqual(
+        expect.stringContaining(DEFAULT_POST_PARAMS.fileId),
+      )
+      expect(DEFAULT_POST_PARAMS.fileId.length).toBeLessThan(
+        response.body.fields.key.length,
+      )
+    })
+
+    it('should return 200 with presigned POST URL object for old client', async () => {
+      // Arrange
+
+      const DEFAULT_POST_PARAMS_OLD_CLIENT = {
+        fileId: 'some file id',
+        fileMd5Hash: SparkMD5.hash('test file name'),
+        fileType: VALID_UPLOAD_FILE_TYPES[0],
+      }
+
+      const form = await EncryptFormModel.create({
+        title: 'form',
+        admin: defaultUser._id,
+        publicKey: 'does not matter',
+      })
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${form._id}/logos/presign`)
+        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Should equal mocked result.
+      expect(response.body).toEqual({
+        url: expect.any(String),
+        fields: expect.objectContaining({
+          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
+          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
+          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
           // Should have correct permissions.
           acl: 'public-read',
           bucket: expect.any(String),

--- a/src/public/services/FileHandlerService.ts
+++ b/src/public/services/FileHandlerService.ts
@@ -63,7 +63,12 @@ type PresignedData = { fields: Record<string, string>; url: string }
 
 const fetchPresignedData = async (
   url: string,
-  params: { fileId: string; fileMd5Hash: string; fileType: string },
+  params: {
+    fileId: string
+    fileMd5Hash: string
+    fileType: string
+    isNewClient: boolean // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
+  },
   cancelToken?: CancelToken,
 ): Promise<PresignedData> => {
   return axios
@@ -110,6 +115,7 @@ export const uploadFile = async ({
     fileId,
     fileMd5Hash,
     fileType: file.type,
+    isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
   }
 
   const postData = await fetchPresignedData(
@@ -126,7 +132,7 @@ export const uploadFile = async ({
   // POST generated formData to presigned url.
   const response = await postToPresignedUrl(postData.url, formData, cancelToken)
 
-  const encodedFileId = encodeURIComponent(fileId)
+  const encodedFileId = encodeURIComponent(postData.fields.key)
 
   const uploadedFileData: UploadedFileData = {
     url: `${response.config.url}/${encodedFileId}`,


### PR DESCRIPTION
## Problem
Fixes [#128](https://github.com/datagovsg/formsg-private/issues/128)
<!-- What problem are you trying to solve? What issue does this close? -->

## Solution
- Backend prefixes random string to image and logo filenames before returning presigned url, hence ensuring filename in bucket is unpredictable to client when `/presign` endpoint is first called
- Backward compatibility is ensured by setting `isNewClient` flag for the frontend, which will be removed at a later date

## Tests
- [ ] Create storage mode form. Test that logo and image upload works and can be displayed in public form. 
- [ ] (safety check, should not be affected by this PR) Add attachment field. Test that file upload works and can be retrieved from storage mode  
- [ ] Repeat with old client
(this can be done by rolling back to commit `d979d0c1`)