### PR TITLE
feat: stop tracking middleware spans with dd-trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-frontend": "webpack --config webpack.prod.js",
     "build-frontend-dev": "webpack --config webpack.dev.js",
     "build-frontend-dev:watch": "webpack --config webpack.dev.js --watch",
-    "start": "node -r dotenv/config -r dd-trace/init dist/backend/src/app/server.js",
+    "start": "node -r dotenv/config dist/backend/src/app/server.js",
     "dev": "docker-compose up --build",
     "docker-dev": "npm run build-frontend-dev:watch & ts-node-dev --respawn --transpile-only --inspect=0.0.0.0 --exit-child -r dotenv/config -- src/app/server.ts",
     "test": "npm run test-backend && npm run test-frontend",

--- a/src/app/loaders/datadog-tracer.ts
+++ b/src/app/loaders/datadog-tracer.ts
@@ -1,0 +1,12 @@
+import tracer from 'dd-trace'
+
+tracer.init()
+
+// setup express to not track middlewares as spans
+// see documentation: https://datadoghq.dev/dd-trace-js/interfaces/plugins.express.html
+tracer.use('express', {
+  enabled: true,
+  middleware: false,
+})
+
+export default tracer

--- a/src/app/loaders/datadog-tracer.ts
+++ b/src/app/loaders/datadog-tracer.ts
@@ -5,7 +5,6 @@ tracer.init()
 // setup express to not track middlewares as spans
 // see documentation: https://datadoghq.dev/dd-trace-js/interfaces/plugins.express.html
 tracer.use('express', {
-  enabled: true,
   middleware: false,
 })
 

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -1,3 +1,5 @@
+import './loaders/datadog-tracer'
+
 import config from './config/config'
 import { createLoggerWithLabel } from './config/logger'
 import loadApp from './loaders'


### PR DESCRIPTION
## Problem
By default, dd-trace's express integration creates spans for all middlewares.

While this is a deep level of granularity, we do not actually expect middleware themselves to be a problem, and this creates a huge number of spans, which are not free!

![image](https://user-images.githubusercontent.com/935223/179447416-21dd6287-970d-4569-baa8-774f599327a4.png)

## Solution

middleware spans can be disabled in dd-trace (see [documentation](https://datadoghq.dev/dd-trace-js/interfaces/plugins.express.html)), if we initialize the tracer manually. The PR does that.

Here is a sample tracking for the same call (otp verify) without the middleware spans.

![image](https://user-images.githubusercontent.com/935223/179447665-9b83a2ad-d6e6-4507-a5a6-2add4a1a218e.png)

