### PR TITLE
fix(form-v2): added handler to return to builder after save

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
@@ -140,7 +140,13 @@ export const EndPageBuilderInput = ({
         justifyContent="end"
         spacing="1rem"
       >
-        <Button isFullWidth={isMobile} onClick={handleUpdateEndPage}>
+        <Button
+          isFullWidth={isMobile}
+          onClick={() => {
+            handleUpdateEndPage()
+            closeBuilderDrawer()
+          }}
+        >
           Save field
         </Button>
         <Button


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Thank You page editor - should go back to Builder (Basic) after saving

Closes [#4366]

## Solution
<!-- How did you solve the problem? -->
added handler for onclick for save button

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<details>


https://user-images.githubusercontent.com/102740235/182035142-cb60347a-d9a2-445b-9a66-0a1f53b0e023.mp4
</details>

**AFTER**:
<details>


https://user-images.githubusercontent.com/102740235/182035147-244c793d-080a-4b86-8927-8dbf2a974a8f.mp4
</details>

