### PR TITLE
feat(v2): add stronger validation for esrvcId and Twilio credential inputs

### DIFF
--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
@@ -20,11 +20,13 @@ import { useMutateTwilioCreds } from '../../mutations'
 interface DeleteTwilioModalProps {
   isOpen: boolean
   onClose: () => void
+  onDelete: () => void
 }
 
 export const DeleteTwilioModal = ({
   isOpen,
   onClose,
+  onDelete,
 }: DeleteTwilioModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -39,9 +41,12 @@ export const DeleteTwilioModal = ({
 
   const handleConfirmDeleteCreds = useCallback(() => {
     mutateFormTwilioDeletion.mutate(undefined, {
-      onSuccess: onClose,
+      onSuccess: () => {
+        onDelete()
+        onClose()
+      },
     })
-  }, [mutateFormTwilioDeletion, onClose])
+  }, [mutateFormTwilioDeletion, onClose, onDelete])
 
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -1,13 +1,12 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   RegisterOptions,
   useForm,
   UseFormRegisterReturn,
 } from 'react-hook-form'
-import { BiHappyHeartEyes, BiHide, BiShow } from 'react-icons/bi'
+import { BiHide, BiShow } from 'react-icons/bi'
 import {
   FormControl,
-  Icon,
   InputGroup,
   InputRightElement,
   Skeleton,
@@ -35,23 +34,15 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
   accountSid: {
     required: 'Account SID is required',
     pattern: {
-      value: /^AC/,
+      value: /^\s*AC\s*/,
       message: 'Account SID must start with AC',
-    },
-    validate: {
-      noWhitespace: (value) =>
-        !value.trim().match(/\s/) || 'Account SID must not contain whitespace',
     },
   },
   apiKey: {
     required: 'API key SID is required',
     pattern: {
-      value: /^SK/,
+      value: /^\s*SK\s*/,
       message: 'API key SID must start with SK',
-    },
-    validate: {
-      noWhitespace: (value) =>
-        !value.trim().match(/\s/) || 'API key SID must not contain whitespace',
     },
   },
   apiSecret: {
@@ -65,13 +56,8 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
   messagingServiceSid: {
     required: 'Messaging service SID is required',
     pattern: {
-      value: /^MG/,
+      value: /^\s*MG\s*/,
       message: 'Messaging service SID must start with MG',
-    },
-    validate: {
-      noWhitespace: (value) =>
-        !value.trim().match(/\s/) ||
-        'Messaging service SID must not contain whitespace',
     },
   },
 }

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -146,19 +146,21 @@ export const TwilioDetailsInputs = (): JSX.Element => {
                 {...registerPropsOrDisabled('apiSecret')}
                 type={isApiSecretShown ? 'text' : 'password'}
               />
-              <InputRightElement>
-                <IconButton
-                  colorScheme="secondary"
-                  minH="auto"
-                  right="2px"
-                  variant="clear"
-                  aria-label={`${
-                    isApiSecretShown ? 'Hide' : 'Show'
-                  } API key secret`}
-                  icon={isApiSecretShown ? <BiHide /> : <BiShow />}
-                  onClick={toggleIsApiSecretShown}
-                ></IconButton>
-              </InputRightElement>
+              {!hasExistingTwilioCreds && (
+                <InputRightElement>
+                  <IconButton
+                    colorScheme="secondary"
+                    minH="auto"
+                    right="2px"
+                    variant="clear"
+                    aria-label={`${
+                      isApiSecretShown ? 'Hide' : 'Show'
+                    } API key secret`}
+                    icon={isApiSecretShown ? <BiHide /> : <BiShow />}
+                    onClick={toggleIsApiSecretShown}
+                  ></IconButton>
+                </InputRightElement>
+              )}
             </InputGroup>
           </Skeleton>
           <FormErrorMessage>{errors.apiSecret?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -34,14 +34,14 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
   accountSid: {
     required: 'Account SID is required',
     pattern: {
-      value: /^\s*AC\s*/,
+      value: /^\s*AC\S+\s*$/,
       message: 'Account SID must start with AC',
     },
   },
   apiKey: {
     required: 'API key SID is required',
     pattern: {
-      value: /^\s*SK\s*/,
+      value: /^\s*SK\S+\s*$/,
       message: 'API key SID must start with SK',
     },
   },
@@ -56,7 +56,7 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
   messagingServiceSid: {
     required: 'Messaging service SID is required',
     pattern: {
-      value: /^\s*MG\s*/,
+      value: /^\s*MG\S+\s*$/,
       message: 'Messaging service SID must start with MG',
     },
   },

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -1,10 +1,20 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   RegisterOptions,
   useForm,
   UseFormRegisterReturn,
 } from 'react-hook-form'
-import { FormControl, Skeleton, Stack, useDisclosure } from '@chakra-ui/react'
+import { BiHappyHeartEyes, BiHide, BiShow } from 'react-icons/bi'
+import {
+  FormControl,
+  Icon,
+  InputGroup,
+  InputRightElement,
+  Skeleton,
+  Stack,
+  useDisclosure,
+} from '@chakra-ui/react'
+import { useToggle } from 'rooks'
 
 import { TwilioCredentials } from '~shared/types/twilio'
 
@@ -12,6 +22,7 @@ import { trimStringsInObject } from '~utils/trimStringsInObject'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import IconButton from '~components/IconButton'
 import Input, { InputProps } from '~components/Input'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
@@ -67,6 +78,8 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
 
 export const TwilioDetailsInputs = (): JSX.Element => {
   const { data: form, isLoading } = useAdminForm()
+
+  const [isApiSecretShown, toggleIsApiSecretShown] = useToggle(false)
 
   const hasExistingTwilioCreds = useMemo(
     () => !!form?.msgSrvcName,
@@ -142,7 +155,25 @@ export const TwilioDetailsInputs = (): JSX.Element => {
         >
           <FormLabel isRequired>API key secret</FormLabel>
           <Skeleton isLoaded={!isLoading}>
-            <Input {...registerPropsOrDisabled('apiSecret')} />
+            <InputGroup>
+              <Input
+                {...registerPropsOrDisabled('apiSecret')}
+                type={isApiSecretShown ? 'text' : 'password'}
+              />
+              <InputRightElement>
+                <IconButton
+                  colorScheme="secondary"
+                  minH="auto"
+                  right="2px"
+                  variant="clear"
+                  aria-label={`${
+                    isApiSecretShown ? 'Hide' : 'Show'
+                  } API key secret`}
+                  icon={isApiSecretShown ? <BiHide /> : <BiShow />}
+                  onClick={toggleIsApiSecretShown}
+                ></IconButton>
+              </InputRightElement>
+            </InputGroup>
           </Skeleton>
           <FormErrorMessage>{errors.apiSecret?.message}</FormErrorMessage>
         </FormControl>

--- a/frontend/src/utils/trimStringsInObject.ts
+++ b/frontend/src/utils/trimStringsInObject.ts
@@ -1,0 +1,13 @@
+import mapValues from 'lodash/mapValues'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const trimStringsInObject = <T extends Record<string, any>>(
+  obj: T,
+): T => {
+  return mapValues(obj, (val) => {
+    if (typeof val === 'string') {
+      return val.trim()
+    }
+    return val
+  })
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Cleaned up esrvcId and Twilio credential inputs. Trim and add validation for them.

Related to #4372, not sure if I missed any tbh.

## Solution
<!-- How did you solve the problem? -->
**Features**:

- feat: use rhf to add proper validation to esrvcId input
- feat: correctly trim/clear/update twilio credentials on update/delete
- feat: add toggle to show/hide API secret during input
