### PR TITLE
fix(v2): add aria-label to select components' chevron icons

### DIFF
--- a/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -117,6 +117,7 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
         >
           <Icon
             as={isOpen ? BxsChevronUp : BxsChevronDown}
+            aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
             aria-disabled={isDisabled}
           />
         </Box>

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -16,6 +16,7 @@ export const ToggleChevron = (): JSX.Element => {
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
+        aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
         aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Accessibility testing revealed that dropdown caret had no label. 

## Solution
<!-- How did you solve the problem? -->


**Improvements**:

- fix: add aria-label to select combobox chevron icon
