### PR TITLE
feat: check if field allows intl numbers before sending intl OTP (#3973)

### DIFF
--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -44,7 +44,7 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { BasicField } from '../../../../../shared/types'
 import { SMS_WARNING_TIERS } from '../../../../../shared/utils/verification'
-import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
+import { DatabaseError } from '../../core/core.errors'
 import * as AdminFormService from '../../form/admin-form/admin-form.service'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as FormUtils from '../../form/form.utils'
@@ -1043,7 +1043,7 @@ describe('Verification service', () => {
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
     })
 
-    it('should return MalformedParametersError if there are no matching form fields with the correct id', async () => {
+    it('should return OtpRequestError if there are no matching form fields with the correct id', async () => {
       // Arrange
       const mockForm = {
         form_fields: [
@@ -1064,10 +1064,10 @@ describe('Verification service', () => {
       )
 
       // Assert
-      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(MalformedParametersError)
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
     })
 
-    it('should return MalformedParametersError if form_fields is empty', async () => {
+    it('should return OtpRequestError if form_fields is empty', async () => {
       // Arrange
       const mockForm = {
         form_fields: [],
@@ -1083,7 +1083,7 @@ describe('Verification service', () => {
       )
 
       // Assert
-      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(MalformedParametersError)
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
     })
 
     it('should return OtpRequestError when OTP is requested for an intl number and the form does not allow intl numbers', async () => {

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -44,7 +44,7 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { BasicField } from '../../../../../shared/types'
 import { SMS_WARNING_TIERS } from '../../../../../shared/utils/verification'
-import { DatabaseError } from '../../core/core.errors'
+import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
 import * as AdminFormService from '../../form/admin-form/admin-form.service'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as FormUtils from '../../form/form.utils'
@@ -64,8 +64,9 @@ import * as VerificationService from '../verification.service'
 import {
   generateFieldParams,
   MOCK_HASHED_OTP,
+  MOCK_INTL_RECIPIENT,
+  MOCK_LOCAL_RECIPIENT,
   MOCK_OTP,
-  MOCK_RECIPIENT,
   MOCK_SENDER_IP,
   MOCK_SIGNED_DATA,
 } from './verification.test.helpers'
@@ -327,13 +328,13 @@ describe('Verification service', () => {
         fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
       // Default mock params has fieldType: 'mobile'
       expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
-        MOCK_RECIPIENT,
+        MOCK_LOCAL_RECIPIENT,
         MOCK_OTP,
         mockTransaction.formId,
         MOCK_SENDER_IP,
@@ -343,7 +344,7 @@ describe('Verification service', () => {
           transactionId: mockTransactionId,
           formId: mockTransaction.formId,
           fieldId: mockFieldId,
-          answer: MOCK_RECIPIENT,
+          answer: MOCK_LOCAL_RECIPIENT,
         },
       )
       expect(updateHashSpy).toHaveBeenCalledWith({
@@ -362,7 +363,7 @@ describe('Verification service', () => {
         fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
@@ -387,7 +388,7 @@ describe('Verification service', () => {
         fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
@@ -407,7 +408,7 @@ describe('Verification service', () => {
         fieldId: new ObjectId().toHexString(),
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
@@ -439,7 +440,7 @@ describe('Verification service', () => {
         fieldId: expiredOtpField._id,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
@@ -468,7 +469,8 @@ describe('Verification service', () => {
         fieldId: maxExceededOtpField._id,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
+        senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).not.toHaveBeenCalled()
@@ -498,12 +500,12 @@ describe('Verification service', () => {
         fieldId: field._id,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockMailService.sendVerificationOtp).toHaveBeenCalledWith(
-        MOCK_RECIPIENT,
+        MOCK_LOCAL_RECIPIENT,
         MOCK_OTP,
       )
       expect(
@@ -533,12 +535,12 @@ describe('Verification service', () => {
         fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
       expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
-        MOCK_RECIPIENT,
+        MOCK_LOCAL_RECIPIENT,
         MOCK_OTP,
         new ObjectId(mockFormId),
         MOCK_SENDER_IP,
@@ -560,13 +562,13 @@ describe('Verification service', () => {
         fieldId: mockFieldId,
         hashedOtp: MOCK_HASHED_OTP,
         otp: MOCK_OTP,
-        recipient: MOCK_RECIPIENT,
+        recipient: MOCK_LOCAL_RECIPIENT,
         senderIp: MOCK_SENDER_IP,
       })
 
       // Mock params default to mobile
       expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
-        MOCK_RECIPIENT,
+        MOCK_LOCAL_RECIPIENT,
         MOCK_OTP,
         new ObjectId(mockFormId),
         MOCK_SENDER_IP,
@@ -576,7 +578,7 @@ describe('Verification service', () => {
           transactionId: mockTransactionId,
           formId: new ObjectId(mockFormId),
           fieldId: mockFieldId,
-          answer: MOCK_RECIPIENT,
+          answer: MOCK_LOCAL_RECIPIENT,
         },
       )
       expect(updateHashSpy).toHaveBeenCalledWith({
@@ -1003,11 +1005,13 @@ describe('Verification service', () => {
           }),
         ],
       }
+      const recipient = MOCK_LOCAL_RECIPIENT
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         mockForm,
         fieldId,
+        recipient,
       )
 
       // Assert
@@ -1026,18 +1030,20 @@ describe('Verification service', () => {
           }),
         ],
       }
+      const recipient = MOCK_LOCAL_RECIPIENT
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         mockForm,
         fieldId,
+        recipient,
       )
 
       // Assert
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
     })
 
-    it('should return OtpRequestError if there are no matching form fields with the correct id', async () => {
+    it('should return MalformedParametersError if there are no matching form fields with the correct id', async () => {
       // Arrange
       const mockForm = {
         form_fields: [
@@ -1047,29 +1053,58 @@ describe('Verification service', () => {
           }),
         ],
       }
+      const recipient = MOCK_LOCAL_RECIPIENT
       const fieldIdOtherString = new ObjectId().toHexString()
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         mockForm,
         fieldIdOtherString,
+        recipient,
       )
 
       // Assert
-      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(OtpRequestError)
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(MalformedParametersError)
     })
 
-    it('should return OtpRequestError if form_fields is empty', async () => {
+    it('should return MalformedParametersError if form_fields is empty', async () => {
       // Arrange
       const mockForm = {
         form_fields: [],
       }
       const fieldId = new ObjectId().toHexString()
+      const recipient = MOCK_LOCAL_RECIPIENT
 
       // Act
       const actual = await VerificationService.shouldGenerateMobileOtp(
         mockForm,
         fieldId,
+        recipient,
+      )
+
+      // Assert
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(MalformedParametersError)
+    })
+
+    it('should return OtpRequestError when OTP is requested for an intl number and the form does not allow intl numbers', async () => {
+      // Arrange
+      const fieldId = new ObjectId().toHexString()
+      const mockForm = {
+        form_fields: [
+          generateDefaultField(BasicField.Mobile, {
+            _id: fieldId,
+            isVerifiable: true,
+            allowIntlNumbers: false,
+          }),
+        ],
+      }
+      const recipient = MOCK_INTL_RECIPIENT
+
+      // Act
+      const actual = await VerificationService.shouldGenerateMobileOtp(
+        mockForm,
+        fieldId,
+        recipient,
       )
 
       // Assert

--- a/src/app/modules/verification/__tests__/verification.test.helpers.ts
+++ b/src/app/modules/verification/__tests__/verification.test.helpers.ts
@@ -6,7 +6,8 @@ import { IVerificationField } from 'src/types'
 export const MOCK_SIGNED_DATA = 'mockSignedData'
 export const MOCK_HASHED_OTP = 'mockHashedOtp'
 export const MOCK_OTP = '123456'
-export const MOCK_RECIPIENT = '81234567'
+export const MOCK_LOCAL_RECIPIENT = '+6581234567'
+export const MOCK_INTL_RECIPIENT = '+011234567890'
 export const MOCK_SENDER_IP = '200.0.0.0'
 
 export const VFN_FIELD_DEFAULTS = {

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -627,14 +627,8 @@ export const shouldGenerateMobileOtp = (
   // Get the field with this fieldId
   const field = form_fields?.find(({ _id }) => fieldId === String(_id))
 
-  if (!field)
-    return errAsync(new MalformedParametersError('Field id not found'))
-
-  if (field.fieldType !== BasicField.Mobile) {
-    return errAsync(
-      new MalformedParametersError('Field id is not a mobile field'),
-    )
-  }
+  if (!field || field.fieldType !== BasicField.Mobile)
+    return errAsync(new OtpRequestError())
 
   // Check if recipient is within the allowed countries set by the field
   const recipientIsWithinAllowedCountries =


### PR DESCRIPTION
## Problem
Currently, SMS OTP is generated for international mobile numbers even though the field from which it is requested did not allow intl numbers to be entered.

Closes #3973  

## Solution
Prior to sending the SMS OTP to an intl mobile number, check if the field it was requested from allows intl numbers to be added.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Should return OtpRequestError if SMS OTP is requested for an international number when the field does not allow it
