### PR TITLE
fix: bounce notification

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -172,6 +172,7 @@ describe('handleSns', () => {
     expect(MockBounceService.getEditorsWithContactNumbers).toHaveBeenCalledWith(
       mockForm,
     )
+    expect(mockBounceDoc.hasNotified).toHaveBeenCalled()
     expect(MockBounceService.sendEmailBounceNotification).toHaveBeenCalledWith(
       mockBounceDoc,
       mockForm,
@@ -229,6 +230,7 @@ describe('handleSns', () => {
     expect(MockBounceService.getEditorsWithContactNumbers).toHaveBeenCalledWith(
       mockForm,
     )
+    expect(mockBounceDoc.hasNotified).toHaveBeenCalled()
     expect(MockBounceService.sendEmailBounceNotification).toHaveBeenCalledWith(
       mockBounceDoc,
       mockForm,
@@ -334,6 +336,7 @@ describe('handleSns', () => {
     expect(MockBounceService.getEditorsWithContactNumbers).toHaveBeenCalledWith(
       mockForm,
     )
+    expect(mockBounceDoc.hasNotified).toHaveBeenCalled()
     expect(mockBounceDoc.areAllPermanentBounces).toHaveBeenCalled()
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,
@@ -367,6 +370,7 @@ describe('handleSns', () => {
     expect(MockBounceService.getEditorsWithContactNumbers).toHaveBeenCalledWith(
       mockForm,
     )
+    expect(mockBounceDoc.hasNotified).toHaveBeenCalled()
     expect(mockBounceDoc.areAllPermanentBounces).toHaveBeenCalled()
     expect(MockFormService.deactivateForm).toHaveBeenCalledWith(
       mockBounceDoc.formId,

--- a/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.controller.spec.ts
@@ -259,7 +259,7 @@ describe('handleSns', () => {
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
   })
 
-  it('should call services correctly when recipients have already been notified of a permanent critical bounce', async () => {
+  it('should call services correctly when recipients have already been notified of a critical bounce', async () => {
     mockBounceDoc.hasNotified.mockReturnValue(true)
 
     await handleSns(MOCK_REQ, MOCK_RES, jest.fn())
@@ -302,51 +302,6 @@ describe('handleSns', () => {
       autoEmailRecipients: [],
       autoSmsRecipients: [],
       hasDeactivated: true,
-    })
-    expect(MockBounceService.saveBounceDoc).toHaveBeenCalledWith(mockBounceDoc)
-    expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)
-  })
-
-  it('should call services correctly when recipients have already been notified of a transient critical bounce', async () => {
-    mockBounceDoc.areAllPermanentBounces.mockReturnValueOnce(false)
-    mockBounceDoc.hasNotified.mockReturnValue(true)
-
-    await handleSns(MOCK_REQ, MOCK_RES, jest.fn())
-
-    expect(MockBounceService.validateSnsRequest).toHaveBeenCalledWith(
-      MOCK_REQ.body,
-    )
-    expect(MockBounceService.logEmailNotification).toHaveBeenCalledWith(
-      MOCK_NOTIFICATION,
-    )
-    expect(MockBounceService.extractEmailType).toHaveBeenCalledWith(
-      MOCK_NOTIFICATION,
-    )
-    expect(MockBounceService.getUpdatedBounceDoc).toHaveBeenCalledWith(
-      MOCK_NOTIFICATION,
-    )
-    expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
-      mockBounceDoc.formId,
-    )
-    expect(mockBounceDoc.isCriticalBounce).toHaveBeenCalled()
-    expect(MockBounceService.getEditorsWithContactNumbers).toHaveBeenCalledWith(
-      mockForm,
-    )
-    expect(mockBounceDoc.hasNotified).toHaveBeenCalled()
-    // Notification functions are not called
-    expect(MockBounceService.sendEmailBounceNotification).not.toHaveBeenCalled()
-    expect(MockBounceService.sendSmsBounceNotification).not.toHaveBeenCalled()
-    expect(mockBounceDoc.setNotificationState).not.toHaveBeenCalled()
-    expect(mockBounceDoc.areAllPermanentBounces).toHaveBeenCalled()
-    // Deactivation functions are not called
-    expect(MockFormService.deactivateForm).not.toHaveBeenCalled()
-    expect(MockBounceService.notifyAdminsOfDeactivation).not.toHaveBeenCalled()
-    expect(MockBounceService.logCriticalBounce).toHaveBeenCalledWith({
-      bounceDoc: mockBounceDoc,
-      notification: MOCK_NOTIFICATION,
-      autoEmailRecipients: [],
-      autoSmsRecipients: [],
-      hasDeactivated: false,
     })
     expect(MockBounceService.saveBounceDoc).toHaveBeenCalledWith(mockBounceDoc)
     expect(MOCK_RES.sendStatus).toHaveBeenCalledWith(200)

--- a/src/app/modules/bounce/bounce.types.ts
+++ b/src/app/modules/bounce/bounce.types.ts
@@ -1,0 +1,6 @@
+import { UserWithContactNumber } from '../user/user.types'
+
+export interface AdminNotificationRecipients {
+  emailRecipients: string[]
+  smsRecipients: UserWithContactNumber[]
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Users are spammed with multiple smses and emails after email-mode responses bounce

Closes #4094 

## Solution
Re-introduce `hasNotified`, which checks if form admins and collaborators have already been sms-ed or emailed after an email response's critical bounce.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
Same tests as those in [Bounce module refactor PR](https://github.com/opengovsg/FormSG/pull/1591)
- [x] Create an email mode form. Add a valid collaborator with a registered contact number, and add a non-existent email as one of the email recipients. Submit the form. The form should NOT be deactivated, and the valid email recipient should not receive any emails/SMSes. Check the document in the Bounces collection corresponding to the form ID. The bounces array should contain the correct hasBounced key for each email address.
- [x] Remove all valid email recipients and leave only non-existent emails. Submit the form. The form should be deactivated, and the form admin + collaborators should each receive only ONE email and TWO smses, informing them of the bounce and form deactivation.

