### PR TITLE
fix(form-fields): disable field creation when field is disabled

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -66,6 +66,17 @@ DesktopAllFields.parameters = {
     responseMode: FormResponseMode.Email,
   }),
 }
+export const DesktopLoading = Template.bind({})
+DesktopLoading.parameters = {
+  msw: buildMswRoutes(
+    {
+      form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+      authType: FormAuthType.MyInfo,
+      responseMode: FormResponseMode.Email,
+    },
+    'infinite',
+  ),
+}
 
 export const TabletEmpty = Template.bind({})
 TabletEmpty.parameters = {
@@ -82,6 +93,17 @@ TabletAllFields.parameters = {
   chromatic: { viewports: [viewports.md] },
   msw: buildMswRoutes({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
 }
+export const TabletLoading = Template.bind({})
+TabletLoading.parameters = {
+  viewport: {
+    defaultViewport: 'tablet',
+  },
+  chromatic: { viewports: [viewports.md] },
+  msw: buildMswRoutes(
+    { form_fields: MOCK_FORM_FIELDS_WITH_MYINFO },
+    'infinite',
+  ),
+}
 
 export const MobileEmpty = Template.bind({})
 MobileEmpty.parameters = {
@@ -97,4 +119,15 @@ MobileAllFields.parameters = {
   },
   chromatic: { viewports: [viewports.xs] },
   msw: buildMswRoutes({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
+}
+export const MobileLoading = Template.bind({})
+MobileLoading.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+  msw: buildMswRoutes(
+    { form_fields: MOCK_FORM_FIELDS_WITH_MYINFO },
+    'infinite',
+  ),
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
@@ -67,10 +67,12 @@ export const DraggableBasicFieldListOption = ({
   fieldType,
   index,
   children,
+  isDisabled,
   ...props
 }: DraggableBasicFieldOptionProps): JSX.Element => (
   <Draggable
     index={index}
+    isDragDisabled={isDisabled}
     disableInteractiveElementBlocking
     draggableId={fieldType}
   >
@@ -79,6 +81,7 @@ export const DraggableBasicFieldListOption = ({
         <>
           <BasicFieldOption
             fieldType={fieldType}
+            isDisabled={isDisabled}
             {...props}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
@@ -103,10 +106,12 @@ export const DraggableMyInfoFieldListOption = ({
   fieldType,
   index,
   children,
+  isDisabled,
   ...props
 }: DraggableMyInfoFieldOptionProps): JSX.Element => (
   <Draggable
     index={index}
+    isDragDisabled={isDisabled}
     disableInteractiveElementBlocking
     draggableId={fieldType}
   >
@@ -115,6 +120,7 @@ export const DraggableMyInfoFieldListOption = ({
         <>
           <MyInfoFieldOption
             fieldType={fieldType}
+            isDisabled={isDisabled}
             {...props}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
@@ -136,7 +142,7 @@ export const DraggableMyInfoFieldListOption = ({
 )
 
 export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
-  ({ fieldType, ...props }, ref) => {
+  ({ fieldType, isDisabled, ...props }, ref) => {
     const meta = useMemo(
       () => BASICFIELD_TO_DRAWER_META[fieldType],
       [fieldType],
@@ -154,11 +160,16 @@ export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
     )
 
     const handleClick = useCallback(() => {
-      updateCreateState(newFieldMeta, numFields)
-    }, [newFieldMeta, numFields, updateCreateState])
+      if (!isDisabled) updateCreateState(newFieldMeta, numFields)
+    }, [newFieldMeta, numFields, updateCreateState, isDisabled])
 
     return (
-      <FieldListOption {...props} onClick={handleClick} ref={ref}>
+      <FieldListOption
+        {...props}
+        isDisabled={isDisabled}
+        onClick={handleClick}
+        ref={ref}
+      >
         <Icon fontSize="1.5rem" as={meta.icon} />
         <Text textStyle="body-1">{meta.label}</Text>
       </FieldListOption>
@@ -167,7 +178,7 @@ export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
 )
 
 export const MyInfoFieldOption = forwardRef<MyInfoFieldOptionProps, 'button'>(
-  ({ fieldType, ...props }, ref) => {
+  ({ fieldType, isDisabled, ...props }, ref) => {
     const meta = useMemo(
       () => MYINFO_FIELD_TO_DRAWER_META[fieldType],
       [fieldType],
@@ -185,11 +196,16 @@ export const MyInfoFieldOption = forwardRef<MyInfoFieldOptionProps, 'button'>(
     )
 
     const handleClick = useCallback(() => {
-      updateCreateState(newFieldMeta, numFields)
-    }, [newFieldMeta, numFields, updateCreateState])
+      if (!isDisabled) updateCreateState(newFieldMeta, numFields)
+    }, [newFieldMeta, numFields, updateCreateState, isDisabled])
 
     return (
-      <FieldListOption {...props} onClick={handleClick} ref={ref}>
+      <FieldListOption
+        {...props}
+        isDisabled={isDisabled}
+        onClick={handleClick}
+        ref={ref}
+      >
         <Icon fontSize="1.5rem" as={meta.icon} />
         <Text textStyle="body-1">{meta.label}</Text>
       </FieldListOption>


### PR DESCRIPTION
## Problem
Previously, `FieldListOption`s were _visually_ disabled but users could still drag/click on them to create fields manually. This was due to the `Draggable`'s state not being tied to the `isDisabled` prop and the `handleClick` not being dependent on the prop also. 

This was most evident during: 
1.  loading states on initial form load 
2. when `myInfo` fields >= 30 

Closes #4118

## Solution
1. Thread the `isDisabled` prop through to `Draggable` and `FieldListOption`
2. add extra loading states for creation to check behaviour for `disabled` states