### PR TITLE
fix(form-v2): make table question display format in storage mode responses consistent with AngularJS

### DIFF
--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -107,6 +107,10 @@ const transformToTableOutput = (
   return {
     ...pickBaseOutputFromSchema(schema),
     answerArray,
+    // override schema question title to include column titles as well.
+    question: `${schema.title} (${schema.columns
+      .map((col) => col.title)
+      .join(', ')})`,
   }
 }
 


### PR DESCRIPTION
## Problem
In angular, individual responses on storage mode display table question titles with the their column names. This is not done in React.

Closes #4376 

## Solution
When the table input is transformed to output before, add the column names with the table question name.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
