### PR TITLE
perf(v2): virtualize Select and MultiSelect components to reduce sluggish loads and filters

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15641,6 +15641,19 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@virtuoso.dev/react-urx": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz",
+      "integrity": "sha512-MY0ugBDjFb5Xt8v2HY7MKcRGqw/3gTpMlLXId2EwQvYJoC8sP7nnXjAxcBtTB50KTZhO0SbzsFimaZ7pSdApwA==",
+      "requires": {
+        "@virtuoso.dev/urx": "^0.2.13"
+      }
+    },
+    "@virtuoso.dev/urx": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@virtuoso.dev/urx/-/urx-0.2.13.tgz",
+      "integrity": "sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -22984,7 +22997,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         }
       }
@@ -35174,6 +35187,15 @@
       "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
       "requires": {
         "debounce": "^1.2.1"
+      }
+    },
+    "react-virtuoso": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.14.0.tgz",
+      "integrity": "sha512-Pk3TL0KkWQs2pswDG2tA9SKx8q/59UFShKrGvTdnpt0dYQKTl1Zjlbl2ItTOfqx9sFAqX/U5acCrIBPQIFSGUw==",
+      "requires": {
+        "@virtuoso.dev/react-urx": "^0.2.12",
+        "@virtuoso.dev/urx": "^0.2.12"
       }
     },
     "react-waypoint": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "react-table": "^7.7.0",
     "react-textarea-autosize": "^8.3.3",
     "react-use": "^17.3.1",
+    "react-virtuoso": "^2.14.0",
     "react-waypoint": "^10.1.0",
     "remark-gfm": "^3.0.1",
     "rooks": "^5.11.0",

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelect.stories.tsx
@@ -60,6 +60,7 @@ const INITIAL_COMBOBOX_ITEMS: ComboboxItem[] = [
     label: 'D5',
     disabled: true,
   },
+  ...[...Array(2000).keys()].map(String),
 ]
 
 export default {

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -12,6 +12,7 @@ import {
   UseMultipleSelectionProps,
 } from 'downshift'
 
+import { VIRTUAL_LIST_MAX_HEIGHT } from '../constants'
 import { useItems } from '../hooks/useItems'
 import { MultiSelectContext } from '../MultiSelectContext'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
@@ -21,7 +22,10 @@ import { itemToLabelString, itemToValue } from '../utils/itemUtils'
 
 export interface MultiSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
-> extends Omit<SharedSelectContextReturnProps<Item>, 'isClearable'>,
+> extends Omit<
+      SharedSelectContextReturnProps<Item>,
+      'isClearable' | 'virtualListRef' | 'virtualListHeight'
+    >,
     FormControlOptions {
   /** Controlled selected values */
   values: string[]
@@ -267,6 +271,13 @@ export const MultiSelectProvider = ({
     isEmpty: selectedItems.length === 0,
   })
 
+  const virtualListHeight = useMemo(() => {
+    const totalHeight = filteredItems.length * 48
+    // If the total height is less than the max height, just return the total height.
+    // Otherwise, return the max height.
+    return Math.min(totalHeight, VIRTUAL_LIST_MAX_HEIGHT)
+  }, [filteredItems.length])
+
   return (
     <SelectContext.Provider
       value={{
@@ -302,6 +313,7 @@ export const MultiSelectProvider = ({
         resetInputValue,
         inputAria,
         virtualListRef,
+        virtualListHeight,
       }}
     >
       <MultiSelectContext.Provider

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { VirtuosoHandle } from 'react-virtuoso'
 import {
   FormControlOptions,
   useFormControlProps,
@@ -76,6 +77,7 @@ export const MultiSelectProvider = ({
 
   // Inject for components to manipulate
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const virtualListRef = useRef<VirtuosoHandle>(null)
 
   const { isInvalid, isDisabled, isReadOnly, isRequired } = useFormControlProps(
     {
@@ -172,6 +174,19 @@ export const MultiSelectProvider = ({
     defaultIsOpen,
     defaultInputValue: '',
     defaultHighlightedIndex: 0,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    scrollIntoView: () => {},
+    onHighlightedIndexChange: ({ highlightedIndex }) => {
+      if (
+        highlightedIndex !== undefined &&
+        highlightedIndex >= 0 &&
+        virtualListRef.current
+      ) {
+        virtualListRef.current.scrollIntoView({
+          index: highlightedIndex,
+        })
+      }
+    },
     onStateChange: ({ inputValue, type }) => {
       switch (type) {
         case useCombobox.stateChangeTypes.FunctionSetInputValue:
@@ -286,6 +301,7 @@ export const MultiSelectProvider = ({
         isRequired,
         resetInputValue,
         inputAria,
+        virtualListRef,
       }}
     >
       <MultiSelectContext.Provider

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -8,6 +8,8 @@ import { ComboboxItem } from './types'
 export interface SharedSelectContextReturnProps<
   Item extends ComboboxItem = ComboboxItem,
 > {
+  /** Ref for list virtualization */
+  virtualListRef?: RefObject<VirtuosoHandle>
   /** Set to true to enable search, defaults to `true` */
   isSearchable?: boolean
   /** Set to true to allow clearing of input, defaults to `true` */
@@ -46,7 +48,6 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   isFocused: boolean
   setIsFocused: (isFocused: boolean) => void
   inputRef?: MutableRefObject<HTMLInputElement | null>
-  virtualListRef?: RefObject<VirtuosoHandle>
   resetInputValue: () => void
 }
 

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -9,7 +9,9 @@ export interface SharedSelectContextReturnProps<
   Item extends ComboboxItem = ComboboxItem,
 > {
   /** Ref for list virtualization */
-  virtualListRef?: RefObject<VirtuosoHandle>
+  virtualListRef: RefObject<VirtuosoHandle>
+  /** Height to assign to virtual list */
+  virtualListHeight: number
   /** Set to true to enable search, defaults to `true` */
   isSearchable?: boolean
   /** Set to true to allow clearing of input, defaults to `true` */

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -8,10 +8,6 @@ import { ComboboxItem } from './types'
 export interface SharedSelectContextReturnProps<
   Item extends ComboboxItem = ComboboxItem,
 > {
-  /** Ref for list virtualization */
-  virtualListRef: RefObject<VirtuosoHandle>
-  /** Height to assign to virtual list */
-  virtualListHeight: number
   /** Set to true to enable search, defaults to `true` */
   isSearchable?: boolean
   /** Set to true to allow clearing of input, defaults to `true` */
@@ -51,6 +47,10 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   setIsFocused: (isFocused: boolean) => void
   inputRef?: MutableRefObject<HTMLInputElement | null>
   resetInputValue: () => void
+  /** Ref for list virtualization */
+  virtualListRef: RefObject<VirtuosoHandle>
+  /** Height to assign to virtual list */
+  virtualListHeight: number
 }
 
 export const SelectContext = createContext<SelectContextReturn | undefined>(

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, MutableRefObject, useContext } from 'react'
+import { createContext, MutableRefObject, RefObject, useContext } from 'react'
+import { VirtuosoHandle } from 'react-virtuoso'
 import { CSSObject, FormControlOptions } from '@chakra-ui/react'
 import { UseComboboxPropGetters, UseComboboxState } from 'downshift'
 
@@ -45,6 +46,7 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   isFocused: boolean
   setIsFocused: (isFocused: boolean) => void
   inputRef?: MutableRefObject<HTMLInputElement | null>
+  virtualListRef?: RefObject<VirtuosoHandle>
   resetInputValue: () => void
 }
 

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -9,6 +9,7 @@ import { useCombobox, UseComboboxProps } from 'downshift'
 
 import { ThemeColorScheme } from '~theme/foundations/colours'
 
+import { VIRTUAL_LIST_MAX_HEIGHT } from '../constants'
 import { useItems } from '../hooks/useItems'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
 import { ComboboxItem } from '../types'
@@ -221,6 +222,13 @@ export const SingleSelectProvider = ({
     }
   }, [inputAriaProp, name, selectedItem])
 
+  const virtualListHeight = useMemo(() => {
+    const totalHeight = filteredItems.length * 48
+    // If the total height is less than the max height, just return the total height.
+    // Otherwise, return the max height.
+    return Math.min(totalHeight, VIRTUAL_LIST_MAX_HEIGHT)
+  }, [filteredItems.length])
+
   return (
     <SelectContext.Provider
       value={{
@@ -255,6 +263,7 @@ export const SingleSelectProvider = ({
         resetInputValue,
         inputAria,
         virtualListRef,
+        virtualListHeight,
       }}
     >
       {children}

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { VirtuosoHandle } from 'react-virtuoso'
 import {
   FormControlOptions,
   useFormControlProps,
@@ -95,6 +96,8 @@ export const SingleSelectProvider = ({
     [getFilteredItems],
   )
 
+  const virtualListRef = useRef<VirtuosoHandle>(null)
+
   const {
     toggleMenu,
     closeMenu,
@@ -121,6 +124,19 @@ export const SingleSelectProvider = ({
     itemToString: itemToValue,
     onSelectedItemChange: ({ selectedItem }) => {
       onChange(itemToValue(selectedItem))
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    scrollIntoView: () => {},
+    onHighlightedIndexChange: ({ highlightedIndex }) => {
+      if (
+        highlightedIndex !== undefined &&
+        highlightedIndex >= 0 &&
+        virtualListRef.current
+      ) {
+        virtualListRef.current.scrollIntoView({
+          index: highlightedIndex,
+        })
+      }
     },
     onStateChange: ({ inputValue, type }) => {
       switch (type) {
@@ -238,6 +254,7 @@ export const SingleSelectProvider = ({
         setIsFocused,
         resetInputValue,
         inputAria,
+        virtualListRef,
       }}
     >
       {children}

--- a/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { Virtuoso } from 'react-virtuoso'
 import { Box, List, ListItem } from '@chakra-ui/react'
 
+import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useMultiSelectContext } from '../MultiSelectContext'
 import { useSelectContext } from '../SelectContext'
 import { itemToValue } from '../utils/itemUtils'
@@ -17,6 +18,7 @@ export const MultiSelectMenu = (): JSX.Element => {
     nothingFoundLabel,
     styles,
     virtualListRef,
+    virtualListHeight,
   } = useSelectContext()
 
   const { selectedItems } = useMultiSelectContext()
@@ -32,14 +34,6 @@ export const MultiSelectMenu = (): JSX.Element => {
       update?.()
     }
   }, [isOpen, selectedItems, update])
-
-  const virtualHeight = useMemo(() => {
-    const maxHeight = 12 * 16
-    const totalHeight = items.length * 48
-    // If the total height is less than the max height, just return the total height.
-    // Otherwise, return the max height.
-    return Math.min(totalHeight, maxHeight)
-  }, [items.length])
 
   return (
     <Box
@@ -59,7 +53,8 @@ export const MultiSelectMenu = (): JSX.Element => {
           <Virtuoso
             ref={virtualListRef}
             data={items}
-            style={{ height: virtualHeight }}
+            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+            style={{ height: virtualListHeight }}
             itemContent={(index, item) => {
               return (
                 <MultiDropdownItem

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+import { Virtuoso } from 'react-virtuoso'
 import { Box, List, ListItem } from '@chakra-ui/react'
 
 import { useSelectContext } from '../SelectContext'
@@ -7,10 +9,24 @@ import { DropdownItem } from './DropdownItem'
 import { useSelectPopover } from './SelectPopover'
 
 export const SelectMenu = (): JSX.Element => {
-  const { getMenuProps, isOpen, items, nothingFoundLabel, styles } =
-    useSelectContext()
+  const {
+    getMenuProps,
+    isOpen,
+    items,
+    nothingFoundLabel,
+    styles,
+    virtualListRef,
+  } = useSelectContext()
 
   const { popperRef, popperStyles, popperAttributes } = useSelectPopover()
+
+  const virtualHeight = useMemo(() => {
+    const maxHeight = 12 * 16
+    const totalHeight = items.length * 48
+    // If the total height is less than the max height, just return the total height.
+    // Otherwise, return the max height.
+    return Math.min(totalHeight, maxHeight)
+  }, [items.length])
 
   return (
     <Box
@@ -25,14 +41,22 @@ export const SelectMenu = (): JSX.Element => {
         })}
         sx={styles.list}
       >
-        {isOpen &&
-          items.map((item, index) => (
-            <DropdownItem
-              key={`${itemToValue(item)}${index}`}
-              item={item}
-              index={index}
-            />
-          ))}
+        {isOpen && items.length > 0 && (
+          <Virtuoso
+            ref={virtualListRef}
+            data={items}
+            style={{ height: virtualHeight }}
+            itemContent={(index, item) => {
+              return (
+                <DropdownItem
+                  key={`${itemToValue(item)}${index}`}
+                  item={item}
+                  index={index}
+                />
+              )
+            }}
+          />
+        )}
         {isOpen && items.length === 0 ? (
           <ListItem role="option" sx={styles.emptyItem}>
             {nothingFoundLabel}

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
 import { Virtuoso } from 'react-virtuoso'
 import { Box, List, ListItem } from '@chakra-ui/react'
 
+import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useSelectContext } from '../SelectContext'
 import { itemToValue } from '../utils/itemUtils'
 
@@ -16,17 +16,10 @@ export const SelectMenu = (): JSX.Element => {
     nothingFoundLabel,
     styles,
     virtualListRef,
+    virtualListHeight,
   } = useSelectContext()
 
   const { popperRef, popperStyles, popperAttributes } = useSelectPopover()
-
-  const virtualHeight = useMemo(() => {
-    const maxHeight = 12 * 16
-    const totalHeight = items.length * 48
-    // If the total height is less than the max height, just return the total height.
-    // Otherwise, return the max height.
-    return Math.min(totalHeight, maxHeight)
-  }, [items.length])
 
   return (
     <Box
@@ -45,7 +38,8 @@ export const SelectMenu = (): JSX.Element => {
           <Virtuoso
             ref={virtualListRef}
             data={items}
-            style={{ height: virtualHeight }}
+            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+            style={{ height: virtualListHeight }}
             itemContent={(index, item) => {
               return (
                 <DropdownItem

--- a/frontend/src/components/Dropdown/constants.ts
+++ b/frontend/src/components/Dropdown/constants.ts
@@ -1,0 +1,2 @@
+export const VIRTUAL_LIST_MAX_HEIGHT = 12 * 16
+export const VIRTUAL_LIST_OVERSCAN_HEIGHT = 4 * 16

--- a/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
@@ -20,11 +20,7 @@ const baseSchema: DropdownFieldSchema = {
   required: true,
   disabled: false,
   fieldType: BasicField.Dropdown,
-  fieldOptions: [
-    'This is the first option',
-    'This is the second option',
-    'Short third option',
-  ],
+  fieldOptions: [...Array(2000).keys()].map(String),
   _id: 'random-id',
 }
 

--- a/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.stories.tsx
@@ -20,7 +20,12 @@ const baseSchema: DropdownFieldSchema = {
   required: true,
   disabled: false,
   fieldType: BasicField.Dropdown,
-  fieldOptions: [...Array(2000).keys()].map(String),
+  fieldOptions: [
+    'This is the first option',
+    'This is the second option',
+    'Short third option',
+    ...[...Array(2000).keys()].map(String),
+  ],
   _id: 'random-id',
 }
 

--- a/frontend/src/theme/components/SingleSelect.ts
+++ b/frontend/src/theme/components/SingleSelect.ts
@@ -27,12 +27,6 @@ const itemBaseStyle: SystemStyleFunction = (props) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     _selected: menuItemStyle._focus,
-    _first: {
-      mt: '0.5rem',
-    },
-    _last: {
-      mb: '0.5rem',
-    },
   })
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When a dropdown field has thousands of fields, rendering those options will slow to a crawl. This PR utilizes `react-virtuoso` to virtualize rendering of the options, resulting in a much more performant scroll for dropdowns with a large amount of options.

side note: we can probably use `react-virtuoso` to virtualize our fields too, though ctrl+f usage may be affected

Closes #4025 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- feat: add virtualisation to `Select` and `MultiSelect` components

## Before & After Screenshots
Stories have been updated to load 2000 options.

**BEFORE**:
<!-- [insert screenshot here] -->
![Recording 2022-06-30 at 12 24 46](https://user-images.githubusercontent.com/22133008/176592536-e9d9df60-5ffe-4c0d-bb6f-9218472d3766.gif)



**AFTER**:
![Recording 2022-06-30 at 12 23 03](https://user-images.githubusercontent.com/22133008/176592341-ee943ffe-7c37-4d99-a384-4d686b7e795e.gif)



## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `react-virtuoso`: for virtualizing dropdown options. 
