### PR TITLE
fix(form-v2): disallow dragging fields before creation

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -177,7 +177,11 @@ export const FieldRowContainer = ({
   return (
     <Draggable
       index={index}
-      isDragDisabled={!isActive || !!numFormFieldMutations}
+      isDragDisabled={
+        !isActive ||
+        !!numFormFieldMutations ||
+        stateData.state === BuildFieldState.CreatingField
+      }
       disableInteractiveElementBlocking
       draggableId={field._id}
     >


### PR DESCRIPTION
## Problem
See issue #4014 

## Solution
Add a check to disallow dragging if the field is still in the process of being created.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Tests
- [X] Fields are not draggable before they are created
- [X] Fields are still draggable in edit mode