### PR TITLE
feat(form-v2): show emergency contact popup in workspace page

### DIFF
--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -22,3 +22,8 @@ export const ROLLOUT_ANNOUNCEMENT_KEY_PREFIX = 'has-seen-rollout-announcement-'
  * Key to store whether the admin has seen the feature tour in localStorage.
  */
 export const FEATURE_TOUR_KEY_PREFIX = 'has-seen-feature-tour-'
+
+/**
+ * Key to store whether a user has seen the emergency contact number modal in localStorage.
+ */
+export const EMERGENCY_CONTACT_KEY_PREFIX = 'has-emergency-contact'

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -13,6 +13,7 @@ import {
   getMobileViewParameters,
   mockDateDecorator,
   StoryRouter,
+  ViewedEmergencyContactDecorator,
   ViewedRolloutDecorator,
 } from '~utils/storybook'
 
@@ -56,6 +57,7 @@ export default {
   component: WorkspacePage,
   decorators: [
     ViewedRolloutDecorator,
+    ViewedEmergencyContactDecorator,
     StoryRouter({
       initialEntries: [ROOT_ROUTE],
       path: ROOT_ROUTE,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -126,13 +126,13 @@ export const WorkspacePage = (): JSX.Element => {
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const EMERGENCY_CONTACT_KEY = useMemo(
-    () => EMERGENCY_CONTACT_KEY_PREFIX + user?._id,
+  const emergencyContactKey = useMemo(
+    () => (user?._id ? EMERGENCY_CONTACT_KEY_PREFIX + user._id : null),
     [user],
   )
 
   const [hasSeenEmergencyContact, setHasSeenEmergencyContact] =
-    useLocalStorage<boolean>(EMERGENCY_CONTACT_KEY)
+    useLocalStorage<boolean>(emergencyContactKey)
 
   const isEmergencyContactModalOpen = useMemo(
     () =>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -10,11 +10,15 @@ import { useSearchParams } from 'react-router-dom'
 import { Box, Container, Grid, useDisclosure } from '@chakra-ui/react'
 import { chunk } from 'lodash'
 
-import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
+import {
+  EMERGENCY_CONTACT_KEY_PREFIX,
+  ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
+} from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import Pagination from '~components/Pagination'
 
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
+import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUser } from '~features/user/queries'
 
 import CreateFormModal from './components/CreateFormModal'
@@ -122,6 +126,24 @@ export const WorkspacePage = (): JSX.Element => {
     [isUserLoading, hasSeenAnnouncement],
   )
 
+  const EMERGENCY_CONTACT_KEY = useMemo(
+    () => EMERGENCY_CONTACT_KEY_PREFIX + user?._id,
+    [user],
+  )
+
+  const [hasSeenEmergencyContact, setHasSeenEmergencyContact] =
+    useLocalStorage<boolean>(EMERGENCY_CONTACT_KEY)
+
+  const isEmergencyContactModalOpen = useMemo(
+    () =>
+      !isUserLoading &&
+      // Open emergency contact modal after the rollout announcement modal
+      Boolean(hasSeenAnnouncement) &&
+      !hasSeenEmergencyContact &&
+      !user?.contact,
+    [isUserLoading, hasSeenAnnouncement, hasSeenEmergencyContact, user],
+  )
+
   return (
     <>
       <CreateFormModal
@@ -159,6 +181,10 @@ export const WorkspacePage = (): JSX.Element => {
             <RolloutAnnouncementModal
               onClose={() => setHasSeenAnnouncement(true)}
               isOpen={isAnnouncementModalOpen}
+            />
+            <EmergencyContactModal
+              onClose={() => setHasSeenEmergencyContact(true)}
+              isOpen={isEmergencyContactModalOpen}
             />
             <WorkspaceFormRows rows={paginatedData} isLoading={isLoading} />
           </Box>

--- a/frontend/src/utils/storybook.tsx
+++ b/frontend/src/utils/storybook.tsx
@@ -9,6 +9,7 @@ import { theme } from '~/theme'
 
 import { AuthContext } from '~contexts/AuthContext'
 import {
+  EMERGENCY_CONTACT_KEY_PREFIX,
   FEATURE_TOUR_KEY_PREFIX,
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
 } from '~constants/localStorage'
@@ -69,6 +70,21 @@ export const ViewedRolloutDecorator: DecoratorFn = (
   useEffect(() => {
     return () => window.localStorage.removeItem(rolloutKey)
   }, [rolloutKey, userId])
+
+  return storyFn()
+}
+
+export const ViewedEmergencyContactDecorator: DecoratorFn = (
+  storyFn,
+  { parameters },
+) => {
+  const userId = parameters.userId
+  const emergencyContactKey = EMERGENCY_CONTACT_KEY_PREFIX + userId
+  window.localStorage.setItem(emergencyContactKey, JSON.stringify(true))
+
+  useEffect(() => {
+    return () => window.localStorage.removeItem(emergencyContactKey)
+  }, [emergencyContactKey, userId])
 
   return storyFn()
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Emergency contact modal does not pop up on the workspace page

Working towards #4110 

Somewhat blocked by #4006

## Solution
Emergency contact modal pops up on the workspace page if the user does not have an existing emergency contact. This appears after the rollout announcement modal.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Local storage is used to track if a user has already seen the emergency contact modal. 
  TODO: Clear `emergencyContactKey` in local storage upon logout, when the logout button is implemented (related to Issue #4006 )

## Before & After Screenshots

**AFTER**:
![emergencyContactModal (1)](https://user-images.githubusercontent.com/56983748/177922996-ac68d01a-caf2-45fb-b342-89375bf4202e.gif)

## Tests
- [ ] Log in. If rollout announcement and emergency contact keys exist in local storage, remove them. On the workspace page, the rollout announcement modal should appear first, then the emergency contact modal. Refresh the workspace page. Both modals should not pop up.