### PR TITLE
feat(form-v2): instantiate emergency contact modal in AdminNavBar

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
@@ -7,6 +7,7 @@ import {
   getTabletViewParameters,
   LoggedInDecorator,
   StoryRouter,
+  ViewedEmergencyContactDecorator,
 } from '~utils/storybook'
 
 import { AdminNavBar, AdminNavBarProps } from './AdminNavBar'
@@ -21,6 +22,7 @@ export default {
   decorators: [
     StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
     LoggedInDecorator,
+    ViewedEmergencyContactDecorator,
   ],
 } as Meta
 

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -94,7 +94,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   )
 
   // Only want to show the modal if user id exists but user has no emergency contact
-  const shouldShowModal = user && !!user._id !== !!user.contact
+  const shouldShowModal = user && user._id && !user.contact
 
   const emergencyContactKey = shouldShowModal
     ? EMERGENCY_CONTACT_KEY_PREFIX + user._id

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -105,6 +105,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     if (emergencyContactKey) {
       localStorage.removeItem(emergencyContactKey)
     }
+    window.location.reload()
   }
 
   return (

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -93,12 +93,14 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     ROLLOUT_ANNOUNCEMENT_KEY,
   )
 
-  // Only want to show the modal if user id exists but user has no emergency contact
-  const shouldShowModal = user && user._id && !user.contact
-
-  const emergencyContactKey = shouldShowModal
-    ? EMERGENCY_CONTACT_KEY_PREFIX + user._id
-    : null
+  // Only want to show the emergency contact modal if user id exists but user has no emergency contact
+  const emergencyContactKey = useMemo(
+    () =>
+      user && user._id && !user.contact
+        ? EMERGENCY_CONTACT_KEY_PREFIX + user._id
+        : null,
+    [user],
+  )
 
   const [hasSeenContactModal, setHasSeenContactModal] =
     useLocalStorage<boolean>(emergencyContactKey)
@@ -115,7 +117,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
 
   // Emergency contact modal appears after the rollout announcement modal
   useEffect(() => {
-    if (!hasSeenContactModal && !user?.contact && hasSeenAnnouncement) {
+    if (!hasSeenContactModal && user && !user?.contact && hasSeenAnnouncement) {
       onContactModalOpen()
     }
   }, [hasSeenContactModal, onContactModalOpen, user, hasSeenAnnouncement])

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -76,7 +76,12 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   const { user, isLoading: isUserLoading } = useUser()
 
   const emergencyContactKey = useMemo(
-    () => (user?._id ? EMERGENCY_CONTACT_KEY_PREFIX + user._id : null),
+    () =>
+      user?._id
+        ? user.contact
+          ? null
+          : EMERGENCY_CONTACT_KEY_PREFIX + user._id
+        : null,
     [user],
   )
 
@@ -93,7 +98,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }
 
   const isEmergencyContactModalOpenOnLogin = useMemo(
-    () => !isUserLoading && !hasSeenContactModal && !user?.contact,
+    () => !isUserLoading && !user?.contact && !hasSeenContactModal,
     [isUserLoading, hasSeenContactModal, user],
   )
 
@@ -105,7 +110,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     if (emergencyContactKey) {
       localStorage.removeItem(emergencyContactKey)
     }
-    window.location.reload()
   }
 
   return (
@@ -127,7 +131,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
             defaultIsOpen={isMenuOpen}
             menuListProps={{ maxWidth: '19rem' }}
           >
-            {/* TODO: Replace with billing route when available */}
             <Menu.Item as={ReactLink} to="/billing">
               Billing
             </Menu.Item>

--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -26,4 +26,4 @@ export const FEATURE_TOUR_KEY_PREFIX = 'has-seen-feature-tour-'
 /**
  * Key to store whether a user has seen the emergency contact number modal in localStorage.
  */
-export const EMERGENCY_CONTACT_KEY_PREFIX = 'has-emergency-contact'
+export const EMERGENCY_CONTACT_KEY_PREFIX = 'has-seen-emergency-contact'

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -8,11 +8,15 @@ import {
   FormStatus,
 } from '~shared/types/form/form'
 
+import { getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
+
 import { ROOT_ROUTE } from '~constants/routes'
 import {
   getMobileViewParameters,
+  LoggedInDecorator,
   mockDateDecorator,
   StoryRouter,
+  ViewedEmergencyContactDecorator,
   ViewedRolloutDecorator,
 } from '~utils/storybook'
 
@@ -61,6 +65,8 @@ export default {
       path: ROOT_ROUTE,
     }),
     mockDateDecorator,
+    LoggedInDecorator,
+    ViewedEmergencyContactDecorator,
   ],
   parameters: {
     layout: 'fullscreen',
@@ -74,6 +80,13 @@ export default {
           return res(ctx.json(THIRTY_FORMS))
         },
       ),
+      getUser({
+        delay: 0,
+        mockUser: {
+          ...MOCK_USER,
+          email: 'super_super_super_super_super_long_name@example.com',
+        },
+      }),
     ],
   },
 } as Meta

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -13,7 +13,6 @@ import {
   getMobileViewParameters,
   mockDateDecorator,
   StoryRouter,
-  ViewedEmergencyContactDecorator,
   ViewedRolloutDecorator,
 } from '~utils/storybook'
 
@@ -57,7 +56,6 @@ export default {
   component: WorkspacePage,
   decorators: [
     ViewedRolloutDecorator,
-    ViewedEmergencyContactDecorator,
     StoryRouter({
       initialEntries: [ROOT_ROUTE],
       path: ROOT_ROUTE,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -10,15 +10,11 @@ import { useSearchParams } from 'react-router-dom'
 import { Box, Container, Grid, useDisclosure } from '@chakra-ui/react'
 import { chunk } from 'lodash'
 
-import {
-  EMERGENCY_CONTACT_KEY_PREFIX,
-  ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
-} from '~constants/localStorage'
+import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import Pagination from '~components/Pagination'
 
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
-import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUser } from '~features/user/queries'
 
 // TODO #4279: Remove after React rollout is complete
@@ -128,24 +124,6 @@ export const WorkspacePage = (): JSX.Element => {
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const emergencyContactKey = useMemo(
-    () => (user?._id ? EMERGENCY_CONTACT_KEY_PREFIX + user._id : null),
-    [user],
-  )
-
-  const [hasSeenEmergencyContact, setHasSeenEmergencyContact] =
-    useLocalStorage<boolean>(emergencyContactKey)
-
-  const isEmergencyContactModalOpen = useMemo(
-    () =>
-      !isUserLoading &&
-      // Open emergency contact modal after the rollout announcement modal
-      Boolean(hasSeenAnnouncement) &&
-      !hasSeenEmergencyContact &&
-      !user?.contact,
-    [isUserLoading, hasSeenAnnouncement, hasSeenEmergencyContact, user],
-  )
-
   return (
     <>
       <CreateFormModal
@@ -186,10 +164,6 @@ export const WorkspacePage = (): JSX.Element => {
             <RolloutAnnouncementModal
               onClose={() => setHasSeenAnnouncement(true)}
               isOpen={isAnnouncementModalOpen}
-            />
-            <EmergencyContactModal
-              onClose={() => setHasSeenEmergencyContact(true)}
-              isOpen={isEmergencyContactModalOpen}
             />
             <WorkspaceFormRows rows={paginatedData} isLoading={isLoading} />
           </Box>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -10,6 +10,8 @@ import { useSearchParams } from 'react-router-dom'
 import { Box, Container, Grid, useDisclosure } from '@chakra-ui/react'
 import { chunk } from 'lodash'
 
+import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
+
 import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import Pagination from '~components/Pagination'
@@ -126,6 +128,7 @@ export const WorkspacePage = (): JSX.Element => {
 
   return (
     <>
+      <AdminNavBar />
       <CreateFormModal
         isOpen={createFormModalDisclosure.isOpen}
         onClose={createFormModalDisclosure.onClose}

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -1,5 +1,7 @@
 import { UserDto } from '~shared/types/user'
 
+import { LOCAL_STORAGE_EVENT, LOGGED_IN_KEY } from '~constants/localStorage'
+
 import { ApiService } from './ApiService'
 
 const AUTH_ENDPOINT = '/auth'
@@ -32,5 +34,9 @@ export const verifyLoginOtp = async (params: {
 }
 
 export const logout = async (): Promise<void> => {
+  // Remove logged in state from localStorage
+  localStorage.removeItem(LOGGED_IN_KEY)
+  // Event to let useLocalStorage know that key is being deleted.
+  window.dispatchEvent(new Event(LOCAL_STORAGE_EVENT))
   return ApiService.get(`${AUTH_ENDPOINT}/logout`)
 }


### PR DESCRIPTION
## Problem
The emergency contact modal should be instantiated in the AdminNavBar instead of the WorkSpacePage

Builds upon #4125 
Closes #4110 , #4153 , #4317

## Solution
This PR instantiates the emergency contact modal in the `AdminNavBar`. The emergency contact modal pops up if:

- The user clicks 'Contact' in the AdminNavBar dropdown menu
- If the user does not have an existing emergency contact upon logging in

**Details**:
- `emergencyContactKey` is deleted from `localStorage` upon logout

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
![chrome-capture-2022-6-27](https://user-images.githubusercontent.com/56983748/181141817-14f44aa2-1420-4e56-beba-6f5ec716223f.gif)

## Tests
In sequence
- [ ] Log in. If rollout announcement and emergency contact keys exist in local storage, delete them. On the workspace page, the rollout announcement modal should appear first, then the emergency contact modal. Refresh the workspace page. Both modals should not pop up.
- [ ] Click on 'Contact' in the Admin Navbar drop down menu. The emergency contact modal should appear. Fill in your contact number.
- [ ] Log out. Check local storage - the emergency contact key should be cleared.
- [ ] Log in again. the emergency contact modal should not pop up.
