### PR TITLE
fix: newline rendering for form field description and end page view

### DIFF
--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -87,7 +87,10 @@ export const FormLabel = ({
         )}
       </Box>
       {description && (
-        <FormLabel.Description useMarkdown={useMarkdownForDescription}>
+        <FormLabel.Description
+          useMarkdown={useMarkdownForDescription}
+          whiteSpace="pre-line"
+        >
           {description}
         </FormLabel.Description>
       )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -32,6 +32,7 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
       p={{ base: '1.5rem', md: 0 }}
       justify="center"
       overflow="auto"
+      height="100%"
       {...props}
     >
       <Stack w="100%">
@@ -50,7 +51,12 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
             <BxsChevronUp color="secondary.500" />
           </Flex>
 
-          <Text textStyle="subhead-1" color="secondary.500" mt="1rem">
+          <Text
+            textStyle="subhead-1"
+            color="secondary.500"
+            mt="1rem"
+            whiteSpace="pre-line"
+          >
             {endPage?.paragraph}
           </Text>
 

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -25,7 +25,7 @@ Default.args = {
     buttonText: 'Continue',
     title:
       'Thank you for your submission with some super long backstory about how important the submission is to them',
-    paragraph: 'We will get back to you shortly.',
+    paragraph: 'We will get back to you shortly.\nOnce again,\r\nthank you.',
   },
   submissionData: {
     id: 'mockSubmissionId',

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -25,7 +25,7 @@ Default.args = {
     buttonText: 'Continue',
     title:
       'Thank you for your submission with some super long backstory about how important the submission is to them',
-    paragraph: 'We will get back to you shortly.\nOnce again,\r\nthank you.',
+    paragraph: 'We will get back to you shortly.\n\nOnce again,\r\nthank you.',
   },
   submissionData: {
     id: 'mockSubmissionId',

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -54,7 +54,11 @@ export const EndPageBlock = ({
                 </Text>
 
                 {endPage.paragraph ? (
-                  <Text color="secondary.500" textStyle="subhead-1">
+                  <Text
+                    color="secondary.500"
+                    textStyle="subhead-1"
+                    whiteSpace="pre-line"
+                  >
                     {endPage.paragraph}
                   </Text>
                 ) : null}

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -47,7 +47,7 @@ export const MOCK_MYINFO_IMPLEMENTED_TYPES = [
 export const MOCK_FORM_FIELDS: FormFieldDto[] = [
   {
     title: 'Yes/No',
-    description: 'This is a\nmultiline description\r\nanother line',
+    description: 'This is a\n\nmultiline description\r\nanother line',
     required: true,
     disabled: false,
     fieldType: BasicField.YesNo,

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -47,7 +47,7 @@ export const MOCK_MYINFO_IMPLEMENTED_TYPES = [
 export const MOCK_FORM_FIELDS: FormFieldDto[] = [
   {
     title: 'Yes/No',
-    description: '',
+    description: 'This is a\nmultiline description\r\nanother line',
     required: true,
     disabled: false,
     fieldType: BasicField.YesNo,

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -79,7 +79,7 @@ export const BASE_FORM = {
   form_fields: [
     {
       title: 'Yes/No',
-      description: '',
+      description: 'This is a\nmultiline description\r\nanother line',
       required: true,
       disabled: false,
       fieldType: 'yes_no',

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -79,7 +79,7 @@ export const BASE_FORM = {
   form_fields: [
     {
       title: 'Yes/No',
-      description: 'This is a\nmultiline description\r\nanother line',
+      description: 'This is a\n\nmultiline description\r\nanother line',
       required: true,
       disabled: false,
       fieldType: 'yes_no',


### PR DESCRIPTION
## Problem
Newlines are not rendered in end page view as well as form field's question descriptions

Closes #4370 
Closes #4377 

## Solution
Use `whiteSpace` css property to render newline.

Note that newlines are still not rendered for descriptions that uses `<ReactMarkdown>` to render the description. Those can actually render newline, but require double whitespaces. See [this](https://github.com/remarkjs/react-markdown/issues/273) issue for details.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  


<img width="1435" alt="Screenshot 2022-07-28 at 12 21 12 PM" src="https://user-images.githubusercontent.com/24553546/181422797-03c2feee-0018-458d-957a-5cd7b1b89695.png">

<img width="1347" alt="Screenshot 2022-07-28 at 12 40 19 PM" src="https://user-images.githubusercontent.com/24553546/181422776-0316cde4-3283-46f8-94be-2371610f791b.png">

