### PR TITLE
fix(BounceService): use stronger regex to validate sns requests

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -28,6 +28,7 @@ import { UserWithContactNumber } from '../../user/user.types'
 import { makeBounceNotification, MOCK_SNS_BODY } from './bounce-test-helpers'
 
 jest.mock('sns-validator')
+const MockedSNSMessageValidator = mocked(SNSMessageValidator)
 
 jest.mock('src/app/config/logger')
 const MockLoggerModule = mocked(LoggerModule, true)
@@ -719,7 +720,7 @@ describe('BounceService', () => {
     })
 
     it('should reject invalid notification with an InvalidNotificationError', async () => {
-      SNSMessageValidator.mockImplementation(() => {
+      MockedSNSMessageValidator.mockImplementation(() => {
         return {
           validate: (message, callback) => {
             // we use a timeout to simulate the asynchronous getting of the validation cert
@@ -734,11 +735,11 @@ describe('BounceService', () => {
     })
 
     it('should accept when requests are valid', async () => {
-      SNSMessageValidator.mockImplementation(() => {
+      MockedSNSMessageValidator.mockImplementation(() => {
         return {
           validate: (message, callback) => {
             // we use a timeout to simulate the asynchronous getting of the validation cert
-            setTimeout(() => callback(null, message), 0)
+            setTimeout(() => callback(null), 0)
           },
         }
       })

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -47,6 +47,11 @@ const logger = createLoggerWithLabel(module)
 const shortTermLogger = createCloudWatchLogger('email')
 const Bounce = getBounceModel(mongoose)
 
+// Hostname for AWS SNS URLs.
+// Using this over sns-validator's default hostname because the latter
+// does not adequately validate that requests only come from SNS.
+const AWS_SNS_HOSTNAME = /^sns\.[a-z]{2}-[a-z]+-\d+\.amazonaws.com$/
+
 /**
  * Verifies if a request object is correctly signed by Amazon SNS. More info:
  * https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
@@ -59,7 +64,7 @@ export const validateSnsRequest = (
 ): ResultAsync<true, InvalidNotificationError> => {
   return ResultAsync.fromPromise(
     new Promise((resolve, reject) => {
-      const snsValidator = new SNSMessageValidator()
+      const snsValidator = new SNSMessageValidator(AWS_SNS_HOSTNAME)
 
       snsValidator.validate(
         body as unknown as Record<string, unknown>,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR passes in a stronger validation regex to `sns-validator`.


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix(BounceService): use stronger regex to validate sns requests
