### PR TITLE
feat: add end-page uri scheme validation

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2167,6 +2167,7 @@ export const handleDeleteFormField: ControllerHandler<
  * @security session
  *
  * @returns 200 with updated end page
+ * @returns 400 when end page form field has invalid updates to be performed
  * @returns 403 when current user does not have permissions to update the end page
  * @returns 404 when form cannot be found
  * @returns 410 when updating the end page for an archived form
@@ -2223,7 +2224,8 @@ export const handleUpdateEndPage = [
       paragraph: Joi.string().allow(''),
       buttonLink: Joi.string()
         .uri({ scheme: ['http', 'https'] })
-        .allow(''),
+        .allow('')
+        .message('Please enter a valid HTTP or HTTPS URI'),
       buttonText: Joi.string().allow(''),
       // TODO(#1895): Remove when deprecated `buttons` key is removed from all forms in the database
     }).unknown(true),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2221,7 +2221,9 @@ export const handleUpdateEndPage = [
     [Segments.BODY]: Joi.object({
       title: Joi.string(),
       paragraph: Joi.string().allow(''),
-      buttonLink: Joi.string().uri().allow(''),
+      buttonLink: Joi.string()
+        .uri({ scheme: ['http', 'https'] })
+        .allow(''),
       buttonText: Joi.string().allow(''),
       // TODO(#1895): Remove when deprecated `buttons` key is removed from all forms in the database
     }).unknown(true),

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -2134,7 +2134,55 @@ describe('admin-form.form.routes', () => {
       buttonText: 'end page button',
     }
 
-    it('should return 400 when button link does not use valid URI scheme', async () => {
+    it('should return 200 when button link is updated with a valid HTTPS URI scheme', async () => {
+      //Arrange
+      const form = await EmailFormModel.create({
+        emails: [defaultUser.email],
+        title: 'email me',
+        admin: defaultUser._id,
+        endpage: MOCK_END_PAGE,
+      })
+
+      //Act
+      const validUriScheme = 'https://valid.scheme'
+      const response = await request
+        .put(`/admin/forms/${form._id}/end-page`)
+        .send({
+          buttonLink: validUriScheme,
+        })
+
+      //Assert
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual(
+        expect.objectContaining({ buttonLink: validUriScheme }),
+      )
+    })
+
+    it('should return 200 when button link is updated with a valid HTTP URI scheme', async () => {
+      //Arrange
+      const form = await EmailFormModel.create({
+        emails: [defaultUser.email],
+        title: 'email me',
+        admin: defaultUser._id,
+        endpage: MOCK_END_PAGE,
+      })
+
+      //Act
+      const validUriScheme = 'http://valid.scheme'
+      const response = await request
+        .put(`/admin/forms/${form._id}/end-page`)
+        .send({
+          buttonLink: validUriScheme,
+        })
+
+      //Assert
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual(
+        expect.objectContaining({ buttonLink: validUriScheme }),
+      )
+    })
+
+    it('should return 400 when button link is updated with an invalid URI scheme', async () => {
       //Arrange
       const form = await EmailFormModel.create({
         emails: [defaultUser.email],

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -30,6 +30,7 @@ import { jsonParseStringify } from 'tests/unit/backend/helpers/serialize-data'
 import {
   BasicField,
   FormColorTheme,
+  FormEndPage,
   FormLogoState,
   FormResponseMode,
   FormStartPage,
@@ -2124,6 +2125,41 @@ describe('admin-form.form.routes', () => {
       // Assert
       expect(resp.status).toBe(500)
       expect(resp.body).toEqual(expectedResponse)
+    })
+  })
+
+  describe('PUT /admin/forms/:formId/end-page', () => {
+    const MOCK_END_PAGE: Partial<FormEndPage> = {
+      title: 'end page title',
+      buttonText: 'end page button',
+    }
+
+    it('should return 400 when button link does not use valid URI scheme', async () => {
+      //Arrange
+      const form = await EmailFormModel.create({
+        emails: [defaultUser.email],
+        title: 'email me',
+        admin: defaultUser._id,
+        endpage: MOCK_END_PAGE,
+      })
+
+      //Act
+      const response = await request
+        .put(`/admin/forms/${form._id}/end-page`)
+        .send({
+          buttonLink: 'scheme://invalid.scheme',
+        })
+
+      //Assert
+      expect(response.status).toBe(400)
+      expect(response.body).toEqual(
+        buildCelebrateError({
+          body: {
+            key: 'buttonLink',
+            message: 'Please enter a valid HTTP or HTTPS URI',
+          },
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
## Problem
No checks are done on the URI scheme in the end page's Thank You message button link

Closes [#134](https://github.com/datagovsg/formsg-private/issues/134)

## Solution
Using [Joi's inbuilt settings](https://github.com/sideway/joi/blob/master/API.md#stringurioptions), only allow URIs with the schemes `http` or `https`

**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Tests
- [x] Change the end-page's thank you button link to a scheme that's not http or https. Submit the HTTP request. You should get a 400 status error and an error message which states "Validation failed"
<img width="682" alt="Screenshot 2022-07-04 at 10 11 01 AM" src="https://user-images.githubusercontent.com/56983748/177069898-7cb9cae7-5158-47cb-a9a8-93bd7a736a1a.png">

- [x] Change the end-page's thank you button link to a scheme that's http or https. Submit the HTTP request. Request should succeed.

