### PR TITLE
feat(form-v2/restrict-particular-days-of-the-week): edit date picker callback for invalid days

### DIFF
--- a/frontend/src/templates/Field/Date/DateField.stories.tsx
+++ b/frontend/src/templates/Field/Date/DateField.stories.tsx
@@ -4,7 +4,11 @@ import { Text } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 import { addDays, lightFormat } from 'date-fns'
 
-import { BasicField, DateSelectedValidation } from '~shared/types/field'
+import {
+  BasicField,
+  DateSelectedValidation,
+  InvalidDaysOptions,
+} from '~shared/types/field'
 
 import { mockDateDecorator } from '~utils/storybook'
 import Button from '~components/Button'
@@ -42,6 +46,7 @@ const baseSchema: DateFieldSchema = {
     customMinDate: null,
     selectedDateValidation: null,
   },
+  invalidDays: [],
   title: 'Date field snapshot',
   description: '',
   required: true,
@@ -153,4 +158,14 @@ ValidationCustomRange.args = {
     },
   },
   defaultValue: '2021-12-26',
+}
+
+export const ValidationInvalidDaysOfTheWeek = Template.bind({})
+ValidationInvalidDaysOfTheWeek.args = {
+  schema: {
+    ...baseSchema,
+    description: 'Wednesdays and Thursdays are invalid days',
+    invalidDays: [InvalidDaysOptions.Wednesday, InvalidDaysOptions.Thursday],
+  },
+  defaultValue: '2022-07-27',
 }

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -38,11 +38,11 @@ export const DateField = ({
       const selectedInvalidDays = schema.invalidDays ?? []
 
       // All dates available.
-      if (!selectedDateValidation && selectedInvalidDays.length === 0)
+      if (!selectedDateValidation && selectedInvalidDays.length === 0) {
         return false
+      }
 
       let isDateUnavailable = false
-      let isDayUnavailable = false
 
       switch (selectedDateValidation) {
         case DateSelectedValidation.NoPast:
@@ -64,8 +64,9 @@ export const DateField = ({
           isDateUnavailable = false
       }
 
-      isDayUnavailable = isDateAnInvalidDay(date, selectedInvalidDays)
-      return isDateUnavailable || isDayUnavailable
+      if (isDateUnavailable) return true
+
+      return isDateAnInvalidDay(date, selectedInvalidDays)
     },
     [schema.dateValidation, schema.invalidDays],
   )

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -38,7 +38,8 @@ export const DateField = ({
       const selectedInvalidDays = schema.invalidDays ?? []
 
       // All dates available.
-      if (!selectedDateValidation && !!selectedInvalidDays.length) return false
+      if (!selectedDateValidation && selectedInvalidDays.length === 0)
+        return false
 
       let isDateUnavailable = false
       let isDayUnavailable = false

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -3,10 +3,10 @@ import { Controller, useFormContext } from 'react-hook-form'
 
 import { FormColorTheme } from '~shared/types'
 import { DateSelectedValidation } from '~shared/types/field'
+import { isDateAnInvalidDay } from '~shared/utils/date-validation'
 
 import {
   isDateAfterToday,
-  isDateAnInvalidDay,
   isDateBeforeToday,
   isDateOutOfRange,
 } from '~utils/date'

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -192,9 +192,6 @@ export const isDateAnInvalidDay = (
 ): boolean => {
   const invalidDaySet = convertInvalidDaysOfTheWeekToNumberSet(invalidDays)
 
-  if (invalidDaySet.has(-1)) {
-    return true
-  }
   const dayNumberFormat = parseInt(format(date, 'i'))
 
   return invalidDaySet.has(dayNumberFormat)

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -161,38 +161,29 @@ export const transformCheckedBoxesValueToInvalidDays = (
   return ALL_INVALID_DAYS_ARR.filter((day) => !validDaysSet.has(day))
 }
 
-const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
-  switch (invalidDay) {
-    case InvalidDaysOptions.Monday:
-      return 1
-    case InvalidDaysOptions.Tuesday:
-      return 2
-    case InvalidDaysOptions.Wednesday:
-      return 3
-    case InvalidDaysOptions.Thursday:
-      return 4
-    case InvalidDaysOptions.Friday:
-      return 5
-    case InvalidDaysOptions.Saturday:
-      return 6
-    case InvalidDaysOptions.Sunday:
-      return 7
-    default:
-      return -1
-  }
+const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
+  [InvalidDaysOptions.Monday]: 1,
+  [InvalidDaysOptions.Tuesday]: 2,
+  [InvalidDaysOptions.Wednesday]: 3,
+  [InvalidDaysOptions.Thursday]: 4,
+  [InvalidDaysOptions.Friday]: 5,
+  [InvalidDaysOptions.Saturday]: 6,
+  [InvalidDaysOptions.Sunday]: 7,
 }
 
-const convertInvalidDaysOfTheWeekToNumberSet = (
+/**
+ * Convert the days of the week in the invalidDays array
+ * to a number array representing the number representation
+ * of the corresponding day of the week
+ */
+export const convertInvalidDaysOfTheWeekToNumberSet = (
   invalidDays: InvalidDaysOptions[],
 ): Set<number> => {
   if (invalidDays.length === 0) {
     return new Set()
   }
 
-  const invaliDaysNumberArray = invalidDays.map((invalidDay) =>
-    convertInvalidDayToNumber(invalidDay),
-  )
-  return new Set(invaliDaysNumberArray)
+  return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
 }
 
 export const isDateAnInvalidDay = (

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -163,8 +163,6 @@ export const transformCheckedBoxesValueToInvalidDays = (
 
 const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
   switch (invalidDay) {
-    case InvalidDaysOptions.Sunday:
-      return 0
     case InvalidDaysOptions.Monday:
       return 1
     case InvalidDaysOptions.Tuesday:
@@ -177,6 +175,8 @@ const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
       return 5
     case InvalidDaysOptions.Saturday:
       return 6
+    case InvalidDaysOptions.Sunday:
+      return 7
     default:
       return -1
   }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -160,3 +160,51 @@ export const transformCheckedBoxesValueToInvalidDays = (
   const validDaysSet = new Set(validDays)
   return ALL_INVALID_DAYS_ARR.filter((day) => !validDaysSet.has(day))
 }
+
+const convertInvalidDayToNumber = (invalidDay: InvalidDaysOptions): number => {
+  switch (invalidDay) {
+    case InvalidDaysOptions.Sunday:
+      return 0
+    case InvalidDaysOptions.Monday:
+      return 1
+    case InvalidDaysOptions.Tuesday:
+      return 2
+    case InvalidDaysOptions.Wednesday:
+      return 3
+    case InvalidDaysOptions.Thursday:
+      return 4
+    case InvalidDaysOptions.Friday:
+      return 5
+    case InvalidDaysOptions.Saturday:
+      return 6
+    default:
+      return -1
+  }
+}
+
+const convertInvalidDaysOfTheWeekToNumberSet = (
+  invalidDays: InvalidDaysOptions[],
+): Set<number> => {
+  if (invalidDays.length === 0) {
+    return new Set()
+  }
+
+  const invaliDaysNumberArray = invalidDays.map((invalidDay) =>
+    convertInvalidDayToNumber(invalidDay),
+  )
+  return new Set(invaliDaysNumberArray)
+}
+
+export const isDateAnInvalidDay = (
+  date: Date,
+  invalidDays: InvalidDaysOptions[],
+): boolean => {
+  const invalidDaySet = convertInvalidDaysOfTheWeekToNumberSet(invalidDays)
+
+  if (invalidDaySet.has(-1)) {
+    return true
+  }
+  const dayNumberFormat = parseInt(format(date, 'i'))
+
+  return invalidDaySet.has(dayNumberFormat)
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -160,39 +160,3 @@ export const transformCheckedBoxesValueToInvalidDays = (
   const validDaysSet = new Set(validDays)
   return ALL_INVALID_DAYS_ARR.filter((day) => !validDaysSet.has(day))
 }
-
-const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
-  [InvalidDaysOptions.Monday]: 1,
-  [InvalidDaysOptions.Tuesday]: 2,
-  [InvalidDaysOptions.Wednesday]: 3,
-  [InvalidDaysOptions.Thursday]: 4,
-  [InvalidDaysOptions.Friday]: 5,
-  [InvalidDaysOptions.Saturday]: 6,
-  [InvalidDaysOptions.Sunday]: 7,
-}
-
-/**
- * Convert the days of the week in the invalidDays array
- * to a number array representing the number representation
- * of the corresponding day of the week
- */
-export const convertInvalidDaysOfTheWeekToNumberSet = (
-  invalidDays: InvalidDaysOptions[],
-): Set<number> => {
-  if (invalidDays.length === 0) {
-    return new Set()
-  }
-
-  return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
-}
-
-export const isDateAnInvalidDay = (
-  date: Date,
-  invalidDays: InvalidDaysOptions[],
-): boolean => {
-  const invalidDaySet = convertInvalidDaysOfTheWeekToNumberSet(invalidDays)
-
-  const dayNumberFormat = parseInt(format(date, 'i'))
-
-  return invalidDaySet.has(dayNumberFormat)
-}

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -399,7 +399,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
 
         return (
           !isDateAnInvalidDay(parseISO(val), schema.invalidDays) ||
-          'This date is not allowed by form admin'
+          'This date is not allowed by the form admin'
         )
       },
     },

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -399,7 +399,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
 
         return (
           !isDateAnInvalidDay(parseISO(val), schema.invalidDays) ||
-          'Error placeholder'
+          'This date is not allowed by form admin'
         )
       },
     },

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -45,7 +45,12 @@ import { VerifiableFieldValues } from '~templates/Field/types'
 
 import { VerifiableFieldBase } from '~features/verifiable-fields/types'
 
-import { isDateAfterToday, isDateBeforeToday, isDateOutOfRange } from './date'
+import {
+  isDateAfterToday,
+  isDateAnInvalidDay,
+  isDateBeforeToday,
+  isDateOutOfRange,
+} from './date'
 import { formatNumberToLocaleString } from './stringFormat'
 
 type OmitUnusedProps<T extends FieldBase> = Omit<
@@ -389,6 +394,16 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
         return (
           !isDateOutOfRange(parseISO(val), customMinDate, customMaxDate) ||
           'Selected date is not within the allowed date range'
+        )
+      },
+      invaliDays: (val) => {
+        if (!val || !schema.invalidDays || !!schema.invalidDays.length) {
+          return true
+        }
+
+        return (
+          !isDateAnInvalidDay(parseISO(val), schema.invalidDays) ||
+          'Error placeholder'
         )
       },
     },

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -28,6 +28,7 @@ import {
   TextSelectedValidation,
   UenFieldBase,
 } from '~shared/types/field'
+import { isDateAnInvalidDay } from '~shared/utils/date-validation'
 import { isMFinSeriesValid, isNricValid } from '~shared/utils/nric-validation'
 import {
   isHomePhoneNumber,
@@ -45,12 +46,7 @@ import { VerifiableFieldValues } from '~templates/Field/types'
 
 import { VerifiableFieldBase } from '~features/verifiable-fields/types'
 
-import {
-  isDateAfterToday,
-  isDateAnInvalidDay,
-  isDateBeforeToday,
-  isDateOutOfRange,
-} from './date'
+import { isDateAfterToday, isDateBeforeToday, isDateOutOfRange } from './date'
 import { formatNumberToLocaleString } from './stringFormat'
 
 type OmitUnusedProps<T extends FieldBase> = Omit<
@@ -396,7 +392,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
           'Selected date is not within the allowed date range'
         )
       },
-      invaliDays: (val) => {
+      invalidDays: (val) => {
         if (!val || !schema.invalidDays || schema.invalidDays.length === 0) {
           return true
         }

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -397,7 +397,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
         )
       },
       invaliDays: (val) => {
-        if (!val || !schema.invalidDays || !!schema.invalidDays.length) {
+        if (!val || !schema.invalidDays || schema.invalidDays.length === 0) {
           return true
         }
 

--- a/shared/utils/__tests__/date-validation.spec.ts
+++ b/shared/utils/__tests__/date-validation.spec.ts
@@ -1,0 +1,54 @@
+import { InvalidDaysOptions } from '../../types'
+import {
+  convertInvalidDaysOfTheWeekToNumberSet,
+  isDateAnInvalidDay,
+} from '../date-validation'
+
+describe('File validation utils', () => {
+  describe('convertInvalidDaysOfTheWeekToNumberSet', () => {
+    it('should return empty set if there are no invalid days in invalid days array', () => {
+      const mockInvalidDays: InvalidDaysOptions[] = []
+      const expectedSet = new Set()
+      expect(convertInvalidDaysOfTheWeekToNumberSet(mockInvalidDays)).toEqual(
+        expectedSet,
+      )
+    })
+
+    it('should return set containing the correct number representation of the days in the invalid days array', () => {
+      const mockInvalidDays = [
+        InvalidDaysOptions.Monday,
+        InvalidDaysOptions.Tuesday,
+        InvalidDaysOptions.Sunday,
+      ]
+      const expectedSet = new Set([1, 2, 7])
+      expect(convertInvalidDaysOfTheWeekToNumberSet(mockInvalidDays)).toEqual(
+        expectedSet,
+      )
+    })
+  })
+  describe('isDateAnInvalidDay', () => {
+    it('should invalidate invalid day if there is a match in invalidDays array', () => {
+      const mockDate = new Date('2022-08-02')
+      const mockInvalidDays = [
+        InvalidDaysOptions.Tuesday,
+        InvalidDaysOptions.Wednesday,
+      ]
+      expect(isDateAnInvalidDay(mockDate, mockInvalidDays)).toBe(true)
+    })
+
+    it('should validate valid day if there is no invalid day in invalidDays array', () => {
+      const mockDate = new Date()
+      const mockInvalidDays: InvalidDaysOptions[] = []
+      expect(isDateAnInvalidDay(mockDate, mockInvalidDays)).toBe(false)
+    })
+
+    it('should validate valid day if there is no match between date and invalidDays array', () => {
+      const mockDate = new Date('2022-08-02')
+      const mockInvalidDays = [
+        InvalidDaysOptions.Friday,
+        InvalidDaysOptions.Monday,
+      ]
+      expect(isDateAnInvalidDay(mockDate, mockInvalidDays)).toBe(false)
+    })
+  })
+})

--- a/shared/utils/date-validation.ts
+++ b/shared/utils/date-validation.ts
@@ -1,0 +1,38 @@
+import { format } from 'date-fns'
+import { InvalidDaysOptions } from '../types/field/dateField'
+
+const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
+  [InvalidDaysOptions.Monday]: 1,
+  [InvalidDaysOptions.Tuesday]: 2,
+  [InvalidDaysOptions.Wednesday]: 3,
+  [InvalidDaysOptions.Thursday]: 4,
+  [InvalidDaysOptions.Friday]: 5,
+  [InvalidDaysOptions.Saturday]: 6,
+  [InvalidDaysOptions.Sunday]: 7,
+}
+
+/**
+ * Convert the days of the week in the invalidDays array
+ * to a number array representing the number representation
+ * of the corresponding day of the week
+ */
+export const convertInvalidDaysOfTheWeekToNumberSet = (
+  invalidDays: InvalidDaysOptions[],
+): Set<number> => {
+  if (invalidDays.length === 0) {
+    return new Set()
+  }
+
+  return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
+}
+
+export const isDateAnInvalidDay = (
+  date: Date,
+  invalidDays: InvalidDaysOptions[],
+): boolean => {
+  const invalidDaySet = convertInvalidDaysOfTheWeekToNumberSet(invalidDays)
+
+  const dayNumberFormat = parseInt(format(date, 'i'))
+
+  return invalidDaySet.has(dayNumberFormat)
+}

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -125,7 +125,7 @@ const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
  * to a number array representing the number representation
  * of the corresponding day of the week
  */
-export const convertInvalidDaysOfTheWeekToNumberSet = (
+const convertInvalidDaysOfTheWeekToNumberSet = (
   invalidDays: InvalidDaysOptions[],
 ): Set<number> => {
   if (invalidDays.length === 0) {

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -110,14 +110,26 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
   }
 }
 
+<<<<<<< HEAD
 const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
+=======
+/**
+ * constant
+ */
+const INVALID_DAY_MAP: Record<InvalidDaysOptions, number> = {
+  [InvalidDaysOptions.Sunday]: 0,
+>>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
   [InvalidDaysOptions.Monday]: 1,
   [InvalidDaysOptions.Tuesday]: 2,
   [InvalidDaysOptions.Wednesday]: 3,
   [InvalidDaysOptions.Thursday]: 4,
   [InvalidDaysOptions.Friday]: 5,
   [InvalidDaysOptions.Saturday]: 6,
+<<<<<<< HEAD
   [InvalidDaysOptions.Sunday]: 7,
+=======
+  [InvalidDaysOptions.SingaporePublicHolidays]: 7,
+>>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
 }
 
 /**
@@ -132,7 +144,11 @@ const convertInvalidDaysOfTheWeekToNumberSet = (
     return new Set()
   }
 
+<<<<<<< HEAD
   return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
+=======
+  return new Set(invalidDays.map((invalidDay) => INVALID_DAY_MAP[invalidDay]))
+>>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
 }
 
 /**

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -125,7 +125,7 @@ const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
  * to a number array representing the number representation
  * of the corresponding day of the week
  */
-const convertInvalidDaysOfTheWeekToNumberSet = (
+export const convertInvalidDaysOfTheWeekToNumberSet = (
   invalidDays: InvalidDaysOptions[],
 ): Set<number> => {
   if (invalidDays.length === 0) {
@@ -145,12 +145,6 @@ const makeInvalidDayOfTheWeekValidator: DateValidatorConstructor =
     const invalidDaysOfTheWeekSet = convertInvalidDaysOfTheWeekToNumberSet(
       dateField.invalidDays ?? [],
     )
-
-    if (invalidDaysOfTheWeekSet.has(-1)) {
-      return left(
-        `DateValidator:\t invalid day value is not a valid invalid day option`,
-      )
-    }
 
     // Convert date response to a ISO day of the week number format
     const dateResponseNumberFormat = parseInt(format(new Date(answer), 'i'))

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -110,26 +110,14 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
   }
 }
 
-<<<<<<< HEAD
 const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
-=======
-/**
- * constant
- */
-const INVALID_DAY_MAP: Record<InvalidDaysOptions, number> = {
-  [InvalidDaysOptions.Sunday]: 0,
->>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
   [InvalidDaysOptions.Monday]: 1,
   [InvalidDaysOptions.Tuesday]: 2,
   [InvalidDaysOptions.Wednesday]: 3,
   [InvalidDaysOptions.Thursday]: 4,
   [InvalidDaysOptions.Friday]: 5,
   [InvalidDaysOptions.Saturday]: 6,
-<<<<<<< HEAD
   [InvalidDaysOptions.Sunday]: 7,
-=======
-  [InvalidDaysOptions.SingaporePublicHolidays]: 7,
->>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
 }
 
 /**
@@ -144,11 +132,7 @@ const convertInvalidDaysOfTheWeekToNumberSet = (
     return new Set()
   }
 
-<<<<<<< HEAD
   return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
-=======
-  return new Set(invalidDays.map((invalidDay) => INVALID_DAY_MAP[invalidDay]))
->>>>>>> d608629c (refactor: simplify mapping between InvalidDaysOptions and number into a constant instead of a function)
 }
 
 /**

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -3,10 +3,8 @@ import { chain, left, right } from 'fp-ts/lib/Either'
 import { flow } from 'fp-ts/lib/function'
 import moment from 'moment-timezone'
 
-import {
-  DateSelectedValidation,
-  InvalidDaysOptions,
-} from '../../../../../shared/types'
+import { DateSelectedValidation } from '../../../../../shared/types'
+import { convertInvalidDaysOfTheWeekToNumberSet } from '../../../../../shared/utils/date-validation'
 import {
   IDateFieldSchema,
   OmitUnusedValidatorProps,
@@ -108,31 +106,6 @@ const makeDateValidator: DateValidatorConstructor = (dateField) => {
     default:
       return right
   }
-}
-
-const DAY_TO_NUMBER_MAP: Record<InvalidDaysOptions, number> = {
-  [InvalidDaysOptions.Monday]: 1,
-  [InvalidDaysOptions.Tuesday]: 2,
-  [InvalidDaysOptions.Wednesday]: 3,
-  [InvalidDaysOptions.Thursday]: 4,
-  [InvalidDaysOptions.Friday]: 5,
-  [InvalidDaysOptions.Saturday]: 6,
-  [InvalidDaysOptions.Sunday]: 7,
-}
-
-/**
- * Convert the days of the week in the invalidDays array
- * to a number array representing the number representation
- * of the corresponding day of the week
- */
-const convertInvalidDaysOfTheWeekToNumberSet = (
-  invalidDays: InvalidDaysOptions[],
-): Set<number> => {
-  if (invalidDays.length === 0) {
-    return new Set()
-  }
-
-  return new Set(invalidDays.map((invalidDay) => DAY_TO_NUMBER_MAP[invalidDay]))
 }
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently the date picker does not check if a day in the date picker is considered an invalid day. Hence public users will still be able to click days from the date picker that are considered invalid based on the days the form admin users have restricted.

## Solution
<!-- How did you solve the problem? -->
Edit callback function in `DateField` to also check if a day in the date picker is considered to be an invalid day.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  
