### PR TITLE
refactor(form-v2): update searchbar to match design system specification

### DIFF
--- a/frontend/src/components/Searchbar/Searchbar.stories.tsx
+++ b/frontend/src/components/Searchbar/Searchbar.stories.tsx
@@ -1,8 +1,6 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
-import Button from '~components/Button'
-
 import { Searchbar, SearchbarProps } from './Searchbar'
 import { useSearchbar } from './useSearchbar'
 
@@ -14,7 +12,7 @@ export default {
 
 export const Default: Story<SearchbarProps> = (args) => <Searchbar {...args} />
 Default.args = {
-  isExpanded: true,
+  onValueChange: (newValue) => console.log('typed: ', newValue),
   onSearch: (query) => console.log(query),
 }
 
@@ -22,22 +20,24 @@ export const ExpandableClosed: Story<SearchbarProps> = ({
   isExpanded: isInitiallyExpanded,
   ...args
 }) => {
-  const { isExpanded, inputRef, handleExpansion } = useSearchbar({
-    isInitiallyExpanded,
-  })
+  const { inputRef, isExpanded, handleExpansion, handleCollapse } =
+    useSearchbar({
+      isInitiallyExpanded,
+    })
 
   return (
     <Searchbar
       ref={inputRef}
       isExpanded={isExpanded}
-      onSearchIconClick={handleExpansion}
+      onExpandIconClick={handleExpansion}
+      onCollapseIconClick={handleCollapse}
       {...args}
     />
   )
 }
 ExpandableClosed.args = {
-  onSearch: (query) => console.log(query),
   isExpanded: false,
+  onSearch: (query) => console.log(query),
 }
 ExpandableClosed.storyName = 'Expandable/Closed'
 
@@ -45,25 +45,55 @@ export const ExpandableOpen: Story<SearchbarProps> = ({
   isExpanded: isInitiallyExpanded,
   ...args
 }) => {
-  const { isExpanded, inputRef, handleExpansion } = useSearchbar({
-    isInitiallyExpanded,
-    isFocusOnExpand: false,
-  })
+  const { inputRef, isExpanded, handleExpansion, handleCollapse } =
+    useSearchbar({
+      isInitiallyExpanded,
+      isFocusOnExpand: false,
+    })
 
   return (
     <Searchbar
       ref={inputRef}
-      onSearchIconClick={isExpanded ? undefined : handleExpansion}
       isExpanded={isExpanded}
+      onExpandIconClick={handleExpansion}
+      onCollapseIconClick={handleCollapse}
       {...args}
     />
   )
 }
 ExpandableOpen.args = {
-  onSearch: (query) => console.log(query),
   isExpanded: true,
+  onSearch: (query) => console.log(query),
 }
 ExpandableOpen.storyName = 'Expandable/Open'
+
+export const Unexpandable: Story<SearchbarProps> = ({
+  isExpandable,
+  isExpanded: isInitiallyExpanded,
+  ...args
+}) => {
+  const { inputRef, isExpanded, handleExpansion, handleCollapse } =
+    useSearchbar({
+      isInitiallyExpanded,
+      isFocusOnExpand: false,
+    })
+
+  return (
+    <Searchbar
+      ref={inputRef}
+      isExpandable={false}
+      isExpanded={isExpanded}
+      onExpandIconClick={handleExpansion}
+      onCollapseIconClick={handleCollapse}
+      {...args}
+    />
+  )
+}
+Unexpandable.args = {
+  isExpandable: false,
+  isExpanded: true,
+  onSearch: (query) => console.log(query),
+}
 
 export const Playground: Story<SearchbarProps> = ({
   isExpanded: isInitiallyExpanded,
@@ -85,22 +115,17 @@ export const Playground: Story<SearchbarProps> = ({
         <Flex align="center" maxW="25rem" justify="flex-end">
           <Searchbar
             ref={inputRef}
-            onSearchIconClick={handleExpansion}
             isExpanded={isExpanded}
+            onExpandIconClick={handleExpansion}
+            onCollapseIconClick={handleCollapse}
             {...args}
           />
-          {isExpanded && (
-            <Button variant="clear" ml="1rem" onClick={handleCollapse}>
-              Reset
-            </Button>
-          )}
         </Flex>
       </Flex>
     </Box>
   )
 }
-
 Playground.args = {
-  onSearch: (query) => alert(`${query} is being searched`),
   isExpanded: false,
+  onSearch: (query) => alert(`${query} is being searched`),
 }

--- a/frontend/src/components/Searchbar/Searchbar.stories.tsx
+++ b/frontend/src/components/Searchbar/Searchbar.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const Default: Story<SearchbarProps> = (args) => <Searchbar {...args} />
 Default.args = {
-  onValueChange: (newValue) => console.log('typed: ', newValue),
+  onChange: (newValue) => console.log('typed: ', newValue),
   onSearch: (query) => console.log(query),
 }
 

--- a/frontend/src/components/Searchbar/Searchbar.tsx
+++ b/frontend/src/components/Searchbar/Searchbar.tsx
@@ -61,7 +61,7 @@ export interface SearchbarProps extends Omit<InputProps, 'onChange'> {
    * Function to be invoked when the value in the searchbar input changes (but
    * the search button has not been clicked).
    */
-  onValueChange?: (newValue: string) => void
+  onChange?: (newValue: string) => void
 }
 
 export const Searchbar = forwardRef<SearchbarProps, 'input'>(
@@ -73,7 +73,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
       onExpandIconClick: onExpandIconClickProp,
       onCollapseIconClick: onCollapseIconClickProp,
       value: valueProp,
-      onValueChange: onValueChangeProp,
+      onChange: onChangeProp,
       isDisabled,
       ...props
     }: SearchbarProps,
@@ -105,8 +105,8 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
       setInnerIsExpanded(false)
     }
 
-    const onValueChange = (newValue: string) => {
-      if (onValueChangeProp) onValueChangeProp(newValue)
+    const onChange = (newValue: string) => {
+      if (onChangeProp) onChangeProp(newValue)
       setValue(newValue)
     }
 
@@ -151,7 +151,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
           sx={styles.field}
           onKeyDown={handleEnterKeySearch}
           value={value}
-          onChange={(e) => onValueChange(e.target.value)}
+          onChange={(e) => onChange(e.target.value)}
           isDisabled={isDisabled}
           {...props}
         />

--- a/frontend/src/components/Searchbar/useSearchbar.ts
+++ b/frontend/src/components/Searchbar/useSearchbar.ts
@@ -6,7 +6,15 @@ import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 type UseSearchbarReturn = {
   inputRef: RefObject<HTMLInputElement>
+
+  /**
+   * Variable representing whether the searchbar is expanded. If you need to
+   * know whether the searchbar is expanded, use this in conjunction with
+   * `handleExpansion` and `handleCollapse`.
+   * @example `<Searchbar onExpandIconClick={handleExpansion} onCollapseIconClick={handleCollapse} ...`
+   */
   isExpanded: boolean
+
   handleExpansion: () => void
   handleCollapse: () => void
 }
@@ -19,6 +27,7 @@ export const useSearchbar = ({
    * If `true`, the searchbar will be expanded on initial render.
    */
   isInitiallyExpanded?: boolean
+
   /**
    * If `true`, the searchbar will be focused whenever the searchbar is expanded.
    * Defaults to `true`.

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -24,7 +24,7 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 100, // maxWidth is only used as a limit for resizing
   },
   {
-    Header: 'Reference',
+    Header: 'Reference ID',
     accessor: 'refNo',
     minWidth: 200,
     width: 300,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState } from 'react'
-import { BiX } from 'react-icons/bi'
-import { InputRightElement } from '@chakra-ui/react'
 
-import IconButton from '~components/IconButton'
 import Searchbar, { useSearchbar } from '~components/Searchbar'
 
-import { useUnlockedResponses } from './UnlockedResponsesProvider'
-
-export const SubmissionSearchbar = (): JSX.Element => {
-  const { submissionId, setSubmissionId, isAnyFetching } =
-    useUnlockedResponses()
-
+export const SubmissionSearchbar = ({
+  submissionId,
+  setSubmissionId,
+  isAnyFetching,
+}: {
+  submissionId?: string
+  setSubmissionId: (submissionId: string | null) => void
+  isAnyFetching: boolean
+}): JSX.Element => {
   const [inputValue, setInputValue] = useState(submissionId)
 
   useEffect(() => {
@@ -18,33 +18,18 @@ export const SubmissionSearchbar = (): JSX.Element => {
     setInputValue(submissionId ?? '')
   }, [submissionId])
 
-  const { isExpanded, inputRef, handleExpansion, handleCollapse } =
-    useSearchbar({
-      isInitiallyExpanded: !!submissionId,
-    })
+  const { inputRef } = useSearchbar()
 
   return (
     <Searchbar
       isDisabled={isAnyFetching}
       ref={inputRef}
       value={inputValue}
-      onChange={(nextValue) => setInputValue(nextValue)}
-      onSearchIconClick={handleExpansion}
-      isExpanded={isExpanded}
+      isExpanded={!!submissionId}
+      onValueChange={(nextValue) => setInputValue(nextValue)}
+      onCollapseIconClick={() => setSubmissionId(null)}
       onSearch={setSubmissionId}
       placeholder="Search by reference ID"
-      rightElement={
-        <InputRightElement>
-          <IconButton
-            variant="clear"
-            colorScheme="secondary"
-            size="sm"
-            onClick={handleCollapse}
-            icon={<BiX />}
-            aria-label="Hide search"
-          />
-        </InputRightElement>
-      }
     />
   )
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -26,7 +26,7 @@ export const SubmissionSearchbar = ({
       ref={inputRef}
       value={inputValue}
       isExpanded={!!submissionId}
-      onValueChange={(nextValue) => setInputValue(nextValue)}
+      onChange={(nextValue) => setInputValue(nextValue)}
       onCollapseIconClick={() => setSubmissionId(null)}
       onSearch={setSubmissionId}
       placeholder="Search by reference ID"

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -26,7 +26,7 @@ export const SubmissionSearchbar = ({
       ref={inputRef}
       value={inputValue}
       isExpanded={!!submissionId}
-      onChange={(nextValue) => setInputValue(nextValue)}
+      onChange={setInputValue}
       onCollapseIconClick={() => setSubmissionId(null)}
       onSearch={setSubmissionId}
       placeholder="Search by reference ID"

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Box, Flex, Grid, Skeleton, Stack, Text } from '@chakra-ui/react'
 import simplur from 'simplur'
 
-import Button from '~components/Button'
 import { DateRangeInput } from '~components/DatePicker/DateRangeInput'
 import Pagination from '~components/Pagination'
 
@@ -21,30 +20,24 @@ export const UnlockedResponses = (): JSX.Element => {
     filteredCount,
     isLoading,
     submissionId,
-    isAnyFetching,
     setSubmissionId,
+    isAnyFetching,
   } = useUnlockedResponses()
 
-  const countToUse = useMemo(() => {
-    if (submissionId) {
-      return filteredCount
-    }
-    return count
-  }, [filteredCount, count, submissionId])
+  const countToUse = useMemo(
+    () => (submissionId ? filteredCount : count),
+    [submissionId, filteredCount, count],
+  )
 
   const { dateRange, setDateRange } = useStorageResponsesContext()
 
-  const prettifiedResponsesCount = useMemo(() => {
-    if (filteredCount !== undefined) {
-      return simplur` ${[filteredCount]}result[|s] found`
-    } else if (count !== undefined) {
-      return simplur` ${[count]}response[|s] to date`
-    }
-  }, [count, filteredCount])
-
-  const clearSubmissionId = useCallback(() => {
-    setSubmissionId(null)
-  }, [setSubmissionId])
+  const prettifiedResponsesCount = useMemo(
+    () =>
+      submissionId
+        ? simplur` ${[filteredCount ?? 0]}result[|s] found`
+        : simplur` ${[count ?? 0]}response[|s] to date`,
+    [submissionId, filteredCount, count],
+  )
 
   return (
     <Flex flexDir="column" h="100%">
@@ -66,21 +59,20 @@ export const UnlockedResponses = (): JSX.Element => {
           gridArea="submissions"
         >
           <Skeleton isLoaded={!isAnyFetching}>
-            <Text textStyle="h4">
+            <Text textStyle="h4" mb="0.5rem">
               <Text as="span" color="primary.500">
                 {countToUse?.toLocaleString()}
               </Text>
               {prettifiedResponsesCount}
             </Text>
           </Skeleton>
-          {submissionId && (
-            <Button onClick={clearSubmissionId} variant="link">
-              Reset
-            </Button>
-          )}
         </Stack>
         <Stack direction="row" gridArea="export" justifySelf="end">
-          <SubmissionSearchbar />
+          <SubmissionSearchbar
+            submissionId={submissionId}
+            setSubmissionId={setSubmissionId}
+            isAnyFetching={isAnyFetching}
+          />
           <DateRangeInput value={dateRange} onChange={setDateRange} />
           <DownloadButton />
         </Stack>

--- a/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
+++ b/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
-import { BiX } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { Box, Container, Flex, Grid, Stack, Text } from '@chakra-ui/react'
 import simplur from 'simplur'
@@ -11,7 +10,6 @@ import Searchbar, { useSearchbar } from '~components/Searchbar'
 
 import { getBillingInfo } from '~features/user/billing/BillingService'
 
-import IconButton from '../../../../components/IconButton'
 import { EsrvcIdFormInputs } from '../BillingForm'
 import { DateRange, dateRangeToString, stringToDateRange } from '../DateRange'
 
@@ -19,6 +17,8 @@ import { BillingDownloadButton } from './components/BillingDownloadButton'
 import { BillingNoChargesContent } from './components/BillingNoChargesContent'
 import { BillingTable } from './components/BillingTable'
 import { BillingTableSkeleton } from './components/BillingTableSkeleton'
+
+const BILLING_MIN_YEAR = 2019
 
 export type BillChargesProps = {
   esrvcId: string
@@ -36,8 +36,8 @@ const getSelectDateDropdownItems = ({ yr, mth }: DateRange): string[] => {
     selectDateDropdownItems.push({ yr, mth: loopMth })
   }
 
-  // Go backwards until 2019
-  for (let loopYr = yr - 1; loopYr >= 2019; loopYr--) {
+  // Go backwards until BILLING_MIN_YEAR
+  for (let loopYr = yr - 1; loopYr >= BILLING_MIN_YEAR; loopYr--) {
     for (let loopMth = 11; loopMth >= 0; loopMth--) {
       selectDateDropdownItems.push({ yr: loopYr, mth: loopMth })
     }
@@ -60,7 +60,7 @@ export const BillCharges = ({
     isLoading,
     isRefetching,
     refetch,
-  } = useQuery(esrvcId, () =>
+  } = useQuery([esrvcId, dateRange.yr, dateRange.mth], () =>
     getBillingInfo({
       esrvcId,
       yr: dateRange.yr.toString(),
@@ -170,22 +170,14 @@ export const BillCharges = ({
               <Flex justifyContent="right">
                 <Searchbar
                   ref={inputRef}
+                  isDisabled={isLoadingOrRefetching}
                   onSearch={(esrvcId) =>
                     esrvcId ? onSubmitEsrvcId({ esrvcId }) : null
                   }
-                  onSearchIconClick={() => handleExpansion()}
-                  placeholder="e-service ID"
                   isExpanded={isExpanded}
-                  rightElement={
-                    <IconButton
-                      ml="1px"
-                      aria-label="Close search bar"
-                      icon={<BiX />}
-                      variant="clear"
-                      colorScheme="secondary"
-                      onClick={() => handleCollapse()}
-                    ></IconButton>
-                  }
+                  onExpandIconClick={handleExpansion}
+                  onCollapseIconClick={handleCollapse}
+                  placeholder="Search an e-service ID"
                 ></Searchbar>
               </Flex>
             </Box>


### PR DESCRIPTION
## Problem
Original searchbar component did not match design spec. This PR implements the searchbar as per design spec and adjusts Storage responses and Billing page to match the new searchbar component props and behavior. 

Closes issue #4119 

## Solution
Incorporate `X` button into the searchbar component itself, which closes and clears the value in the searchbar. Remove `RightElement` prop.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [X] Expandable searchbar should be able to collapse when X is clicked, and the original value should be cleared from the searchbar (when expanding the searchbar again, the input field should be empty).
- [X] Non-expandable searchbar should always be open, and no X should be seen.