### PR TITLE
fix(form-v2): perform input validation for field validation options in text, number, table and checkbox fields

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -91,7 +91,10 @@ export const FieldRowContainer = ({
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {
       return {
-        [field._id]: times(field.minimumRows, () => createTableRow(field)),
+        [field._id]: times(
+          field.minimumRows === '' ? 0 : field.minimumRows,
+          () => createTableRow(field),
+        ),
       }
     }
   }, [field])

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -91,10 +91,7 @@ export const FieldRowContainer = ({
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {
       return {
-        [field._id]: times(
-          field.minimumRows === '' ? 0 : field.minimumRows,
-          () => createTableRow(field),
-        ),
+        [field._id]: times(field.minimumRows || 0, () => createTableRow(field)),
       }
     }
   }, [field])

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -247,10 +247,8 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(val) => {
-                    // Only allow numeric inputs and return it as a number
-                    const numericValue = parseInt(val.replace(/\D/g, ''))
-                    onChange(isNaN(numericValue) ? val : numericValue)
+                  onChange={(_, valNum) => {
+                    onChange(isNaN(valNum) ? '' : valNum)
                   }}
                   {...rest}
                   placeholder="Minimum"
@@ -267,10 +265,8 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(val) => {
-                    // Only allow numeric inputs and return it as a number
-                    const numericValue = parseInt(val.replace(/\D/g, ''))
-                    onChange(isNaN(numericValue) ? val : numericValue)
+                  onChange={(_, valNum) => {
+                    onChange(isNaN(valNum) ? '' : valNum)
                   }}
                   {...rest}
                   placeholder="Maximum"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -13,6 +13,8 @@ import NumberInput from '~components/NumberInput'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
+import { validateNumberInput } from '../../../utils/validateNumberInput'
+
 import {
   SPLIT_TEXTAREA_TRANSFORM,
   SPLIT_TEXTAREA_VALIDATION,
@@ -247,8 +249,8 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(_, valNum) => {
-                    onChange(isNaN(valNum) ? '' : valNum)
+                  onChange={(valStr, valNum) => {
+                    validateNumberInput(onChange, valStr, valNum)
                   }}
                   {...rest}
                   placeholder="Minimum"
@@ -265,8 +267,8 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(_, valNum) => {
-                    onChange(isNaN(valNum) ? '' : valNum)
+                  onChange={(valStr, valNum) => {
+                    validateNumberInput(onChange, valStr, valNum)
                   }}
                   {...rest}
                   placeholder="Maximum"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -249,9 +249,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(valStr, valNum) => {
-                    validateNumberInput(onChange, valStr, valNum)
-                  }}
+                  onChange={validateNumberInput(onChange)}
                   {...rest}
                   placeholder="Minimum"
                 />
@@ -267,9 +265,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   precision={0}
                   flex={1}
                   showSteppers={false}
-                  onChange={(valStr, valNum) => {
-                    validateNumberInput(onChange, valStr, valNum)
-                  }}
+                  onChange={validateNumberInput(onChange)}
                   {...rest}
                   placeholder="Maximum"
                 />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -248,8 +248,9 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   flex={1}
                   showSteppers={false}
                   onChange={(val) => {
-                    // Only allow numeric inputs
-                    onChange(val.replace(/\D/g, ''))
+                    // Only allow numeric inputs and return it as a number
+                    const numericValue = parseInt(val.replace(/\D/g, ''))
+                    onChange(isNaN(numericValue) ? val : numericValue)
                   }}
                   {...rest}
                   placeholder="Minimum"
@@ -267,8 +268,9 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
                   flex={1}
                   showSteppers={false}
                   onChange={(val) => {
-                    // Only allow numeric inputs
-                    onChange(val.replace(/\D/g, ''))
+                    // Only allow numeric inputs and return it as a number
+                    const numericValue = parseInt(val.replace(/\D/g, ''))
+                    onChange(isNaN(numericValue) ? val : numericValue)
                   }}
                   {...rest}
                   placeholder="Maximum"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -168,13 +168,19 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
             name="ValidationOptions.customVal"
             control={control}
             rules={customValValidationOptions}
-            render={({ field }) => (
+            render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
+                inputMode="numeric"
                 showSteppers={false}
-                {...field}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
+                onChange={(val) => {
+                  // Only allow numeric inputs and return it as a number
+                  const numericValue = parseInt(val.replace(/\D/g, ''))
+                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                }}
+                {...rest}
               />
             )}
           />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -175,10 +175,8 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(val) => {
-                  // Only allow numeric inputs and return it as a number
-                  const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? val : numericValue)
+                onChange={(_, valNum) => {
+                  onChange(isNaN(valNum) ? '' : valNum)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -178,7 +178,7 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
                 onChange={(val) => {
                   // Only allow numeric inputs and return it as a number
                   const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                  onChange(isNaN(numericValue) ? val : numericValue)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -177,9 +177,7 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(valStr, valNum) => {
-                  validateNumberInput(onChange, valStr, valNum)
-                }}
+                onChange={validateNumberInput(onChange)}
                 {...rest}
               />
             )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -14,6 +14,8 @@ import NumberInput from '~components/NumberInput'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
+import { validateNumberInput } from '~features/admin-form/create/builder-and-design/utils/validateNumberInput'
+
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
 import { EditFieldProps } from '../common/types'
@@ -175,8 +177,8 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(_, valNum) => {
-                  onChange(isNaN(valNum) ? '' : valNum)
+                onChange={(valStr, valNum) => {
+                  validateNumberInput(onChange, valStr, valNum)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -184,9 +184,7 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(valStr, valNum) => {
-                  validateNumberInput(onChange, valStr, valNum)
-                }}
+                onChange={validateNumberInput(onChange)}
                 {...rest}
               />
             )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -175,13 +175,19 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
             name="ValidationOptions.customVal"
             control={control}
             rules={customValValidationOptions}
-            render={({ field }) => (
+            render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
+                inputMode="numeric"
                 showSteppers={false}
-                {...field}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
+                onChange={(val) => {
+                  // Only allow numeric inputs and return it as a number
+                  const numericValue = parseInt(val.replace(/\D/g, ''))
+                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                }}
+                {...rest}
               />
             )}
           />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -14,6 +14,8 @@ import NumberInput from '~components/NumberInput'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
+import { validateNumberInput } from '~features/admin-form/create/builder-and-design/utils/validateNumberInput'
+
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
 import { EditFieldProps } from '../common/types'
@@ -182,10 +184,8 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(val) => {
-                  // Only allow numeric inputs and return it as a number
-                  const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? val : numericValue)
+                onChange={(valStr, valNum) => {
+                  validateNumberInput(onChange, valStr, valNum)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -185,7 +185,7 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
                 onChange={(val) => {
                   // Only allow numeric inputs and return it as a number
                   const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                  onChange(isNaN(numericValue) ? val : numericValue)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -198,7 +198,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 onChange={(val) => {
                   // Only allow numeric inputs and return it as a number
                   const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                  onChange(isNaN(numericValue) ? val : numericValue)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -197,9 +197,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(valStr, valNum) => {
-                  validateNumberInput(onChange, valStr, valNum)
-                }}
+                onChange={validateNumberInput(onChange)}
                 {...rest}
               />
             )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -195,10 +195,8 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(val) => {
-                  // Only allow numeric inputs and return it as a number
-                  const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? val : numericValue)
+                onChange={(_, valNum) => {
+                  onChange(isNaN(valNum) ? '' : valNum)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -20,6 +20,8 @@ import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 import { CopyButton } from '~templates/CopyButton'
 
+import { validateNumberInput } from '~features/admin-form/create/builder-and-design/utils/validateNumberInput'
+
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
 import { EditFieldProps } from '../common/types'
@@ -195,8 +197,8 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 showSteppers={false}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
-                onChange={(_, valNum) => {
-                  onChange(isNaN(valNum) ? '' : valNum)
+                onChange={(valStr, valNum) => {
+                  validateNumberInput(onChange, valStr, valNum)
                 }}
                 {...rest}
               />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -188,13 +188,19 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
             name="ValidationOptions.customVal"
             control={control}
             rules={customValValidationOptions}
-            render={({ field }) => (
+            render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
+                inputMode="numeric"
                 showSteppers={false}
-                {...field}
                 placeholder="Number of characters"
                 isDisabled={!watchedSelectedValidation}
+                onChange={(val) => {
+                  // Only allow numeric inputs and return it as a number
+                  const numericValue = parseInt(val.replace(/\D/g, ''))
+                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                }}
+                {...rest}
               />
             )}
           />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.stories.tsx
@@ -75,7 +75,7 @@ WithAddMoreRows.args = {
   field: {
     ...DEFAULT_TABLE_FIELD,
     addMoreRows: true,
-    maximumRows: DEFAULT_TABLE_FIELD.minimumRows - 1,
+    maximumRows: (DEFAULT_TABLE_FIELD.minimumRows || 0) - 1,
   },
 }
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -151,9 +151,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
             render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
-                onChange={(valStr, valNum) => {
-                  validateNumberInput(onChange, valStr, valNum)
-                }}
+                onChange={validateNumberInput(onChange)}
                 {...rest}
               />
             )}
@@ -192,9 +190,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
               render={({ field: { onChange, ...rest } }) => (
                 <NumberInput
                   flex={1}
-                  onChange={(valStr, valNum) => {
-                    validateNumberInput(onChange, valStr, valNum)
-                  }}
+                  onChange={validateNumberInput(onChange)}
                   {...rest}
                 />
               )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -147,7 +147,17 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
               },
               deps: ['maximumRows'],
             }}
-            render={({ field }) => <NumberInput flex={1} {...field} />}
+            render={({ field: { onChange, ...rest } }) => (
+              <NumberInput
+                flex={1}
+                onChange={(val) => {
+                  // Only allow numeric inputs and return it as a number
+                  const numericValue = parseInt(val.replace(/\D/g, ''))
+                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                }}
+                {...rest}
+              />
+            )}
           />
           <FormErrorMessage>{errors?.minimumRows?.message}</FormErrorMessage>
         </FormControl>
@@ -180,7 +190,17 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
                   'Maximum rows must be greater than minimum rows',
               }}
               control={control}
-              render={({ field }) => <NumberInput flex={1} {...field} />}
+              render={({ field: { onChange, ...rest } }) => (
+                <NumberInput
+                  flex={1}
+                  onChange={(val) => {
+                    // Only allow numeric inputs and return it as a number
+                    const numericValue = parseInt(val.replace(/\D/g, ''))
+                    onChange(isNaN(numericValue) ? 0 : numericValue)
+                  }}
+                  {...rest}
+                />
+              )}
             />
             <FormErrorMessage>{errors?.maximumRows?.message}</FormErrorMessage>
           </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -21,6 +21,7 @@ import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
 import { isTemporaryColumnId } from '~features/admin-form/create/builder-and-design/utils/columnCreation'
+import { validateNumberInput } from '~features/admin-form/create/builder-and-design/utils/validateNumberInput'
 
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
@@ -150,8 +151,8 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
             render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
-                onChange={(_, valNum) => {
-                  onChange(isNaN(valNum) ? '' : valNum)
+                onChange={(valStr, valNum) => {
+                  validateNumberInput(onChange, valStr, valNum)
                 }}
                 {...rest}
               />
@@ -191,8 +192,8 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
               render={({ field: { onChange, ...rest } }) => (
                 <NumberInput
                   flex={1}
-                  onChange={(_, valNum) => {
-                    onChange(isNaN(valNum) ? '' : valNum)
+                  onChange={(valStr, valNum) => {
+                    validateNumberInput(onChange, valStr, valNum)
                   }}
                   {...rest}
                 />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -150,10 +150,8 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
             render={({ field: { onChange, ...rest } }) => (
               <NumberInput
                 flex={1}
-                onChange={(val) => {
-                  // Only allow numeric inputs and return it as a number
-                  const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? val : numericValue)
+                onChange={(_, valNum) => {
+                  onChange(isNaN(valNum) ? '' : valNum)
                 }}
                 {...rest}
               />
@@ -193,10 +191,8 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
               render={({ field: { onChange, ...rest } }) => (
                 <NumberInput
                   flex={1}
-                  onChange={(val) => {
-                    // Only allow numeric inputs and return it as a number
-                    const numericValue = parseInt(val.replace(/\D/g, ''))
-                    onChange(isNaN(numericValue) ? val : numericValue)
+                  onChange={(_, valNum) => {
+                    onChange(isNaN(valNum) ? '' : valNum)
                   }}
                   {...rest}
                 />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -153,7 +153,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
                 onChange={(val) => {
                   // Only allow numeric inputs and return it as a number
                   const numericValue = parseInt(val.replace(/\D/g, ''))
-                  onChange(isNaN(numericValue) ? 0 : numericValue)
+                  onChange(isNaN(numericValue) ? val : numericValue)
                 }}
                 {...rest}
               />
@@ -196,7 +196,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
                   onChange={(val) => {
                     // Only allow numeric inputs and return it as a number
                     const numericValue = parseInt(val.replace(/\D/g, ''))
-                    onChange(isNaN(numericValue) ? 0 : numericValue)
+                    onChange(isNaN(numericValue) ? val : numericValue)
                   }}
                   {...rest}
                 />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -45,8 +45,8 @@ export type EditTableInputs = Omit<
 > & {
   // Every column must have an ID for react-table to render.
   columns: ColumnDto[]
-  maximumRows: string | number
-  minimumRows: string | number
+  maximumRows: number | ''
+  minimumRows: number | ''
 }
 
 export type EditTableProps = EditFieldProps<TableFieldBase>

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
@@ -3,16 +3,20 @@
  * onChange parameter for NumberInput. Calls onChange('') if the input is empty,
  * onChange(number) if the input is a number, and does nothing if the input is
  * invalid.
+ *
+ * Usage:
+ *  <NumberInput
+ *    ...
+ *    onChange={validateNumberInput(onChange)}
+ *  />
  * @param onChange react Component onChange
  * @param valStr input value as string
  * @param valNum input value as number (can be NaN!)
  * @returns void
  */
-export const validateNumberInput = (
-  onChange: (...event: any[]) => void,
-  valStr: string,
-  valNum: number,
-): void => {
-  if (!valStr) return onChange('')
-  if (!isNaN(valNum)) onChange(valNum)
-}
+export const validateNumberInput =
+  (onChange: (...event: any[]) => void) =>
+  (valStr: string, valNum: number): void => {
+    if (!valStr) return onChange('')
+    if (!isNaN(valNum)) onChange(valNum)
+  }

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
@@ -1,0 +1,22 @@
+/**
+ * Validates the input given to Chakra's NumberInput component. Pass this to the
+ * onChange parameter for NumberInput. Calls onChange('') if the input is empty,
+ * onChange(number) if the input is a number, and does nothing if the input is
+ * invalid.
+ * @param onChange react Component onChange
+ * @param valStr input value as string
+ * @param valNum input value as number (can be NaN!)
+ * @returns void
+ */
+export const validateNumberInput = (
+  onChange: (...event: any[]) => void,
+  valStr: string,
+  valNum: number,
+): void => {
+  if (!valStr) {
+    onChange('')
+    return
+  }
+  if (isNaN(valNum)) return
+  onChange(valNum)
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/validateNumberInput.ts
@@ -13,10 +13,6 @@ export const validateNumberInput = (
   valStr: string,
   valNum: number,
 ): void => {
-  if (!valStr) {
-    onChange('')
-    return
-  }
-  if (isNaN(valNum)) return
-  onChange(valNum)
+  if (!valStr) return onChange('')
+  if (!isNaN(valNum)) onChange(valNum)
 }

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -43,9 +43,8 @@ export const FormFields = ({
         // Required so table column fields will render due to useFieldArray usage.
         // See https://react-hook-form.com/api/usefieldarray
         case BasicField.Table:
-          acc[field._id] = times(
-            field.minimumRows === '' ? 0 : field.minimumRows,
-            () => createTableRow(field),
+          acc[field._id] = times(field.minimumRows || 0, () =>
+            createTableRow(field),
           )
           break
       }

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -43,7 +43,10 @@ export const FormFields = ({
         // Required so table column fields will render due to useFieldArray usage.
         // See https://react-hook-form.com/api/usefieldarray
         case BasicField.Table:
-          acc[field._id] = times(field.minimumRows, () => createTableRow(field))
+          acc[field._id] = times(
+            field.minimumRows === '' ? 0 : field.minimumRows,
+            () => createTableRow(field),
+          )
           break
       }
       return acc

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -98,7 +98,7 @@ const transformToTableOutput = (
   // Build table shape
   // Set default input if undefined.
   const populatedInput =
-    input ?? times(schema.minimumRows, () => createTableRow(schema))
+    input ?? times(schema.minimumRows || 0, () => createTableRow(schema))
   const orderedColumnIds = schema.columns.map((col) => col._id)
   const answerArray = populatedInput.map(
     (rowResponse) =>

--- a/frontend/src/templates/Field/Table/TableField.stories.tsx
+++ b/frontend/src/templates/Field/Table/TableField.stories.tsx
@@ -119,7 +119,10 @@ const Template: Story<StoryTableFieldProps> = ({
   )
 
   const data = useMemo(() => {
-    return times(args.schema.minimumRows, () => defaultValue ?? baseRowData)
+    return times(
+      args.schema.minimumRows || 0,
+      () => defaultValue ?? baseRowData,
+    )
   }, [args.schema.minimumRows, defaultValue, baseRowData])
 
   const formMethods = useForm({

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -176,7 +176,7 @@ export const TableField = ({
       {schema.addMoreRows && schema.maximumRows !== undefined ? (
         <AddRowFooter
           currentRows={fields.length}
-          maxRows={schema.maximumRows}
+          maxRows={schema.maximumRows === '' ? 0 : schema.maximumRows}
           handleAddRow={handleAddRow}
         />
       ) : null}

--- a/shared/types/field/checkboxField.ts
+++ b/shared/types/field/checkboxField.ts
@@ -1,8 +1,8 @@
 import { BasicField, FieldBase } from './base'
 
 export type CheckboxValidationOptions = {
-  customMax: number | null
-  customMin: number | null
+  customMax: number | '' | null
+  customMin: number | '' | null
 }
 
 export interface CheckboxFieldBase extends FieldBase {

--- a/shared/types/field/numberField.ts
+++ b/shared/types/field/numberField.ts
@@ -7,7 +7,7 @@ export enum NumberSelectedValidation {
 }
 
 export type NumberValidationOptions = {
-  customVal: number | null
+  customVal: number | '' | null
   selectedValidation: NumberSelectedValidation | null
 }
 

--- a/shared/types/field/tableField.ts
+++ b/shared/types/field/tableField.ts
@@ -21,9 +21,9 @@ export type ColumnDto<C extends Column = Column> = C & { _id: string }
 
 export interface TableFieldBase extends FieldBase {
   fieldType: BasicField.Table
-  minimumRows: number
+  minimumRows: number | ''
   addMoreRows?: boolean
-  maximumRows?: number
+  maximumRows?: number | ''
   columns: Column[]
 }
 

--- a/shared/types/field/utils/textField.ts
+++ b/shared/types/field/utils/textField.ts
@@ -10,6 +10,6 @@ export enum TextSelectedValidation {
 }
 
 export type TextValidationOptions = {
-  customVal: number | null
+  customVal: number | '' | null
   selectedValidation: TextSelectedValidation | null
 }


### PR DESCRIPTION
## Problem

For short and long answer fields, number field and table (max and min row) in the form builder,

1. Exact matching does not work (always reports an error)
2. "Number of characters allowed" field allows decimals, nonpositive numbers and numbers in "e" notation.

Root cause of point 1 is that the value being passed up from the form builder is a `string` whereas the form field validation checks expect a `number` for this value. For point 2, we just need to add input validation checks.

Closes issue #4027 

## Solution

Added input validation checks to ensure only numerals [0-9] can be input into those fields. Also modified `onChange` to parse the user input from a `string` to a `number` prior to assigning it to the `schema` property.

**Breaking Changes** 

- [X] No - this PR is backwards compatible  

## Tests

For **Edit [Short answer, Long answer, Number, Checkbox]** > **Number of characters allowed**:

- [X] Unable to enter characters `e`, `-` and `.`
- [X] Appropriate error message appears when "Exact _x_" and field does not contain _x_ characters
- [X] No error message appears when "Exact _x_" and field contains _x_ characters

and for **Edit Table** > **[Minimum rows, Maximum rows allowed]**:

- [X] Unable to enter characters `e`, `-` and `.`
- [X] Unable to delete rows in form builder when respondent is allowed to add rows and the number of rows is already equal to minimum rows
- [X] Unable to add more rows when respondent is allowed to add rows and the number of rows is already equal to maximum rows