### PR TITLE
feat: add new user endpoint to update user last seen feature update date attribute

### DIFF
--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -53,7 +53,3 @@ export type VerifyUserContactOtpDto = {
   otp: string
   contact: string
 }
-
-export type UpdateUserLastFeatureUpdateDateDto = {
-  latestLastSeenFeatureUpdateDate: Date
-}

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -53,3 +53,7 @@ export type VerifyUserContactOtpDto = {
   otp: string
   contact: string
 }
+
+export type UpdateUserLastFeatureUpdateDateDto = {
+  latestLastSeenFeatureUpdateDate: Date
+}

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -16,6 +16,7 @@ import { IPopulatedUser } from 'src/types'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import { DatabaseError } from '../../core/core.errors'
+import { UNAUTHORIZED_USER_MESSAGE } from '../user.constant'
 
 jest.mock('src/app/modules/user/user.service')
 jest.mock('src/app/services/sms/sms.factory')
@@ -89,7 +90,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -120,7 +121,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -240,7 +241,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -272,7 +273,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -409,7 +410,7 @@ describe('user.controller', () => {
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
       expect(mockRes.json).toBeCalledWith({
-        message: 'User is unauthorized.',
+        message: UNAUTHORIZED_USER_MESSAGE,
       })
     })
 
@@ -439,12 +440,6 @@ describe('user.controller', () => {
         },
       },
     })
-    // Mock implementaion of Date.now() due to slight difference in Date.now() execution in test and when
-    // Date.now() in updateUserLastSeenFeatureUpdateDate function is executed
-    jest
-      .spyOn(global.Date, 'now')
-      .mockReturnValue(new Date('2022-07-14T11:01:58.135Z').valueOf())
-    const MOCK_DATE = new Date('2022-07-14T11:01:58.135Z')
 
     it('should return 200 when successful', async () => {
       // Arrange
@@ -471,7 +466,7 @@ describe('user.controller', () => {
       // Expect services to be called with correct arguments.
       expect(
         MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_DATE)
+      ).toBeCalledWith(MOCK_REQ.session.user?._id)
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.json).toBeCalledWith(mockPopulatedUser)
     })
@@ -479,7 +474,6 @@ describe('user.controller', () => {
     it('should return 401 if session does not contain user id', async () => {
       // Arrange
       const MOCK_REQ_WITH_NO_USER_ID_IN_SESSION = expressHandler.mockRequest({
-        body: { date: MOCK_DATE },
         session: {},
       })
       const mockRes = expressHandler.mockResponse()
@@ -495,7 +489,7 @@ describe('user.controller', () => {
         MockUserService.updateUserLastSeenFeatureUpdateDate,
       ).not.toHaveBeenCalled()
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNAUTHORIZED)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
     })
 
     it('should return 422 if user id does not exist in database', async () => {
@@ -517,7 +511,7 @@ describe('user.controller', () => {
 
       expect(
         MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_DATE)
+      ).toBeCalledWith(MOCK_REQ.session.user?._id)
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNPROCESSABLE_ENTITY)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
@@ -541,7 +535,7 @@ describe('user.controller', () => {
 
       expect(
         MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_DATE)
+      ).toBeCalledWith(MOCK_REQ.session.user?._id)
       expect(mockRes.status).toBeCalledWith(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -16,7 +16,10 @@ import { IPopulatedUser } from 'src/types'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import { DatabaseError } from '../../core/core.errors'
-import { UPDATE_LAST_SEEN_FEATURE_DATE } from '../user.constant'
+import {
+  UNAUTHORIZED_USER_MESSAGE,
+  UPDATE_LAST_SEEN_FEATURE_DATE,
+} from '../user.constant'
 
 jest.mock('src/app/modules/user/user.service')
 jest.mock('src/app/services/sms/sms.factory')
@@ -90,7 +93,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -121,7 +124,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -241,7 +244,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -273,7 +276,7 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
       // Service functions should not be called.
       expect(MockUserService.verifyContactOtp).not.toHaveBeenCalled()
       expect(MockUserService.updateUserContact).not.toHaveBeenCalled()
@@ -409,7 +412,9 @@ describe('user.controller', () => {
       // Assert
       // Should trigger unauthorized response.
       expect(mockRes.status).toBeCalledWith(401)
-      expect(mockRes.json).toBeCalledWith({ message: 'User is unauthorized.' })
+      expect(mockRes.json).toBeCalledWith({
+        message: UNAUTHORIZED_USER_MESSAGE,
+      })
     })
 
     it('should return 422 when MissingUserError is returned when retrieving user', async () => {
@@ -488,7 +493,7 @@ describe('user.controller', () => {
         MockUserService.updateUserLastSeenFeatureUpdateDate,
       ).not.toHaveBeenCalled()
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNAUTHORIZED)
-      expect(mockRes.json).toBeCalledWith('User is unauthorized.')
+      expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
     })
 
     it('should return 422 if user id does not exist in database', async () => {

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -16,6 +16,7 @@ import { IPopulatedUser } from 'src/types'
 import expressHandler from 'tests/unit/backend/helpers/jest-express'
 
 import { DatabaseError } from '../../core/core.errors'
+import { UPDATE_LAST_SEEN_FEATURE_DATE } from '../user.constant'
 
 jest.mock('src/app/modules/user/user.service')
 jest.mock('src/app/services/sms/sms.factory')
@@ -465,9 +466,7 @@ describe('user.controller', () => {
         MOCK_REQ.body.latestLastSeenFeatureUpdateDate,
       )
       expect(mockRes.status).toBeCalledWith(200)
-      expect(mockRes.json).toBeCalledWith(
-        "Updated user's last seen feature update date successfully.",
-      )
+      expect(mockRes.json).toBeCalledWith(UPDATE_LAST_SEEN_FEATURE_DATE.SUCCESS)
     })
 
     it('should return 401 if session does not contain user id', async () => {

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -327,7 +327,12 @@ describe('user.service', () => {
           MOCK_DATE,
         )
 
+      const updatedUser = await UserService.getPopulatedUserById(user._id)
       expect(actualResult.isOk()).toEqual(true)
+      expect(
+        updatedUser._unsafeUnwrap()?.toObject().flags
+          ?.lastSeenFeatureUpdateDate,
+      ).toEqual(MOCK_DATE)
     })
 
     it('should return MissingUserError if userId is invalid', async () => {

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -322,10 +322,7 @@ describe('user.service', () => {
       expect(user.flags?.lastSeenFeatureUpdateDate).toBeUndefined()
 
       const actualResult =
-        await UserService.updateUserLastSeenFeatureUpdateDate(
-          user._id,
-          MOCK_DATE,
-        )
+        await UserService.updateUserLastSeenFeatureUpdateDate(user._id)
 
       const updatedUser = await UserService.getPopulatedUserById(user._id)
       expect(actualResult.isOk()).toEqual(true)
@@ -338,14 +335,10 @@ describe('user.service', () => {
     it('should return MissingUserError if userId is invalid', async () => {
       // Arrange
       const invalidUserId = new ObjectID()
-      const MOCK_DATE = new Date()
 
       // Act
       const actualResult =
-        await UserService.updateUserLastSeenFeatureUpdateDate(
-          invalidUserId,
-          MOCK_DATE,
-        )
+        await UserService.updateUserLastSeenFeatureUpdateDate(invalidUserId)
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(MissingUserError)
     })

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -311,6 +311,41 @@ describe('user.service', () => {
     })
   })
 
+  describe('updateUserLastSeenFeatureUpdateDate', () => {
+    it('should update user successfully', async () => {
+      const user = await dbHandler.insertUser({
+        agencyId: defaultAgency._id,
+        mailName: 'updateUserLastSeenFeatureUpdateDate',
+      })
+      const MOCK_DATE = new Date()
+
+      expect(user.flags?.lastSeenFeatureUpdateDate).toBeUndefined()
+
+      const actualResult =
+        await UserService.updateUserLastSeenFeatureUpdateDate(
+          user._id,
+          MOCK_DATE,
+        )
+
+      expect(actualResult.isOk()).toEqual(true)
+    })
+
+    it('should return MissingUserError if userId is invalid', async () => {
+      // Arrange
+      const invalidUserId = new ObjectID()
+      const MOCK_DATE = new Date()
+
+      // Act
+      const actualResult =
+        await UserService.updateUserLastSeenFeatureUpdateDate(
+          invalidUserId,
+          MOCK_DATE,
+        )
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(MissingUserError)
+    })
+  })
+
   describe('getPopulatedUserById', () => {
     it('should return populated user successfully', async () => {
       // Arrange

--- a/src/app/modules/user/user.constant.ts
+++ b/src/app/modules/user/user.constant.ts
@@ -1,0 +1,1 @@
+export const UNAUTHORIZED_USER_MESSAGE = 'User is unauthorized.'

--- a/src/app/modules/user/user.constant.ts
+++ b/src/app/modules/user/user.constant.ts
@@ -1,5 +1,0 @@
-export const UPDATE_LAST_SEEN_FEATURE_DATE = {
-  SUCCESS: 'Updated user last seen feature update date successfully.',
-  ERROR: 'Error occurred while updating user last seen feature update date',
-}
-export const UNAUTHORIZED_USER_MESSAGE = 'User is unauthorized.'

--- a/src/app/modules/user/user.constant.ts
+++ b/src/app/modules/user/user.constant.ts
@@ -1,0 +1,5 @@
+export const UPDATE_LAST_SEEN_FEATURE_DATE = {
+  SUCCESS: 'Updated user last seen feature update date successfully.',
+  ERROR: 'Error occurred while updating user last seen feature update date',
+}
+export const UNAUTHORIZED_USER_MESSAGE = 'User is unauthorized.'

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -11,6 +11,7 @@ import { getRequestIp } from '../../utils/request'
 import { getUserIdFromSession } from '../auth/auth.utils'
 import { ControllerHandler } from '../core/core.types'
 
+import { UNAUTHORIZED_USER_MESSAGE } from './user.constant'
 import {
   validateContactOtpVerificationParams,
   validateContactSendOtpParams,
@@ -38,7 +39,7 @@ export const _handleContactSendOtp: ControllerHandler<
   // Guard against user updating for a different user, or if user is not logged
   // in.
   if (!sessionUserId || sessionUserId !== userId) {
-    return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+    return res.status(StatusCodes.UNAUTHORIZED).json(UNAUTHORIZED_USER_MESSAGE)
   }
 
   const senderIp = getRequestIp(req)
@@ -120,7 +121,7 @@ export const _handleContactVerifyOtp: ControllerHandler<
   // Guard against user updating for a different user, or if user is not logged
   // in.
   if (!sessionUserId || sessionUserId !== userId) {
-    return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+    return res.status(StatusCodes.UNAUTHORIZED).json(UNAUTHORIZED_USER_MESSAGE)
   }
 
   const logMeta = {
@@ -189,7 +190,7 @@ export const handleFetchUser: ControllerHandler = async (req, res) => {
   if (!sessionUserId) {
     return res
       .status(StatusCodes.UNAUTHORIZED)
-      .json({ message: 'User is unauthorized.' })
+      .json({ message: UNAUTHORIZED_USER_MESSAGE })
   }
 
   return getPopulatedUserById(sessionUserId)
@@ -218,14 +219,15 @@ export const handleFetchUser: ControllerHandler = async (req, res) => {
  */
 export const handleUpdateUserLastSeenFeatureUpdateDate: ControllerHandler =
   async (req, res) => {
-    const currentDateTime = new Date(Date.now())
     const sessionUserId = getUserIdFromSession(req.session)
 
     if (!sessionUserId) {
-      return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+      return res
+        .status(StatusCodes.UNAUTHORIZED)
+        .json(UNAUTHORIZED_USER_MESSAGE)
     }
 
-    return updateUserLastSeenFeatureUpdateDate(sessionUserId, currentDateTime)
+    return updateUserLastSeenFeatureUpdateDate(sessionUserId)
       .map((updatedUser) => {
         return res.status(StatusCodes.OK).json(updatedUser)
       })

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -13,6 +13,10 @@ import { getUserIdFromSession } from '../auth/auth.utils'
 import { ControllerHandler } from '../core/core.types'
 
 import {
+  UNAUTHORIZED_USER_MESSAGE,
+  UPDATE_LAST_SEEN_FEATURE_DATE,
+} from './user.constant'
+import {
   validateContactOtpVerificationParams,
   validateContactSendOtpParams,
   validateUpdateUserLastSeenFeatureUpdateParams,
@@ -40,7 +44,7 @@ export const _handleContactSendOtp: ControllerHandler<
   // Guard against user updating for a different user, or if user is not logged
   // in.
   if (!sessionUserId || sessionUserId !== userId) {
-    return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+    return res.status(StatusCodes.UNAUTHORIZED).json(UNAUTHORIZED_USER_MESSAGE)
   }
 
   const senderIp = getRequestIp(req)
@@ -122,7 +126,7 @@ export const _handleContactVerifyOtp: ControllerHandler<
   // Guard against user updating for a different user, or if user is not logged
   // in.
   if (!sessionUserId || sessionUserId !== userId) {
-    return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+    return res.status(StatusCodes.UNAUTHORIZED).json(UNAUTHORIZED_USER_MESSAGE)
   }
 
   const logMeta = {
@@ -191,7 +195,7 @@ export const handleFetchUser: ControllerHandler = async (req, res) => {
   if (!sessionUserId) {
     return res
       .status(StatusCodes.UNAUTHORIZED)
-      .json({ message: 'User is unauthorized.' })
+      .json({ message: UNAUTHORIZED_USER_MESSAGE })
   }
 
   return getPopulatedUserById(sessionUserId)
@@ -220,7 +224,7 @@ export const _handleUpdateUserLastSeenFeatureUpdateDate: ControllerHandler<
   const sessionUserId = getUserIdFromSession(req.session)
 
   if (!sessionUserId) {
-    return res.status(StatusCodes.UNAUTHORIZED).json('User is unauthorized.')
+    return res.status(StatusCodes.UNAUTHORIZED).json(UNAUTHORIZED_USER_MESSAGE)
   }
 
   return updateUserLastSeenFeatureUpdateDate(
@@ -230,12 +234,11 @@ export const _handleUpdateUserLastSeenFeatureUpdateDate: ControllerHandler<
     .map(() => {
       return res
         .status(StatusCodes.OK)
-        .json("Updated user's last seen feature update date successfully.")
+        .json(UPDATE_LAST_SEEN_FEATURE_DATE.SUCCESS)
     })
     .mapErr((error) => {
       logger.error({
-        message:
-          "Error occurred while updating user's last seen feature update date",
+        message: UPDATE_LAST_SEEN_FEATURE_DATE.ERROR,
         meta: {
           action: 'handleUpdateUserLastSeenFeatureUpdate',
           userId: sessionUserId,

--- a/src/app/modules/user/user.middleware.ts
+++ b/src/app/modules/user/user.middleware.ts
@@ -25,15 +25,3 @@ export const validateContactOtpVerificationParams = celebrate({
     contact: Joi.string().required(),
   }),
 })
-
-/**
- * Celebrate validation for the update user's last seen feature update date endpoint.
- */
-export const validateUpdateUserLastSeenFeatureUpdateParams = celebrate({
-  [Segments.BODY]: Joi.object({
-    latestLastSeenFeatureUpdateDate: Joi.date()
-      .format('YYYY-MM-DD')
-      .raw()
-      .required(),
-  }),
-})

--- a/src/app/modules/user/user.middleware.ts
+++ b/src/app/modules/user/user.middleware.ts
@@ -1,4 +1,7 @@
-import { celebrate, Joi, Segments } from 'celebrate'
+import JoiDate from '@joi/date'
+import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
+
+const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
 
 /**
  * Celebrate validation for the contact OTP sending endpoint.
@@ -20,5 +23,17 @@ export const validateContactOtpVerificationParams = celebrate({
       .required()
       .regex(/^\d{6}$/),
     contact: Joi.string().required(),
+  }),
+})
+
+/**
+ * Celebrate validation for the update user's last seen feature update date endpoint.
+ */
+export const validateUpdateUserLastSeenFeatureUpdateParams = celebrate({
+  [Segments.BODY]: Joi.object({
+    latestLastSeenFeatureUpdateDate: Joi.date()
+      .format('YYYY-MM-DD')
+      .raw()
+      .required(),
   }),
 })

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -163,6 +163,48 @@ export const updateUserContact = (
 }
 
 /**
+ * Updates the user document with the userId with the given latest seen feature update date and
+ * returns the populated updated user.
+ * @param userId the user id of the user document to update
+ * @param latestLastSeenFeatureUpdateDate the latest last seen feature update date to update with
+ * @returns ok(true) if update was successful
+ * @returns err(MissingUserError) if user document cannot be found
+ * @returns err(DatabaseError) if any error occurs whilst querying the database
+ */
+export const updateUserLastSeenFeatureUpdateDate = (
+  userId: IUserSchema['_id'],
+  latestLastSeenFeatureUpdateDate: Date,
+): ResultAsync<true, MissingUserError | DatabaseError> => {
+  // Retrieve user from database and.
+  // Update user's last seen feature update date attribute.
+  return ResultAsync.fromPromise(
+    UserModel.findByIdAndUpdate(
+      userId,
+      {
+        $set: {
+          flags: { lastSeenFeatureUpdateDate: latestLastSeenFeatureUpdateDate },
+        },
+      },
+      { new: true },
+    ).exec(),
+    (error) => {
+      logger.error({
+        message: 'Database error when updating user contacts',
+        meta: { action: 'updateUserLastSeenFeatureUpdateDate', userId },
+        error,
+      })
+
+      return new DatabaseError()
+    },
+  ).andThen((admin) => {
+    if (!admin) {
+      return errAsync(new MissingUserError())
+    }
+    return okAsync(true as const)
+  })
+}
+
+/**
  * Retrieved the user with populated references by given id.
  * @param userId the id of the user to retrieve
  * @returns ok(populated user document) if user exists

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -166,15 +166,15 @@ export const updateUserContact = (
  * Updates the user document with the userId with the given latest seen feature update date and
  * returns the populated updated user.
  * @param userId the user id of the user document to update
- * @param latestLastSeenFeatureUpdateDate the latest last seen feature update date to update with
+ * @param date the latest last seen feature update date to update with
  * @returns ok(true) if update was successful
  * @returns err(MissingUserError) if user document cannot be found
  * @returns err(DatabaseError) if any error occurs whilst querying the database
  */
 export const updateUserLastSeenFeatureUpdateDate = (
   userId: IUserSchema['_id'],
-  latestLastSeenFeatureUpdateDate: Date,
-): ResultAsync<true, MissingUserError | DatabaseError> => {
+  date: Date,
+): ResultAsync<IPopulatedUser, MissingUserError | DatabaseError> => {
   // Retrieve user from database and
   // update user's last seen feature update date attribute.
   return ResultAsync.fromPromise(
@@ -182,11 +182,16 @@ export const updateUserLastSeenFeatureUpdateDate = (
       userId,
       {
         $set: {
-          flags: { lastSeenFeatureUpdateDate: latestLastSeenFeatureUpdateDate },
+          flags: { lastSeenFeatureUpdateDate: date },
         },
       },
       { new: true },
-    ).exec(),
+    )
+      .populate({
+        path: 'agency',
+        model: AGENCY_SCHEMA_ID,
+      })
+      .exec(),
     (error) => {
       logger.error({
         message:
@@ -201,7 +206,7 @@ export const updateUserLastSeenFeatureUpdateDate = (
     if (!admin) {
       return errAsync(new MissingUserError())
     }
-    return okAsync(true as const)
+    return okAsync(admin as IPopulatedUser)
   })
 }
 

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -166,15 +166,14 @@ export const updateUserContact = (
  * Updates the user document with the userId with the given latest seen feature update date and
  * returns the populated updated user.
  * @param userId the user id of the user document to update
- * @param date the latest last seen feature update date to update with
  * @returns ok(true) if update was successful
  * @returns err(MissingUserError) if user document cannot be found
  * @returns err(DatabaseError) if any error occurs whilst querying the database
  */
 export const updateUserLastSeenFeatureUpdateDate = (
   userId: IUserSchema['_id'],
-  date: Date,
 ): ResultAsync<IPopulatedUser, MissingUserError | DatabaseError> => {
+  const currentDate = new Date()
   // Retrieve user from database and
   // update user's last seen feature update date attribute.
   return ResultAsync.fromPromise(
@@ -182,7 +181,7 @@ export const updateUserLastSeenFeatureUpdateDate = (
       userId,
       {
         $set: {
-          flags: { lastSeenFeatureUpdateDate: date },
+          flags: { lastSeenFeatureUpdateDate: currentDate },
         },
       },
       { new: true },

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -175,8 +175,8 @@ export const updateUserLastSeenFeatureUpdateDate = (
   userId: IUserSchema['_id'],
   latestLastSeenFeatureUpdateDate: Date,
 ): ResultAsync<true, MissingUserError | DatabaseError> => {
-  // Retrieve user from database and.
-  // Update user's last seen feature update date attribute.
+  // Retrieve user from database and
+  // update user's last seen feature update date attribute.
   return ResultAsync.fromPromise(
     UserModel.findByIdAndUpdate(
       userId,
@@ -189,7 +189,8 @@ export const updateUserLastSeenFeatureUpdateDate = (
     ).exec(),
     (error) => {
       logger.error({
-        message: 'Database error when updating user contacts',
+        message:
+          'Database error when updating user last seen feature update date',
         meta: { action: 'updateUserLastSeenFeatureUpdateDate', userId },
         error,
       })

--- a/src/app/routes/api/v3/user/user.routes.ts
+++ b/src/app/routes/api/v3/user/user.routes.ts
@@ -46,15 +46,14 @@ UserRouter.post('/contact/otp/verify', UserController.handleContactVerifyOtp)
 /**
  * Verify the contact verification one-time password (OTP) for the user as part
  * of the contact verification process
- * @route POST /user/flag/last-seen
- * @param body.date the latest seen feature update date to update user with
+ * @route POST /user/flag/new-features-last-seen
  * @returns 200 when user last seen feature update updates sucessfully
  * @returns 401 if user is not currently logged in
  * @returns 422 when userId does not exist in the database
  * @returns 500 when database errors occurs
  */
 UserRouter.post(
-  '/flag/last-seen',
+  '/flag/new-features-last-seen',
   UserController.handleUpdateUserLastSeenFeatureUpdateDate,
 )
 

--- a/src/app/routes/api/v3/user/user.routes.ts
+++ b/src/app/routes/api/v3/user/user.routes.ts
@@ -46,15 +46,15 @@ UserRouter.post('/contact/otp/verify', UserController.handleContactVerifyOtp)
 /**
  * Verify the contact verification one-time password (OTP) for the user as part
  * of the contact verification process
- * @route POST /user/whats-new/last-seen
- * @param body.latestLastSeenFeatureUpdateDate the latest seen feature update date to update user with
+ * @route POST /user/flag/last-seen
+ * @param body.date the latest seen feature update date to update user with
  * @returns 200 when user last seen feature update updates sucessfully
  * @returns 401 if user is not currently logged in
  * @returns 422 when userId does not exist in the database
  * @returns 500 when database errors occurs
  */
 UserRouter.post(
-  '/whats-new/last-seen',
+  '/flag/last-seen',
   UserController.handleUpdateUserLastSeenFeatureUpdateDate,
 )
 

--- a/src/app/routes/api/v3/user/user.routes.ts
+++ b/src/app/routes/api/v3/user/user.routes.ts
@@ -10,7 +10,8 @@ export const UserRouter = Router()
  * Retrieves and returns the session user from the database.
  * @route GET /
  * @returns 200 with the retrieved user if session user is valid
- * @returns 401 if user id does not exist in session
+ * @returns 401 if user is not currently logged in
+ * @returns 422 when userId does not exist in the database
  * @returns 500 when user cannot be found or database errors occurs
  */
 UserRouter.get('/', UserController.handleFetchUser)
@@ -41,5 +42,20 @@ UserRouter.post('/contact/otp/generate', UserController.handleContactSendOtp)
  * @returns 500 when OTP is malformed or for unknown errors
  */
 UserRouter.post('/contact/otp/verify', UserController.handleContactVerifyOtp)
+
+/**
+ * Verify the contact verification one-time password (OTP) for the user as part
+ * of the contact verification process
+ * @route POST /user/whats-new/last-seen
+ * @param body.latestLastSeenFeatureUpdateDate the latest seen feature update date to update user with
+ * @returns 200 when user last seen feature update updates sucessfully
+ * @returns 401 if user is not currently logged in
+ * @returns 422 when userId does not exist in the database
+ * @returns 500 when database errors occurs
+ */
+UserRouter.post(
+  '/whats-new/last-seen',
+  UserController.handleUpdateUserLastSeenFeatureUpdateDate,
+)
 
 export default UserRouter


### PR DESCRIPTION
## Problem
Currently there is no endpoint to update user's last seen feature update date attribute which will be used to handle logic on whether or not to notify form admin users when there is a new feature update.

Closes #3986 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Should return 200 if update is done successfully
- [x] Should return 401 if form admin user is not logged in 
- [x] Should return 422 if form admin user id does not exist in the User Collection
- [x] Should return 500 if there is a database error 
