### PR TITLE
feat(v2): add "proper" loading screens when switching React bundles

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -51,7 +51,6 @@ const WithSuspense = ({ children }: { children: React.ReactNode }) => (
 )
 
 export const AppRouter = (): JSX.Element => {
-  // code here?
   return (
     <WithSuspense>
       <Routes>

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { Route, Routes } from 'react-router-dom'
+import { Box } from '@chakra-ui/react'
 
 import {
   ADMINFORM_PREVIEW_ROUTE,
@@ -44,7 +45,9 @@ const TermsOfUsePage = lazy(() => import('~pages/TermsOfUse'))
 const PreviewFormPage = lazy(() => import('~features/admin-form/preview'))
 
 const WithSuspense = ({ children }: { children: React.ReactNode }) => (
-  <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+  <Suspense fallback={<Box bg="neutral.100" h="100vh" w="100vw" />}>
+    {children}
+  </Suspense>
 )
 
 export const AppRouter = (): JSX.Element => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Basically removing loading screens since it should not take long for bundles to load.

Closes #4194
