### PR TITLE
feat(form-v2/form-instructions-3): pull sidebar out into PublicFormWrapper and add instructions to sections sidebar

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -4,6 +4,8 @@ import { UserId } from '~shared/types'
 import {
   AdminFormDto,
   FormAuthType,
+  FormColorTheme,
+  FormLogoState,
   FormResponseMode,
 } from '~shared/types/form'
 
@@ -32,7 +34,12 @@ const buildMswRoutes = (
     ...createFormBuilderMocks(
       {
         ...overrides,
-        startPage: { paragraph: 'Fill in this mock form in this story.' },
+        startPage: {
+          logo: { state: FormLogoState.Default },
+          colorTheme: FormColorTheme.Blue,
+          paragraph: 'Fill in this mock form in this story.',
+          estTimeTaken: 300,
+        },
       },
       delay,
     ),

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -29,7 +29,13 @@ const buildMswRoutes = (
   delay?: number | 'infinite' | 'real',
 ) => {
   return [
-    ...createFormBuilderMocks(overrides, delay),
+    ...createFormBuilderMocks(
+      {
+        ...overrides,
+        startPage: { paragraph: 'Fill in this mock form in this story.' },
+      },
+      delay,
+    ),
     getUser({
       delay: 0,
       mockUser: { ...MOCK_USER, _id: 'adminFormTestUserId' as UserId },

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -69,8 +69,8 @@ export default {
 const Template: Story = () => <PreviewFormPage />
 export const Default = Template.bind({})
 
-export const WithInstructions = Template.bind({})
-WithInstructions.parameters = {
+export const WithShortInstructions = Template.bind({})
+WithShortInstructions.parameters = {
   msw: [
     ...envHandlers,
     getPreviewFormResponse({
@@ -78,6 +78,45 @@ WithInstructions.parameters = {
       overrides: {
         form: {
           startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
+export const WithLongInstructions = Template.bind({})
+WithLongInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPreviewFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: {
+            paragraph: `Fill in this mock form in this story. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+          risus.
+
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
+          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          fames ac turpis egestas.
+          
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          neque fermentum orci, vitae fermentum neque mi non arcu.`,
+          },
         },
       },
     }),

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -69,6 +69,21 @@ export default {
 const Template: Story = () => <PreviewFormPage />
 export const Default = Template.bind({})
 
+export const WithInstructions = Template.bind({})
+WithInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPreviewFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
 export const WithCaptcha = Template.bind({})
 WithCaptcha.parameters = {
   msw: [

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -124,6 +124,11 @@ export const PreviewFormProvider = ({
       return []
     }
     const sections: SidebarSectionMeta[] = []
+    if (form.startPage.paragraph)
+      sections.push({
+        title: 'Instructions',
+        _id: 'instructions',
+      })
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
       sections.push({
@@ -131,7 +136,6 @@ export const PreviewFormProvider = ({
         _id: f._id,
       })
     })
-
     return sections
   }, [cachedDto, isAuthRequired])
 

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -89,6 +89,21 @@ export default {
 const Template: Story = () => <PublicFormPage />
 export const Default = Template.bind({})
 
+export const WithInstructions = Template.bind({})
+WithInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
 export const WithCaptcha = Template.bind({})
 WithCaptcha.parameters = {
   msw: [

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -89,8 +89,8 @@ export default {
 const Template: Story = () => <PublicFormPage />
 export const Default = Template.bind({})
 
-export const WithInstructions = Template.bind({})
-WithInstructions.parameters = {
+export const WithShortInstructions = Template.bind({})
+WithShortInstructions.parameters = {
   msw: [
     ...envHandlers,
     getPublicFormResponse({
@@ -98,6 +98,45 @@ WithInstructions.parameters = {
       overrides: {
         form: {
           startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
+export const WithLongInstructions = Template.bind({})
+WithLongInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: {
+            paragraph: `Fill in this mock form in this story. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+          risus.
+
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
+          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          fames ac turpis egestas.
+          
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          neque fermentum orci, vitae fermentum neque mi non arcu.`,
+          },
         },
       },
     }),

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -274,6 +274,11 @@ export const PublicFormProvider = ({
       return []
     }
     const sections: SidebarSectionMeta[] = []
+    if (form.startPage.paragraph)
+      sections.push({
+        title: 'Instructions',
+        _id: 'instructions',
+      })
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
       sections.push({
@@ -281,7 +286,6 @@ export const PublicFormProvider = ({
         _id: f._id,
       })
     })
-
     return sections
   }, [cachedDto, isAuthRequired])
 

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Flex, Spacer } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types/form/form'
 
@@ -9,7 +9,6 @@ import { FormAuth } from '../FormAuth'
 
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
-import { SectionSidebar } from './SectionSidebar'
 
 export const FormFieldsContainer = (): JSX.Element | null => {
   const { form, isAuthRequired, isLoading, handleSubmitForm, submissionData } =
@@ -45,11 +44,9 @@ export const FormFieldsContainer = (): JSX.Element | null => {
 
   return (
     <Flex justify="center">
-      {isAuthRequired ? null : <SectionSidebar />}
       <Box w="100%" minW={0} h="fit-content" maxW="57rem">
         {renderFields}
       </Box>
-      {isAuthRequired ? null : <Spacer />}
     </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -43,10 +43,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
   if (submissionData) return null
 
   return (
-    <Flex justify="center">
-      <Box w="100%" minW={0} h="fit-content" maxW="57rem">
-        {renderFields}
-      </Box>
-    </Flex>
+    <Box w="100%" minW={0} h="fit-content" maxW="57rem">
+      {renderFields}
+    </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -53,7 +53,7 @@ export const FormSectionsProvider = ({
    */
   useEffect(() => {
     if (isFirstLoad && orderedSectionFieldIds) {
-      setActiveSectionId(orderedSectionFieldIds?.[0])
+      setActiveSectionId(orderedSectionFieldIds[0])
       isFirstLoad.current = false
     }
   }, [orderedSectionFieldIds])

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -35,10 +35,15 @@ export const FormSectionsProvider = ({
     Record<string, RefObject<HTMLDivElement>>
   >({})
 
-  const orderedSectionFields = useMemo(
-    () => form?.form_fields.filter((f) => f.fieldType === BasicField.Section),
-    [form],
-  )
+  const orderedSectionFieldIds = useMemo(() => {
+    if (!form) return
+    const sections = form.form_fields
+      .filter((f) => f.fieldType === BasicField.Section)
+      .map((f) => f._id)
+    return form.startPage.paragraph
+      ? ['instructions'].concat(sections)
+      : sections
+  }, [form])
   const [activeSectionId, setActiveSectionId] = useState<string>()
 
   const isFirstLoad = useRef(false)
@@ -47,20 +52,20 @@ export const FormSectionsProvider = ({
    * Set default active section id on first load of the form.
    */
   useEffect(() => {
-    if (isFirstLoad && orderedSectionFields) {
-      setActiveSectionId(orderedSectionFields[0]?._id)
+    if (isFirstLoad && orderedSectionFieldIds) {
+      setActiveSectionId(orderedSectionFieldIds?.[0])
       isFirstLoad.current = false
     }
-  }, [orderedSectionFields])
+  }, [orderedSectionFieldIds])
 
   useEffect(() => {
     if (!form) return
     const nextSectionRefs: Record<string, RefObject<HTMLDivElement>> = {}
-    orderedSectionFields?.forEach((f) => {
-      nextSectionRefs[f._id] = createRef()
+    orderedSectionFieldIds?.forEach((id) => {
+      nextSectionRefs[id] = createRef()
     })
     setSectionRefs(nextSectionRefs)
-  }, [activeSectionId, form, orderedSectionFields])
+  }, [activeSectionId, form, orderedSectionFieldIds])
 
   return (
     <FormSectionsContext.Provider

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -28,7 +28,6 @@ export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
           py="2.5rem"
           px={{ base: '1rem', md: '2.5rem' }}
           mb="1.5rem"
-          mt={{ base: '2rem', md: '0' }}
         >
           <Box id="instructions" ref={ref}>
             <Text textStyle="h2" color={sectionColor}>

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { Flex } from '@chakra-ui/react'
+import { Flex, Spacer } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
 // TODO #4279: Remove after React rollout is complete
 import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
+import SectionSidebar from './SectionSidebar'
 
 export interface PublicFormWrapperProps {
   children: React.ReactNode
@@ -17,7 +18,7 @@ export interface PublicFormWrapperProps {
 export const PublicFormWrapper = ({
   children,
 }: PublicFormWrapperProps): JSX.Element => {
-  const { form, isLoading } = usePublicFormContext()
+  const { form, isLoading, isAuthRequired } = usePublicFormContext()
 
   const bgColour = useMemo(() => {
     if (isLoading || !form) return 'neutral.100'
@@ -25,9 +26,13 @@ export const PublicFormWrapper = ({
   }, [form, isLoading])
 
   return (
-    <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} flexDir="column">
-      <PublicSwitchEnvMessage />
-      {children}
+    <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">
+      {isAuthRequired ? null : <SectionSidebar />}
+      <Flex flexDir="column">
+        <PublicSwitchEnvMessage />
+        {children}
+      </Flex>
+      {isAuthRequired ? null : <Spacer />}
     </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -15,7 +15,8 @@ import { useIsMobile } from '~hooks/useIsMobile'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-import { useFormSections } from './FormSectionsContext'
+import { useFormSections } from '../FormFields/FormSectionsContext'
+
 import { SidebarLink } from './SidebarLink'
 
 export const SectionSidebar = (): JSX.Element => {

--- a/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
@@ -6,7 +6,7 @@ import {
   usePublicFormContext,
 } from '~features/public-form/PublicFormContext'
 
-import { useFormSections } from './FormSectionsContext'
+import { useFormSections } from '../FormFields/FormSectionsContext'
 
 interface SidebarLinkProps {
   /**

--- a/frontend/src/features/public-form/components/SectionSidebar/index.ts
+++ b/frontend/src/features/public-form/components/SectionSidebar/index.ts
@@ -1,0 +1,1 @@
+export { SectionSidebar as default } from './SectionSidebar'


### PR DESCRIPTION
## Problem
The section sidebar currently does not include the instructions. This PR adds it in, and pulls sidebar from `FormFieldsContainer.tsx` into `PublicFormWrapper.tsx` to support this.

Makes progress towards #4236 

## Solution

`FormFieldsContainer.tsx`, `PublicFormWrapper.tsx`
- Moved sidebar from `FormFieldsContainer` to `PublicFormWrapper`.

`SectionSidebar/`
- Unchanged, moved out of `FormFields/`.

`FormSectionsContext.tsx`, `PublicFormProvider.tsx`, `PreviewFormProvider.tsx`
- Added instructions into section arrays so that it will display on the sidebar.

`FormInstructions.tsx`
- Removed `mt` to make mobile view display correctly.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Before & After Screenshots

Instructions only

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/25571626/181202580-24e9e609-95c2-4cdb-800a-f7b7cfd821b1.png">

Instructions + headers

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/25571626/181203183-272de7ff-9073-4dbc-9e83-175ba7f2f721.png">

Instructions + headers on scroll
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/25571626/181203298-a0c2bcb0-4623-4795-b3a6-3e4937d0fbed.png">