### PR TITLE
chore: remove isNewClient flag

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -952,7 +952,6 @@ describe('admin-form.controller', () => {
         fileId: 'any file id',
         fileMd5Hash: 'any hash',
         fileType: 'any type',
-        isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
       },
     })
 
@@ -980,55 +979,6 @@ describe('admin-form.controller', () => {
       // Act
       await AdminFormController.createPresignedPostUrlForImages(
         MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
-    })
-
-    it('should return 200 with presigned POST URL object when successful for old clients', async () => {
-      // TODO (#128): Test to be removed after isNewClient flag has been removed
-      // Arrange
-      const MOCK_REQ_OLD = expressHandler.mockRequest({
-        params: {
-          formId: MOCK_FORM_ID,
-        },
-        session: {
-          user: {
-            _id: MOCK_USER_ID,
-          },
-        },
-        body: {
-          fileId: 'any file id',
-          fileMd5Hash: 'any hash',
-          fileType: 'any type',
-        },
-      })
-
-      const mockRes = expressHandler.mockResponse()
-      // Mock various services to return expected results.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      const expectedPresignedPost: PresignedPost = {
-        fields: {
-          'X-Amz-Signature': 'some-amz-signature',
-          Policy: 'some policy',
-        },
-        url: 'some url',
-      }
-      MockAdminFormService.createPresignedPostUrlForImages.mockReturnValueOnce(
-        okAsync(expectedPresignedPost),
-      )
-
-      // Act
-      await AdminFormController.createPresignedPostUrlForImages(
-        MOCK_REQ_OLD,
         mockRes,
         jest.fn(),
       )
@@ -1237,7 +1187,6 @@ describe('admin-form.controller', () => {
         fileId: 'any file id',
         fileMd5Hash: 'any hash',
         fileType: 'any type',
-        isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
       },
     })
 
@@ -1265,55 +1214,6 @@ describe('admin-form.controller', () => {
       // Act
       await AdminFormController.createPresignedPostUrlForLogos(
         MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.json).toHaveBeenCalledWith(expectedPresignedPost)
-    })
-
-    it('should return 200 with presigned POST URL object when successful for old clients', async () => {
-      // TODO (#128): Test to be removed after isNewClient flag has been removed
-      // Arrange
-      const MOCK_REQ_OLD = expressHandler.mockRequest({
-        params: {
-          formId: MOCK_FORM_ID,
-        },
-        session: {
-          user: {
-            _id: MOCK_USER_ID,
-          },
-        },
-        body: {
-          fileId: 'any file id',
-          fileMd5Hash: 'any hash',
-          fileType: 'any type',
-        },
-      })
-      // Arrange
-      const mockRes = expressHandler.mockResponse()
-      // Mock various services to return expected results.
-      MockUserService.getPopulatedUserById.mockReturnValueOnce(
-        okAsync(MOCK_USER),
-      )
-      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-      const expectedPresignedPost: PresignedPost = {
-        fields: {
-          'X-Amz-Signature': 'some-amz-signature',
-          Policy: 'some policy',
-        },
-        url: 'some url',
-      }
-      MockAdminFormService.createPresignedPostUrlForLogos.mockReturnValueOnce(
-        okAsync(expectedPresignedPost),
-      )
-
-      // Act
-      await AdminFormController.createPresignedPostUrlForLogos(
-        MOCK_REQ_OLD,
         mockRes,
         jest.fn(),
       )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -4909,14 +4909,6 @@ describe('admin-form.routes', () => {
       fileId: 'some file id',
       fileMd5Hash: SparkMD5.hash('test file name'),
       fileType: VALID_UPLOAD_FILE_TYPES[0],
-      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
-    }
-
-    const DEFAULT_POST_PARAMS_OLD_CLIENT = {
-      // TODO (#128): Clean up tests after isNewClient flag has been removed.
-      fileId: 'some other file id',
-      fileMd5Hash: SparkMD5.hash('test file name again'),
-      fileType: VALID_UPLOAD_FILE_TYPES[2],
     }
 
     it('should return 200 with presigned POST URL object and append an objectId to the key', async () => {
@@ -4954,36 +4946,6 @@ describe('admin-form.routes', () => {
       )
 
       expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
-    })
-
-    it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {
-      // TODO (#128): Test to be removed after isNewClient flag has been removed.
-      // Arrange
-      const form = await EncryptFormModel.create({
-        title: 'form',
-        admin: defaultUser._id,
-        publicKey: 'does not matter',
-      })
-
-      // Act
-      const response = await request
-        .post(`/${form._id}/adminform/logos`)
-        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
-
-      // Assert
-      expect(response.status).toEqual(200)
-      // Should equal mocked result.
-      expect(response.body).toEqual({
-        url: expect.any(String),
-        fields: expect.objectContaining({
-          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
-          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
-          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
-          // Should have correct permissions.
-          acl: 'public-read',
-          bucket: expect.any(String),
-        }),
-      })
     })
 
     it('should return 400 when body.fileId is missing', async () => {
@@ -5193,14 +5155,6 @@ describe('admin-form.routes', () => {
       fileId: 'some other file id',
       fileMd5Hash: SparkMD5.hash('test file name again'),
       fileType: VALID_UPLOAD_FILE_TYPES[2],
-      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
-    }
-
-    const DEFAULT_POST_PARAMS_OLD_CLIENT = {
-      // TODO (#128): Clean up tests after isNewClient flag has been removed.
-      fileId: 'some other file id',
-      fileMd5Hash: SparkMD5.hash('test file name again'),
-      fileType: VALID_UPLOAD_FILE_TYPES[2],
     }
 
     it('should return 200 with presigned POST URL object and append an objectId to the key', async () => {
@@ -5238,36 +5192,6 @@ describe('admin-form.routes', () => {
       )
 
       expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
-    })
-
-    it('should return 200 with presigned POST URL object and NOT append an objectId to the key if !isNewClient', async () => {
-      // TODO (#128): Test to be removed after isNewClient flag has been removed.
-      // Arrange
-      const form = await EncryptFormModel.create({
-        title: 'form',
-        admin: defaultUser._id,
-        publicKey: 'does not matter',
-      })
-
-      // Act
-      const response = await request
-        .post(`/${form._id}/adminform/logos`)
-        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
-
-      // Assert
-      expect(response.status).toEqual(200)
-      // Should equal mocked result.
-      expect(response.body).toEqual({
-        url: expect.any(String),
-        fields: expect.objectContaining({
-          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
-          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
-          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
-          // Should have correct permissions.
-          acl: 'public-read',
-          bucket: expect.any(String),
-        }),
-      })
     })
 
     it('should return 400 when body.fileId is missing', async () => {

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -189,7 +189,6 @@ const fileUploadValidator = celebrate({
     fileType: Joi.string()
       .valid(...VALID_UPLOAD_FILE_TYPES)
       .required(),
-    isNewClient: Joi.boolean().optional(),
   },
 })
 
@@ -385,17 +384,14 @@ export const createPresignedPostUrlForImages: ControllerHandler<
     fileId: string
     fileMd5Hash: string
     fileType: string
-    isNewClient?: boolean // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
   }
 > = async (req, res) => {
   const { formId } = req.params
-  const { fileId, fileMd5Hash, fileType, isNewClient } = req.body
+  const { fileId, fileMd5Hash, fileType } = req.body
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Adding random objectId ensures fileId is unpredictable by client
-  const randomizedFileId = isNewClient
-    ? `${String(new ObjectId())}-${fileId}`
-    : fileId // TODO (#128): if !isNewClient, returns fileId for backward compatability. To remove fallback for !isNewClient 2 weeks after release.
+  const randomizedFileId = `${String(new ObjectId())}-${fileId}`
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -456,17 +452,14 @@ export const createPresignedPostUrlForLogos: ControllerHandler<
     fileId: string
     fileMd5Hash: string
     fileType: string
-    isNewClient?: boolean // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
   }
 > = async (req, res) => {
   const { formId } = req.params
-  const { fileId, fileMd5Hash, fileType, isNewClient } = req.body
+  const { fileId, fileMd5Hash, fileType } = req.body
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
   // Adding random objectId ensures fileId is unpredictable by client
-  const randomizedFileId = isNewClient
-    ? `${String(new ObjectId())}-${fileId}`
-    : fileId // TODO (#128): if !isNewClient, returns fileId for backward compatability. To remove fallback for !isNewClient 2 weeks after release.
+  const randomizedFileId = `${String(new ObjectId())}-${fileId}`
 
   return (
     // Step 1: Retrieve currently logged in user.

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.presign.routes.spec.ts
@@ -62,7 +62,6 @@ describe('admin-form.presign.routes', () => {
       fileId: 'some file id',
       fileMd5Hash: SparkMD5.hash('test file name'),
       fileType: VALID_UPLOAD_FILE_TYPES[0],
-      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
     it('should return 200 with presigned POST URL object', async () => {
@@ -100,42 +99,6 @@ describe('admin-form.presign.routes', () => {
       )
 
       expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
-    })
-
-    it('should return 200 with presigned POST URL object for old client', async () => {
-      // Arrange
-
-      const DEFAULT_POST_PARAMS_OLD_CLIENT = {
-        fileId: 'some file id',
-        fileMd5Hash: SparkMD5.hash('test file name'),
-        fileType: VALID_UPLOAD_FILE_TYPES[0],
-      }
-
-      const form = await EncryptFormModel.create({
-        title: 'form',
-        admin: defaultUser._id,
-        publicKey: 'does not matter',
-      })
-
-      // Act
-      const response = await request
-        .post(`/admin/forms/${form._id}/images/presign`)
-        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
-
-      // Assert
-      expect(response.status).toEqual(200)
-      // Should equal mocked result.
-      expect(response.body).toEqual({
-        url: expect.any(String),
-        fields: expect.objectContaining({
-          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
-          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
-          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
-          // Should have correct permissions.
-          acl: 'public-read',
-          bucket: expect.any(String),
-        }),
-      })
     })
 
     it('should return 400 when body.fileId is missing', async () => {
@@ -345,7 +308,6 @@ describe('admin-form.presign.routes', () => {
       fileId: 'some other file id',
       fileMd5Hash: SparkMD5.hash('test file name again'),
       fileType: VALID_UPLOAD_FILE_TYPES[2],
-      isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
     }
 
     it('should return 200 with presigned POST URL object', async () => {
@@ -384,42 +346,6 @@ describe('admin-form.presign.routes', () => {
       )
 
       expect(response.body.fields.key).toMatch(/^[a-fA-F0-9]{24}-/)
-    })
-
-    it('should return 200 with presigned POST URL object for old client', async () => {
-      // Arrange
-
-      const DEFAULT_POST_PARAMS_OLD_CLIENT = {
-        fileId: 'some file id',
-        fileMd5Hash: SparkMD5.hash('test file name'),
-        fileType: VALID_UPLOAD_FILE_TYPES[0],
-      }
-
-      const form = await EncryptFormModel.create({
-        title: 'form',
-        admin: defaultUser._id,
-        publicKey: 'does not matter',
-      })
-
-      // Act
-      const response = await request
-        .post(`/admin/forms/${form._id}/logos/presign`)
-        .send(DEFAULT_POST_PARAMS_OLD_CLIENT)
-
-      // Assert
-      expect(response.status).toEqual(200)
-      // Should equal mocked result.
-      expect(response.body).toEqual({
-        url: expect.any(String),
-        fields: expect.objectContaining({
-          'Content-MD5': DEFAULT_POST_PARAMS_OLD_CLIENT.fileMd5Hash,
-          'Content-Type': DEFAULT_POST_PARAMS_OLD_CLIENT.fileType,
-          key: DEFAULT_POST_PARAMS_OLD_CLIENT.fileId,
-          // Should have correct permissions.
-          acl: 'public-read',
-          bucket: expect.any(String),
-        }),
-      })
     })
 
     it('should return 400 when body.fileId is missing', async () => {

--- a/src/public/services/FileHandlerService.ts
+++ b/src/public/services/FileHandlerService.ts
@@ -67,7 +67,6 @@ const fetchPresignedData = async (
     fileId: string
     fileMd5Hash: string
     fileType: string
-    isNewClient: boolean // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
   },
   cancelToken?: CancelToken,
 ): Promise<PresignedData> => {
@@ -115,7 +114,6 @@ export const uploadFile = async ({
     fileId,
     fileMd5Hash,
     fileType: file.type,
-    isNewClient: true, // TODO (#128): Flag for server to know whether to append random object ID in front. To remove 2 weeks after release.
   }
 
   const postData = await fetchPresignedData(

--- a/src/public/services/__tests__/FileHandlerService.test.ts
+++ b/src/public/services/__tests__/FileHandlerService.test.ts
@@ -132,7 +132,6 @@ describe('FileHandlerService', () => {
         fileId: mockFileId,
         fileMd5Hash: expect.any(String),
         fileType: mockUpload.type,
-        isNewClient: true,
       }
 
       const expectedFinalValue: FileHandlerService.UploadedFileData = {


### PR DESCRIPTION
## Problem
- Removes `isNewClient` flag
- follow up to #3927
- closes #4103 

## Tests
<!-- What problem are you trying to solve? What issue does this close? -->
- [ ] Create storage mode form. Test that logo and image upload works and can be displayed in public form.
- [ ] (safety check, should not be affected by this PR) Add attachment field. Test that file upload works and can be retrieved from storage mode
