### PR TITLE
feat(v2): add logic to show feature tour only once to admins

### DIFF
--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -12,3 +12,8 @@ export const LOGGED_IN_KEY = 'is-logged-in'
  * been modified.
  */
 export const LOCAL_STORAGE_EVENT = 'local-storage'
+
+/**
+ * Key to store whether the admin has seen the feature tour in localStorage.
+ */
+export const FEATURE_TOUR_KEY_PREFIX = 'has-seen-feature-tour-'

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -45,7 +45,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 50 },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
     userId: 'adminFormTestUserId',

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -1,5 +1,3 @@
-import { MemoryRouter, Route } from 'react-router'
-import { Routes } from 'react-router-dom'
 import { Meta, Story } from '@storybook/react'
 
 import { AdminFormDto } from '~shared/types/form'
@@ -10,11 +8,13 @@ import {
 } from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
 
-import { viewports } from '~utils/storybook'
+import {
+  AdminFormCreatePageDecorator,
+  ViewedFeatureTourDecorator,
+  viewports,
+} from '~utils/storybook'
 
 import { CreatePage } from '~features/admin-form/create/CreatePage'
-
-import { AdminFormLayout } from './common/AdminFormLayout'
 
 const buildMswRoutes = (
   overrides?: Partial<AdminFormDto>,
@@ -29,21 +29,7 @@ const buildMswRoutes = (
 export default {
   title: 'Pages/AdminFormPage/Create',
   // component: To be implemented,
-  decorators: [
-    (storyFn) => {
-      // MemoryRouter is used so react-router-dom#Link components can work
-      // (and also to force the initial tab the page renders to be the settings tab).
-      return (
-        <MemoryRouter initialEntries={['/12345']}>
-          <Routes>
-            <Route path={'/:formId'} element={<AdminFormLayout />}>
-              <Route index element={storyFn()} />
-            </Route>
-          </Routes>
-        </MemoryRouter>
-      )
-    },
-  ],
+  decorators: [ViewedFeatureTourDecorator, AdminFormCreatePageDecorator],
   parameters: {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
@@ -51,10 +37,11 @@ export default {
     chromatic: { pauseAnimationAtEnd: true, delay: 50 },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
+    userId: 'adminFormTestUserId',
   },
 } as Meta
 
-const Template: Story = () => <CreatePage />
+const Template: Story = () => <CreatePage testUserId={'adminFormTestUserId'} />
 export const DesktopEmpty = Template.bind({})
 export const DesktopAllFields = Template.bind({})
 DesktopAllFields.parameters = {

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 
+import { UserId } from '~shared/types'
 import { AdminFormDto } from '~shared/types/form'
 
 import {
@@ -7,9 +8,11 @@ import {
   MOCK_FORM_FIELDS,
 } from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
+import { getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
 
 import {
   AdminFormCreatePageDecorator,
+  LoggedInDecorator,
   ViewedFeatureTourDecorator,
   viewports,
 } from '~utils/storybook'
@@ -22,6 +25,10 @@ const buildMswRoutes = (
 ) => {
   return [
     ...createFormBuilderMocks(overrides, delay),
+    getUser({
+      delay: 0,
+      mockUser: { ...MOCK_USER, _id: 'adminFormTestUserId' as UserId },
+    }),
     getFreeSmsQuota({ delay }),
   ]
 }
@@ -29,7 +36,11 @@ const buildMswRoutes = (
 export default {
   title: 'Pages/AdminFormPage/Create',
   // component: To be implemented,
-  decorators: [ViewedFeatureTourDecorator, AdminFormCreatePageDecorator],
+  decorators: [
+    ViewedFeatureTourDecorator,
+    AdminFormCreatePageDecorator,
+    LoggedInDecorator,
+  ],
   parameters: {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
@@ -41,7 +52,7 @@ export default {
   },
 } as Meta
 
-const Template: Story = () => <CreatePage testUserId={'adminFormTestUserId'} />
+const Template: Story = () => <CreatePage />
 export const DesktopEmpty = Template.bind({})
 export const DesktopAllFields = Template.bind({})
 DesktopAllFields.parameters = {

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -16,7 +16,7 @@ interface CreatePageProps {
 
 export const CreatePage = ({ testUserId }: CreatePageProps): JSX.Element => {
   const { user, isLoading } = useUser()
-  // User id will never undefined unless it's in storybook testing because
+  // User id will never be undefined unless it's in storybook testing because
   // user will have to be logged in to be able to reach this page
   const userId = user?._id ?? testUserId
   const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + userId

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -13,17 +13,16 @@ import { FeatureTour } from './featureTour/FeatureTour'
 export const CreatePage = (): JSX.Element => {
   const { user, isLoading } = useUser()
   const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + user?._id
-  const [shouldFeatureRun, setShouldFeatureTourRun] = useLocalStorage<boolean>(
-    localStorageFeatureTourKey,
-  )
+  const [hasAdminSeenFeatureTour, setHasAdminSeenFeatureTour] =
+    useLocalStorage<boolean>(localStorageFeatureTourKey)
 
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
       <CreatePageSidebarProvider>
         {!isLoading && (
           <FeatureTour
-            shouldRun={!shouldFeatureRun ?? true}
-            onClose={() => setShouldFeatureTourRun(true)}
+            shouldRun={!hasAdminSeenFeatureTour ?? true}
+            onClose={() => setHasAdminSeenFeatureTour(true)}
           />
         )}
         <CreatePageSidebar />

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
 import { FEATURE_TOUR_KEY_PREFIX } from '~constants/localStorage'
@@ -10,27 +11,25 @@ import { CreatePageSidebar } from './common/CreatePageSidebar'
 import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 import { FeatureTour } from './featureTour/FeatureTour'
 
-interface CreatePageProps {
-  testUserId?: string
-}
-
-export const CreatePage = ({ testUserId }: CreatePageProps): JSX.Element => {
+export const CreatePage = (): JSX.Element => {
   const { user, isLoading } = useUser()
   // User id will never be undefined unless it's in storybook testing because
   // user will have to be logged in to be able to reach this page
-  const userId = user?._id ?? testUserId
-  const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + userId
+  const userId = user?._id
+  const localStorageFeatureTourKey = useMemo(
+    () => FEATURE_TOUR_KEY_PREFIX + userId,
+    [userId],
+  )
   const [hasAdminSeenFeatureTour, setHasAdminSeenFeatureTour] =
     useLocalStorage<boolean>(localStorageFeatureTourKey)
+
+  const shouldFeatureTourRun = !hasAdminSeenFeatureTour ?? true
 
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
       <CreatePageSidebarProvider>
-        {!isLoading && (
-          <FeatureTour
-            shouldRun={!hasAdminSeenFeatureTour ?? true}
-            onClose={() => setHasAdminSeenFeatureTour(true)}
-          />
+        {!isLoading && shouldFeatureTourRun && (
+          <FeatureTour onClose={() => setHasAdminSeenFeatureTour(true)} />
         )}
         <CreatePageSidebar />
         <CreatePageContent />

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -1,24 +1,31 @@
 import { Flex } from '@chakra-ui/react'
 
+import { FEATURE_TOUR_KEY_PREFIX } from '~constants/localStorage'
+import { useLocalStorage } from '~hooks/useLocalStorage'
+
+import { useUser } from '~features/user/queries'
+
 import { CreatePageContent } from './common/CreatePageContent'
 import { CreatePageSidebar } from './common/CreatePageSidebar'
 import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 import { FeatureTour } from './featureTour/FeatureTour'
 
-export interface CreatePageProps {
-  shouldFeatureTourRun?: boolean
-}
-
-export const CreatePage = ({
-  shouldFeatureTourRun,
-}: CreatePageProps): JSX.Element => {
-  // TODO: need to add logic to only show feature tour when user has
-  // not seen it before
+export const CreatePage = (): JSX.Element => {
+  const { user, isLoading } = useUser()
+  const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + user?._id
+  const [shouldFeatureRun, setShouldFeatureTourRun] = useLocalStorage<boolean>(
+    localStorageFeatureTourKey,
+  )
 
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
       <CreatePageSidebarProvider>
-        <FeatureTour shouldRun={shouldFeatureTourRun ?? false} />
+        {!isLoading && (
+          <FeatureTour
+            shouldRun={!shouldFeatureRun ?? true}
+            onClose={() => setShouldFeatureTourRun(true)}
+          />
+        )}
         <CreatePageSidebar />
         <CreatePageContent />
       </CreatePageSidebarProvider>

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -13,22 +13,23 @@ import { FeatureTour } from './featureTour/FeatureTour'
 
 export const CreatePage = (): JSX.Element => {
   const { user, isLoading } = useUser()
-  // User id will never be undefined unless it's in storybook testing because
-  // user will have to be logged in to be able to reach this page
-  const userId = user?._id
-  const localStorageFeatureTourKey = useMemo(
-    () => FEATURE_TOUR_KEY_PREFIX + userId,
-    [userId],
-  )
+  const localStorageFeatureTourKey = useMemo(() => {
+    if (!user?._id) {
+      return null
+    }
+    return `${FEATURE_TOUR_KEY_PREFIX}${user?._id}`
+  }, [user?._id])
   const [hasAdminSeenFeatureTour, setHasAdminSeenFeatureTour] =
     useLocalStorage<boolean>(localStorageFeatureTourKey)
 
-  const shouldFeatureTourRun = !hasAdminSeenFeatureTour ?? true
+  const shouldFeatureTourRender = useMemo(() => {
+    return !isLoading && !hasAdminSeenFeatureTour
+  }, [isLoading, hasAdminSeenFeatureTour])
 
   return (
     <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
       <CreatePageSidebarProvider>
-        {!isLoading && shouldFeatureTourRun && (
+        {shouldFeatureTourRender && (
           <FeatureTour onClose={() => setHasAdminSeenFeatureTour(true)} />
         )}
         <CreatePageSidebar />

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -10,9 +10,16 @@ import { CreatePageSidebar } from './common/CreatePageSidebar'
 import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 import { FeatureTour } from './featureTour/FeatureTour'
 
-export const CreatePage = (): JSX.Element => {
+interface CreatePageProps {
+  testUserId?: string
+}
+
+export const CreatePage = ({ testUserId }: CreatePageProps): JSX.Element => {
   const { user, isLoading } = useUser()
-  const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + user?._id
+  // User id will never undefined unless it's in storybook testing because
+  // user will have to be logged in to be able to reach this page
+  const userId = user?._id ?? testUserId
+  const localStorageFeatureTourKey = FEATURE_TOUR_KEY_PREFIX + userId
   const [hasAdminSeenFeatureTour, setHasAdminSeenFeatureTour] =
     useLocalStorage<boolean>(localStorageFeatureTourKey)
 

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
@@ -1,5 +1,3 @@
-import { MemoryRouter, Route } from 'react-router'
-import { Routes } from 'react-router-dom'
 import { Meta, Story } from '@storybook/react'
 
 import { AdminFormDto } from '~shared/types/form'
@@ -7,7 +5,8 @@ import { AdminFormDto } from '~shared/types/form'
 import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
 
-import { AdminFormLayout } from '../../common/AdminFormLayout'
+import { AdminFormCreatePageDecorator } from '~utils/storybook'
+
 import { CreatePage } from '../CreatePage'
 
 const buildMswRoutes = (
@@ -23,21 +22,7 @@ const buildMswRoutes = (
 export default {
   title: 'Pages/FeatureTour/AdminFormBuilder',
   // component: To be implemented,
-  decorators: [
-    (storyFn) => {
-      // MemoryRouter is used so react-router-dom#Link components can work
-      // (and also to force the initial tab the page renders to be the settings tab).
-      return (
-        <MemoryRouter initialEntries={['/12345']}>
-          <Routes>
-            <Route path={'/:formId'} element={<AdminFormLayout />}>
-              <Route index element={storyFn()} />
-            </Route>
-          </Routes>
-        </MemoryRouter>
-      )
-    },
-  ],
+  decorators: [AdminFormCreatePageDecorator],
   parameters: {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
@@ -48,6 +33,6 @@ export default {
   },
 } as Meta
 
-const Template: Story = () => <CreatePage />
+const Template: Story = () => <CreatePage testUserId="featureTourUserId" />
 
 export const AdminFormBuilderFeatureTour = Template.bind({})

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
@@ -8,7 +8,7 @@ import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
 
 import { AdminFormLayout } from '../../common/AdminFormLayout'
-import { CreatePage, CreatePageProps } from '../CreatePage'
+import { CreatePage } from '../CreatePage'
 
 const buildMswRoutes = (
   overrides?: Partial<AdminFormDto>,
@@ -48,9 +48,6 @@ export default {
   },
 } as Meta
 
-const Template: Story<CreatePageProps> = (args) => <CreatePage {...args} />
+const Template: Story = () => <CreatePage />
 
 export const AdminFormBuilderFeatureTour = Template.bind({})
-AdminFormBuilderFeatureTour.args = {
-  shouldFeatureTourRun: true,
-}

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
@@ -33,6 +33,6 @@ export default {
   },
 } as Meta
 
-const Template: Story = () => <CreatePage testUserId="featureTourUserId" />
+const Template: Story = () => <CreatePage />
 
 export const AdminFormBuilderFeatureTour = Template.bind({})

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
@@ -27,7 +27,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 50 },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
   },

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -6,14 +6,10 @@ import { FEATURE_STEPS } from './constants'
 import { FeatureTourTooltip } from './FeatureTourTooltip'
 
 interface FeatureTourProps {
-  shouldRun: boolean
   onClose: () => void
 }
 
-export const FeatureTour = ({
-  shouldRun,
-  onClose,
-}: FeatureTourProps): JSX.Element => {
+export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
   const [stepIndex, setStepIndex] = useState<number>(0)
   const arrowColor: string = useToken('colors', ['primary.100'])
 
@@ -34,7 +30,7 @@ export const FeatureTour = ({
       steps={FEATURE_STEPS}
       callback={handleJoyrideCallback}
       stepIndex={stepIndex}
-      run={shouldRun}
+      run={true}
       hideBackButton
       floaterProps={{
         placement: 'right-start',

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -1,4 +1,5 @@
-import Joyride from 'react-joyride'
+import { useState } from 'react'
+import Joyride, { CallBackProps, EVENTS, STATUS } from 'react-joyride'
 import { useToken } from '@chakra-ui/react'
 
 import { FEATURE_STEPS } from './constants'
@@ -6,13 +7,33 @@ import { FeatureTourTooltip } from './FeatureTourTooltip'
 
 interface FeatureTourProps {
   shouldRun: boolean
+  onClose: () => void
 }
 
-export const FeatureTour = ({ shouldRun }: FeatureTourProps): JSX.Element => {
+export const FeatureTour = ({
+  shouldRun,
+  onClose,
+}: FeatureTourProps): JSX.Element => {
+  const [stepIndex, setStepIndex] = useState<number>(0)
   const arrowColor: string = useToken('colors', ['primary.100'])
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { index, status, type } = data
+
+    if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
+      setStepIndex(index + 1)
+    }
+
+    if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      onClose()
+    }
+  }
+
   return (
     <Joyride
       steps={FEATURE_STEPS}
+      callback={handleJoyrideCallback}
+      stepIndex={stepIndex}
       run={shouldRun}
       hideBackButton
       floaterProps={{

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import Joyride, { CallBackProps, EVENTS, STATUS } from 'react-joyride'
+import Joyride, { EVENTS, STATUS, status, valueof } from 'react-joyride'
 import { useToken } from '@chakra-ui/react'
 
 import { FEATURE_STEPS } from './constants'
@@ -13,9 +13,15 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
   const [stepIndex, setStepIndex] = useState<number>(0)
   const arrowColor: string = useToken('colors', ['primary.100'])
 
-  const handleJoyrideCallback = (data: CallBackProps) => {
-    const { index, status, type } = data
-
+  const handleJoyrideCallback = ({
+    index,
+    status,
+    type,
+  }: {
+    index: number
+    status: valueof<status>
+    type: string
+  }) => {
     if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
       setStepIndex(index + 1)
     }
@@ -30,7 +36,7 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
       steps={FEATURE_STEPS}
       callback={handleJoyrideCallback}
       stepIndex={stepIndex}
-      run={true}
+      run
       hideBackButton
       floaterProps={{
         placement: 'right-start',

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -9,17 +9,11 @@ interface FeatureTourProps {
   onClose: () => void
 }
 
-type JoyrideCallbackProps = Pick<CallBackProps, 'index' | 'status' | 'type'>
-
 export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
   const [stepIndex, setStepIndex] = useState<number>(0)
   const arrowColor: string = useToken('colors', ['primary.100'])
 
-  const handleJoyrideCallback = ({
-    index,
-    status,
-    type,
-  }: JoyrideCallbackProps) => {
+  const handleJoyrideCallback = ({ index, status, type }: CallBackProps) => {
     if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
       setStepIndex(index + 1)
     }

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import Joyride, { EVENTS, STATUS, status, valueof } from 'react-joyride'
+import Joyride, { CallBackProps, EVENTS, STATUS } from 'react-joyride'
 import { useToken } from '@chakra-ui/react'
 
 import { FEATURE_STEPS } from './constants'
@@ -9,6 +9,8 @@ interface FeatureTourProps {
   onClose: () => void
 }
 
+type JoyrideCallbackProps = Pick<CallBackProps, 'index' | 'status' | 'type'>
+
 export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
   const [stepIndex, setStepIndex] = useState<number>(0)
   const arrowColor: string = useToken('colors', ['primary.100'])
@@ -17,11 +19,7 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
     index,
     status,
     type,
-  }: {
-    index: number
-    status: valueof<status>
-    type: string
-  }) => {
+  }: JoyrideCallbackProps) => {
     if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
       setStepIndex(index + 1)
     }

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
@@ -24,7 +24,7 @@ export const FeatureTourTooltip = ({
   primaryProps,
   skipProps,
   isLastStep,
-}: FeatureTourTooltipProps) => {
+}: FeatureTourTooltipProps): JSX.Element => {
   return (
     <Box
       padding="1.5rem"

--- a/frontend/src/features/login/LoginPage.stories.tsx
+++ b/frontend/src/features/login/LoginPage.stories.tsx
@@ -19,6 +19,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
     msw: authHandlers,
+    chromatic: { delay: 200 },
   },
 } as Meta
 

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -15,13 +15,14 @@ export const useLocalStorage = <T>(
     if (typeof window === 'undefined') {
       return initialValue
     }
-    if (key) {
-      try {
-        const item = window.localStorage.getItem(key)
-        return item ? JSON.parse(item) : initialValue
-      } catch (error) {
-        return initialValue
-      }
+    if (!key) {
+      return
+    }
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      return initialValue
     }
   }, [initialValue, key])
   // State to store our value
@@ -30,25 +31,26 @@ export const useLocalStorage = <T>(
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.
   const setValue = (value?: T) => {
-    if (key) {
-      try {
-        // Allow value to be a function so we have the same API as useState
-        const newValue = value instanceof Function ? value(storedValue) : value
+    if (!key) {
+      return
+    }
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value
 
-        if (value === undefined) {
-          window.localStorage.removeItem(key)
-        } else {
-          // Save to local storage
-          window.localStorage.setItem(key, JSON.stringify(newValue))
-          // Save state
-        }
-        setStoredValue(newValue)
-        // We dispatch a custom event so every useLocalStorage hook are notified
-        window.dispatchEvent(new Event(LOCAL_STORAGE_EVENT))
-        // eslint-disable-next-line no-empty
-      } catch {
-        // TODO (#2640) Pass in some sort of logger here.
+      if (value === undefined) {
+        window.localStorage.removeItem(key)
+      } else {
+        // Save to local storage
+        window.localStorage.setItem(key, JSON.stringify(newValue))
+        // Save state
       }
+      setStoredValue(newValue)
+      // We dispatch a custom event so every useLocalStorage hook are notified
+      window.dispatchEvent(new Event(LOCAL_STORAGE_EVENT))
+      // eslint-disable-next-line no-empty
+    } catch {
+      // TODO (#2640) Pass in some sort of logger here.
     }
   }
   useEffect(() => {

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -32,7 +32,7 @@ export const useLocalStorage = <T>(
       // Allow value to be a function so we have the same API as useState
       const newValue = value instanceof Function ? value(storedValue) : value
 
-      if (!value) {
+      if (value === undefined) {
         window.localStorage.removeItem(key)
       } else {
         // Save to local storage

--- a/frontend/src/utils/storybook.tsx
+++ b/frontend/src/utils/storybook.tsx
@@ -38,14 +38,12 @@ export const ViewedFeatureTourDecorator: DecoratorFn = (
   { parameters },
 ) => {
   const userId = parameters.userId
+  const featureTourKey = FEATURE_TOUR_KEY_PREFIX + userId
   useEffect(() => {
-    window.localStorage.setItem(
-      FEATURE_TOUR_KEY_PREFIX + userId,
-      JSON.stringify(true),
-    )
+    window.localStorage.setItem(featureTourKey, JSON.stringify(true))
 
-    return () => window.localStorage.removeItem(LOGGED_IN_KEY)
-  }, [userId])
+    return () => window.localStorage.removeItem(featureTourKey)
+  }, [featureTourKey, userId])
 
   return storyFn()
 }

--- a/frontend/src/utils/storybook.tsx
+++ b/frontend/src/utils/storybook.tsx
@@ -7,8 +7,9 @@ import mockdate from 'mockdate'
 
 import { theme } from '~/theme'
 
-import { LOGGED_IN_KEY } from '~constants/localStorage'
+import { FEATURE_TOUR_KEY_PREFIX, LOGGED_IN_KEY } from '~constants/localStorage'
 
+import { AdminFormLayout } from '~features/admin-form/common/AdminFormLayout'
 import { BuilderAndDesignContext } from '~features/admin-form/create/builder-and-design/BuilderAndDesignContext'
 import { CreatePageSidebarProvider } from '~features/admin-form/create/common/CreatePageSidebarContext'
 
@@ -32,6 +33,23 @@ export const LoggedInDecorator: DecoratorFn = (storyFn) => {
   return storyFn()
 }
 
+export const ViewedFeatureTourDecorator: DecoratorFn = (
+  storyFn,
+  { parameters },
+) => {
+  const userId = parameters.userId
+  useEffect(() => {
+    window.localStorage.setItem(
+      FEATURE_TOUR_KEY_PREFIX + userId,
+      JSON.stringify(true),
+    )
+
+    return () => window.localStorage.removeItem(LOGGED_IN_KEY)
+  }, [userId])
+
+  return storyFn()
+}
+
 export const EditFieldDrawerDecorator: DecoratorFn = (storyFn) => {
   const deleteFieldModalDisclosure = useDisclosure()
   return (
@@ -46,6 +64,18 @@ export const EditFieldDrawerDecorator: DecoratorFn = (storyFn) => {
         </BuilderAndDesignContext.Provider>
       </CreatePageSidebarProvider>
     </Box>
+  )
+}
+
+export const AdminFormCreatePageDecorator: DecoratorFn = (storyFn) => {
+  return (
+    <MemoryRouter initialEntries={['/12345']}>
+      <Routes>
+        <Route path={'/:formId'} element={<AdminFormLayout />}>
+          <Route index element={storyFn()} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
   )
 }
 


### PR DESCRIPTION
## Problem
Feature tour should only be shown once to form admins.

## Solution
<!-- How did you solve the problem? -->
Store a key-value pair in local storage to encapsulate information for each user on whether they have seen the feature tour before or not.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  