### PR TITLE
feat(v2/SingleSelect): prevent clearing of selected item when isClearable is true, prevent clearing of EditRating select fields

### DIFF
--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -148,6 +148,13 @@ export const SingleSelectProvider = ({
             // Clear inputValue on item selection
             inputValue: '',
           }
+        case useCombobox.stateChangeTypes.InputKeyDownEscape: {
+          if (isClearable) return changes
+          return {
+            ...changes,
+            selectedItem: _state.selectedItem,
+          }
+        }
         case useCombobox.stateChangeTypes.FunctionSelectItem:
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.InputBlur:

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
@@ -83,6 +83,7 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
           name="ratingOptions.steps"
           render={({ field: { value, ...field } }) => (
             <SingleSelect
+              isClearable={false}
               items={EDIT_RATING_OPTIONS.stepOptions}
               value={String(value)}
               {...field}
@@ -96,7 +97,11 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
           control={control}
           name="ratingOptions.shape"
           render={({ field }) => (
-            <SingleSelect items={EDIT_RATING_OPTIONS.shapeOptions} {...field} />
+            <SingleSelect
+              isClearable={false}
+              items={EDIT_RATING_OPTIONS.shapeOptions}
+              {...field}
+            />
           )}
         />
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
@@ -76,7 +76,7 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
       <FormControl isReadOnly={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl id="ratingOptions.steps" isReadOnly={isLoading}>
         <FormLabel isRequired>Number of steps</FormLabel>
         <Controller
           control={control}
@@ -91,7 +91,7 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
           )}
         />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl id="ratingOptions.shape" isReadOnly={isLoading}>
         <FormLabel isRequired>Shape</FormLabel>
         <Controller
           control={control}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, the isClearable prop only controls whether the clear button is shown. However, when one presses the escape key, the item can still be cleared.

This PR fixes that issue and prevents clearing of the item when isClearable is true.

Also sets EditRating dropdown selection to not be clearable.
 
Closes #3932
