### PR TITLE
feat(form-v2/form-instructions-1): display instructions on public forms, admin builder and preview tool

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react'
-import { Flex, Skeleton } from '@chakra-ui/react'
+import { Box, Flex, Skeleton } from '@chakra-ui/react'
 
 import { FormAuthType, FormLogoState, FormStartPage } from '~shared/types'
 
 import { useEnv } from '~features/env/queries'
+import { FormInstructions } from '~features/public-form/components/FormInstructions/FormInstructions'
 import { FormBannerLogo } from '~features/public-form/components/FormStartPage/FormBannerLogo'
 import { FormHeader } from '~features/public-form/components/FormStartPage/FormHeader'
 import { useFormBannerLogo } from '~features/public-form/components/FormStartPage/useFormBannerLogo'
@@ -101,6 +102,12 @@ export const StartPageView = () => {
           form?.authType !== FormAuthType.NIL ? 'S8899000D' : undefined
         }
       />
+      <Box mt="1.5rem">
+        <FormInstructions
+          content={startPage?.paragraph}
+          colorTheme={startPage?.colorTheme}
+        />
+      </Box>
     </>
   )
 }

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -6,6 +6,7 @@ import FormEndPage from '~features/public-form/components/FormEndPage'
 import FormFields from '~features/public-form/components/FormFields'
 import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
 import { FormFooter } from '~features/public-form/components/FormFooter'
+import FormInstructions from '~features/public-form/components/FormInstructions'
 import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 
@@ -24,6 +25,7 @@ export const PreviewFormPage = (): JSX.Element => {
       <FormSectionsProvider>
         <FormStartPage />
         <PublicFormWrapper>
+          <FormInstructions />
           <FormFields />
           <FormEndPage isPreview />
           <FormFooter />

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -4,6 +4,7 @@ import FormEndPage from './components/FormEndPage'
 import FormFields from './components/FormFields'
 import { FormSectionsProvider } from './components/FormFields/FormSectionsContext'
 import { FormFooter } from './components/FormFooter'
+import FormInstructions from './components/FormInstructions'
 import FormStartPage from './components/FormStartPage'
 import { PublicFormWrapper } from './components/PublicFormWrapper'
 import { PublicFormProvider } from './PublicFormProvider'
@@ -17,6 +18,7 @@ export const PublicFormPage = (): JSX.Element => {
       <FormSectionsProvider>
         <FormStartPage />
         <PublicFormWrapper>
+          <FormInstructions />
           <FormFields />
           <FormEndPage />
           <FormFooter />

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -1,0 +1,50 @@
+import { Waypoint } from 'react-waypoint'
+import { Box, Flex, forwardRef, Text } from '@chakra-ui/react'
+
+import { FormColorTheme } from '~shared/types'
+
+import { useSectionColor } from '~templates/Field/Section/SectionField'
+
+interface FormInstructionsProps {
+  content?: string
+  colorTheme?: FormColorTheme
+  handleSectionEnter?: () => void
+}
+
+export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
+  ({ content, colorTheme, handleSectionEnter }, ref): JSX.Element | null => {
+    const sectionColor = useSectionColor(colorTheme)
+
+    if (!content) return null
+
+    return (
+      <Flex justify="center">
+        <Box
+          w="100%"
+          minW={0}
+          h="fit-content"
+          maxW="57rem"
+          bg="white"
+          py="2.5rem"
+          px={{ base: '1rem', md: '2.5rem' }}
+          mb="1.5rem"
+          mt={{ base: '2rem', md: '0' }}
+        >
+          <Box id="instructions" ref={ref}>
+            <Text textStyle="h2" color={sectionColor}>
+              Instructions
+            </Text>
+            <Text textStyle="body-1" color="secondary.700" mt="1rem">
+              {content}
+            </Text>
+          </Box>
+          <Waypoint
+            topOffset="80px"
+            bottomOffset="70%"
+            onEnter={handleSectionEnter}
+          />
+        </Box>
+      </Flex>
+    )
+  },
+)

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -1,0 +1,19 @@
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
+import { useFormSections } from '../FormFields/FormSectionsContext'
+
+import { FormInstructions } from './FormInstructions'
+
+export const FormInstructionsContainer = (): JSX.Element | null => {
+  const { sectionRefs, setActiveSectionId } = useFormSections()
+  const { form } = usePublicFormContext()
+
+  return (
+    <FormInstructions
+      content={form?.startPage.paragraph}
+      colorTheme={form?.startPage.colorTheme}
+      handleSectionEnter={() => setActiveSectionId('instructions')}
+      ref={sectionRefs['instructions']}
+    />
+  )
+}

--- a/frontend/src/features/public-form/components/FormInstructions/index.ts
+++ b/frontend/src/features/public-form/components/FormInstructions/index.ts
@@ -1,0 +1,1 @@
+export { FormInstructionsContainer as default } from './FormInstructionsContainer'

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -14,18 +14,21 @@ export interface SectionFieldProps extends SectionFieldContainerProps {
   handleSectionEnter?: () => void
 }
 
+export const useSectionColor = (colorTheme?: FormColorTheme) =>
+  useMemo(() => {
+    switch (colorTheme) {
+      case FormColorTheme.Orange:
+      case FormColorTheme.Red:
+        return `theme-${colorTheme}.600` as const
+      default:
+        return `theme-${colorTheme}.500` as const
+    }
+  }, [colorTheme])
+
 // Used by SectionFieldContainer
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
   ({ schema, colorTheme = FormColorTheme.Blue, handleSectionEnter }, ref) => {
-    const sectionColor = useMemo(() => {
-      switch (colorTheme) {
-        case FormColorTheme.Orange:
-        case FormColorTheme.Red:
-          return `theme-${colorTheme}.600` as const
-        default:
-          return `theme-${colorTheme}.500` as const
-      }
-    }, [])
+    const sectionColor = useSectionColor(colorTheme)
 
     return (
       <Box


### PR DESCRIPTION
## Problem
Currently, instructions are not displayed on forms. We need to display them in public and admin forms.

Makes progress towards [#4236 ]

## Solution
`FormInstructions/`
- Adds new component to display form instructions.

`PublicFormPage.tsx`, `StartPageView.tsx`, `PreviewFormPage.tsx`
- Adds `FormInstructions` component into the public, builder and preview form pages respectively.
- In builder tool, we put the form instructions with the start page since we need access to the drawer data.

`SectionField.tsx`
- Pull computation of header color out for reusability with `FormInstructions.tsx`.
 
**Breaking Changes** 
- [X] No - this PR is backwards compatible  

**Improvements**:

- feat(form-v2/form-instructions-2): pull `PublicSwitchEnvMessage` above form instructions
- feat(form-v2/form-instructions-3): pull sidebar out into `PublicFormWrapper` and add instructions to sections sidebar

## Before & After Screenshots

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25571626/180906046-40938304-4f7a-4546-9d27-c55e626e65b0.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25571626/180906105-08e1a49e-3b67-4dbb-9185-2f36f16a6e44.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25571626/180906126-a58daf1d-4055-495e-a1e3-847959bc793b.png">
