### PR TITLE
feat: add server date validation for invalid days of the week

### DIFF
--- a/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
@@ -325,6 +325,24 @@ describe('Date field validation', () => {
     )
   })
 
+  it('should allow dates if invalid day array is empty', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMinDate: null,
+        customMaxDate: null,
+      },
+      invalidDays: [],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '26 Jul 2022',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
   it('should allow dates that is not an invalid day', () => {
     const formField = generateDefaultField(BasicField.Date, {
       dateValidation: {
@@ -335,11 +353,12 @@ describe('Date field validation', () => {
       invalidDays: [InvalidDaysOptions.Wednesday, InvalidDaysOptions.Thursday],
     })
     const response = generateNewSingleAnswerResponse(BasicField.Date, {
-      answer: '29 July 2022',
+      answer: '29 Jul 2022',
     })
 
     const validateResult = validateField('formId', formField, response)
-    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
   it('should disallow dates that is an invalid day', () => {
@@ -352,10 +371,13 @@ describe('Date field validation', () => {
       invalidDays: [InvalidDaysOptions.Wednesday, InvalidDaysOptions.Thursday],
     })
     const response = generateNewSingleAnswerResponse(BasicField.Date, {
-      answer: '27 July 2022',
+      answer: '27 Jul 2022',
     })
 
     const validateResult = validateField('formId', formField, response)
     expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
   })
 })

--- a/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   BasicField,
   DateSelectedValidation,
+  InvalidDaysOptions,
 } from '../../../../../../shared/types'
 
 describe('Date field validation', () => {
@@ -322,5 +323,39 @@ describe('Date field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Attempted to submit response on a hidden field'),
     )
+  })
+
+  it('should allow dates that is not an invalid day', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMinDate: null,
+        customMaxDate: null,
+      },
+      invalidDays: [InvalidDaysOptions.Wednesday, InvalidDaysOptions.Thursday],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '29 July 2022',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
+  })
+
+  it('should disallow dates that is an invalid day', () => {
+    const formField = generateDefaultField(BasicField.Date, {
+      dateValidation: {
+        selectedDateValidation: null,
+        customMinDate: null,
+        customMaxDate: null,
+      },
+      invalidDays: [InvalidDaysOptions.Wednesday, InvalidDaysOptions.Thursday],
+    })
+    const response = generateNewSingleAnswerResponse(BasicField.Date, {
+      answer: '27 July 2022',
+    })
+
+    const validateResult = validateField('formId', formField, response)
+    expect(validateResult.isErr()).toBe(true)
   })
 })

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -113,7 +113,7 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
 /**
  * constant
  */
-const INVALID_DAY_MAP: Record<InvalidDaysOptions, number> = {
+const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
   [InvalidDaysOptions.Sunday]: 0,
   [InvalidDaysOptions.Monday]: 1,
   [InvalidDaysOptions.Tuesday]: 2,
@@ -121,7 +121,6 @@ const INVALID_DAY_MAP: Record<InvalidDaysOptions, number> = {
   [InvalidDaysOptions.Thursday]: 4,
   [InvalidDaysOptions.Friday]: 5,
   [InvalidDaysOptions.Saturday]: 6,
-  [InvalidDaysOptions.SingaporePublicHolidays]: 7,
 }
 
 /**
@@ -136,7 +135,7 @@ const convertInvalidDaysOfTheWeekToNumberSet = (
     return new Set()
   }
 
-  return new Set(invalidDays.map((invalidDay) => INVALID_DAY_MAP[invalidDay]))
+  return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
 }
 
 /**

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -111,27 +111,17 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
 }
 
 /**
- * Returns the number representation of a day of the week
+ * constant
  */
-const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
-  switch (invalidDay) {
-    case InvalidDaysOptions.Sunday:
-      return 0
-    case InvalidDaysOptions.Monday:
-      return 1
-    case InvalidDaysOptions.Tuesday:
-      return 2
-    case InvalidDaysOptions.Wednesday:
-      return 3
-    case InvalidDaysOptions.Thursday:
-      return 4
-    case InvalidDaysOptions.Friday:
-      return 5
-    case InvalidDaysOptions.Saturday:
-      return 6
-    default:
-      return -1
-  }
+const INVALID_DAY_MAP: Record<InvalidDaysOptions, number> = {
+  [InvalidDaysOptions.Sunday]: 0,
+  [InvalidDaysOptions.Monday]: 1,
+  [InvalidDaysOptions.Tuesday]: 2,
+  [InvalidDaysOptions.Wednesday]: 3,
+  [InvalidDaysOptions.Thursday]: 4,
+  [InvalidDaysOptions.Friday]: 5,
+  [InvalidDaysOptions.Saturday]: 6,
+  [InvalidDaysOptions.SingaporePublicHolidays]: 7,
 }
 
 /**
@@ -146,10 +136,7 @@ const convertInvalidDaysOfTheWeekToNumberSet = (
     return new Set()
   }
 
-  const invaliDaysNumberArray = invalidDays.map((invalidDay) =>
-    convertInvalidDayToNumber(invalidDay),
-  )
-  return new Set(invaliDaysNumberArray)
+  return new Set(invalidDays.map((invalidDay) => INVALID_DAY_MAP[invalidDay]))
 }
 
 /**

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -152,11 +152,6 @@ const convertInvalidDayOfTheWeekToNumberSet = (
   return new Set(invaliDaysNumberArray)
 }
 
-// TODO: Add logic to validate if date response is a Singapore public holiday
-const noPublicHolidayValidator: DateValidator = (response) => {
-  return right(response)
-}
-
 const makeInvalidDayOfTheWeekValidator: DateValidatorConstructor =
   (dateField) => (response) => {
     const { answer } = response
@@ -174,14 +169,6 @@ const makeInvalidDayOfTheWeekValidator: DateValidatorConstructor =
   }
 
 const invalidDaysValidator: DateValidatorConstructor = (dateField) => {
-  const selectedInvalidDaysSet = new Set(dateField.invalidDays)
-
-  // Check if Singapore public holiday is a value in invalidDays
-  if (selectedInvalidDaysSet.has(InvalidDaysOptions.SingaporePublicHolidays)) {
-    // TODO: Validate if date response is a Singapore public holiday
-    return noPublicHolidayValidator
-  }
-
   return makeInvalidDayOfTheWeekValidator(dateField)
 }
 

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -139,7 +139,7 @@ const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
  * to a number array representing the number representation
  * of the corresponding day of the week
  */
-const convertInvalidDayOfTheWeekToNumberSet = (
+const convertInvalidDaysOfTheWeekToNumberSet = (
   invalidDays: InvalidDaysOptions[],
 ): Set<number> => {
   if (invalidDays.length === 0) {
@@ -152,17 +152,19 @@ const convertInvalidDayOfTheWeekToNumberSet = (
   return new Set(invaliDaysNumberArray)
 }
 
+/**
+ * Returns a validator to check if date is an invalid day of the week.
+ */
 const makeInvalidDayOfTheWeekValidator: DateValidatorConstructor =
   (dateField) => (response) => {
     const { answer } = response
 
-    // Convert invalidDays, containing only days of the week, to a Set<number>
-    const invalidDaysOfTheWeekSet = convertInvalidDayOfTheWeekToNumberSet(
+    const invalidDaysOfTheWeekSet = convertInvalidDaysOfTheWeekToNumberSet(
       dateField.invalidDays ?? [],
     )
     // Convert date response to a ISO day of the week number format
     const dateResponseNumberFormat = parseInt(format(new Date(answer), 'i'))
-    // Validate date response
+
     return invalidDaysOfTheWeekSet.has(dateResponseNumberFormat)
       ? left(`DateValidator:\t answer is an invalid day`)
       : right(response)

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -110,9 +110,6 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
   }
 }
 
-/**
- * constant
- */
 const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
   [InvalidDaysOptions.Sunday]: 0,
   [InvalidDaysOptions.Monday]: 1,

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -162,6 +162,13 @@ const makeInvalidDayOfTheWeekValidator: DateValidatorConstructor =
     const invalidDaysOfTheWeekSet = convertInvalidDaysOfTheWeekToNumberSet(
       dateField.invalidDays ?? [],
     )
+
+    if (invalidDaysOfTheWeekSet.has(-1)) {
+      return left(
+        `DateValidator:\t invalid day value is not a valid invalid day option`,
+      )
+    }
+
     // Convert date response to a ISO day of the week number format
     const dateResponseNumberFormat = parseInt(format(new Date(answer), 'i'))
 

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -111,13 +111,13 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
 }
 
 const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
-  [InvalidDaysOptions.Sunday]: 0,
   [InvalidDaysOptions.Monday]: 1,
   [InvalidDaysOptions.Tuesday]: 2,
   [InvalidDaysOptions.Wednesday]: 3,
   [InvalidDaysOptions.Thursday]: 4,
   [InvalidDaysOptions.Friday]: 5,
   [InvalidDaysOptions.Saturday]: 6,
+  [InvalidDaysOptions.Sunday]: 7,
 }
 
 /**

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -1,8 +1,12 @@
+import { format } from 'date-fns'
 import { chain, left, right } from 'fp-ts/lib/Either'
 import { flow } from 'fp-ts/lib/function'
 import moment from 'moment-timezone'
 
-import { DateSelectedValidation } from '../../../../../shared/types'
+import {
+  DateSelectedValidation,
+  InvalidDaysOptions,
+} from '../../../../../shared/types'
 import {
   IDateFieldSchema,
   OmitUnusedValidatorProps,
@@ -106,6 +110,67 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
   }
 }
 
+const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
+  switch (invalidDay) {
+    case InvalidDaysOptions.Sunday:
+      return 0
+    case InvalidDaysOptions.Monday:
+      return 1
+    case InvalidDaysOptions.Tuesday:
+      return 2
+    case InvalidDaysOptions.Wednesday:
+      return 3
+    case InvalidDaysOptions.Thursday:
+      return 4
+    case InvalidDaysOptions.Friday:
+      return 5
+    case InvalidDaysOptions.Saturday:
+      return 6
+    default:
+      return -1
+  }
+}
+
+const convertInvalidDayToNumberSet = (
+  invalidDays: InvalidDaysOptions[],
+): Set<number> => {
+  const invaliDaysNumberArray = invalidDays.map((invalidDay) =>
+    convertInvalidDayToNumber(invalidDay),
+  )
+  return new Set(invaliDaysNumberArray)
+}
+
+const invalidDaysValidator: DateValidatorConstructor =
+  (dateField) => (response) => {
+    const invalidDays = dateField.invalidDays
+
+    if (!invalidDays) {
+      return right(response)
+    }
+
+    const selectedInvalidDaysSet = new Set(invalidDays)
+    const { answer } = response
+
+    /** TODO: Add logic to validate date against Singapore public holidays */
+    if (
+      selectedInvalidDaysSet.has(InvalidDaysOptions.SingaporePublicHolidays)
+    ) {
+      return right(response)
+    }
+
+    // Validate date against list of invalid days set for date field
+    const selectedDayNumberFormat: number = +format(new Date(answer), 'i')
+    const invalidDayNumberSet = convertInvalidDayToNumberSet(invalidDays)
+
+    if (invalidDayNumberSet.has(-1)) {
+      return left('DateValidator:\t invalid day is not a valid day option')
+    }
+
+    return invalidDayNumberSet.has(selectedDayNumberFormat)
+      ? left('DateValidator:\t answer is an invalid day')
+      : right(response)
+  }
+
 /**
  * Returns a validation function for a date field when called.
  */
@@ -114,4 +179,5 @@ export const constructDateValidator: DateValidatorConstructor = (dateField) =>
     notEmptySingleAnswerResponse,
     chain(dateFormatValidator),
     chain(makeDateValidator(dateField)),
+    chain(invalidDaysValidator(dateField)),
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Date response selected by public user has to be validated against the days of the week restricted by form admin user.

Partially closes #4138 

## Solution
<!-- How did you solve the problem? -->
Add server side date validation to validate date sent from client side against the invalid days of the week chosen by form admin users for the form date field.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible 