### PR TITLE
fix: trim secret key before validating it

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/SecretKeyVerification.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/SecretKeyVerification.tsx
@@ -47,17 +47,15 @@ const useSecretKeyVerification = () => {
   const secretKeyValidationRules: RegisterOptions = useMemo(() => {
     return {
       required: "Please enter the form's secret key",
-      pattern: {
-        value: SECRET_KEY_REGEX,
-        message: 'The secret key provided is invalid',
-      },
       validate: (secretKey) => {
         // Should not see this error message.
         if (!formPublicKey) return 'This form is not a storage mode form'
-        const isKeypairValid = formsgSdk.crypto.valid(
-          formPublicKey,
-          secretKey.trim(),
-        )
+
+        const trimmedSecretKey = secretKey.trim()
+        const isKeypairValid =
+          SECRET_KEY_REGEX.test(trimmedSecretKey) &&
+          formsgSdk.crypto.valid(formPublicKey, trimmedSecretKey)
+
         return isKeypairValid || 'The secret key provided is invalid'
       },
     }
@@ -81,7 +79,7 @@ const useSecretKeyVerification = () => {
       const reader = new FileReader()
       reader.onload = async (e) => {
         if (!e.target) return
-        const text = e.target.result?.toString()
+        const text = e.target.result?.toString().trim()
 
         if (!text || !SECRET_KEY_REGEX.test(text)) {
           return setError(


### PR DESCRIPTION
## Problem
A Secret key could be accidentally supplied with leading or tailing whitespaces (by copy paste or by file). The code does trim the values, but the regexp fails the validation earlier than that

Closes #4373

## Solution
* Remove the pattern check and move it into the validator
* Trim the secretKey before doing validations