### PR TITLE
feat: add new feature update notification logic

### DIFF
--- a/frontend/src/features/user/mutations.ts
+++ b/frontend/src/features/user/mutations.ts
@@ -11,6 +11,7 @@ import { ApiError } from '~typings/core'
 import { useToast } from '~hooks/useToast'
 import {
   generateUserContactOtp,
+  updateUserLastSeenFeatureUpdateDate,
   verifyUserContactOtp,
 } from '~services/UserService'
 
@@ -39,8 +40,19 @@ export const useUserMutations = () => {
     },
   })
 
+  const updateUserLastSeenFeatureUpdateDateMutation = useMutation<
+    UserDto,
+    ApiError,
+    void
+  >(() => updateUserLastSeenFeatureUpdateDate(), {
+    onSuccess: (newData) => {
+      queryClient.setQueryData(userKeys.base, newData)
+    },
+  })
+
   return {
     generateOtpMutation,
     verifyOtpMutation,
+    updateUserLastSeenFeatureUpdateDateMutation,
   }
 }

--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -7,17 +7,17 @@ export interface FeatureUpdateImage {
 }
 export interface FeatureUpdate {
   id: number
-  date: string
+  date: Date
   title: string
   description: string
   image?: FeatureUpdateImage
 }
 
 // TODO: Confirm the actual features which will be showcased in the What's New section
-export const FeatureUpdateList: FeatureUpdate[] = [
+export const FEATURE_UPDATE_LIST: FeatureUpdate[] = [
   {
     id: 1,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'UI Improvements',
     description: `
   * Cool new datepicker with day, month, and year views
@@ -27,7 +27,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 2,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -38,7 +38,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 3,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -49,7 +49,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 4,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -59,7 +59,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 5,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -70,7 +70,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 6,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -81,7 +81,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 7,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -91,7 +91,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 8,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -102,7 +102,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 9,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -113,7 +113,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 10,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -123,7 +123,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 11,
-    date: '17 June 2022',
+    date: new Date('17 June 2022 GMT+8'),
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -134,7 +134,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 12,
-    date: '10 June 2022',
+    date: new Date('10 June 2022 GMT+8'),
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -145,7 +145,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 13,
-    date: '10 June 2022',
+    date: new Date('10 June 2022 GMT+8'),
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -155,7 +155,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 14,
-    date: '10 June 2022',
+    date: new Date('10 June 2022 GMT+8'),
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -166,7 +166,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 15,
-    date: '10 June 2022',
+    date: new Date('10 June 2022 GMT+8'),
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",

--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -13,6 +13,7 @@ export interface FeatureUpdate {
   image?: FeatureUpdateImage
 }
 
+// TODO: Confirm the actual features which will be showcased in the What's New section
 export const FeatureUpdateList: FeatureUpdate[] = [
   {
     id: 1,

--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -16,7 +16,7 @@ export interface FeatureUpdate {
 export const FeatureUpdateList: FeatureUpdate[] = [
   {
     id: 1,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'UI Improvements',
     description: `
   * Cool new datepicker with day, month, and year views
@@ -26,7 +26,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 2,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -37,7 +37,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 3,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -48,7 +48,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 4,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -58,7 +58,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 5,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -69,7 +69,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 6,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -80,7 +80,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 7,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -90,7 +90,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 8,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -101,7 +101,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 9,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -112,7 +112,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 10,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -122,7 +122,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 11,
-    date: '17 July',
+    date: '17 June 2022',
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -133,7 +133,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 12,
-    date: '10 July',
+    date: '10 June 2022',
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
@@ -144,7 +144,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 13,
-    date: '10 July',
+    date: '10 June 2022',
     title: 'UI Improvements',
     description: `
 * Cool new datepicker with day, month, and year views
@@ -154,7 +154,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 14,
-    date: '10 July',
+    date: '10 June 2022',
     title: 'No more hangups',
     description:
       'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
@@ -165,7 +165,7 @@ export const FeatureUpdateList: FeatureUpdate[] = [
   },
   {
     id: 15,
-    date: '10 July',
+    date: '10 June 2022',
     title: 'Introducing Workspaces',
     description:
       "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",

--- a/frontend/src/features/whats-new/WhatsNewContent.stories.tsx
+++ b/frontend/src/features/whats-new/WhatsNewContent.stories.tsx
@@ -21,7 +21,7 @@ const Template: Story<WhatsNewContentProps> = (args) => {
 
 export const Desktop = Template.bind({})
 Desktop.args = {
-  date: '17 July',
+  date: new Date('17 July 2020 GMT+8'),
   title: 'Introducing Workspaces',
   description:
     'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',

--- a/frontend/src/features/whats-new/WhatsNewContent.tsx
+++ b/frontend/src/features/whats-new/WhatsNewContent.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from 'react-markdown'
 import { Box, Image, Text } from '@chakra-ui/react'
+import { format } from 'date-fns'
 import gfm from 'remark-gfm'
 
 import { useMdComponents } from '~hooks/useMdComponents'
@@ -7,11 +8,13 @@ import { useMdComponents } from '~hooks/useMdComponents'
 import { FeatureUpdateImage } from './FeatureUpdateList'
 
 export interface WhatsNewContentProps {
-  date: string
+  date: Date
   title: string
   description: string
   image?: FeatureUpdateImage
 }
+
+const DATE_FORMAT = 'dd MMMM YYY'
 
 export const WhatsNewContent = ({
   date,
@@ -30,9 +33,10 @@ export const WhatsNewContent = ({
       },
     },
   })
+  const formattedDate = format(date, DATE_FORMAT)
   return (
     <Box paddingX="2.5rem" paddingY="1.25">
-      <Text textStyle="caption-1">{date}</Text>
+      <Text textStyle="caption-1">{formattedDate}</Text>
       <Text textStyle="h4" mb="0.5rem" mt="1rem">
         {title}
       </Text>

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -12,7 +12,7 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
-import { FeatureUpdate, FeatureUpdateList } from './FeatureUpdateList'
+import { FEATURE_UPDATE_LIST, FeatureUpdate } from './FeatureUpdateList'
 import { WhatsNewContent } from './WhatsNewContent'
 
 export type WhatsNewDrawerProps = Pick<
@@ -30,13 +30,15 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
   const [linkText, setLinkText] = useState<string>(UNEXTENDED_LIST_LINK_TEXT)
   const [isListExtended, setIsListExtended] = useState<boolean>(false)
 
-  const listOfFeatureUpdatesShown: FeatureUpdate[] = FeatureUpdateList.filter(
+  const listOfFeatureUpdatesShown: FeatureUpdate[] = FEATURE_UPDATE_LIST.filter(
     (featureUpdate) => featureUpdate.id <= numberOfFeatureUpdatesShown,
   )
 
   const handleOnViewAllUpdatesClick = () => {
     setNumberOfFeatureUpdatesShown(
-      isListExtended ? DEFAULT_FEATURE_UPDATE_COUNT : FeatureUpdateList.length,
+      isListExtended
+        ? DEFAULT_FEATURE_UPDATE_COUNT
+        : FEATURE_UPDATE_LIST.length,
     )
     setLinkText(
       isListExtended ? UNEXTENDED_LIST_LINK_TEXT : EXTENDED_LIST_LINK_TEXT,

--- a/frontend/src/features/whats-new/utils/utils.ts
+++ b/frontend/src/features/whats-new/utils/utils.ts
@@ -1,25 +1,23 @@
-import { isAfter } from 'date-fns'
+import { compareDesc, isAfter } from 'date-fns'
 
 import { UserDto } from '~shared/types/user'
 
-import { FeatureUpdateList } from '../FeatureUpdateList'
+import { FEATURE_UPDATE_LIST } from '../FeatureUpdateList'
 
 export const getShowLatestFeatureUpdateNotification = (
   user: UserDto | undefined,
 ): boolean => {
-  if (user?.flags?.lastSeenFeatureUpdateDate) {
-    const sortedFeatureUpdateList = FeatureUpdateList.sort(
-      (featureUpdateA, featureUpdateB) =>
-        Date.parse(featureUpdateB.date) - Date.parse(featureUpdateA.date),
-    )
-    const lastSeenUserFeatureUpdateDate = new Date(
-      user?.flags?.lastSeenFeatureUpdateDate,
-    )
-
-    const latestFeatureUpdateDate = new Date(sortedFeatureUpdateList[0].date)
-
-    return isAfter(latestFeatureUpdateDate, lastSeenUserFeatureUpdateDate)
+  if (!user?.flags?.lastSeenFeatureUpdateDate) {
+    return true
   }
 
-  return true
+  const latestFeatureUpdate = FEATURE_UPDATE_LIST.sort((a, b) =>
+    compareDesc(a.date, b.date),
+  ).shift()
+
+  if (!latestFeatureUpdate) {
+    return false
+  }
+
+  return isAfter(latestFeatureUpdate.date, user.flags.lastSeenFeatureUpdateDate)
 }

--- a/frontend/src/features/whats-new/utils/utils.ts
+++ b/frontend/src/features/whats-new/utils/utils.ts
@@ -4,28 +4,22 @@ import { UserDto } from '~shared/types/user'
 
 import { FeatureUpdateList } from '../FeatureUpdateList'
 
-export interface shouldShowLatestFeatureUpdateNotificationProps {
-  user: UserDto | undefined
-  isLoading: boolean
-}
+export const getShowLatestFeatureUpdateNotification = (
+  user: UserDto | undefined,
+): boolean => {
+  if (user?.flags?.lastSeenFeatureUpdateDate) {
+    const sortedFeatureUpdateList = FeatureUpdateList.sort(
+      (featureUpdateA, featureUpdateB) =>
+        Date.parse(featureUpdateB.date) - Date.parse(featureUpdateA.date),
+    )
+    const lastSeenUserFeatureUpdateDate = new Date(
+      user?.flags?.lastSeenFeatureUpdateDate,
+    )
 
-export const shouldShowLatestFeatureUpdateNotification = ({
-  user,
-  isLoading,
-}: shouldShowLatestFeatureUpdateNotificationProps): boolean => {
-  if (isLoading) {
-    return false
+    const latestFeatureUpdateDate = new Date(sortedFeatureUpdateList[0].date)
+
+    return isAfter(latestFeatureUpdateDate, lastSeenUserFeatureUpdateDate)
   }
-  const sortedFeatureUpdateList = FeatureUpdateList.sort(
-    (featureUpdateA, featureUpdateB) =>
-      Date.parse(featureUpdateB.date) - Date.parse(featureUpdateA.date),
-  )
-  const lastSeenUserFeatureUpdateDate = new Date(
-    user?.flags?.lastSeenFeatureUpdateDate ??
-      sortedFeatureUpdateList[sortedFeatureUpdateList.length - 1].date,
-  )
 
-  const latestFeatureUpdateDate = new Date(sortedFeatureUpdateList[0].date)
-
-  return isAfter(latestFeatureUpdateDate, lastSeenUserFeatureUpdateDate)
+  return true
 }

--- a/frontend/src/features/whats-new/utils/utils.ts
+++ b/frontend/src/features/whats-new/utils/utils.ts
@@ -1,0 +1,31 @@
+import { isAfter } from 'date-fns'
+
+import { UserDto } from '~shared/types/user'
+
+import { FeatureUpdateList } from '../FeatureUpdateList'
+
+export interface shouldShowLatestFeatureUpdateNotificationProps {
+  user: UserDto | undefined
+  isLoading: boolean
+}
+
+export const shouldShowLatestFeatureUpdateNotification = ({
+  user,
+  isLoading,
+}: shouldShowLatestFeatureUpdateNotificationProps): boolean => {
+  if (isLoading) {
+    return false
+  }
+  const sortedFeatureUpdateList = FeatureUpdateList.sort(
+    (featureUpdateA, featureUpdateB) =>
+      Date.parse(featureUpdateB.date) - Date.parse(featureUpdateA.date),
+  )
+  const lastSeenUserFeatureUpdateDate = new Date(
+    user?.flags?.lastSeenFeatureUpdateDate ??
+      sortedFeatureUpdateList[sortedFeatureUpdateList.length - 1].date,
+  )
+
+  const latestFeatureUpdateDate = new Date(sortedFeatureUpdateList[0].date)
+
+  return isAfter(latestFeatureUpdateDate, lastSeenUserFeatureUpdateDate)
+}

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -12,6 +12,9 @@ import { chunk } from 'lodash'
 
 import Pagination from '~components/Pagination'
 
+import { useUserMutations } from '~features/user/mutations'
+import { useUser } from '~features/user/queries'
+import { shouldShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
 import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
 import CreateFormModal from './components/CreateFormModal'
@@ -108,6 +111,24 @@ export const WorkspacePage = (): JSX.Element => {
     createFormModalDisclosure,
     whatsNewFeatureDrawerDisclosure,
   } = useWorkspaceForms()
+  const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
+  const { user, isLoading: isUserLoading } = useUser()
+  const [shouldShowWhatsNewNotification, setShouldShowWhatsNewNotification] =
+    useState(false)
+  const shouldShowFeatureUpdateNotification =
+    shouldShowLatestFeatureUpdateNotification({
+      user,
+      isLoading: isUserLoading,
+    })
+
+  useEffect(() => {
+    setShouldShowWhatsNewNotification(shouldShowFeatureUpdateNotification)
+  }, [shouldShowFeatureUpdateNotification])
+
+  const onWhatsNewDrawerOpen = () => {
+    whatsNewFeatureDrawerDisclosure.onOpen()
+    updateUserLastSeenFeatureUpdateDateMutation.mutate()
+  }
 
   return (
     <>
@@ -143,7 +164,8 @@ export const WorkspacePage = (): JSX.Element => {
               isLoading={isLoading}
               totalFormCount={totalFormCount}
               handleOpenCreateFormModal={createFormModalDisclosure.onOpen}
-              handleOpenWhatsNewDrawer={whatsNewFeatureDrawerDisclosure.onOpen}
+              handleOpenWhatsNewDrawer={onWhatsNewDrawerOpen}
+              isWhatsNewButtonSolid={shouldShowWhatsNewNotification}
             />
           </Container>
           <Box gridArea="main">

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -14,7 +14,7 @@ import Pagination from '~components/Pagination'
 
 import { useUserMutations } from '~features/user/mutations'
 import { useUser } from '~features/user/queries'
-import { shouldShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
+import { getShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
 import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
 import CreateFormModal from './components/CreateFormModal'
@@ -113,22 +113,18 @@ export const WorkspacePage = (): JSX.Element => {
   } = useWorkspaceForms()
   const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
   const { user, isLoading: isUserLoading } = useUser()
-  const [shouldShowWhatsNewNotification, setShouldShowWhatsNewNotification] =
-    useState(false)
-  const shouldShowFeatureUpdateNotification =
-    shouldShowLatestFeatureUpdateNotification({
-      user,
-      isLoading: isUserLoading,
-    })
+  const shouldShowFeatureUpdateNotification = useMemo(() => {
+    if (isUserLoading || !user) return false
+    return getShowLatestFeatureUpdateNotification(user)
+  }, [isUserLoading, user])
 
-  useEffect(() => {
-    setShouldShowWhatsNewNotification(shouldShowFeatureUpdateNotification)
-  }, [shouldShowFeatureUpdateNotification])
-
-  const onWhatsNewDrawerOpen = () => {
+  const onWhatsNewDrawerOpen = useCallback(() => {
     whatsNewFeatureDrawerDisclosure.onOpen()
     updateUserLastSeenFeatureUpdateDateMutation.mutate()
-  }
+  }, [
+    updateUserLastSeenFeatureUpdateDateMutation,
+    whatsNewFeatureDrawerDisclosure,
+  ])
 
   return (
     <>
@@ -165,7 +161,7 @@ export const WorkspacePage = (): JSX.Element => {
               totalFormCount={totalFormCount}
               handleOpenCreateFormModal={createFormModalDisclosure.onOpen}
               handleOpenWhatsNewDrawer={onWhatsNewDrawerOpen}
-              isWhatsNewButtonSolid={shouldShowWhatsNewNotification}
+              isWhatsNewButtonSolid={shouldShowFeatureUpdateNotification}
             />
           </Container>
           <Box gridArea="main">

--- a/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
@@ -18,6 +18,7 @@ export interface WorkspaceHeaderProps {
   isLoading: boolean
   handleOpenCreateFormModal: () => void
   handleOpenWhatsNewDrawer: () => void
+  isWhatsNewButtonSolid: boolean
 }
 
 /**
@@ -28,9 +29,12 @@ export const WorkspaceHeader = ({
   isLoading,
   handleOpenCreateFormModal,
   handleOpenWhatsNewDrawer,
+  isWhatsNewButtonSolid,
 }: WorkspaceHeaderProps): JSX.Element => {
   const [sortOption, setSortOption] = useState(SortOption.LastUpdated)
   const isMobile = useIsMobile()
+
+  const whatsNewButtonVariant = isWhatsNewButtonSolid ? 'solid' : 'outline'
 
   return (
     <Stack
@@ -67,7 +71,11 @@ export const WorkspaceHeader = ({
         >
           Create form
         </Button>
-        <Button isFullWidth={isMobile} onClick={handleOpenWhatsNewDrawer}>
+        <Button
+          isFullWidth={isMobile}
+          onClick={handleOpenWhatsNewDrawer}
+          variant={whatsNewButtonVariant}
+        >
           What's New
         </Button>
       </Stack>

--- a/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
@@ -71,6 +71,8 @@ export const WorkspaceHeader = ({
         >
           Create form
         </Button>
+        {/* TODO: Button with button variant prop is used temporarily to represent the what's new tab functionality in the admin header. 
+        Shift this to admin header once admin header is implemented.*/}
         <Button
           isFullWidth={isMobile}
           onClick={handleOpenWhatsNewDrawer}

--- a/frontend/src/services/UserService.ts
+++ b/frontend/src/services/UserService.ts
@@ -31,3 +31,10 @@ export const verifyUserContactOtp = (
     params,
   ).then(({ data }) => data)
 }
+
+export const updateUserLastSeenFeatureUpdateDate =
+  async (): Promise<UserDto> => {
+    return ApiService.post<UserDto>(
+      `${USER_ENDPOINT}/flag/new-features-last-seen`,
+    ).then(({ data }) => data)
+  }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
There is currently no logic to check whether or not form admin users should be notified on a new feature update and when to update form admin user's last seen feature update date which is used in the notification logic.

Closes #3988
Closes #3989

## Solution
<!-- How did you solve the problem? -->
As the current header in the Figma design has not been implemented, a solid button signifies that there is a new feature update that the form admin user has not seen while a outlined button signifies that the form admin user is up to date with all the latest feature updates.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

