### PR TITLE
feat(storage-responses/3): allow searching of individual using full submission id

### DIFF
--- a/frontend/src/components/Pagination/PaginationDesktop.tsx
+++ b/frontend/src/components/Pagination/PaginationDesktop.tsx
@@ -39,9 +39,9 @@ const DesktopPageButton = ({
   const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
 
   const handleClick = useCallback(() => {
-    if (page === SEPARATOR) return
+    if (page === SEPARATOR || page === selectedPage) return
     onClick(page)
-  }, [onClick, page])
+  }, [onClick, page, selectedPage])
 
   if (page === SEPARATOR) {
     return <Text sx={styles.separator}>{page}</Text>

--- a/frontend/src/components/Searchbar/useSearchbar.ts
+++ b/frontend/src/components/Searchbar/useSearchbar.ts
@@ -24,7 +24,7 @@ export const useSearchbar = ({
    * Defaults to `true`.
    */
   isFocusOnExpand?: boolean
-}): UseSearchbarReturn => {
+} = {}): UseSearchbarReturn => {
   const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded)
   const inputRef = useRef<HTMLInputElement>(null)
 

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -41,14 +41,12 @@ export const countFormSubmissions = async ({
  */
 export const getFormSubmissionsMetadata = async (
   formId: string,
-  page: NonNullable<FormSubmissionMetadataQueryDto['page']> = 1,
+  queryParams: FormSubmissionMetadataQueryDto,
 ): Promise<StorageModeSubmissionMetadataList> => {
   return ApiService.get(
     `${ADMIN_FORM_ENDPOINT}/${formId}/submissions/metadata`,
     {
-      params: {
-        page,
-      },
+      params: queryParams,
     },
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -67,7 +67,7 @@ export const IndividualResponsePage = (): JSX.Element => {
     getPreviousSubmissionId,
     onNavNextSubmissionId,
     onNavPreviousSubmissionId,
-    isAnyLoading,
+    isAnyFetching,
   } = useUnlockedResponses()
   const { data, isLoading } = useIndividualSubmission()
 
@@ -152,13 +152,13 @@ export const IndividualResponsePage = (): JSX.Element => {
           </Skeleton>
           <ButtonGroup>
             <IconButton
-              isDisabled={!prevSubmissionId || isAnyLoading}
+              isDisabled={!prevSubmissionId || isAnyFetching}
               onClick={handleNavigatePrev}
               icon={<BiChevronLeft />}
               aria-label="Previous submission"
             />
             <IconButton
-              isDisabled={!nextSubmissionId || isAnyLoading}
+              isDisabled={!nextSubmissionId || isAnyFetching}
               onClick={handleNavigateNext}
               icon={<BiChevronRight />}
               aria-label="Next submission"

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -63,6 +63,7 @@ export const IndividualResponsePage = (): JSX.Element => {
   const { secretKey } = useStorageResponsesContext()
   const {
     lastNavPage,
+    lastNavSubmissionId,
     getNextSubmissionId,
     getPreviousSubmissionId,
     onNavNextSubmissionId,
@@ -117,11 +118,19 @@ export const IndividualResponsePage = (): JSX.Element => {
   ])
 
   const backLink = useMemo(() => {
-    if (lastNavPage) {
-      return `..?page=${lastNavPage}`
+    const searchParams = new URLSearchParams()
+    if (!lastNavPage && !lastNavSubmissionId) {
+      return `..`
     }
-    return `..`
-  }, [lastNavPage])
+
+    if (lastNavPage) {
+      searchParams.append('page', lastNavPage.toString())
+    }
+    if (lastNavSubmissionId) {
+      searchParams.append('submissionId', lastNavSubmissionId)
+    }
+    return `..?${searchParams}`
+  }, [lastNavPage, lastNavSubmissionId])
 
   if (!secretKey) {
     return <SecretKeyVerification />

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -118,16 +118,16 @@ export const IndividualResponsePage = (): JSX.Element => {
   ])
 
   const backLink = useMemo(() => {
-    const searchParams = new URLSearchParams()
     if (!lastNavPage && !lastNavSubmissionId) {
       return `..`
     }
 
+    const searchParams = new URLSearchParams()
     if (lastNavPage) {
-      searchParams.append('page', lastNavPage.toString())
+      searchParams.set('page', lastNavPage.toString())
     }
     if (lastNavSubmissionId) {
-      searchParams.append('submissionId', lastNavSubmissionId)
+      searchParams.set('submissionId', lastNavSubmissionId)
     }
     return `..?${searchParams}`
   }, [lastNavPage, lastNavSubmissionId])

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -40,7 +40,13 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
 ]
 
 export const ResponsesTable = () => {
-  const { currentPage: currentPage1Indexed, metadata } = useUnlockedResponses()
+  const {
+    currentPage: currentPage1Indexed,
+    metadata,
+    filteredMetadata,
+    submissionId,
+    onRowClick,
+  } = useUnlockedResponses()
 
   const navigate = useNavigate()
 
@@ -48,6 +54,14 @@ export const ResponsesTable = () => {
     () => (currentPage1Indexed ?? 1) - 1,
     [currentPage1Indexed],
   )
+
+  const metadataToUse = useMemo(() => {
+    if (submissionId) {
+      return filteredMetadata
+    } else {
+      return metadata
+    }
+  }, [filteredMetadata, metadata, submissionId])
 
   const {
     prepareRow,
@@ -59,7 +73,7 @@ export const ResponsesTable = () => {
   } = useTable<ResponseColumnData>(
     {
       columns: RESPONSE_TABLE_COLUMNS,
-      data: metadata,
+      data: metadataToUse,
       // Server side pagination.
       manualPagination: true,
       pageCount: currentPage,
@@ -79,13 +93,14 @@ export const ResponsesTable = () => {
 
   const handleRowClick = useCallback(
     (submissionId: string, respondentNumber) => {
+      onRowClick()
       return navigate(submissionId, {
         state: {
           respondentNumber,
         },
       })
     },
-    [navigate],
+    [navigate, onRowClick],
   )
 
   return (

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { BiX } from 'react-icons/bi'
+import { InputRightElement } from '@chakra-ui/react'
+
+import IconButton from '~components/IconButton'
+import Searchbar, { useSearchbar } from '~components/Searchbar'
+
+import { useUnlockedResponses } from './UnlockedResponsesProvider'
+
+export const SubmissionSearchbar = (): JSX.Element => {
+  const { submissionId, setSubmissionId, isAnyFetching } =
+    useUnlockedResponses()
+
+  const [inputValue, setInputValue] = useState(submissionId)
+
+  const { isExpanded, inputRef, handleExpansion, handleCollapse } =
+    useSearchbar({
+      isInitiallyExpanded: !!submissionId,
+    })
+
+  return (
+    <Searchbar
+      isDisabled={isAnyFetching}
+      ref={inputRef}
+      value={inputValue}
+      onChange={(nextValue) => setInputValue(nextValue)}
+      onSearchIconClick={handleExpansion}
+      isExpanded={isExpanded}
+      onSearch={setSubmissionId}
+      placeholder="Search by reference ID"
+      rightElement={
+        <InputRightElement>
+          <IconButton
+            variant="clear"
+            colorScheme="secondary"
+            size="sm"
+            onClick={handleCollapse}
+            icon={<BiX />}
+            aria-label="Hide search"
+          />
+        </InputRightElement>
+      }
+    />
+  )
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { BiX } from 'react-icons/bi'
 import { InputRightElement } from '@chakra-ui/react'
 
@@ -12,6 +12,11 @@ export const SubmissionSearchbar = (): JSX.Element => {
     useUnlockedResponses()
 
   const [inputValue, setInputValue] = useState(submissionId)
+
+  useEffect(() => {
+    // Sync input value with submissionId.
+    setInputValue(submissionId ?? '')
+  }, [submissionId])
 
   const { isExpanded, inputRef, handleExpansion, handleCollapse } =
     useSearchbar({

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Box, Flex, Grid, Skeleton, Stack, Text } from '@chakra-ui/react'
 import simplur from 'simplur'
 
+import Button from '~components/Button'
 import Pagination from '~components/Pagination'
 
 import { DownloadButton } from './DownloadButton'
@@ -18,6 +19,7 @@ export const UnlockedResponses = (): JSX.Element => {
     isLoading,
     submissionId,
     isAnyFetching,
+    setSubmissionId,
   } = useUnlockedResponses()
 
   const countToUse = useMemo(() => {
@@ -35,6 +37,10 @@ export const UnlockedResponses = (): JSX.Element => {
     }
   }, [count, filteredCount])
 
+  const clearSubmissionId = useCallback(() => {
+    setSubmissionId(null)
+  }, [setSubmissionId])
+
   return (
     <Flex flexDir="column" h="100%">
       <Grid
@@ -48,7 +54,12 @@ export const UnlockedResponses = (): JSX.Element => {
           md: "'submissions export'",
         }}
       >
-        <Box gridArea="submissions">
+        <Stack
+          align="center"
+          spacing="1rem"
+          direction="row"
+          gridArea="submissions"
+        >
           <Skeleton isLoaded={!isAnyFetching}>
             <Text textStyle="h4">
               <Text as="span" color="primary.500">
@@ -57,7 +68,12 @@ export const UnlockedResponses = (): JSX.Element => {
               {prettifiedResponsesCount}
             </Text>
           </Skeleton>
-        </Box>
+          {submissionId && (
+            <Button onClick={clearSubmissionId} variant="link">
+              Reset
+            </Button>
+          )}
+        </Stack>
         <Stack direction="row" gridArea="export" justifySelf="end">
           <SubmissionSearchbar />
           <DownloadButton />

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider.tsx
@@ -21,7 +21,7 @@ interface UnlockedResponsesContextProps {
   count?: number
   metadata: StorageModeSubmissionMetadata[]
   isLoading: boolean
-  isAnyLoading: boolean
+  isAnyFetching: boolean
   getNextSubmissionId: (currentSubmissionId: string) => SubmissionId | undefined
   getPreviousSubmissionId: (
     currentSubmissionId: string,
@@ -57,30 +57,31 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
     }
   }, [currentPage, lastNavPage])
 
-  const { data: { count, metadata = [] } = {}, isLoading } =
-    useFormResponses(lastNavPage)
+  const { data: { count, metadata = [] } = {}, isLoading } = useFormResponses(
+    lastNavPage ?? 1,
+  )
   const {
     data: { metadata: prevMetadata = [] } = {},
-    isLoading: isPrevLoading,
-  } = useFormResponses(lastNavPage ?? 0)
+    isFetching: isPrevFetching,
+  } = useFormResponses(currentPage ? 0 : lastNavPage ?? 0)
   const {
     data: { metadata: nextMetadata = [] } = {},
-    isLoading: isNextLoading,
-  } = useFormResponses(lastNavPage ?? 2)
+    isFetching: isNextFetching,
+  } = useFormResponses(currentPage ? 0 : lastNavPage ?? 2)
 
   const totalPageCount = useMemo(
     () => (count ? Math.ceil(count / PAGE_SIZE) : 0),
     [count],
   )
 
-  const isAnyLoading = useMemo(
-    () => isLoading || isPrevLoading || isNextLoading,
-    [isLoading, isNextLoading, isPrevLoading],
+  const isAnyFetching = useMemo(
+    () => isLoading || isPrevFetching || isNextFetching,
+    [isLoading, isNextFetching, isPrevFetching],
   )
 
   const onNavNextSubmissionId = useCallback(
     (currentSubmissionId: string) => {
-      if (isAnyLoading || (lastNavPage ?? 1) >= totalPageCount) return
+      if (isAnyFetching || (lastNavPage ?? 1) >= totalPageCount) return
       // Get row index of current submission in the metadata.
       const currentResponseIndex = metadata.findIndex(
         (response) => response.refNo === currentSubmissionId,
@@ -93,12 +94,12 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
         setLastNavPage((lastNavPage ?? 1) + 1)
       }
     },
-    [isAnyLoading, lastNavPage, metadata, totalPageCount],
+    [isAnyFetching, lastNavPage, metadata, totalPageCount],
   )
 
   const onNavPreviousSubmissionId = useCallback(
     (currentSubmissionId: string) => {
-      if (isAnyLoading) return
+      if (isAnyFetching) return
 
       // Get row index of current submission in the metadata.
       const currentResponseIndex = metadata.findIndex(
@@ -110,12 +111,12 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
         setLastNavPage(lastNavPage - 1)
       }
     },
-    [isAnyLoading, lastNavPage, metadata],
+    [isAnyFetching, lastNavPage, metadata],
   )
 
   const getNextSubmissionId = useCallback(
     (currentSubmissionId: string) => {
-      if (isAnyLoading) return
+      if (isAnyFetching) return
       // Get row index of current submission in the metadata.
       const currentResponseIndex = metadata.findIndex(
         (response) => response.refNo === currentSubmissionId,
@@ -129,12 +130,12 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
       }
       return metadata[currentResponseIndex + 1]?.refNo
     },
-    [isAnyLoading, metadata, nextMetadata],
+    [isAnyFetching, metadata, nextMetadata],
   )
 
   const getPreviousSubmissionId = useCallback(
     (currentSubmissionId: string) => {
-      if (isAnyLoading) return
+      if (isAnyFetching) return
 
       // Get row index of current submission in the metadata.
       const currentResponseIndex = metadata.findIndex(
@@ -149,7 +150,7 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
       }
       return metadata[currentResponseIndex - 1]?.refNo
     },
-    [isAnyLoading, lastNavPage, metadata, prevMetadata],
+    [isAnyFetching, lastNavPage, metadata, prevMetadata],
   )
 
   return {
@@ -158,7 +159,7 @@ const useProvideUnlockedResponses = (): UnlockedResponsesContextProps => {
     count,
     metadata,
     isLoading,
-    isAnyLoading,
+    isAnyFetching,
     getNextSubmissionId,
     getPreviousSubmissionId,
     onNavNextSubmissionId,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/hooks/usePageSearchParams.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/hooks/usePageSearchParams.ts
@@ -2,9 +2,11 @@ import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 const PAGE_KEY = 'page'
+const SUBMISSION_ID_KEY = 'submissionId'
 
 export const usePageSearchParams = () => {
   const [params, setParams] = useSearchParams()
+
   const currentPage = useMemo(() => {
     const value = params.get(PAGE_KEY)
     if (!value) return
@@ -17,12 +19,35 @@ export const usePageSearchParams = () => {
       if (page < 0) {
         page = 1
       }
-      setParams({
-        [PAGE_KEY]: String(page),
-      })
+      params.set(PAGE_KEY, page.toString())
+      setParams(params)
     },
-    [setParams],
+    [params, setParams],
   )
 
-  return [currentPage, setCurrentPage] as const
+  const submissionId = useMemo(() => {
+    const value = params.get(SUBMISSION_ID_KEY)
+    if (!value) return
+    return value
+  }, [params])
+
+  const setSubmissionId = useCallback(
+    (submissionId: string | null) => {
+      if (!submissionId) {
+        params.delete(SUBMISSION_ID_KEY)
+        setParams(params)
+      } else {
+        // Not using params.set due to wanting to remove other params if they exist.
+        setParams({
+          [SUBMISSION_ID_KEY]: submissionId,
+        })
+      }
+    },
+    [params, setParams],
+  )
+
+  return {
+    submissionId: [submissionId, setSubmissionId],
+    page: [currentPage, setCurrentPage],
+  } as const
 }

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -82,7 +82,9 @@ export const useFormResponses = ({
     {
       refetchOnMount: true,
       refetchOnWindowFocus: false,
-      keepPreviousData: true,
+      // Data will never change.
+      staleTime: Infinity,
+      keepPreviousData: !submissionId,
       enabled: !!secretKey && (page > 0 || !!submissionId),
     },
   )

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -1,8 +1,12 @@
+import { useMemo } from 'react'
 import { useQuery, UseQueryResult } from 'react-query'
 import { useParams } from 'react-router-dom'
 
 import { FormFeedbackMetaDto } from '~shared/types'
-import { StorageModeSubmissionMetadataList } from '~shared/types/submission'
+import {
+  FormSubmissionMetadataQueryDto,
+  StorageModeSubmissionMetadataList,
+} from '~shared/types/submission'
 
 import { adminFormKeys } from '../common/queries'
 
@@ -17,8 +21,16 @@ export const adminFormResponsesKeys = {
   base: [...adminFormKeys.base, 'responses'] as const,
   id: (id: string) => [...adminFormResponsesKeys.base, id] as const,
   count: (id: string) => [...adminFormResponsesKeys.id(id), 'count'] as const,
-  metadata: (id: string, page = 1) =>
-    [...adminFormResponsesKeys.id(id), 'metadata', page] as const,
+  metadata: (id: string, params: FormSubmissionMetadataQueryDto) => {
+    const builtParams = params.submissionId
+      ? [params.submissionId]
+      : [params.page ?? 1]
+    return [
+      ...adminFormResponsesKeys.id(id),
+      'metadata',
+      ...builtParams,
+    ] as const
+  },
   individual: (id: string, submissionId: string) =>
     [...adminFormResponsesKeys.id(id), 'individual', submissionId] as const,
 }
@@ -45,22 +57,33 @@ export const useFormResponsesCount = (): UseQueryResult<number> => {
 /**
  * @precondition Must be wrapped in a Router as `useParam` is used.
  */
-export const useFormResponses = (
+export const useFormResponses = ({
   page = 1,
-): UseQueryResult<StorageModeSubmissionMetadataList> => {
+  submissionId,
+}: {
+  page?: number
+  submissionId?: string
+} = {}): UseQueryResult<StorageModeSubmissionMetadataList> => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
   const { secretKey } = useStorageResponsesContext()
 
+  const params = useMemo(() => {
+    if (submissionId) {
+      return { submissionId }
+    }
+    return { page }
+  }, [page, submissionId])
+
   return useQuery(
-    adminFormResponsesKeys.metadata(formId, page),
-    () => getFormSubmissionsMetadata(formId, page),
+    adminFormResponsesKeys.metadata(formId, params),
+    () => getFormSubmissionsMetadata(formId, params),
     {
       refetchOnMount: true,
       refetchOnWindowFocus: false,
       keepPreviousData: true,
-      enabled: !!secretKey && page > 0,
+      enabled: !!secretKey && (page > 0 || !!submissionId),
     },
   )
 }

--- a/frontend/src/theme/components/Searchbar.ts
+++ b/frontend/src/theme/components/Searchbar.ts
@@ -16,13 +16,6 @@ export const Searchbar: ComponentMultiStyleConfig<typeof parts> = {
       const { isExpanded } = props
 
       return {
-        icon: {
-          display: 'flex',
-          fontSize: '1rem',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'secondary.500',
-        },
         field: {
           ...field,
           display: isExpanded ? 'initial' : 'none',


### PR DESCRIPTION
Builds on #3001

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the ability for form admins to search for an individual form response with its response id.

Closes #3128 

## Solution
<!-- How did you solve the problem? -->

**Features**:

- feat: update usePageSearchParams to also return subId search state
- feat: allow searching by id and navigation from searched response
- feat: allow reset of searched submission id

**Improvements**:

- feat: use fetching state instead of loading state to discern loading state of components

## Before & After Screenshots
Unlocked story should show new search bar.
