### PR TITLE
feat: wrap csv cell contents in quotes

### DIFF
--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -18,6 +18,7 @@ import {
   generateNewAttachmentResponse,
   generateNewCheckboxResponse,
   generateNewSingleAnswerResponse,
+  generateNewSingleDataCollationAnswerResponse,
   generateNewTableResponse,
 } from 'tests/unit/backend/helpers/generate-form-data'
 
@@ -108,6 +109,16 @@ const ALL_SINGLE_SUBMITTED_RESPONSES = basicTypes
       ![BasicField.Attachment, BasicField.Section].includes(t.name),
   )
   .map((t) => generateNewSingleAnswerResponse(t.name))
+
+const ALL_SINGLE_SUBMITTED_RESPONSES_FOR_DATA_COLLATION = basicTypes
+  // This differs from ALL_SINGLE_SUBMITTED_RESPONSES in that answers
+  // which are not pure numbers are wrapped by quotes
+  .filter(
+    (t) =>
+      !t.answerArray &&
+      ![BasicField.Attachment, BasicField.Section].includes(t.name),
+  )
+  .map((t) => generateNewSingleDataCollationAnswerResponse(t.name))
 
 describe('email-submission.util', () => {
   describe('getInvalidFileExtensions', () => {
@@ -371,9 +382,10 @@ describe('email-submission.util', () => {
       const expectedAutoReplyData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerAutoreply,
       )
-      const expectedDataCollationData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
-        generateSingleAnswerJson,
-      )
+      const expectedDataCollationData =
+        ALL_SINGLE_SUBMITTED_RESPONSES_FOR_DATA_COLLATION.map(
+          generateSingleAnswerJson,
+        )
       const expectedFormData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerFormData,
       )
@@ -403,6 +415,10 @@ describe('email-submission.util', () => {
       const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
         isVisible: false,
       })
+      const dataCollationResponse =
+        generateNewSingleDataCollationAnswerResponse(BasicField.ShortText, {
+          isVisible: false,
+        })
 
       const emailData = new SubmissionEmailObj(
         [response],
@@ -411,7 +427,7 @@ describe('email-submission.util', () => {
       )
 
       expect(emailData.dataCollationData).toEqual([
-        generateSingleAnswerJson(response),
+        generateSingleAnswerJson(dataCollationResponse),
       ])
       expect(emailData.autoReplyData).toEqual([])
       expect(emailData.formData).toEqual([
@@ -433,8 +449,8 @@ describe('email-submission.util', () => {
       const secondRow = response.answerArray[1].join(',')
 
       const expectedDataCollationData = [
-        { question: `${TABLE_PREFIX}${question}`, answer: firstRow },
-        { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
+        { question: `${TABLE_PREFIX}${question}`, answer: `'${firstRow}'` },
+        { question: `${TABLE_PREFIX}${question}`, answer: `'${secondRow}'` },
       ]
 
       const expectedAutoReplyData = [
@@ -474,7 +490,9 @@ describe('email-submission.util', () => {
       const question = response.question
       const answer = response.answerArray.join(', ')
 
-      const expectedDataCollationData = [{ question, answer }]
+      const expectedDataCollationData = [
+        { question, answer: isNaN(Number(answer)) ? `'${answer}'` : answer },
+      ]
       const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
       const expectedFormData = [
         {
@@ -503,13 +521,16 @@ describe('email-submission.util', () => {
       const answer = response.answer
 
       const expectedDataCollationData = [
-        { question: `${ATTACHMENT_PREFIX}${question}`, answer },
+        {
+          question: `${ATTACHMENT_PREFIX}${question}`,
+          answer: isNaN(Number(answer)) ? `'${answer}'` : answer,
+        },
       ]
       const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
       const expectedFormData = [
         {
           question: `${ATTACHMENT_PREFIX}${question}`,
-          answer,
+          answer: answer,
           answerTemplate: [answer],
           fieldType: BasicField.Attachment,
         },
@@ -534,7 +555,9 @@ describe('email-submission.util', () => {
 
       const question = response.question
 
-      const expectedDataCollationData = [{ question, answer }]
+      const expectedDataCollationData = [
+        { question, answer: isNaN(Number(answer)) ? `'${answer}'` : answer },
+      ]
       const expectedAutoReplyData = [
         { question, answerTemplate: answer.split('\n') },
       ]
@@ -568,7 +591,10 @@ describe('email-submission.util', () => {
       const answer = answerArray[0].join(',')
 
       const expectedDataCollationData = [
-        { question: `${TABLE_PREFIX}${question}`, answer },
+        {
+          question: `${TABLE_PREFIX}${question}`,
+          answer: isNaN(Number(answer)) ? `'${answer}'` : answer,
+        },
       ]
       const expectedAutoReplyData = [
         { question, answerTemplate: answer.split('\n') },
@@ -600,7 +626,9 @@ describe('email-submission.util', () => {
       const question = response.question
       const answer = answerArray.join(', ')
 
-      const expectedDataCollationData = [{ question, answer }]
+      const expectedDataCollationData = [
+        { question, answer: isNaN(Number(answer)) ? `'${answer}'` : answer },
+      ]
       const expectedAutoReplyData = [
         { question, answerTemplate: answer.split('\n') },
       ]
@@ -632,12 +660,14 @@ describe('email-submission.util', () => {
       const question = response.question
       const answer = response.answer
 
-      const expectedDataCollationData = [{ question, answer }]
+      const expectedDataCollationData = [
+        { question, answer: isNaN(Number(answer)) ? `'${answer}'` : answer },
+      ]
       const expectedAutoReplyData = [{ question, answerTemplate: [answer] }]
       const expectedFormData = [
         {
           question: `${VERIFIED_PREFIX}${question}`,
-          answer,
+          answer: answer,
           answerTemplate: [answer],
           fieldType: BasicField.Email,
         },
@@ -674,10 +704,17 @@ describe('email-submission.util', () => {
       )
 
       const expectedDataCollationData = [
-        { question: nameResponse.question, answer: nameResponse.answer },
+        {
+          question: nameResponse.question,
+          answer: isNaN(Number(nameResponse.answer))
+            ? `'${nameResponse.answer}'`
+            : nameResponse.answer,
+        },
         {
           question: vehicleResponse.question,
-          answer: vehicleResponse.answer,
+          answer: isNaN(Number(vehicleResponse.answer))
+            ? `'${vehicleResponse.answer}'`
+            : vehicleResponse.answer,
         },
       ]
       const expectedAutoReplyData = [
@@ -713,18 +750,24 @@ describe('email-submission.util', () => {
     })
 
     it('should return the response in correct json format when dataCollationData() method is called', () => {
+      const response1Answer = (response1 as ResponseFormattedForEmail).answer
+      const response2Answer = (response2 as ResponseFormattedForEmail).answer
       const correctJson = [
         {
           question: getJsonPrefixedQuestion(
             response1 as ResponseFormattedForEmail,
           ),
-          answer: (response1 as ResponseFormattedForEmail).answer,
+          answer: isNaN(Number(response1Answer))
+            ? `'${response1Answer}'`
+            : response1Answer,
         },
         {
           question: getJsonPrefixedQuestion(
             response2 as ResponseFormattedForEmail,
           ),
-          answer: (response2 as ResponseFormattedForEmail).answer,
+          answer: isNaN(Number(response2Answer))
+            ? `'${response2Answer}'`
+            : response2Answer,
         },
       ]
       expect(submissionEmailObj.dataCollationData).toEqual(correctJson)

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -651,7 +651,7 @@ const getDataCollationFormattedResponse = (
   if (fieldType !== BasicField.Section) {
     return {
       question: getJsonPrefixedQuestion(response),
-      answer,
+      answer: isNaN(Number(answer)) ? `'${answer}'` : answer,
     }
   }
   return undefined

--- a/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
+++ b/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
@@ -148,7 +148,7 @@ export class CsvMergedHeadersGenerator extends CsvGenerator {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
     const answer = fieldRecord.getAnswer(colIndex)
-    // wrap answer in quotes if answer is not a number. 
+    // wrap answer in quotes if answer is not a number.
     // for number, do not wrap in quotes so that excel parses it as number
     return isNaN(Number(answer)) ? `'${answer}'` : answer
   }

--- a/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
+++ b/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
@@ -147,7 +147,9 @@ export class CsvMergedHeadersGenerator extends CsvGenerator {
   ): string {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
-    return fieldRecord.getAnswer(colIndex)
+    const answer = fieldRecord.getAnswer(colIndex)
+    // wrap answer in quotes if answer is not a number
+    return isNaN(Number(answer)) ? `'${answer}'` : answer
   }
 
   /**

--- a/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
+++ b/src/public/modules/forms/helpers/CsvMergedHeadersGenerator.ts
@@ -148,7 +148,8 @@ export class CsvMergedHeadersGenerator extends CsvGenerator {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
     const answer = fieldRecord.getAnswer(colIndex)
-    // wrap answer in quotes if answer is not a number
+    // wrap answer in quotes if answer is not a number. 
+    // for number, do not wrap in quotes so that excel parses it as number
     return isNaN(Number(answer)) ? `'${answer}'` : answer
   }
 

--- a/src/public/modules/forms/helpers/FeedbackCsvGenerator.ts
+++ b/src/public/modules/forms/helpers/FeedbackCsvGenerator.ts
@@ -20,7 +20,11 @@ export class FeedbackCsvGenerator extends CsvGenerator {
     const createdAt = moment(feedback.created)
       .tz('Asia/Singapore')
       .format('DD MMM YYYY hh:mm:ss A')
-
-    this.addLine([createdAt, feedback.comment || '', feedback.rating])
+    // wrap feedback comment in quotes
+    this.addLine([
+      createdAt,
+      feedback.comment ? `'${feedback.comment}'` : '',
+      feedback.rating,
+    ])
   }
 }

--- a/src/public/modules/forms/helpers/__tests__/FeedbackCsvGenerator.spec.ts
+++ b/src/public/modules/forms/helpers/__tests__/FeedbackCsvGenerator.spec.ts
@@ -35,7 +35,7 @@ describe('FeedbackCsvGenerator', () => {
         .tz('Asia/Singapore')
         .format('DD MMM YYYY hh:mm:ss A')
 
-      const insertedLine = `${insertedCreatedDate},${feedback.comment},${feedback.rating}`
+      const insertedLine = `${insertedCreatedDate},'${feedback.comment}',${feedback.rating}`
 
       // Act
       feedbackCsv.addLineFromFeedback(feedback)

--- a/tests/end-to-end/helpers/encrypt-mode.js
+++ b/tests/end-to-end/helpers/encrypt-mode.js
@@ -30,14 +30,19 @@ const WEBHOOK_PORT = process.env.MOCK_WEBHOOK_PORT
 const WEBHOOK_CONFIG_FILE = process.env.MOCK_WEBHOOK_CONFIG_FILE
 
 // We can't just call getResponseArray because CSVs use different
-// delimiters for checkbox and table. Hence we treat checbox and table
-// specially, and call getResponseArray for the rest.
+// delimiters for checkbox and table. Radiobutton is also singled
+// out to account for the case where the field is hidden or
+// optional. Additionally, we have to wrap
+// the CSV fields in quotes if the value is not a pure number.
+// Hence we treat checkbox, table and radiobutton specially, and
+// call getResponseArray for the rest.
 const addExpectedCsvAnswer = (field, answers) => {
   const numCols = field.fieldType === 'table' ? field.val.length : 1
+  let responseArray = getResponseArray(field).join('')
   switch (field.fieldType) {
     case 'table':
       for (let i = 0; i < numCols; i++) {
-        answers.push(field.val[i].join(';'))
+        answers.push(`'${field.val[i].join(';')}'`)
       }
       break
     case 'checkbox':
@@ -45,18 +50,37 @@ const addExpectedCsvAnswer = (field, answers) => {
         answers.push('')
       } else {
         answers.push(
-          field.val
+          `'${field.val
             .map((selected) => {
               return field.fieldOptions.includes(selected)
                 ? selected
                 : `Others: ${selected}`
             })
-            .join(';'),
+            .join(';')}'`,
         )
       }
       break
+    case 'radiobutton':
+      if (!field.isVisible || field.isLeftBlank) {
+        answers.push('')
+      } else {
+        if (field.fieldOptions.includes(field.val)) {
+          if (isNaN(Number(field.val))) {
+            answers.push(`'${field.val}'`)
+          } else {
+            answers.push(field.val)
+          }
+        } else {
+          answers.push(`'Others: ${field.val}'`)
+        }
+      }
+      break
     default:
-      answers.push(...getResponseArray(field))
+      if (isNaN(Number(responseArray))) {
+        answers.push(`'${responseArray}'`)
+      } else {
+        answers.push(responseArray)
+      }
   }
 }
 

--- a/tests/end-to-end/helpers/util.js
+++ b/tests/end-to-end/helpers/util.js
@@ -1041,11 +1041,15 @@ const tableHandler = {
     return tableTitle
   },
   getValues: (tableField, formMode) => {
-    if (formMode === 'email') {
-      return tableField.val.map((row) => row.join(','))
-    } else {
-      // storage mode has a space
-      return tableField.val.map((row) => row.join(', '))
+    switch (formMode) {
+      case 'email':
+        return tableField.val.map((row) => row.join(','))
+      case 'emailDataCollation':
+        // wrap data collation fields in quotes
+        return tableField.val.map((row) => `'${row.join(',')}'`)
+      default:
+        // storage mode has a space
+        return tableField.val.map((row) => row.join(', '))
     }
   },
 }
@@ -1278,4 +1282,5 @@ module.exports = {
   verifySubmissionDisabled,
   getDownloadsFolder,
   getFeatureState,
+  tableHandler,
 }

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -222,6 +222,30 @@ export const generateNewSingleAnswerResponse = (
   } as ProcessedSingleAnswerResponse
 }
 
+export const generateNewSingleDataCollationAnswerResponse = (
+  fieldType: BasicField,
+  customParams?: Partial<ProcessedSingleAnswerResponse>,
+): ProcessedSingleAnswerResponse => {
+  if (
+    [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
+      fieldType,
+    )
+  ) {
+    throw new Error(
+      'Call the custom response generator functions for attachment, table and checkbox.',
+    )
+  }
+  return {
+    // Wrap answer in quotes
+    _id: new ObjectId().toHexString(),
+    question: `${fieldType} question`,
+    answer: `'${fieldType} answer'`,
+    fieldType: fieldType,
+    isVisible: true,
+    ...customParams,
+  } as ProcessedSingleAnswerResponse
+}
+
 export const generateUnprocessedSingleAnswerResponse = (
   fieldType: BasicField,
   customParams?: Partial<SingleAnswerFieldResponse>,

--- a/tests/unit/frontend/forms/helpers/CsvMergedHeadersGenerator.test.js
+++ b/tests/unit/frontend/forms/helpers/CsvMergedHeadersGenerator.test.js
@@ -370,10 +370,10 @@ describe('CsvMergedHeadersGenerator', () => {
           moment(mockRecord.created)
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
-          mockDecryptedRecord[0].answer,
-          mockDecryptedRecord[1].answer,
-          mockDecryptedRecord[2].answer,
-          mockDecryptedRecord[3].answer,
+          `'${mockDecryptedRecord[0].answer}'`,
+          `'${mockDecryptedRecord[1].answer}'`,
+          `'${mockDecryptedRecord[2].answer}'`,
+          `'${mockDecryptedRecord[3].answer}'`,
         ])
         expect(generator.records).toEqual([
           UTF8_BYTE_ORDER_MARK,
@@ -432,10 +432,10 @@ describe('CsvMergedHeadersGenerator', () => {
           moment(mockFirstRecord.created)
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
-          mockFirstDecryptedRecord[0].answer,
-          mockFirstDecryptedRecord[1].answer,
-          mockFirstDecryptedRecord[2].answer,
-          mockFirstDecryptedRecord[3].answer,
+          `'${mockFirstDecryptedRecord[0].answer}'`,
+          `'${mockFirstDecryptedRecord[1].answer}'`,
+          `'${mockFirstDecryptedRecord[2].answer}'`,
+          `'${mockFirstDecryptedRecord[3].answer}'`,
         ])
         // Second processed row should be mockReversedRecord's answers in reversed
         // order since the fieldIds are reversed
@@ -444,10 +444,10 @@ describe('CsvMergedHeadersGenerator', () => {
           moment(mockReversedRecord.created)
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
-          mockReversedDecryptedRecord[3].answer,
-          mockReversedDecryptedRecord[2].answer,
-          mockReversedDecryptedRecord[1].answer,
-          mockReversedDecryptedRecord[0].answer,
+          `'${mockReversedDecryptedRecord[3].answer}'`,
+          `'${mockReversedDecryptedRecord[2].answer}'`,
+          `'${mockReversedDecryptedRecord[1].answer}'`,
+          `'${mockReversedDecryptedRecord[0].answer}'`,
         ])
 
         expect(generator.records).toEqual([
@@ -510,10 +510,10 @@ describe('CsvMergedHeadersGenerator', () => {
           moment(mockRecord.created)
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
-          mockDecryptedRecord[0].answer,
-          mockDecryptedRecord[1].answer,
-          mockDecryptedRecord[2].answer,
-          mockDecryptedRecord[3].answer,
+          `'${mockDecryptedRecord[0].answer}'`,
+          `'${mockDecryptedRecord[1].answer}'`,
+          `'${mockDecryptedRecord[2].answer}'`,
+          `'${mockDecryptedRecord[3].answer}'`,
           // Should have extra blank space due to new header
           '',
         ])
@@ -529,8 +529,8 @@ describe('CsvMergedHeadersGenerator', () => {
           '',
           '',
           // Others should be blank, but the later 'intersect' key should be first
-          newDecryptedRecord[1].answer,
-          newDecryptedRecord[0].answer,
+          `'${newDecryptedRecord[1].answer}'`,
+          `'${newDecryptedRecord[0].answer}'`,
         ])
         expect(generator.records).toEqual([
           UTF8_BYTE_ORDER_MARK,
@@ -572,7 +572,7 @@ describe('CsvMergedHeadersGenerator', () => {
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
           // Answer array values should be joined by a semicolon
-          mockDecryptedRecord[0].answerArray.join(';'),
+          `'${mockDecryptedRecord[0].answerArray.join(';')}'`,
         ])
 
         expect(generator.records).toEqual([
@@ -621,8 +621,8 @@ describe('CsvMergedHeadersGenerator', () => {
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
           // Answer array values should be joined by a semicolon
-          mockDecryptedRecord[0].answerArray[0].join(';'),
-          mockDecryptedRecord[0].answerArray[1].join(';'),
+          `'${mockDecryptedRecord[0].answerArray[0].join(';')}'`,
+          `'${mockDecryptedRecord[0].answerArray[1].join(';')}'`,
         ])
 
         expect(generator.records).toEqual([
@@ -668,7 +668,7 @@ describe('CsvMergedHeadersGenerator', () => {
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
           // Answer array values should be joined by a semicolon
-          mockAnswerArray[0].answerArray.join(';'),
+          `'${mockAnswerArray[0].answerArray.join(';')}'`,
         ])
         // Second row is answer, but same field Id, so same number of headers
         const expectedSubmissionRow2 = stringify([
@@ -677,7 +677,7 @@ describe('CsvMergedHeadersGenerator', () => {
             .tz('Asia/Singapore')
             .format('DD MMM YYYY hh:mm:ss A'),
           // Answer array values should be joined by a semicolon
-          mockAnswer[0].answer,
+          `'${mockAnswer[0].answer}'`,
         ])
 
         expect(generator.records).toEqual([


### PR DESCRIPTION
## Problem
See [#133](https://github.com/datagovsg/formsg-private/issues/133)

## Solution
Storage mode responses, Form feedback: For the generated CSV files, wrap cell contents in quotes unless they are pure numbers

Data collation tool: Answer fields in the JSON data collation tool section sent in emails are wrapped in quotes, unless they are pure numbers

Pure numbers are left as they are so that excel is able to parse them as numbers

Closes [#133](https://github.com/datagovsg/formsg-private/issues/133)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
- [x] Test that cell contents in downloaded storage mode responses CSV are wrapped in quotes unless they are pure numbers
- [x] Test that comments in downloaded form feedback CSV are wrapped in quotes unless they are pure numbers
- [x] Test that the answer fields for the data collation tool section in emails are wrapped in quotes unless they are pure numbers
- [x] Submit a form using email responses with command specified in [#133](https://github.com/datagovsg/formsg-private/issues/133) in one of the fields. Convert to excel using the data collation tool. Open the excel file with macro enabled, the app should not launch
