### PR TITLE
feat(v2): add handling of prefill for authed public forms, show fields correctly when logged in

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -261,8 +261,11 @@ export const PublicFormProvider = ({
   useTimeout(generateVfnExpiryToast, expiryInMs)
 
   const isAuthRequired = useMemo(
-    () => !!cachedDto?.form && cachedDto.form.authType !== FormAuthType.NIL,
-    [cachedDto?.form],
+    () =>
+      !!cachedDto?.form &&
+      cachedDto.form.authType !== FormAuthType.NIL &&
+      !cachedDto.spcpSession,
+    [cachedDto?.form, cachedDto?.spcpSession],
   )
 
   const sectionScrollData = useMemo(() => {

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -42,10 +42,11 @@ export const getPublicFormView = async (
 export const getPublicFormAuthRedirectUrl = async (
   formId: string,
   isPersistentLogin = false,
+  encodedQuery?: string,
 ): Promise<PublicFormAuthRedirectDto['redirectURL']> => {
   return ApiService.get<PublicFormAuthRedirectDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/auth/redirect`,
-    { params: { isPersistentLogin } },
+    { params: { encodedQuery, isPersistentLogin } },
   ).then(({ data }) => data.redirectURL)
 }
 

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -16,7 +16,7 @@ import {
   extractPreviewValue,
   hasExistingFieldValue,
 } from '~features/myinfo/utils'
-import { useStorePrefillQuery } from '~features/public-form/hooks/useStorePrefillQuery'
+import { useFetchPrefillQuery } from '~features/public-form/hooks/useFetchPrefillQuery'
 
 import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
@@ -34,7 +34,7 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-  useStorePrefillQuery()
+  useFetchPrefillQuery()
   const [searchParams] = useSearchParams()
 
   const fieldPrefillMap = useMemo(() => {

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
@@ -88,6 +88,18 @@ export const FormFields = ({
     mode: 'onTouched',
     shouldUnregister: true,
   })
+
+  const {
+    reset,
+    formState: { isDirty },
+  } = formMethods
+
+  // Reset default values when they change
+  useEffect(() => {
+    if (!isDirty) {
+      reset(defaultFormValues)
+    }
+  }, [defaultFormValues, isDirty, reset])
 
   return (
     <FormProvider {...formMethods}>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -16,6 +16,7 @@ import {
   extractPreviewValue,
   hasExistingFieldValue,
 } from '~features/myinfo/utils'
+import { useStorePrefillQuery } from '~features/public-form/hooks/useStorePrefillQuery'
 
 import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
@@ -33,6 +34,7 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
+  useStorePrefillQuery()
   const [searchParams] = useSearchParams()
 
   const fieldPrefillMap = useMemo(() => {

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.stories.tsx
@@ -1,3 +1,4 @@
+import { MemoryRouter } from 'react-router-dom'
 import { Meta, Story } from '@storybook/react'
 
 import { FormColorTheme } from '~shared/types/form/form'
@@ -27,9 +28,11 @@ export default {
   component: FormStartPage,
   decorators: [
     (storyFn) => (
-      <PublicFormProvider formId="61540ece3d4a6e50ac0cc6ff">
-        <FormSectionsProvider>{storyFn()}</FormSectionsProvider>
-      </PublicFormProvider>
+      <MemoryRouter initialEntries={['/12345']}>
+        <PublicFormProvider formId="61540ece3d4a6e50ac0cc6ff">
+          <FormSectionsProvider>{storyFn()}</FormSectionsProvider>
+        </PublicFormProvider>
+      </MemoryRouter>
     ),
   ],
   parameters: {

--- a/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
@@ -1,14 +1,11 @@
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useSessionstorage } from 'rooks'
+import { useSessionstorageState } from 'rooks'
 
-const STORED_QUERY_KEY = 'storedQuery'
-const REDIRECTED_QUERY_KEY = 'queryId'
+import { StoredRedirectionQuery } from './useStorePrefillQuery'
 
-type StoredRedirectionQuery = {
-  _id: string
-  queryString: string
-}
+export const STORED_QUERY_KEY = 'storedQuery'
+export const REDIRECTED_QUERY_KEY = 'queryId'
 
 const isValidStoredQuery = (
   queryId: string,
@@ -28,10 +25,8 @@ const isValidStoredQuery = (
 
 export const useFetchPrefillQuery = () => {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [storedQuery, setStoredQuery, removeStoredQuery] = useSessionstorage(
-    STORED_QUERY_KEY,
-    {},
-  )
+  const [storedQuery, setStoredQuery, removeStoredQuery] =
+    useSessionstorageState(STORED_QUERY_KEY, {})
 
   useEffect(() => {
     const previouslyStoredId = searchParams.get(REDIRECTED_QUERY_KEY)

--- a/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useSessionstorageState } from 'rooks'
+
+import { useSessionStorage } from '~hooks/useSessionStorage'
 
 import { StoredRedirectionQuery } from './useStorePrefillQuery'
 
@@ -25,8 +26,9 @@ const isValidStoredQuery = (
 
 export const useFetchPrefillQuery = () => {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [storedQuery, setStoredQuery, removeStoredQuery] =
-    useSessionstorageState(STORED_QUERY_KEY, {})
+  const [storedQuery, , removeStoredQuery] = useSessionStorage<
+    StoredRedirectionQuery | undefined
+  >(STORED_QUERY_KEY)
 
   useEffect(() => {
     const previouslyStoredId = searchParams.get(REDIRECTED_QUERY_KEY)
@@ -37,11 +39,5 @@ export const useFetchPrefillQuery = () => {
       setSearchParams(JSON.parse(storedQuery.queryString))
       removeStoredQuery()
     }
-  }, [
-    storedQuery,
-    setStoredQuery,
-    searchParams,
-    setSearchParams,
-    removeStoredQuery,
-  ])
+  }, [removeStoredQuery, searchParams, setSearchParams, storedQuery])
 }

--- a/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
@@ -34,7 +34,7 @@ export const useFetchPrefillQuery = () => {
       previouslyStoredId &&
       isValidStoredQuery(previouslyStoredId, storedQuery)
     ) {
-      setSearchParams(storedQuery.queryString)
+      setSearchParams(JSON.parse(storedQuery.queryString))
       removeStoredQuery()
     }
   }, [

--- a/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useFetchPrefillQuery.ts
@@ -26,7 +26,7 @@ const isValidStoredQuery = (
   return queryId === (storedQuery as StoredRedirectionQuery)._id
 }
 
-export const useStorePrefillQuery = () => {
+export const useFetchPrefillQuery = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const [storedQuery, setStoredQuery, removeStoredQuery] = useSessionstorage(
     STORED_QUERY_KEY,

--- a/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useSessionstorage } from 'rooks'
+
+const STORED_QUERY_KEY = 'storedQuery'
+const REDIRECTED_QUERY_KEY = 'queryId'
+
+type StoredRedirectionQuery = {
+  _id: string
+  queryString: string
+}
+
+const isValidStoredQuery = (
+  queryId: string,
+  storedQuery: unknown,
+): storedQuery is StoredRedirectionQuery => {
+  // Check if the stored query is a valid object and has expected keys
+  if (
+    typeof storedQuery !== 'object' ||
+    storedQuery === null ||
+    !('_id' in storedQuery && 'queryString' in storedQuery)
+  ) {
+    return false
+  }
+
+  return queryId === (storedQuery as StoredRedirectionQuery)._id
+}
+
+export const useStorePrefillQuery = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [storedQuery, setStoredQuery, removeStoredQuery] = useSessionstorage(
+    STORED_QUERY_KEY,
+    {},
+  )
+
+  useEffect(() => {
+    const previouslyStoredId = searchParams.get(REDIRECTED_QUERY_KEY)
+    if (
+      previouslyStoredId &&
+      isValidStoredQuery(previouslyStoredId, storedQuery)
+    ) {
+      setSearchParams(storedQuery.queryString)
+      removeStoredQuery()
+    }
+  }, [
+    storedQuery,
+    setStoredQuery,
+    searchParams,
+    setSearchParams,
+    removeStoredQuery,
+  ])
+}

--- a/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
@@ -1,0 +1,38 @@
+import { useSearchParams } from 'react-router-dom'
+import cuid from 'cuid'
+import { isEmpty } from 'lodash'
+import { useSessionstorageState } from 'rooks'
+
+import { REDIRECTED_QUERY_KEY, STORED_QUERY_KEY } from './useFetchPrefillQuery'
+
+export type StoredRedirectionQuery = {
+  _id: string
+  queryString: string
+}
+
+export const useStorePrefillQuery = () => {
+  const [searchParams] = useSearchParams()
+  const [, setStoredQuery] = useSessionstorageState(STORED_QUERY_KEY)
+
+  const storePrefillQuery = () => {
+    // Do nothing if key is already query key. Might result in infinite loop if handled.
+    if (searchParams.get(REDIRECTED_QUERY_KEY)) return
+
+    const queryParams = Object.fromEntries([...searchParams])
+    if (!isEmpty(queryParams)) {
+      const queryId = cuid()
+      const encodedQuery = btoa(`${REDIRECTED_QUERY_KEY}=${queryId}`)
+      const store: StoredRedirectionQuery = {
+        _id: queryId,
+        queryString: JSON.stringify(queryParams),
+      }
+      // Store search params otherwise.
+      setStoredQuery(store)
+      return encodedQuery
+    }
+  }
+
+  return {
+    storePrefillQuery,
+  }
+}

--- a/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
+++ b/frontend/src/features/public-form/hooks/useStorePrefillQuery.ts
@@ -1,7 +1,8 @@
 import { useSearchParams } from 'react-router-dom'
 import cuid from 'cuid'
 import { isEmpty } from 'lodash'
-import { useSessionstorageState } from 'rooks'
+
+import { useSessionStorage } from '~hooks/useSessionStorage'
 
 import { REDIRECTED_QUERY_KEY, STORED_QUERY_KEY } from './useFetchPrefillQuery'
 
@@ -12,7 +13,9 @@ export type StoredRedirectionQuery = {
 
 export const useStorePrefillQuery = () => {
   const [searchParams] = useSearchParams()
-  const [, setStoredQuery] = useSessionstorageState(STORED_QUERY_KEY)
+  const [, setStoredQuery] = useSessionStorage<
+    StoredRedirectionQuery | undefined
+  >(STORED_QUERY_KEY)
 
   const storePrefillQuery = () => {
     // Do nothing if key is already query key. Might result in infinite loop if handled.

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -4,6 +4,7 @@ import { FormAuthType, SubmitFormFeedbackBodyDto } from '~shared/types/form'
 
 import { useToast } from '~hooks/useToast'
 
+import { useStorePrefillQuery } from './hooks/useStorePrefillQuery'
 import {
   getPublicFormAuthRedirectUrl,
   logoutPublicForm,
@@ -16,12 +17,16 @@ import {
 import { publicFormKeys } from './queries'
 
 export const usePublicAuthMutations = (formId: string) => {
+  const { storePrefillQuery } = useStorePrefillQuery()
   const queryClient = useQueryClient()
 
   const toast = useToast({ status: 'success', isClosable: true })
 
   const handleLoginMutation = useMutation(
-    () => getPublicFormAuthRedirectUrl(formId),
+    () => {
+      const encodedQuery = storePrefillQuery()
+      return getPublicFormAuthRedirectUrl(formId, false, encodedQuery)
+    },
     {
       onSuccess: (redirectUrl) => {
         window.location.assign(redirectUrl)

--- a/frontend/src/hooks/useSessionStorage.ts
+++ b/frontend/src/hooks/useSessionStorage.ts
@@ -1,0 +1,191 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+// Modified from rooks/useSessionstorageStage
+// https://github.com/imbhargav5/rooks/blob/main/src/hooks/useSessionstorageState.ts
+// Fixing the issue of the hook setting undefined string as the value when none is provided.
+
+function getValueFromSessionStorage(key: string) {
+  if (typeof sessionStorage === 'undefined') {
+    return null
+  }
+  const storedValue = sessionStorage.getItem(key) ?? 'null'
+  try {
+    return JSON.parse(storedValue)
+  } catch (error) {
+    console.error(error)
+  }
+
+  return storedValue
+}
+
+function saveValueToSessionStorage<S>(key: string, value: S) {
+  if (typeof sessionStorage === 'undefined' || value === undefined) {
+    return null
+  }
+  return sessionStorage.setItem(key, JSON.stringify(value))
+}
+
+/**
+ * @param key Key of the sessionStorage object
+ * @param initialState Default initial value
+ */
+function initialize<S>(key: string, initialState: S) {
+  const valueLoadedFromSessionStorage = getValueFromSessionStorage(key)
+
+  if (valueLoadedFromSessionStorage === null) {
+    return initialState
+  } else {
+    return valueLoadedFromSessionStorage
+  }
+}
+
+type UseSessionstorateStateReturnValue<S> = [
+  S,
+  Dispatch<SetStateAction<S>>,
+  () => void,
+]
+type BroadcastCustomEvent<S> = CustomEvent<{ newValue: S }>
+/**
+ * useSessionStorage hook
+ * Tracks a value within sessionStorage and updates it
+ *
+ * @param {string} key - Key of the sessionStorage object
+ * @param {any} initialState - Default initial value
+ */
+export function useSessionStorage<S>(
+  key: string,
+  initialState?: S | (() => S),
+): UseSessionstorateStateReturnValue<S> {
+  const [value, setValue] = useState(() => initialize(key, initialState))
+
+  const isUpdateFromCrossDocumentListener = useRef(false)
+  const isUpdateFromWithinDocumentListener = useRef(false)
+  const customEventTypeName = useMemo(() => {
+    return `rooks-${key}-sessionstorage-update`
+  }, [key])
+  useEffect(() => {
+    /**
+     * We need to ensure there is no loop of
+     * storage events fired. Hence we are using a ref
+     * to keep track of whether setValue is from another
+     * storage event
+     */
+    if (!isUpdateFromCrossDocumentListener.current && value !== undefined) {
+      saveValueToSessionStorage(key, value)
+    }
+  }, [key, value])
+
+  const listenToCrossDocumentStorageEvents = useCallback(
+    (event: StorageEvent) => {
+      if (event.storageArea === sessionStorage && event.key === key) {
+        try {
+          isUpdateFromCrossDocumentListener.current = true
+          const newValue = JSON.parse(event.newValue ?? 'null')
+          if (value !== newValue) {
+            setValue(newValue)
+          }
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    },
+    [key, value],
+  )
+
+  // check for changes across windows
+  useEffect(() => {
+    // eslint-disable-next-line no-negated-condition
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', listenToCrossDocumentStorageEvents)
+
+      return () => {
+        window.removeEventListener(
+          'storage',
+          listenToCrossDocumentStorageEvents,
+        )
+      }
+    } else {
+      console.warn('[useSessionstorageState] window is undefined.')
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {}
+    }
+  }, [listenToCrossDocumentStorageEvents])
+
+  const listenToCustomEventWithinDocument = useCallback(
+    (event: BroadcastCustomEvent<S>) => {
+      try {
+        isUpdateFromWithinDocumentListener.current = true
+        const { newValue } = event.detail
+        if (value !== newValue) {
+          setValue(newValue)
+        }
+      } catch (error) {
+        console.log(error)
+      }
+    },
+    [value],
+  )
+
+  // check for changes within document
+  useEffect(() => {
+    // eslint-disable-next-line no-negated-condition
+    if (typeof document !== 'undefined') {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      document.addEventListener(
+        customEventTypeName,
+        listenToCustomEventWithinDocument,
+      )
+
+      return () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        document.removeEventListener(
+          customEventTypeName,
+          listenToCustomEventWithinDocument,
+        )
+      }
+    } else {
+      console.warn('[useSessionstorageState] document is undefined.')
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {}
+    }
+  }, [customEventTypeName, listenToCustomEventWithinDocument])
+
+  const broadcastValueWithinDocument = useCallback(
+    (newValue: S) => {
+      // eslint-disable-next-line no-negated-condition
+      if (typeof document !== 'undefined') {
+        const event: BroadcastCustomEvent<S> = new CustomEvent(
+          customEventTypeName,
+          { detail: { newValue } },
+        )
+        document.dispatchEvent(event)
+      } else {
+        console.warn('[useSessionstorageState] document is undefined.')
+      }
+    },
+    [customEventTypeName],
+  )
+
+  const set = useCallback(
+    (newValue: S) => {
+      isUpdateFromCrossDocumentListener.current = false
+      isUpdateFromWithinDocumentListener.current = false
+      setValue(newValue)
+      broadcastValueWithinDocument(newValue)
+    },
+    [broadcastValueWithinDocument],
+  )
+
+  const remove = useCallback(() => {
+    sessionStorage.removeItem(key)
+  }, [key])
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return [value, set, remove]
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements prefill for authenticatable public forms following AngularJS implementation in #3920.
Also contains a bug fix where form fields are still not shown when user is logged in.

Closes #3630

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- add hooks to store and retrieve prefill query strings when user is logging into a form
  - feat: add `useStorePrefillQuery` and `useFetchPrefillQuery` hooks
- feat: reset default form values to new values if changed (allows for query to get updated when search params get set programatically)
- add `useSessionStorage` hook for session storage manipulation

**Bug Fixes**:

- fix: correctly show public auth only if spcpSession is not defined
