### PR TITLE
fix(form-v2): form preview should open in new tab

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -56,8 +56,7 @@ const useAdminFormNavbar = () => {
 
   const handlePreviewForm = useCallback((): void => {
     window.open(
-      window.location.origin +
-        `${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
+      `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
     )
   }, [formId])
 

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -55,8 +55,11 @@ const useAdminFormNavbar = () => {
   )
 
   const handlePreviewForm = useCallback((): void => {
-    navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`)
-  }, [navigate, formId])
+    window.open(
+      window.location.origin +
+        `${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
+    )
+  }, [formId])
 
   const handleTabsChange = useCallback(
     (index: number) => navigate(ADMINFORM_ROUTES[index]),

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
@@ -25,7 +25,10 @@ export const useRowActionDropdown = (
     shareFormModalDisclosure,
     handleEditForm: () => navigate(`${ADMINFORM_ROUTE}/${formId}`),
     handlePreviewForm: () =>
-      navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`),
+      window.open(
+        window.location.origin +
+          `${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
+      ),
     handleDuplicateForm: () =>
       console.log(`duplicate form button clicked for ${formId}`),
     handleManageFormAccess: () =>

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
@@ -26,8 +26,7 @@ export const useRowActionDropdown = (
     handleEditForm: () => navigate(`${ADMINFORM_ROUTE}/${formId}`),
     handlePreviewForm: () =>
       window.open(
-        window.location.origin +
-          `${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
+        `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
       ),
     handleDuplicateForm: () =>
       console.log(`duplicate form button clicked for ${formId}`),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Form preview should open in new tab

Closes [#4314]

## Solution
use window.open instead of react router navigate

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<details>




https://user-images.githubusercontent.com/102740235/181352245-36df818b-369d-44ee-8d96-369319edd63b.mp4
</details>

**AFTER**:
<details>


https://user-images.githubusercontent.com/102740235/181352284-0f89fa5a-51a8-4491-ac22-e22924f4e787.mp4
</details>

