### PR TITLE
feat(storage-responses/2): render individual storage mode form response

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -21,6 +21,7 @@ import { CreatePage } from '~features/admin-form/create/CreatePage'
 import {
   FeedbackPage,
   FormResultsLayout,
+  IndividualResponsePage,
   ResponsesLayout,
   ResponsesPage,
 } from '~features/admin-form/responses'
@@ -90,7 +91,7 @@ export const AppRouter = (): JSX.Element => {
               <Route index element={<ResponsesPage />} />
               <Route
                 path=":submissionId"
-                element={<div>individual response page</div>}
+                element={<IndividualResponsePage />}
               />
             </Route>
             <Route

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -1,5 +1,6 @@
 import {
   FormSubmissionMetadataQueryDto,
+  StorageModeSubmissionDto,
   StorageModeSubmissionMetadataList,
   SubmissionCountQueryDto,
 } from '~shared/types/submission'
@@ -45,5 +46,23 @@ export const getFormSubmissionsMetadata = async (
         page,
       },
     },
+  ).then(({ data }) => data)
+}
+
+/**
+ * Returns the data of a single submission of a given storage mode form
+ * @param formId The id of the form to query
+ * @param submissionId The id of the submission
+ * @returns The data of the submission
+ */
+export const getEncryptedSubmissionById = async ({
+  formId,
+  submissionId,
+}: {
+  formId: string
+  submissionId: string
+}): Promise<StorageModeSubmissionDto> => {
+  return ApiService.get<StorageModeSubmissionDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/${submissionId}`,
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -1,0 +1,120 @@
+import { memo, useCallback } from 'react'
+import { BiDownload } from 'react-icons/bi'
+import { useMutation } from 'react-query'
+import { Stack, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react'
+import FileSaver from 'file-saver'
+
+import { BasicField } from '~shared/types'
+
+import Button from '~components/Button'
+import FormLabel from '~components/FormControl/FormLabel'
+
+import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
+import { downloadAndDecryptAttachment } from '../ResponsesPage/storage/utils/downloadAndDecryptAttachment'
+
+export interface DecryptedRowBaseProps {
+  row: AugmentedDecryptedResponse
+}
+type DecryptedRowProps = DecryptedRowBaseProps & {
+  secretKey: string
+}
+
+const DecryptedQuestionLabel = ({ row }: DecryptedRowBaseProps) => {
+  return (
+    <FormLabel questionNumber={`${row.questionNumber}.`} isRequired>
+      {row.question}
+    </FormLabel>
+  )
+}
+
+const DecryptedHeaderRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
+  return (
+    <Text
+      textStyle="h2"
+      as="h2"
+      color="primary.500"
+      mb="0.5rem"
+      _notFirst={{ mt: '2.5rem' }}
+    >
+      {row.signature ? `[verified] ` : ''}
+      {row.question}
+    </Text>
+  )
+}
+
+const DecryptedTableRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
+  return (
+    <Stack>
+      <DecryptedQuestionLabel row={row} />
+      <Table variant="column-stripe" sx={{ tableLayout: 'fixed' }}>
+        <Tbody>
+          {row.answerArray?.map((row, idx) => (
+            <Tr key={idx}>
+              {Array.isArray(row) ? (
+                row.map((col, cidx) => <Td key={cidx}>{col}</Td>)
+              ) : (
+                <Td>{row}</Td>
+              )}
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Stack>
+  )
+}
+
+const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
+  const handleDownloadMutation = useMutation(async (url: string) => {
+    const byteArray = await downloadAndDecryptAttachment(url, secretKey)
+    if (!byteArray) throw new Error('Invalid file')
+    return FileSaver.saveAs(new Blob([byteArray]), row.answer)
+  })
+
+  const handleDownload = useCallback(() => {
+    if (!row.downloadUrl) return
+    return handleDownloadMutation.mutate(row.downloadUrl)
+  }, [handleDownloadMutation, row.downloadUrl])
+
+  return (
+    <Stack>
+      <DecryptedQuestionLabel row={row} />
+      <Text textStyle="body-1">
+        Filename:{' '}
+        {row.answer && (
+          <Button
+            variant="link"
+            aria-label="Download file"
+            isDisabled={handleDownloadMutation.isLoading}
+            onClick={handleDownload}
+            rightIcon={<BiDownload fontSize="1.5rem" />}
+          >
+            {row.answer}
+          </Button>
+        )}
+      </Text>
+    </Stack>
+  )
+}
+
+export const DecryptedRow = memo(
+  ({ row, secretKey }: DecryptedRowProps): JSX.Element => {
+    switch (row.fieldType) {
+      case BasicField.Section:
+        return <DecryptedHeaderRow row={row} />
+      case BasicField.Attachment:
+        return <DecryptedAttachmentRow row={row} secretKey={secretKey} />
+      case BasicField.Table:
+        return <DecryptedTableRow row={row} />
+      default:
+        return (
+          <Stack>
+            <DecryptedQuestionLabel row={row} />
+            {row.answer && <Text textStyle="body-1">{row.answer}</Text>}
+            {row.answerArray && (
+              <Text textStyle="body-1">{row.answerArray.join(', ')}</Text>
+            )}
+          </Stack>
+        )
+    }
+  },
+)

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -128,6 +128,9 @@ export const IndividualResponsePage = (): JSX.Element => {
         </Stack>
         <Stack>
           <LoadingDecryption />
+          {data?.responses.map((r) => (
+            <div>{JSON.stringify(r)}</div>
+          ))}
         </Stack>
       </Stack>
     </Grid>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useMemo } from 'react'
+import {
+  BiChevronLeft,
+  BiChevronRight,
+  BiLeftArrow,
+  BiLeftArrowAlt,
+} from 'react-icons/bi'
+import { Link as ReactLink, useParams } from 'react-router-dom'
+import {
+  Box,
+  ButtonGroup,
+  Flex,
+  Grid,
+  Icon,
+  Link,
+  Skeleton,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+
+import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
+import IconButton from '~components/IconButton'
+
+import {
+  SecretKeyVerification,
+  useStorageResponsesContext,
+} from '../ResponsesPage/storage'
+import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
+
+export const IndividualResponsePage = (): JSX.Element => {
+  const { submissionId } = useParams()
+  if (!submissionId) throw new Error('Missing submissionId')
+
+  const { secretKey } = useStorageResponsesContext()
+  const { lastNavPage } = useUnlockedResponses()
+
+  const backLink = useMemo(() => {
+    if (lastNavPage) {
+      return `..?page=${lastNavPage}`
+    }
+    return `..`
+  }, [lastNavPage])
+
+  if (!secretKey) {
+    return <SecretKeyVerification />
+  }
+
+  return (
+    <Grid
+      px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
+      columnGap={{ base: '0.5rem', lg: '1rem' }}
+      templateColumns={{ base: 'repeat(4, 1fr)', md: 'repeat(12, 1fr)' }}
+    >
+      <Stack direction="row" gridColumn="2 / -2" justify="space-between">
+        <Link
+          display="inline-flex"
+          as={ReactLink}
+          variant="standalone"
+          to={backLink}
+        >
+          <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
+          Back to list
+        </Link>
+        <Skeleton>
+          <Text textStyle="h2" as="h2">
+            Respondent #2
+          </Text>
+        </Skeleton>
+        <ButtonGroup>
+          <IconButton
+            icon={<BiChevronLeft />}
+            aria-label="Previous submission"
+          />
+          <IconButton icon={<BiChevronRight />} aria-label="Next submission" />
+        </ButtonGroup>
+      </Stack>
+    </Grid>
+  )
+}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -117,14 +117,14 @@ export const IndividualResponsePage = (): JSX.Element => {
             </Text>
             &nbsp;{submissionId}
           </Text>
-          <Text display="inline-flex">
+          <Box display="inline-flex">
             <Text as="span" textStyle="subhead-1">
               Time:
             </Text>
             <Skeleton isLoaded={!isLoading}>
               &nbsp;{data?.submissionTime ?? 'Loading...'}
             </Skeleton>
-          </Text>
+          </Box>
         </Stack>
         <Stack>
           <LoadingDecryption />

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import {
   BiChevronLeft,
   BiChevronRight,
@@ -15,10 +15,11 @@ import {
   Link,
   Skeleton,
   Stack,
+  StackDivider,
   Text,
 } from '@chakra-ui/react'
+import { times } from 'lodash'
 
-import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import IconButton from '~components/IconButton'
 
 import {
@@ -27,12 +28,37 @@ import {
 } from '../ResponsesPage/storage'
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
+import { useIndividualSubmission } from './queries'
+
+const LoadingDecryption = memo(() => {
+  return (
+    <Stack spacing="1.5rem" divider={<StackDivider />}>
+      <Skeleton h="2rem" maxW="20rem" mb="0.5rem" />
+      <Stack>
+        <Skeleton h="1.5rem" maxW="32rem" />
+        <Skeleton h="1.5rem" maxW="5rem" />
+      </Stack>
+      <Stack>
+        <Skeleton h="1.5rem" maxW="12rem" />
+        <Skeleton h="1.5rem" maxW="5rem" />
+      </Stack>
+      <Stack>
+        <Skeleton h="1.5rem" maxW="24rem" />
+        <Skeleton h="1.5rem" maxW="3rem" />
+      </Stack>
+      <Box />
+    </Stack>
+  )
+})
+
 export const IndividualResponsePage = (): JSX.Element => {
   const { submissionId } = useParams()
   if (!submissionId) throw new Error('Missing submissionId')
 
   const { secretKey } = useStorageResponsesContext()
-  const { lastNavPage } = useUnlockedResponses()
+  const { lastNavPage, getNextSubmissionId, getPreviousSubmissionId } =
+    useUnlockedResponses()
+  const { data, isLoading } = useIndividualSubmission()
 
   const backLink = useMemo(() => {
     if (lastNavPage) {
@@ -51,28 +77,58 @@ export const IndividualResponsePage = (): JSX.Element => {
       columnGap={{ base: '0.5rem', lg: '1rem' }}
       templateColumns={{ base: 'repeat(4, 1fr)', md: 'repeat(12, 1fr)' }}
     >
-      <Stack direction="row" gridColumn="2 / -2" justify="space-between">
-        <Link
-          display="inline-flex"
-          as={ReactLink}
-          variant="standalone"
-          to={backLink}
+      <Stack spacing="2.5rem" gridColumn="2 / -2">
+        <Stack direction="row" justify="space-between" align="center">
+          <Link
+            display="inline-flex"
+            as={ReactLink}
+            variant="standalone"
+            to={backLink}
+          >
+            <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
+            Back to list
+          </Link>
+          <Skeleton isLoaded={!isLoading}>
+            <Text textStyle="h2" as="h2">
+              Respondent #2
+            </Text>
+          </Skeleton>
+          <ButtonGroup>
+            <IconButton
+              icon={<BiChevronLeft />}
+              aria-label="Previous submission"
+            />
+            <IconButton
+              icon={<BiChevronRight />}
+              aria-label="Next submission"
+            />
+          </ButtonGroup>
+        </Stack>
+        <Stack
+          bg="primary.100"
+          p="1.5rem"
+          sx={{
+            fontFeatureSettings: "'tnum' on, 'lnum' on, 'zero' on, 'cv05' on",
+          }}
         >
-          <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
-          Back to list
-        </Link>
-        <Skeleton>
-          <Text textStyle="h2" as="h2">
-            Respondent #2
+          <Text display="inline-flex">
+            <Text as="span" textStyle="subhead-1">
+              Reference number:
+            </Text>
+            &nbsp;{submissionId}
           </Text>
-        </Skeleton>
-        <ButtonGroup>
-          <IconButton
-            icon={<BiChevronLeft />}
-            aria-label="Previous submission"
-          />
-          <IconButton icon={<BiChevronRight />} aria-label="Next submission" />
-        </ButtonGroup>
+          <Text display="inline-flex">
+            <Text as="span" textStyle="subhead-1">
+              Time:
+            </Text>
+            <Skeleton isLoaded={!isLoading}>
+              &nbsp;{data?.submissionTime ?? 'Loading...'}
+            </Skeleton>
+          </Text>
+        </Stack>
+        <Stack>
+          <LoadingDecryption />
+        </Stack>
       </Stack>
     </Grid>
   )

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,15 +1,9 @@
-import { memo, useCallback, useMemo } from 'react'
-import {
-  BiChevronLeft,
-  BiChevronRight,
-  BiLeftArrow,
-  BiLeftArrowAlt,
-} from 'react-icons/bi'
+import { memo, useMemo } from 'react'
+import { BiChevronLeft, BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
 import { Link as ReactLink, useParams } from 'react-router-dom'
 import {
   Box,
   ButtonGroup,
-  Flex,
   Grid,
   Icon,
   Link,
@@ -18,7 +12,6 @@ import {
   StackDivider,
   Text,
 } from '@chakra-ui/react'
-import { times } from 'lodash'
 
 import IconButton from '~components/IconButton'
 
@@ -28,6 +21,7 @@ import {
 } from '../ResponsesPage/storage'
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
+import { DecryptedRow } from './DecryptedRow'
 import { useIndividualSubmission } from './queries'
 
 const LoadingDecryption = memo(() => {
@@ -127,10 +121,16 @@ export const IndividualResponsePage = (): JSX.Element => {
           </Box>
         </Stack>
         <Stack>
-          <LoadingDecryption />
-          {data?.responses.map((r) => (
-            <div>{JSON.stringify(r)}</div>
-          ))}
+          {isLoading ? (
+            <LoadingDecryption />
+          ) : (
+            <Stack spacing="1.5rem" divider={<StackDivider />}>
+              {data?.responses.map((r, idx) => (
+                <DecryptedRow row={r} secretKey={secretKey} key={idx} />
+              ))}
+              <Box />
+            </Stack>
+          )}
         </Stack>
       </Stack>
     </Grid>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/index.ts
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/index.ts
@@ -1,0 +1,1 @@
+export { IndividualResponsePage } from './IndividualResponsePage'

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query'
 import { useParams } from 'react-router-dom'
 
-import { getEncryptedSubmissionById } from '../AdminSubmissionsService'
+import { getDecryptedSubmissionById } from '../AdminSubmissionsService'
 import { adminFormResponsesKeys } from '../queries'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
 
@@ -18,7 +18,7 @@ export const useIndividualSubmission = () => {
 
   return useQuery(
     adminFormResponsesKeys.individual(formId, submissionId),
-    () => getEncryptedSubmissionById({ formId, submissionId }),
+    () => getDecryptedSubmissionById({ formId, submissionId, secretKey }),
     {
       staleTime: 10 * 60 * 1000,
       enabled: !!secretKey,

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
@@ -20,7 +20,8 @@ export const useIndividualSubmission = () => {
     adminFormResponsesKeys.individual(formId, submissionId),
     () => getDecryptedSubmissionById({ formId, submissionId, secretKey }),
     {
-      staleTime: 10 * 60 * 1000,
+      // Will never update once fetched.
+      staleTime: Infinity,
       enabled: !!secretKey,
     },
   )

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/queries.ts
@@ -1,0 +1,27 @@
+import { useQuery } from 'react-query'
+import { useParams } from 'react-router-dom'
+
+import { getEncryptedSubmissionById } from '../AdminSubmissionsService'
+import { adminFormResponsesKeys } from '../queries'
+import { useStorageResponsesContext } from '../ResponsesPage/storage'
+
+/**
+ * @precondition Must be wrapped in a Router as `useParam` is used.
+ */
+export const useIndividualSubmission = () => {
+  const { formId, submissionId } = useParams()
+  if (!formId || !submissionId) {
+    throw new Error('No formId or submissionId provided')
+  }
+
+  const { secretKey } = useStorageResponsesContext()
+
+  return useQuery(
+    adminFormResponsesKeys.individual(formId, submissionId),
+    () => getEncryptedSubmissionById({ formId, submissionId }),
+    {
+      staleTime: 10 * 60 * 1000,
+      enabled: !!secretKey,
+    },
+  )
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/common/ResponsesTabWrapper.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/common/ResponsesTabWrapper.tsx
@@ -1,4 +1,4 @@
-import { Container } from '@chakra-ui/react'
+import { Box, Container } from '@chakra-ui/react'
 
 export const ResponsesTabWrapper = ({
   children,
@@ -6,17 +6,18 @@ export const ResponsesTabWrapper = ({
   children: React.ReactNode
 }): JSX.Element => {
   return (
-    <Container
-      overflowY="auto"
-      px={{ base: '1.5rem', md: '1.25rem' }}
-      py={{ base: '1.5rem', md: '3rem' }}
-      maxW="69.5rem"
-      flex={1}
-      display="flex"
-      flexDir="column"
-      color="secondary.500"
-    >
-      {children}
-    </Container>
+    <Box overflowY="auto">
+      <Container
+        px={{ base: '1.5rem', md: '1.25rem' }}
+        py={{ base: '1.5rem', md: '3rem' }}
+        maxW="69.5rem"
+        flex={1}
+        display="flex"
+        flexDir="column"
+        color="secondary.500"
+      >
+        {children}
+      </Container>
+    </Box>
   )
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -78,8 +78,12 @@ export const ResponsesTable = () => {
   }, [currentPage, gotoPage])
 
   const handleRowClick = useCallback(
-    (submissionId: string) => {
-      return navigate(`${submissionId}`)
+    (submissionId: string, respondentNumber) => {
+      return navigate(submissionId, {
+        state: {
+          respondentNumber,
+        },
+      })
     },
     [navigate],
   )
@@ -144,7 +148,9 @@ export const ResponsesTable = () => {
               as="div"
               {...row.getRowProps()}
               px={0}
-              onClick={() => handleRowClick(row.values.refNo)}
+              onClick={() =>
+                handleRowClick(row.values.refNo, row.values.number)
+              }
             >
               {row.cells.map((cell) => {
                 return (

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
@@ -76,6 +76,9 @@ const useProvideUnlockedResponses = () => {
       const currentResponseIndex = metadata.findIndex(
         (response) => response.refNo === currentSubmissionId,
       )
+
+      if (currentResponseIndex === -1) return
+
       // If id belongs to the last submission in page, return first of next page
       if (currentResponseIndex === metadata.length - 1) {
         const data = nextMetadata[0]
@@ -96,6 +99,9 @@ const useProvideUnlockedResponses = () => {
       const currentResponseIndex = metadata.findIndex(
         (response) => response.refNo === currentSubmissionId,
       )
+
+      if (currentResponseIndex === -1) return
+
       // If id belongs to the first submission in page, return last of previous page
       if (currentResponseIndex === 0) {
         if (!currentPage || currentPage === 1) return

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
@@ -13,6 +13,8 @@ import { useFormResponses } from '~features/admin-form/responses/queries'
 
 import { usePageSearchParams } from './hooks/usePageSearchParams'
 
+const PAGE_SIZE = 10
+
 interface UnlockedResponsesContextProps {
   currentPage?: number
   setCurrentPage: (page: number) => void
@@ -24,6 +26,8 @@ interface UnlockedResponsesContextProps {
   getPreviousSubmissionId: (
     currentSubmissionId: string,
   ) => SubmissionId | undefined
+  onNavNextSubmissionId: (currentSubmissionId: string) => void
+  onNavPreviousSubmissionId: (currentSubmissionId: string) => void
   lastNavPage?: number
 }
 
@@ -41,7 +45,7 @@ export const useUnlockedResponses = (): UnlockedResponsesContextProps => {
   return context
 }
 
-const useProvideUnlockedResponses = () => {
+const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
   const [currentPage, setCurrentPage] = usePageSearchParams()
   // Storing the params in the state for navigation when user returns from
   // individual response view.
@@ -54,19 +58,59 @@ const useProvideUnlockedResponses = () => {
   }, [currentPage, lastNavPage])
 
   const { data: { count, metadata = [] } = {}, isLoading } =
-    useFormResponses(currentPage)
+    useFormResponses(lastNavPage)
   const {
     data: { metadata: prevMetadata = [] } = {},
     isLoading: isPrevLoading,
-  } = useFormResponses(currentPage ?? 0)
+  } = useFormResponses(lastNavPage ?? 0)
   const {
     data: { metadata: nextMetadata = [] } = {},
     isLoading: isNextLoading,
-  } = useFormResponses(currentPage ?? 2)
+  } = useFormResponses(lastNavPage ?? 2)
+
+  const totalPageCount = useMemo(
+    () => (count ? Math.ceil(count / PAGE_SIZE) : 0),
+    [count],
+  )
 
   const isAnyLoading = useMemo(
     () => isLoading || isPrevLoading || isNextLoading,
     [isLoading, isNextLoading, isPrevLoading],
+  )
+
+  const onNavNextSubmissionId = useCallback(
+    (currentSubmissionId: string) => {
+      if (isAnyLoading || (lastNavPage ?? 1) >= totalPageCount) return
+      // Get row index of current submission in the metadata.
+      const currentResponseIndex = metadata.findIndex(
+        (response) => response.refNo === currentSubmissionId,
+      )
+
+      if (currentResponseIndex === -1) return
+
+      // If id belongs to the last submission in page, return first of next page
+      if (currentResponseIndex === metadata.length - 1) {
+        setLastNavPage((lastNavPage ?? 1) + 1)
+      }
+    },
+    [isAnyLoading, lastNavPage, metadata, totalPageCount],
+  )
+
+  const onNavPreviousSubmissionId = useCallback(
+    (currentSubmissionId: string) => {
+      if (isAnyLoading) return
+
+      // Get row index of current submission in the metadata.
+      const currentResponseIndex = metadata.findIndex(
+        (response) => response.refNo === currentSubmissionId,
+      )
+
+      // If id belongs to the first submission in page, return last of previous page
+      if (currentResponseIndex === 0 && lastNavPage && lastNavPage > 1) {
+        setLastNavPage(lastNavPage - 1)
+      }
+    },
+    [isAnyLoading, lastNavPage, metadata],
   )
 
   const getNextSubmissionId = useCallback(
@@ -81,14 +125,11 @@ const useProvideUnlockedResponses = () => {
 
       // If id belongs to the last submission in page, return first of next page
       if (currentResponseIndex === metadata.length - 1) {
-        const data = nextMetadata[0]
-        setCurrentPage(currentPage ?? 2)
-        return data?.refNo
-      } else {
-        return metadata[currentResponseIndex + 1]?.refNo
+        return nextMetadata[0]?.refNo
       }
+      return metadata[currentResponseIndex + 1]?.refNo
     },
-    [currentPage, isAnyLoading, metadata, nextMetadata, setCurrentPage],
+    [isAnyLoading, metadata, nextMetadata],
   )
 
   const getPreviousSubmissionId = useCallback(
@@ -103,16 +144,12 @@ const useProvideUnlockedResponses = () => {
       if (currentResponseIndex === -1) return
 
       // If id belongs to the first submission in page, return last of previous page
-      if (currentResponseIndex === 0) {
-        if (!currentPage || currentPage === 1) return
-        const data = prevMetadata[prevMetadata.length - 1]
-        setCurrentPage(currentPage - 1)
-        return data?.refNo
-      } else {
-        return metadata[currentResponseIndex - 1]?.refNo
+      if (currentResponseIndex === 0 && lastNavPage && lastNavPage > 1) {
+        return prevMetadata[prevMetadata.length - 1]?.refNo
       }
+      return metadata[currentResponseIndex - 1]?.refNo
     },
-    [currentPage, isAnyLoading, metadata, prevMetadata, setCurrentPage],
+    [isAnyLoading, lastNavPage, metadata, prevMetadata],
   )
 
   return {
@@ -124,6 +161,8 @@ const useProvideUnlockedResponses = () => {
     isAnyLoading,
     getNextSubmissionId,
     getPreviousSubmissionId,
+    onNavNextSubmissionId,
+    onNavPreviousSubmissionId,
     lastNavPage,
   }
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/index.ts
@@ -1,1 +1,3 @@
+export { SecretKeyVerification } from './SecretKeyVerification'
+export { useStorageResponsesContext } from './StorageResponsesContext'
 export { StorageResponsesTab } from './StorageResponsesTab'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
@@ -7,8 +7,13 @@ import { BasicField } from '~shared/types'
 
 import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
 
+export type AugmentedDecryptedResponse = FormField & {
+  questionNumber?: number
+  downloadUrl?: string
+}
+
 type AugmentedFieldAccumulator = {
-  fields: (FormField & { questionNumber?: number; downloadUrl?: string })[]
+  fields: AugmentedDecryptedResponse[]
   nonResponseFieldsCount: number
 }
 
@@ -19,7 +24,7 @@ const isBasicField = (test: string): test is BasicField => {
 export const augmentDecryptedResponses = (
   formFields: FormField[],
   attachmentMetadata: EncryptedAttachmentRecords,
-) => {
+): AugmentedDecryptedResponse[] => {
   const { fields } = formFields.reduce<AugmentedFieldAccumulator>(
     (acc, field, index) => {
       if (!isBasicField(field.fieldType)) return acc

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
@@ -1,0 +1,46 @@
+import type {
+  EncryptedAttachmentRecords,
+  FormField,
+} from '@opengovsg/formsg-sdk/dist/types'
+
+import { BasicField } from '~shared/types'
+
+import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
+
+type AugmentedFieldAccumulator = {
+  fields: (FormField & { questionNumber?: number; downloadUrl?: string })[]
+  nonResponseFieldsCount: number
+}
+
+const isBasicField = (test: string): test is BasicField => {
+  return Object.values(BasicField).indexOf(test as BasicField) !== -1
+}
+
+export const augmentDecryptedResponses = (
+  formFields: FormField[],
+  attachmentMetadata: EncryptedAttachmentRecords,
+) => {
+  const { fields } = formFields.reduce<AugmentedFieldAccumulator>(
+    (acc, field, index) => {
+      if (!isBasicField(field.fieldType)) return acc
+
+      const fieldToAdd: AugmentedFieldAccumulator['fields'][number] = field
+
+      if (NON_RESPONSE_FIELD_SET.has(field.fieldType)) {
+        acc.nonResponseFieldsCount += 1
+      } else {
+        fieldToAdd.questionNumber = index + 1 - acc.nonResponseFieldsCount
+      }
+
+      if (attachmentMetadata[field._id]) {
+        fieldToAdd.downloadUrl = attachmentMetadata[field._id]
+      }
+
+      acc.fields.push(fieldToAdd)
+      return acc
+    },
+    { fields: [], nonResponseFieldsCount: 0 },
+  )
+
+  return fields
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
@@ -1,0 +1,40 @@
+import { decode as decodeBase64 } from '@stablelib/base64'
+import JSZip from 'jszip'
+
+import formsgSdk from '~utils/formSdk'
+
+import { AttachmentsDownloadMap } from '../types'
+
+export const downloadAndDecryptAttachment = async (
+  url: string,
+  secretKey: string,
+) => {
+  const response = await fetch(url)
+  const data = await response.json()
+  data.encryptedFile.binary = decodeBase64(data.encryptedFile.binary)
+  return await formsgSdk.crypto.decryptFile(secretKey, data.encryptedFile)
+}
+
+export const downloadAndDecryptAttachmentsAsZip = async (
+  attachmentDownloadUrls: AttachmentsDownloadMap,
+  secretKey: string,
+) => {
+  const zip = new JSZip()
+  const downloadPromises = []
+  for (const [questionNum, metadata] of attachmentDownloadUrls) {
+    downloadPromises.push(
+      downloadAndDecryptAttachment(metadata.url, secretKey).then(
+        (bytesArray) => {
+          if (bytesArray) {
+            zip.file(
+              'Question ' + questionNum + ' - ' + metadata.filename,
+              bytesArray,
+            )
+          }
+        },
+      ),
+    )
+  }
+  await Promise.all(downloadPromises)
+  return await zip.generateAsync({ type: 'blob' })
+}

--- a/frontend/src/features/admin-form/responses/index.ts
+++ b/frontend/src/features/admin-form/responses/index.ts
@@ -1,3 +1,4 @@
 export { FeedbackPage } from './FeedbackPage'
 export { FormResultsLayout } from './FormResultsLayout'
+export { IndividualResponsePage } from './IndividualResponsePage'
 export { ResponsesLayout, ResponsesPage } from './ResponsesPage'

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -19,6 +19,8 @@ export const adminFormResponsesKeys = {
   count: (id: string) => [...adminFormResponsesKeys.id(id), 'count'] as const,
   metadata: (id: string, page = 1) =>
     [...adminFormResponsesKeys.id(id), 'metadata', page] as const,
+  individual: (id: string, submissionId: string) =>
+    [...adminFormResponsesKeys.id(id), 'individual', submissionId] as const,
 }
 
 export const adminFormFeedbackKeys = {

--- a/frontend/src/features/form/constants.ts
+++ b/frontend/src/features/form/constants.ts
@@ -1,0 +1,7 @@
+import { BasicField } from '~shared/types'
+
+export const NON_RESPONSE_FIELD_SET = new Set([
+  BasicField.Section,
+  BasicField.Statement,
+  BasicField.Image,
+])

--- a/frontend/src/features/form/utils/augmentWithQuestionNo.ts
+++ b/frontend/src/features/form/utils/augmentWithQuestionNo.ts
@@ -1,17 +1,12 @@
-import { BasicField, FormFieldDto } from '~shared/types/field'
+import { FormFieldDto } from '~shared/types/field'
 
+import { NON_RESPONSE_FIELD_SET } from '../constants'
 import { FormFieldWithQuestionNo } from '../types'
 
 type AugmentedFieldAccumulator = {
   fields: FormFieldWithQuestionNo[]
   questionNumber: number
 }
-
-const NON_RESPONSE_FIELD_SET = new Set([
-  BasicField.Section,
-  BasicField.Statement,
-  BasicField.Image,
-])
 
 export const augmentWithQuestionNo = (
   formFields: FormFieldDto[],

--- a/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
@@ -1,16 +1,16 @@
-import { getModeFilter } from 'src/app/modules/submission/submission.utils'
+import { getResponseModeFilter } from 'src/app/modules/submission/submission.utils'
 
 import { BasicField, FormResponseMode } from '../../../../../../shared/types'
 
 describe('submission.utils', () => {
-  describe('getModeFilter', () => {
+  describe('getResponseModeFilter', () => {
     const ALL_FIELD_TYPES = Object.values(BasicField).map((fieldType) => ({
       fieldType,
     }))
 
     it('should return emailMode filter when ResponseMode.Email is passed', async () => {
       // Act
-      const modeFilter = getModeFilter(FormResponseMode.Email)
+      const modeFilter = getResponseModeFilter(FormResponseMode.Email)
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert
@@ -31,7 +31,7 @@ describe('submission.utils', () => {
 
     it('should return encryptMode filter when ResponseMode.Encrypt is passed', async () => {
       // Act
-      const modeFilter = getModeFilter(FormResponseMode.Encrypt)
+      const modeFilter = getResponseModeFilter(FormResponseMode.Encrypt)
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert


### PR DESCRIPTION
> Builds on top of PR to add ResponseTable, #4000.


## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements individual storage mode form response feature. 
It is available on its own endpoint, meaning form admins can navigate to the individual response if they wanted to.

Some metadata is lost if an individual response is navigated to, such as its respondent index from the table, or the ability to go to the next/previous response.
If navigated via the response table, moving to the next/previous respondent will move the page number of the table backlink accordingly.

Allows for downloading of individual attachment in this view, though not the entire attachments of the individual response (pending design).

Related to #3128

TODO: (will be done in future PRs)
- [ ] add feature to download all attachments in submission to achieve feature parity with current AngularJS client.
- [ ] add hover/active styling when clicking in from response table

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: add `IndividualResponsePage` and route
- feat: add `DecryptedRow` component to render responses inside the decrypted submission
- feat: allow nav between individual responses when metadata exists


**Bug Fixes**:

> Bug fix logic will also be moved to the `develop` branch for backwards compatibility

This PR also contains a bug fix for the bug where the server will reject form submissions due to perceived missing fields due to the change in  processing of mobile and email fields in storage mode:
- previously (and the current behaviour in `develop`), all mobile and email field answers are sent to the server in storage mode due to the possibility of requiring the data to email users or to verify fields. 
- in  #3600, the behaviour of the fields to send to the server in storage mode was tightened to only send the minimum data required. This conflicts with the fields the server expects to receive and would return a conflict error.


## Before & After Screenshots
TODO: add stories


