### PR TITLE
feat(form-v2/form-instructions): add form instructions to views

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -4,6 +4,8 @@ import { UserId } from '~shared/types'
 import {
   AdminFormDto,
   FormAuthType,
+  FormColorTheme,
+  FormLogoState,
   FormResponseMode,
 } from '~shared/types/form'
 
@@ -29,7 +31,18 @@ const buildMswRoutes = (
   delay?: number | 'infinite' | 'real',
 ) => {
   return [
-    ...createFormBuilderMocks(overrides, delay),
+    ...createFormBuilderMocks(
+      {
+        ...overrides,
+        startPage: {
+          logo: { state: FormLogoState.Default },
+          colorTheme: FormColorTheme.Blue,
+          paragraph: 'Fill in this mock form in this story.',
+          estTimeTaken: 300,
+        },
+      },
+      delay,
+    ),
     getUser({
       delay: 0,
       mockUser: { ...MOCK_USER, _id: 'adminFormTestUserId' as UserId },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react'
-import { Flex, Skeleton } from '@chakra-ui/react'
+import { Box, Flex, Skeleton } from '@chakra-ui/react'
 
 import { FormAuthType, FormLogoState, FormStartPage } from '~shared/types'
 
 import { useEnv } from '~features/env/queries'
+import { FormInstructions } from '~features/public-form/components/FormInstructions/FormInstructions'
 import { FormBannerLogo } from '~features/public-form/components/FormStartPage/FormBannerLogo'
 import { FormHeader } from '~features/public-form/components/FormStartPage/FormHeader'
 import { useFormBannerLogo } from '~features/public-form/components/FormStartPage/useFormBannerLogo'
@@ -101,6 +102,12 @@ export const StartPageView = () => {
           form?.authType !== FormAuthType.NIL ? 'S8899000D' : undefined
         }
       />
+      <Box mt="1.5rem">
+        <FormInstructions
+          content={startPage?.paragraph}
+          colorTheme={startPage?.colorTheme}
+        />
+      </Box>
     </>
   )
 }

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -69,6 +69,60 @@ export default {
 const Template: Story = () => <PreviewFormPage />
 export const Default = Template.bind({})
 
+export const WithShortInstructions = Template.bind({})
+WithShortInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPreviewFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
+export const WithLongInstructions = Template.bind({})
+WithLongInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPreviewFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: {
+            paragraph: `Fill in this mock form in this story. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+          risus.
+
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
+          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          fames ac turpis egestas.
+          
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          neque fermentum orci, vitae fermentum neque mi non arcu.`,
+          },
+        },
+      },
+    }),
+  ],
+}
+
 export const WithCaptcha = Template.bind({})
 WithCaptcha.parameters = {
   msw: [

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -93,28 +93,28 @@ WithLongInstructions.parameters = {
       overrides: {
         form: {
           startPage: {
-            paragraph: `Fill in this mock form in this story. Lorem
-          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
-          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
-          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
-          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
-          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+            paragraph: `Fill in this mock form in this story. Lorem\
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt\
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare.\
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris\
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas\
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est\
           risus.
 
-          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
-          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
-          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
-          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
-          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
-          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex,\
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non\
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce\
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor\
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim.\
+          Pellentesque habitant morbi tristique senectus et netus et malesuada\
           fames ac turpis egestas.
           
-          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
-          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
-          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
-          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
-          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
-          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante,\
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus\
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque\
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra.\
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a\
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum\
           neque fermentum orci, vitae fermentum neque mi non arcu.`,
           },
         },

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -6,6 +6,7 @@ import FormEndPage from '~features/public-form/components/FormEndPage'
 import FormFields from '~features/public-form/components/FormFields'
 import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
 import { FormFooter } from '~features/public-form/components/FormFooter'
+import FormInstructions from '~features/public-form/components/FormInstructions'
 import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 
@@ -24,6 +25,7 @@ export const PreviewFormPage = (): JSX.Element => {
       <FormSectionsProvider>
         <FormStartPage />
         <PublicFormWrapper>
+          <FormInstructions />
           <FormFields />
           <FormEndPage isPreview />
           <FormFooter />

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -124,6 +124,11 @@ export const PreviewFormProvider = ({
       return []
     }
     const sections: SidebarSectionMeta[] = []
+    if (form.startPage.paragraph)
+      sections.push({
+        title: 'Instructions',
+        _id: 'instructions',
+      })
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
       sections.push({
@@ -131,7 +136,6 @@ export const PreviewFormProvider = ({
         _id: f._id,
       })
     })
-
     return sections
   }, [cachedDto, isAuthRequired])
 

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -113,28 +113,28 @@ WithLongInstructions.parameters = {
       overrides: {
         form: {
           startPage: {
-            paragraph: `Fill in this mock form in this story. Lorem
-          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
-          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
-          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
-          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
-          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+            paragraph: `Fill in this mock form in this story. Lorem\
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt\
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare.\
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris\
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas\
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est\
           risus.
 
-          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
-          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
-          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
-          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
-          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
-          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex,\
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non\
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce\
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor\
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim.\
+          Pellentesque habitant morbi tristique senectus et netus et malesuada\
           fames ac turpis egestas.
           
-          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
-          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
-          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
-          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
-          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
-          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante,\
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus\
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque\
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra.\
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a\
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum\
           neque fermentum orci, vitae fermentum neque mi non arcu.`,
           },
         },

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -89,6 +89,60 @@ export default {
 const Template: Story = () => <PublicFormPage />
 export const Default = Template.bind({})
 
+export const WithShortInstructions = Template.bind({})
+WithShortInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: { paragraph: 'Fill in this mock form in this story.' },
+        },
+      },
+    }),
+  ],
+}
+
+export const WithLongInstructions = Template.bind({})
+WithLongInstructions.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          startPage: {
+            paragraph: `Fill in this mock form in this story. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt 
+          orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. 
+          Praesent mattis ligula egestas magna sagittis, non aliquet mauris 
+          sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas 
+          sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est 
+          risus.
+
+          Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, 
+          fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non 
+          velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce
+          quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor 
+          lacus. Aliquam dignissim laoreet libero, sed pharetra enim. 
+          Pellentesque habitant morbi tristique senectus et netus et malesuada 
+          fames ac turpis egestas.
+          
+          Donec scelerisque eros mattis tempor commodo. Vestibulum massa ante, 
+          fermentum nec sollicitudin eu, tincidunt sed lectus. Etiam maximus 
+          luctus dapibus. Morbi et mollis nibh. Praesent ante orci, pellentesque 
+          vel molestie ut, lobortis nec dui. Aliquam eleifend luctus pharetra. 
+          Nullam lacinia eget erat ac commodo. Curabitur suscipit felis a 
+          venenatis consectetur. Cras dictum, metus a egestas aliquam, ipsum 
+          neque fermentum orci, vitae fermentum neque mi non arcu.`,
+          },
+        },
+      },
+    }),
+  ],
+}
+
 export const WithCaptcha = Template.bind({})
 WithCaptcha.parameters = {
   msw: [

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -4,6 +4,7 @@ import FormEndPage from './components/FormEndPage'
 import FormFields from './components/FormFields'
 import { FormSectionsProvider } from './components/FormFields/FormSectionsContext'
 import { FormFooter } from './components/FormFooter'
+import FormInstructions from './components/FormInstructions'
 import FormStartPage from './components/FormStartPage'
 import { PublicFormWrapper } from './components/PublicFormWrapper'
 import { PublicFormProvider } from './PublicFormProvider'
@@ -17,6 +18,7 @@ export const PublicFormPage = (): JSX.Element => {
       <FormSectionsProvider>
         <FormStartPage />
         <PublicFormWrapper>
+          <FormInstructions />
           <FormFields />
           <FormEndPage />
           <FormFooter />

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -274,6 +274,11 @@ export const PublicFormProvider = ({
       return []
     }
     const sections: SidebarSectionMeta[] = []
+    if (form.startPage.paragraph)
+      sections.push({
+        title: 'Instructions',
+        _id: 'instructions',
+      })
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section) return
       sections.push({
@@ -281,7 +286,6 @@ export const PublicFormProvider = ({
         _id: f._id,
       })
     })
-
     return sections
   }, [cachedDto, isAuthRequired])
 

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Flex, Spacer } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types/form/form'
 
@@ -9,7 +9,6 @@ import { FormAuth } from '../FormAuth'
 
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
-import { SectionSidebar } from './SectionSidebar'
 
 export const FormFieldsContainer = (): JSX.Element | null => {
   const { form, isAuthRequired, isLoading, handleSubmitForm, submissionData } =
@@ -44,12 +43,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
   if (submissionData) return null
 
   return (
-    <Flex justify="center">
-      {isAuthRequired ? null : <SectionSidebar />}
-      <Box w="100%" minW={0} h="fit-content" maxW="57rem">
-        {renderFields}
-      </Box>
-      {isAuthRequired ? null : <Spacer />}
-    </Flex>
+    <Box w="100%" minW={0} h="fit-content" maxW="57rem">
+      {renderFields}
+    </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Flex } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types/form/form'
 

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -6,8 +6,6 @@ import { FormAuthType } from '~shared/types/form/form'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FormAuth } from '../FormAuth'
-// TODO #4279: Remove after React rollout is complete
-import { PublicSwitchEnvMessage } from '../PublicSwitchEnvMessage'
 
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
@@ -49,7 +47,6 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     <Flex justify="center">
       {isAuthRequired ? null : <SectionSidebar />}
       <Box w="100%" minW={0} h="fit-content" maxW="57rem">
-        <PublicSwitchEnvMessage />
         {renderFields}
       </Box>
       {isAuthRequired ? null : <Spacer />}

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -35,10 +35,15 @@ export const FormSectionsProvider = ({
     Record<string, RefObject<HTMLDivElement>>
   >({})
 
-  const orderedSectionFields = useMemo(
-    () => form?.form_fields.filter((f) => f.fieldType === BasicField.Section),
-    [form],
-  )
+  const orderedSectionFieldIds = useMemo(() => {
+    if (!form) return
+    const sections = form.form_fields
+      .filter((f) => f.fieldType === BasicField.Section)
+      .map((f) => f._id)
+    return form.startPage.paragraph
+      ? ['instructions'].concat(sections)
+      : sections
+  }, [form])
   const [activeSectionId, setActiveSectionId] = useState<string>()
 
   const isFirstLoad = useRef(false)
@@ -47,20 +52,20 @@ export const FormSectionsProvider = ({
    * Set default active section id on first load of the form.
    */
   useEffect(() => {
-    if (isFirstLoad && orderedSectionFields) {
-      setActiveSectionId(orderedSectionFields[0]?._id)
+    if (isFirstLoad && orderedSectionFieldIds) {
+      setActiveSectionId(orderedSectionFieldIds[0])
       isFirstLoad.current = false
     }
-  }, [orderedSectionFields])
+  }, [orderedSectionFieldIds])
 
   useEffect(() => {
     if (!form) return
     const nextSectionRefs: Record<string, RefObject<HTMLDivElement>> = {}
-    orderedSectionFields?.forEach((f) => {
-      nextSectionRefs[f._id] = createRef()
+    orderedSectionFieldIds?.forEach((id) => {
+      nextSectionRefs[id] = createRef()
     })
     setSectionRefs(nextSectionRefs)
-  }, [activeSectionId, form, orderedSectionFields])
+  }, [activeSectionId, form, orderedSectionFieldIds])
 
   return (
     <FormSectionsContext.Provider

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -28,7 +28,6 @@ export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
           py="2.5rem"
           px={{ base: '1rem', md: '2.5rem' }}
           mb="1.5rem"
-          mt={{ base: '2rem', md: '0' }}
         >
           <Box id="instructions" ref={ref}>
             <Text textStyle="h2" color={sectionColor}>

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -1,0 +1,50 @@
+import { Waypoint } from 'react-waypoint'
+import { Box, Flex, forwardRef, Text } from '@chakra-ui/react'
+
+import { FormColorTheme } from '~shared/types'
+
+import { useSectionColor } from '~templates/Field/Section/SectionField'
+
+interface FormInstructionsProps {
+  content?: string
+  colorTheme?: FormColorTheme
+  handleSectionEnter?: () => void
+}
+
+export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
+  ({ content, colorTheme, handleSectionEnter }, ref): JSX.Element | null => {
+    const sectionColor = useSectionColor(colorTheme)
+
+    if (!content) return null
+
+    return (
+      <Flex justify="center">
+        <Box
+          w="100%"
+          minW={0}
+          h="fit-content"
+          maxW="57rem"
+          bg="white"
+          py="2.5rem"
+          px={{ base: '1rem', md: '2.5rem' }}
+          mb="1.5rem"
+          mt={{ base: '2rem', md: '0' }}
+        >
+          <Box id="instructions" ref={ref}>
+            <Text textStyle="h2" color={sectionColor}>
+              Instructions
+            </Text>
+            <Text textStyle="body-1" color="secondary.700" mt="1rem">
+              {content}
+            </Text>
+          </Box>
+          <Waypoint
+            topOffset="80px"
+            bottomOffset="70%"
+            onEnter={handleSectionEnter}
+          />
+        </Box>
+      </Flex>
+    )
+  },
+)

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -33,7 +33,12 @@ export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
             <Text textStyle="h2" color={sectionColor}>
               Instructions
             </Text>
-            <Text textStyle="body-1" color="secondary.700" mt="1rem">
+            <Text
+              textStyle="body-1"
+              color="secondary.700"
+              mt="1rem"
+              whiteSpace="pre-line"
+            >
               {content}
             </Text>
           </Box>

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -1,0 +1,19 @@
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
+import { useFormSections } from '../FormFields/FormSectionsContext'
+
+import { FormInstructions } from './FormInstructions'
+
+export const FormInstructionsContainer = (): JSX.Element | null => {
+  const { sectionRefs, setActiveSectionId } = useFormSections()
+  const { form } = usePublicFormContext()
+
+  return (
+    <FormInstructions
+      content={form?.startPage.paragraph}
+      colorTheme={form?.startPage.colorTheme}
+      handleSectionEnter={() => setActiveSectionId('instructions')}
+      ref={sectionRefs['instructions']}
+    />
+  )
+}

--- a/frontend/src/features/public-form/components/FormInstructions/index.ts
+++ b/frontend/src/features/public-form/components/FormInstructions/index.ts
@@ -1,0 +1,1 @@
+export { FormInstructionsContainer as default } from './FormInstructionsContainer'

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -3,6 +3,9 @@ import { Flex } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
+// TODO #4279: Remove after React rollout is complete
+import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
+
 export interface PublicFormWrapperProps {
   children: React.ReactNode
 }
@@ -23,6 +26,7 @@ export const PublicFormWrapper = ({
 
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} flexDir="column">
+      <PublicSwitchEnvMessage />
       {children}
     </Flex>
   )

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { Flex } from '@chakra-ui/react'
+import { Flex, Spacer } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
 // TODO #4279: Remove after React rollout is complete
 import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
+import SectionSidebar from './SectionSidebar'
 
 export interface PublicFormWrapperProps {
   children: React.ReactNode
@@ -17,7 +18,7 @@ export interface PublicFormWrapperProps {
 export const PublicFormWrapper = ({
   children,
 }: PublicFormWrapperProps): JSX.Element => {
-  const { form, isLoading } = usePublicFormContext()
+  const { form, isLoading, isAuthRequired } = usePublicFormContext()
 
   const bgColour = useMemo(() => {
     if (isLoading || !form) return 'neutral.100'
@@ -25,9 +26,13 @@ export const PublicFormWrapper = ({
   }, [form, isLoading])
 
   return (
-    <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} flexDir="column">
-      <PublicSwitchEnvMessage />
-      {children}
+    <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">
+      {isAuthRequired ? null : <SectionSidebar />}
+      <Flex flexDir="column">
+        <PublicSwitchEnvMessage />
+        {children}
+      </Flex>
+      {isAuthRequired ? null : <Spacer />}
     </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -1,5 +1,5 @@
 // TODO #4279: Remove after React rollout is complete
-import { Text } from '@chakra-ui/react'
+import { Box, Flex, Text } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
@@ -10,14 +10,25 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
   const { publicSwitchEnvMutation } = useEnvMutations()
 
   return (
-    <InlineMessage variant="warning" mb="1.5rem" mt={{ base: '2rem', md: '0' }}>
-      <Text>
-        You’re filling this form on the new FormSG. If you have trouble
-        submitting,{' '}
-        <Button variant="link" onClick={() => publicSwitchEnvMutation.mutate}>
-          <Text as="u">switch to the original one here.</Text>
-        </Button>
-      </Text>
-    </InlineMessage>
+    <Flex justify="center">
+      <Box w="100%" minW={0} h="fit-content" maxW="57rem">
+        <InlineMessage
+          variant="warning"
+          mb="1.5rem"
+          mt={{ base: '1.5rem', md: '0' }}
+        >
+          <Text>
+            You're filling this form on the new FormSG. If you have trouble
+            submitting,
+            <Button
+              variant="link"
+              onClick={() => publicSwitchEnvMutation.mutate}
+            >
+              <Text as="u">switch to the original one here.</Text>
+            </Button>
+          </Text>
+        </InlineMessage>
+      </Box>
+    </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -15,7 +15,8 @@ import { useIsMobile } from '~hooks/useIsMobile'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-import { useFormSections } from './FormSectionsContext'
+import { useFormSections } from '../FormFields/FormSectionsContext'
+
 import { SidebarLink } from './SidebarLink'
 
 export const SectionSidebar = (): JSX.Element => {

--- a/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
@@ -6,7 +6,7 @@ import {
   usePublicFormContext,
 } from '~features/public-form/PublicFormContext'
 
-import { useFormSections } from './FormSectionsContext'
+import { useFormSections } from '../FormFields/FormSectionsContext'
 
 interface SidebarLinkProps {
   /**

--- a/frontend/src/features/public-form/components/SectionSidebar/index.ts
+++ b/frontend/src/features/public-form/components/SectionSidebar/index.ts
@@ -1,0 +1,1 @@
+export { SectionSidebar as default } from './SectionSidebar'

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -14,18 +14,21 @@ export interface SectionFieldProps extends SectionFieldContainerProps {
   handleSectionEnter?: () => void
 }
 
+export const useSectionColor = (colorTheme?: FormColorTheme) =>
+  useMemo(() => {
+    switch (colorTheme) {
+      case FormColorTheme.Orange:
+      case FormColorTheme.Red:
+        return `theme-${colorTheme}.600` as const
+      default:
+        return `theme-${colorTheme}.500` as const
+    }
+  }, [colorTheme])
+
 // Used by SectionFieldContainer
 export const SectionField = forwardRef<SectionFieldProps, 'div'>(
   ({ schema, colorTheme = FormColorTheme.Blue, handleSectionEnter }, ref) => {
-    const sectionColor = useMemo(() => {
-      switch (colorTheme) {
-        case FormColorTheme.Orange:
-        case FormColorTheme.Red:
-          return `theme-${colorTheme}.600` as const
-        default:
-          return `theme-${colorTheme}.500` as const
-      }
-    }, [])
+    const sectionColor = useSectionColor(colorTheme)
 
     return (
       <Box


### PR DESCRIPTION
## Problem
Form instructions are not displayed currently on forms. This PR implements form instructions in all views (admin builder, admin preview, public) and updates the sidebar to show instructions as a section when instructions exist.

Closes [#4236 ]

## Solution

- #4306
- #4323
- #4391

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
