### PR TITLE
feat: remove Singapore public holiday option from restricting particular days

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -296,7 +296,6 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
-                  console.log(!!val.length)
                   return !!val.length || 'Error placeholder'
                 },
               }}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -50,7 +50,6 @@ const INVALID_DAYS_OPTIONS: InvalidDaysOptions[] = [
   InvalidDaysOptions.Friday,
   InvalidDaysOptions.Saturday,
   InvalidDaysOptions.Sunday,
-  InvalidDaysOptions.SingaporePublicHolidays,
 ]
 
 const EDIT_DATE_FIELD_KEYS = [
@@ -297,18 +296,8 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
-                  /**
-                   * A day is considered to be restricted if it either falls on an invalid
-                   * day of the week or on a Singapore public holiday. Hence, to ensure that
-                   * public users are able to select unrestricted days, the array should
-                   * contain at least one valid day of the week.
-                   */
-                  const validDaysSet = new Set(val)
-                  return validDaysSet.has(
-                    InvalidDaysOptions.SingaporePublicHolidays,
-                  )
-                    ? val.length >= 2 || 'Error placeholder'
-                    : val.length >= 1 || 'Error placeholder'
+                  console.log(!!val.length)
+                  return !!val.length || 'Error placeholder'
                 },
               }}
               render={({ field: { ref, ...field } }) => (

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -15,7 +15,6 @@ export enum InvalidDaysOptions {
   Thursday = 'Thursday',
   Friday = 'Friday',
   Saturday = 'Saturday',
-  SingaporePublicHolidays = 'Singapore public holidays',
 }
 
 export type DateValidationOptions = {


### PR DESCRIPTION
## Solution
<!-- How did you solve the problem? -->
Split the implementation of restricting particular days into 2 separate big features instead of 1. Hence, removal of all instances of Singapore public holidays as an invalid day option.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] Yes - this PR contains breaking changes
    - In the DB there might be existing date fields with Singapore public holidays as selected invalid days. During validation on the server side, date responses selected by public users might be Singapore public holidays and there would be inaccurate validations.