### PR TITLE
dev: enable eb deploy for staging-alt2 branch

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -1,8 +1,8 @@
 name: Deploy to AWS Elastic Beanstalk
 on:
   push:
-    # There should be 6 environments in github actions secrets:
-    # release, release-al2, staging, staging-al2, staging-alt, uat.
+    # There should be 7 environments in github actions secrets:
+    # release, release-al2, staging, staging-al2, staging-alt, staging-alt2, uat.
     # This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name.
     branches:
       - release
@@ -10,6 +10,7 @@ on:
       - staging
       - staging-al2
       - staging-alt
+      - staging-alt2
       - uat
 
 jobs:


### PR DESCRIPTION
## Problem
- Updates `deploy-eb` to enable deployments to the new `staging-alt2` branch
