### PR TITLE
Augment apm spans

### DIFF
--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -1,0 +1,14 @@
+import tracer from 'dd-trace'
+
+import { IPopulatedForm } from '../../../types'
+
+export const setFormTags = (form: IPopulatedForm) => {
+  const span = tracer.scope().active()
+
+  if (span) {
+    span.setTag('form.id', `${form._id}`)
+    span.setTag('form.adminid', `${form.admin._id}`)
+    span.setTag('form.agency.id', `${form.admin.agency._id}`)
+    span.setTag('form.agency.shortname', `${form.admin.agency.shortName}`)
+  }
+}

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -1,4 +1,3 @@
-import tracer from 'dd-trace'
 import { ok, okAsync, ResultAsync } from 'neverthrow'
 
 import {
@@ -14,6 +13,7 @@ import * as CaptchaService from '../../../services/captcha/captcha.service'
 import MailService from '../../../services/mail/mail.service'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { ControllerHandler } from '../../core/core.types'
+import { setFormTags } from '../../datadog/datadog.utils'
 import * as FormService from '../../form/form.service'
 import {
   MYINFO_COOKIE_NAME,
@@ -78,13 +78,7 @@ const submitEmailModeForm: ControllerHandler<
         return error
       })
       .andThen((form) => {
-        const span = tracer.scope().active()
-
-        if (span) {
-          span.setTag('form.id', formId)
-          span.setTag('form.adminid', `${form.admin._id}`)
-          span.setTag('form.agencyid', `${form.admin.agency._id}`)
-        }
+        setFormTags(form)
 
         return EmailSubmissionService.checkFormIsEmailMode(form).mapErr(
           (error) => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -1,6 +1,5 @@
 import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
-import tracer from 'dd-trace'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
@@ -25,6 +24,7 @@ import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { getFormAfterPermissionChecks } from '../../auth/auth.service'
 import { MalformedParametersError } from '../../core/core.errors'
 import { ControllerHandler } from '../../core/core.types'
+import { setFormTags } from '../../datadog/datadog.utils'
 import { PermissionLevel } from '../../form/admin-form/admin-form.types'
 import * as FormService from '../../form/form.service'
 import { SpOidcService } from '../../spcp/sp.oidc.service'
@@ -95,13 +95,7 @@ const submitEncryptModeForm: ControllerHandler<
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  const span = tracer.scope().active()
-
-  if (span) {
-    span.setTag('form.id', formId)
-    span.setTag('form.adminid', `${formResult.value.admin._id}`)
-    span.setTag('form.agencyid', `${formResult.value.admin.agency._id}`)
-  }
+  setFormTags(formResult.value)
 
   const checkFormIsEncryptModeResult = checkFormIsEncryptMode(formResult.value)
   if (checkFormIsEncryptModeResult.isErr()) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -1,5 +1,6 @@
 import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
+import tracer from 'dd-trace'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
@@ -92,6 +93,14 @@ const submitEncryptModeForm: ControllerHandler<
     })
     const { errorMessage, statusCode } = mapRouteError(formResult.error)
     return res.status(statusCode).json({ message: errorMessage })
+  }
+
+  const span = tracer.scope().active()
+
+  if (span) {
+    span.setTag('form.id', formId)
+    span.setTag('form.adminid', `${formResult.value.admin._id}`)
+    span.setTag('form.agencyid', `${formResult.value.admin.agency._id}`)
   }
 
   const checkFormIsEncryptModeResult = checkFormIsEncryptMode(formResult.value)

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -8,6 +8,7 @@ import { createLoggerWithLabel } from '../../config/logger'
 import { generateOtpWithHash } from '../../utils/otp'
 import { createReqMeta, getRequestIp } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
+import { setFormTags } from '../datadog/datadog.utils'
 import * as FormService from '../form/form.service'
 import * as MyInfoUtil from '../myinfo/myinfo.util'
 import { SgidService } from '../sgid/sgid.service'
@@ -221,6 +222,7 @@ export const _handleGenerateOtp: ControllerHandler<
     FormService.retrieveFullFormById(formId)
       // Step 2: Verify SPCP/MyInfo, if form requires it
       .andThen((form) => {
+        setFormTags(form)
         const { authType } = form
         switch (authType) {
           case FormAuthType.CP: {


### PR DESCRIPTION
## Problem
The Datadog traces do not include any admin or agency information, and therefore has no visualization capabilities for them.

## Solution
This PR reports form information as tags into the traces for:
* submissions (both storage and email)
* OTP generation

## Sample trace views

![image](https://user-images.githubusercontent.com/935223/181687680-fb3c3bf3-6583-4f66-aa00-287f8b0e617e.png)


**Breaking Changes** 
- [X] No - this PR is backwards compatible  

