### PR TITLE
feat(form-v2/form-instructions-2): pull PublicSwitchEnvMessage into public form wrapper

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -6,8 +6,6 @@ import { FormAuthType } from '~shared/types/form/form'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FormAuth } from '../FormAuth'
-// TODO #4279: Remove after React rollout is complete
-import { PublicSwitchEnvMessage } from '../PublicSwitchEnvMessage'
 
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
@@ -49,7 +47,6 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     <Flex justify="center">
       {isAuthRequired ? null : <SectionSidebar />}
       <Box w="100%" minW={0} h="fit-content" maxW="57rem">
-        <PublicSwitchEnvMessage />
         {renderFields}
       </Box>
       {isAuthRequired ? null : <Spacer />}

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -3,6 +3,9 @@ import { Flex } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
+// TODO #4279: Remove after React rollout is complete
+import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
+
 export interface PublicFormWrapperProps {
   children: React.ReactNode
 }
@@ -23,6 +26,7 @@ export const PublicFormWrapper = ({
 
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} flexDir="column">
+      <PublicSwitchEnvMessage />
       {children}
     </Flex>
   )

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -1,5 +1,5 @@
 // TODO #4279: Remove after React rollout is complete
-import { Text } from '@chakra-ui/react'
+import { Box, Flex, Text } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
@@ -10,14 +10,25 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
   const { publicSwitchEnvMutation } = useEnvMutations()
 
   return (
-    <InlineMessage variant="warning" mb="1.5rem" mt={{ base: '2rem', md: '0' }}>
-      <Text>
-        You’re filling this form on the new FormSG. If you have trouble
-        submitting,{' '}
-        <Button variant="link" onClick={() => publicSwitchEnvMutation.mutate}>
-          <Text as="u">switch to the original one here.</Text>
-        </Button>
-      </Text>
-    </InlineMessage>
+    <Flex justify="center">
+      <Box w="100%" minW={0} h="fit-content" maxW="57rem">
+        <InlineMessage
+          variant="warning"
+          mb="1.5rem"
+          mt={{ base: '1.5rem', md: '0' }}
+        >
+          <Text>
+            You're filling this form on the new FormSG. If you have trouble
+            submitting,
+            <Button
+              variant="link"
+              onClick={() => publicSwitchEnvMutation.mutate}
+            >
+              <Text as="u">switch to the original one here.</Text>
+            </Button>
+          </Text>
+        </InlineMessage>
+      </Box>
+    </Flex>
   )
 }


### PR DESCRIPTION
## Problem
The react message currently shows up immediately before the form fields. However, we want this to be at the top of the form, immediately after the header. Moving it into the public form wrapper allows the message, form instructions and form fields to be displayed in the correct order. 

Makes progress towards [#4236 ]

## Solution

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  
