### PR TITLE
feat(form-workspaces-be/6): add move forms from a single source workspace functionality

### DIFF
--- a/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.controller.spec.ts
@@ -328,4 +328,120 @@ describe('workspace.controller', () => {
       expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
     })
   })
+
+  describe('updateFormsWorkspace', () => {
+    const MOCK_REQ = expressHandler.mockRequest({
+      params: {
+        workspaceId: new ObjectId() as IWorkspaceSchema['_id'],
+      },
+      session: {
+        user: {
+          _id: 'exists',
+        },
+      },
+      body: {
+        formIds: [new ObjectId().toHexString()],
+        destWorkspaceId: new ObjectId() as IWorkspaceSchema['_id'],
+      },
+    })
+    const MOCK_WORKSPACE = {
+      _id: new ObjectId() as IWorkspaceSchema['_id'],
+      title: 'Workspace1',
+      admin: new ObjectId() as IUserSchema['_id'],
+      formIds: [],
+    }
+
+    it('should return 200 with success message', async () => {
+      const mockRes = expressHandler.mockResponse()
+      MockWorkspaceService.getWorkspace.mockReturnValue(okAsync(MOCK_WORKSPACE))
+      MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValue(okAsync(true))
+      MockWorkspaceService.moveForms.mockReturnValueOnce(
+        okAsync(MOCK_WORKSPACE),
+      )
+
+      await WorkspaceController.updateFormsWorkspace(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_WORKSPACE)
+    })
+
+    it('should return 403 when workspace is not found', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.getWorkspace.mockReturnValue(okAsync(MOCK_WORKSPACE))
+      MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValue(
+        errAsync(new ForbiddenWorkspaceError(mockErrorString)),
+      )
+
+      await WorkspaceController.updateFormsWorkspace(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(403)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 404 when workspace is not found', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.getWorkspace.mockReturnValue(
+        errAsync(new WorkspaceNotFoundError(mockErrorString)),
+      )
+      MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValue(okAsync(true))
+
+      await WorkspaceController.updateFormsWorkspace(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(404)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 409 when database conflict occurs', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.getWorkspace.mockReturnValue(okAsync(MOCK_WORKSPACE))
+      MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValue(okAsync(true))
+      MockWorkspaceService.moveForms.mockReturnValueOnce(
+        errAsync(new DatabaseConflictError(mockErrorString)),
+      )
+      await WorkspaceController.updateFormsWorkspace(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(409)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+
+    it('should return 500 when database error occurs', async () => {
+      const mockRes = expressHandler.mockResponse()
+      const mockErrorString = 'something went wrong'
+
+      MockWorkspaceService.getWorkspace.mockReturnValue(okAsync(MOCK_WORKSPACE))
+      MockWorkspaceService.verifyWorkspaceAdmin.mockReturnValue(okAsync(true))
+      MockWorkspaceService.moveForms.mockReturnValueOnce(
+        errAsync(new DatabaseError(mockErrorString)),
+      )
+      await WorkspaceController.updateFormsWorkspace(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      expect(mockRes.status).toBeCalledWith(500)
+      expect(mockRes.json).toBeCalledWith({ message: mockErrorString })
+    })
+  })
 })

--- a/src/app/modules/workspace/__tests__/workspace.form.routes.spec.ts
+++ b/src/app/modules/workspace/__tests__/workspace.form.routes.spec.ts
@@ -1,0 +1,227 @@
+import { ObjectId } from 'bson-ext'
+import mongoose from 'mongoose'
+import supertest, { Session } from 'supertest-session'
+
+import { getWorkspaceModel } from 'src/app/models/workspace.server.model'
+import { WorkspacesRouter } from 'src/app/routes/api/v3/admin/workspaces'
+import { formatErrorRecoveryMessage } from 'src/app/utils/handle-mongo-error'
+
+import {
+  createAuthedSession,
+  logoutSession,
+} from 'tests/integration/helpers/express-auth'
+import { setupApp } from 'tests/integration/helpers/express-setup'
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+
+import {
+  ForbiddenWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../workspace.errors'
+
+const WorkspaceModel = getWorkspaceModel(mongoose)
+
+const app = setupApp('/workspaces', WorkspacesRouter, {
+  setupWithAuth: true,
+})
+
+const MOCK_USER_ID = new ObjectId()
+const MOCK_FORM_ID = new ObjectId()
+const MOCK_WORKSPACE_ID = new ObjectId()
+const MOCK_WORKSPACE_DOC = {
+  _id: MOCK_WORKSPACE_ID,
+  title: 'Workspace1',
+  admin: MOCK_USER_ID,
+  formIds: [MOCK_FORM_ID],
+}
+
+describe('workspace.form.routes', () => {
+  let request: Session
+  let connection: typeof mongoose
+
+  beforeAll(async () => {
+    connection = await dbHandler.connect()
+    await connection.startSession()
+  })
+  beforeEach(async () => {
+    request = supertest(app)
+    const { user } = await dbHandler.insertEncryptForm({
+      formId: MOCK_FORM_ID,
+      userId: MOCK_USER_ID,
+    })
+    request = await createAuthedSession(user.email, request)
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.restoreAllMocks()
+  })
+  afterAll(async () => {
+    await dbHandler.closeDatabase()
+  })
+
+  describe('POST /workspaces/:workspaceId/forms/move', () => {
+    const MOVE_FORM_WORKSPACE_ENDPOINT = `/workspaces/${MOCK_WORKSPACE_ID}/forms/move`
+    const mockDestWorkspaceId = new ObjectId()
+    const mockDestWorkspaceDoc = {
+      _id: mockDestWorkspaceId,
+      title: 'destWorkspace',
+      admin: MOCK_USER_ID,
+      formIds: [],
+    }
+
+    beforeEach(async () => {
+      await WorkspaceModel.create(MOCK_WORKSPACE_DOC)
+      await WorkspaceModel.create(mockDestWorkspaceDoc)
+      jest
+        .spyOn(WorkspaceModel, 'removeFormIdsFromWorkspace')
+        .mockImplementationOnce(({ workspaceId, formIds }) =>
+          WorkspaceModel.removeFormIdsFromWorkspace({
+            workspaceId,
+            formIds,
+          }),
+        )
+      jest
+        .spyOn(WorkspaceModel, 'addFormIdsToWorkspace')
+        .mockImplementationOnce(({ workspaceId, formIds }) =>
+          WorkspaceModel.addFormIdsToWorkspace({
+            workspaceId,
+            formIds,
+          }),
+        )
+    })
+    afterEach(async () => {
+      await dbHandler.clearDatabase()
+      jest.clearAllMocks()
+    })
+
+    it('should return 200 with destination workspace on successful update of form workspace', async () => {
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: mockDestWorkspaceId.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      const response = await request
+        .post(MOVE_FORM_WORKSPACE_ENDPOINT)
+        .send(updateFormWorkspaceParams)
+      const expected = {
+        title: mockDestWorkspaceDoc.title,
+        admin: MOCK_USER_ID.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      expect(response.status).toEqual(200)
+      expect(response.body).toMatchObject(expected)
+    })
+
+    it('should return 401 when user is not logged in', async () => {
+      await logoutSession(request)
+      const response = await request.post(MOVE_FORM_WORKSPACE_ENDPOINT)
+
+      expect(response.status).toEqual(401)
+      expect(response.body).toEqual({ message: 'User is unauthorized.' })
+    })
+
+    it('should return 403 when user does not have permission to edit the source workspace', async () => {
+      const otherWorkspace = {
+        _id: new ObjectId(),
+        title: 'Workspace1',
+        admin: new ObjectId(),
+        formIds: [],
+      }
+      await WorkspaceModel.create(otherWorkspace)
+
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: mockDestWorkspaceId.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      const response = await request
+        .post(`/workspaces/${otherWorkspace._id}/forms/move`)
+        .send(updateFormWorkspaceParams)
+
+      expect(response.status).toEqual(403)
+      expect(response.body).toEqual({
+        message: new ForbiddenWorkspaceError().message,
+      })
+    })
+
+    it('should return 403 when user does not have permission to edit the destination workspace', async () => {
+      const otherWorkspace = {
+        _id: new ObjectId(),
+        title: 'Workspace1',
+        admin: new ObjectId(),
+        formIds: [],
+      }
+      await WorkspaceModel.create(otherWorkspace)
+
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: otherWorkspace._id.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      const response = await request
+        .post(MOVE_FORM_WORKSPACE_ENDPOINT)
+        .send(updateFormWorkspaceParams)
+
+      expect(response.status).toEqual(403)
+      expect(response.body).toEqual({
+        message: new ForbiddenWorkspaceError().message,
+      })
+    })
+
+    it('should return 404 when source workspace does not exist', async () => {
+      const nonExistentWorkspaceId = new ObjectId()
+
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: mockDestWorkspaceId.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      const response = await request
+        .post(`/workspaces/${nonExistentWorkspaceId}/forms/move`)
+        .send(updateFormWorkspaceParams)
+
+      expect(response.status).toEqual(404)
+      expect(response.body).toEqual({
+        message: new WorkspaceNotFoundError().message,
+      })
+    })
+
+    it('should return 404 when destination workspace does not exist', async () => {
+      const nonExistentWorkspaceId = new ObjectId()
+
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: nonExistentWorkspaceId.toHexString(),
+        formIds: [MOCK_FORM_ID.toHexString()],
+      }
+
+      const response = await request
+        .post(MOVE_FORM_WORKSPACE_ENDPOINT)
+        .send(updateFormWorkspaceParams)
+
+      expect(response.status).toEqual(404)
+      expect(response.body).toEqual({
+        message: new WorkspaceNotFoundError().message,
+      })
+    })
+
+    it('should return 500 when database errors occur', async () => {
+      const updateFormWorkspaceParams = {
+        destWorkspaceId: mockDestWorkspaceId.toHexString(),
+        formIds: [],
+      }
+
+      const mockErrorMessage = 'something went wrong'
+      jest
+        .spyOn(WorkspaceModel, 'removeFormIdsFromWorkspace')
+        .mockRejectedValueOnce(new Error(mockErrorMessage))
+      const response = await request
+        .post(MOVE_FORM_WORKSPACE_ENDPOINT)
+        .send(updateFormWorkspaceParams)
+
+      expect(response.status).toEqual(500)
+      expect(response.body).toEqual({
+        message: formatErrorRecoveryMessage(mockErrorMessage),
+      })
+    })
+  })
+})


### PR DESCRIPTION
Builds on #4254 

Part of #4039 

## Solution
Add endpoint logic for POST `api/v3/admin/workspaces/{workspaceId}/forms/move` for moving forms from one source workspace to one destination workspace

**Breaking Changes** 
- [x] No - this PR is backwards compatible  
