### PR TITLE
feat: add SPCP validation before generating OTP

### DIFF
--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -87,7 +87,7 @@ describe('Verification controller', () => {
   const MOCK_OTP = 'otp'
   let mockTransaction: IVerificationSchema
   let mockRes: Response
-  const expectedParamsForSendingOtp = {
+  const EXPECTED_PARAMS_FOR_SENDING_OTP = {
     transactionId: MOCK_TRANSACTION_ID,
     fieldId: MOCK_FIELD_ID,
     otp: MOCK_OTP,
@@ -111,8 +111,7 @@ describe('Verification controller', () => {
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
-    // jest.resetAllMocks()
+    jest.resetAllMocks()
   })
 
   afterAll(async () => {
@@ -424,7 +423,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
@@ -438,7 +437,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -453,7 +452,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -468,7 +467,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -498,7 +497,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
@@ -515,7 +514,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -530,7 +529,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -545,7 +544,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -560,7 +559,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -575,7 +574,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
@@ -590,7 +589,7 @@ describe('Verification controller', () => {
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
@@ -676,7 +675,7 @@ describe('Verification controller', () => {
       expect(MockMyInfoUtil.extractAccessTokenFromCookie).not.toHaveBeenCalled()
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -728,7 +727,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -781,7 +780,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -832,7 +831,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -876,7 +875,7 @@ describe('Verification controller', () => {
       expect(MockMyInfoUtil.extractAccessTokenFromCookie).toHaveBeenCalled()
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
@@ -910,7 +909,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -938,7 +937,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -966,7 +965,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -995,7 +994,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1024,7 +1023,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1074,7 +1073,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1418,7 +1417,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1446,7 +1445,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
@@ -1474,7 +1473,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
@@ -1529,7 +1528,7 @@ describe('Verification controller', () => {
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
-        expectedParamsForSendingOtp,
+        EXPECTED_PARAMS_FOR_SENDING_OTP,
       )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -2,10 +2,12 @@ import { ObjectId } from 'bson'
 import { Request, Response } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
-import { errAsync, okAsync } from 'neverthrow'
+import { err, errAsync, ok, okAsync } from 'neverthrow'
+import { FormAuthType } from 'shared/types'
 import { WAIT_FOR_OTP_SECONDS } from 'shared/utils/verification'
 import { mocked } from 'ts-jest/utils'
 
+import * as MyInfoUtils from 'src/app/modules/myinfo/myinfo.util'
 import { MailSendError } from 'src/app/services/mail/mail.errors'
 import {
   InvalidNumberError,
@@ -21,6 +23,25 @@ import expressHandler from '../../../../../tests/unit/backend/helpers/jest-expre
 import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
+import {
+  MOCK_ACCESS_TOKEN,
+  MOCK_SUCCESSFUL_COOKIE,
+} from '../../myinfo/__tests__/myinfo.test.constants'
+import {
+  MyInfoCookieStateError,
+  MyInfoMissingAccessTokenError,
+} from '../../myinfo/myinfo.errors'
+import {
+  SgidInvalidJwtError,
+  SgidMissingJwtError,
+} from '../../sgid/sgid.errors'
+import { SgidService } from '../../sgid/sgid.service'
+import {
+  MOCK_JWT,
+  MOCK_JWT_PAYLOAD,
+} from '../../spcp/__tests__/spcp.test.constants'
+import { InvalidJwtError, MissingJwtError } from '../../spcp/spcp.errors'
+import { SpcpService } from '../../spcp/spcp.service'
 import * as VerificationController from '../verification.controller'
 import {
   FieldNotFoundInTransactionError,
@@ -51,6 +72,12 @@ jest.mock('src/app/utils/otp')
 const MockOtpUtils = mocked(OtpUtils, true)
 jest.mock('../../form/form.service')
 const MockFormService = mocked(FormService, true)
+jest.mock('../../spcp/spcp.service')
+const MockSpcpService = mocked(SpcpService, true)
+jest.mock('../../myinfo/myinfo.util')
+const MockMyInfoUtil = mocked(MyInfoUtils, true)
+jest.mock('../../sgid/sgid.service')
+const MockSgidService = mocked(SgidService, true)
 
 describe('Verification controller', () => {
   const MOCK_FORM_ID = new ObjectId().toHexString()
@@ -60,6 +87,14 @@ describe('Verification controller', () => {
   const MOCK_OTP = 'otp'
   let mockTransaction: IVerificationSchema
   let mockRes: Response
+  const expectedParamsForSendingOtp = {
+    transactionId: MOCK_TRANSACTION_ID,
+    fieldId: MOCK_FIELD_ID,
+    otp: MOCK_OTP,
+    hashedOtp: MOCK_HASHED_OTP,
+    recipient: MOCK_ANSWER,
+    senderIp: 'MOCK_IP',
+  }
 
   beforeAll(async () => {
     await dbHandler.connect()
@@ -71,11 +106,14 @@ describe('Verification controller', () => {
     })
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockRes = expressHandler.mockResponse()
   })
 
-  afterEach(() => jest.resetAllMocks())
+  afterEach(() => {
+    jest.clearAllMocks()
+    // jest.resetAllMocks()
+  })
 
   afterAll(async () => {
     // mockTransaction is reused throughout the tests
@@ -385,14 +423,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -404,14 +437,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -424,14 +452,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -444,14 +467,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -479,14 +497,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
       )
@@ -501,14 +514,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -521,14 +529,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -541,14 +544,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -561,14 +559,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -581,14 +574,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith({ message: expect.any(String) })
     })
@@ -601,14 +589,9 @@ describe('Verification controller', () => {
       await VerificationController.handleGetOtp(MOCK_REQ, mockRes, jest.fn())
 
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
       )
@@ -634,7 +617,24 @@ describe('Verification controller', () => {
       permissionList: [{ email: 'former@forms.sg' }],
     } as IPopulatedForm
 
-    beforeEach(() => {
+    const MOCK_SP_FORM = {
+      ...MOCK_FORM,
+      authType: FormAuthType.SP,
+    } as IPopulatedForm
+    const MOCK_CP_FORM = {
+      ...MOCK_FORM,
+      authType: FormAuthType.CP,
+    } as IPopulatedForm
+    const MOCK_SGID_FORM = {
+      ...MOCK_FORM,
+      authType: FormAuthType.SGID,
+    } as IPopulatedForm
+    const MOCK_MYINFO_FORM = {
+      ...MOCK_FORM,
+      authType: FormAuthType.MyInfo,
+    } as IPopulatedForm
+
+    beforeEach(async () => {
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(MOCK_FORM))
 
       MockOtpUtils.generateOtpWithHash.mockReturnValue(
@@ -651,7 +651,7 @@ describe('Verification controller', () => {
       )
     })
 
-    it('should return 201 when params are valid', async () => {
+    it('should return 201 when params are valid and form has no SPCP/MyInfo authentication required', async () => {
       // Arrange
       MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
         okAsync(true),
@@ -668,19 +668,220 @@ describe('Verification controller', () => {
       expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
         MOCK_FORM_ID,
       )
+      expect(MockSpcpService.extractJwt).not.toHaveBeenCalled()
+      expect(MockSpcpService.extractSingpassJwtPayload).not.toHaveBeenCalled()
+      expect(MockSpcpService.extractCorppassJwtPayload).not.toHaveBeenCalled()
+      expect(MockSgidService.extractSgidJwtPayload).not.toHaveBeenCalled()
+      expect(MockMyInfoUtil.extractMyInfoCookie).not.toHaveBeenCalled()
+      expect(MockMyInfoUtil.extractAccessTokenFromCookie).not.toHaveBeenCalled()
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(
         MockVerificationService.disableVerifiedFieldsIfRequired,
       ).toHaveBeenCalledWith(
         MOCK_FORM,
+        mockTransaction,
+        MOCK_REQ.params.fieldId,
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+    })
+
+    it('should return 201 when Singpass authentication is enabled and jwt token is valid', async () => {
+      // Arrange
+      const MOCK_SP_SESSION = {
+        userName: MOCK_JWT_PAYLOAD.userName,
+        exp: 1000000000,
+        iat: 100000000,
+        rememberMe: false,
+      }
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SP_FORM),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
+      MockSpcpService.extractSingpassJwtPayload.mockReturnValueOnce(
+        okAsync(MOCK_SP_SESSION),
+      )
+      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
+        okAsync(true),
+      )
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_SP_FORM.authType,
+      )
+      expect(MockSpcpService.extractSingpassJwtPayload).toHaveBeenCalledWith(
+        MOCK_JWT,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
+      expect(
+        MockVerificationService.disableVerifiedFieldsIfRequired,
+      ).toHaveBeenCalledWith(
+        MOCK_SP_FORM,
+        mockTransaction,
+        MOCK_REQ.params.fieldId,
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+    })
+
+    it('should return 201 when Corpass authentication is enabled and jwt token is valid', async () => {
+      // Arrange
+      const MOCK_CP_SESSION = {
+        userName: MOCK_JWT_PAYLOAD.userName,
+        userInfo: MOCK_JWT_PAYLOAD.userInfo,
+        exp: 1000000000,
+        iat: 100000000,
+        rememberMe: false,
+      }
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_CP_FORM),
+      )
+      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
+        okAsync(true),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
+      MockSpcpService.extractCorppassJwtPayload.mockReturnValueOnce(
+        okAsync(MOCK_CP_SESSION),
+      )
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_CP_FORM.authType,
+      )
+      expect(MockSpcpService.extractCorppassJwtPayload).toHaveBeenCalledWith(
+        MOCK_JWT,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
+      expect(
+        MockVerificationService.disableVerifiedFieldsIfRequired,
+      ).toHaveBeenCalledWith(
+        MOCK_CP_FORM,
+        mockTransaction,
+        MOCK_REQ.params.fieldId,
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+    })
+
+    it('should return 201 when SGID authentication is enabled and sgid jwt token is valid', async () => {
+      // Arrange
+      const MOCK_VALID_SGID_PAYLOAD = { userName: MOCK_JWT_PAYLOAD.userName }
+      const MOCK_SGID_REQ = expressHandler.mockRequest({
+        body: { answer: MOCK_ANSWER },
+        params: {
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+        },
+      })
+      MOCK_SGID_REQ.cookies = { jwtSgid: {} }
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SGID_FORM),
+      )
+      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
+        okAsync(true),
+      )
+      MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+        ok(MOCK_VALID_SGID_PAYLOAD),
+      )
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_SGID_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSgidService.extractSgidJwtPayload).toHaveBeenCalledWith(
+        MOCK_SGID_REQ.cookies.jwtSgid,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
+      expect(
+        MockVerificationService.disableVerifiedFieldsIfRequired,
+      ).toHaveBeenCalledWith(
+        MOCK_SGID_FORM,
+        mockTransaction,
+        MOCK_REQ.params.fieldId,
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.CREATED)
+    })
+
+    it('should return 201 when MyInfo authentication is enabled and MyInfo cookie is valid', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_MYINFO_FORM),
+      )
+      MockMyInfoUtil.extractMyInfoCookie.mockReturnValueOnce(
+        ok(MOCK_SUCCESSFUL_COOKIE),
+      )
+      MockMyInfoUtil.extractAccessTokenFromCookie.mockReturnValueOnce(
+        ok(MOCK_ACCESS_TOKEN),
+      )
+      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
+        okAsync(true),
+      )
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockMyInfoUtil.extractMyInfoCookie).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+      )
+      expect(MockMyInfoUtil.extractAccessTokenFromCookie).toHaveBeenCalled()
+      expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
+      expect(
+        MockVerificationService.disableVerifiedFieldsIfRequired,
+      ).toHaveBeenCalledWith(
+        MOCK_MYINFO_FORM,
         mockTransaction,
         MOCK_REQ.params.fieldId,
       )
@@ -708,14 +909,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -741,14 +937,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -774,14 +965,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -808,14 +994,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -842,14 +1023,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -897,14 +1073,299 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when Singpass authentication is enabled but jwt token is missing in session', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SP_FORM),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(err(new MissingJwtError()))
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_SP_FORM.authType,
+      )
+      expect(MockSpcpService.extractSingpassJwtPayload).not.toHaveBeenCalled()
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when Singpass authentication is enabled but jwt token is invalid', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SP_FORM),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
+      MockSpcpService.extractSingpassJwtPayload.mockReturnValueOnce(
+        errAsync(new InvalidJwtError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_SP_FORM.authType,
+      )
+      expect(MockSpcpService.extractSingpassJwtPayload).toHaveBeenCalledWith(
+        MOCK_JWT,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when Corpass authentication is enabled but jwt token is missing in session', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_CP_FORM),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(err(new MissingJwtError()))
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_CP_FORM.authType,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when Corpass authentication is enabled but jwt token is invalid', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_CP_FORM),
+      )
+      MockSpcpService.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
+      MockSpcpService.extractCorppassJwtPayload.mockReturnValueOnce(
+        errAsync(new InvalidJwtError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSpcpService.extractJwt).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+        MOCK_CP_FORM.authType,
+      )
+      expect(MockSpcpService.extractCorppassJwtPayload).toHaveBeenCalledWith(
+        MOCK_JWT,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when SGID authentication is enabled but jwt token is missing in session', async () => {
+      // Arrange
+      const MOCK_SGID_REQ = expressHandler.mockRequest({
+        body: { answer: MOCK_ANSWER },
+        params: {
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+        },
       })
+      MOCK_SGID_REQ.cookies = {}
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SGID_FORM),
+      )
+      MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+        err(new SgidMissingJwtError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_SGID_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSgidService.extractSgidJwtPayload).toHaveBeenCalledWith(
+        MOCK_SGID_REQ.cookies.jwtSgid,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when SGID authentication is enabled but jwt token is invalid', async () => {
+      // Arrange
+      const MOCK_SGID_REQ = expressHandler.mockRequest({
+        body: { answer: MOCK_ANSWER },
+        params: {
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+        },
+      })
+      MOCK_SGID_REQ.cookies = {}
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_SGID_FORM),
+      )
+      MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+        err(new SgidInvalidJwtError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_SGID_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockSgidService.extractSgidJwtPayload).toHaveBeenCalledWith(
+        MOCK_SGID_REQ.cookies.jwt,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when MyInfo authentication is enabled but MyInfo cookie is missing in session', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_MYINFO_FORM),
+      )
+      MockMyInfoUtil.extractMyInfoCookie.mockReturnValueOnce(
+        err(new MyInfoMissingAccessTokenError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockMyInfoUtil.extractMyInfoCookie).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+      )
+      expect(MockMyInfoUtil.extractAccessTokenFromCookie).not.toHaveBeenCalled()
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 400 when MyInfo authentication is enabled but MyInfo cookie has incorrect state', async () => {
+      // Arrange
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_MYINFO_FORM),
+      )
+      MockMyInfoUtil.extractMyInfoCookie.mockReturnValueOnce(
+        ok(MOCK_SUCCESSFUL_COOKIE),
+      )
+      MockMyInfoUtil.extractAccessTokenFromCookie.mockReturnValueOnce(
+        err(new MyInfoCookieStateError()),
+      )
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockMyInfoUtil.extractMyInfoCookie).toHaveBeenCalledWith(
+        MOCK_REQ.cookies,
+      )
+      expect(MockMyInfoUtil.extractAccessTokenFromCookie).toHaveBeenCalledWith(
+        MOCK_SUCCESSFUL_COOKIE,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -956,14 +1417,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -989,14 +1445,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
@@ -1022,14 +1473,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.UNPROCESSABLE_ENTITY,
       )
@@ -1082,14 +1528,9 @@ describe('Verification controller', () => {
         MOCK_FORM_ID,
       )
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
-      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith({
-        transactionId: MOCK_TRANSACTION_ID,
-        fieldId: MOCK_FIELD_ID,
-        otp: MOCK_OTP,
-        hashedOtp: MOCK_HASHED_OTP,
-        recipient: MOCK_ANSWER,
-        senderIp: 'MOCK_IP',
-      })
+      expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
+        expectedParamsForSendingOtp,
+      )
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
       )

--- a/src/app/modules/verification/verification.util.ts
+++ b/src/app/modules/verification/verification.util.ts
@@ -30,6 +30,20 @@ import {
   MalformedParametersError,
 } from '../core/core.errors'
 import { FormNotFoundError } from '../form/form.errors'
+import {
+  MyInfoCookieStateError,
+  MyInfoMissingAccessTokenError,
+} from '../myinfo/myinfo.errors'
+import {
+  SgidInvalidJwtError,
+  SgidMissingJwtError,
+  SgidVerifyJwtError,
+} from '../sgid/sgid.errors'
+import {
+  InvalidJwtError,
+  MissingJwtError,
+  VerifyJwtError,
+} from '../spcp/spcp.errors'
 
 import {
   FieldNotFoundInTransactionError,
@@ -183,6 +197,18 @@ export const mapRouteError: MapRouteError = (
     case NonVerifiedFieldTypeError:
     case MissingHashDataError:
     case DatabaseValidationError:
+      return {
+        errorMessage: coreErrorMsg,
+        statusCode: StatusCodes.BAD_REQUEST,
+      }
+    case MissingJwtError:
+    case InvalidJwtError:
+    case VerifyJwtError:
+    case SgidVerifyJwtError:
+    case SgidInvalidJwtError:
+    case SgidMissingJwtError:
+    case MyInfoMissingAccessTokenError:
+    case MyInfoCookieStateError:
       return {
         errorMessage: coreErrorMsg,
         statusCode: StatusCodes.BAD_REQUEST,


### PR DESCRIPTION
## Problem
Currently users can call the OTP generation endpoint via API even for forms protected by SPCP/MyInfo. 

## Solution
<!-- How did you solve the problem? -->
Before generating an OTP when the API is called, verify users if the form is protected by SPCP/MyInfo.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Test that if a form requires users to authenticate themselves via Singpass, calling the endpoint to generate OTP without successfully verifying Singpass will return `400 Bad Request` error
- [x] Test that if a form requires users to authenticate themselves via Corpass, calling the endpoint to generate OTP without successfully verifying Corpass will return `400 Bad Request` error
- [x] Test that if a form requires users to authenticate themselves via MyInfo, calling the endpoint to generate OTP without successfully verifying MyInfo will return `400 Bad Request` error
- [x] Test that if a form requires users to authenticate themselves via SGID, calling the endpoint to generate OTP without successfully verifying SGID will return `400 Bad Request` error 