### PR TITLE
chore: improve webpack bundling

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -2,6 +2,7 @@
 const CracoAlias = require('craco-alias')
 const merge = require('lodash/merge')
 const path = require('path')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
 const customJestConfig = require('./jest.config')
 
@@ -24,6 +25,9 @@ module.exports = {
         ],
       },
     },
+    plugins: process.env.ANALYZE && [
+      new BundleAnalyzerPlugin({ generateStatsFile: true }),
+    ],
   },
   plugins: [
     {

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -55,6 +55,13 @@ module.exports = {
     {
       plugin: {
         overrideWebpackConfig: ({ webpackConfig }) => {
+          /**
+           * Utility to allow for referencing folders outside of create-react-app root. \
+           * See https://github.com/facebook/create-react-app/issues/9127.
+           *
+           * Retrieved from https://gist.github.com/stevemu/53c5006c5e66fc277dea1454eb6acdb4.
+           * bascially tells webpack to use babel-loader for specified paths
+           */
           const oneOfRule = webpackConfig.module.rules.find(
             (rule) => rule.oneOf,
           )

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -14,6 +14,16 @@ module.exports = {
     },
   },
   webpack: {
+    alias: {
+      'libphonenumber-js': path.resolve(
+        __dirname,
+        'node_modules/libphonenumber-js',
+      ),
+      jszip: path.resolve(__dirname, 'node_modules/jszip'),
+      lodash: path.resolve(__dirname, 'node_modules/lodash'),
+      validator: path.resolve(__dirname, 'node_modules/validator'),
+      'date-fns': path.resolve(__dirname, 'node_modules/date-fns/esm'),
+    },
     configure: {
       module: {
         rules: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4055,6 +4055,12 @@
         }
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
+    },
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
@@ -30860,6 +30866,12 @@
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -31645,6 +31657,12 @@
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "opn": {
       "version": "5.5.0",
@@ -37071,6 +37089,25 @@
       "resolved": "https://registry.npmjs.org/simplur/-/simplur-3.0.1.tgz",
       "integrity": "sha512-bBAoTn75tuKh83opmZ1VoyVoQIsvLCKzSxuasAxbnKofrT8eGyOEIaXSuNfhi/hI160+fwsR7ObcbBpOyzDvXg=="
     },
+    "sirv": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "totalist": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+          "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -40318,6 +40355,101 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "gzip-size": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
     "postinstall": "npm run gen:theme-typings && npm run clean:emotion-types && npm run partytown && npm --prefix ../shared install",
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true craco start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build",
+    "build:analyze": "cross-env ANALYZE=true npm run build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
@@ -182,6 +183,7 @@
     "storybook-preset-craco": "0.0.6",
     "storybook-react-i18next": "^1.0.20",
     "ts-jest": "^27.1.1",
+    "webpack-bundle-analyzer": "^4.5.0",
     "worker-loader": "^3.0.8"
   },
   "proxy": "http://localhost:5000",

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -19,21 +19,27 @@ import {
 
 import NotFoundErrorPage from '~pages/NotFoundError'
 import { AdminFormLayout } from '~features/admin-form/common/AdminFormLayout'
-import { CreatePage } from '~features/admin-form/create/CreatePage'
 import {
-  FeedbackPage,
   FormResultsLayout,
   IndividualResponsePage,
   ResponsesLayout,
-  ResponsesPage,
 } from '~features/admin-form/responses'
-import { SettingsPage } from '~features/admin-form/settings/SettingsPage'
-import { BillingPage } from '~features/user/billing'
 
 import { HashRouterElement } from './HashRouterElement'
 import { PrivateElement } from './PrivateElement'
 import { PublicElement } from './PublicElement'
 
+const FeedbackPage = lazy(
+  () => import('~features/admin-form/responses/FeedbackPage/FeedbackPage'),
+)
+const ResponsesPage = lazy(
+  () => import('~features/admin-form/responses/ResponsesPage/ResponsesPage'),
+)
+const SettingsPage = lazy(
+  () => import('~features/admin-form/settings/SettingsPage'),
+)
+const BillingPage = lazy(() => import('~features/user/billing'))
+const CreatePage = lazy(() => import('~features/admin-form/create/CreatePage'))
 const PublicFormPage = lazy(
   () => import('~features/public-form/PublicFormPage'),
 )

--- a/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
@@ -16,7 +16,8 @@ import {
 import { getMobileViewParameters, viewports } from '~utils/storybook'
 
 import { AdminFormLayout } from './common/AdminFormLayout'
-import { FeedbackPage, FormResultsLayout, ResponsesPage } from './responses'
+import ResponsesPage from './responses/ResponsesPage/ResponsesPage'
+import { FeedbackPage, FormResultsLayout } from './responses'
 
 const DEFAULT_MSW_ROUTES = [
   ...createFormBuilderMocks({}, 0),

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -19,12 +19,8 @@ import {
 import { getMobileViewParameters, viewports } from '~utils/storybook'
 
 import { AdminFormLayout } from './common/AdminFormLayout'
-import {
-  FeedbackPage,
-  FormResultsLayout,
-  ResponsesLayout,
-  ResponsesPage,
-} from './responses'
+import ResponsesPage from './responses/ResponsesPage/ResponsesPage'
+import { FeedbackPage, FormResultsLayout, ResponsesLayout } from './responses'
 
 export default {
   title: 'Pages/AdminFormPage/Results/ResponsesTab',

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -44,3 +44,5 @@ export const CreatePage = (): JSX.Element => {
     </Flex>
   )
 }
+
+export default CreatePage

--- a/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -98,3 +98,5 @@ export const FeedbackPage = (): JSX.Element => {
     </Container>
   )
 }
+
+export default FeedbackPage

--- a/frontend/src/features/admin-form/responses/ResponsesPage/ResponsesPage.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/ResponsesPage.tsx
@@ -2,8 +2,8 @@ import { FormResponseMode } from '~shared/types/form'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
+import { StorageResponsesTab } from './storage/StorageResponsesTab'
 import { EmailResponsesTab } from './email'
-import { StorageResponsesTab } from './storage'
 
 export const ResponsesPage = (): JSX.Element => {
   const { data: form, isLoading } = useAdminForm()
@@ -22,3 +22,5 @@ export const ResponsesPage = (): JSX.Element => {
 
   return <EmailResponsesTab />
 }
+
+export default ResponsesPage

--- a/frontend/src/features/admin-form/responses/ResponsesPage/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/index.ts
@@ -1,2 +1,1 @@
 export { ResponsesLayout } from './ResponsesLayout'
-export { ResponsesPage } from './ResponsesPage'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
@@ -1,8 +1,8 @@
 import { EmptyResponses } from '../common/EmptyResponses'
 
+import { UnlockedResponses } from './UnlockedResponses/UnlockedResponses'
 import { SecretKeyVerification } from './SecretKeyVerification'
 import { useStorageResponsesContext } from './StorageResponsesContext'
-import { UnlockedResponses } from './UnlockedResponses'
 
 export const StorageResponsesTab = (): JSX.Element => {
   const { totalResponsesCount, secretKey } = useStorageResponsesContext()

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/index.ts
@@ -1,2 +1,1 @@
-export { UnlockedResponses } from './UnlockedResponses'
 export { UnlockedResponsesProvider } from './UnlockedResponsesProvider'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/index.ts
@@ -1,3 +1,2 @@
 export { SecretKeyVerification } from './SecretKeyVerification'
 export { useStorageResponsesContext } from './StorageResponsesContext'
-export { StorageResponsesTab } from './StorageResponsesTab'

--- a/frontend/src/features/admin-form/responses/index.ts
+++ b/frontend/src/features/admin-form/responses/index.ts
@@ -1,4 +1,4 @@
 export { FeedbackPage } from './FeedbackPage'
 export { FormResultsLayout } from './FormResultsLayout'
 export { IndividualResponsePage } from './IndividualResponsePage'
-export { ResponsesLayout, ResponsesPage } from './ResponsesPage'
+export { ResponsesLayout } from './ResponsesPage'

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -103,3 +103,5 @@ export const SettingsPage = (): JSX.Element => {
     </Box>
   )
 }
+
+export default SettingsPage

--- a/frontend/src/features/user/billing/index.ts
+++ b/frontend/src/features/user/billing/index.ts
@@ -1,1 +1,1 @@
-export { BillingPage } from './BillingPage'
+export { BillingPage as default } from './BillingPage'


### PR DESCRIPTION
## Overview
this PR covers some low-hanging fruits to improve the bundling of the v2 react frontend. while it might not be that important as you can get away with a lot these days (especially for a country [pretty fast](https://www.speedtest.net/global-index) broadband and mobile speeds), its at least good to take note. for example, i think the landing page bundles almost all the dependencies

## Problem
current bundle for react frontend has duplicate dependencies and lots of modules in main/vendor bundle

## Solution
add bundle analyzer plugin
update webpack alias to bundle from frontend/node_modules instead of shared
lazy import some of the bigger modules/pages

**Breaking Changes** 
probably the latest commit on this branch needs a bit more checking/testing. Not sure why some pages are lazily imported and others are not, maybe there are some considerations i am unaware of. Also didn't run the full docker workflow and just ran the frontend project on native host, so I can't be sure that nothing has broken
- [x] this PR contains breaking changes - Maybe
   
## Before & After Screenshots

**BEFORE**:
<img width="1633" alt="Screenshot 2022-07-29 at 12 14 15 AM" src="https://user-images.githubusercontent.com/39296145/181587935-741e0c0b-0fc1-4303-8925-641236810da7.png">


**AFTER**:
<img width="1633" alt="Screenshot 2022-07-29 at 12 17 52 AM" src="https://user-images.githubusercontent.com/39296145/181587948-6668af05-0cdd-4e16-adf9-14c8c40d946c.png">

definitely more opportunities for improvement with splitting the vendor bundle and it also looks like lodash is not tree-shaken

**New dev dependencies**:

- `dependency` : :[webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer)

Other things that might be considered could be updating to [CRA v5](https://github.com/dilanx/craco/issues/378) to see if there's any improvements, or maybe even ejecting from CRA. 
