### PR TITLE
feat(form-v2): add tooltips for auth settings page

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -18,7 +18,12 @@ import Tooltip from '~components/Tooltip'
 
 import { useMutateFormSettings } from '../../mutations'
 
-import { AUTHTYPE_TO_TEXT, STORAGE_MODE_AUTHTYPES } from './constants'
+import {
+  AUTHTYPE_TO_TEXT,
+  CP_TOOLTIP,
+  SGID_TOOLTIP,
+  STORAGE_MODE_AUTHTYPES,
+} from './constants'
 import { EsrvcIdBox } from './EsrvcIdBox'
 
 interface AuthSettingsSectionProps {
@@ -97,21 +102,6 @@ export const AuthSettingsSection = ({
     ][]
   }, [settings.responseMode])
 
-  const sgidTip = useMemo(
-    () =>
-      `Free Singpass authentication via Singpass app QR code login. Respondents\ 
-      must have the Singpass mobile app installed to log in and submit \
-      responses. Password login is not supported. Form admin will receive respondent's NRIC.`,
-    [],
-  )
-
-  const cpTip = useMemo(
-    () =>
-      `Corppass no longer has its own login page, and now uses Singpass to\
-      authenticate corporate users. You will still need a separate Corppass e-service ID.`,
-    [],
-  )
-
   return (
     <Box>
       {isFormPublic ? (
@@ -132,7 +122,11 @@ export const AuthSettingsSection = ({
                 {text}
                 {authType === FormAuthType.SGID ? (
                   <>
-                    <Tooltip label={sgidTip} placement="top" textAlign="center">
+                    <Tooltip
+                      label={SGID_TOOLTIP}
+                      placement="top"
+                      textAlign="center"
+                    >
                       <Icon as={BxsHelpCircle} aria-hidden marginX="0.5rem" />
                     </Tooltip>
                     <Link
@@ -146,7 +140,11 @@ export const AuthSettingsSection = ({
                   </>
                 ) : null}
                 {authType === FormAuthType.CP ? (
-                  <Tooltip label={cpTip} placement="top" textAlign="center">
+                  <Tooltip
+                    label={CP_TOOLTIP}
+                    placement="top"
+                    textAlign="center"
+                  >
                     <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
                   </Tooltip>
                 ) : null}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -6,12 +6,15 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { Box, Skeleton } from '@chakra-ui/react'
+import { Box, Icon, Skeleton } from '@chakra-ui/react'
 
 import { FormAuthType, FormSettings, FormStatus } from '~shared/types/form'
 
+import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import InlineMessage from '~components/InlineMessage'
+import Link from '~components/Link'
 import Radio from '~components/Radio'
+import Tooltip from '~components/Tooltip'
 
 import { useMutateFormSettings } from '../../mutations'
 
@@ -94,6 +97,21 @@ export const AuthSettingsSection = ({
     ][]
   }, [settings.responseMode])
 
+  const sgidTip = useMemo(
+    () =>
+      `Free Singpass authentication via Singpass app QR code login. Respondents\ 
+      must have the Singpass mobile app installed to log in and submit \
+      responses. Password login is not supported. Form admin will receive respondent's NRIC.`,
+    [],
+  )
+
+  const cpTip = useMemo(
+    () =>
+      `Corppass no longer has its own login page, and now uses Singpass to\
+      authenticate corporate users. You will still need a separate Corppass e-service ID.`,
+    [],
+  )
+
   return (
     <Box>
       {isFormPublic ? (
@@ -112,6 +130,26 @@ export const AuthSettingsSection = ({
             <Box onClick={handleOptionClick(authType)}>
               <Radio value={authType} isDisabled={isDisabled}>
                 {text}
+                {authType === FormAuthType.SGID ? (
+                  <>
+                    <Tooltip label={sgidTip} placement="top" textAlign="center">
+                      <Icon as={BxsHelpCircle} aria-hidden marginX="0.5rem" />
+                    </Tooltip>
+                    <Link
+                      href="https://go.gov.sg/sgid-formsg"
+                      isExternal
+                      // Needed for link to open since there are nested onClicks
+                      onClickCapture={(e) => e.stopPropagation()}
+                    >
+                      Contact us to find out more
+                    </Link>
+                  </>
+                ) : null}
+                {authType === FormAuthType.CP ? (
+                  <Tooltip label={cpTip} placement="top" textAlign="center">
+                    <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
+                  </Tooltip>
+                ) : null}
               </Radio>
             </Box>
             {authType !== FormAuthType.NIL && authType === settings.authType ? (

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -24,3 +24,12 @@ export const AUTHTYPE_TO_TEXT = {
   [FormResponseMode.Email]: EMAIL_MODE_AUTHTYPES,
   [FormResponseMode.Encrypt]: STORAGE_MODE_AUTHTYPES,
 }
+
+export const SGID_TOOLTIP = `Free Singpass authentication via Singpass app QR\
+  code login. Respondents must have the Singpass mobile app installed to log in\
+  and submit responses. Password login is not supported. Form admin will receive\
+  respondent's NRIC.`
+
+export const CP_TOOLTIP = `Corppass no longer has its own login page, and now\
+  uses Singpass to authenticate corporate users. You will still need a separate\
+  Corppass e-service ID.`


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, tooltips were not in the auth settings page but which were in the AngularJS version of the app.

Makes progress towards [#4246]

## Solution

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

**Features**
- Added tooltips and links to Singpass authentication settings identical to AngularJS version.

## After Screenshots

<img width="1619" alt="image" src="https://user-images.githubusercontent.com/25571626/180158683-73b83753-d4bf-4376-a98f-0f3926a969b1.png">
<img width="1615" alt="image" src="https://user-images.githubusercontent.com/25571626/180158759-e236e8b4-1b35-4770-98bb-26f0bd594117.png">

## Tests
Email mode
- [X] Hovering over each tooltip should reveal the tool.
- [X] When SGID is selected, clicking on the SGID contact us link should open the link.
- [X] When SGID is not selected, clicking on the SGID contact us link should open the link but not select SGID. 
