### PR TITLE
bug: fix refreshing form title gone bug

### DIFF
--- a/src/public/modules/forms/base/components/start-page.client.component.js
+++ b/src/public/modules/forms/base/components/start-page.client.component.js
@@ -17,11 +17,11 @@ angular.module('forms').component('startPageComponent', {
     isTemplate: '<',
     formLogin: '&',
   },
-  controller: ['SpcpSession', 'Toastr', startPageController],
+  controller: ['SpcpSession', 'Toastr', '$window', startPageController],
   controllerAs: 'vm',
 })
 
-function startPageController(SpcpSession, Toastr) {
+function startPageController(SpcpSession, Toastr, $window) {
   const vm = this
 
   vm.formLogout = SpcpSession.logout
@@ -31,6 +31,7 @@ function startPageController(SpcpSession, Toastr) {
   }
 
   vm.$onInit = () => {
+    $window.document.title = this.formTitle
     vm.userName = SpcpSession.userName
     vm.FormLogoState = FormLogoState
 
@@ -43,6 +44,10 @@ function startPageController(SpcpSession, Toastr) {
         'There was an unexpected error with your log in. Please try again later.',
       )
     }
+  }
+
+  vm.$onDestroy = () => {
+    $window.document.title = 'FormSG'
   }
 
   const isInViewport = function () {


### PR DESCRIPTION
## Problem
form title doesn't persist after refresh

Closes #47

## Solution
inject title during client form component life cycle.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

-  inject form title during client form component init, reset title to formsg during component destroy

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/102740235/179163495-1056e053-e7a3-4cd6-9e9f-ce1ba0b0101c.mp4

**AFTER**:

https://user-images.githubusercontent.com/102740235/179163736-2d8f2814-351c-409c-b886-7b90caa0e64e.mp4

## Tests
no unit test needed
