### PR TITLE
feat(form-v2): replace icon with BiHomeCircle

### DIFF
--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -23,6 +23,7 @@ import {
   BiHeartCircle,
   BiHome,
   BiHomeAlt,
+  BiHomeCircle,
   BiHomeHeart,
   BiIdCard,
   BiImage,
@@ -246,7 +247,7 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
   },
   [MyInfoAttribute.RegisteredAddress]: {
     label: 'Registered Address',
-    icon: BiBuildings,
+    icon: BiHomeCircle,
     isSubmitted: true,
   },
   [MyInfoAttribute.MobileNo]: {

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -252,7 +252,7 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
   },
   [MyInfoAttribute.MobileNo]: {
     label: 'Mobile Number',
-    icon: BiBuildings,
+    icon: BiMobile,
     isSubmitted: true,
   },
   [MyInfoAttribute.Occupation]: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
"The icons for UEN and MyInfo registered address fields are identical under the Build tab. The icon for "Registered Address" should be changed to bx-home-circle as per @pearlyong's recommendation." as per issue #2166

Closes [#2166]

## Solution
update the icon to the correct one

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<details>
<summary>before</summary>

![image](https://user-images.githubusercontent.com/102740235/180494043-390911dc-a109-4b5f-9cdd-d94dc5237ec9.png)
</details>

**AFTER**:
<details>
<summary>after</summary>

![image](https://user-images.githubusercontent.com/102740235/180494102-e4958a36-6eec-47ee-a91c-b394c0191323.png)
</details>