### PR TITLE
feat: add swipe gestures for rollout announcement modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18795,7 +18795,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
@@ -24897,7 +24897,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immer": {
       "version": "9.0.12",
@@ -25682,7 +25682,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -31082,7 +31082,7 @@
     "nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
       "requires": {
         "big-integer": "^1.6.16"
       }
@@ -35085,6 +35085,11 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
+    },
+    "react-swipeable": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.0.tgz",
+      "integrity": "sha512-NI7KGfQ6gwNFN0Hor3vytYW3iRfMMaivGEuxcADOOfBCx/kqwXE8IfHFxEcxSUkxCYf38COLKYd9EMYZghqaUA=="
     },
     "react-syntax-highlighter": {
       "version": "15.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "react-popper": "^2.3.0",
     "react-query": "^3.34.2",
     "react-router-dom": "^6.0.2",
+    "react-swipeable": "^7.0.0",
     "react-table": "^7.7.0",
     "react-textarea-autosize": "^8.3.3",
     "react-use": "^17.3.1",

--- a/frontend/src/features/rollout-announcement/RolloutAnnouncementModal.tsx
+++ b/frontend/src/features/rollout-announcement/RolloutAnnouncementModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { BiRightArrowAlt } from 'react-icons/bi'
+import { useSwipeable } from 'react-swipeable'
 import {
   Flex,
   Modal,
@@ -47,10 +48,16 @@ export const RolloutAnnouncementModal = ({
     setCurrActiveIdx(Math.min(currActiveIdx + 1, NUM_NEW_FEATURES - 1))
   }, [currActiveIdx, isLastAnnouncement, onClose])
 
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () =>
+      setCurrActiveIdx(Math.min(currActiveIdx + 1, NUM_NEW_FEATURES - 1)),
+    onSwipedRight: () => setCurrActiveIdx(Math.max(currActiveIdx - 1, 0)),
+  })
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={isMobile ? 'full' : 'md'}>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent {...swipeHandlers}>
         <ModalCloseButton />
         {isLastAnnouncement ? (
           <LastFeatureContent updates={OTHER_UPDATES} />


### PR DESCRIPTION
## Solution
Add swipe gestures to navigate to next and previous pages of rollout announcement modal

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Deploy Notes

**New dependencies**:

- [react-swipeable](https://www.npmjs.com/package/react-swipeable) package added to handle swipe gestures