### PR TITLE
feat: add last seen feature update date attribute to user collection

### DIFF
--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -16,6 +16,9 @@ export const UserBase = z.object({
       sgid: z.boolean().optional(),
     })
     .optional(),
+  flags: z
+    .object({ lastSeenFeatureUpdateDate: z.string().optional() })
+    .optional(),
   created: z.date(),
   lastAccessed: z.date().optional(),
   updatedAt: z.date(),

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -17,7 +17,7 @@ export const UserBase = z.object({
     })
     .optional(),
   flags: z
-    .object({ lastSeenFeatureUpdateDate: z.string().optional() })
+    .object({ lastSeenFeatureUpdateDate: z.date().optional() })
     .optional(),
   created: z.date(),
   lastAccessed: z.date().optional(),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -71,6 +71,9 @@ const compileUserModel = (db: Mongoose) => {
       betaFlags: {
         sgid: Boolean,
       },
+      flags: {
+        lastSeenFeatureUpdateDate: String,
+      },
     },
     {
       timestamps: {

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -72,7 +72,7 @@ const compileUserModel = (db: Mongoose) => {
         sgid: Boolean,
       },
       flags: {
-        lastSeenFeatureUpdateDate: String,
+        lastSeenFeatureUpdateDate: Date,
       },
     },
     {

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -333,7 +333,7 @@ describe('user.service', () => {
         userId: mockUserIdWithLastSeenFeatureUpdate,
         mailName: 'userWithLastSeenFeatureUpdate',
         mailDomain: ALLOWED_DOMAIN,
-        flags: { lastSeenFeatureUpdateDate: '17/07/2022' },
+        flags: { lastSeenFeatureUpdateDate: MOCKED_DATE },
       })
 
       const defaultUserWithLastSeenFeatureUpdate: IUserSchema = user

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -327,6 +327,32 @@ describe('user.service', () => {
       expect(actualResult._unsafeUnwrap()?.toObject()).toEqual(expected)
     })
 
+    it('should return populated user with last seen feature update date successfully', async () => {
+      const mockUserIdWithLastSeenFeatureUpdate = new ObjectID()
+      const { agency, user } = await dbHandler.insertFormCollectionReqs({
+        userId: mockUserIdWithLastSeenFeatureUpdate,
+        mailName: 'userWithLastSeenFeatureUpdate',
+        mailDomain: ALLOWED_DOMAIN,
+        flags: { lastSeenFeatureUpdateDate: '17/07/2022' },
+      })
+
+      const defaultUserWithLastSeenFeatureUpdate: IUserSchema = user
+      const defaultAgencyWithLastSeenFeatureUpdate: AgencyDocument = agency
+      const expected = {
+        ...defaultUserWithLastSeenFeatureUpdate.toObject(),
+        agency: defaultAgencyWithLastSeenFeatureUpdate.toObject(),
+      }
+
+      // Act
+      const actualResult = await UserService.getPopulatedUserById(
+        mockUserIdWithLastSeenFeatureUpdate,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()?.toObject()).toEqual(expected)
+    })
+
     it('should return MissingUserError when user cannot be found', async () => {
       // Arrange
       const invalidUser = new ObjectID()

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -117,7 +117,7 @@ const insertFormCollectionReqs = async ({
   mailName?: string
   mailDomain?: string
   shortName?: string
-  flags?: { lastSeenFeatureUpdateDate: string }
+  flags?: { lastSeenFeatureUpdateDate: Date }
 } = {}): Promise<{
   agency: AgencyDocument
   user: IUserSchema

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -111,11 +111,13 @@ const insertFormCollectionReqs = async ({
   mailDomain = 'test.gov.sg',
   mailName = 'test',
   shortName = 'govtest',
+  flags,
 }: {
   userId?: ObjectID
   mailName?: string
   mailDomain?: string
   shortName?: string
+  flags?: { lastSeenFeatureUpdateDate: string }
 } = {}): Promise<{
   agency: AgencyDocument
   user: IUserSchema
@@ -128,6 +130,7 @@ const insertFormCollectionReqs = async ({
     email: `${mailName}@${mailDomain}`,
     _id: userId ?? new ObjectID(),
     agency: agency._id,
+    flags: flags,
   })
 
   return { agency, user }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds attribute to user collection to store user's last seen feature update date which will be used in future PRs to decide whether or not to notify users on the latest feature updates.

Closes #3985 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Test to ensure that user with last seen feature update date attribute is returned appropriately when added to collection