### PR TITLE
feat: add views to restrict particular days for date field

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
@@ -82,6 +82,6 @@ export const WithParticularDaysRestricted = Template.bind({})
 WithParticularDaysRestricted.args = {
   field: {
     ...DEFAULT_DATE_FIELD,
-    invalidDaysOfTheWeek: [1, 2, 5],
+    invalidDaysOfTheWeek: [],
   },
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
@@ -18,10 +18,7 @@ const DEFAULT_DATE_FIELD: DateFieldBase = {
     customMaxDate: null,
     customMinDate: null,
   },
-  restrictParticularDays: {
-    addParticularDayRestriction: false,
-    invalidDaysOfTheWeek: [],
-  },
+  invalidDaysOfTheWeek: [],
   required: true,
   disabled: false,
   fieldType: BasicField.Date,
@@ -85,9 +82,6 @@ export const WithParticularDaysRestricted = Template.bind({})
 WithParticularDaysRestricted.args = {
   field: {
     ...DEFAULT_DATE_FIELD,
-    restrictParticularDays: {
-      addParticularDayRestriction: true,
-      invalidDaysOfTheWeek: [1, 2, 5],
-    },
+    invalidDaysOfTheWeek: [1, 2, 5],
   },
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
@@ -4,6 +4,7 @@ import {
   BasicField,
   DateFieldBase,
   DateSelectedValidation,
+  DaysOfTheWeek,
 } from '~shared/types'
 
 import { EditFieldDrawerDecorator, StoryRouter } from '~utils/storybook'
@@ -82,6 +83,6 @@ export const WithParticularDaysRestricted = Template.bind({})
 WithParticularDaysRestricted.args = {
   field: {
     ...DEFAULT_DATE_FIELD,
-    invalidDaysOfTheWeek: [],
+    invalidDaysOfTheWeek: [DaysOfTheWeek.Monday, DaysOfTheWeek.Saturday],
   },
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
@@ -18,6 +18,10 @@ const DEFAULT_DATE_FIELD: DateFieldBase = {
     customMaxDate: null,
     customMinDate: null,
   },
+  restrictParticularDays: {
+    addParticularDayRestriction: false,
+    invalidDaysOfTheWeek: [],
+  },
   required: true,
   disabled: false,
   fieldType: BasicField.Date,
@@ -73,6 +77,17 @@ WithCustomDateRange.args = {
       selectedDateValidation: DateSelectedValidation.Custom,
       customMinDate: new Date('2020-01-01T00:00:00Z'),
       customMaxDate: new Date('2020-01-12T00:00:00Z'),
+    },
+  },
+}
+
+export const WithParticularDaysRestricted = Template.bind({})
+WithParticularDaysRestricted.args = {
+  field: {
+    ...DEFAULT_DATE_FIELD,
+    restrictParticularDays: {
+      addParticularDayRestriction: true,
+      invalidDaysOfTheWeek: [1, 2, 5],
     },
   },
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.stories.tsx
@@ -4,7 +4,7 @@ import {
   BasicField,
   DateFieldBase,
   DateSelectedValidation,
-  DaysOfTheWeek,
+  InvalidDaysOptions,
 } from '~shared/types'
 
 import { EditFieldDrawerDecorator, StoryRouter } from '~utils/storybook'
@@ -19,7 +19,7 @@ const DEFAULT_DATE_FIELD: DateFieldBase = {
     customMaxDate: null,
     customMinDate: null,
   },
-  invalidDaysOfTheWeek: [],
+  invalidDays: [],
   required: true,
   disabled: false,
   fieldType: BasicField.Date,
@@ -83,6 +83,6 @@ export const WithParticularDaysRestricted = Template.bind({})
 WithParticularDaysRestricted.args = {
   field: {
     ...DEFAULT_DATE_FIELD,
-    invalidDaysOfTheWeek: [DaysOfTheWeek.Monday, DaysOfTheWeek.Saturday],
+    invalidDays: [InvalidDaysOptions.Monday, InvalidDaysOptions.Saturday],
   },
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -297,12 +297,7 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
-                  const validDaysSet = new Set(val)
-                  return validDaysSet.has(
-                    InvalidDaysOptions.SingaporePublicHolidays,
-                  )
-                    ? val.length >= 2
-                    : val.length >= 1
+                  return !!val.length || 'Error placeholder'
                 },
               }}
               render={({ field: { ref, ...field } }) => (
@@ -330,6 +325,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
                 </CheckboxGroup>
               )}
             />
+            <FormErrorMessage>
+              {get(errors, 'invalidDays.message')}
+            </FormErrorMessage>
           </FormControl>
         ) : null}
       </Stack>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -297,7 +297,12 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
-                  return !!val.length || 'Error placeholder'
+                  const validDaysSet = new Set(val)
+                  return validDaysSet.has(
+                    InvalidDaysOptions.SingaporePublicHolidays,
+                  )
+                    ? val.length >= 2 || 'Error placeholder'
+                    : val.length >= 1 || 'Error placeholder'
                 },
               }}
               render={({ field: { ref, ...field } }) => (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -44,13 +44,14 @@ export interface InvalidDaysCheckboxOptions {
 }
 
 const INVALID_DAYS_CHECKBOX_VALUES: InvalidDaysCheckboxOptions[] = [
-  { label: 'Monday', value: DaysOfTheWeek.Monday },
-  { label: 'Tuesday', value: DaysOfTheWeek.Tuesday },
-  { label: 'Wednesday', value: DaysOfTheWeek.Wednesday },
-  { label: 'Thursday', value: DaysOfTheWeek.Thursday },
-  { label: 'Friday', value: DaysOfTheWeek.Friday },
-  { label: 'Saturday', value: DaysOfTheWeek.Saturday },
-  { label: 'Sunday', value: DaysOfTheWeek.Sunday },
+  { label: DaysOfTheWeek.Monday, value: DaysOfTheWeek.Monday },
+  { label: DaysOfTheWeek.Tuesday, value: DaysOfTheWeek.Tuesday },
+  { label: DaysOfTheWeek.Wednesday, value: DaysOfTheWeek.Wednesday },
+  { label: DaysOfTheWeek.Thursday, value: DaysOfTheWeek.Thursday },
+  { label: DaysOfTheWeek.Friday, value: DaysOfTheWeek.Friday },
+  { label: DaysOfTheWeek.Saturday, value: DaysOfTheWeek.Saturday },
+  { label: DaysOfTheWeek.Sunday, value: DaysOfTheWeek.Sunday },
+  { label: 'Singapore public holidays', value: 'Singapore public holidays' },
 ]
 
 type EditDateProps = EditFieldProps<DateFieldBase>
@@ -270,59 +271,34 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         </FormControl>
         {getValues('addParticularDayRestriction') ? (
           <FormControl isRequired isReadOnly={isLoading}>
-            <input
-              type="checkbox"
-              hidden
-              value=""
-              {...register('invalidDaysOfTheWeek')}
-            />
-            <Wrap>
-              <Controller
-                control={control}
-                name="invalidDaysOfTheWeek"
-                render={({ field: { ref, ...field } }) => {
-                  return (
-                    <CheckboxGroup {...field}>
+            <Controller
+              control={control}
+              name="invalidDaysOfTheWeek"
+              render={({ field: { ref, ...field } }) => {
+                return (
+                  <CheckboxGroup {...field}>
+                    <Wrap spacing="0.75rem">
                       {INVALID_DAYS_CHECKBOX_VALUES.map((invalidDayOption) => {
-                        console.log(field.value)
                         return (
-                          <Checkbox
+                          <WrapItem
                             key={invalidDayOption.value}
-                            value={invalidDayOption.value}
+                            minW="9.75rem"
+                            maxW="21.25rem"
                           >
-                            {invalidDayOption.label}
-                          </Checkbox>
+                            <Checkbox
+                              key={invalidDayOption.value}
+                              value={invalidDayOption.value}
+                            >
+                              {invalidDayOption.label}
+                            </Checkbox>
+                          </WrapItem>
                         )
                       })}
-                    </CheckboxGroup>
-                  )
-                }}
-              />
-              {/* {INVALID_DAYS_CHECKBOX_VALUES.map((invalidDayOption) => {
-                let width = '9.25rem'
-
-                if (invalidDayOption.value % 2 === 0) {
-                  width = '20rem'
-                }
-
-                return (
-                  <WrapItem key={invalidDayOption.value} width={width}>
-                    <Controller
-                      control={control}
-                      name="invalidDaysOfTheWeek"
-                      render={({ field: { onChange, value, ref } }) => {
-                        console.log(value)
-                        return (
-                          <Checkbox onChange={onChange}>
-                            {invalidDayOption.label}
-                          </Checkbox>
-                        )
-                      }}
-                    />
-                  </WrapItem>
+                    </Wrap>
+                  </CheckboxGroup>
                 )
-              })} */}
-            </Wrap>
+              }}
+            />
           </FormControl>
         ) : null}
       </Stack>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -1,6 +1,13 @@
 import { useMemo } from 'react'
 import { Controller, RegisterOptions } from 'react-hook-form'
-import { Box, FormControl, SimpleGrid } from '@chakra-ui/react'
+import {
+  Box,
+  FormControl,
+  HStack,
+  SimpleGrid,
+  Stack,
+  VStack,
+} from '@chakra-ui/react'
 import { isBefore, isDate, isEqual } from 'date-fns'
 import { extend, get, isEmpty, pick } from 'lodash'
 
@@ -15,6 +22,7 @@ import {
   transformShortIsoStringToDate,
 } from '~utils/date'
 import { createBaseValidationRules } from '~utils/fieldValidation'
+import Checkbox from '~components/Checkbox'
 import DateInput from '~components/DatePicker'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -27,6 +35,13 @@ import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
 import { EditFieldProps } from '../common/types'
 import { useEditFieldForm } from '../common/useEditFieldForm'
+
+const PARTICULAR_DAYS_OPTIONS = [
+  { leftOption: 'Monday', rightOption: 'Tuesday' },
+  { leftOption: 'Wednesday', rightOption: 'Thursday' },
+  { leftOption: 'Friday', rightOption: 'Saturday' },
+  { leftOption: 'Sunday', rightOption: 'Singapore Public Holidays' },
+]
 
 type EditDateProps = EditFieldProps<DateFieldBase>
 
@@ -41,6 +56,10 @@ type EditDateInputs = Pick<
     customMaxDate: string
     customMinDate: string
   }
+  restrictParticularDays: {
+    addParticularDayRestriction: boolean
+    invalidDaysOfTheWeek: number[]
+  }
 }
 
 const transformDateFieldToEditForm = (field: DateFieldBase): EditDateInputs => {
@@ -54,9 +73,17 @@ const transformDateFieldToEditForm = (field: DateFieldBase): EditDateInputs => {
       ? transformDateToShortIsoString(field.dateValidation.customMinDate) ?? ''
       : ('' as const),
   }
+
+  const nextParticularDayRestrictionOption = {
+    addParticularDayRestriction:
+      field.restrictParticularDays?.addParticularDayRestriction ?? false,
+    invalidDaysOfTheWeek:
+      field.restrictParticularDays?.invalidDaysOfTheWeek ?? [],
+  }
   return {
     ...pick(field, EDIT_DATE_FIELD_KEYS),
     dateValidation: nextValidationOptions,
+    restrictParticularDays: nextParticularDayRestrictionOption,
   }
 }
 
@@ -216,6 +243,33 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
           {get(errors, 'dateValidation.customMinDate.message')}
         </FormErrorMessage>
       </FormControl>
+      <Stack>
+        <FormControl isReadOnly={isLoading}>
+          <Toggle
+            {...register('restrictParticularDays.addParticularDayRestriction')}
+            label="Customize days of the week"
+          />
+        </FormControl>
+        {getValues('restrictParticularDays.addParticularDayRestriction') ? (
+          <FormControl isRequired isReadOnly={isLoading}>
+            <Stack direction="column">
+              {PARTICULAR_DAYS_OPTIONS.map((option, index) => {
+                return (
+                  <HStack spacing="0.75rem">
+                    <Box w="9.25rem">
+                      <Checkbox>{option.leftOption}</Checkbox>
+                    </Box>
+                    <Box>
+                      <Checkbox>{option.rightOption}</Checkbox>
+                    </Box>
+                  </HStack>
+                )
+              })}
+            </Stack>
+          </FormControl>
+        ) : null}
+      </Stack>
+
       <FormFieldDrawerActions
         isLoading={isLoading}
         isSaveEnabled={isSaveEnabled}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -6,7 +6,7 @@ import {
   HStack,
   SimpleGrid,
   Stack,
-  VStack,
+  Text,
 } from '@chakra-ui/react'
 import { isBefore, isDate, isEqual } from 'date-fns'
 import { extend, get, isEmpty, pick } from 'lodash'
@@ -249,6 +249,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
             {...register('restrictParticularDays.addParticularDayRestriction')}
             label="Customize days of the week"
           />
+          <Text textStyle="body-2" color="secondary.400">
+            Unchecking a day will disable all the same days in the calendar
+          </Text>
         </FormControl>
         {getValues('restrictParticularDays.addParticularDayRestriction') ? (
           <FormControl isRequired isReadOnly={isLoading}>
@@ -257,10 +260,10 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
                 return (
                   <HStack spacing="0.75rem">
                     <Box w="9.25rem">
-                      <Checkbox>{option.leftOption}</Checkbox>
+                      <Checkbox defaultChecked>{option.leftOption}</Checkbox>
                     </Box>
                     <Box>
-                      <Checkbox>{option.rightOption}</Checkbox>
+                      <Checkbox defaultChecked>{option.rightOption}</Checkbox>
                     </Box>
                   </HStack>
                 )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -180,7 +180,7 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
   })
 
   const watchAddParticularDayRestriction = useWatch({
-    control: control,
+    control,
     name: 'addParticularDayRestriction',
   })
 
@@ -297,6 +297,12 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
+                  /**
+                   * A day is considered to be restricted if it either falls on an invalid
+                   * day of the week or on a Singapore public holiday. Hence, to ensure that
+                   * public users are able to select unrestricted days, the array should
+                   * contain at least one valid day of the week.
+                   */
                   const validDaysSet = new Set(val)
                   return validDaysSet.has(
                     InvalidDaysOptions.SingaporePublicHolidays,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Controller, RegisterOptions } from 'react-hook-form'
 import {
   Box,
+  CheckboxGroup,
   FormControl,
   SimpleGrid,
   Stack,
@@ -39,7 +40,7 @@ import { useEditFieldForm } from '../common/useEditFieldForm'
 
 export interface InvalidDaysCheckboxOptions {
   label: string
-  value: number
+  value: string
 }
 
 const INVALID_DAYS_CHECKBOX_VALUES: InvalidDaysCheckboxOptions[] = [
@@ -71,6 +72,7 @@ type EditDateInputs = Pick<
     customMinDate: string
   }
   addParticularDayRestriction: boolean
+  invalidDaysOfTheWeek: NonNullable<DateFieldBase['invalidDaysOfTheWeek']>
 }
 
 const transformDateFieldToEditForm = (field: DateFieldBase): EditDateInputs => {
@@ -89,10 +91,13 @@ const transformDateFieldToEditForm = (field: DateFieldBase): EditDateInputs => {
     ? field.invalidDaysOfTheWeek.length > 0
     : false
 
+  const nextInvalidDayOptions = field.invalidDaysOfTheWeek ?? []
+
   return {
     ...pick(field, EDIT_DATE_FIELD_KEYS),
     dateValidation: nextValidationOptions,
     addParticularDayRestriction: nextAddParticularDayRestriction,
+    invalidDaysOfTheWeek: nextInvalidDayOptions,
   }
 }
 
@@ -101,7 +106,6 @@ const transformDateEditFormToField = (
   originalField: DateFieldBase,
 ): DateFieldBase => {
   let nextValidationOptions: DateValidationOptions
-  console.log(inputs)
 
   switch (inputs.dateValidation.selectedDateValidation) {
     case '':
@@ -155,6 +159,8 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
       output: transformDateEditFormToField,
     },
   })
+  const invalidDaysOfTheWeek = getValues('invalidDaysOfTheWeek') ?? []
+  console.log(invalidDaysOfTheWeek)
 
   const requiredValidationRule = useMemo(
     () => createBaseValidationRules({ required: true }),
@@ -264,8 +270,35 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         </FormControl>
         {getValues('addParticularDayRestriction') ? (
           <FormControl isRequired isReadOnly={isLoading}>
+            <input
+              type="checkbox"
+              hidden
+              value=""
+              {...register('invalidDaysOfTheWeek')}
+            />
             <Wrap>
-              {INVALID_DAYS_CHECKBOX_VALUES.map((invalidDayOption) => {
+              <Controller
+                control={control}
+                name="invalidDaysOfTheWeek"
+                render={({ field: { ref, ...field } }) => {
+                  return (
+                    <CheckboxGroup {...field}>
+                      {INVALID_DAYS_CHECKBOX_VALUES.map((invalidDayOption) => {
+                        console.log(field.value)
+                        return (
+                          <Checkbox
+                            key={invalidDayOption.value}
+                            value={invalidDayOption.value}
+                          >
+                            {invalidDayOption.label}
+                          </Checkbox>
+                        )
+                      })}
+                    </CheckboxGroup>
+                  )
+                }}
+              />
+              {/* {INVALID_DAYS_CHECKBOX_VALUES.map((invalidDayOption) => {
                 let width = '9.25rem'
 
                 if (invalidDayOption.value % 2 === 0) {
@@ -274,22 +307,25 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
 
                 return (
                   <WrapItem key={invalidDayOption.value} width={width}>
-                    <Checkbox
-                      value={invalidDayOption.value}
-                      {...register('invalidDaysOfTheWeek')}
-                      defaultChecked={false}
+                    <Controller
+                      control={control}
                       name="invalidDaysOfTheWeek"
-                    >
-                      {invalidDayOption.label}
-                    </Checkbox>
+                      render={({ field: { onChange, value, ref } }) => {
+                        console.log(value)
+                        return (
+                          <Checkbox onChange={onChange}>
+                            {invalidDayOption.label}
+                          </Checkbox>
+                        )
+                      }}
+                    />
                   </WrapItem>
                 )
-              })}
+              })} */}
             </Wrap>
           </FormControl>
         ) : null}
       </Stack>
-
       <FormFieldDrawerActions
         isLoading={isLoading}
         isSaveEnabled={isSaveEnabled}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -42,7 +42,7 @@ import { useEditFieldForm } from '../common/useEditFieldForm'
 
 type EditDateProps = EditFieldProps<DateFieldBase>
 
-const INVALID_DAYS_OPTIONS: string[] = [
+const INVALID_DAYS_OPTIONS: InvalidDaysOptions[] = [
   InvalidDaysOptions.Monday,
   InvalidDaysOptions.Tuesday,
   InvalidDaysOptions.Wednesday,
@@ -291,10 +291,20 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
           />
         </FormControl>
         {watchAddParticularDayRestriction ? (
-          <FormControl isRequired>
+          <FormControl isRequired isInvalid={!!errors.invalidDays}>
             <Controller
               control={control}
               name="invalidDays"
+              rules={{
+                validate: (val) => {
+                  const validDaysSet = new Set(val)
+                  return validDaysSet.has(
+                    InvalidDaysOptions.SingaporePublicHolidays,
+                  )
+                    ? val.length >= 2
+                    : val.length >= 1
+                },
+              }}
               render={({ field: { ref, ...field } }) => (
                 <CheckboxGroup
                   {...field}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -143,20 +143,20 @@ export const transformDateToShortIsoString = (date: unknown): string | null => {
   return isDate(date) ? format(date as Date, 'yyyy-MM-dd') : null
 }
 
-/** Transforms the invalid days array to checkbox group value */
+const ALL_INVALID_DAYS_ARR = Object.values(InvalidDaysOptions)
+
+/** Transforms the invalid days array to valid days checkbox group value */
 export const transformInvalidDaysToCheckedBoxesValue = (
   invalidDays: InvalidDaysOptions[],
 ): InvalidDaysOptions[] => {
-  return Object.values(InvalidDaysOptions).filter(
-    (invalidDaysOption) => !invalidDays.includes(invalidDaysOption),
-  )
+  const invalidDaysSet = new Set(invalidDays)
+  return ALL_INVALID_DAYS_ARR.filter((day) => !invalidDaysSet.has(day))
 }
 
-/** Transforms the checkbox group value to invalid days array */
+/** Transforms the valid days checkbox group value to invalid days array */
 export const transformCheckedBoxesValueToInvalidDays = (
   validDays: InvalidDaysOptions[],
 ): InvalidDaysOptions[] => {
-  return Object.values(InvalidDaysOptions).filter(
-    (invalidDaysOptions) => !validDays.includes(invalidDaysOptions),
-  )
+  const validDaysSet = new Set(validDays)
+  return ALL_INVALID_DAYS_ARR.filter((day) => !validDaysSet.has(day))
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -9,6 +9,8 @@ import {
   startOfToday,
 } from 'date-fns'
 
+import { InvalidDaysOptions } from '~shared/types'
+
 import { JsonDate } from '~typings/core'
 
 /**
@@ -139,4 +141,22 @@ export const transformShortIsoStringToDate = (
 
 export const transformDateToShortIsoString = (date: unknown): string | null => {
   return isDate(date) ? format(date as Date, 'yyyy-MM-dd') : null
+}
+
+/** Transforms the invalid days array to checkbox group value */
+export const transformInvalidDaysToCheckedBoxesValue = (
+  invalidDays: InvalidDaysOptions[],
+): InvalidDaysOptions[] => {
+  return Object.values(InvalidDaysOptions).filter(
+    (invalidDaysOption) => !invalidDays.includes(invalidDaysOption),
+  )
+}
+
+/** Transforms the checkbox group value to invalid days array */
+export const transformCheckedBoxesValueToInvalidDays = (
+  validDays: InvalidDaysOptions[],
+): InvalidDaysOptions[] => {
+  return Object.values(InvalidDaysOptions).filter(
+    (invalidDaysOptions) => !validDays.includes(invalidDaysOptions),
+  )
 }

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -24,11 +24,6 @@ export type DateValidationOptions = {
   selectedDateValidation: DateSelectedValidation | null
 }
 
-export type RestrictParticularDaysOption = {
-  addParticularDayRestriction: boolean
-  invalidDaysOfTheWeek: number[]
-}
-
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -24,6 +24,11 @@ export type DateValidationOptions = {
   selectedDateValidation: DateSelectedValidation | null
 }
 
+export type RestrictParticularDaysOption = {
+  addParticularDayRestriction: boolean
+  invalidDaysOfTheWeek: number[]
+}
+
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Add views to allow form-admin users to restrict particular days for the date field

Closes #4134 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

## Before & After Screenshots
New stories added as `WithParticularDaysRestricted` under `Features/EditFieldDrawer/EditDate`
