### PR TITLE
fix: correct ts-essentials dependency specifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28960,9 +28960,10 @@
       }
     },
     "ts-essentials": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.1.2.tgz",
-      "integrity": "sha512-EaSmXsAhEiirrTY1Oaa7TSpei9dzuCuFPmjKRJRPamERYtfaGS8/KpOSbjergLz/Y76/aZlV9i/krgzsuWEBbg=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.2.0.tgz",
+      "integrity": "sha512-HLl+am6q+ulOWcjUFghpIQXXyaH0hVTnFTVWNqwz1iDxyN+t+lwDfqPB5FmPUTFw3J+y26UR3hNGmK/1jehokA==",
+      "dev": true
     },
     "ts-jest": {
       "version": "26.5.6",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "text-encoding": "^0.7.0",
     "toastr": "^2.1.4",
     "triple-beam": "^1.3.0",
-    "ts-essentials": "^9.1.2",
     "tweetnacl": "^1.0.1",
     "twilio": "^3.78.0",
     "ui-select": "^0.19.8",


### PR DESCRIPTION
## Problem
The last develop merge into v2-develop had some issue and we accidentally messed up the ts-essentials dependency.

## Solution
Fix the dependency declaration by removing the old erroneous one from dependencies (and leave the correct ones indev dependencies), and re-generate package-lock.json