### PR TITLE
feat(v2): add ability to pre-fill public forms fields

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -2,10 +2,13 @@ import { expect } from '@storybook/jest'
 import { Meta, Story } from '@storybook/react'
 import { userEvent, waitFor, within } from '@storybook/testing-library'
 
-import { BasicField } from '~shared/types/field'
+import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormAuthType, FormColorTheme } from '~shared/types/form'
 
-import { MOCK_PREFILLED_MYINFO_FIELDS } from '~/mocks/msw/handlers/admin-form'
+import {
+  MOCK_FORM_FIELDS,
+  MOCK_PREFILLED_MYINFO_FIELDS,
+} from '~/mocks/msw/handlers/admin-form'
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   getPublicFormErrorResponse,
@@ -18,6 +21,7 @@ import {
 } from '~/mocks/msw/handlers/public-form'
 
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
+import { ShortTextFieldSchema } from '~templates/Field'
 
 import PublicFormPage from './PublicFormPage'
 
@@ -28,6 +32,29 @@ const DEFAULT_MSW_HANDLERS = [
   postGenerateVfnOtpResponse(),
   postVerifyVfnOtpResponse(),
 ]
+
+// Bunch of encodings to test prefill and its sanitization.
+const PREFILLABLE_TEST_STRING =
+  '%E8%87%AA%E7%94%B1 %F0%90%90%80 hello+world 日本語%20normal space'
+
+const PREFILLABLE_SHORTTEXT_FIELD: ShortTextFieldSchema = {
+  ValidationOptions: {
+    customVal: null,
+    selectedValidation: null,
+  },
+  allowPrefill: true, // This prop allows for prefill
+  title: 'Short Text With Prefill',
+  description:
+    'Probably do not have to worry so much, React automatically sanitizes what gets rendered',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.ShortText,
+  _id: '5da04eafe397fc0013f63c22',
+}
+
+const FORM_FIELDS_WITH_PREFILL = (
+  [PREFILLABLE_SHORTTEXT_FIELD] as FormFieldDto[]
+).concat(MOCK_FORM_FIELDS)
 
 const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
   return [
@@ -52,7 +79,9 @@ export default {
   component: PublicFormPage,
   decorators: [
     StoryRouter({
-      initialEntries: ['/61540ece3d4a6e50ac0cc6ff'],
+      initialEntries: [
+        `/61540ece3d4a6e50ac0cc6ff?${PREFILLABLE_SHORTTEXT_FIELD._id}=${PREFILLABLE_TEST_STRING}`,
+      ],
       path: '/:formId',
     }),
   ],
@@ -76,6 +105,20 @@ WithCaptcha.parameters = {
       overrides: {
         form: {
           hasCaptcha: true,
+        },
+      },
+    }),
+  ],
+}
+
+export const WithPrefilledFields = Template.bind({})
+WithPrefilledFields.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          form_fields: FORM_FIELDS_WITH_PREFILL,
         },
       },
     }),

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -2,13 +2,10 @@ import { expect } from '@storybook/jest'
 import { Meta, Story } from '@storybook/react'
 import { userEvent, waitFor, within } from '@storybook/testing-library'
 
-import { BasicField, FormFieldDto } from '~shared/types/field'
+import { BasicField } from '~shared/types/field'
 import { FormAuthType, FormColorTheme } from '~shared/types/form'
 
-import {
-  MOCK_FORM_FIELDS,
-  MOCK_PREFILLED_MYINFO_FIELDS,
-} from '~/mocks/msw/handlers/admin-form'
+import { MOCK_PREFILLED_MYINFO_FIELDS } from '~/mocks/msw/handlers/admin-form'
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   getPublicFormErrorResponse,
@@ -49,12 +46,8 @@ const PREFILLABLE_SHORTTEXT_FIELD: ShortTextFieldSchema = {
   required: true,
   disabled: false,
   fieldType: BasicField.ShortText,
-  _id: '5da04eafe397fc0013f63c22',
+  _id: '5da04eafe397fc0013f63b22',
 }
-
-const FORM_FIELDS_WITH_PREFILL = (
-  [PREFILLABLE_SHORTTEXT_FIELD] as FormFieldDto[]
-).concat(MOCK_FORM_FIELDS)
 
 const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
   return [
@@ -118,7 +111,7 @@ WithPrefilledFields.parameters = {
       delay: 0,
       overrides: {
         form: {
-          form_fields: FORM_FIELDS_WITH_PREFILL,
+          form_fields: [PREFILLABLE_SHORTTEXT_FIELD],
         },
       },
     }),

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -118,6 +118,12 @@ WithPrefilledFields.parameters = {
   ],
 }
 
+export const WithPrefilledFieldsMobile = Template.bind({})
+WithPrefilledFieldsMobile.parameters = {
+  ...WithPrefilledFields.parameters,
+  ...getMobileViewParameters(),
+}
+
 export const Mobile = Template.bind({})
 Mobile.parameters = getMobileViewParameters()
 

--- a/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -38,68 +38,69 @@ import {
 
 interface FieldFactoryProps {
   field: FormFieldWithQuestionNo
+  isPrefilled?: boolean
   colorTheme?: FormColorTheme
 }
 
 export const FieldFactory = memo(
-  ({ field, colorTheme }: FieldFactoryProps) => {
+  ({ field, ...rest }: FieldFactoryProps) => {
     switch (field.fieldType) {
       case BasicField.Section:
-        return <SectionField schema={field} colorTheme={colorTheme} />
+        return <SectionField schema={field} {...rest} />
       case BasicField.Checkbox:
-        return <CheckboxField schema={field} colorTheme={colorTheme} />
+        return <CheckboxField schema={field} {...rest} />
       case BasicField.Radio:
-        return <RadioField schema={field} colorTheme={colorTheme} />
+        return <RadioField schema={field} {...rest} />
       case BasicField.Nric:
-        return <NricField schema={field} colorTheme={colorTheme} />
+        return <NricField schema={field} {...rest} />
       case BasicField.Number:
-        return <NumberField schema={field} colorTheme={colorTheme} />
+        return <NumberField schema={field} {...rest} />
       case BasicField.Decimal:
-        return <DecimalField schema={field} colorTheme={colorTheme} />
+        return <DecimalField schema={field} {...rest} />
       case BasicField.ShortText:
-        return <ShortTextField schema={field} colorTheme={colorTheme} />
+        return <ShortTextField schema={field} {...rest} />
       case BasicField.LongText:
-        return <LongTextField schema={field} colorTheme={colorTheme} />
+        return <LongTextField schema={field} {...rest} />
       case BasicField.YesNo:
-        return <YesNoField schema={field} colorTheme={colorTheme} />
+        return <YesNoField schema={field} {...rest} />
       case BasicField.Dropdown:
-        return <DropdownField schema={field} colorTheme={colorTheme} />
+        return <DropdownField schema={field} {...rest} />
       case BasicField.Date:
-        return <DateField schema={field} colorTheme={colorTheme} />
+        return <DateField schema={field} {...rest} />
       case BasicField.Uen:
-        return <UenField schema={field} colorTheme={colorTheme} />
+        return <UenField schema={field} {...rest} />
       case BasicField.Attachment:
-        return <AttachmentField schema={field} colorTheme={colorTheme} />
+        return <AttachmentField schema={field} {...rest} />
       case BasicField.HomeNo:
-        return <HomeNoField schema={field} colorTheme={colorTheme} />
+        return <HomeNoField schema={field} {...rest} />
       case BasicField.Mobile: {
         return field.isVerifiable ? (
           <VerifiableMobileField
             schema={field as VerifiableMobileFieldSchema}
-            colorTheme={colorTheme}
+            {...rest}
           />
         ) : (
-          <MobileField schema={field} colorTheme={colorTheme} />
+          <MobileField schema={field} {...rest} />
         )
       }
       case BasicField.Statement:
-        return <ParagraphField schema={field} colorTheme={colorTheme} />
+        return <ParagraphField schema={field} {...rest} />
       case BasicField.Rating:
-        return <RatingField schema={field} colorTheme={colorTheme} />
+        return <RatingField schema={field} {...rest} />
       case BasicField.Email: {
         return field.isVerifiable ? (
           <VerifiableEmailField
             schema={field as VerifiableEmailFieldSchema}
-            colorTheme={colorTheme}
+            {...rest}
           />
         ) : (
-          <EmailField schema={field} colorTheme={colorTheme} />
+          <EmailField schema={field} {...rest} />
         )
       }
       case BasicField.Image:
-        return <ImageField schema={field} colorTheme={colorTheme} />
+        return <ImageField schema={field} {...rest} />
       case BasicField.Table:
-        return <TableField schema={field} colorTheme={colorTheme} />
+        return <TableField schema={field} {...rest} />
     }
   },
   (prevProps, nextProps) =>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -2,11 +2,12 @@ import { useMemo } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
-import { times } from 'lodash'
+import { isEmpty, times } from 'lodash'
 
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, LogicDto } from '~shared/types/form'
 
+import InlineMessage from '~components/InlineMessage'
 import { FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
@@ -94,6 +95,13 @@ export const FormFields = ({
       <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
         <Box bg="white" py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
           <Stack spacing="2.25rem">
+            {!isEmpty(fieldPrefillMap) && (
+              <InlineMessage variant="warning">
+                The highlighted fields in this form have been pre-filled
+                according to the link that you clicked. Please check that these
+                values are what you intend to submit, and edit if necessary.
+              </InlineMessage>
+            )}
             <VisibleFormFields
               colorTheme={colorTheme}
               control={formMethods.control}

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -99,6 +99,7 @@ export const FormFields = ({
               control={formMethods.control}
               formFields={augmentedFormFields}
               formLogics={formLogics}
+              fieldPrefillMap={fieldPrefillMap}
             />
           </Stack>
         </Box>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -36,17 +36,14 @@ export const FormFields = ({
   const [searchParams] = useSearchParams()
 
   const fieldPrefillMap = useMemo(() => {
-    const queryParams = Object.fromEntries([...searchParams])
-    const ids = new Set(Object.keys(queryParams))
-
     // Return object containing field id and query param value only if id exists in form fields.
     return formFields.reduce((acc, field) => {
       if (
         field.fieldType === BasicField.ShortText &&
         field.allowPrefill &&
-        ids.has(field._id)
+        searchParams.has(field._id)
       ) {
-        acc[field._id] = queryParams[field._id]
+        acc[field._id] = searchParams.get(field._id) ?? ''
       }
       return acc
     }, {} as Record<string, string>)

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -16,6 +16,7 @@ interface VisibleFormFieldsProps {
   formFields: FormFieldWithQuestionNo[]
   formLogics: LogicDto[]
   colorTheme: FormColorTheme
+  fieldPrefillMap: Record<string, string>
 }
 
 /**
@@ -27,6 +28,7 @@ export const VisibleFormFields = ({
   formFields,
   formLogics,
   colorTheme,
+  fieldPrefillMap,
 }: VisibleFormFieldsProps) => {
   const watchedValues = useWatch({ control })
   const [visibleFormFields, setVisibleFormFields] = useState(formFields)
@@ -46,7 +48,12 @@ export const VisibleFormFields = ({
   return (
     <>
       {visibleFormFields.map((field) => (
-        <FieldFactory colorTheme={colorTheme} field={field} key={field._id} />
+        <FieldFactory
+          colorTheme={colorTheme}
+          field={field}
+          key={field._id}
+          isPrefilled={!!fieldPrefillMap[field._id]}
+        />
       ))}
     </>
   )

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -29,6 +29,11 @@ export type BaseFieldProps = {
    * If not provided, will default to given `schema._id`.
    */
   errorKey?: string
+
+  /**
+   * Whether or not the field was prefilled.
+   */
+  isPrefilled?: boolean
 }
 
 export interface FieldContainerProps extends BaseFieldProps {

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -16,6 +16,7 @@ export interface ShortTextFieldProps extends BaseFieldProps {
 
 export const ShortTextField = ({
   schema,
+  isPrefilled,
 }: ShortTextFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createTextValidationRules(schema),
@@ -27,6 +28,7 @@ export const ShortTextField = ({
   return (
     <FieldContainer schema={schema}>
       <Input
+        isPrefilled={isPrefilled}
         aria-label={schema.title}
         {...register(schema._id, validationRules)}
       />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the implementation for allowing form fields to be prefilled. Note that SPCP authentication prefill will come in a later PR. 

Related to #3630, not closing since there is still the auth variant to implement.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: add prefilled fields to default field values if they exist
- feat: add prefilled field banner if any fields are prefilled

## Before & After Screenshots
feat: add prefilled public form story
