### PR TITLE
feat: edit date field schema to add additional attribute for invalid days of the week

### DIFF
--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -16,4 +16,5 @@ export type DateValidationOptions = {
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions
+  invalidDaysOfTheWeek?: number[]
 }

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -7,6 +7,16 @@ export enum DateSelectedValidation {
   Custom = 'Custom date range',
 }
 
+export enum DaysOfTheWeek {
+  Sunday = 0,
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
+}
+
 export type DateValidationOptions = {
   customMaxDate: Date | null
   customMinDate: Date | null
@@ -16,5 +26,5 @@ export type DateValidationOptions = {
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions
-  invalidDaysOfTheWeek?: number[]
+  invalidDaysOfTheWeek?: DaysOfTheWeek[] | null
 }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -158,53 +158,6 @@ describe('Form Model', () => {
         expect(actualSavedObject).toEqual(expectedObject)
       })
 
-      it('should create new date form field with default empty array of invalid days of the week and save successfully', async () => {
-        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-          admin: MOCK_ADMIN_OBJ_ID,
-          form_fields: [generateDefaultField(BasicField.Date)],
-        })
-
-        const form = await Form.create(formParams)
-        const saved = await form.save()
-
-        expect(saved._id).toBeDefined()
-        expect(saved.created).toBeInstanceOf(Date)
-        expect(saved.lastModified).toBeInstanceOf(Date)
-
-        const savedObjectFormFields = (
-          saved.form_fields as Types.DocumentArray<IFieldSchema>
-        ).toObject()
-
-        expect(savedObjectFormFields[0].invalidDaysOfTheWeek).toEqual([])
-      })
-
-      it('should create new date form field with expected array of invalid days of the week and save successfully', async () => {
-        const expectedInvalidDaysOfTheWeek = [1, 2, 3]
-        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-          admin: MOCK_ADMIN_OBJ_ID,
-          form_fields: [
-            generateDefaultField(BasicField.Date, {
-              invalidDaysOfTheWeek: expectedInvalidDaysOfTheWeek,
-            }),
-          ],
-        })
-
-        const form = await Form.create(formParams)
-        const saved = await form.save()
-
-        expect(saved._id).toBeDefined()
-        expect(saved.created).toBeInstanceOf(Date)
-        expect(saved.lastModified).toBeInstanceOf(Date)
-
-        const savedObjectFormFields = (
-          saved.form_fields as Types.DocumentArray<IFieldSchema>
-        ).toObject()
-
-        expect(savedObjectFormFields[0].invalidDaysOfTheWeek).toEqual(
-          expectedInvalidDaysOfTheWeek,
-        )
-      })
-
       it('should save successfully, but not save fields that is not defined in the schema', async () => {
         // Arrange
         const formParamsWithExtra = merge({}, MOCK_FORM_PARAMS, {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { Type } from 'aws-sdk/clients/cloudformation'
 import { ObjectId } from 'bson-ext'
 import { cloneDeep, map, merge, omit, orderBy, pick, range } from 'lodash'
 import mongoose, { Types } from 'mongoose'

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -119,4 +119,24 @@ describe('models.fields.dateField', () => {
       }),
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
+
+  it('should throw an error when null value is added to invalidDaysOfTheWeek attribute array', async () => {
+    // Arrange
+    const mockInvalidDaysOfTheWeek = [null]
+    const mockDateField = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+    }
+
+    await expect(
+      MockParent.create({
+        responseMode: FormResponseMode.Encrypt,
+        field: mockDateField,
+      }),
+    ).rejects.toThrowError(mongoose.Error.ValidationError)
+  })
 })

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -139,4 +139,24 @@ describe('models.fields.dateField', () => {
       }),
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
+
+  it('should throw an error when null value is added to invalidDaysOfTheWeek attribute array with valid values', async () => {
+    // Arrange
+    const mockInvalidDaysOfTheWeek = [null, 1, 2, 3]
+    const mockDateField = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+    }
+
+    await expect(
+      MockParent.create({
+        responseMode: FormResponseMode.Encrypt,
+        field: mockDateField,
+      }),
+    ).rejects.toThrowError(mongoose.Error.ValidationError)
+  })
 })

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -1,0 +1,98 @@
+import merge from 'lodash/merge'
+import { Model, Schema } from 'mongoose'
+import { DateFieldBase, FormResponseMode } from 'shared/types'
+
+import { IDateFieldSchema } from 'src/types'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import createDateFieldSchema from '../dateField'
+
+describe('models.fields.dateField', () => {
+  // Required as the field validator has a this.parent() check for response mode.
+  let MockParent: Model<{
+    responseMode: FormResponseMode
+    field: IDateFieldSchema
+  }>
+
+  beforeAll(async () => {
+    const db = await dbHandler.connect()
+    const dateFieldSchema = createDateFieldSchema()
+    MockParent = db.model(
+      'mockParent',
+      new Schema({
+        responseMode: {
+          type: String,
+          enum: Object.values(FormResponseMode),
+        },
+        field: dateFieldSchema,
+      }),
+    )
+  })
+  beforeEach(async () => await dbHandler.clearDatabase())
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  it('should set default empty array for invalid days of the week when date field does not specify', async () => {
+    // Arrange
+    const mockDateField = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+    }
+    const expectedDateField: Partial<DateFieldBase> = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: [],
+    }
+
+    // Act
+    const actual = await MockParent.create({
+      responseMode: FormResponseMode.Encrypt,
+      field: mockDateField,
+    })
+
+    // Assert
+    const expected = merge(expectedDateField, mockDateField, {
+      _id: expect.anything(),
+    })
+    expect(actual.field.toObject()).toEqual(expected)
+  })
+
+  it('should set expected array for invalid days of the week when date field specifies', async () => {
+    // Arrange
+    const mockInvalidDaysOfTheWeek = [1, 2, 3]
+    const mockDateField = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+    }
+    const expectedDateField: Partial<DateFieldBase> = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+    }
+
+    // Act
+    const actual = await MockParent.create({
+      responseMode: FormResponseMode.Encrypt,
+      field: mockDateField,
+    })
+
+    // Assert
+    const expected = merge(expectedDateField, mockDateField, {
+      _id: expect.anything(),
+    })
+    expect(actual.field.toObject()).toEqual(expected)
+  })
+})

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -100,7 +100,7 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should set throw an error when invalid values are added to invalidDaysOfTheWeek attribute', async () => {
+  it('should throw an error when invalid values are added to invalidDaysOfTheWeek attribute', async () => {
     // Arrange
     const mockInvalidDaysOfTheWeek = [10000]
     const mockDateField = {

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge'
-import { Model, Schema } from 'mongoose'
-import { DateFieldBase, FormResponseMode } from 'shared/types'
+import mongoose, { Model, Schema } from 'mongoose'
+import { DateFieldBase, DaysOfTheWeek, FormResponseMode } from 'shared/types'
 
 import { IDateFieldSchema } from 'src/types'
 
@@ -32,7 +32,7 @@ describe('models.fields.dateField', () => {
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  it('should set default empty array for invalid days of the week when date field does not specify', async () => {
+  it('should set default empty array for invalidDaysOfTheWeek when date field does not specify', async () => {
     // Arrange
     const mockDateField = {
       dateValidation: {
@@ -63,9 +63,13 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should set expected array for invalid days of the week when date field specifies', async () => {
+  it('should set expected array for invalidDaysOfTheWeek when date field specifies', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [1, 2, 3]
+    const mockInvalidDaysOfTheWeek = [
+      DaysOfTheWeek.Monday,
+      DaysOfTheWeek.Tuesday,
+      DaysOfTheWeek.Wednesday,
+    ]
     const mockDateField = {
       dateValidation: {
         selectedDateValidation: null,
@@ -94,5 +98,25 @@ describe('models.fields.dateField', () => {
       _id: expect.anything(),
     })
     expect(actual.field.toObject()).toEqual(expected)
+  })
+
+  it('should set throw an error when invalid values are added to invalidDaysOfTheWeek attribute', async () => {
+    // Arrange
+    const mockInvalidDaysOfTheWeek = [10000]
+    const mockDateField = {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMaxDate: null,
+        customMinDate: null,
+      },
+      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+    }
+
+    await expect(
+      MockParent.create({
+        responseMode: FormResponseMode.Encrypt,
+        field: mockDateField,
+      }),
+    ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 })

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'mongoose'
 
-import { DateSelectedValidation } from '../../../../shared/types'
+import { DateSelectedValidation, DaysOfTheWeek } from '../../../../shared/types'
 import { IDateFieldSchema } from '../../../types'
 
 import { MyInfoSchema } from './baseField'
@@ -25,7 +25,7 @@ const createDateFieldSchema = () => {
     },
     invalidDaysOfTheWeek: {
       type: [Number],
-      default: [],
+      enum: [...Object.values(DaysOfTheWeek), null],
     },
   })
 }

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -25,7 +25,7 @@ const createDateFieldSchema = () => {
     },
     invalidDaysOfTheWeek: {
       type: [Number],
-      enum: [...Object.values(DaysOfTheWeek), null],
+      enum: [...Object.values(DaysOfTheWeek)],
     },
   })
 }

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -26,23 +26,8 @@ const createDateFieldSchema = () => {
     invalidDaysOfTheWeek: {
       type: [Number],
       enum: [...Object.values(DaysOfTheWeek)],
-      validate: {
-        async validator(this: IDateFieldSchema) {
-          if (!this.invalidDaysOfTheWeek) {
-            return true
-          }
-
-          const daysOfTheWeekValues = Object.values(DaysOfTheWeek).filter(
-            (v) => !isNaN(Number(v)),
-          )
-          for (const daysOfTheWeek of this.invalidDaysOfTheWeek) {
-            if (!daysOfTheWeekValues.includes(daysOfTheWeek)) {
-              return false
-            }
-          }
-          return true
-        },
-      },
+      validate: (v: DaysOfTheWeek) =>
+        Array.isArray(v) && !v.some((el) => el === null),
     },
   })
 }

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -26,6 +26,23 @@ const createDateFieldSchema = () => {
     invalidDaysOfTheWeek: {
       type: [Number],
       enum: [...Object.values(DaysOfTheWeek)],
+      validate: {
+        async validator(this: IDateFieldSchema) {
+          if (!this.invalidDaysOfTheWeek) {
+            return true
+          }
+
+          const daysOfTheWeekValues = Object.values(DaysOfTheWeek).filter(
+            (v) => !isNaN(Number(v)),
+          )
+          for (const daysOfTheWeek of this.invalidDaysOfTheWeek) {
+            if (!daysOfTheWeekValues.includes(daysOfTheWeek)) {
+              return false
+            }
+          }
+          return true
+        },
+      },
     },
   })
 }

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -23,6 +23,10 @@ const createDateFieldSchema = () => {
         default: null,
       },
     },
+    invalidDaysOfTheWeek: {
+      type: [Number],
+      default: [],
+    },
   })
 }
 

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -24,10 +24,13 @@ const createDateFieldSchema = () => {
       },
     },
     invalidDaysOfTheWeek: {
-      type: [Number],
+      type: [
+        {
+          type: Number,
+          required: true,
+        },
+      ],
       enum: [...Object.values(DaysOfTheWeek)],
-      validate: (v: DaysOfTheWeek) =>
-        Array.isArray(v) && !v.some((el) => el === null),
     },
   })
 }


### PR DESCRIPTION
## Problem
Currently in the date field schema, there is no attribute which is able to encapsulate information regarding restricted days of the week.

Closes #4136 

## Solution
<!-- How did you solve the problem? -->
Add an additional attribute to date field schema to encapsulate information on restricted days of the week


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  