### PR TITLE
fix(v2): fix overflow in workspace row

### DIFF
--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -86,7 +86,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             ) : null}
             <Text
               textStyle="body-1"
-              isTruncated
+              noOfLines={1}
               color={isDisabled ? 'neutral.500' : undefined}
             >
               {selectedItemMeta.label}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorRow.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorRow.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Skeleton, Stack, Text } from '@chakra-ui/react'
 
 interface CollaboratorRowProps {
@@ -8,12 +7,13 @@ interface CollaboratorRowProps {
   children: React.ReactNode
 }
 
-export const CollaboratorText: FC = ({ children }) => {
+export const CollaboratorText = ({ children }: { children?: string }) => {
   return (
     <Text
       textStyle={{ base: 'subhead-1', md: 'body-2' }}
       color={{ base: 'secondary.700', md: 'secondary.500' }}
       noOfLines={{ base: 0, md: 1 }}
+      title={children}
     >
       {children}
     </Text>

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorRow.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorRow.tsx
@@ -13,7 +13,7 @@ export const CollaboratorText: FC = ({ children }) => {
     <Text
       textStyle={{ base: 'subhead-1', md: 'body-2' }}
       color={{ base: 'secondary.700', md: 'secondary.500' }}
-      isTruncated
+      noOfLines={{ base: 0, md: 1 }}
     >
       {children}
     </Text>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -32,7 +32,7 @@ export const FieldLogicBadge = ({ field }: FieldLogicBadgeProps) => {
           <Icon as={fieldMeta.icon} fontSize="1rem" />
         </Tooltip>
         {field.questionNumber ? <Text>{field.questionNumber}.</Text> : null}
-        <Text isTruncated>{field.title}</Text>
+        <Text noOfLines={1}>{field.title}</Text>
       </Stack>
     </LogicBadge>
   )

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -48,7 +48,7 @@ const THIRTY_FORMS = [
     1,
     'This is a very very very very very very very very long title it should be properly truncated only in desktop view',
   ),
-  ...createForm(30),
+  ...createForm(29),
 ]
 
 export default {

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -18,13 +18,13 @@ import {
 
 import { WorkspacePage } from './WorkspacePage'
 
-const createForm = (num: number) => {
+const createForm = (num: number, overrideTitle?: string) => {
   return times(num, (x) => {
     return {
       _id: `618b2d5e648fb700700002b${x}`,
       status: x % 2 ? FormStatus.Public : FormStatus.Private,
       responseMode: x % 2 ? FormResponseMode.Email : FormResponseMode.Encrypt,
-      title: `Test workspace form email ${x}`,
+      title: overrideTitle ?? `Test workspace form email ${x}`,
       admin: {
         _id: '618b2cc0648fb70070000292',
         email: 'test@example.com',
@@ -43,7 +43,13 @@ const createForm = (num: number) => {
   }).reverse()
 }
 
-const THIRTY_FORMS = createForm(30)
+const THIRTY_FORMS = [
+  ...createForm(
+    1,
+    'This is a very very very very very very very very long title it should be properly truncated only in desktop view',
+  ),
+  ...createForm(30),
+]
 
 export default {
   title: 'Pages/WorkspacePage',

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -1,12 +1,5 @@
 import { useMemo } from 'react'
-import {
-  Box,
-  ButtonProps,
-  chakra,
-  Flex,
-  Text,
-  useBreakpointValue,
-} from '@chakra-ui/react'
+import { Box, ButtonProps, chakra, Flex, Text } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 
 import { AdminDashboardFormMetaDto } from '~shared/types/form/form'
@@ -37,11 +30,6 @@ export const WorkspaceFormRow = ({
   }, [formMeta.lastModified])
 
   const { handleEditForm } = useRowActionDropdown(formMeta._id)
-
-  const isTruncated = useBreakpointValue({
-    base: false,
-    md: true,
-  })
 
   return (
     <Box pos="relative">
@@ -74,9 +62,14 @@ export const WorkspaceFormRow = ({
         }}
         {...buttonProps}
       >
-        <Flex flexDir="column" gridArea="title" textAlign="initial">
+        <Flex
+          flexDir="column"
+          gridArea="title"
+          textAlign="initial"
+          overflow="auto"
+        >
           <Text
-            isTruncated={isTruncated}
+            noOfLines={{ base: 0, md: 1 }}
             title={formMeta.title}
             textStyle="subhead-1"
             color="secondary.700"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Extremely long form titles were resulting in incorrect overflow of the page. This PR fixes that bug.
Also replace deprecated usage of `isTruncated` prop and replace them with the `noOfLine` prop.


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

**Improvements**:

- ref: replace deprecated usage of isTruncated with noOfLines

**Bug Fixes**:

- fix: correctly truncate workspace form row on long title

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![Screenshot 2022-07-01 at 11 20 20 AM](https://user-images.githubusercontent.com/22133008/176817030-a7283fcb-366a-4677-959d-26ee69e7ecb0.png)
**AFTER**:
<!-- [insert screenshot here] -->

![Screenshot 2022-07-01 at 11 20 13 AM](https://user-images.githubusercontent.com/22133008/176817041-10c67e5d-2fdf-4128-a358-c71694f13ed8.png)

