### PR TITLE
fix(form-v2): automatically return to field selection after creating/saving field

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -113,8 +113,9 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
         // @ts-ignore
         transform.input(newField),
       )
+      setToInactive()
     },
-    [editForm, transform],
+    [editForm, transform, setToInactive],
   )
 
   const handleUpdateField = editForm.handleSubmit(async (inputs) => {


### PR DESCRIPTION
## Problem

Closes #4018 

## Solution
Set the build state to be inactive once saved.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Tests
- [X] Return to field drawer after creating a completely new field
- [X] Return to field drawer after saving a change to an existing field