### PR TITLE
fix(form-v2): disable sgid auth option in settings for non-beta users

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -16,7 +16,7 @@ import Link from '~components/Link'
 import Radio from '~components/Radio'
 import Tooltip from '~components/Tooltip'
 
-import { useAdminForm } from '~features/admin-form/common/queries'
+import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../../mutations'
 
@@ -50,7 +50,7 @@ export const AuthSettingsSection = ({
   settings,
 }: AuthSettingsSectionProps): JSX.Element => {
   const { mutateFormAuthType } = useMutateFormSettings()
-  const { data: form } = useAdminForm()
+  const { user } = useUser()
 
   const [focusedValue, setFocusedValue] = useState<FormAuthType>()
 
@@ -63,8 +63,8 @@ export const AuthSettingsSection = ({
     (authType: FormAuthType) =>
       isFormPublic ||
       mutateFormAuthType.isLoading ||
-      (authType === FormAuthType.SGID && !form?.admin.betaFlags?.sgid),
-    [form?.admin.betaFlags?.sgid, isFormPublic, mutateFormAuthType.isLoading],
+      (authType === FormAuthType.SGID && !user?.betaFlags?.sgid),
+    [user?.betaFlags?.sgid, isFormPublic, mutateFormAuthType.isLoading],
   )
 
   const handleEnterKeyDown: KeyboardEventHandler = useCallback(

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -16,6 +16,8 @@ import Link from '~components/Link'
 import Radio from '~components/Radio'
 import Tooltip from '~components/Tooltip'
 
+import { useAdminForm } from '~features/admin-form/common/queries'
+
 import { useMutateFormSettings } from '../../mutations'
 
 import {
@@ -48,6 +50,7 @@ export const AuthSettingsSection = ({
   settings,
 }: AuthSettingsSectionProps): JSX.Element => {
   const { mutateFormAuthType } = useMutateFormSettings()
+  const { data: form } = useAdminForm()
 
   const [focusedValue, setFocusedValue] = useState<FormAuthType>()
 
@@ -56,9 +59,12 @@ export const AuthSettingsSection = ({
     [settings],
   )
 
-  const isDisabled = useMemo(
-    () => isFormPublic || mutateFormAuthType.isLoading,
-    [isFormPublic, mutateFormAuthType.isLoading],
+  const isDisabled = useCallback(
+    (authType: FormAuthType) =>
+      isFormPublic ||
+      mutateFormAuthType.isLoading ||
+      (authType === FormAuthType.SGID && !form?.admin.betaFlags?.sgid),
+    [form?.admin.betaFlags?.sgid, isFormPublic, mutateFormAuthType.isLoading],
   )
 
   const handleEnterKeyDown: KeyboardEventHandler = useCallback(
@@ -79,7 +85,7 @@ export const AuthSettingsSection = ({
     (authType: FormAuthType): MouseEventHandler =>
       (e) => {
         if (
-          !isDisabled &&
+          !isDisabled(authType) &&
           e.type === 'click' &&
           // Required so only real clicks get registered.
           // Typical radio behaviour is that the 'click' event is triggered on change.
@@ -115,10 +121,9 @@ export const AuthSettingsSection = ({
         onChange={(e: FormAuthType) => setFocusedValue(e)}
       >
         {radioOptions.map(([authType, text]) => (
-          // TODO: Check whether user has permissions for SGID, etc
           <Fragment key={authType}>
             <Box onClick={handleOptionClick(authType)}>
-              <Radio value={authType} isDisabled={isDisabled}>
+              <Radio value={authType} isDisabled={isDisabled(authType)}>
                 {text}
                 {authType === FormAuthType.SGID ? (
                   <>
@@ -151,7 +156,10 @@ export const AuthSettingsSection = ({
               </Radio>
             </Box>
             {authType !== FormAuthType.NIL && authType === settings.authType ? (
-              <EsrvcIdBox settings={settings} isDisabled={isDisabled} />
+              <EsrvcIdBox
+                settings={settings}
+                isDisabled={isDisabled(authType)}
+              />
             ) : null}
           </Fragment>
         ))}


### PR DESCRIPTION
## Problem
Currently, the SGID auth option is open for all to select. We need to disable it for non-beta users.

Closes [#4246 ]

## Solution

- `isDisabled` is now a function that takes the `authType` as an input, which checks for `betaFlags.sgid` when the `authtype` is `FormAuthType.SGID`.
- Add the `authType` input to all calls to `isDisabled`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Screenshots

![image](https://user-images.githubusercontent.com/25571626/180385733-bb168c78-743d-4851-b584-d751de66742b.png)

## Tests
- [X] Non-beta testers should not be able to select the SGID option.
