### PR TITLE
chore: expose public jwks endpoint

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -95,6 +95,7 @@ FORMSG_SDK_MODE=
 # SINGPASS_ESRVC_ID=GOVTECH-FORMSG-SP
 # SINGPASS_PARTNER_ENTITY_ID=http://staging-dsd.form.sg/forms/soap
 # SINGPASS_IDP_ID=https://saml-internet.singpass.gov.sg/FIM/sps/SingpassIDPFed/saml20
+# SP_OIDC_RP_JWKS_PUBLIC_PATH=
 
 # CP_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
 # CP_FORMSG_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/server.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - SINGPASS_ESRVC_ID=spEsrvcId
       - SINGPASS_PARTNER_ENTITY_ID=https://localhost:5000/singpass
       - SINGPASS_IDP_ID=https://saml-internet.singpass.gov.sg/FIM/sps/SingpassIDPFed/saml20
+      - SP_OIDC_RP_JWKS_PUBLIC_PATH=./tests/certs/test_rp_public_jwks.json
       - CP_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
       - CP_FORMSG_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/server.crt
       - CP_IDP_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/spcp.crt

--- a/src/app/config/features/spcp-myinfo.config.ts
+++ b/src/app/config/features/spcp-myinfo.config.ts
@@ -29,6 +29,7 @@ type ISpcpConfig = {
   cpFormSgCertPath: string
   spIdpCertPath: string
   cpIdpCertPath: string
+  spOidcRpJwksPublicPath: string
 }
 
 type IMyInfoConfig = {
@@ -214,6 +215,12 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: String,
     default: null,
     env: 'MYINFO_CLIENT_SECRET',
+  },
+  spOidcRpJwksPublicPath: {
+    doc: "Path to the Relying Party's Public Json Web Key Set used for Singpass-related communication with NDI.  This will be hosted at /singpass/.well-known/jwks.json endpoint.",
+    format: String,
+    default: null,
+    env: 'SP_OIDC_RP_JWKS_PUBLIC_PATH',
   },
 }
 

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -29,6 +29,7 @@ import { SubmissionRouter } from '../../modules/submission/submission.routes'
 import UserRouter from '../../modules/user/user.routes'
 import { VfnRouter } from '../../modules/verification/verification.routes'
 import { ApiRouter } from '../../routes/api'
+import { SpOidcJwksRouter } from '../../routes/singpass'
 import * as IntranetMiddleware from '../../services/intranet/intranet.middleware'
 
 import errorHandlerMiddlewares from './error-handler'
@@ -156,6 +157,8 @@ const loadExpressApp = async (connection: Connection) => {
   // Registered routes with the Singpass/Corppass servers
   app.use('/singpass/login', SingpassLoginRouter)
   app.use('/corppass/login', CorppassLoginRouter)
+  // jwks endpoint for SP OIDC
+  app.use('/singpass/.well-known/jwks.json', SpOidcJwksRouter)
   // Registered routes with sgID
   app.use('/sgid', SgidRouter)
   // Use constant for registered routes with MyInfo servers

--- a/src/app/modules/spcp/__tests__/spcp.test.constants.ts
+++ b/src/app/modules/spcp/__tests__/spcp.test.constants.ts
@@ -40,6 +40,7 @@ export const MOCK_SERVICE_PARAMS: ISpcpMyInfo = {
   myInfoCertPath: 'myInfoCertPath',
   myInfoClientId: 'myInfoClientId',
   myInfoClientSecret: 'myInfoClientSecret',
+  spOidcRpJwksPublicPath: 'tests/certs/test_rp_public_jwks.json',
 }
 
 export const MOCK_ESRVCID = 'eServiceId'

--- a/src/app/routes/singpass/__tests__/sp.oidc.jwks.routes.spec.ts
+++ b/src/app/routes/singpass/__tests__/sp.oidc.jwks.routes.spec.ts
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import session, { Session } from 'supertest-session'
+
+import { setupApp } from 'tests/integration/helpers/express-setup'
+
+import { MOCK_SERVICE_PARAMS } from '../../../modules/spcp/__tests__/spcp.test.constants'
+import { SpOidcJwksRouter } from '../sp.oidc.jwks.routes'
+
+const app = setupApp('/singpass/.well-known/jwks.json', SpOidcJwksRouter)
+
+describe('sp.oidc.jwks.router', () => {
+  let request: Session
+
+  beforeEach(() => {
+    request = session(app)
+  })
+
+  describe('GET /singpass/.well-known/jwks.json', () => {
+    it('should return 200 with the public jwks', async () => {
+      // Act
+      const response = await request.get('/singpass/.well-known/jwks.json')
+
+      const responseJson = JSON.parse(response.text)
+      const expectedJson = JSON.parse(
+        fs.readFileSync(MOCK_SERVICE_PARAMS.spOidcRpJwksPublicPath).toString(),
+      )
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(responseJson).toMatchObject(expectedJson)
+    })
+  })
+})

--- a/src/app/routes/singpass/index.ts
+++ b/src/app/routes/singpass/index.ts
@@ -1,0 +1,1 @@
+export { SpOidcJwksRouter } from './sp.oidc.jwks.routes'

--- a/src/app/routes/singpass/sp.oidc.jwks.routes.ts
+++ b/src/app/routes/singpass/sp.oidc.jwks.routes.ts
@@ -1,0 +1,17 @@
+import express, { Router } from 'express'
+
+import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
+
+// Handles SingPass JWKS requests
+export const SpOidcJwksRouter = Router()
+
+/**
+ * Returns the RP's public json web key set (JWKS) for communication with NDI
+ * @route GET /singpass/.well-known/jwks.json
+ * @returns 200
+ */
+
+SpOidcJwksRouter.get(
+  '/',
+  express.static(spcpMyInfoConfig.spOidcRpJwksPublicPath),
+)

--- a/tests/.test-env
+++ b/tests/.test-env
@@ -10,6 +10,7 @@ SINGPASS_IDP_ID=https://saml-internet.singpass.gov.sg/FIM/sps/SingpassIDPFed/sam
 MOCKPASS_PORT=5156
 SINGPASS_ESRVC_ID=Test-eServiceId-Sp
 
+SP_OIDC_RP_JWKS_PUBLIC_PATH=./tests/certs/test_rp_public_jwks.json
 MYINFO_CLIENT_CONFIG=dev
 MYINFO_FORMSG_KEY_PATH=./node_modules/@opengovsg/mockpass/static/certs/key.pem
 MYINFO_CERT_PATH=./node_modules/@opengovsg/mockpass/static/certs/spcp.crt

--- a/tests/certs/test_rp_public_jwks.json
+++ b/tests/certs/test_rp_public_jwks.json
@@ -1,0 +1,22 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "use": "sig",
+            "crv": "P-521",
+            "kid": "sig-2022-06-04T09:22:28Z",
+            "x": "AAj_CAKL9NmP6agPCMto6_LiYQqko3o3ZWTtBg75bA__Z8yKEv_CwHzaibkVLnJ9XKWxCQeyEk9ROLhJoJuZxnsI",
+            "y": "AZeoe0v-EwqD3oo1V5lxUAmC80qHt-ybqOsl1mYKPgE_ctGcD4hj8tVhmD0Of6ARuKVTxNWej-X82hEW_7Aa-XpR",
+            "alg": "ES512"
+        },
+        {
+            "kty": "EC",
+            "use": "enc",
+            "crv": "P-521",
+            "kid": "enc-2022-06-04T13:46:15Z",
+            "x": "AB-16HyJwnlSZbQtqhFskADqFrm6rgX9XeaV8FgynX61750GCRbYjoueDosSNt-qzK5QNHskdQw0QZ700YF2JIlb",
+            "y": "AZwYlSBSdV-CxGRMz6ovTvWxKJ6e44gaZHf-YfbJV7w9VdAJb3OuzbHNGRuzNDjEa8eH-paLDaAB84ezrEm1SRHq",
+            "alg": "ECDH-ES+A256KW"
+        }        
+    ]
+}


### PR DESCRIPTION
## Problem
- Part of #4011
- This PR deploys the public jwks endpoint ahead of the OIDC migration


## Tests
- [ ] `/singpass/.well-known/jwks.json` endpoint should return the public jwks

## Ahead of deployment
- SSH into prod and load the public jwks in /certs/singpass/prod_spoidc_jwks_public.json
- Add the `SP_OIDC_RP_JWKS_PUBLIC_PATH` env var