### PR TITLE
fix(form-v2): added handler so date popover auto closes on select

### DIFF
--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -95,7 +95,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
           initialFocusRef={initialFocusRef}
           isLazy
         >
-          {({ isOpen }) => (
+          {({ isOpen, onClose }) => (
             <>
               <PopoverAnchor>
                 <Input
@@ -157,7 +157,10 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                       colorScheme={colorScheme}
                       date={datePickerDate}
                       isDateUnavailable={isDateUnavailable}
-                      onSelectDate={handleDatepickerSelection}
+                      onSelectDate={(e) => {
+                        handleDatepickerSelection(e)
+                        onClose()
+                      }}
                       ref={initialFocusRef}
                     />
                   </PopoverBody>


### PR DESCRIPTION
my 10th PR 🎉, thank you 🙏🙏🙏 formSG team for being so kind to review my code even during your crunch period! i am very grateful! i hope i have not taken away too much of your time from important matters. 
 
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
datefield popover doesn't close after selecting a date.

Closes [#4308 ]

## Solution
<!-- How did you solve the problem? -->
utilise popover onClose as provided by chakra popover component and invoked it when onSelectDate by dateinput component.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<details>
<summary>before bug fix</summary>


https://user-images.githubusercontent.com/102740235/181586388-e9ac5df1-605b-4385-81f9-28254c57c718.mp4
</details>

**AFTER**:
<!-- [insert screenshot here] -->
<details>
<summary>after bug fix</summary>


https://user-images.githubusercontent.com/102740235/181586411-1a58062c-0634-4b4a-88e1-cddf38265084.mp4
</details>

## Tests
<!-- What tests should be run to confirm functionality? -->
No tests, but a question to the maintainers. Was it a technical decision that there are no unit tests for many of the front end components? Because I realised that most of the tests i have encountered so far are non unit tests for front end like integration or e2e.

