### PR TITLE
fix(form-v2): submit another form now returns to form page

### DIFF
--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -78,7 +78,7 @@ export const EndPageBlock = ({
       <Box mt="2.25rem">
         <Button
           as="a"
-          href={endPage.buttonLink ?? window.location.href}
+          href={window.location.href}
           variant="solid"
           colorScheme={`theme-${colorTheme}`}
         >

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -78,11 +78,7 @@ export const EndPageBlock = ({
       <Box mt="2.25rem">
         <Button
           as="a"
-          href={
-            endPage.buttonLink?.length
-              ? endPage.buttonLink
-              : window.location.href
-          }
+          href={endPage.buttonLink || window.location.href}
           variant="solid"
           colorScheme={`theme-${colorTheme}`}
         >

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -78,7 +78,11 @@ export const EndPageBlock = ({
       <Box mt="2.25rem">
         <Button
           as="a"
-          href={window.location.href}
+          href={
+            endPage.buttonLink?.length
+              ? endPage.buttonLink
+              : window.location.href
+          }
           variant="solid"
           colorScheme={`theme-${colorTheme}`}
         >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Submit another form button leads to landing page

Closes [#4336 ]

## Solution
<!-- How did you solve the problem? -->
removed faulty ?? operator

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:
- `a ?? b` will return a if a is not null or undefined. `endPage.buttonLink` was returning empty string if alternative link not provided hence giving unexpected behaviour as outlined under
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<details>


https://user-images.githubusercontent.com/102740235/182036912-93025202-3e4c-4aea-9f1d-d3d94b1bf717.mp4
</details>

**AFTER**:
<!-- [insert screenshot here] -->
<details>


https://user-images.githubusercontent.com/102740235/182036914-3236d71e-36e9-4cc8-8138-fbb621c8e46d.mp4
</details>

