### PR TITLE
feat: enforce max 10 OTP requests for verified field

### DIFF
--- a/shared/utils/verification.ts
+++ b/shared/utils/verification.ts
@@ -5,6 +5,8 @@ export const SALT_ROUNDS = 10
 export const TRANSACTION_EXPIRE_AFTER_SECONDS = 14400 // 4 hours
 export const HASH_EXPIRE_AFTER_SECONDS = 60 * 30 // 30 minutes
 export const WAIT_FOR_OTP_SECONDS = 30
+export const MAX_OTP_REQUESTS = 10
+
 /**
  * WAIT_FOR_OTP_SECONDS tolerance. Server allows OTPs to be requested every
  * (WAIT_FOR_OTP_SECONDS - WAIT_FOR_OTP_TOLERANCE_SECONDS) seconds.

--- a/src/app/modules/verification/__tests__/verification.model.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.model.spec.ts
@@ -77,6 +77,7 @@ describe('Verification Model', () => {
         hashedOtp: 'hashedOtp',
         hashCreatedAt: new Date(),
         hashRetries: 5,
+        otpRequests: 6,
       }
       const vfnParams = merge({}, VFN_PARAMS, { fields: [field] })
       const verification = new VerificationModel(vfnParams)
@@ -457,6 +458,7 @@ describe('Verification Model', () => {
           hashedOtp: 'mockHashedOtp',
           hashCreatedAt: new Date(),
           hashRetries: 3,
+          otpRequests: 3,
         }
         const transaction = await VerificationModel.create({
           ...VFN_PARAMS,
@@ -477,6 +479,7 @@ describe('Verification Model', () => {
         expect(result!.fields[0].hashCreatedAt).not.toEqual(field.hashCreatedAt)
         expect(result!.fields[0].signedData).toEqual(updateParams.signedData)
         expect(result!.fields[0].hashedOtp).toEqual(updateParams.hashedOtp)
+        expect(result!.fields[0].otpRequests).toEqual(field.otpRequests + 1)
 
         expect(result!.formId).toEqual(transaction.formId)
       })
@@ -488,6 +491,7 @@ describe('Verification Model', () => {
           hashedOtp: 'mockHashedOtp',
           hashCreatedAt: new Date(),
           hashRetries: 3,
+          otpRequests: 1,
         }
         const field2 = {
           ...generateFieldParams(),
@@ -495,6 +499,7 @@ describe('Verification Model', () => {
           hashedOtp: 'mockHashedOtp2',
           hashCreatedAt: new Date(),
           hashRetries: 2,
+          otpRequests: 3,
         }
         const transaction = await VerificationModel.create({
           ...VFN_PARAMS,
@@ -517,12 +522,14 @@ describe('Verification Model', () => {
         )
         expect(result!.fields[0].signedData).toEqual(updateParams.signedData)
         expect(result!.fields[0].hashedOtp).toEqual(updateParams.hashedOtp)
+        expect(result!.fields[0].otpRequests).toEqual(field1.otpRequests + 1)
 
         // field2 should remain completely unchanged
         expect(result!.fields[1].hashRetries).toEqual(field2.hashRetries)
         expect(result!.fields[1].signedData).toEqual(field2.signedData)
         expect(result!.fields[1].hashedOtp).toEqual(field2.hashedOtp)
         expect(result!.fields[1].hashCreatedAt).toEqual(field2.hashCreatedAt)
+        expect(result!.fields[1].otpRequests).toEqual(field2.otpRequests)
 
         expect(result!.formId).toEqual(transaction.formId)
       })

--- a/src/app/modules/verification/__tests__/verification.test.helpers.ts
+++ b/src/app/modules/verification/__tests__/verification.test.helpers.ts
@@ -13,6 +13,7 @@ export const VFN_FIELD_DEFAULTS = {
   hashedOtp: null,
   hashCreatedAt: null,
   hashRetries: 0,
+  otpRequests: 0,
 }
 
 export const generateFieldParams = (

--- a/src/app/modules/verification/verification.errors.ts
+++ b/src/app/modules/verification/verification.errors.ts
@@ -73,6 +73,15 @@ export class WaitForOtpError extends ApplicationError {
 }
 
 /**
+ * Max OTP request count exceeded
+ */
+export class OtpRequestCountExceededError extends ApplicationError {
+  constructor(message = 'Max OTP request count exceeded') {
+    super(message)
+  }
+}
+
+/**
  * Unsupported field type for OTP verification
  */
 export class NonVerifiedFieldTypeError extends ApplicationError {

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -30,7 +30,10 @@ const VerificationFieldSchema = new Schema<IVerificationFieldSchema>({
   // No ttl index is applied on hashCreatedAt, as we do not want to delete the
   // entire document when a hash expires.
   hashCreatedAt: { type: Date, default: null },
+  // Number of retries attempted for a given OTP
   hashRetries: { type: Number, default: 0 },
+  // Number of OTPs requested for this field
+  otpRequests: { type: Number, default: 0 },
 })
 
 const compileVerificationModel = (db: Mongoose): IVerificationModel => {
@@ -164,6 +167,9 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
           'fields.$.hashedOtp': updateData.hashedOtp,
           'fields.$.signedData': updateData.signedData,
           'fields.$.hashRetries': 0,
+        },
+        $inc: {
+          'fields.$.otpRequests': 1,
         },
       },
       {

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import {
   HASH_EXPIRE_AFTER_SECONDS,
+  MAX_OTP_REQUESTS,
   VERIFIED_FIELDTYPES,
   WAIT_FOR_OTP_SECONDS,
   WAIT_FOR_OTP_TOLERANCE_SECONDS,
@@ -14,6 +15,7 @@ import {
 import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
 import {
+  OtpRequestCountExceededError,
   OtpRequestError,
   SmsLimitExceededError,
 } from '../../modules/verification/verification.errors'
@@ -124,6 +126,16 @@ export const isOtpWaitTimeElapsed = (hashCreatedAt: Date | null): boolean => {
   return currentDate > elapseAt
 }
 
+/**
+ * Computes whether the number of OTPs requested has exceeded the maximum allowed.
+ * @param otpRequests Number of OTPs already requested
+ * @returns true if the number of OTPs has exceeded the maximum allowed
+ */
+export const isOtpRequestCountExceeded = (otpRequests: number): boolean => {
+  // Use >= because otpRequests is the number of OTPs previously requested
+  return otpRequests >= MAX_OTP_REQUESTS
+}
+
 export const mapRouteError: MapRouteError = (
   error,
   coreErrorMsg = 'Sorry, something went wrong. Please refresh and try again.',
@@ -154,6 +166,11 @@ export const mapRouteError: MapRouteError = (
       return {
         errorMessage: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+      }
+    case OtpRequestCountExceededError:
+      return {
+        errorMessage: `You have requested for too many OTPs. Please refresh and try again.`,
+        statusCode: StatusCodes.BAD_REQUEST,
       }
     case InvalidNumberError:
       return {

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -169,7 +169,7 @@ export const mapRouteError: MapRouteError = (
       }
     case OtpRequestCountExceededError:
       return {
-        errorMessage: `You have requested for too many OTPs. Please refresh and try again.`,
+        errorMessage: `You have requested too many OTPs. Please refresh and try again.`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case InvalidNumberError:

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -11,6 +11,7 @@ export interface IVerificationField {
   hashedOtp: string | null
   hashCreatedAt: Date | null
   hashRetries: number
+  otpRequests: number
 }
 
 export interface IVerificationFieldSchema


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There is no limit to the number of OTPs users can request for a given transaction ID. This allows users to continually request for OTPs, which can be costly in the case of SMSes.

## Solution
<!-- How did you solve the problem? -->

Enforce a limit of maximum 10 OTPs before user needs to refresh.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Screenshots

![Screenshot 2022-06-03 at 3 51 20 PM](https://user-images.githubusercontent.com/29480346/171812110-14aef0be-7cbc-4ce4-8a91-7c898f83b2fe.png)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Requesting OTP for the 11th time results in the error seen in above screenshot
- [x] Refreshing page clears error, allowing user to verify the field
- [x] Entering a wrong OTP results in `hashRetries` incrementing but not `otpRequests`
- [x] Requesting for a new OTP results in `otpRequests` incrementing and `hashRetries` being reset to 0
- [x] Request an OTP on the old server, then switch over to the new server. Requesting another OTP results in the `otpRequests` key being added to the `field` object in the database, with a value of 1.