### PR TITLE
feat: edit dateField schema attribute name

### DIFF
--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -7,7 +7,7 @@ export enum DateSelectedValidation {
   Custom = 'Custom date range',
 }
 
-export enum DaysOfTheWeek {
+export enum ValidDaysOptions {
   Sunday = 'Sunday',
   Monday = 'Monday',
   Tuesday = 'Tuesday',
@@ -15,6 +15,7 @@ export enum DaysOfTheWeek {
   Thursday = 'Thursday',
   Friday = 'Friday',
   Saturday = 'Saturday',
+  SingaporePublicHolidays = 'Singapore public holidays',
 }
 
 export type DateValidationOptions = {
@@ -26,5 +27,5 @@ export type DateValidationOptions = {
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions
-  invalidDaysOfTheWeek?: DaysOfTheWeek[] | null
+  validDays?: ValidDaysOptions[]
 }

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -7,7 +7,7 @@ export enum DateSelectedValidation {
   Custom = 'Custom date range',
 }
 
-export enum ValidDaysOptions {
+export enum InvalidDaysOptions {
   Sunday = 'Sunday',
   Monday = 'Monday',
   Tuesday = 'Tuesday',
@@ -27,5 +27,5 @@ export type DateValidationOptions = {
 export interface DateFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Date
   dateValidation: DateValidationOptions
-  validDays?: ValidDaysOptions[]
+  invalidDays?: InvalidDaysOptions[]
 }

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -1,6 +1,10 @@
 import merge from 'lodash/merge'
 import mongoose, { Model, Schema } from 'mongoose'
-import { DateFieldBase, FormResponseMode, ValidDaysOptions } from 'shared/types'
+import {
+  DateFieldBase,
+  FormResponseMode,
+  InvalidDaysOptions,
+} from 'shared/types'
 
 import { IDateFieldSchema } from 'src/types'
 
@@ -32,7 +36,7 @@ describe('models.fields.dateField', () => {
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  it('should set default array containing all the enum valid days options for validDays when date field does not specify', async () => {
+  it('should set default empty array for invalidDays when date field does not specify', async () => {
     // Arrange
     const mockDateField = {
       dateValidation: {
@@ -47,7 +51,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: Object.values(ValidDaysOptions),
+      invalidDays: [],
     }
 
     // Act
@@ -63,12 +67,12 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should successfully assign an array with valid values to validDays attribute', async () => {
+  it('should successfully assign an array with valid values to invalidDays attribute', async () => {
     // Arrange
     const mockInvalidDays = [
-      ValidDaysOptions.Monday,
-      ValidDaysOptions.Tuesday,
-      ValidDaysOptions.Wednesday,
+      InvalidDaysOptions.Monday,
+      InvalidDaysOptions.Tuesday,
+      InvalidDaysOptions.Wednesday,
     ]
     const mockDateField = {
       dateValidation: {
@@ -76,7 +80,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: mockInvalidDays,
+      invalidDays: mockInvalidDays,
     }
     const expectedDateField: Partial<DateFieldBase> = {
       dateValidation: {
@@ -84,7 +88,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: mockInvalidDays,
+      invalidDays: mockInvalidDays,
     }
 
     // Act
@@ -100,7 +104,7 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should throw an error when an array with invalid values are assigned to validDays attribute', async () => {
+  it('should throw an error when an array with invalid values are assigned to invalidDays attribute', async () => {
     // Arrange
     const mockInvalidDays = ['January']
     const mockDateField = {
@@ -109,7 +113,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: mockInvalidDays,
+      invalidDays: mockInvalidDays,
     }
 
     await expect(
@@ -120,7 +124,7 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when an array with null value is assigned to validDays attribute array', async () => {
+  it('should throw an error when an array with null value is assigned to invalidDays attribute array', async () => {
     // Arrange
     const mockInvalidDays = [null]
     const mockDateField = {
@@ -129,7 +133,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: mockInvalidDays,
+      invalidDays: mockInvalidDays,
     }
 
     await expect(
@@ -140,13 +144,13 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when an array with null value and valid values are assigned to validDays attribute array', async () => {
+  it('should throw an error when an array with null value and valid values are assigned to invalidDays attribute array', async () => {
     // Arrange
     const mockInvalidDays = [
       null,
-      ValidDaysOptions.Monday,
-      ValidDaysOptions.Tuesday,
-      ValidDaysOptions.Wednesday,
+      InvalidDaysOptions.Monday,
+      InvalidDaysOptions.Tuesday,
+      InvalidDaysOptions.Wednesday,
     ]
     const mockDateField = {
       dateValidation: {
@@ -154,7 +158,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      validDays: mockInvalidDays,
+      invalidDays: mockInvalidDays,
     }
 
     await expect(

--- a/src/app/models/field/__tests__/dateField.spec.ts
+++ b/src/app/models/field/__tests__/dateField.spec.ts
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge'
 import mongoose, { Model, Schema } from 'mongoose'
-import { DateFieldBase, DaysOfTheWeek, FormResponseMode } from 'shared/types'
+import { DateFieldBase, FormResponseMode, ValidDaysOptions } from 'shared/types'
 
 import { IDateFieldSchema } from 'src/types'
 
@@ -32,7 +32,7 @@ describe('models.fields.dateField', () => {
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  it('should set default empty array for invalidDaysOfTheWeek when date field does not specify', async () => {
+  it('should set default array containing all the enum valid days options for validDays when date field does not specify', async () => {
     // Arrange
     const mockDateField = {
       dateValidation: {
@@ -47,7 +47,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: [],
+      validDays: Object.values(ValidDaysOptions),
     }
 
     // Act
@@ -63,12 +63,12 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should successfully assign an array with valid values to invalidDaysOfTheWeek attribute', async () => {
+  it('should successfully assign an array with valid values to validDays attribute', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [
-      DaysOfTheWeek.Monday,
-      DaysOfTheWeek.Tuesday,
-      DaysOfTheWeek.Wednesday,
+    const mockInvalidDays = [
+      ValidDaysOptions.Monday,
+      ValidDaysOptions.Tuesday,
+      ValidDaysOptions.Wednesday,
     ]
     const mockDateField = {
       dateValidation: {
@@ -76,7 +76,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+      validDays: mockInvalidDays,
     }
     const expectedDateField: Partial<DateFieldBase> = {
       dateValidation: {
@@ -84,7 +84,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+      validDays: mockInvalidDays,
     }
 
     // Act
@@ -100,16 +100,16 @@ describe('models.fields.dateField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should throw an error when an array with invalid values are assigned to invalidDaysOfTheWeek attribute', async () => {
+  it('should throw an error when an array with invalid values are assigned to validDays attribute', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = ['January']
+    const mockInvalidDays = ['January']
     const mockDateField = {
       dateValidation: {
         selectedDateValidation: null,
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+      validDays: mockInvalidDays,
     }
 
     await expect(
@@ -120,16 +120,16 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when an array with null value is assigned to invalidDaysOfTheWeek attribute array', async () => {
+  it('should throw an error when an array with null value is assigned to validDays attribute array', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [null]
+    const mockInvalidDays = [null]
     const mockDateField = {
       dateValidation: {
         selectedDateValidation: null,
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+      validDays: mockInvalidDays,
     }
 
     await expect(
@@ -140,13 +140,13 @@ describe('models.fields.dateField', () => {
     ).rejects.toThrowError(mongoose.Error.ValidationError)
   })
 
-  it('should throw an error when an array with null value and valid values are assigned to invalidDaysOfTheWeek attribute array', async () => {
+  it('should throw an error when an array with null value and valid values are assigned to validDays attribute array', async () => {
     // Arrange
-    const mockInvalidDaysOfTheWeek = [
+    const mockInvalidDays = [
       null,
-      DaysOfTheWeek.Monday,
-      DaysOfTheWeek.Tuesday,
-      DaysOfTheWeek.Wednesday,
+      ValidDaysOptions.Monday,
+      ValidDaysOptions.Tuesday,
+      ValidDaysOptions.Wednesday,
     ]
     const mockDateField = {
       dateValidation: {
@@ -154,7 +154,7 @@ describe('models.fields.dateField', () => {
         customMaxDate: null,
         customMinDate: null,
       },
-      invalidDaysOfTheWeek: mockInvalidDaysOfTheWeek,
+      validDays: mockInvalidDays,
     }
 
     await expect(

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -2,7 +2,7 @@ import { Schema } from 'mongoose'
 
 import {
   DateSelectedValidation,
-  ValidDaysOptions,
+  InvalidDaysOptions,
 } from '../../../../shared/types'
 import { IDateFieldSchema } from '../../../types'
 
@@ -26,15 +26,14 @@ const createDateFieldSchema = () => {
         default: null,
       },
     },
-    validDays: {
+    invalidDays: {
       type: [
         {
           type: String,
           required: true,
         },
       ],
-      enum: [...Object.values(ValidDaysOptions)],
-      default: Object.values(ValidDaysOptions),
+      enum: [...Object.values(InvalidDaysOptions)],
     },
   })
 }

--- a/src/app/models/field/dateField.ts
+++ b/src/app/models/field/dateField.ts
@@ -1,6 +1,9 @@
 import { Schema } from 'mongoose'
 
-import { DateSelectedValidation, DaysOfTheWeek } from '../../../../shared/types'
+import {
+  DateSelectedValidation,
+  ValidDaysOptions,
+} from '../../../../shared/types'
 import { IDateFieldSchema } from '../../../types'
 
 import { MyInfoSchema } from './baseField'
@@ -23,14 +26,15 @@ const createDateFieldSchema = () => {
         default: null,
       },
     },
-    invalidDaysOfTheWeek: {
+    validDays: {
       type: [
         {
           type: String,
           required: true,
         },
       ],
-      enum: [...Object.values(DaysOfTheWeek)],
+      enum: [...Object.values(ValidDaysOptions)],
+      default: Object.values(ValidDaysOptions),
     },
   })
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
According to the Figma design, form admin users should be able to restrict Singapore public holidays on top of days of the week. Currently, the dateField schema attribute to encapsulate that information is named `invalidDaysOfTheWeek` which is not accurate since form admin users can restrict Singapore public holidays as well. 

Furthermore, since the Figma design shows that on default all the options will be checked, the default value of the attribute should be a string array containing all the options values instead of an empty array.

## Solution
<!-- How did you solve the problem? -->
Change the attribute in dateField to be `validDays` instead of `invalidDaysOfTheWeek`. Set the default value of the attribute to be a string array containing all the options values.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] Yes - this PR contains breaking changes
    - Due to the change in one of the attributes in dateField schema, rolling back this PR might cause inconsistencies in the database values.