### PR TITLE
feat(form-workspaces-be/5): add delete workspace logic

### DIFF
--- a/src/app/models/__tests__/workspace.server.model.spec.ts
+++ b/src/app/models/__tests__/workspace.server.model.spec.ts
@@ -208,7 +208,6 @@ describe('Workspace Model', () => {
       it('workspace should no loger be in database when deleted', async () => {
         await Workspace.deleteWorkspace({
           workspaceId: MOCK_WORKSPACE_ID,
-          admin: MOCK_USER_ID,
         })
 
         const actual = await Workspace.exists({ _id: MOCK_WORKSPACE_ID })
@@ -222,7 +221,6 @@ describe('Workspace Model', () => {
         )
         await Workspace.deleteWorkspace({
           workspaceId: MOCK_WORKSPACE_ID,
-          admin: MOCK_USER_ID,
         })
 
         const actual = await Workspace.exists({ _id: MOCK_WORKSPACE_ID })

--- a/src/app/models/__tests__/workspace.server.model.spec.ts
+++ b/src/app/models/__tests__/workspace.server.model.spec.ts
@@ -205,7 +205,7 @@ describe('Workspace Model', () => {
     })
 
     describe('deleteWorkspace', () => {
-      it('workspace should no loger be in database when deleted', async () => {
+      it('should correctly remove workspace from database when deleted', async () => {
         await Workspace.deleteWorkspace({
           workspaceId: MOCK_WORKSPACE_ID,
         })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -881,6 +881,17 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       .exec()
   }
 
+  FormSchema.statics.archiveForms = async function (
+    formIds: IFormSchema['_id'],
+    session?: ClientSession,
+  ) {
+    return await this.updateMany(
+      { _id: { $in: formIds } },
+      { status: FormStatus.Archived },
+      { session },
+    ).read('primary')
+  }
+
   // Hooks
   FormSchema.pre<IFormSchema>('validate', function (next) {
     // Reject save if form document is too large

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -519,14 +519,14 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   }
 
   // Archives form.
-  FormSchema.methods.archive = function (session?: ClientSession) {
+  FormSchema.methods.archive = function () {
     // Return instantly when form is already archived.
     if (this.status === FormStatus.Archived) {
       return Promise.resolve(this)
     }
 
     this.status = FormStatus.Archived
-    return this.save({ session })
+    return this.save()
   }
 
   FormSchema.methods.updateMsgSrvcName = async function (

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -519,14 +519,14 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   }
 
   // Archives form.
-  FormSchema.methods.archive = function () {
+  FormSchema.methods.archive = function (session?: ClientSession) {
     // Return instantly when form is already archived.
     if (this.status === FormStatus.Archived) {
       return Promise.resolve(this)
     }
 
     this.status = FormStatus.Archived
-    return this.save()
+    return this.save({ session })
   }
 
   FormSchema.methods.updateMsgSrvcName = async function (
@@ -879,17 +879,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     })
       .read('secondary')
       .exec()
-  }
-
-  FormSchema.statics.archiveForms = async function (
-    formIds: IFormSchema['_id'][],
-    session?: ClientSession,
-  ) {
-    await this.updateMany(
-      { _id: { $in: formIds } },
-      { $set: { status: FormStatus.Archived } },
-      { session },
-    )
   }
 
   // Hooks

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -881,6 +881,17 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       .exec()
   }
 
+  FormSchema.statics.archiveForms = async function (
+    formIds: IFormSchema['_id'][],
+    session?: ClientSession,
+  ) {
+    await this.updateMany(
+      { _id: { $in: formIds } },
+      { $set: { status: FormStatus.Archived } },
+      { session },
+    )
+  }
+
   // Hooks
   FormSchema.pre<IFormSchema>('validate', function (next) {
     // Reject save if form document is too large

--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -9,6 +9,7 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
     id: false,
     timestamps: true,
   }
+
   const WorkspaceSchema = new Schema<IWorkspaceSchema, IWorkspaceModel>(
     {
       title: {
@@ -74,15 +75,14 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
     session,
   }: {
     workspaceId: IWorkspaceSchema['_id']
-    session?: ClientSession
+    session: ClientSession
   }) {
-    const deleted = await this.deleteOne(
+    return this.findOneAndDelete(
       {
         _id: workspaceId,
       },
       { session },
     )
-    return deleted.deletedCount == 1
   }
 
   return db.model<IWorkspaceSchema, IWorkspaceModel>(

--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -1,14 +1,10 @@
-import mongoose, { Mongoose, Schema } from 'mongoose'
+import { ClientSession, Mongoose, Schema } from 'mongoose'
 
-import { FormStatus } from '../../../shared/types/form'
 import { IUserSchema, IWorkspaceModel, IWorkspaceSchema } from '../../types'
-
-import getFormModel from './form.server.model'
 
 export const WORKSPACE_SCHEMA_ID = 'Workspace'
 
 const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
-  const Form = getFormModel(mongoose)
   const schemaOptions = {
     id: false,
     timestamps: true,
@@ -73,32 +69,22 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
     return this.findOneAndUpdate({ _id: workspaceId }, { title }, { new: true })
   }
 
-  WorkspaceSchema.statics.deleteWorkspace = async function (
-    workspaceId: IWorkspaceSchema['_id'],
-    admin: IUserSchema['_id'],
-    shouldDeleteForms: boolean,
-  ): Promise<number> {
-    const workspaceToDelete = await this.findOne({
-      _id: workspaceId,
-      admin: admin,
-    })
-    const session = await this.startSession()
-
-    session.startTransaction()
-    const deleted = await this.deleteOne({
-      _id: workspaceId,
-      admin: admin,
-    })
-    if (shouldDeleteForms) {
-      await Form.updateMany(
-        { _id: { $in: workspaceToDelete?.formIds } },
-        { $set: { status: FormStatus.Archived } },
-      )
-    }
-    await session.commitTransaction()
-    session.endSession()
-
-    return deleted.deletedCount ?? 0
+  WorkspaceSchema.statics.deleteWorkspace = async function ({
+    workspaceId,
+    admin,
+    session,
+  }: {
+    workspaceId: IWorkspaceSchema['_id']
+    admin: IUserSchema['_id']
+    session?: ClientSession
+  }) {
+    await this.deleteOne(
+      {
+        _id: workspaceId,
+        admin,
+      },
+      { session },
+    )
   }
 
   return db.model<IWorkspaceSchema, IWorkspaceModel>(

--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -71,17 +71,14 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
 
   WorkspaceSchema.statics.deleteWorkspace = async function ({
     workspaceId,
-    admin,
     session,
   }: {
     workspaceId: IWorkspaceSchema['_id']
-    admin: IUserSchema['_id']
     session?: ClientSession
   }) {
     const deleted = await this.deleteOne(
       {
         _id: workspaceId,
-        admin,
       },
       { session },
     )

--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -78,13 +78,14 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
     admin: IUserSchema['_id']
     session?: ClientSession
   }) {
-    await this.deleteOne(
+    const deleted = await this.deleteOne(
       {
         _id: workspaceId,
         admin,
       },
       { session },
     )
+    return deleted.deletedCount == 1
   }
 
   return db.model<IWorkspaceSchema, IWorkspaceModel>(

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1498,3 +1498,20 @@ const deleteTwilioTransaction = async (
     throw new SecretsManagerError(awsError.message)
   }
 }
+
+export const archiveForms = async ({
+  formIds,
+  userId,
+  session,
+}: {
+  formIds: string[]
+  userId: string
+  session?: ClientSession
+}): Promise<void> => {
+  const canBeArchivedForms = await FormModel.find({
+    _id: { $in: formIds },
+    admin: userId,
+  })
+
+  canBeArchivedForms.forEach(async (form) => await form.archive(session))
+}

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1502,13 +1502,17 @@ const deleteTwilioTransaction = async (
 export const archiveForms = async ({
   formIds,
   session,
+  admin,
 }: {
   formIds: string[]
-  session?: ClientSession
+  admin: string
+  session: ClientSession
 }): Promise<void> => {
   const canBeArchivedForms = await FormModel.find({
     _id: { $in: formIds },
+    admin,
   })
+  const canBeArchivedFormIds = canBeArchivedForms.map((form) => form._id)
 
-  canBeArchivedForms.forEach(async (form) => await form.archive(session))
+  await FormModel.archiveForms(canBeArchivedFormIds, session)
 }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1501,16 +1501,13 @@ const deleteTwilioTransaction = async (
 
 export const archiveForms = async ({
   formIds,
-  userId,
   session,
 }: {
   formIds: string[]
-  userId: string
   session?: ClientSession
 }): Promise<void> => {
   const canBeArchivedForms = await FormModel.find({
     _id: { $in: formIds },
-    admin: userId,
   })
 
   canBeArchivedForms.forEach(async (form) => await form.archive(session))

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose'
+import mongoose, { ClientSession } from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import {
@@ -342,4 +342,22 @@ export const retrievePublicFormsWithSmsVerification = (
     }
     return okAsync(forms)
   })
+}
+
+export const archiveForms = async ({
+  formIds,
+  userId,
+  session,
+}: {
+  formIds: string[]
+  userId: string
+  session?: ClientSession
+}): Promise<void> => {
+  const canBeArchivedForms = await FormModel.find({
+    _id: { $in: formIds },
+    admin: userId,
+  }).exec()
+
+  const canBeArchivedFormIds = canBeArchivedForms.map((form) => form._id)
+  await FormModel.archiveForms(canBeArchivedFormIds, session)
 }

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -1,4 +1,4 @@
-import mongoose, { ClientSession } from 'mongoose'
+import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import {
@@ -342,22 +342,4 @@ export const retrievePublicFormsWithSmsVerification = (
     }
     return okAsync(forms)
   })
-}
-
-export const archiveForms = async ({
-  formIds,
-  userId,
-  session,
-}: {
-  formIds: string[]
-  userId: string
-  session?: ClientSession
-}): Promise<void> => {
-  const canBeArchivedForms = await FormModel.find({
-    _id: { $in: formIds },
-    admin: userId,
-  }).exec()
-
-  const canBeArchivedFormIds = canBeArchivedForms.map((form) => form._id)
-  await FormModel.archiveForms(canBeArchivedFormIds, session)
 }

--- a/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
@@ -246,15 +246,17 @@ describe('workspace.controller', () => {
         shouldDeleteForms: true,
       },
     })
-    const deleteWorkspaceSpy = jest.spyOn(
-      MockWorkspaceService,
-      'deleteWorkspace',
-    )
+    const MOCK_WORKSPACE = {
+      _id: new ObjectId() as IWorkspaceSchema['_id'],
+      title: 'Workspace1',
+      admin: new ObjectId() as IUserSchema['_id'],
+      formIds: [],
+    }
 
     it('should return 200 with success message', async () => {
       const mockRes = expressHandler.mockResponse()
-      MockWorkspaceService.checkWorkspaceExists.mockReturnValueOnce(
-        okAsync(true),
+      MockWorkspaceService.getWorkspace.mockReturnValueOnce(
+        okAsync(MOCK_WORKSPACE),
       )
       MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValueOnce(
         okAsync(true),
@@ -274,7 +276,7 @@ describe('workspace.controller', () => {
       const mockRes = expressHandler.mockResponse()
       const mockErrorString = 'something went wrong'
 
-      MockWorkspaceService.checkWorkspaceExists.mockReturnValueOnce(
+      MockWorkspaceService.getWorkspace.mockReturnValueOnce(
         errAsync(new WorkspaceNotFoundError(mockErrorString)),
       )
       MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValueOnce(
@@ -283,7 +285,6 @@ describe('workspace.controller', () => {
 
       await WorkspaceController.deleteWorkspace(MOCK_REQ, mockRes, jest.fn())
 
-      expect(deleteWorkspaceSpy).not.toHaveBeenCalled()
       expect(mockRes.status).toBeCalledWith(404)
       expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
     })
@@ -292,8 +293,8 @@ describe('workspace.controller', () => {
       const mockRes = expressHandler.mockResponse()
       const mockErrorString = 'something went wrong'
 
-      MockWorkspaceService.checkWorkspaceExists.mockReturnValueOnce(
-        okAsync(true),
+      MockWorkspaceService.getWorkspace.mockReturnValueOnce(
+        okAsync(MOCK_WORKSPACE),
       )
       MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValueOnce(
         okAsync(true),
@@ -311,8 +312,8 @@ describe('workspace.controller', () => {
       const mockRes = expressHandler.mockResponse()
       const mockErrorString = 'something went wrong'
 
-      MockWorkspaceService.checkWorkspaceExists.mockReturnValueOnce(
-        okAsync(true),
+      MockWorkspaceService.getWorkspace.mockReturnValueOnce(
+        okAsync(MOCK_WORKSPACE),
       )
       MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValueOnce(
         okAsync(true),

--- a/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
@@ -231,4 +231,53 @@ describe('workspace.controller', () => {
       expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
     })
   })
+
+  describe('deleteWorkspace', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        workspaceId: new ObjectId() as IWorkspaceSchema['_id'],
+      },
+      session: {
+        user: {
+          _id: 'exists',
+        },
+      },
+    })
+
+    it('should return 200 with success message', async () => {
+      const mockRes = expressHandler.mockResponse()
+      MockWorkspaceService.deleteWorkspace.mockReturnValueOnce(okAsync(1))
+      await WorkspaceController.deleteWorkspace(MOCK_REQ, mockRes, jest.fn())
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Successfully deleted workspace',
+      })
+    })
+
+    it('should return 404 when workspace is not found', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.deleteWorkspace.mockReturnValueOnce(
+        errAsync(new WorkspaceNotFoundError(mockErrorString)),
+      )
+      await WorkspaceController.deleteWorkspace(MOCK_REQ, mockRes, jest.fn())
+
+      expect(mockRes.status).toBeCalledWith(404)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.deleteWorkspace.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+      await WorkspaceController.deleteWorkspace(MOCK_REQ, mockRes, jest.fn())
+
+      expect(mockRes.status).toBeCalledWith(500)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+  })
 })

--- a/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
@@ -262,7 +262,7 @@ describe('workspace.controller', () => {
         okAsync(true),
       )
       MockWorkspaceService.deleteWorkspace.mockReturnValueOnce(
-        okAsync(undefined),
+        okAsync(MOCK_WORKSPACE),
       )
 
       await WorkspaceController.deleteWorkspace(MOCK_REQ, mockRes, jest.fn())

--- a/src/app/modules/workspace/__tests__/workspace.routes.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.routes.spec.ts
@@ -38,8 +38,12 @@ const MOCK_WORKSPACE_DOC = {
 
 describe('workspaces.routes', () => {
   let request: Session
+  let connection: typeof mongoose
 
-  beforeAll(async () => await dbHandler.connect())
+  beforeAll(async () => {
+    connection = await dbHandler.connect()
+    await connection.startSession()
+  })
   beforeEach(async () => {
     request = supertest(app)
     const { user } = await dbHandler.insertEncryptForm({
@@ -52,7 +56,9 @@ describe('workspaces.routes', () => {
     await dbHandler.clearDatabase()
     jest.restoreAllMocks()
   })
-  afterAll(async () => await dbHandler.closeDatabase())
+  afterAll(async () => {
+    await dbHandler.closeDatabase()
+  })
 
   describe('GET /workspaces', () => {
     const GET_WORKSPACES_ENDPOINT = '/workspaces'
@@ -298,11 +304,26 @@ describe('workspaces.routes', () => {
   describe('DELETE /workspaces/:workspaceId', () => {
     const DELETE_WORKSPACE_ENDPOINT = `/workspaces/${MOCK_WORKSPACE_ID}`
     const DELETE_SUCCESS_MESSAGE = 'Successfully deleted workspace'
+    const deleteWorkspaceParam = {
+      shouldDeleteForms: true,
+    }
 
     it('should return 200 with success message on successful deletion', async () => {
-      await WorkspaceModel.create(MOCK_WORKSPACE_FIELDS)
+      await WorkspaceModel.create(MOCK_WORKSPACE_DOC)
+      /**
+       * We mock deleteWorkspace to run without use of mongoose session, i.e without a transaction
+       * because the mocked mongoose MemoryDatabaseServer doesn't support transactions.
+       **/
+      jest.spyOn(WorkspaceModel, 'deleteWorkspace').mockImplementationOnce(() =>
+        WorkspaceModel.deleteWorkspace({
+          workspaceId: MOCK_WORKSPACE_DOC._id,
+          admin: MOCK_WORKSPACE_DOC.admin,
+        }),
+      )
 
-      const response = await request.delete(DELETE_WORKSPACE_ENDPOINT)
+      const response = await request
+        .delete(DELETE_WORKSPACE_ENDPOINT)
+        .send(deleteWorkspaceParam)
       const expected = { message: DELETE_SUCCESS_MESSAGE }
 
       expect(response.status).toEqual(200)
@@ -311,36 +332,43 @@ describe('workspaces.routes', () => {
 
     it('should return 401 when user is not logged in', async () => {
       await logoutSession(request)
-      const response = await request.delete(DELETE_WORKSPACE_ENDPOINT)
+      const response = await request
+        .delete(DELETE_WORKSPACE_ENDPOINT)
+        .send(deleteWorkspaceParam)
 
       expect(response.status).toEqual(401)
       expect(response.body).toEqual({ message: 'User is unauthorized.' })
     })
 
-    it('should return 404 when workspace is not found', async () => {
-      const response = await request.delete(DELETE_WORKSPACE_ENDPOINT)
-
-      expect(response.status).toEqual(404)
-      expect(response.body).toEqual({
-        message: new WorkspaceNotFoundError().message,
-      })
-    })
-
-    it('should return 404 when user does not own the workspace', async () => {
+    it('should return 403 when user does not own the workspace', async () => {
       const otherUserId = new ObjectId()
+      const otherWorkspaceId = new ObjectId()
       await dbHandler.insertUser({
         userId: otherUserId,
         agencyId: new ObjectId(),
         mailName: 'different',
       })
       const workspaceBelongingToOtherAdmin = {
-        _id: new ObjectId(),
+        _id: otherWorkspaceId,
         title: 'Workspace2',
         admin: otherUserId,
         formIds: [],
       }
       await WorkspaceModel.create(workspaceBelongingToOtherAdmin)
-      const response = await request.delete(DELETE_WORKSPACE_ENDPOINT)
+      const response = await request
+        .delete(`/workspaces/${otherWorkspaceId.toHexString()}`)
+        .send(deleteWorkspaceParam)
+
+      expect(response.status).toEqual(403)
+      expect(response.body).toEqual({
+        message: new ForbiddenWorkspaceError().message,
+      })
+    })
+
+    it('should return 404 when workspace is not found', async () => {
+      const response = await request
+        .delete(`/workspaces/${new ObjectId().toHexString()}`)
+        .send(deleteWorkspaceParam)
 
       expect(response.status).toEqual(404)
       expect(response.body).toEqual({
@@ -349,14 +377,16 @@ describe('workspaces.routes', () => {
     })
 
     it('should return 500 when database errors occur', async () => {
-      await WorkspaceModel.create(MOCK_WORKSPACE_FIELDS)
+      await WorkspaceModel.create(MOCK_WORKSPACE_DOC)
 
       const mockErrorMessage = 'something went wrong'
 
       jest
         .spyOn(WorkspaceModel, 'deleteWorkspace')
         .mockRejectedValueOnce(new Error(mockErrorMessage))
-      const response = await request.delete(DELETE_WORKSPACE_ENDPOINT)
+      const response = await request
+        .delete(DELETE_WORKSPACE_ENDPOINT)
+        .send(deleteWorkspaceParam)
 
       expect(response.status).toEqual(500)
       expect(response.body).toEqual({

--- a/src/app/modules/workspace/__tests__/workspace.routes.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.routes.spec.ts
@@ -317,7 +317,6 @@ describe('workspaces.routes', () => {
       jest.spyOn(WorkspaceModel, 'deleteWorkspace').mockImplementationOnce(() =>
         WorkspaceModel.deleteWorkspace({
           workspaceId: MOCK_WORKSPACE_DOC._id,
-          admin: MOCK_WORKSPACE_DOC.admin,
         }),
       )
 

--- a/src/app/modules/workspace/__tests__/workspace.service.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.service.spec.ts
@@ -275,4 +275,77 @@ describe('workspace.service', () => {
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(WorkspaceNotFoundError)
     })
   })
+
+  describe('deleteWorkspace', () => {
+    const mockWorkspace = {
+      _id: 'workspaceId' as WorkspaceId,
+      admin: 'user' as UserId,
+      title: 'workspace1',
+      formIds: [] as FormId[],
+      count: 0,
+    }
+    const shouldDeleteWorkspace = true
+
+    it('should successfully delete workspace', async () => {
+      const updateSpy = jest
+        .spyOn(WorkspaceModel, 'deleteWorkspace')
+        .mockResolvedValueOnce(1)
+      const actual = await WorkspaceService.deleteWorkspace(
+        mockWorkspace._id,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        mockWorkspace._id,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+      expect(actual.isOk()).toEqual(true)
+      expect(actual._unsafeUnwrap()).toEqual(1)
+    })
+
+    it('should return WorkspaceNotFoundError on invalid workspaceId', async () => {
+      const invalidWorkspaceId = new ObjectId().toHexString()
+      const updateSpy = jest
+        .spyOn(WorkspaceModel, 'deleteWorkspace')
+        .mockResolvedValueOnce(0)
+
+      const actual = await WorkspaceService.deleteWorkspace(
+        invalidWorkspaceId,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        invalidWorkspaceId,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(WorkspaceNotFoundError)
+    })
+
+    it('should return DatabaseError when error occurs whilst creating workspace', async () => {
+      const mockErrorMessage = 'some error'
+
+      const updateSpy = jest
+        .spyOn(WorkspaceModel, 'deleteWorkspace')
+        .mockRejectedValueOnce(new Error(mockErrorMessage))
+      const actual = await WorkspaceService.deleteWorkspace(
+        mockWorkspace._id,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        mockWorkspace._id,
+        mockWorkspace.admin,
+        shouldDeleteWorkspace,
+      )
+      expect(actual.isErr()).toEqual(true)
+      expect(actual._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(formatErrorRecoveryMessage(mockErrorMessage)),
+      )
+    })
+  })
 })

--- a/src/app/modules/workspace/__tests__/workspace.service.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.service.spec.ts
@@ -284,22 +284,22 @@ describe('workspace.service', () => {
       formIds: [] as FormId[],
       count: 0,
     }
-    const shouldDeleteWorkspace = true
+    const shouldDeleteForms = true
 
     it('should successfully delete workspace', async () => {
       const updateSpy = jest
         .spyOn(WorkspaceModel, 'deleteWorkspace')
         .mockResolvedValueOnce(1)
-      const actual = await WorkspaceService.deleteWorkspace(
-        mockWorkspace._id,
-        mockWorkspace.admin,
-        shouldDeleteWorkspace,
-      )
+      const actual = await WorkspaceService.deleteWorkspace({
+        workspaceId: mockWorkspace._id,
+        userId: mockWorkspace.admin,
+        shouldDeleteForms,
+      })
 
       expect(updateSpy).toHaveBeenCalledWith(
         mockWorkspace._id,
         mockWorkspace.admin,
-        shouldDeleteWorkspace,
+        shouldDeleteForms,
       )
       expect(actual.isOk()).toEqual(true)
       expect(actual._unsafeUnwrap()).toEqual(1)
@@ -311,16 +311,16 @@ describe('workspace.service', () => {
         .spyOn(WorkspaceModel, 'deleteWorkspace')
         .mockResolvedValueOnce(0)
 
-      const actual = await WorkspaceService.deleteWorkspace(
-        invalidWorkspaceId,
-        mockWorkspace.admin,
-        shouldDeleteWorkspace,
-      )
+      const actual = await WorkspaceService.deleteWorkspace({
+        workspaceId: invalidWorkspaceId,
+        userId: mockWorkspace.admin,
+        shouldDeleteForms,
+      })
 
       expect(updateSpy).toHaveBeenCalledWith(
         invalidWorkspaceId,
         mockWorkspace.admin,
-        shouldDeleteWorkspace,
+        shouldDeleteForms,
       )
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(WorkspaceNotFoundError)
     })
@@ -331,16 +331,16 @@ describe('workspace.service', () => {
       const updateSpy = jest
         .spyOn(WorkspaceModel, 'deleteWorkspace')
         .mockRejectedValueOnce(new Error(mockErrorMessage))
-      const actual = await WorkspaceService.deleteWorkspace(
-        mockWorkspace._id,
-        mockWorkspace.admin,
-        shouldDeleteWorkspace,
-      )
+      const actual = await WorkspaceService.deleteWorkspace({
+        workspaceId: mockWorkspace._id,
+        userId: mockWorkspace.admin,
+        shouldDeleteForms,
+      })
 
       expect(updateSpy).toHaveBeenCalledWith(
         mockWorkspace._id,
         mockWorkspace.admin,
-        shouldDeleteWorkspace,
+        shouldDeleteForms,
       )
       expect(actual.isErr()).toEqual(true)
       expect(actual._unsafeUnwrapErr()).toEqual(

--- a/src/app/modules/workspace/__tests__/workspace.service.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.service.spec.ts
@@ -334,16 +334,12 @@ describe('workspace.service', () => {
         userId: mockWorkspace.admin,
         shouldDeleteForms: false,
       })
-      const doesFormExist = await FormModel.exists({ _id: mockFormId })
-      const isFormArchived = await FormModel.exists({
-        _id: mockFormId,
-        status: FormStatus.Archived,
-      })
+      const form = await FormModel.findById(mockFormId)
 
       expect(actual.isOk()).toEqual(true)
       expect(actual._unsafeUnwrap()).toEqual(mockWorkspace)
-      expect(doesFormExist).toEqual(true)
-      expect(isFormArchived).toEqual(false)
+      expect(form).not.toBeNull()
+      expect(form?.status).not.toEqual(FormStatus.Archived)
     })
 
     it('should archive forms in the workspace when shouldDeleteForms is true', async () => {
@@ -368,16 +364,12 @@ describe('workspace.service', () => {
         userId: mockWorkspace.admin,
         shouldDeleteForms: true,
       })
-      const doesFormExist = await FormModel.exists({ _id: mockFormId })
-      const isFormArchived = await FormModel.exists({
-        _id: mockFormId,
-        status: FormStatus.Archived,
-      })
+      const form = await FormModel.findById(mockFormId)
 
       expect(actual.isOk()).toEqual(true)
       expect(actual._unsafeUnwrap()).toEqual(mockWorkspace)
-      expect(doesFormExist).toEqual(true)
-      expect(isFormArchived).toEqual(true)
+      expect(form).not.toBeNull()
+      expect(form?.status).toEqual(FormStatus.Archived)
     })
 
     it('should return DatabaseError when error occurs whilst creating workspace', async () => {

--- a/src/app/modules/workspace/__tests__/workspace.service.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.service.spec.ts
@@ -294,7 +294,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: false,
       })
 
@@ -307,7 +306,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: false,
       })
 
@@ -329,7 +327,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: false,
       })
       const doesFormExist = await FormModel.exists({ _id: mockFormId })
@@ -358,7 +355,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: true,
       })
       const doesFormExist = await FormModel.exists({ _id: mockFormId })
@@ -390,7 +386,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: true,
       })
       const doesFormExist = await FormModel.exists({ _id: mockFormId })
@@ -426,7 +421,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: true,
       })
       const doesFormExist = await FormModel.exists({ _id: mockFormId })
@@ -454,7 +448,6 @@ describe('workspace.service', () => {
 
       const actual = await WorkspaceService.deleteWorkspace({
         workspaceId: mockWorkspace._id.toHexString(),
-        userId: mockWorkspace.admin.toHexString(),
         shouldDeleteForms: false,
       })
 

--- a/src/app/modules/workspace/workspace.controller.ts
+++ b/src/app/modules/workspace/workspace.controller.ts
@@ -164,12 +164,13 @@ export const deleteWorkspace: ControllerHandler<
   const { shouldDeleteForms } = req.body
   const userId = (req.session as AuthedSessionData).user._id
 
-  return WorkspaceService.checkWorkspaceExists(workspaceId)
-    .andThen(() => WorkspaceService.verifyWorkspaceAdmin(workspaceId, userId))
+  return WorkspaceService.getWorkspace(workspaceId)
+    .andThen((workspace) =>
+      WorkspaceService.verifyWorkspaceAdmin(workspace, userId),
+    )
     .andThen(() =>
       WorkspaceService.deleteWorkspace({
         workspaceId,
-        userId,
         shouldDeleteForms,
       }).map(() =>
         res

--- a/src/app/modules/workspace/workspace.controller.ts
+++ b/src/app/modules/workspace/workspace.controller.ts
@@ -171,12 +171,18 @@ export const deleteWorkspace: ControllerHandler<
     .andThen(() =>
       WorkspaceService.deleteWorkspace({
         workspaceId,
+        userId,
         shouldDeleteForms,
-      }).map(() =>
-        res
-          .status(StatusCodes.OK)
-          .json({ message: 'Successfully deleted workspace' }),
-      ),
+      }).map((workspace) => {
+        return workspace
+          ? res
+              .status(StatusCodes.OK)
+              .json({ message: 'Successfully deleted workspace' })
+          : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+              message:
+                'Sorry something went wrong, we are unable to delete the workspace',
+            })
+      }),
     )
     .mapErr((error) => {
       logger.error({

--- a/src/app/modules/workspace/workspace.service.ts
+++ b/src/app/modules/workspace/workspace.service.ts
@@ -72,7 +72,6 @@ export const updateWorkspaceTitle = ({
           action: 'updateWorkspaceTitle',
           workspaceId,
           title,
-          userId,
         },
         error,
       })
@@ -87,11 +86,9 @@ export const updateWorkspaceTitle = ({
 
 export const deleteWorkspace = ({
   workspaceId,
-  userId,
   shouldDeleteForms,
 }: {
   workspaceId: string
-  userId: string
   shouldDeleteForms: boolean
 }): ResultAsync<void, DatabaseError> => {
   return ResultAsync.fromPromise(
@@ -100,7 +97,6 @@ export const deleteWorkspace = ({
         .withTransaction(() =>
           deleteWorkspaceTransaction({
             workspaceId,
-            userId,
             shouldDeleteForms,
             session,
           }),
@@ -114,7 +110,6 @@ export const deleteWorkspace = ({
         meta: {
           action: 'deleteWorkspace',
           workspaceId,
-          userId,
           shouldDeleteForms,
         },
         error,
@@ -126,30 +121,25 @@ export const deleteWorkspace = ({
 
 const deleteWorkspaceTransaction = async ({
   workspaceId,
-  userId,
   shouldDeleteForms,
   session,
 }: {
   workspaceId: string
-  userId: string
   shouldDeleteForms: boolean
   session: ClientSession
 }): Promise<void> => {
   const workspaceToDelete = await WorkspaceModel.findOne({
     _id: workspaceId,
-    admin: userId,
   })
 
   await WorkspaceModel.deleteWorkspace({
     workspaceId,
-    admin: userId,
     session,
   })
 
   if (shouldDeleteForms && workspaceToDelete?.formIds) {
     await AdminFormService.archiveForms({
       formIds: workspaceToDelete?.formIds,
-      userId,
       session,
     })
   }

--- a/src/app/modules/workspace/workspace.service.ts
+++ b/src/app/modules/workspace/workspace.service.ts
@@ -84,11 +84,15 @@ export const updateWorkspaceTitle = ({
   )
 }
 
-export const deleteWorkspace = (
-  workspaceId: string,
-  userId: string,
-  shouldDeleteForms: boolean,
-): ResultAsync<number, DatabaseError | WorkspaceNotFoundError> => {
+export const deleteWorkspace = ({
+  workspaceId,
+  userId,
+  shouldDeleteForms,
+}: {
+  workspaceId: string
+  userId: string
+  shouldDeleteForms: boolean
+}): ResultAsync<number, DatabaseError | WorkspaceNotFoundError> => {
   return ResultAsync.fromPromise(
     WorkspaceModel.deleteWorkspace(workspaceId, userId, shouldDeleteForms),
     (error) => {

--- a/src/app/modules/workspace/workspace.service.ts
+++ b/src/app/modules/workspace/workspace.service.ts
@@ -6,7 +6,7 @@ import { createLoggerWithLabel } from '../../config/logger'
 import { getWorkspaceModel } from '../../models/workspace.server.model'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { DatabaseError, DatabaseValidationError } from '../core/core.errors'
-import * as FormService from '../form/form.service'
+import * as AdminFormService from '../form/admin-form/admin-form.service'
 
 import {
   ForbiddenWorkspaceError,
@@ -93,22 +93,24 @@ export const deleteWorkspace = ({
   workspaceId: string
   userId: string
   shouldDeleteForms: boolean
-}): ResultAsync<boolean, DatabaseError> => {
+}): ResultAsync<void, DatabaseError> => {
   return ResultAsync.fromPromise(
     WorkspaceModel.startSession().then((session: ClientSession) =>
-      session.withTransaction(() =>
-        deleteWorkspaceTransaction({
-          workspaceId,
-          userId,
-          shouldDeleteForms,
-          session,
-        }).then(() => session.endSession()),
-      ),
+      session
+        .withTransaction(() =>
+          deleteWorkspaceTransaction({
+            workspaceId,
+            userId,
+            shouldDeleteForms,
+            session,
+          }),
+        )
+        .then(() => session.endSession()),
     ),
-
     (error) => {
       logger.error({
-        message: 'Database error when deleting workspace',
+        message:
+          'Database error when deleting workspace, rolling back transaction',
         meta: {
           action: 'deleteWorkspace',
           workspaceId,
@@ -117,7 +119,7 @@ export const deleteWorkspace = ({
         },
         error,
       })
-      return error as ReturnType<typeof transformMongoError>
+      return transformMongoError(error)
     },
   )
 }
@@ -132,52 +134,25 @@ const deleteWorkspaceTransaction = async ({
   userId: string
   shouldDeleteForms: boolean
   session: ClientSession
-}): Promise<boolean> => {
-  const logMeta = {
-    action: 'deleteWorkspaceTransaction',
-    workspaceId,
-    userId,
-    shouldDeleteForms,
-  }
-  let isDeleteSuccessful = false
+}): Promise<void> => {
   const workspaceToDelete = await WorkspaceModel.findOne({
     _id: workspaceId,
     admin: userId,
   })
 
-  try {
-    isDeleteSuccessful = await WorkspaceModel.deleteWorkspace({
-      workspaceId,
-      admin: userId,
-      session,
-    })
-  } catch (error) {
-    logger.error({
-      message: 'Error while deleting workspace, rolling back transaction',
-      meta: logMeta,
-      error,
-    })
-    throw transformMongoError(error)
-  }
+  await WorkspaceModel.deleteWorkspace({
+    workspaceId,
+    admin: userId,
+    session,
+  })
 
   if (shouldDeleteForms && workspaceToDelete?.formIds) {
-    try {
-      await FormService.archiveForms({
-        formIds: workspaceToDelete?.formIds,
-        userId,
-        session,
-      })
-    } catch (error) {
-      logger.error({
-        message: 'Error while archiving forms, rolling back transaction',
-        meta: logMeta,
-        error,
-      })
-      throw transformMongoError(error)
-    }
+    await AdminFormService.archiveForms({
+      formIds: workspaceToDelete?.formIds,
+      userId,
+      session,
+    })
   }
-
-  return isDeleteSuccessful
 }
 
 export const getForms = (

--- a/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
+++ b/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
@@ -50,7 +50,9 @@ WorkspacesRouter.route('/:workspaceId([a-fA-F0-9]{24})')
    *
    * @returns 200 with success message
    * @returns 401 when user does not exist in session
+   * @returns 403 when user does not have permissions to delete the workspace
    * @returns 404 when workspace cannot be found
+   * @returns 409 when a database conflict error occurs
    * @returns 500 when database error occurs
    */
   .delete(WorkspaceController.deleteWorkspace)

--- a/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
+++ b/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
@@ -51,7 +51,6 @@ WorkspacesRouter.route('/:workspaceId([a-fA-F0-9]{24})')
    * @returns 200 with success message
    * @returns 401 when user does not exist in session
    * @returns 404 when workspace cannot be found
-   * @returns 422 when user of given id cannnot be found in the database
    * @returns 500 when database error occurs
    */
   .delete(WorkspaceController.deleteWorkspace)
@@ -65,7 +64,6 @@ WorkspacesRouter.route('/:workspaceId([a-fA-F0-9]{24})/title')
    * @returns 400 when new title fails Joi validation
    * @returns 401 when user does not exist in session
    * @returns 404 when workspace cannot be found
-   * @returns 422 when user of given id cannnot be found in the database
    * @returns 500 when database error occurs
    */
   .put(WorkspaceController.updateWorkspaceTitle)

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -334,6 +334,16 @@ export interface IFormModel extends Model<IFormSchema> {
     logicId: string,
     updatedLogic: LogicDto,
   ): Promise<IFormSchema | null>
+
+  archiveForms(
+    formIds: IFormSchema['_id'][],
+    /**
+     * Session is optional so that we can mock this function in our tests to test it without a session.
+     * Reason is our mocked mongo database does not support transactions.
+     * See issue #4503 for more details.
+     */
+    session?: ClientSession,
+  ): Promise<void>
 }
 
 export type IEncryptedFormModel = IFormModel & Model<IEncryptedFormSchema>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -175,7 +175,7 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
    * Archives form.
    * @returns form that has been archived
    */
-  archive(): Promise<IFormSchema>
+  archive(session?: ClientSession): Promise<IFormSchema>
 
   /**
    * Transfer ownership of the form to another user.
@@ -334,11 +334,6 @@ export interface IFormModel extends Model<IFormSchema> {
     logicId: string,
     updatedLogic: LogicDto,
   ): Promise<IFormSchema | null>
-
-  archiveForms(
-    formIds: IFormSchema['_id'][],
-    session?: ClientSession,
-  ): Promise<void>
 }
 
 export type IEncryptedFormModel = IFormModel & Model<IEncryptedFormSchema>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -175,7 +175,7 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
    * Archives form.
    * @returns form that has been archived
    */
-  archive(session?: ClientSession): Promise<IFormSchema>
+  archive(): Promise<IFormSchema>
 
   /**
    * Transfer ownership of the form to another user.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -334,6 +334,11 @@ export interface IFormModel extends Model<IFormSchema> {
     logicId: string,
     updatedLogic: LogicDto,
   ): Promise<IFormSchema | null>
+
+  archiveForms(
+    formIds: IFormSchema['_id'][],
+    session?: ClientSession,
+  ): Promise<void>
 }
 
 export type IEncryptedFormModel = IFormModel & Model<IEncryptedFormSchema>

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -29,13 +29,12 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
     title: string
     workspaceId: IWorkspaceSchema['_id']
   }): Promise<WorkspaceDto | null>
+
   deleteWorkspace({
     workspaceId,
-    admin,
     session,
   }: {
     workspaceId: IWorkspaceSchema['_id']
-    admin: IUserSchema['_id']
     session?: ClientSession
   }): Promise<boolean>
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -29,4 +29,9 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
     title: string
     workspaceId: IWorkspaceSchema['_id']
   }): Promise<WorkspaceDto | null>
+  deleteWorkspace(
+    workspaceId: IWorkspaceSchema['_id'],
+    admin: IUserSchema['_id'],
+    shouldDeleteForms: boolean,
+  ): Promise<number>
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -37,5 +37,5 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
     workspaceId: IWorkspaceSchema['_id']
     admin: IUserSchema['_id']
     session?: ClientSession
-  }): Promise<void>
+  }): Promise<boolean>
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -35,6 +35,11 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
     session,
   }: {
     workspaceId: IWorkspaceSchema['_id']
+    /**
+     * Session is optional so that we can mock this function in our tests to test it without a session.
+     * Reason is our mocked mongo database does not support transactions.
+     * See issue #4503 for more details.
+     */
     session?: ClientSession
-  }): Promise<boolean>
+  }): Promise<WorkspaceDto | null>
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,4 +1,4 @@
-import { Document, Model } from 'mongoose'
+import { ClientSession, Document, Model } from 'mongoose'
 import { WorkspaceDto } from 'shared/types/workspace'
 
 import { IFormSchema } from './form'
@@ -29,9 +29,13 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
     title: string
     workspaceId: IWorkspaceSchema['_id']
   }): Promise<WorkspaceDto | null>
-  deleteWorkspace(
-    workspaceId: IWorkspaceSchema['_id'],
-    admin: IUserSchema['_id'],
-    shouldDeleteForms: boolean,
-  ): Promise<number>
+  deleteWorkspace({
+    workspaceId,
+    admin,
+    session,
+  }: {
+    workspaceId: IWorkspaceSchema['_id']
+    admin: IUserSchema['_id']
+    session?: ClientSession
+  }): Promise<void>
 }


### PR DESCRIPTION
Builds on #4252 

Part of #4039 

## Solution
Add logic for DELETE `api/v3/admin/workspaces/{workspaceId}` endpoint

**Breaking Changes** 
- [x] No - this PR is backwards compatible  