### PR TITLE
update: number of bcrypt salt rounds for otp and myinfo hashing

### DIFF
--- a/shared/utils/verification.ts
+++ b/shared/utils/verification.ts
@@ -1,7 +1,7 @@
 import { BasicField } from '../types/field'
 
 export const VERIFIED_FIELDTYPES = [BasicField.Email, BasicField.Mobile]
-export const SALT_ROUNDS = 10
+export const SALT_ROUNDS = 1
 export const TRANSACTION_EXPIRE_AFTER_SECONDS = 14400 // 4 hours
 export const HASH_EXPIRE_AFTER_SECONDS = 60 * 30 // 30 minutes
 export const WAIT_FOR_OTP_SECONDS = 30

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -50,7 +50,7 @@ import {
 } from './myinfo.types'
 
 const logger = createLoggerWithLabel(module)
-const HASH_SALT_ROUNDS = 10
+const HASH_SALT_ROUNDS = 1
 
 /**
  * Hashes field values which are prefilled and MyInfo-verified.

--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -3,7 +3,7 @@ import { ResultAsync } from 'neverthrow'
 
 import { hashData, HashingError } from './hash'
 
-const DEFAULT_SALT_ROUNDS = 10
+const DEFAULT_SALT_ROUNDS = 1
 
 /**
  * Randomly generates and returns a 6 digit OTP.


### PR DESCRIPTION
## Problem
Bcrypt hashing is highly CPU-intensive, we want to reduce the time taken in hashing for data that does not require cryptographic security

Related to #3968

## Solution
This is a quick fix to reduce the time taken to hash OTPs as well as MyInfo verification while we explore alternative hashing mechanisms and open another PR to update the hashing mechanism once that decision is finalised.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
- [x] Test that we can request OTP and successfully verify the OTP on the new server
- [x] Test that we can request OTP on the old server, switch to the new server (with `salt rounds` reduced to 1), and verify the requested OTP on the new server