### PR TITLE
feat: log ip address on callback from twilio

### DIFF
--- a/src/app/modules/twilio/__tests__/twilio.controller.spec.ts
+++ b/src/app/modules/twilio/__tests__/twilio.controller.spec.ts
@@ -48,6 +48,11 @@ describe('twilio.controller', () => {
     it('should return 200 when successfully delivered message is sent', async () => {
       const mockReq = expressHandler.mockRequest({
         body: MOCK_SUCCESSFUL_MESSAGE,
+        others: {
+          url: `https://webhook-endpoint.gov.sg?${encodeURI(
+            'senderIp=200.0.0.0',
+          )}`,
+        },
       })
       const mockRes = expressHandler.mockResponse()
       await twilioSmsUpdates(mockReq, mockRes, jest.fn())
@@ -57,6 +62,7 @@ describe('twilio.controller', () => {
         meta: {
           action: 'twilioSmsUpdates',
           body: MOCK_SUCCESSFUL_MESSAGE,
+          senderIp: '200.0.0.0',
         },
       })
       expect(mockLogger.error).not.toBeCalled()
@@ -66,6 +72,11 @@ describe('twilio.controller', () => {
     it('should return 200 when failed delivered message is sent', async () => {
       const mockReq = expressHandler.mockRequest({
         body: MOCK_FAILED_MESSAGE,
+        others: {
+          url: `https://webhook-endpoint.gov.sg?${encodeURI(
+            'senderIp=200.0.0.0',
+          )}`,
+        },
       })
       const mockRes = expressHandler.mockResponse()
       await twilioSmsUpdates(mockReq, mockRes, jest.fn())
@@ -76,6 +87,7 @@ describe('twilio.controller', () => {
         meta: {
           action: 'twilioSmsUpdates',
           body: MOCK_FAILED_MESSAGE,
+          senderIp: '200.0.0.0',
         },
       })
       expect(mockRes.sendStatus).toBeCalledWith(200)

--- a/src/app/modules/twilio/__tests__/twilio.controller.spec.ts
+++ b/src/app/modules/twilio/__tests__/twilio.controller.spec.ts
@@ -49,9 +49,11 @@ describe('twilio.controller', () => {
       const mockReq = expressHandler.mockRequest({
         body: MOCK_SUCCESSFUL_MESSAGE,
         others: {
-          url: `https://webhook-endpoint.gov.sg?${encodeURI(
-            'senderIp=200.0.0.0',
-          )}`,
+          protocol: 'https',
+          host: 'webhook-endpoint.gov.sg',
+          url: `/endpoint?${encodeURI('senderIp=200.0.0.0')}`,
+          originalUrl: `/endpoint?${encodeURI('senderIp=200.0.0.0')}`,
+          get: () => 'webhook-endpoint.gov.sg',
         },
       })
       const mockRes = expressHandler.mockResponse()
@@ -73,9 +75,11 @@ describe('twilio.controller', () => {
       const mockReq = expressHandler.mockRequest({
         body: MOCK_FAILED_MESSAGE,
         others: {
-          url: `https://webhook-endpoint.gov.sg?${encodeURI(
-            'senderIp=200.0.0.0',
-          )}`,
+          protocol: 'https',
+          host: 'webhook-endpoint.gov.sg',
+          url: `/endpoint?${encodeURI('senderIp=200.0.0.0')}`,
+          originalUrl: `/endpoint?${encodeURI('senderIp=200.0.0.0')}`,
+          get: () => 'webhook-endpoint.gov.sg',
         },
       })
       const mockRes = expressHandler.mockResponse()

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -54,6 +54,12 @@ export const twilioSmsUpdates: ControllerHandler<
    * Example: https://www.twilio.com/docs/usage/webhooks/sms-webhooks.
    */
 
+  // Extract public sender's ip address which was passed to twilio as a query param in the status callback
+  const url = req.url.split('?')
+  const paramsString = url.length > 1 ? url[1] : ''
+  const queryParams = new URLSearchParams(paramsString)
+  const senderIp = queryParams.get('senderIp')
+
   const ddTags: TwilioSmsStatsdTags = {
     // msgSrvcSid not included to limit tag cardinality (for now?)
     smsstatus: req.body.SmsStatus,
@@ -70,6 +76,7 @@ export const twilioSmsUpdates: ControllerHandler<
       meta: {
         action: 'twilioSmsUpdates',
         body: req.body,
+        senderIp,
       },
     })
   } else {
@@ -78,6 +85,7 @@ export const twilioSmsUpdates: ControllerHandler<
       meta: {
         action: 'twilioSmsUpdates',
         body: req.body,
+        senderIp,
       },
     })
   }

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -55,7 +55,7 @@ export const twilioSmsUpdates: ControllerHandler<
    */
 
   // Extract public sender's ip address which was passed to twilio as a query param in the status callback
-  const url = new URL(req.url)
+  const url = new URL(req.protocol + '://' + req.get('host') + req.originalUrl)
   const senderIp = url.searchParams.get('senderIp')
 
   const ddTags: TwilioSmsStatsdTags = {

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -55,8 +55,22 @@ export const twilioSmsUpdates: ControllerHandler<
    */
 
   // Extract public sender's ip address which was passed to twilio as a query param in the status callback
-  const url = new URL(req.protocol + '://' + req.get('host') + req.originalUrl)
-  const senderIp = url.searchParams.get('senderIp')
+  let senderIp = null
+  try {
+    const url = new URL(
+      req.protocol + '://' + req.get('host') + req.originalUrl,
+    )
+    senderIp = url.searchParams.get('senderIp')
+  } catch {
+    logger.error({
+      message: 'Error occurred when extracting senderIp',
+      meta: {
+        action: 'twilioSmsUpdates',
+        body: req.body,
+        originalUrl: req.originalUrl,
+      },
+    })
+  }
 
   const ddTags: TwilioSmsStatsdTags = {
     // msgSrvcSid not included to limit tag cardinality (for now?)

--- a/src/app/modules/twilio/twilio.controller.ts
+++ b/src/app/modules/twilio/twilio.controller.ts
@@ -55,10 +55,8 @@ export const twilioSmsUpdates: ControllerHandler<
    */
 
   // Extract public sender's ip address which was passed to twilio as a query param in the status callback
-  const url = req.url.split('?')
-  const paramsString = url.length > 1 ? url[1] : ''
-  const queryParams = new URLSearchParams(paramsString)
-  const senderIp = queryParams.get('senderIp')
+  const url = new URL(req.url)
+  const senderIp = url.searchParams.get('senderIp')
 
   const ddTags: TwilioSmsStatsdTags = {
     // msgSrvcSid not included to limit tag cardinality (for now?)

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -63,6 +63,7 @@ describe('user.controller', () => {
         MOCK_REQ.body.contact,
         expectedOtp,
         MOCK_REQ.body.userId,
+        'MOCK_IP',
       )
       expect(mockRes.sendStatus).toBeCalledWith(200)
     })

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -40,10 +40,12 @@ export const _handleContactSendOtp: ControllerHandler<
     return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
   }
 
+  const senderIp = getRequestIp(req)
+
   const logMeta = {
     action: 'handleContactSendOtp',
     userId,
-    ip: getRequestIp(req),
+    ip: senderIp,
   }
 
   // Step 1: Create OTP for contact verification.
@@ -67,6 +69,7 @@ export const _handleContactSendOtp: ControllerHandler<
     contact,
     otp,
     userId,
+    senderIp,
   )
 
   // Error sending OTP.

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -391,6 +391,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
@@ -409,6 +410,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -428,6 +430,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -447,6 +450,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -481,6 +485,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
@@ -502,6 +507,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -521,6 +527,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -540,6 +547,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -559,6 +567,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -578,6 +587,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -597,6 +607,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
@@ -664,6 +675,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -702,6 +714,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -734,6 +747,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -766,6 +780,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -799,6 +814,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -832,6 +848,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -886,6 +903,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -944,6 +962,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -976,6 +995,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1008,6 +1028,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
@@ -1067,6 +1088,7 @@ describe('Verification controller', () => {
         otp: MOCK_OTP,
         hashedOtp: MOCK_HASHED_OTP,
         recipient: MOCK_ANSWER,
+        senderIp: 'MOCK_IP',
       })
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -66,6 +66,7 @@ import {
   MOCK_HASHED_OTP,
   MOCK_OTP,
   MOCK_RECIPIENT,
+  MOCK_SENDER_IP,
   MOCK_SIGNED_DATA,
 } from './verification.test.helpers'
 
@@ -327,6 +328,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       // Default mock params has fieldType: 'mobile'
@@ -334,6 +336,7 @@ describe('Verification service', () => {
         MOCK_RECIPIENT,
         MOCK_OTP,
         mockTransaction.formId,
+        MOCK_SENDER_IP,
       )
       expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
         {
@@ -360,6 +363,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
@@ -384,6 +388,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
@@ -403,6 +408,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
@@ -434,6 +440,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
@@ -492,6 +499,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).toHaveBeenCalledWith(
@@ -526,12 +534,14 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
         MOCK_RECIPIENT,
         MOCK_OTP,
         new ObjectId(mockFormId),
+        MOCK_SENDER_IP,
       )
       expect(
         MockFormsgSdk.verification.generateSignature,
@@ -551,6 +561,7 @@ describe('Verification service', () => {
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
         recipient: MOCK_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       // Mock params default to mobile
@@ -558,6 +569,7 @@ describe('Verification service', () => {
         MOCK_RECIPIENT,
         MOCK_OTP,
         new ObjectId(mockFormId),
+        MOCK_SENDER_IP,
       )
       expect(MockFormsgSdk.verification.generateSignature).toHaveBeenCalledWith(
         {

--- a/src/app/modules/verification/__tests__/verification.test.helpers.ts
+++ b/src/app/modules/verification/__tests__/verification.test.helpers.ts
@@ -7,6 +7,7 @@ export const MOCK_SIGNED_DATA = 'mockSignedData'
 export const MOCK_HASHED_OTP = 'mockHashedOtp'
 export const MOCK_OTP = '123456'
 export const MOCK_RECIPIENT = '81234567'
+export const MOCK_SENDER_IP = '200.0.0.0'
 
 export const VFN_FIELD_DEFAULTS = {
   signedData: null,

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -5,7 +5,7 @@ import { ErrorDto } from '../../../../shared/types'
 import { SALT_ROUNDS } from '../../../../shared/utils/verification'
 import { createLoggerWithLabel } from '../../config/logger'
 import { generateOtpWithHash } from '../../utils/otp'
-import { createReqMeta } from '../../utils/request'
+import { createReqMeta, getRequestIp } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
 
@@ -143,6 +143,8 @@ export const handleGetOtp: ControllerHandler<
 > = async (req, res) => {
   const { transactionId } = req.params
   const { answer, fieldId } = req.body
+  const senderIp = getRequestIp(req)
+
   const logMeta = {
     action: 'handleGetOtp',
     transactionId,
@@ -157,6 +159,7 @@ export const handleGetOtp: ControllerHandler<
         otp,
         recipient: answer,
         transactionId,
+        senderIp,
       }),
     )
     .map(() => res.sendStatus(StatusCodes.CREATED))
@@ -200,6 +203,8 @@ export const _handleGenerateOtp: ControllerHandler<
 > = async (req, res) => {
   const { transactionId, formId, fieldId } = req.params
   const { answer } = req.body
+  const senderIp = getRequestIp(req)
+
   const logMeta = {
     action: 'handleGenerateOtp',
     transactionId,
@@ -220,6 +225,7 @@ export const _handleGenerateOtp: ControllerHandler<
               otp,
               recipient: answer,
               transactionId,
+              senderIp,
             }),
           )
           // Return the required data for next steps.

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -204,6 +204,7 @@ export const _handleGenerateOtp: ControllerHandler<
     action: 'handleGenerateOtp',
     transactionId,
     fieldId,
+    mobileNumber: answer,
     ...createReqMeta(req),
   }
   // Step 1: Ensure that the form for the specified transaction exists

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -204,7 +204,6 @@ export const _handleGenerateOtp: ControllerHandler<
     action: 'handleGenerateOtp',
     transactionId,
     fieldId,
-    mobileNumber: answer,
     ...createReqMeta(req),
   }
   // Step 1: Ensure that the form for the specified transaction exists

--- a/src/app/modules/verification/verification.types.ts
+++ b/src/app/modules/verification/verification.types.ts
@@ -13,4 +13,5 @@ export type SendOtpParams = {
   recipient: string
   otp: string
   hashedOtp: string
+  senderIp: string
 }

--- a/src/app/services/sms/__tests__/sms.factory.spec.ts
+++ b/src/app/services/sms/__tests__/sms.factory.spec.ts
@@ -56,6 +56,7 @@ describe('sms.factory', () => {
       'mockRecipient',
       'mockOtp',
       'mockFormId',
+      'mockSenderIp',
     ]
 
     // Act
@@ -77,6 +78,7 @@ describe('sms.factory', () => {
       'mockRecipient',
       'mockOtp',
       'mockUserId',
+      'mockSenderIp',
     ]
 
     // Act

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -34,6 +34,7 @@ const MOCK_ADMIN_EMAIL = 'adminEmail@email.com'
 const MOCK_ADMIN_ID = new ObjectId().toHexString()
 const MOCK_FORM_ID = new ObjectId().toHexString()
 const MOCK_FORM_TITLE = 'formTitle'
+const MOCK_SENDER_IP = '200.000.000.000'
 
 const MOCK_TWILIO_WEBHOOK_ROUTE = '/api/v3/notifications/twilio'
 
@@ -275,6 +276,7 @@ describe('sms.service', () => {
         /* recipient= */ TWILIO_TEST_NUMBER,
         /* otp= */ '111111',
         /* formId= */ testForm._id,
+        /* senderIp= */ MOCK_SENDER_IP,
         /* defaultConfig= */ MOCK_VALID_CONFIG,
       )
 
@@ -295,6 +297,7 @@ describe('sms.service', () => {
         /* recipient= */ TWILIO_TEST_NUMBER,
         /* otp= */ '111111',
         /* formId= */ testForm._id,
+        /* senderIp= */ MOCK_SENDER_IP,
         /* defaultConfig= */ MOCK_VALID_CONFIG,
       )
 
@@ -319,6 +322,7 @@ describe('sms.service', () => {
         /* recipient= */ TWILIO_TEST_NUMBER,
         /* otp= */ '111111',
         /* formId= */ testForm._id,
+        /* senderIp= */ MOCK_SENDER_IP,
         /* defaultConfig= */ MOCK_INVALID_CONFIG,
       )
 
@@ -342,6 +346,7 @@ describe('sms.service', () => {
         /* recipient= */ TWILIO_TEST_NUMBER,
         /* otp= */ '111111',
         /* userId= */ testUser._id,
+        /* senderIp= */ MOCK_SENDER_IP,
         /* defaultConfig= */ MOCK_VALID_CONFIG,
       )
 
@@ -398,6 +403,7 @@ describe('sms.service', () => {
       /* recipient= */ TWILIO_TEST_NUMBER,
       /* otp= */ '111111',
       /* userId= */ testUser._id,
+      /* senderIp= */ MOCK_SENDER_IP,
       /* defaultConfig= */ MOCK_INVALID_CONFIG,
     )
 

--- a/src/app/services/sms/__tests__/sms.service.spec.ts
+++ b/src/app/services/sms/__tests__/sms.service.spec.ts
@@ -104,6 +104,11 @@ describe('sms.service', () => {
         forceDelivery: true,
         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
       })
+
+      expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+        expect.not.stringContaining('?senderIp'),
+      )
+
       expect(smsCountSpy).toHaveBeenCalledWith({
         smsData: {
           form: MOCK_FORM_ID,
@@ -186,6 +191,11 @@ describe('sms.service', () => {
         forceDelivery: true,
         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
       })
+
+      expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+        expect.not.stringContaining('?senderIp'),
+      )
+
       expect(smsCountSpy).toHaveBeenCalledWith({
         smsData: {
           form: MOCK_FORM_ID,
@@ -302,6 +312,10 @@ describe('sms.service', () => {
       )
 
       // Assert
+      expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+        expect.stringContaining('?senderIp'),
+      )
+
       expect(actualResult._unsafeUnwrap()).toEqual(true)
       // Logging should also have happened.
       const expectedLogParams = {
@@ -351,6 +365,10 @@ describe('sms.service', () => {
       )
 
       // Assert
+      expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+        expect.stringContaining('?senderIp'),
+      )
+
       // Should resolve to true
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(true)

--- a/src/app/services/sms/sms.factory.ts
+++ b/src/app/services/sms/sms.factory.ts
@@ -15,11 +15,13 @@ interface ISmsFactory {
     recipient: string,
     otp: string,
     formId: string,
+    senderIp: string,
   ) => ReturnType<typeof sendVerificationOtp>
   sendAdminContactOtp: (
     recipient: string,
     otp: string,
     userId: string,
+    senderIp: string,
   ) => ReturnType<typeof sendAdminContactOtp>
   /**
    * Informs recipient that the given form was deactivated. Rejects if SMS feature
@@ -65,10 +67,10 @@ export const createSmsFactory = (smsConfig: ISms): ISmsFactory => {
   }
 
   return {
-    sendVerificationOtp: (recipient, otp, formId) =>
-      sendVerificationOtp(recipient, otp, formId, twilioConfig),
-    sendAdminContactOtp: (recipient, otp, userId) =>
-      sendAdminContactOtp(recipient, otp, userId, twilioConfig),
+    sendVerificationOtp: (recipient, otp, formId, senderIp) =>
+      sendVerificationOtp(recipient, otp, formId, senderIp, twilioConfig),
+    sendAdminContactOtp: (recipient, otp, userId, senderIp) =>
+      sendAdminContactOtp(recipient, otp, userId, senderIp, twilioConfig),
     sendFormDeactivatedSms: (params) =>
       sendFormDeactivatedSms(params, twilioConfig),
     sendBouncedSubmissionSms: (params) =>


### PR DESCRIPTION
## Problem
- Currently, we are unable to match the sender IP address to the twilio sms delivery report

## Solution
- pass sender IP address to twilio as part of query param for callback

## Tests

- [ ] Create form. Test that email and mobile field OTP verification and submission works
- [ ] Check that twilio webhooks contain sender IP address after OTP has been sent
- [ ] Check that admin contact number adding works normally