### PR TITLE
feat(v2/storage): add download completion/cancelation modal screen

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -38,7 +38,7 @@ export const StorageResponsesProvider = ({
   }, [form])
 
   const downloadParams = useMemo(() => {
-    if (!secretKey || !dateRangeResponsesCount) return null
+    if (!secretKey || dateRangeResponsesCount === undefined) return null
 
     return {
       secretKey,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -29,7 +29,9 @@ export const DownloadButton = (): JSX.Element => {
     onOpen: onProgressModalOpen,
   } = useDisclosure()
 
-  const toast = useToast()
+  const toast = useToast({
+    isClosable: true,
+  })
 
   const [progressModalTimeout, setProgressModalTimeout] = useState<
     number | null

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -104,7 +104,7 @@ export const DownloadButton = (): JSX.Element => {
 
   const handleExportCsvNoAttachments = useCallback(() => {
     if (!downloadParams) return
-    setProgressModalTimeout(2000)
+    setProgressModalTimeout(5000)
     return handleExportCsvMutation.mutate({
       ...downloadParams,
       downloadAttachments: false,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/CanceledScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/CanceledScreen.tsx
@@ -32,8 +32,7 @@ export const CanceledScreen = ({
         </Wrap>
       </ModalHeader>
       <ModalBody whiteSpace="pre-line" color="secondary.500">
-        Some attachments have been downloaded. Download of responses has been
-        canceled.
+        Your responses and attachments have not been downloaded successfully.
       </ModalBody>
       <ModalFooter>
         <Button isFullWidth={isMobile} onClick={onClose}>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/CanceledScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/CanceledScreen.tsx
@@ -1,0 +1,45 @@
+import {
+  Badge,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Text,
+  Wrap,
+} from '@chakra-ui/react'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
+import { ModalCloseButton } from '~components/Modal'
+
+interface CanceledScreenProps {
+  onClose: () => void
+}
+
+export const CanceledScreen = ({
+  onClose,
+}: CanceledScreenProps): JSX.Element => {
+  const isMobile = useIsMobile()
+
+  return (
+    <>
+      <ModalCloseButton />
+      <ModalHeader color="secondary.700" pr="4.5rem">
+        <Wrap shouldWrapChildren direction="row" align="center">
+          <Text>Download stopped</Text>
+          <Badge w="fit-content" colorScheme="success">
+            beta
+          </Badge>
+        </Wrap>
+      </ModalHeader>
+      <ModalBody whiteSpace="pre-line" color="secondary.500">
+        Some attachments have been downloaded. Download of responses has been
+        canceled.
+      </ModalBody>
+      <ModalFooter>
+        <Button isFullWidth={isMobile} onClick={onClose}>
+          Back to responses
+        </Button>
+      </ModalFooter>
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
@@ -87,6 +87,12 @@ export const ConfirmationScreen = ({
               </List>
             </Stack>
           </InlineMessage>
+          {responsesCount === 0 && (
+            <InlineMessage variant="warning">
+              The date range you selected does not contain any responses. Please
+              select a date range containing responses and try again.
+            </InlineMessage>
+          )}
         </Stack>
       </ModalBody>
       <ModalFooter>
@@ -99,6 +105,7 @@ export const ConfirmationScreen = ({
             isFullWidth={isMobile}
             onClick={onDownload}
             isLoading={isDownloading}
+            isDisabled={responsesCount === 0}
           >
             Start download
           </Button>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
@@ -84,5 +84,12 @@ PartialSuccessStateDesktop.args = {
 }
 
 export const PartialSuccessStateMobile = Template.bind({})
-PartialSuccessStateMobile.args = PartialSuccessStateDesktop.args
+PartialSuccessStateMobile.args = {
+  downloadMetadata: {
+    errorCount: 10,
+    successCount: 1,
+    expectedCount: 11,
+  },
+}
+
 PartialSuccessStateMobile.parameters = getMobileViewParameters()

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
@@ -53,3 +53,36 @@ DownloadingStateDesktop.args = {
 export const DownloadingStateMobile = Template.bind({})
 DownloadingStateMobile.args = DownloadingStateDesktop.args
 DownloadingStateMobile.parameters = getMobileViewParameters()
+
+export const CompleteStateDesktop = Template.bind({})
+CompleteStateDesktop.args = {
+  downloadMetadata: {
+    errorCount: 0,
+    successCount: 12345,
+    expectedCount: 12345,
+  },
+}
+
+export const CompleteStateMobile = Template.bind({})
+CompleteStateMobile.args = CompleteStateDesktop.args
+CompleteStateMobile.parameters = getMobileViewParameters()
+
+export const CanceledStateDesktop = Template.bind({})
+CanceledStateDesktop.args = {
+  downloadMetadata: {
+    isCanceled: true,
+  },
+}
+
+export const PartialSuccessStateDesktop = Template.bind({})
+PartialSuccessStateDesktop.args = {
+  downloadMetadata: {
+    errorCount: 10,
+    successCount: 12335,
+    expectedCount: 12345,
+  },
+}
+
+export const PartialSuccessStateMobile = Template.bind({})
+PartialSuccessStateMobile.args = PartialSuccessStateDesktop.args
+PartialSuccessStateMobile.parameters = getMobileViewParameters()

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -14,6 +14,7 @@ import { CanceledResult, DownloadResult } from '../../types'
 import { isCanceledResult } from '../../utils/typeguards'
 import { CompleteScreen, ProgressModalContent } from '../ProgressModal'
 
+import { CanceledScreen } from './CanceledScreen'
 import { ConfirmationScreen } from './ConfirmationScreen'
 
 export interface DownloadWithAttachmentModalProps
@@ -110,7 +111,7 @@ export const DownloadWithAttachmentModal = ({
           )}
           {currentStep === DownloadWithAttachmentFlowStates.Complete ? (
             isCanceledResult(downloadMetadata) ? (
-              <div>Canceled!!!</div>
+              <CanceledScreen onClose={onClose} />
             ) : (
               <CompleteScreen
                 downloadMetadata={downloadMetadata}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -10,7 +10,8 @@ import {
 
 import { XMotionBox } from '~templates/MotionBox'
 
-import { ProgressModalContent } from '../ProgressModal'
+import { DownloadResult } from '../../types'
+import { CompleteScreen, ProgressModalContent } from '../ProgressModal'
 
 import { ConfirmationScreen } from './ConfirmationScreen'
 
@@ -22,6 +23,7 @@ export interface DownloadWithAttachmentModalProps
   responsesCount: number
   downloadPercentage: number
   initialState?: [DownloadWithAttachmentFlowStates, number]
+  downloadMetadata?: DownloadResult
 }
 
 /** Exported for testing. */
@@ -44,6 +46,7 @@ export const DownloadWithAttachmentModal = ({
   isDownloading,
   responsesCount,
   downloadPercentage,
+  downloadMetadata,
   initialState = INITIAL_STEP_STATE,
 }: DownloadWithAttachmentModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
@@ -60,16 +63,16 @@ export const DownloadWithAttachmentModal = ({
     }
   }, [isOpen])
 
+  useEffect(() => {
+    if (isOpen && downloadMetadata) {
+      setCurrentStep([DownloadWithAttachmentFlowStates.Complete, 1])
+    }
+  }, [downloadMetadata, isOpen])
+
   const handleDownload = useCallback(() => {
     setCurrentStep([DownloadWithAttachmentFlowStates.Progress, 1])
     return onDownload()
   }, [onDownload])
-
-  const handleCancel = useCallback(() => {
-    // TODO: Move to conclusion page.
-    setCurrentStep([DownloadWithAttachmentFlowStates.Confirmation, 1])
-    return onCancel()
-  }, [onCancel])
 
   return (
     <Modal
@@ -95,7 +98,7 @@ export const DownloadWithAttachmentModal = ({
             <ProgressModalContent
               downloadPercentage={downloadPercentage}
               isDownloading={isDownloading}
-              onClose={handleCancel}
+              onClose={onCancel}
             >
               <Text mb="1rem">
                 Up to <b>{responsesCount.toLocaleString()}</b> files are being
@@ -103,6 +106,12 @@ export const DownloadWithAttachmentModal = ({
                 this page will stop the download.
               </Text>
             </ProgressModalContent>
+          )}
+          {currentStep === DownloadWithAttachmentFlowStates.Complete && (
+            <CompleteScreen
+              downloadMetadata={downloadMetadata}
+              onClose={onClose}
+            />
           )}
         </XMotionBox>
       </ModalContent>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -10,7 +10,8 @@ import {
 
 import { XMotionBox } from '~templates/MotionBox'
 
-import { DownloadResult } from '../../types'
+import { CanceledResult, DownloadResult } from '../../types'
+import { isCanceledResult } from '../../utils/typeguards'
 import { CompleteScreen, ProgressModalContent } from '../ProgressModal'
 
 import { ConfirmationScreen } from './ConfirmationScreen'
@@ -23,7 +24,7 @@ export interface DownloadWithAttachmentModalProps
   responsesCount: number
   downloadPercentage: number
   initialState?: [DownloadWithAttachmentFlowStates, number]
-  downloadMetadata?: DownloadResult
+  downloadMetadata?: DownloadResult | CanceledResult
 }
 
 /** Exported for testing. */
@@ -98,7 +99,7 @@ export const DownloadWithAttachmentModal = ({
             <ProgressModalContent
               downloadPercentage={downloadPercentage}
               isDownloading={isDownloading}
-              onClose={onCancel}
+              onCancel={onCancel}
             >
               <Text mb="1rem">
                 Up to <b>{responsesCount.toLocaleString()}</b> files are being
@@ -107,12 +108,16 @@ export const DownloadWithAttachmentModal = ({
               </Text>
             </ProgressModalContent>
           )}
-          {currentStep === DownloadWithAttachmentFlowStates.Complete && (
-            <CompleteScreen
-              downloadMetadata={downloadMetadata}
-              onClose={onClose}
-            />
-          )}
+          {currentStep === DownloadWithAttachmentFlowStates.Complete ? (
+            isCanceledResult(downloadMetadata) ? (
+              <div>Canceled!!!</div>
+            ) : (
+              <CompleteScreen
+                downloadMetadata={downloadMetadata}
+                onClose={onClose}
+              />
+            )
+          ) : null}
         </XMotionBox>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
+import ReactMarkdown from 'react-markdown'
 import {
   Badge,
+  Icon,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -10,7 +12,9 @@ import {
 } from '@chakra-ui/react'
 import simplur from 'simplur'
 
+import { BxsCheckCircle, BxsXCircle } from '~assets/icons'
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useMdComponents } from '~hooks/useMdComponents'
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 import { ModalCloseButton } from '~components/Modal'
@@ -27,6 +31,7 @@ export const CompleteScreen = ({
   downloadMetadata,
 }: CompleteScreenProps): JSX.Element => {
   const isMobile = useIsMobile()
+  const mdComponents = useMdComponents()
 
   const completionMessage = useMemo(() => {
     if (!downloadMetadata) return ''
@@ -37,19 +42,15 @@ export const CompleteScreen = ({
     // Success count is less than expected count.
     // This means some responses were not downloaded successfully.
     // Show the user the number of responses that were not downloaded.
-    return simplur`${successCount} of ${expectedCount} ${[
+    return simplur`**${successCount.toLocaleString()}** ${[
       successCount,
-    ]}response[|s] ha[s|ve] been downloaded successfully.`
+    ]}response[|s] and attachment[|s] ha[s|ve] been downloaded successfully, refer to the downloaded CSV file for more details`
   }, [downloadMetadata])
 
   const attachmentErrorMessage = useMemo(() => {
-    if (!downloadMetadata?.errorCount) return
+    if (!downloadMetadata?.errorCount) return ''
 
-    return (
-      <InlineMessage variant="warning">
-        {simplur`${downloadMetadata.errorCount} response[|s] could not be downloaded. Any attachments related to [that|these] response[|s] will also not be downloaded.\n\nRefer to the exported CSV file for details on responses and attachments that were downloaded successfully.`}
-      </InlineMessage>
-    )
+    return simplur`**${downloadMetadata.errorCount}** response[|s] and attachment[|s] could not be downloaded.`
   }, [downloadMetadata])
 
   return (
@@ -65,8 +66,32 @@ export const CompleteScreen = ({
       </ModalHeader>
       <ModalBody whiteSpace="pre-line" color="secondary.500">
         <Stack spacing="1rem">
-          {attachmentErrorMessage}
-          <Text>{completionMessage}</Text>
+          <Stack direction="row" spacing="0.5rem">
+            <Icon
+              color="success.500"
+              fontSize="1.25rem"
+              height="1.5rem"
+              as={BxsCheckCircle}
+              aria-hidden
+            />
+            <ReactMarkdown components={mdComponents}>
+              {completionMessage}
+            </ReactMarkdown>
+          </Stack>
+          {attachmentErrorMessage && (
+            <Stack direction="row" spacing="0.5rem">
+              <Icon
+                height="1.5rem"
+                color="danger.500"
+                fontSize="1.25rem"
+                as={BxsXCircle}
+                aria-hidden
+              />
+              <ReactMarkdown components={mdComponents}>
+                {attachmentErrorMessage}
+              </ReactMarkdown>
+            </Stack>
+          )}
         </Stack>
       </ModalBody>
       <ModalFooter>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react'
+import {
+  Badge,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  Text,
+  Wrap,
+} from '@chakra-ui/react'
+import simplur from 'simplur'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
+import InlineMessage from '~components/InlineMessage'
+import { ModalCloseButton } from '~components/Modal'
+
+import { DownloadResult } from '../../types'
+
+interface CompleteScreenProps {
+  onClose: () => void
+  downloadMetadata?: DownloadResult
+}
+
+export const CompleteScreen = ({
+  onClose,
+  downloadMetadata,
+}: CompleteScreenProps): JSX.Element => {
+  const isMobile = useIsMobile()
+
+  const completionMessage = useMemo(() => {
+    if (!downloadMetadata) return ''
+    const { successCount, expectedCount } = downloadMetadata
+    if (successCount >= expectedCount) {
+      return 'All responses and attachments have been downloaded successfully.'
+    }
+    // Success count is less than expected count.
+    // This means some responses were not downloaded successfully.
+    // Show the user the number of responses that were not downloaded.
+    return simplur`${successCount} of ${expectedCount} ${[
+      successCount,
+    ]}response[|s] ha[s|ve] been downloaded successfully.`
+  }, [downloadMetadata])
+
+  const attachmentErrorMessage = useMemo(() => {
+    if (!downloadMetadata?.errorCount) return
+
+    return (
+      <InlineMessage variant="warning">
+        {simplur`${downloadMetadata.errorCount} response[|s] could not be downloaded. Any attachments related to [that|these] response[|s] will also not be downloaded.\n\nRefer to the exported CSV file for details on responses and attachments that were downloaded successfully.`}
+      </InlineMessage>
+    )
+  }, [downloadMetadata])
+
+  return (
+    <>
+      <ModalCloseButton />
+      <ModalHeader color="secondary.700" pr="4.5rem">
+        <Wrap shouldWrapChildren direction="row" align="center">
+          <Text>Download complete</Text>
+          <Badge w="fit-content" colorScheme="success">
+            beta
+          </Badge>
+        </Wrap>
+      </ModalHeader>
+      <ModalBody whiteSpace="pre-line" color="secondary.500">
+        <Stack spacing="1rem">
+          {attachmentErrorMessage}
+          <Text>{completionMessage}</Text>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        <Button isFullWidth={isMobile} onClick={onClose}>
+          Back to responses
+        </Button>
+      </ModalFooter>
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.stories.tsx
@@ -33,3 +33,28 @@ export const Desktop = Template.bind({})
 
 export const Mobile = Template.bind({})
 Mobile.parameters = getMobileViewParameters()
+
+export const CompleteStateDesktop = Template.bind({})
+CompleteStateDesktop.args = {
+  downloadMetadata: {
+    errorCount: 0,
+    expectedCount: 9001,
+    successCount: 9001,
+  },
+}
+
+export const CompleteStateMobile = Template.bind({})
+CompleteStateMobile.args = CompleteStateDesktop.args
+CompleteStateMobile.parameters = getMobileViewParameters()
+
+export const PartialSuccessStateDesktop = Template.bind({})
+PartialSuccessStateDesktop.args = {
+  downloadMetadata: {
+    errorCount: 1,
+    expectedCount: 9001,
+    successCount: 9000,
+  },
+}
+export const PartialSuccessStateMobile = Template.bind({})
+PartialSuccessStateMobile.args = PartialSuccessStateDesktop.args
+PartialSuccessStateMobile.parameters = getMobileViewParameters()

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
@@ -9,7 +9,8 @@ import {
 
 import { XMotionBox } from '~templates/MotionBox'
 
-import { DownloadResult } from '../../types'
+import { CanceledResult, DownloadResult } from '../../types'
+import { isCanceledResult } from '../../utils/typeguards'
 
 import { CompleteScreen } from './CompleteScreen'
 import { ProgressModalContent } from './ProgressModalContent'
@@ -19,7 +20,8 @@ export interface ProgressModalProps
   downloadPercentage: number
   isDownloading: boolean
   children: React.ReactNode
-  downloadMetadata?: DownloadResult
+  downloadMetadata?: DownloadResult | CanceledResult
+  onCancel: () => void
 }
 
 enum ProgressFlowStates {
@@ -36,6 +38,7 @@ export const ProgressModal = ({
   isOpen,
   isDownloading,
   onClose,
+  onCancel,
   downloadPercentage,
   downloadMetadata,
   children,
@@ -75,17 +78,18 @@ export const ProgressModal = ({
           {currentStep === ProgressFlowStates.Progress && (
             <ProgressModalContent
               isDownloading={isDownloading}
-              onClose={onClose}
+              onCancel={onCancel}
               children={children}
               downloadPercentage={downloadPercentage}
             />
           )}
-          {currentStep === ProgressFlowStates.Complete && (
-            <CompleteScreen
-              downloadMetadata={downloadMetadata}
-              onClose={onClose}
-            />
-          )}
+          {currentStep === ProgressFlowStates.Complete &&
+            !isCanceledResult(downloadMetadata) && (
+              <CompleteScreen
+                downloadMetadata={downloadMetadata}
+                onClose={onClose}
+              />
+            )}
         </XMotionBox>
       </ModalContent>
     </Modal>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import {
   Modal,
   ModalContent,
@@ -6,6 +7,11 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
+import { XMotionBox } from '~templates/MotionBox'
+
+import { DownloadResult } from '../../types'
+
+import { CompleteScreen } from './CompleteScreen'
 import { ProgressModalContent } from './ProgressModalContent'
 
 export interface ProgressModalProps
@@ -13,13 +19,25 @@ export interface ProgressModalProps
   downloadPercentage: number
   isDownloading: boolean
   children: React.ReactNode
+  downloadMetadata?: DownloadResult
 }
+
+enum ProgressFlowStates {
+  Progress = 'progress',
+  Complete = 'complete',
+}
+
+const INITIAL_STEP_STATE: [ProgressFlowStates, 1 | -1] = [
+  ProgressFlowStates.Progress,
+  -1,
+]
 
 export const ProgressModal = ({
   isOpen,
   isDownloading,
   onClose,
   downloadPercentage,
+  downloadMetadata,
   children,
 }: ProgressModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
@@ -27,21 +45,48 @@ export const ProgressModal = ({
     xs: 'mobile',
     md: 'md',
   })
+
+  const [[currentStep, direction], setCurrentStep] =
+    useState(INITIAL_STEP_STATE)
+
+  useEffect(() => {
+    // Reset step whenever modal is closed.
+    if (!isOpen) {
+      setCurrentStep(INITIAL_STEP_STATE)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen && downloadMetadata) {
+      setCurrentStep([ProgressFlowStates.Complete, 1])
+    }
+  }, [downloadMetadata, isOpen])
+
   return (
     <Modal
       size={modalSize}
       isOpen={isOpen}
       onClose={onClose}
-      closeOnOverlayClick={false}
+      closeOnOverlayClick={currentStep !== ProgressFlowStates.Progress}
     >
       <ModalOverlay />
-      <ModalContent>
-        <ProgressModalContent
-          isDownloading={isDownloading}
-          onClose={onClose}
-          children={children}
-          downloadPercentage={downloadPercentage}
-        />
+      <ModalContent overflow="hidden">
+        <XMotionBox keyProp={currentStep} custom={direction}>
+          {currentStep === ProgressFlowStates.Progress && (
+            <ProgressModalContent
+              isDownloading={isDownloading}
+              onClose={onClose}
+              children={children}
+              downloadPercentage={downloadPercentage}
+            />
+          )}
+          {currentStep === ProgressFlowStates.Complete && (
+            <CompleteScreen
+              downloadMetadata={downloadMetadata}
+              onClose={onClose}
+            />
+          )}
+        </XMotionBox>
       </ModalContent>
     </Modal>
   )

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModalContent.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModalContent.tsx
@@ -14,14 +14,14 @@ import { ProgressModalProps } from './ProgressModal'
 
 type ProgressModalContentProps = Pick<
   ProgressModalProps,
-  'children' | 'downloadPercentage' | 'onClose' | 'isDownloading'
+  'children' | 'downloadPercentage' | 'onCancel' | 'isDownloading'
 >
 
 export const ProgressModalContent = ({
   children,
   downloadPercentage,
   isDownloading,
-  onClose,
+  onCancel,
 }: ProgressModalContentProps): JSX.Element => {
   const isMobile = useIsMobile()
 
@@ -41,7 +41,7 @@ export const ProgressModalContent = ({
         <Progress size="xl" value={downloadPercentage} hasStripe isAnimated />
       </ModalBody>
       <ModalFooter>
-        <Button colorScheme="danger" onClick={onClose} isFullWidth={isMobile}>
+        <Button colorScheme="danger" onClick={onCancel} isFullWidth={isMobile}>
           Stop download
         </Button>
       </ModalFooter>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/index.ts
@@ -1,2 +1,3 @@
+export { CompleteScreen } from './CompleteScreen'
 export { ProgressModal } from './ProgressModal'
 export { ProgressModalContent } from './ProgressModalContent'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -46,3 +46,7 @@ export type DownloadResult = {
   errorCount: number
   unverifiedCount?: number
 }
+
+export type CanceledResult = {
+  isCanceled: true
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -38,3 +38,11 @@ export type CleanableDecryptionWorkerApi = {
   workerApi: Remote<DecryptionWorkerApi>
   cleanup: () => void
 }
+
+/** Download result after downloading storage mode responses */
+export type DownloadResult = {
+  expectedCount: number
+  successCount: number
+  errorCount: number
+  unverifiedCount?: number
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -14,6 +14,13 @@ import { CleanableDecryptionWorkerApi, CsvRecordStatus } from './types'
 
 const NUM_OF_METADATA_ROWS = 5
 
+type DecryptResult = {
+  expectedCount: number
+  successCount: number
+  errorCount: number
+  unverifiedCount?: number
+}
+
 const killWorkers = (workers: CleanableDecryptionWorkerApi[]): void => {
   return workers.forEach((worker) => worker.cleanup())
 }
@@ -27,7 +34,7 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
 interface UseDecryptionWorkersProps {
   onProgress: (progress: number) => void
   mutateProps: UseMutationOptions<
-    void,
+    DecryptResult,
     unknown,
     DownloadEncryptedParams,
     unknown
@@ -62,7 +69,13 @@ const useDecryptionWorkers = ({
       endDate,
       startDate,
     }: DownloadEncryptedParams) => {
-      if (!adminForm || !responsesCount) return
+      if (!adminForm || !responsesCount) {
+        return Promise.resolve({
+          expectedCount: 0,
+          successCount: 0,
+          errorCount: 0,
+        })
+      }
 
       abortControllerRef.current.abort()
       const freshAbortController = new AbortController()
@@ -105,145 +118,146 @@ const useDecryptionWorkers = ({
 
       let progress = 0
 
-      return reader
-        .read()
-        .then(
-          (read = async (result) => {
-            if (result.done) return
-            try {
-              // round-robin scheduling
-              const { workerApi } = workerPool[receivedRecordCount % numWorkers]
-              const decryptResult = await workerApi.decryptIntoCsv({
-                line: result.value,
-                secretKey,
-                downloadAttachments,
-              })
-              progress += 1
-              onProgress(progress)
+      return new Promise<DecryptResult>((resolve, reject) => {
+        reader
+          .read()
+          .then(
+            (read = async (result) => {
+              if (result.done) return
+              try {
+                // round-robin scheduling
+                const { workerApi } =
+                  workerPool[receivedRecordCount % numWorkers]
+                const decryptResult = await workerApi.decryptIntoCsv({
+                  line: result.value,
+                  secretKey,
+                  downloadAttachments,
+                })
+                progress += 1
+                onProgress(progress)
 
-              switch (decryptResult.status) {
-                case CsvRecordStatus.Error:
-                  errorCount++
-                  break
-                case CsvRecordStatus.Unverified:
-                  unverifiedCount++
-                  break
-                case CsvRecordStatus.AttachmentError:
-                  errorCount++
-                  attachmentErrorCount++
-                  break
-                case CsvRecordStatus.Ok: {
-                  try {
-                    csvGenerator.addRecord(decryptResult.submissionData)
-                    receivedRecordCount++
-                  } catch (e) {
+                switch (decryptResult.status) {
+                  case CsvRecordStatus.Error:
                     errorCount++
-                    console.error('Error in getResponseInstance', e)
-                  }
-                  if (downloadAttachments && decryptResult.downloadBlob) {
-                    await downloadResponseAttachment(
-                      decryptResult.downloadBlob,
-                      decryptResult.id,
-                    )
+                    break
+                  case CsvRecordStatus.Unverified:
+                    unverifiedCount++
+                    break
+                  case CsvRecordStatus.AttachmentError:
+                    errorCount++
+                    attachmentErrorCount++
+                    break
+                  case CsvRecordStatus.Ok: {
+                    try {
+                      csvGenerator.addRecord(decryptResult.submissionData)
+                      receivedRecordCount++
+                    } catch (e) {
+                      errorCount++
+                      console.error('Error in getResponseInstance', e)
+                    }
+                    if (downloadAttachments && decryptResult.downloadBlob) {
+                      await downloadResponseAttachment(
+                        decryptResult.downloadBlob,
+                        decryptResult.id,
+                      )
+                    }
                   }
                 }
+              } catch (e) {
+                console.error('Error parsing JSON', e)
               }
-            } catch (e) {
-              console.error('Error parsing JSON', e)
-            }
-            // recurse through the stream
-            return reader.read().then(read)
-          }),
-        )
-        .catch((err) => {
-          if (!downloadStartTime) {
-            // No start time, means did not even start http request.
-            // TODO: Google analytics tracking for failure.
-            // GTag.downloadNetworkFailure(params, err)
-          } else {
-            const downloadFailedTime = performance.now()
-            const timeDifference = downloadFailedTime - downloadStartTime
-            // TODO: Google analytics tracking for failure.
-            // GTag.downloadResponseFailure(
-            //   params,
-            //   numWorkers,
-            //   expectedNumResponses,
-            //   timeDifference,
-            //   err,
-            // )
-          }
-
-          console.error(
-            'Failed to download data, is there a network issue?',
-            err,
+              // recurse through the stream
+              return reader.read().then(read)
+            }),
           )
-          killWorkers(workerPool)
-          throw err
-        })
-        .finally(() => {
-          const checkComplete = () => {
-            // If all the records could not be decrypted
-            if (errorCount + unverifiedCount === responsesCount) {
-              const failureEndTime = performance.now()
-              const timeDifference = failureEndTime - downloadStartTime
-              // TODO: Google analytics tracking for partial decrypt
-              // failure.
-              // GTag.partialDecryptionFailure(
+          .catch((err) => {
+            if (!downloadStartTime) {
+              // No start time, means did not even start http request.
+              // TODO: Google analytics tracking for failure.
+              // GTag.downloadNetworkFailure(params, err)
+            } else {
+              const downloadFailedTime = performance.now()
+              const timeDifference = downloadFailedTime - downloadStartTime
+              // TODO: Google analytics tracking for failure.
+              // GTag.downloadResponseFailure(
               //   params,
               //   numWorkers,
-              //   csvGenerator.length(),
-              //   errorCount,
-              //   attachmentErrorCount,
+              //   expectedNumResponses,
               //   timeDifference,
+              //   err,
               // )
-              killWorkers(workerPool)
-              throw new Error(
-                JSON.stringify({
+            }
+
+            console.error(
+              'Failed to download data, is there a network issue?',
+              err,
+            )
+            killWorkers(workerPool)
+            reject(err)
+          })
+          .finally(() => {
+            const checkComplete = () => {
+              // If all the records could not be decrypted
+              if (errorCount + unverifiedCount === responsesCount) {
+                const failureEndTime = performance.now()
+                const timeDifference = failureEndTime - downloadStartTime
+                // TODO: Google analytics tracking for partial decrypt
+                // failure.
+                // GTag.partialDecryptionFailure(
+                //   params,
+                //   numWorkers,
+                //   csvGenerator.length(),
+                //   errorCount,
+                //   attachmentErrorCount,
+                //   timeDifference,
+                // )
+                killWorkers(workerPool)
+                resolve({
                   expectedCount: responsesCount,
                   successCount: csvGenerator.length(),
                   errorCount,
                   unverifiedCount,
-                }),
-              )
-            } else if (
-              // All results have been decrypted
-              csvGenerator.length() + errorCount + unverifiedCount >=
-              responsesCount
-            ) {
-              killWorkers(workerPool)
-              // Generate first three rows of meta-data before download
-              csvGenerator.addMetaDataFromSubmission(
-                errorCount,
-                unverifiedCount,
-              )
-              csvGenerator.downloadCsv(
-                `${adminForm.title}-${adminForm._id}.csv`,
-              )
+                })
+              } else if (
+                // All results have been decrypted
+                csvGenerator.length() + errorCount + unverifiedCount >=
+                responsesCount
+              ) {
+                killWorkers(workerPool)
+                // Generate first three rows of meta-data before download
+                csvGenerator.addMetaDataFromSubmission(
+                  errorCount,
+                  unverifiedCount,
+                )
+                csvGenerator.downloadCsv(
+                  `${adminForm.title}-${adminForm._id}.csv`,
+                )
 
-              const downloadEndTime = performance.now()
-              const timeDifference = downloadEndTime - downloadStartTime
+                const downloadEndTime = performance.now()
+                const timeDifference = downloadEndTime - downloadStartTime
 
-              // TODO: Google analytics tracking for success.
-              // GTag.downloadResponseSuccess(
-              //   params,
-              //   numWorkers,
-              //   csvGenerator.length(),
-              //   timeDifference,
-              // )
+                // TODO: Google analytics tracking for success.
+                // GTag.downloadResponseSuccess(
+                //   params,
+                //   numWorkers,
+                //   csvGenerator.length(),
+                //   timeDifference,
+                // )
 
-              return {
-                expectedCount: responsesCount,
-                successCount: csvGenerator.length(),
-                errorCount,
-                unverifiedCount,
+                resolve({
+                  expectedCount: responsesCount,
+                  successCount: csvGenerator.length(),
+                  errorCount,
+                  unverifiedCount,
+                })
+              } else {
+                setTimeout(checkComplete, 100)
               }
-            } else {
-              setTimeout(checkComplete, 100)
             }
-          }
 
-          checkComplete()
-        })
+            checkComplete()
+          })
+      })
     },
     [adminForm, onProgress, workers],
   )

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -5,7 +5,6 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { downloadResponseAttachment } from './utils/downloadCsv'
 import { EncryptedResponseCsvGenerator } from './utils/EncryptedResponseCsvGenerator'
-import { useStorageResponsesContext } from './StorageResponsesContext'
 import {
   EncryptedResponsesStreamParams,
   getEncryptedResponsesStream,
@@ -43,7 +42,6 @@ const useDecryptionWorkers = ({
   const abortControllerRef = useRef(new AbortController())
 
   const { data: adminForm } = useAdminForm()
-  const { dateRange } = useStorageResponsesContext()
 
   useEffect(() => {
     return () => killWorkers(workers)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -10,16 +10,13 @@ import {
   getEncryptedResponsesStream,
   makeWorkerApiAndCleanup,
 } from './StorageResponsesService'
-import { CleanableDecryptionWorkerApi, CsvRecordStatus } from './types'
+import {
+  CleanableDecryptionWorkerApi,
+  CsvRecordStatus,
+  DownloadResult,
+} from './types'
 
 const NUM_OF_METADATA_ROWS = 5
-
-type DecryptResult = {
-  expectedCount: number
-  successCount: number
-  errorCount: number
-  unverifiedCount?: number
-}
 
 const killWorkers = (workers: CleanableDecryptionWorkerApi[]): void => {
   return workers.forEach((worker) => worker.cleanup())
@@ -34,7 +31,7 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
 interface UseDecryptionWorkersProps {
   onProgress: (progress: number) => void
   mutateProps: UseMutationOptions<
-    DecryptResult,
+    DownloadResult,
     unknown,
     DownloadEncryptedParams,
     unknown
@@ -118,7 +115,7 @@ const useDecryptionWorkers = ({
 
       let progress = 0
 
-      return new Promise<DecryptResult>((resolve, reject) => {
+      return new Promise<DownloadResult>((resolve, reject) => {
         reader
           .read()
           .then(

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/typeguards.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/typeguards.ts
@@ -1,0 +1,7 @@
+import { CanceledResult, DownloadResult } from '../types'
+
+export const isCanceledResult = (
+  result?: DownloadResult | CanceledResult,
+): result is CanceledResult => {
+  return !!(result as Partial<CanceledResult>)?.isCanceled
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the completion or cancelation screens as denoted in design.


Closes #4141 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Allow clicking of export button even when response count is 0 for particular range
  - this allows a better UX where the reason for failure can be better shown to users, via:
    - warning toast when not downloading attachments,
    - warning info message in modal screen when attempting to download responses with attachments.
- Show cancelation screen on cancelation when downloading with attachments
- Show cancelation toast on cancelation when downloading without attachments
- Show complete screen after decryption is complete when downloading with attachments
- Show status toast with download status after decryption is complete when downloading without attachments

## Before & After Screenshots
Stories have been added for the various states.

