### PR TITLE
fix: reject invalid utf8 encoded characters

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -81,6 +81,7 @@ import {
 import * as UserService from '../../user/user.service'
 import { PrivateFormError } from '../form.errors'
 import * as FormService from '../form.service'
+import { UNICODE_ESCAPED_REGEX } from '../form.utils'
 
 import { TwilioCredentials } from './../../../services/sms/sms.types'
 import {
@@ -1699,7 +1700,25 @@ export const handleUpdateFormField = [
         disabled: Joi.boolean().required(),
         // Allow other field related key-values to be provided and let the model
         // layer handle the validation.
-      }).unknown(true),
+      })
+        .unknown(true)
+        .custom((value, helpers) => {
+          // If there are unicode-escaped characters are not valid utf-8 encoded,
+          // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
+          // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode character
+          // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
+          // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
+
+          const valueStr = JSON.stringify(value)
+
+          if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
+            return helpers.message({
+              custom:
+                'Please check that there are no improperly encoded characters in your input',
+            })
+          }
+          return value
+        }),
     },
     undefined,
     // Required so req.body can be validated against values in req.params.
@@ -1951,7 +1970,25 @@ export const handleCreateFormField = [
       disabled: Joi.boolean(),
       // Allow other field related key-values to be provided and let the model
       // layer handle the validation.
-    }).unknown(true),
+    })
+      .unknown(true)
+      .custom((value, helpers) => {
+        // If there are unicode-escaped characters are not valid utf-8 encoded,
+        // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
+        // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode sequence
+        // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
+        // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
+
+        const valueStr = JSON.stringify(value)
+
+        if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
+          return helpers.message({
+            custom:
+              'Please check that there are no improperly encoded characters in your input',
+          })
+        }
+        return value
+      }),
     [Segments.QUERY]: {
       // Optional index to insert the field at.
       to: Joi.number().min(0),

--- a/src/app/modules/form/form.utils.ts
+++ b/src/app/modules/form/form.utils.ts
@@ -149,3 +149,10 @@ export const extractFormLinkView = <T extends IFormDocument>(
     link: `${appUrl}/${_id}`,
   }
 }
+
+/**
+ * Regex to to detect invalid-encoded utf-8 characters in stringified form field input
+ * Matches any sequence which starts with a non-backslash, an odd number of backslashes, followed by unicode escape sequence
+ * See https://mathiasbynens.be/notes/javascript-escapes for regex on unicode escape sequences
+ */
+export const UNICODE_ESCAPED_REGEX = /[^\\](\\\\)*\\u[0-9a-fA-F]{4}/

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1610,6 +1610,93 @@ describe('admin-form.form.routes', () => {
     })
   })
 
+  describe('PUT /:formId/fields', () => {
+    it('should return 200 if form field contains valid utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1'],
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      const formToCheck = await EmailFormModel.findById(formToUpdate._id).lean()
+
+      const insertedField = formToCheck!.form_fields![1]
+      const insertedFieldId = insertedField._id
+
+      const updatedField = { ...insertedField, fieldOptions: ['Option1\u00ae'] }
+
+      const fieldUpdateResponse = await request
+        .put(`/admin/forms/${formToUpdate._id}/fields/${insertedFieldId}`)
+        // No positional argument
+        .send(updatedField)
+
+      const formToCheckUpdated = await EmailFormModel.findById(
+        formToUpdate._id,
+      ).lean()
+
+      // Assert
+      expect(formToCheckUpdated!.form_fields![1]).toMatchObject(updatedField) //Updated field should be last in array
+      expect(fieldUpdateResponse.status).toEqual(200)
+      expect(fieldUpdateResponse.body).toMatchObject(omit(updatedField, '_id'))
+    })
+
+    it('should return 400 if form field contains invalid utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1'],
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      const formToCheck = await EmailFormModel.findById(formToUpdate._id).lean()
+
+      const insertedField = formToCheck!.form_fields![1]
+      const insertedFieldId = insertedField._id
+
+      const updatedField = {
+        ...insertedField,
+        fieldOptions: ['Option1\u00ae\udbbb'],
+      }
+
+      const fieldUpdateResponse = await request
+        .put(`/admin/forms/${formToUpdate._id}/fields/${insertedFieldId}`)
+        // No positional argument
+        .send(updatedField)
+
+      // Assert
+      expect(fieldUpdateResponse.status).toEqual(400)
+    })
+  })
+
   describe('POST /:formId/fields', () => {
     it('should return 200 with created form field with positional argument', async () => {
       // Arrange
@@ -1712,6 +1799,63 @@ describe('admin-form.form.routes', () => {
       ])
       expect(response.status).toEqual(200)
       expect(response.body).toMatchObject(fieldToInsert)
+    })
+
+    it('should return 200 if form field contains valid utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1\u00ae'],
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      // Assert
+      const formToCheck = await EmailFormModel.findById(formToUpdate._id).lean()
+      expect(formToCheck?.form_fields).toMatchObject([
+        ...formToUpdate.toObject().form_fields,
+        // Inserted field should be last in field array.
+        fieldToInsert,
+      ])
+      expect(response.status).toEqual(200)
+      expect(response.body).toMatchObject(fieldToInsert)
+    })
+
+    it('should return 400 if form field contains invalid utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1\u00ae\udbbb'], // \udbbb is invalid encoding
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      // Assert
+      expect(response.status).toEqual(400)
     })
 
     it('should return 400 with negative positional argument', async () => {

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1655,6 +1655,53 @@ describe('admin-form.form.routes', () => {
       expect(fieldUpdateResponse.body).toMatchObject(omit(updatedField, '_id'))
     })
 
+    it('should return 200 if form field contains string with escaped backslash which looks like utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1'],
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      const formToCheck = await EmailFormModel.findById(formToUpdate._id).lean()
+
+      const insertedField = formToCheck!.form_fields![1]
+      const insertedFieldId = insertedField._id
+
+      const updatedField = {
+        ...insertedField,
+        fieldOptions: ['Option1\\udbbb'],
+      }
+
+      const fieldUpdateResponse = await request
+        .put(`/admin/forms/${formToUpdate._id}/fields/${insertedFieldId}`)
+        // No positional argument
+        .send(updatedField)
+
+      const formToCheckUpdated = await EmailFormModel.findById(
+        formToUpdate._id,
+      ).lean()
+
+      // Assert
+      expect(formToCheckUpdated!.form_fields![1]).toMatchObject(updatedField) //Updated field should be last in array
+      expect(fieldUpdateResponse.status).toEqual(200)
+      expect(fieldUpdateResponse.body).toMatchObject(omit(updatedField, '_id'))
+    })
+
     it('should return 400 if form field contains invalid utf8 encoded unicode character sequence', async () => {
       // Arrange
       const fieldToInsert = omit(
@@ -1806,6 +1853,38 @@ describe('admin-form.form.routes', () => {
       const fieldToInsert = omit(
         generateDefaultField(BasicField.Dropdown, {
           fieldOptions: ['Option1\u00ae'],
+        }),
+        ['_id', 'globalId', 'getQuestion'],
+      )
+      const formToUpdate = (await EmailFormModel.create({
+        title: 'Form to update',
+        emails: [defaultUser.email],
+        admin: defaultUser._id,
+        form_fields: [generateDefaultField(BasicField.Rating)],
+      })) as IPopulatedForm
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${formToUpdate._id}/fields`)
+        // No positional argument
+        .send(fieldToInsert)
+
+      // Assert
+      const formToCheck = await EmailFormModel.findById(formToUpdate._id).lean()
+      expect(formToCheck?.form_fields).toMatchObject([
+        ...formToUpdate.toObject().form_fields,
+        // Inserted field should be last in field array.
+        fieldToInsert,
+      ])
+      expect(response.status).toEqual(200)
+      expect(response.body).toMatchObject(fieldToInsert)
+    })
+
+    it('should return 200 if form field contains string with escaped backslash which looks like utf8 encoded unicode character sequence', async () => {
+      // Arrange
+      const fieldToInsert = omit(
+        generateDefaultField(BasicField.Dropdown, {
+          fieldOptions: ['Option1\\udbbb'],
         }),
         ['_id', 'globalId', 'getQuestion'],
       )

--- a/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -147,7 +147,7 @@ function AdminFormController(
       case StatusCodes.CONFLICT:
       case StatusCodes.BAD_REQUEST:
         errorMessage =
-          'This page seems outdated, and your changes could not be saved. Please refresh.'
+          'Your changes could not be saved. The page may be outdated, or your input is invalid. Please refresh and try again.'
         break
       case StatusCodes.FORBIDDEN:
       case StatusCodes.UNAUTHORIZED:


### PR DESCRIPTION
## Problem
Closes [#144](https://github.com/datagovsg/formsg-private/issues/144)

## Explanation
- Unicode characters can be escaped as `\\u[0-9a-fA-F]{4}` in JS: see https://mathiasbynens.be/notes/javascript-escapes
- Not all 65536 combinations are valid unicode (see https://charbase.com/dbbb-unicode-invalid-character for some examples). 
- If the node14 application receives unicode-escaped characters are not valid unicode, node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence (not found in documentation, but this is observed through testing)
- Although the 6-character string is considered as a valid UTF-8 encoded string by the application (because each individual character is correctly encoded), if this is saved into the db, an error is thrown when the mongodb driver attempts to read the db document, because the driver interprets the sequence as an invalid UTF8 encoded character
- The fix implements a regex check at the application level when form fields are created or updated, to reject unicode character sequences that exist as a 6-character string
  - Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ® instead of the 6-character string), they will not trigger an error. 
  - If the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash `\\udbbb`) and hence this will also not trigger an error.
  
Sample code for nodejs:
```javascript
// valid utf8
console.log(JSON.stringify("\u4E09"))
// "三"

// invalid utf8
console.log(JSON.stringify("\udbbb"))
// "\udbbb"
```

## Tests

*Valid UTF8 encoding is accepted*
- [ ] (POST) Create dropdown form field. Clone the network request as cURL. Modify it such that the fieldoptions includes `\u00ae` e.g. `fieldOptions: ['Option1\u00ae']`. Send the network request. You should receive 200.
- [ ] (PUT) Modify the dropdown form field options. Clone the network request. Now modify the network request so that the fieldoptions includes `fieldOptions: ['Option1\u00ae']`. Send the network request. You should receive 200.

*String that _looks_ like invalid UTF8 encoding is accepted*
- [ ] (POST) Create dropdown form field. Clone the network request as cURL. Modify it such that the fieldoptions includes `\\udbbb` e.g. `fieldOptions: ['Option1\\udbbb']`. Send the network request. You should receive 200.
- [ ] (PUT) Modify the dropdown form field options. Clone the network request. Now modify the network request so that the fieldoptions includes `fieldOptions: ['Option1\\udbbb']`. Send the network request. You should receive 200.

*Invalid UTF8 encoding is rejected*
- [ ] (POST) Create dropdown form field. Clone the network request as cURL. Modify it such that the fieldoptions includes `\udbbb` e.g. `fieldOptions: ['Option1\udbbb']`. Send the network request. You should receive 400.
- [ ] (PUT) Modify the dropdown form field options. Clone the network request. Now modify the network request so that the fieldoptions includes `fieldOptions: ['Option1\udbbb']`. Send the network request. You should receive 200.
