### PR TITLE
fix: add 'self' to workerSrc to allow storage mode downloads

### DIFF
--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -74,6 +74,7 @@ const helmetMiddlewares = () => {
       "'unsafe-inline'",
     ],
     workerSrc: [
+      "'self'",
       'blob:', // DataDog RUM session replay - https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
     ],
     frameAncestors: ['*'],


### PR DESCRIPTION
`helmet.workerSrc` was updated in #3887. However, this removed the default of `'self'` and storage mode downloads stopped working (due to disallowing web workers).

This PR fixes that bug.