### PR TITLE
feat: add functionality for question fields in builder tool to reflect selected colortheme

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react'
 import { times } from 'lodash'
 
+import { FormColorTheme } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -60,6 +61,8 @@ import {
   updateEditStateSelector,
   useBuilderAndDesignStore,
 } from '../../useBuilderAndDesignStore'
+import { useCreateTabForm } from '../../useCreateTabForm'
+import { startPageDataSelector, useDesignStore } from '../../useDesignStore'
 
 import { SectionFieldRow } from './SectionFieldRow'
 
@@ -75,6 +78,7 @@ export const FieldRowContainer = ({
   isDraggingOver,
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
+  const { data: form } = useCreateTabForm()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
   const { stateData, setToInactive, updateEditState } =
     useBuilderAndDesignStore(
@@ -88,10 +92,18 @@ export const FieldRowContainer = ({
       ),
     )
 
+  const startPageData = useDesignStore(useMemo(() => startPageDataSelector, []))
+
   const { handleBuilderClick } = useCreatePageSidebar()
 
   const { duplicateFieldMutation } = useDuplicateFormField()
   const { deleteFieldMutation } = useDeleteFormField()
+
+  const colorTheme = useMemo(
+    () =>
+      startPageData ? startPageData.colorTheme : form?.startPage.colorTheme,
+    [startPageData, form?.startPage.colorTheme],
+  )
 
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {
@@ -269,7 +281,7 @@ export const FieldRowContainer = ({
               pointerEvents={isActive ? undefined : 'none'}
             >
               <FormProvider {...formMethods}>
-                <MemoFieldRow field={field} />
+                <MemoFieldRow field={field} colorTheme={colorTheme} />
               </FormProvider>
             </Box>
             <Collapse in={isActive} style={{ width: '100%' }}>
@@ -325,6 +337,7 @@ export const FieldRowContainer = ({
 
 type MemoFieldRowProps = {
   field: FormFieldDto
+  colorTheme?: FormColorTheme
 }
 
 const MemoFieldRow = memo(({ field, ...rest }: MemoFieldRowProps) => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/SectionFieldRow.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/SectionFieldRow.tsx
@@ -1,13 +1,16 @@
+import { FormColorTheme } from '~shared/types'
 import { FormFieldWithId, SectionFieldBase } from '~shared/types/field'
 
 import { BaseSectionField } from '~templates/Field/Section/SectionField'
 
 export interface SectionFieldRowProps {
   field: FormFieldWithId<SectionFieldBase>
+  colorTheme?: FormColorTheme
 }
 
 export const SectionFieldRow = ({
   field,
+  colorTheme,
 }: SectionFieldRowProps): JSX.Element => {
-  return <BaseSectionField schema={field} />
+  return <BaseSectionField schema={field} colorTheme={colorTheme} />
 }

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -56,13 +56,15 @@ export const SectionField = forwardRef<SectionFieldProps, 'div'>(
 )
 
 export const BaseSectionField = forwardRef<
-  Pick<SectionFieldProps, 'schema'>,
+  Pick<SectionFieldProps, 'schema' | 'colorTheme'>,
   'div'
->(({ schema }, ref) => {
+>(({ schema, colorTheme = FormColorTheme.Blue }, ref) => {
+  const sectionColor = useSectionColor(colorTheme)
+
   return (
     // id given so app can scrolled to this section.
     <Box id={schema._id} ref={ref}>
-      <Text textStyle="h2" color="primary.600">
+      <Text textStyle="h2" color={sectionColor}>
         {schema.title}
       </Text>
       <Text


### PR DESCRIPTION
## Problem
Currently, the builder content only shows all questions in the default blue theme, even if a different theme is selected. This PR adds support for the builder content to display with the correct color scheme even in the builder content.

Closes #4327 

## Solution
- Add calls to `useDesignStore` and `useCreateTabForm` in `FieldRowContainer` to retrieve correct `colorTheme`, and pass it along to children.
- Updated section row components to accept color themes and display correctly.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/181669968-94c3011f-eb47-4408-9ee2-082340594b42.mov


