### PR TITLE
fix: add check that there is at least 1 option for split text areas

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
@@ -9,6 +9,7 @@ export const SPLIT_TEXTAREA_TRANSFORM = {
 
 export const SPLIT_TEXTAREA_VALIDATION = {
   validate: (opts: string) => {
+    if (!opts) return 'Please provide at least 1 option.'
     const optsArr = SPLIT_TEXTAREA_TRANSFORM.output(opts)
     return (
       new Set(optsArr).size === optsArr.length ||

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
@@ -9,8 +9,8 @@ export const SPLIT_TEXTAREA_TRANSFORM = {
 
 export const SPLIT_TEXTAREA_VALIDATION = {
   validate: (opts: string) => {
-    if (!opts) return 'Please provide at least 1 option.'
     const optsArr = SPLIT_TEXTAREA_TRANSFORM.output(opts)
+    if (!optsArr.length) return 'Please provide at least 1 option.'
     return (
       new Set(optsArr).size === optsArr.length ||
       'Please remove duplicate options.'


### PR DESCRIPTION
## Problem
Radio, checkbox and dropdown currently allow 0 options. They shouldn't.

Closes [#4378 ]

## Solution
Add check to ensure that the textarea is nonempty. 
- [X] No - this PR is backwards compatible  