### PR TITLE
fix(v2): redirect users to current browser link instead of homepage when prompting a refresh

### DIFF
--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -74,7 +74,8 @@ export const PreviewFormProvider = ({
           ),
           description: (
             <Text as="span">
-              <Link href="">Refresh</Link> for the latest version of the form.
+              <Link href={window.location.href}>Refresh</Link> for the latest
+              version of the form.
             </Text>
           ),
           duration: null,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -149,7 +149,8 @@ export const PublicFormProvider = ({
           ),
           description: (
             <Text as="span">
-              <Link href="">Refresh</Link> for the latest version of the form.
+              <Link href={window.location.href}>Refresh</Link> for the latest
+              version of the form.
             </Text>
           ),
           duration: null,

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -53,7 +53,7 @@ export const FormEndPageContainer = ({
         })
       }
     },
-    [submitFormFeedbackMutation, toast],
+    [isPreview, submitFormFeedbackMutation, toast],
   )
 
   if (!form || !submissionData) return null

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -74,7 +74,7 @@ export const EndPageBlock = ({
       <Box mt="2.25rem">
         <Button
           as="a"
-          href={endPage.buttonLink ?? ''}
+          href={endPage.buttonLink ?? window.location.href}
           variant="solid"
           colorScheme={`theme-${colorTheme}`}
         >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
3 locations were directing users to the home page instead of the intended refresh:

1. When end page button link is not provided, the default behaviour should be to refresh the page to submit the form again.
2. When form has changed and the toast prompts the user to refresh to fetch the latest changes in public form
3. Above but for preview form (should not happen once #4296 is closed, but including here for completeness)


Closes #4297, #4328

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- feat: use current location as href instead of empty string for link `href` props when directing to homepage is not desired (it probably never is)
