### PR TITLE
fix(form-v2) : remove invalid conditional to fix feature tour bug

### DIFF
--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -25,12 +25,7 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
       if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
         setStepIndex(index + 1)
       }
-
-      if (
-        status === STATUS.FINISHED ||
-        status === STATUS.SKIPPED ||
-        action === ACTIONS.CLOSE
-      ) {
+      if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
         onClose()
       }
     } else {


### PR DESCRIPTION
* joyride action value for next button is 'close' because continuous prop is false for tooltip

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Feature tour does not move on to design/logic

Closes [#4303 ]

## Solution
<!-- How did you solve the problem? -->

If continuous prop for joyride is false, then the default value for next button action is 'close'. 

Original code used a condition `ACTION.close` to determine whether to set local storage key to true, but this will lead to buggy behaviour as the next button has value `ACTION.close` which will incorrectly trigger the `onClose` function in `handleJoyrideCallback`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<details>


https://user-images.githubusercontent.com/102740235/180828894-4a8a4df5-d662-40f9-b04e-935ba4fae88f.mp4
</details>

**AFTER**:
<!-- [insert screenshot here] -->

<details>



https://user-images.githubusercontent.com/102740235/180828971-766e1897-7ed9-4f0c-9fc1-d54b521a7048.mp4
</details>


**ADDITIONAL ISSUES DISCOVERED NOT IN SCOPE OF THIS TASK**
the html title is wrong for the joyride tooltip for all buttons
<details>
<summary>picture of invalid titles</summary>

![image](https://user-images.githubusercontent.com/102740235/180829444-5b51a2b9-9358-494c-a687-036213aa7c88.png)
</details>

