### PR TITLE
fix: avoid calling useDesignStore on every render

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Box, Flex, Skeleton } from '@chakra-ui/react'
 
 import { FormAuthType, FormLogoState, FormStartPage } from '~shared/types'
@@ -19,10 +19,15 @@ import {
 
 export const StartPageView = () => {
   const { data: form } = useCreateTabForm()
-  const { startPageData, customLogoMeta } = useDesignStore((state) => ({
-    startPageData: startPageDataSelector(state),
-    customLogoMeta: customLogoMetaSelector(state),
-  }))
+  const { startPageData, customLogoMeta } = useDesignStore(
+    useCallback(
+      (state) => ({
+        startPageData: startPageDataSelector(state),
+        customLogoMeta: customLogoMetaSelector(state),
+      }),
+      [],
+    ),
+  )
   const { data: { logoBucketUrl } = {} } = useEnv(
     form?.startPage.logo.state === FormLogoState.Custom,
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -81,14 +81,19 @@ export const DesignDrawer = (): JSX.Element | null => {
     setAttachment,
     setCustomLogoMeta,
     resetDesignStore,
-  } = useDesignStore((state) => ({
-    startPageData: startPageDataSelector(state),
-    customLogoMeta: customLogoMetaSelector(state),
-    setStartPageData: setStartPageDataSelector(state),
-    setAttachment: setAttachmentSelector(state),
-    setCustomLogoMeta: setCustomLogoMetaSelector(state),
-    resetDesignStore: resetDesignStoreSelector(state),
-  }))
+  } = useDesignStore(
+    useCallback(
+      (state) => ({
+        startPageData: startPageDataSelector(state),
+        customLogoMeta: customLogoMetaSelector(state),
+        setStartPageData: setStartPageDataSelector(state),
+        setAttachment: setAttachmentSelector(state),
+        setCustomLogoMeta: setCustomLogoMetaSelector(state),
+        resetDesignStore: resetDesignStoreSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const {
     register,


### PR DESCRIPTION
This PR introduces a small fix to useCallback on each call to useDesignStore to avoid making the same call on every render.

- [X] No - this PR is backwards compatible  