### PR TITLE
chore: upgrade nodejs docker image to fermium 3.16

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM node:fermium-alpine3.15
+FROM node:fermium-alpine3.16
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 
 WORKDIR /opt/formsg

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM node:fermium-alpine3.13
+FROM node:fermium-alpine3.15
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 
 WORKDIR /opt/formsg

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM node:fermium-alpine3.13 AS node-modules-builder
+FROM node:fermium-alpine3.15 AS node-modules-builder
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
 RUN apk update && apk upgrade && \
@@ -11,7 +11,7 @@ RUN npm ci
 COPY . /opt/formsg
 
 # This stage builds the final container
-FROM node:fermium-alpine3.13
+FROM node:fermium-alpine3.15
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 WORKDIR /opt/formsg
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM node:fermium-alpine3.15 AS node-modules-builder
+FROM node:fermium-alpine3.16 AS node-modules-builder
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
 RUN apk update && apk upgrade && \
@@ -11,7 +11,7 @@ RUN npm ci
 COPY . /opt/formsg
 
 # This stage builds the final container
-FROM node:fermium-alpine3.15
+FROM node:fermium-alpine3.16
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 WORKDIR /opt/formsg
 


### PR DESCRIPTION
## Problem
[Snyk reported](https://app.snyk.io/org/formsg) that the nodejs fermium image has several security issues reported against it. 

Most are not a concern (e.g. ssh vulnerability is not a concern to us since we do not enable ssh anyway), but still, we should keep dependency fresh and patched.

## Solution
Upgrade to latest fermium image 3.16 . See docker hub for available versions [here](https://hub.docker.com/_/node)