### PR TITLE
fix(form-v2): add correct html titles to feature tour tooltip buttons

### DIFF
--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.tsx
@@ -16,16 +16,20 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
   const [isPaginationClicked, setIsPaginationClicked] = useState<boolean>(false)
 
   const handleJoyrideCallback = ({
-    action,
     index,
     status,
     type,
+    action,
   }: CallBackProps) => {
     if (!isPaginationClicked) {
       if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
         setStepIndex(index + 1)
       }
-      if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      if (
+        status === STATUS.FINISHED ||
+        status === STATUS.SKIPPED ||
+        action === ACTIONS.CLOSE
+      ) {
         onClose()
       }
     } else {
@@ -48,6 +52,7 @@ export const FeatureTour = ({ onClose }: FeatureTourProps): JSX.Element => {
         steps={FEATURE_STEPS}
         callback={handleJoyrideCallback}
         stepIndex={stepIndex}
+        continuous
         run
         hideBackButton
         floaterProps={{

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
@@ -17,7 +17,6 @@ export interface FeatureTourTooltipProps {
   step: FeatureTourStep
   tooltipProps: BoxProps
   primaryProps: ButtonProps
-  skipProps: ButtonProps
   closeProps: ButtonProps
   isLastStep: boolean
   index: number

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTourTooltip.tsx
@@ -18,6 +18,7 @@ export interface FeatureTourTooltipProps {
   tooltipProps: BoxProps
   primaryProps: ButtonProps
   skipProps: ButtonProps
+  closeProps: ButtonProps
   isLastStep: boolean
   index: number
 }
@@ -26,7 +27,7 @@ export const FeatureTourTooltip = ({
   step,
   tooltipProps,
   primaryProps,
-  skipProps,
+  closeProps,
   isLastStep,
   index,
 }: FeatureTourTooltipProps): JSX.Element => {
@@ -49,7 +50,7 @@ export const FeatureTourTooltip = ({
         position="absolute"
         right="1.25rem"
         top="1.25rem"
-        {...skipProps}
+        {...closeProps}
       />
       <Badge
         colorScheme="success"
@@ -78,7 +79,9 @@ export const FeatureTourTooltip = ({
           onClick={paginationCallback}
         />
         {isLastStep ? (
-          <Button {...skipProps}>Done</Button>
+          <Button {...primaryProps} title="Done">
+            Done
+          </Button>
         ) : (
           <Button rightIcon={<BiRightArrowAlt />} {...primaryProps}>
             Next


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently the feature tour tooltip have incorrect html title for the buttons due the assignment of incorrect props supplied by react joyride to the incorrect buttons.

Closes #4385 

## Solution
<!-- How did you solve the problem? -->
Add the correct props supplied by react joyride to the appropriate buttons and override the button title for the `Done` button.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  