### PR TITLE
fix(form-v2): update OTP resend button to wait 60s on first send, update copy for OTP validity

### DIFF
--- a/frontend/src/features/verifiable-fields/components/VerificationBox/constants.ts
+++ b/frontend/src/features/verifiable-fields/components/VerificationBox/constants.ts
@@ -21,12 +21,12 @@ export const VFN_RENDER_DATA: Record<
     logo: MobileOtpSvgr,
     header: 'Verify your mobile number',
     subheader:
-      'An SMS with a 6-digit verification code was sent to you. It will be valid for 10 minutes.',
+      'An SMS with a 6-digit verification code was sent to you. It will be valid for 30 minutes.',
   },
   [BasicField.Email]: {
     logo: EmailOtpSvgr,
     header: 'Verify your email',
     subheader:
-      'An email with a 6-digit verification code was sent to you. It will be valid for 10 minutes.',
+      'An email with a 6-digit verification code was sent to you. It will be valid for 30 minutes.',
   },
 }

--- a/frontend/src/templates/ResendOtpButton/ResendOtpButtonContainer.tsx
+++ b/frontend/src/templates/ResendOtpButton/ResendOtpButtonContainer.tsx
@@ -21,7 +21,7 @@ export const ResendOtpButtonContainer = ({
   ...buttonProps
 }: ResendOtpButtonContainerProps): JSX.Element => {
   // The counter
-  const [timer, setTimer] = useState(0)
+  const [timer, setTimer] = useState(propTimer)
 
   const { isLoading, mutate } = useMutation(onResendOtp, {
     // On success, restart the timer before this can be called again.


### PR DESCRIPTION
## Problem
1. Currently, users who request for an OTP for the first time can resend immediately. #4344
2. Also, the copy for OTP validity says 10 min whereas the actual validity (in prod and as sent via email) is 30 min. #4403

## Solution
- [X] No - this PR is backwards compatible  

## Screenshots

1. 
https://user-images.githubusercontent.com/25571626/181412848-6d044bd0-9c4e-4e52-8b93-0316003ce481.mov

2.
<img width="847" alt="image" src="https://user-images.githubusercontent.com/25571626/181413031-b935fcd8-3151-4f45-91bf-21350327b5c8.png">

