### PR TITLE
feat: update color scheme and endpage view

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect } from 'react'
 import { Flex } from '@chakra-ui/react'
 
+import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
+
 import { DndPlaceholderProps } from '../types'
 import {
   BuildFieldState,
@@ -8,6 +10,7 @@ import {
   stateDataSelector,
   useBuilderAndDesignStore,
 } from '../useBuilderAndDesignStore'
+import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import { EndPageView } from './EndPageView'
 import { FormBuilder } from './FormBuilder'
@@ -32,8 +35,10 @@ export const BuilderAndDesignContent = ({
 
   useEffect(() => setFieldsToInactive, [setFieldsToInactive])
 
+  const bg = useBgColor(useDesignColorTheme())
+
   return (
-    <Flex flex={1} bg="neutral.200" overflow="auto">
+    <Flex flex={1} bg={bg} overflow="auto">
       <EndPageView
         display={
           // Don't conditionally render EndPageView and FormBuilder because it

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -1,17 +1,24 @@
 import { useMemo } from 'react'
-import { Box, Flex, FlexProps, Image, Stack, Text } from '@chakra-ui/react'
+import { Box, Flex, FlexProps, Stack, Text } from '@chakra-ui/react'
 import { format } from 'date-fns'
+
+import { FormColorTheme, FormLogoState } from '~shared/types'
 
 import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
 import Button from '~components/Button'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useEnv } from '~features/env/queries'
 import { ThankYouSvgr } from '~features/public-form/components/FormEndPage/components/ThankYouSvgr'
+import { FormBannerLogo } from '~features/public-form/components/FormStartPage/FormBannerLogo'
+import { useFormBannerLogo } from '~features/public-form/components/FormStartPage/useFormBannerLogo'
+import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
 
 import {
   endPageDataSelector,
   useEndPageBuilderStore,
 } from '../useEndPageBuilderStore'
+import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
   const { data: form } = useAdminForm()
@@ -23,6 +30,19 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
     () => (endPageFromStore ? endPageFromStore : form?.endPage),
     [endPageFromStore, form?.endPage],
   )
+  const { data: { logoBucketUrl } = {} } = useEnv(
+    form?.startPage.logo.state === FormLogoState.Custom,
+  )
+
+  const formBannerLogoProps = useFormBannerLogo({
+    logoBucketUrl,
+    logo: form?.startPage.logo,
+    agency: form?.admin.agency,
+  })
+
+  const colorTheme = useDesignColorTheme()
+  const backgroundColor = useBgColor(colorTheme)
+
   return (
     <Flex
       m={{ base: 0, md: '2rem' }}
@@ -35,10 +55,8 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
       {...props}
     >
       <Stack w="100%">
-        <Flex justifyContent="center" pt="1rem" pb="0.5rem">
-          <Image src={form?.admin?.agency?.logo} h="4rem" />
-        </Flex>
-        <Flex backgroundColor="primary.100" justifyContent="center">
+        <FormBannerLogo {...formBannerLogoProps} />
+        <Flex backgroundColor={backgroundColor} justifyContent="center">
           <ThankYouSvgr h="100%" pt="2.5rem" />
         </Flex>
 
@@ -63,10 +81,16 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
             {format(new Date(), 'dd MMM yyyy, h:m aa')}
           </Text>
 
-          <Flex pt="1.75rem" gap="2rem">
-            <Button>Save this response</Button>
-            <Button variant="clear">{endPage?.buttonText}</Button>
-          </Flex>
+          <Box mt="2.25rem">
+            <Button
+              variant="solid"
+              colorScheme={`theme-${
+                colorTheme ? colorTheme : FormColorTheme.Blue
+              }`}
+            >
+              {endPage?.buttonText}
+            </Button>
+          </Box>
         </Box>
       </Stack>
     </Flex>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -61,8 +61,7 @@ import {
   updateEditStateSelector,
   useBuilderAndDesignStore,
 } from '../../useBuilderAndDesignStore'
-import { useCreateTabForm } from '../../useCreateTabForm'
-import { startPageDataSelector, useDesignStore } from '../../useDesignStore'
+import { useDesignColorTheme } from '../../utils/useDesignColorTheme'
 
 import { SectionFieldRow } from './SectionFieldRow'
 
@@ -78,7 +77,6 @@ export const FieldRowContainer = ({
   isDraggingOver,
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
-  const { data: form } = useCreateTabForm()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
   const { stateData, setToInactive, updateEditState } =
     useBuilderAndDesignStore(
@@ -92,18 +90,12 @@ export const FieldRowContainer = ({
       ),
     )
 
-  const startPageData = useDesignStore(useMemo(() => startPageDataSelector, []))
-
   const { handleBuilderClick } = useCreatePageSidebar()
 
   const { duplicateFieldMutation } = useDuplicateFormField()
   const { deleteFieldMutation } = useDeleteFormField()
 
-  const colorTheme = useMemo(
-    () =>
-      startPageData ? startPageData.colorTheme : form?.startPage.colorTheme,
-    [startPageData, form?.startPage.colorTheme],
-  )
+  const colorTheme = useDesignColorTheme()
 
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -3,6 +3,8 @@ import { Box, Flex, FlexProps, Text } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 
+import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
+
 import { useCreatePageSidebar } from '../../common/CreatePageSidebarContext'
 import { FIELD_LIST_DROP_ID } from '../constants'
 import { DndPlaceholderProps } from '../types'
@@ -10,6 +12,7 @@ import {
   setToEditEndPageSelector,
   useBuilderAndDesignStore,
 } from '../useBuilderAndDesignStore'
+import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import { EmptyFormPlaceholder } from './BuilderAndDesignPlaceholder/EmptyFormPlaceholder'
 import BuilderAndDesignPlaceholder from './BuilderAndDesignPlaceholder'
@@ -29,12 +32,14 @@ export const FormBuilder = ({
   const { handleBuilderClick } = useCreatePageSidebar()
   const setEditEndPage = useBuilderAndDesignStore(setToEditEndPageSelector)
 
+  const bg = useBgColor(useDesignColorTheme())
+
   return (
     <Flex
       m={{ base: 0, md: '2rem' }}
       mb={0}
       flex={1}
-      bg={{ base: 'secondary.100', md: 'primary.100' }}
+      bg={bg}
       p={{ base: '1.5rem', md: '2.5rem' }}
       justify="center"
       overflow="auto"

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/useDesignColorTheme.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/useDesignColorTheme.tsx
@@ -1,0 +1,15 @@
+import { useMemo } from 'react'
+
+import { useCreateTabForm } from '../useCreateTabForm'
+import { startPageDataSelector, useDesignStore } from '../useDesignStore'
+
+export const useDesignColorTheme = () => {
+  const { data: form } = useCreateTabForm()
+  const startPageData = useDesignStore(useMemo(() => startPageDataSelector, []))
+  const colorTheme = useMemo(
+    () =>
+      startPageData ? startPageData.colorTheme : form?.startPage.colorTheme,
+    [startPageData, form?.startPage.colorTheme],
+  )
+  return colorTheme
+}

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -1,11 +1,19 @@
 import { useMemo } from 'react'
 import { Flex, Spacer } from '@chakra-ui/react'
 
+import { FormColorTheme } from '~shared/types'
+
 import { usePublicFormContext } from '../PublicFormContext'
 
 // TODO #4279: Remove after React rollout is complete
 import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
 import SectionSidebar from './SectionSidebar'
+
+export const useBgColor = (colorTheme?: FormColorTheme) =>
+  useMemo(
+    () => (colorTheme ? `theme-${colorTheme}.100` : 'neutral.100'),
+    [colorTheme],
+  )
 
 export interface PublicFormWrapperProps {
   children: React.ReactNode
@@ -20,10 +28,9 @@ export const PublicFormWrapper = ({
 }: PublicFormWrapperProps): JSX.Element => {
   const { form, isLoading, isAuthRequired } = usePublicFormContext()
 
-  const bgColour = useMemo(() => {
-    if (isLoading || !form) return 'neutral.100'
-    return `theme-${form.startPage.colorTheme}.100`
-  }, [form, isLoading])
+  const bgColour = useBgColor(
+    isLoading ? undefined : form?.startPage.colorTheme,
+  )
 
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">


### PR DESCRIPTION
## Problem
Currently, the builder tool uses the default blue background color scheme regardless of what color scheme the form is using. This PR updates the color scheme for the builder content so that the builder content looks _exactly the same_ as the public form.

Additionally, endpage view does not match current form endpage. This PR fixes that.

## Solution
`FieldRowContainer.tsx`, `useDesignColorTheme.tsx`
- Pull function that provides color theme from form design for builder tool out for reusability.

`PublicFormWrapper.tsx`
- Pull bg color computation into a separate function for reusability.

`BuilderAndDesignContent.tsx`, `FormBuilder.tsx`, `EndPageView.tsx`
- Updates to color theme.
- For end page view, button and logo change to more accurately reflect public form end page.

**Backward Compatibility**
- [X] No - this PR is backwards compatible  
