### PR TITLE
feat(v2/storage-5): allow download of responses with date range

### DIFF
--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -186,13 +186,18 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
           {({ isOpen }) => (
             <>
               <PopoverAnchor>
-                <Wrap shouldWrapChildren spacing="0.5rem" align="center">
+                <Wrap
+                  shouldWrapChildren
+                  spacingX="0.5rem"
+                  spacingY={0}
+                  align="center"
+                >
                   <Input
                     aria-label="Start date"
                     id={`${props.name}-start-date`}
                     onKeyDown={handlePreventOpenNativeCalendar}
                     type="date"
-                    w="fit-content"
+                    w="8.5rem"
                     sx={{
                       // Chrome displays a default calendar icon, which we want to hide
                       // so all browsers display our icon consistently.
@@ -213,7 +218,8 @@ export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(
                     id={`${props.name}-end-date`}
                     onKeyDown={handlePreventOpenNativeCalendar}
                     type="date"
-                    w="fit-content"
+                    w="8.5rem"
+                    borderRightRadius={0}
                     sx={{
                       // Chrome displays a default calendar icon, which we want to hide
                       // so all browsers display our icon consistently.

--- a/frontend/src/components/DatePicker/DateRangeInput.tsx
+++ b/frontend/src/components/DatePicker/DateRangeInput.tsx
@@ -23,17 +23,19 @@ import {
 } from '@chakra-ui/react'
 import { compareAsc } from 'date-fns'
 
+import { DateString } from '~shared/types'
+
 import { BxCalendar } from '~assets/icons'
 import IconButton from '~components/IconButton'
 import Input, { InputProps } from '~components/Input'
 
 import { DateRangePicker } from './DateRangePicker'
-import { convertToDateString, IsoDateString } from './utils'
+import { convertToDateString } from './utils'
 
 export interface DateRangeInputProps
   extends Omit<InputProps, 'value' | 'onChange'> {
-  value?: IsoDateString[]
-  onChange?: (val: IsoDateString[]) => void
+  value?: DateString[]
+  onChange?: (val: DateString[]) => void
 }
 
 export const DateRangeInput = forwardRef<DateRangeInputProps, 'input'>(

--- a/frontend/src/components/DatePicker/utils.ts
+++ b/frontend/src/components/DatePicker/utils.ts
@@ -6,11 +6,9 @@ import {
   subDays,
 } from 'date-fns'
 import range from 'lodash/range'
-import { Opaque } from 'type-fest'
 import { v4 as uuidv4 } from 'uuid'
 
-// Format yyyy-MM-dd
-export type IsoDateString = Opaque<string, 'IsoDateString'>
+import { DateString } from '~shared/types'
 
 /**
  * Full names of calendar months
@@ -128,6 +126,6 @@ export const generateValidUuidClass = (): string => {
   return `a${uuidv4().replaceAll('-', '_')}`
 }
 
-export const convertToDateString = (date: Date): IsoDateString => {
-  return format(date, 'yyyy-MM-dd') as IsoDateString
+export const convertToDateString = (date: Date): DateString => {
+  return format(date, 'yyyy-MM-dd') as DateString
 }

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -23,9 +23,13 @@ export const countFormSubmissions = async ({
   dates,
 }: {
   formId: string
-  dates?: SubmissionCountQueryDto
+  dates?: Partial<SubmissionCountQueryDto>
 }): Promise<number> => {
   const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
+  if (dates && (!dates.startDate || !dates.endDate)) {
+    delete dates.startDate
+    delete dates.endDate
+  }
   if (dates) {
     return ApiService.get(queryUrl, {
       params: { ...dates },

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -26,13 +26,9 @@ export const countFormSubmissions = async ({
   dates?: Partial<SubmissionCountQueryDto>
 }): Promise<number> => {
   const queryUrl = `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/count`
-  if (dates && (!dates.startDate || !dates.endDate)) {
-    delete dates.startDate
-    delete dates.endDate
-  }
-  if (dates) {
+  if (dates && dates.startDate && dates.endDate) {
     return ApiService.get(queryUrl, {
-      params: { ...dates },
+      params: dates,
     }).then(({ data }) => data)
   }
   return ApiService.get(queryUrl).then(({ data }) => data)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/SecretKeyVerification.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/SecretKeyVerification.tsx
@@ -31,7 +31,7 @@ interface SecretKeyFormInputs {
 }
 
 const useSecretKeyVerification = () => {
-  const { setSecretKey, formPublicKey, isLoading, responsesCount } =
+  const { setSecretKey, formPublicKey, isLoading, totalResponsesCount } =
     useStorageResponsesContext()
 
   const {
@@ -103,7 +103,7 @@ const useSecretKeyVerification = () => {
 
   return {
     isLoading,
-    responsesCount,
+    totalResponsesCount,
     fileUploadRef,
     handleFileSelect,
     handleVerifyKeypair,
@@ -116,7 +116,7 @@ const useSecretKeyVerification = () => {
 export const SecretKeyVerification = (): JSX.Element => {
   const {
     isLoading,
-    responsesCount,
+    totalResponsesCount,
     fileUploadRef,
     handleVerifyKeypair,
     register,
@@ -134,9 +134,9 @@ export const SecretKeyVerification = (): JSX.Element => {
         <Skeleton isLoaded={!isLoading} w="fit-content">
           <Text as="h2" textStyle="h2" whiteSpace="pre-line">
             <Text color="primary.500" as="span">
-              {responsesCount?.toLocaleString() ?? '-'}
+              {totalResponsesCount?.toLocaleString() ?? '-'}
             </Text>
-            {simplur` ${[responsesCount ?? 0]}response[|s] to date`}
+            {simplur` ${[totalResponsesCount ?? 0]}response[|s] to date`}
           </Text>
         </Skeleton>
         <form onSubmit={handleVerifyKeypair} noValidate>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
@@ -1,10 +1,14 @@
 import { createContext, useContext } from 'react'
 
+import { DateString } from '~shared/types'
+
 import { DownloadEncryptedParams } from './useDecryptionWorkers'
 
 export interface StorageResponsesContextProps {
   secretKey?: string
   setSecretKey: (secretKey: string) => void
+  dateRange: DateString[]
+  setDateRange: (dateRange: DateString[]) => void
   downloadParams: Omit<DownloadEncryptedParams, 'downloadAttachments'> | null
   responsesCount?: number
   formPublicKey: string | null

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
@@ -11,6 +11,7 @@ export interface StorageResponsesContextProps {
   setDateRange: (dateRange: DateString[]) => void
   downloadParams: Omit<DownloadEncryptedParams, 'downloadAttachments'> | null
   totalResponsesCount?: number
+  dateRangeResponsesCount?: number
   formPublicKey: string | null
   isLoading: boolean
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
@@ -10,7 +10,7 @@ export interface StorageResponsesContextProps {
   dateRange: DateString[]
   setDateRange: (dateRange: DateString[]) => void
   downloadParams: Omit<DownloadEncryptedParams, 'downloadAttachments'> | null
-  responsesCount?: number
+  totalResponsesCount?: number
   formPublicKey: string | null
   isLoading: boolean
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -19,10 +19,18 @@ export const StorageResponsesProvider = ({
   if (!formId) throw new Error('No formId provided')
 
   const { data: form, isLoading: isAdminFormLoading } = useAdminForm()
+
+  const [dateRange, setDateRange] = useState<DateString[]>([])
   const { data: totalResponsesCount, isLoading: isFormResponsesLoading } =
     useFormResponsesCount()
+  const {
+    data: dateRangeResponsesCount,
+    isLoading: isDateRangeResponsesCountLoading,
+  } = useFormResponsesCount({
+    startDate: dateRange?.[0],
+    endDate: dateRange?.[1],
+  })
   const [secretKey, setSecretKey] = useSecretKey(formId)
-  const [dateRange, setDateRange] = useState<DateString[]>([])
 
   const formPublicKey = useMemo(() => {
     if (!form || form.responseMode !== FormResponseMode.Encrypt) return null
@@ -42,9 +50,13 @@ export const StorageResponsesProvider = ({
   return (
     <StorageResponsesContext.Provider
       value={{
-        isLoading: isAdminFormLoading || isFormResponsesLoading,
+        isLoading:
+          isAdminFormLoading ||
+          isFormResponsesLoading ||
+          isDateRangeResponsesCountLoading,
         formPublicKey,
         totalResponsesCount,
+        dateRangeResponsesCount,
         downloadParams,
         secretKey,
         setSecretKey,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -38,14 +38,15 @@ export const StorageResponsesProvider = ({
   }, [form])
 
   const downloadParams = useMemo(() => {
-    if (!secretKey) return null
+    if (!secretKey || !dateRangeResponsesCount) return null
 
     return {
       secretKey,
+      responsesCount: dateRangeResponsesCount,
       startDate: dateRange[0],
       endDate: dateRange[1],
     }
-  }, [dateRange, secretKey])
+  }, [dateRange, dateRangeResponsesCount, secretKey])
 
   return (
     <StorageResponsesContext.Provider

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { FormResponseMode } from '~shared/types'
+import { DateString, FormResponseMode } from '~shared/types'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
@@ -22,6 +22,7 @@ export const StorageResponsesProvider = ({
   const { data: responsesCount, isLoading: isFormResponsesLoading } =
     useFormResponsesCount()
   const [secretKey, setSecretKey] = useSecretKey(formId)
+  const [dateRange, setDateRange] = useState<DateString[]>([])
 
   const formPublicKey = useMemo(() => {
     if (!form || form.responseMode !== FormResponseMode.Encrypt) return null
@@ -33,11 +34,10 @@ export const StorageResponsesProvider = ({
 
     return {
       secretKey,
-      // TODO: Add selector for start and end dates.
-      endDate: undefined,
-      startDate: undefined,
+      startDate: dateRange[0],
+      endDate: dateRange[1],
     }
-  }, [secretKey])
+  }, [dateRange, secretKey])
 
   return (
     <StorageResponsesContext.Provider
@@ -48,6 +48,8 @@ export const StorageResponsesProvider = ({
         downloadParams,
         secretKey,
         setSecretKey,
+        dateRange,
+        setDateRange,
       }}
     >
       {children}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -19,7 +19,7 @@ export const StorageResponsesProvider = ({
   if (!formId) throw new Error('No formId provided')
 
   const { data: form, isLoading: isAdminFormLoading } = useAdminForm()
-  const { data: responsesCount, isLoading: isFormResponsesLoading } =
+  const { data: totalResponsesCount, isLoading: isFormResponsesLoading } =
     useFormResponsesCount()
   const [secretKey, setSecretKey] = useSecretKey(formId)
   const [dateRange, setDateRange] = useState<DateString[]>([])
@@ -44,7 +44,7 @@ export const StorageResponsesProvider = ({
       value={{
         isLoading: isAdminFormLoading || isFormResponsesLoading,
         formPublicKey,
-        responsesCount,
+        totalResponsesCount,
         downloadParams,
         secretKey,
         setSecretKey,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -27,8 +27,8 @@ export const StorageResponsesProvider = ({
     data: dateRangeResponsesCount,
     isLoading: isDateRangeResponsesCountLoading,
   } = useFormResponsesCount({
-    startDate: dateRange?.[0],
-    endDate: dateRange?.[1],
+    startDate: dateRange[0],
+    endDate: dateRange[1],
   })
   const [secretKey, setSecretKey] = useSecretKey(formId)
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
@@ -2,12 +2,21 @@ import { EmptyResponses } from '../common/EmptyResponses'
 
 import { SecretKeyVerification } from './SecretKeyVerification'
 import { useStorageResponsesContext } from './StorageResponsesContext'
+import { StorageResponsesProvider } from './StorageResponsesProvider'
 import { UnlockedResponses } from './UnlockedResponses'
 
-export const StorageResponsesTab = (): JSX.Element => {
-  const { responsesCount, secretKey } = useStorageResponsesContext()
+export const StorageResponsesTab = () => {
+  return (
+    <StorageResponsesProvider>
+      <ProvidedStorageResponsesTab />
+    </StorageResponsesProvider>
+  )
+}
 
-  if (responsesCount === 0) {
+const ProvidedStorageResponsesTab = (): JSX.Element => {
+  const { totalResponsesCount, secretKey } = useStorageResponsesContext()
+
+  if (totalResponsesCount === 0) {
     return <EmptyResponses />
   }
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
@@ -2,18 +2,9 @@ import { EmptyResponses } from '../common/EmptyResponses'
 
 import { SecretKeyVerification } from './SecretKeyVerification'
 import { useStorageResponsesContext } from './StorageResponsesContext'
-import { StorageResponsesProvider } from './StorageResponsesProvider'
 import { UnlockedResponses } from './UnlockedResponses'
 
-export const StorageResponsesTab = () => {
-  return (
-    <StorageResponsesProvider>
-      <ProvidedStorageResponsesTab />
-    </StorageResponsesProvider>
-  )
-}
-
-const ProvidedStorageResponsesTab = (): JSX.Element => {
+export const StorageResponsesTab = (): JSX.Element => {
   const { totalResponsesCount, secretKey } = useStorageResponsesContext()
 
   if (totalResponsesCount === 0) {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -30,14 +30,16 @@ export const DownloadButton = (): JSX.Element => {
   const [progressModalTimeout, setProgressModalTimeout] = useState<
     number | null
   >(null)
-  const { downloadParams, totalResponsesCount } = useStorageResponsesContext()
+  const { downloadParams, dateRangeResponsesCount } =
+    useStorageResponsesContext()
+
   const [_downloadCount, setDownloadCount] = useState(0)
   const downloadCount = useThrottle(_downloadCount, 1000)
 
   const downloadPercentage = useMemo(() => {
-    if (!totalResponsesCount) return 0
-    return Math.floor((downloadCount / totalResponsesCount) * 100)
-  }, [downloadCount, totalResponsesCount])
+    if (!dateRangeResponsesCount) return 0
+    return Math.floor((downloadCount / dateRangeResponsesCount) * 100)
+  }, [downloadCount, dateRangeResponsesCount])
 
   useTimeout(onProgressModalOpen, progressModalTimeout)
 
@@ -84,9 +86,9 @@ export const DownloadButton = (): JSX.Element => {
 
   return (
     <>
-      {totalResponsesCount && (
+      {dateRangeResponsesCount !== undefined && (
         <DownloadWithAttachmentModal
-          responsesCount={totalResponsesCount}
+          responsesCount={dateRangeResponsesCount}
           isOpen={isDownloadModalOpen}
           onClose={onDownloadModalClose}
           onDownload={handleExportCsvWithAttachments}
@@ -95,7 +97,7 @@ export const DownloadButton = (): JSX.Element => {
           isDownloading={handleExportCsvMutation.isLoading}
         />
       )}
-      {totalResponsesCount && (
+      {dateRangeResponsesCount !== undefined && (
         <ProgressModal
           isOpen={isProgressModalOpen}
           onClose={handleAbortDecryption}
@@ -103,8 +105,9 @@ export const DownloadButton = (): JSX.Element => {
           isDownloading={handleExportCsvMutation.isLoading}
         >
           <Text mb="1rem">
-            <b>{totalResponsesCount.toLocaleString()}</b> responses are being
-            processed. Navigating away from this page will stop the download.
+            <b>{dateRangeResponsesCount.toLocaleString()}</b> responses are
+            being processed. Navigating away from this page will stop the
+            download.
           </Text>
         </ProgressModal>
       )}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -30,14 +30,14 @@ export const DownloadButton = (): JSX.Element => {
   const [progressModalTimeout, setProgressModalTimeout] = useState<
     number | null
   >(null)
-  const { downloadParams, responsesCount } = useStorageResponsesContext()
+  const { downloadParams, totalResponsesCount } = useStorageResponsesContext()
   const [_downloadCount, setDownloadCount] = useState(0)
   const downloadCount = useThrottle(_downloadCount, 1000)
 
   const downloadPercentage = useMemo(() => {
-    if (!responsesCount) return 0
-    return Math.floor((downloadCount / responsesCount) * 100)
-  }, [downloadCount, responsesCount])
+    if (!totalResponsesCount) return 0
+    return Math.floor((downloadCount / totalResponsesCount) * 100)
+  }, [downloadCount, totalResponsesCount])
 
   useTimeout(onProgressModalOpen, progressModalTimeout)
 
@@ -84,9 +84,9 @@ export const DownloadButton = (): JSX.Element => {
 
   return (
     <>
-      {responsesCount && (
+      {totalResponsesCount && (
         <DownloadWithAttachmentModal
-          responsesCount={responsesCount}
+          responsesCount={totalResponsesCount}
           isOpen={isDownloadModalOpen}
           onClose={onDownloadModalClose}
           onDownload={handleExportCsvWithAttachments}
@@ -95,7 +95,7 @@ export const DownloadButton = (): JSX.Element => {
           isDownloading={handleExportCsvMutation.isLoading}
         />
       )}
-      {responsesCount && (
+      {totalResponsesCount && (
         <ProgressModal
           isOpen={isProgressModalOpen}
           onClose={handleAbortDecryption}
@@ -103,7 +103,7 @@ export const DownloadButton = (): JSX.Element => {
           isDownloading={handleExportCsvMutation.isLoading}
         >
           <Text mb="1rem">
-            <b>{responsesCount.toLocaleString()}</b> responses are being
+            <b>{totalResponsesCount.toLocaleString()}</b> responses are being
             processed. Navigating away from this page will stop the download.
           </Text>
         </ProgressModal>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
@@ -3,7 +3,10 @@ import { Box, Flex, Grid, Skeleton, Stack, Text } from '@chakra-ui/react'
 import simplur from 'simplur'
 
 import Button from '~components/Button'
+import { DateRangeInput } from '~components/DatePicker/DateRangeInput'
 import Pagination from '~components/Pagination'
+
+import { useStorageResponsesContext } from '../StorageResponsesContext'
 
 import { DownloadButton } from './DownloadButton'
 import { ResponsesTable } from './ResponsesTable'
@@ -28,6 +31,8 @@ export const UnlockedResponses = (): JSX.Element => {
     }
     return count
   }, [filteredCount, count, submissionId])
+
+  const { dateRange, setDateRange } = useStorageResponsesContext()
 
   const prettifiedResponsesCount = useMemo(() => {
     if (filteredCount !== undefined) {
@@ -76,6 +81,7 @@ export const UnlockedResponses = (): JSX.Element => {
         </Stack>
         <Stack direction="row" gridArea="export" justifySelf="end">
           <SubmissionSearchbar />
+          <DateRangeInput value={dateRange} onChange={setDateRange} />
           <DownloadButton />
         </Stack>
       </Grid>

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -6,6 +6,7 @@ import { FormFeedbackMetaDto } from '~shared/types'
 import {
   FormSubmissionMetadataQueryDto,
   StorageModeSubmissionMetadataList,
+  SubmissionCountQueryDto,
 } from '~shared/types/submission'
 
 import { adminFormKeys } from '../common/queries'
@@ -20,7 +21,8 @@ import {
 export const adminFormResponsesKeys = {
   base: [...adminFormKeys.base, 'responses'] as const,
   id: (id: string) => [...adminFormResponsesKeys.base, id] as const,
-  count: (id: string) => [...adminFormResponsesKeys.id(id), 'count'] as const,
+  count: (id: string, dates: [startDate: string, endDate: string] | []) =>
+    [...adminFormResponsesKeys.id(id), 'count', ...dates] as const,
   metadata: (id: string, params: FormSubmissionMetadataQueryDto) => {
     const builtParams = params.submissionId
       ? [params.submissionId]
@@ -43,13 +45,21 @@ export const adminFormFeedbackKeys = {
 /**
  * @precondition Must be wrapped in a Router as `useParam` is used.
  */
-export const useFormResponsesCount = (): UseQueryResult<number> => {
+export const useFormResponsesCount = (
+  dates?: SubmissionCountQueryDto,
+): UseQueryResult<number> => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
+  let dateParams: [startDate: string, endDate: string] | [] = []
+
+  if (dates?.startDate && dates.endDate) {
+    dateParams = [dates.startDate, dates.endDate]
+  }
+
   return useQuery(
-    adminFormResponsesKeys.count(formId),
-    () => countFormSubmissions({ formId }),
+    adminFormResponsesKeys.count(formId, dateParams),
+    () => countFormSubmissions({ formId, dates }),
     { staleTime: 10 * 60 * 1000 },
   )
 }


### PR DESCRIPTION
Builds on #3965

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR allows for downloading of responses by entering a date range. Also updates the method of calculating the number of responses to download by retrieving responses count by date on date range selection instead of only during decryption.

Related to #3129

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: pass in selected date range to storage download
- feat: pass separate `dateRangeResponsesCount` prop via context
- feat: use `dateRangeResponseCount` for rendering download progress

**Improvements**:

- ref(storage): rename `responsesCount` prop passed down from context to `totalResponsesCount`

## Before & After Screenshots
None needed i think...
