### PR TITLE
feat: edit dateField schema

### DIFF
--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -8,13 +8,13 @@ export enum DateSelectedValidation {
 }
 
 export enum DaysOfTheWeek {
-  Sunday = 0,
-  Monday = 1,
-  Tuesday = 2,
-  Wednesday = 3,
-  Thursday = 4,
-  Friday = 5,
-  Saturday = 6,
+  Sunday = 'Sunday',
+  Monday = 'Monday',
+  Tuesday = 'Tuesday',
+  Wednesday = 'Wednesday',
+  Thursday = 'Thursday',
+  Friday = 'Friday',
+  Saturday = 'Saturday',
 }
 
 export type DateValidationOptions = {

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -63,7 +63,7 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should set expected array for invalidDaysOfTheWeek when date field specifies', async () => {
+  it('should successfully assign an array with valid values to invalidDaysOfTheWeek attribute', async () => {
     // Arrange
     const mockInvalidDaysOfTheWeek = [
       DaysOfTheWeek.Monday,
@@ -100,9 +100,9 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should throw an error when invalid values are added to invalidDaysOfTheWeek attribute', async () => {
+  it('should throw an error when an array with invalid values are assigned to invalidDaysOfTheWeek attribute', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [10000]
+    const mockInvalidDaysOfTheWeek = ['January']
     const mockDateField = {
       dateValidation: {
         selectedDateValidation: null,
@@ -120,7 +120,7 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when null value is added to invalidDaysOfTheWeek attribute array', async () => {
+  it('should throw an error when an array with null value is assigned to invalidDaysOfTheWeek attribute array', async () => {
     // Arrange
     const mockInvalidDaysOfTheWeek = [null]
     const mockDateField = {
@@ -140,9 +140,14 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when null value is added to invalidDaysOfTheWeek attribute array with valid values', async () => {
+  it('should throw an error when an array with null value and valid values are assigned to invalidDaysOfTheWeek attribute array', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [null, 1, 2, 3]
+    const mockInvalidDaysOfTheWeek = [
+      null,
+      DaysOfTheWeek.Monday,
+      DaysOfTheWeek.Tuesday,
+      DaysOfTheWeek.Wednesday,
+    ]
     const mockDateField = {
       dateValidation: {
         selectedDateValidation: null,

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -26,7 +26,7 @@ const createDateFieldSchema = () => {
     invalidDaysOfTheWeek: {
       type: [
         {
-          type: Number,
+          type: String,
           required: true,
         },
       ],


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
There was an issue where checkbox group would serialise the values and store it as a `String` which created inconsistencies as the current `invalidDaysOfTheWeek` array in the schema was being stored as a `Number` array.

closes #4136 

## Solution
<!-- How did you solve the problem? -->
 Edit `dateField` schema to store invalidDaysOfTheWeek as a `String` enum array instead of a `Number` enum array

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] Yes - this PR contains breaking changes
   - Details:
      - There might be a chance that the database might contain an array that does not match the same type as the current type of `invalidDaysOfTheWeek`. Hence this PR might cause a break in the database due to the mismatch in the attribute's type.