### PR TITLE
feat(form-v2): percentage-based react rollout for admins

### DIFF
--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -303,6 +303,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 0,
       env: 'REACT_MIGRATION_RESP_ROLLOUT_AUTH',
     },
+    adminRollout: {
+      doc: 'Percentage threshold to serve React for admins',
+      format: 'int',
+      default: 0,
+      env: 'REACT_MIGRATION_ADMIN_ROLLOUT',
+    },
     respondentCookieName: {
       doc: "Name of the cookie that will store respondents' assigned environment.",
       format: String,

--- a/src/app/loaders/express/logging.ts
+++ b/src/app/loaders/express/logging.ts
@@ -17,6 +17,7 @@ type LogMeta = {
   reactMigration?: {
     respRolloutAuth: number
     respRolloutNoAuth: number
+    adminRollout: number
     qaCookie: string | undefined
     adminCookie: string | undefined
     respCookie: string | undefined
@@ -78,6 +79,7 @@ const loggingMiddleware = () => {
         meta.reactMigration = {
           respRolloutAuth: config.reactMigration.respondentRolloutAuth,
           respRolloutNoAuth: config.reactMigration.respondentRolloutNoAuth,
+          adminRollout: config.reactMigration.adminRollout,
           qaCookie: req.cookies?.[config.reactMigration.qaCookieName],
           adminCookie: req.cookies?.[config.reactMigration.adminCookieName],
           respCookie: req.cookies?.[config.reactMigration.respondentCookieName],

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -149,7 +149,8 @@ export const serveForm: ControllerHandler<
 }
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
-  // only admin who chose react should see react, everybody else is plain angular
+  // Admins assigned react, or who choose react will stay on react until they opt out
+  // Admins assigned angular will stay on it for that session
   let showReact: boolean | undefined = undefined
 
   const adminThreshold = config.reactMigration.adminRollout
@@ -161,10 +162,13 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     // Check the rollout value first, if it's 0, react is DISABLED
     // And we ignore cookies entirely!
     showReact = false
-  } else {
-    showReact =
-      req.cookies[config.reactMigration.adminCookieName] ===
-      UiCookieValues.React
+  } else if (req.cookies) {
+    if (config.reactMigration.adminCookieName in req.cookies) {
+      // Check if admin had already chosen react previously
+      showReact =
+        req.cookies[config.reactMigration.adminCookieName] ===
+        UiCookieValues.React
+    }
   }
 
   if (showReact === undefined) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -55,6 +55,7 @@ export type RateLimitConfig = {
 export type ReactMigrationConfig = {
   respondentRolloutNoAuth: number
   respondentRolloutAuth: number
+  adminRollout: number
   respondentCookieName: string
   adminCookieName: string
   qaCookieName: string
@@ -159,6 +160,7 @@ export interface IOptionalVarsSchema {
   reactMigration: {
     respondentRolloutNoAuth: number
     respondentRolloutAuth: number
+    adminRollout: number
     respondentCookieName: string
     adminCookieName: string
     qaCookieName: string


### PR DESCRIPTION
## Problem
Currently, the React rollout for admins is either for all or none.

Closes #4217 

## Solution
<!-- How did you solve the problem? -->
Implement percentage-based React rollout for admins
- We can change the rollout percentage by changing the `REACT_MIGRATION_ADMIN_ROLLOUT` env var
- Depending on the % threshold, a randomly chosen selection of admins will be served the React app
- Admins who are shown the React app, or actively choose to switch to React will **stay on React** (admin cookie expiry is 2 months long)
- Admins who are shown the AngularJS app will remain on it **for that session** (session cookie)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
- [ ] Change the admin rollout percentage to 100. Delete the `v2-admin-ui` cookie if it exists. Navigate to the forms homepage, you should be shown the React app. The `v2-admin-ui` cookie should be set to `react`
- [ ] Change the admin rollout percentage to 0. Delete the `v2-admin-ui` cookie if it exists. Navigate to the forms homepage, you should be shown the AngularJS app. The` v2-admin-ui` cookie should be set to `angular`
 
## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:
- `REACT_MIGRATION_ADMIN_ROLLOUT ` : number between 0 and 100

