### PR TITLE
feat(sgid): enable storage mode for sgid

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -671,17 +671,18 @@ describe('Form Model', () => {
         await expect(invalidForm.authType).toBe(FormAuthType.NIL)
       })
 
-      it('should set authType to NIL when given authType is SGID', async () => {
+      // Ensure that encrypted sgID forms can be created since they could not before
+      it('should set authType to SGID when given authType is SGID', async () => {
         // Arrange
-        const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+        const encryptFormParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
           authType: FormAuthType.SGID,
         })
 
         // Act
-        const invalidForm = await EncryptedForm.create(malformedParams)
+        const sgidForm = await EncryptedForm.create(encryptFormParams)
 
         // Assert
-        await expect(invalidForm.authType).toBe(FormAuthType.NIL)
+        await expect(sgidForm.authType).toBe(FormAuthType.SGID)
       })
     })
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -341,17 +341,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           // Do not allow authType to be changed if form is published
           if (this.authType !== v && this.status === FormStatus.Public) {
             return this.authType
-            // Singpass/Corppass authentication is available for both email
+            // Singpass/Corppass/SGID authentication is available for both email
             // and storage mode
-            // Important - this case must come before the MyInfo/SGID + storage
-            // mode case, or else we may accidentally set Singpass/Corppass storage
-            // mode forms to FormAuthType.NIL
-          } else if ([FormAuthType.SP, FormAuthType.CP].includes(v)) {
+            // Important - this case must come before the MyInfo + storage
+            // mode case, or else we may accidentally set Singpass/Corppass/SGID
+            // storage mode forms to FormAuthType.NIL
+          } else if (
+            [FormAuthType.SP, FormAuthType.CP, FormAuthType.SGID].includes(v)
+          ) {
             return v
           } else if (
             this.responseMode === FormResponseMode.Encrypt &&
-            // SGID and MyInfo are not available for storage mode
-            (v === FormAuthType.MyInfo || v === FormAuthType.SGID)
+            // MyInfo is not available for storage mode
+            v === FormAuthType.MyInfo
           ) {
             return FormAuthType.NIL
           } else {

--- a/src/app/modules/verified-content/__tests__/verified-content.service.spec.ts
+++ b/src/app/modules/verified-content/__tests__/verified-content.service.spec.ts
@@ -9,7 +9,11 @@ import {
   encryptVerifiedContent,
   getVerifiedContent,
 } from '../verified-content.service'
-import { CpVerifiedContent, SpVerifiedContent } from '../verified-content.types'
+import {
+  CpVerifiedContent,
+  SgidVerifiedContent,
+  SpVerifiedContent,
+} from '../verified-content.types'
 
 describe('verified-content.service', () => {
   describe('getVerifiedContent', () => {
@@ -56,6 +60,26 @@ describe('verified-content.service', () => {
       expect(result._unsafeUnwrap()).toEqual(expected)
     })
 
+    it('should return verified content for FormAuthType.SGID data', async () => {
+      // Arrange
+      const mockData = {
+        extraData: 'some extra data again',
+        uinFin: 'S1234567Z',
+      }
+      const expected: SgidVerifiedContent = {
+        sgidUinFin: mockData['uinFin'],
+      }
+
+      // Act
+      const result = getVerifiedContent({
+        type: FormAuthType.SGID,
+        data: mockData,
+      })
+
+      // Assert
+      expect(result._unsafeUnwrap()).toEqual(expected)
+    })
+
     it('should return error if retrieved SP data does not fit the expected shape', async () => {
       // Arrange
       const mockDataWithoutUin = {
@@ -87,6 +111,25 @@ describe('verified-content.service', () => {
       // Act
       const result = getVerifiedContent({
         type: FormAuthType.CP,
+        data: mockDataWithoutUin,
+      })
+
+      // Assert
+      expect(result._unsafeUnwrapErr()).toEqual(
+        new MalformedVerifiedContentError(),
+      )
+    })
+
+    it('should return error if retrieved SGID data does not fit the expected shape', async () => {
+      // Arrange
+      const mockDataWithoutUin = {
+        extraData: 'some data',
+        anotherExtraData: 'more useless data',
+      }
+
+      // Act
+      const result = getVerifiedContent({
+        type: FormAuthType.SGID,
         data: mockDataWithoutUin,
       })
 

--- a/src/app/modules/verified-content/__tests__/verified-content.utils.spec.ts
+++ b/src/app/modules/verified-content/__tests__/verified-content.utils.spec.ts
@@ -1,6 +1,9 @@
+import { VerifiedKeys } from 'shared/utils/verified-content'
+
 import { MalformedVerifiedContentError } from '../verified-content.errors'
 import {
   getCpVerifiedContent,
+  getSgidVerifiedContent,
   getSpVerifiedContent,
 } from '../verified-content.utils'
 
@@ -83,6 +86,39 @@ describe('verified-content.utils', () => {
 
       // Act
       const actualResult = getCpVerifiedContent(incorrectData)
+
+      // Assert
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new MalformedVerifiedContentError(),
+      )
+    })
+  })
+
+  describe('getSgidVerifiedContent', () => {
+    it('should successfully create SgidVerifiedContent', async () => {
+      // Arrange
+      const correctDataWithExtra = {
+        uinFin: 'something',
+        extraData: 'extra',
+      }
+
+      // Act
+      const actualResult = getSgidVerifiedContent(correctDataWithExtra)
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual({
+        [VerifiedKeys.SgidUinFin]: correctDataWithExtra.uinFin,
+      })
+    })
+    it('should return MalformedVerifiedContentError on invalid shape', async () => {
+      // Arrange
+      const incorrectData = {
+        incorrect: 'something',
+        extraData: 'extra',
+      }
+
+      // Act
+      const actualResult = getSgidVerifiedContent(incorrectData)
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(

--- a/src/app/modules/verified-content/verified-content.service.ts
+++ b/src/app/modules/verified-content/verified-content.service.ts
@@ -10,11 +10,13 @@ import {
   CpVerifiedContent,
   EncryptVerificationContentParams,
   GetVerifiedContentParams,
+  SgidVerifiedContent,
   SpVerifiedContent,
   VerifiedContentResult,
 } from './verified-content.types'
 import {
   getCpVerifiedContent,
+  getSgidVerifiedContent,
   getSpVerifiedContent,
 } from './verified-content.utils'
 
@@ -29,7 +31,7 @@ export const getVerifiedContent = ({
   type,
   data,
 }: GetVerifiedContentParams): VerifiedContentResult<
-  CpVerifiedContent | SpVerifiedContent
+  CpVerifiedContent | SpVerifiedContent | SgidVerifiedContent
 > => {
   switch (type) {
     case FormAuthType.SP:
@@ -37,11 +39,7 @@ export const getVerifiedContent = ({
     case FormAuthType.CP:
       return getCpVerifiedContent(data)
     case FormAuthType.SGID:
-      return err(
-        new EncryptVerifiedContentError(
-          'Fields from sgID not currently supported',
-        ),
-      )
+      return getSgidVerifiedContent(data)
   }
 }
 

--- a/src/app/modules/verified-content/verified-content.types.ts
+++ b/src/app/modules/verified-content/verified-content.types.ts
@@ -14,7 +14,11 @@ export type ICpVerifiedKeys = {
   userInfo: VerifiedKeys.CpUid
 }
 
-export type VerifiedKeyMap = SpVerifiedKeys | ICpVerifiedKeys
+export type SgidVerifiedKeys = {
+  uinFin: VerifiedKeys.SgidUinFin
+}
+
+export type VerifiedKeyMap = SpVerifiedKeys | ICpVerifiedKeys | SgidVerifiedKeys
 
 export type CpVerifiedContent = {
   [VerifiedKeys.CpUen]: string
@@ -25,10 +29,14 @@ export type SpVerifiedContent = {
   [VerifiedKeys.SpUinFin]: string
 }
 
+export type SgidVerifiedContent = {
+  [VerifiedKeys.SgidUinFin]: string
+}
+
 export type VerifiedContentResult<T> = Result<T, MalformedVerifiedContentError>
 
 export type EncryptVerificationContentParams = {
-  verifiedContent: CpVerifiedContent | SpVerifiedContent
+  verifiedContent: CpVerifiedContent | SpVerifiedContent | SgidVerifiedContent
   formPublicKey: string
 }
 

--- a/src/app/modules/verified-content/verified-content.utils.ts
+++ b/src/app/modules/verified-content/verified-content.utils.ts
@@ -5,6 +5,7 @@ import { VerifiedKeys } from '../../../../shared/utils/verified-content'
 import { MalformedVerifiedContentError } from './verified-content.errors'
 import {
   CpVerifiedContent,
+  SgidVerifiedContent,
   SpVerifiedContent,
   VerifiedContentResult,
 } from './verified-content.types'
@@ -31,6 +32,15 @@ const isSpVerifiedContent = (
   data: Record<string, unknown>,
 ): data is SpVerifiedContent => {
   return typeof data[VerifiedKeys.SpUinFin] === 'string'
+}
+
+/**
+ * Typeguard to assert that the given data has the shape of `SgidVerifiedContent`.
+ */
+const isSgidVerifiedContent = (
+  data: Record<string, unknown>,
+): data is SgidVerifiedContent => {
+  return typeof data[VerifiedKeys.SgidUinFin] === 'string'
 }
 
 /**
@@ -73,5 +83,26 @@ export const getSpVerifiedContent = (
   // Check if the newly created object is of expected shape.
   return isSpVerifiedContent(createdSpVerifiedContent)
     ? ok(createdSpVerifiedContent)
+    : err(new MalformedVerifiedContentError())
+}
+
+/**
+ * Retrieve Sgid verified content object from given data.
+ * @param data the data to retrieve the verified content object from
+ * @returns ok(verified content object) if retrieved object is of valid expected shape
+ * @returns err(MalformedVerifiedContentError) if object cannot be retrieved
+ */
+export const getSgidVerifiedContent = (
+  data: Record<string, unknown>,
+): VerifiedContentResult<SgidVerifiedContent> => {
+  // Create new Sgid verifiedContent object from current data.
+  // Extract value of data.uinFin set to new VerifiedKeys.SgidUinFin key.
+  const createdSgidVerifiedContent = {
+    [VerifiedKeys.SgidUinFin]: data.uinFin,
+  }
+
+  // Check if the newly created object is of expected shape.
+  return isSgidVerifiedContent(createdSgidVerifiedContent)
+    ? ok(createdSgidVerifiedContent)
     : err(new MalformedVerifiedContentError())
 }

--- a/src/public/modules/forms/admin/directives/settings-form.client.directive.js
+++ b/src/public/modules/forms/admin/directives/settings-form.client.directive.js
@@ -183,7 +183,7 @@ function settingsFormDirective(
           {
             val: 'SGID',
             name: 'Singpass App-only Login (Free)',
-            isEnabledInStorageMode: false,
+            isEnabledInStorageMode: true,
           },
           {
             val: 'MyInfo',

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -74,7 +74,7 @@ function SubmitFormController(
     }
   }
 
-  // For SP / CP forms, also include the spcpSession details
+  // For SP / CP / SGID forms, also include the spcpSession details
   // This allows the log out button to be correctly populated with the UID
   // Also provides time to cookie expiry so that client can refresh page
   if (isSpcpSgidForm && isUserLoggedIn) {


### PR DESCRIPTION
## Problem
sgID is actively trying to grow their product, and part of the growth strategy is to have more sgID FormSG forms. However, sgID is currently available only in email mode. This is a big deterrence for form admins who expect a large number of respondents for their forms. 

In particular, sgID has a big use case (expected form submissions in the range of the tens of thousands) looking to collect feedback related to National Day, so we're looking to enable sgID storage mode forms before then.

## Solution
This PR enables storage mode for sgID on both the frontend and the backend. The main change made was to add functions for getting verified sgID content. Other changes involved mainly flipping switches to handle sgID as a valid auth type for encrypt mode forms.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Alternative solutions considered
**Using email mode but managing the data collation for them**
If we manage data collation on their half, we don't need to do additional development work on the FormSG codebase.

**Not using authentication**
This would save us the effort of not having to do additional development work. Authentication is probably a good-to-have feature for form admins for now. However, form admins are keen to have authentication because it gives them a greater signal on the form data (prevents spam and fake users).

### sgID stance
sgID is keen to work on this because it would be useful to have a full working prototype to persuade other clients to onboard, instead of an ad-hoc workaround solution (managed data collation). Taking into account the fact that we have the capacity to work on this, the preference is to make the change on the FormSG codebase.

## Before & After Screenshots

**BEFORE**:
<img width="644" alt="Screenshot 2022-07-27 at 5 17 07 PM" src="https://user-images.githubusercontent.com/31984694/181214801-2e4ca97e-b027-4815-8f3e-127b6db3f46d.png">

**AFTER**:
<img width="698" alt="Screenshot 2022-07-27 at 5 16 55 PM" src="https://user-images.githubusercontent.com/31984694/181210950-c006661e-9609-4a6f-b768-f0af1ff82968.png">


## Tests
Expected outcomes:
- [ ] sgID option appears in storage mode form settings
- [ ] User is able to login with sgID for storage mode form and submit the form
- [ ] Admin is able to successfully decrypt sgID storage mode form responses
- [ ] Check that end-to-end flow for sgid email mode is unaffected


## Questions
- The current text for the sgID radio button in the form settings is “Singpass App-only Login (Free)”. Are we okay with this, or do we want to change the copy for this button? 