### PR TITLE
fix(authTypes): disable changing of authtype with MyInfo, remove esrvcId box from SGID option

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -8,7 +8,9 @@ import {
 } from '~shared/types/form'
 
 import {
+  createFormBuilderMocks,
   getAdminFormSettings,
+  MOCK_FORM_FIELDS_WITH_MYINFO,
   patchAdminFormSettings,
 } from '~/mocks/msw/handlers/admin-form'
 
@@ -39,7 +41,6 @@ PrivateEmailForm.parameters = {
 }
 
 export const PrivateStorageForm = Template.bind({})
-
 PrivateStorageForm.parameters = {
   msw: buildMswRoutes({
     responseMode: FormResponseMode.Encrypt,
@@ -63,6 +64,18 @@ PrivateStorageCorppassForm.parameters = {
     authType: FormAuthType.CP,
     responseMode: FormResponseMode.Encrypt,
   }),
+}
+
+export const PrivateEmailMyinfoForm = Template.bind({})
+PrivateEmailMyinfoForm.parameters = {
+  msw: [
+    ...buildMswRoutes({
+      status: FormStatus.Private,
+      authType: FormAuthType.MyInfo,
+      esrvcId: 'STORYBOOK-TEST',
+    }),
+    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
+  ],
 }
 
 export const Loading = Template.bind({})

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -30,6 +30,17 @@ import {
 } from './constants'
 import { EsrvcIdBox } from './EsrvcIdBox'
 
+const esrvcidRequired = (authType: FormAuthType) => {
+  switch (authType) {
+    case FormAuthType.SP:
+    case FormAuthType.MyInfo:
+    case FormAuthType.CP:
+      return true
+    default:
+      return false
+  }
+}
+
 interface AuthSettingsSectionProps {
   settings: FormSettings
 }
@@ -57,7 +68,7 @@ export const AuthSettingsSection = ({
 
   const containsMyInfoFields = useMemo(
     () => form?.form_fields.some(isMyInfo) ?? false,
-    [form],
+    [form?.form_fields],
   )
 
   const [focusedValue, setFocusedValue] = useState<FormAuthType>()
@@ -70,14 +81,14 @@ export const AuthSettingsSection = ({
   const isDisabled = useCallback(
     (authType: FormAuthType) =>
       isFormPublic ||
+      containsMyInfoFields ||
       mutateFormAuthType.isLoading ||
-      (authType === FormAuthType.SGID && !user?.betaFlags?.sgid) ||
-      containsMyInfoFields,
+      (authType === FormAuthType.SGID && !user?.betaFlags?.sgid),
     [
-      user?.betaFlags?.sgid,
       isFormPublic,
-      mutateFormAuthType.isLoading,
       containsMyInfoFields,
+      mutateFormAuthType.isLoading,
+      user?.betaFlags?.sgid,
     ],
   )
 
@@ -128,8 +139,7 @@ export const AuthSettingsSection = ({
         <InlineMessage mb="1.25rem">
           To change authentication method, close your form to new responses.
         </InlineMessage>
-      ) : null}
-      {containsMyInfoFields ? (
+      ) : containsMyInfoFields ? (
         <InlineMessage mb="1.25rem">
           Authentication method cannot be changed without first removing MyInfo
           fields.
@@ -186,14 +196,4 @@ export const AuthSettingsSection = ({
       </Radio.RadioGroup>
     </Box>
   )
-}
-const esrvcidRequired = (authType: FormAuthType) => {
-  switch (authType) {
-    case FormAuthType.SP:
-    case FormAuthType.MyInfo:
-    case FormAuthType.CP:
-      return true
-    default:
-      return false
-  }
 }


### PR DESCRIPTION
## Problem
Form creators can currently change the authtype from MyInfo to something else while they have MyInfo fields in the form.
Also, we currently show an esrvcId box under the SGID option, which should not occur. 

Closes #4310 and #4312 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25571626/180916630-05bc0a8b-6d02-4570-8fda-d85069f6eb5c.png">

