### PR TITLE
feat(form-v2): add myinfo inline messages

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -2,7 +2,11 @@ import { MemoryRouter, Route } from 'react-router'
 import { Routes } from 'react-router-dom'
 import { Meta, Story } from '@storybook/react'
 
-import { AdminFormDto } from '~shared/types/form'
+import {
+  AdminFormDto,
+  FormAuthType,
+  FormResponseMode,
+} from '~shared/types/form'
 
 import {
   createFormBuilderMocks,
@@ -58,7 +62,11 @@ const Template: Story = () => <CreatePage />
 export const DesktopEmpty = Template.bind({})
 export const DesktopAllFields = Template.bind({})
 DesktopAllFields.parameters = {
-  msw: buildMswRoutes({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
+  msw: buildMswRoutes({
+    form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+    authType: FormAuthType.MyInfo,
+    responseMode: FormResponseMode.Email,
+  }),
 }
 
 export const TabletEmpty = Template.bind({})

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
 import {
   Box,
@@ -121,10 +122,13 @@ const MyInfoFieldPanelContent = () => {
   // 1. form response mode is not email mode
   // 2. form auth type is not myInfo
   // 3. # of myInfo fields >= 30
-  const isMyInfoDisabled =
-    form?.responseMode !== FormResponseMode.Email ||
-    form?.authType !== FormAuthType.MyInfo ||
-    (form ? form.form_fields.filter(isMyInfo).length >= 30 : true)
+  const isMyInfoDisabled = useMemo(
+    () =>
+      form?.responseMode !== FormResponseMode.Email ||
+      form?.authType !== FormAuthType.MyInfo ||
+      (form ? form.form_fields.filter(isMyInfo).length >= 30 : true),
+    [form],
+  )
   const isDisabled = isMyInfoDisabled || isLoading
 
   return (
@@ -215,7 +219,10 @@ const MyInfoText = ({
   form_fields,
 }: MyInfoTextProps): JSX.Element => {
   const isMyInfoDisabled = authType !== FormAuthType.MyInfo
-  const numMyInfoFields = form_fields.filter((ff) => isMyInfo(ff)).length
+  const numMyInfoFields = useMemo(
+    () => form_fields.filter((ff) => isMyInfo(ff)).length,
+    [form_fields],
+  )
 
   if (responseMode !== FormResponseMode.Email) {
     return <Text>MyInfo fields are not available in Storage mode forms.</Text>
@@ -235,21 +242,21 @@ const MyInfoText = ({
   )
 }
 
-const MyInfoMessage = (): JSX.Element => {
+const MyInfoMessage = (): JSX.Element | null => {
   const { data: form } = useCreateTabForm()
-  if (!form) {
-    return <Box display="none" />
-  }
-  const numMyInfoFields = form.form_fields.filter((ff) => isMyInfo(ff)).length
-  const hasExceededLimit = numMyInfoFields >= 30
+  const numMyInfoFields = form?.form_fields.filter((ff) => isMyInfo(ff)).length
+  const hasExceededLimit = useMemo(
+    () => numMyInfoFields && numMyInfoFields >= 30,
+    [numMyInfoFields],
+  )
 
-  return (
+  return form ? (
     <Box px="1.5rem" pt="2rem" pb="1.5rem">
       <InlineMessage variant={hasExceededLimit ? 'error' : 'info'}>
         <MyInfoText {...form} />
       </InlineMessage>
     </Box>
-  )
+  ) : null
 }
 
 const FieldSection = ({

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -237,7 +237,12 @@ const MyInfoText = ({
   return (
     <Text>
       {`Only 30 MyInfo fields are allowed in Email mode (${numMyInfoFields}/30).`}{' '}
-      <Link isExternal>Learn more</Link>
+      <Link
+        isExternal
+        href="https://guide.form.gov.sg/AdvancedGuide.html#email-mode"
+      >
+        Learn more
+      </Link>
     </Text>
   )
 }


### PR DESCRIPTION
## Problem
MyInfo has certain restrictions on usage; this PR adds an inline mesage at the top of the myInfo tab and disable the fields when the requirements for myInfo usage is not met

Part of #3360 

## Solution
1. Add myInfo specific `InlineMessage` component

## TODO
1. check with design on link ref 

## Notes
1. Didn't feel the need to set up a `MyInfoContext` as there is only 1 level of prop drilling 
2. Not sure if it's possible to trigger the drawer to slide out on initial storybook render as the drawer state is in `useCreatePageSidebar` and i didn't want to expose a prop solely for storybook. 