### PR TITLE
feat(form-v2): add error handling for deleted logic fields

### DIFF
--- a/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.stories.tsx
+++ b/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, Story } from '@storybook/react'
 
-import { AttachmentSize, BasicField } from '~shared/types/field'
+import { AttachmentSize, BasicField, FormFieldDto } from '~shared/types/field'
 import {
   AdminFormDto,
   LogicConditionState,
+  LogicDto,
   LogicIfValue,
   LogicType,
 } from '~shared/types/form'
@@ -38,87 +39,91 @@ export default {
   },
 } as Meta
 
+const form_field_1: FormFieldDto = {
+  title: 'Do you want to upload an attachment?',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.YesNo,
+  _id: '620115cf3bc125001349f9c3',
+}
+
+const form_field_2: FormFieldDto = {
+  title: 'Are you really sure you want to upload an attachment?',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.YesNo,
+  _id: '620115cf3bc125001349f9c6',
+}
+
+const form_field_3: FormFieldDto = {
+  title: 'Upload instructions',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.Image,
+  _id: '6200e1534ad4f00012848d65',
+  url: 'some-mock-url',
+  fileMd5Hash: 'wrjH62qBTpg0uIk4GMzOCA==',
+  name: 'Upload instructions.png',
+  size: '0.03 MB',
+}
+
+const form_field_4: FormFieldDto = {
+  title: 'Upload attachment',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.Attachment,
+  _id: '61e6857c9c794b0012f1c6f7',
+  attachmentSize: AttachmentSize.OneMb,
+}
+
+const if_12_show_34: LogicDto = {
+  show: ['6200e1534ad4f00012848d65', '61e6857c9c794b0012f1c6f7'],
+  _id: '620115f74ad4f00012900a8c',
+  logicType: LogicType.ShowFields,
+  conditions: [
+    {
+      ifValueType: LogicIfValue.SingleSelect,
+      field: '620115cf3bc125001349f9c3',
+      state: LogicConditionState.Equal,
+      value: 'Yes',
+    },
+    {
+      ifValueType: LogicIfValue.SingleSelect,
+      field: '620115cf3bc125001349f9c6',
+      state: LogicConditionState.Equal,
+      value: 'Yes',
+    },
+  ],
+}
+
+const if_12_preventsubmit: LogicDto = {
+  preventSubmitMessage:
+    'Some message to tell the user why they can not submit. This should be rendered in the storybook mock.',
+  _id: '620115f74ad4f00012900a8d',
+  logicType: LogicType.PreventSubmit,
+  conditions: [
+    {
+      ifValueType: LogicIfValue.SingleSelect,
+      field: '620115cf3bc125001349f9c3',
+      state: LogicConditionState.Equal,
+      value: 'Yes',
+    },
+    {
+      ifValueType: LogicIfValue.SingleSelect,
+      field: '620115cf3bc125001349f9c6',
+      state: LogicConditionState.Equal,
+      value: 'Yes',
+    },
+  ],
+}
+
 const FORM_WITH_LOGIC: Partial<AdminFormDto> = {
-  form_fields: [
-    {
-      title: 'Do you want to upload an attachment?',
-      description: '',
-      required: true,
-      disabled: false,
-      fieldType: BasicField.YesNo,
-      _id: '620115cf3bc125001349f9c3',
-    },
-    {
-      title: 'Are you really sure you want to upload an attachment?',
-      description: '',
-      required: true,
-      disabled: false,
-      fieldType: BasicField.YesNo,
-      _id: '620115cf3bc125001349f9c6',
-    },
-    {
-      title: 'Upload instructions',
-      description: '',
-      required: true,
-      disabled: false,
-      fieldType: BasicField.Image,
-      _id: '6200e1534ad4f00012848d65',
-      url: 'some-mock-url',
-      fileMd5Hash: 'wrjH62qBTpg0uIk4GMzOCA==',
-      name: 'Upload instructions.png',
-      size: '0.03 MB',
-    },
-    {
-      title: 'Upload attachment',
-      description: '',
-      required: true,
-      disabled: false,
-      fieldType: BasicField.Attachment,
-      _id: '61e6857c9c794b0012f1c6f7',
-      attachmentSize: AttachmentSize.OneMb,
-    },
-  ],
-  form_logics: [
-    {
-      show: ['6200e1534ad4f00012848d65', '61e6857c9c794b0012f1c6f7'],
-      _id: '620115f74ad4f00012900a8c',
-      logicType: LogicType.ShowFields,
-      conditions: [
-        {
-          ifValueType: LogicIfValue.SingleSelect,
-          field: '620115cf3bc125001349f9c3',
-          state: LogicConditionState.Equal,
-          value: 'Yes',
-        },
-        {
-          ifValueType: LogicIfValue.SingleSelect,
-          field: '620115cf3bc125001349f9c6',
-          state: LogicConditionState.Equal,
-          value: 'Yes',
-        },
-      ],
-    },
-    {
-      preventSubmitMessage:
-        'Some message to tell the user why they can not submit. This should be rendered in the storybook mock.',
-      _id: '620115f74ad4f00012900a8d',
-      logicType: LogicType.PreventSubmit,
-      conditions: [
-        {
-          ifValueType: LogicIfValue.SingleSelect,
-          field: '620115cf3bc125001349f9c3',
-          state: LogicConditionState.Equal,
-          value: 'Yes',
-        },
-        {
-          ifValueType: LogicIfValue.SingleSelect,
-          field: '620115cf3bc125001349f9c6',
-          state: LogicConditionState.Equal,
-          value: 'Yes',
-        },
-      ],
-    },
-  ],
+  form_fields: [form_field_1, form_field_2, form_field_3, form_field_4],
+  form_logics: [if_12_show_34, if_12_preventsubmit],
 }
 
 const Template: Story = () => <CreatePageLogicTab />
@@ -148,4 +153,33 @@ MobileWithLogic.parameters = {
     defaultViewport: 'mobile1',
   },
   chromatic: { viewports: [viewports.xs] },
+}
+
+export const ErrorIfDeleted = Template.bind({})
+ErrorIfDeleted.parameters = {
+  msw: buildMswRoutes({
+    form_fields: [form_field_2, form_field_3, form_field_4],
+    form_logics: [if_12_show_34, if_12_preventsubmit],
+  }),
+}
+
+export const ErrorShowSomeDeleted = Template.bind({})
+ErrorShowSomeDeleted.parameters = {
+  msw: buildMswRoutes({
+    form_fields: [form_field_1, form_field_2, form_field_4],
+    form_logics: [if_12_show_34, if_12_preventsubmit],
+  }),
+}
+
+export const ErrorShowAllDeleted = Template.bind({})
+ErrorShowAllDeleted.parameters = {
+  msw: buildMswRoutes({
+    form_fields: [form_field_1, form_field_2],
+    form_logics: [if_12_show_34, if_12_preventsubmit],
+  }),
+}
+
+export const ErrorAllDeleted = Template.bind({})
+ErrorAllDeleted.parameters = {
+  msw: buildMswRoutes({ form_logics: [if_12_show_34, if_12_preventsubmit] }),
 }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -86,7 +86,7 @@ export const EditConditionBlock = ({
       resetField(`${name}.field`)
       setError(`${name}.field`, {
         type: 'manual',
-        message: 'This field was deleted. Please add a different field.',
+        message: 'This field was deleted. Please select a different field.',
       })
     }
   }, [])

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -77,8 +77,7 @@ export const EditConditionBlock = ({
   }, [ifFieldIdValue, mapIdToField])
 
   /**
-   * Effect to set value and error if the user deleted the field. Run this only
-   * once, on render.
+   * Effect to set value and error if the user conditions on a deleted field.
    */
   useEffect(() => {
     if (!ifFieldIdValue || !mapIdToField) return
@@ -89,7 +88,7 @@ export const EditConditionBlock = ({
         message: 'This field was deleted. Please select a different field.',
       })
     }
-  }, [])
+  }, [ifFieldIdValue, mapIdToField, name, resetField, setError])
 
   /**
    * Effect to reset the field if the field to apply a condition on is changed.

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -60,6 +60,7 @@ export const EditConditionBlock = ({
     register,
     setValue,
     control,
+    setError,
   } = formMethods
   const ifFieldIdValue = watch(`${name}.field`)
   const hasFieldIdChanged = useHasChanged(
@@ -74,6 +75,21 @@ export const EditConditionBlock = ({
     if (!ifFieldIdValue || !mapIdToField) return
     return mapIdToField[ifFieldIdValue]
   }, [ifFieldIdValue, mapIdToField])
+
+  /**
+   * Effect to set value and error if the user deleted the field. Run this only
+   * once, on render.
+   */
+  useEffect(() => {
+    if (!ifFieldIdValue || !mapIdToField) return
+    if (!(ifFieldIdValue in mapIdToField)) {
+      resetField(`${name}.field`)
+      setError(`${name}.field`, {
+        type: 'manual',
+        message: 'This field was deleted. Please add a different field.',
+      })
+    }
+  }, [])
 
   /**
    * Effect to reset the field if the field to apply a condition on is changed.

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -85,7 +85,7 @@ export const EditConditionBlock = ({
       resetField(`${name}.field`)
       setError(`${name}.field`, {
         type: 'manual',
-        message: 'This field was deleted. Please select a different field.',
+        message: 'This field was deleted, please select another field',
       })
     }
   }, [ifFieldIdValue, mapIdToField, name, resetField, setError])

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -40,6 +40,7 @@ export const ThenShowBlock = ({
     resetField,
     setError,
     control,
+    trigger,
   } = formMethods
 
   const logicTypeValue = watch('logicType')
@@ -87,7 +88,7 @@ export const ThenShowBlock = ({
   useEffect(() => {
     if (
       logicTypeValue !== LogicType.ShowFields ||
-      !showValueWatch.value ||
+      !showValueWatch.value?.length ||
       !mapIdToField
     )
       return
@@ -109,6 +110,7 @@ export const ThenShowBlock = ({
       setValue('show', filteredShowFields)
       return
     }
+    trigger('show')
   }, [
     logicTypeValue,
     mapIdToField,
@@ -116,6 +118,7 @@ export const ThenShowBlock = ({
     setError,
     setValue,
     showValueWatch.value,
+    trigger,
   ])
 
   return (

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -94,8 +94,6 @@ export const ThenShowBlock = ({
     const filteredShowFields = showValueWatch.value.filter(
       (field) => field in mapIdToField,
     )
-    const deletedFieldsCount =
-      showValueWatch.value.length - filteredShowFields.length
     if (filteredShowFields.length === 0) {
       resetField('show')
       setError('show', {
@@ -104,6 +102,8 @@ export const ThenShowBlock = ({
       })
       return
     }
+    const deletedFieldsCount =
+      showValueWatch.value.length - filteredShowFields.length
     if (deletedFieldsCount > 0) {
       setDeletedFieldsCount(deletedFieldsCount)
       setValue('show', filteredShowFields)

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -74,11 +74,13 @@ export const ThenShowBlock = ({
       : 'show'
   }, [logicTypeValue])
 
-  const [deletedFieldsCount, setDeletedFieldsCount] = useState<number>(0)
+  const [deletedFieldsCount, setDeletedFieldsCount] = useState(0)
 
   /**
    * Compute whether any/all fields in the show fields are deleted, then run
    * effect to delete fields on render and show appropriate error/infobox.
+   * useWatch here to avoid infinite re-render (since if there are deleted
+   * fields, we always reset the value of the show).
    */
   const showValueWatch = useWatchDependency(watch, 'show')
 

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -105,7 +105,7 @@ export const ThenShowBlock = ({
     if (filteredShowFields.length === 0)
       setError('show', {
         type: 'manual',
-        message: 'All fields were deleted. Please select other field(s).',
+        message: 'All fields were deleted, please select at least one field',
       })
     else setDeletedFieldsCount(deletedFieldsCount)
   }, [
@@ -126,13 +126,11 @@ export const ThenShowBlock = ({
       px={{ base: '1.5rem', md: '2rem' }}
     >
       {deletedFieldsCount ? (
-        <InlineMessage variant="info">
+        <InlineMessage variant="info" p={0}>
           <Text>
             <strong>{simplur`${deletedFieldsCount} Show field[|s]`}</strong>{' '}
-            {simplur`${[
-              deletedFieldsCount,
-            ]}[was|were] deleted. [It has|They have]`}{' '}
-            been removed from your logic.
+            {simplur`${[deletedFieldsCount]}[was|were] deleted, and [has|have]`}{' '}
+            been removed from your logic
           </Text>
         </InlineMessage>
       ) : null}

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -95,22 +95,19 @@ export const ThenShowBlock = ({
     const filteredShowFields = showValueWatch.value.filter(
       (field) => field in mapIdToField,
     )
-    if (filteredShowFields.length === 0) {
-      resetField('show')
+    const deletedFieldsCount =
+      showValueWatch.value.length - filteredShowFields.length
+    if (deletedFieldsCount === 0) {
+      trigger('show')
+      return
+    }
+    setValue('show', filteredShowFields)
+    if (filteredShowFields.length === 0)
       setError('show', {
         type: 'manual',
         message: 'All fields were deleted. Please select other field(s).',
       })
-      return
-    }
-    const deletedFieldsCount =
-      showValueWatch.value.length - filteredShowFields.length
-    if (deletedFieldsCount > 0) {
-      setDeletedFieldsCount(deletedFieldsCount)
-      setValue('show', filteredShowFields)
-      return
-    }
-    trigger('show')
+    else setDeletedFieldsCount(deletedFieldsCount)
   }, [
     logicTypeValue,
     mapIdToField,

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -78,7 +78,7 @@ export const ThenShowBlock = ({
 
   /**
    * Compute whether any/all fields in the show fields are deleted, then run
-   * effect once on render to delete fields and show appropriate error/infobox.
+   * effect to delete fields on render and show appropriate error/infobox.
    */
   const showValueWatch = useWatchDependency(watch, 'show')
 
@@ -107,7 +107,14 @@ export const ThenShowBlock = ({
       setValue('show', filteredShowFields)
       return
     }
-  }, [])
+  }, [
+    logicTypeValue,
+    mapIdToField,
+    resetField,
+    setError,
+    setValue,
+    showValueWatch.value,
+  ])
 
   return (
     <Stack

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Icon, Stack, Text } from '@chakra-ui/react'
 
+import { BxsErrorCircle, BxsInfoCircle } from '~assets/icons'
 import Tooltip from '~components/Tooltip'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
@@ -9,30 +10,73 @@ import { FormFieldWithQuestionNo } from '~features/form/types'
 import { LogicBadge } from './LogicBadge'
 
 interface FieldLogicBadgeProps {
-  field: FormFieldWithQuestionNo
+  field: FormFieldWithQuestionNo | null
+  errorType?: 'error' | 'info'
+  errorString?: string
 }
 
 /**
  * Field specific logic badge. Adds field icon and question number to the displayed badge.
  */
-export const FieldLogicBadge = ({ field }: FieldLogicBadgeProps) => {
+export const FieldLogicBadge = ({
+  field,
+  errorType = 'error',
+  errorString = 'Field not found',
+}: FieldLogicBadgeProps) => {
   const fieldMeta = useMemo(
-    () => BASICFIELD_TO_DRAWER_META[field.fieldType],
-    [field.fieldType],
+    () => (field ? BASICFIELD_TO_DRAWER_META[field.fieldType] : null),
+    [field],
   )
+
+  const tooltipLabel = useMemo(
+    () => (!fieldMeta ? errorString : `${fieldMeta.label} field`),
+    [fieldMeta, errorString],
+  )
+
+  const errorIcon = useMemo(() => {
+    switch (errorType) {
+      case 'error':
+        return <Icon as={BxsErrorCircle} fontSize="1rem" color="danger.500" />
+      case 'info':
+        return <Icon as={BxsInfoCircle} fontSize="1rem" color="primary.500" />
+    }
+  }, [errorType])
+
+  const errorText = useMemo(() => {
+    switch (errorType) {
+      case 'error':
+        return (
+          <Text textColor="danger.500" noOfLines={1}>
+            {errorString}
+          </Text>
+        )
+      case 'info':
+        return (
+          <Text textColor="primary.500" noOfLines={1}>
+            {errorString}
+          </Text>
+        )
+    }
+  }, [errorType, errorString])
 
   return (
     <LogicBadge display="inline-flex">
       <Stack direction="row" spacing="0.25rem" maxW="100%">
         <Tooltip
           placement="top"
-          label={`${fieldMeta.label} field`}
+          label={tooltipLabel}
           wrapperStyles={{ display: 'flex' }}
         >
-          <Icon as={fieldMeta.icon} fontSize="1rem" />
+          {fieldMeta ? <Icon as={fieldMeta.icon} fontSize="1rem" /> : errorIcon}
         </Tooltip>
-        {field.questionNumber ? <Text>{field.questionNumber}.</Text> : null}
-        <Text noOfLines={1}>{field.title}</Text>
+        {field ? (
+          <>
+            {field.questionNumber ? <Text>{field.questionNumber}.</Text> : null}
+            <Text noOfLines={1}>{field.title}</Text>
+          </>
+        ) : (
+          errorText
+        )}
       </Stack>
     </LogicBadge>
   )

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -10,9 +10,11 @@ import { FormFieldWithQuestionNo } from '~features/form/types'
 import { LogicBadge } from './LogicBadge'
 
 interface FieldLogicBadgeProps {
-  field: FormFieldWithQuestionNo | null
-  errorType?: 'error' | 'info'
-  errorString?: string
+  field?: FormFieldWithQuestionNo
+  defaults?: {
+    variant: 'error' | 'info'
+    message: string
+  }
 }
 
 /**
@@ -20,8 +22,7 @@ interface FieldLogicBadgeProps {
  */
 export const FieldLogicBadge = ({
   field,
-  errorType = 'error',
-  errorString = 'Field not found',
+  defaults = { variant: 'error', message: 'Field not found' },
 }: FieldLogicBadgeProps) => {
   const fieldMeta = useMemo(
     () => (field ? BASICFIELD_TO_DRAWER_META[field.fieldType] : null),
@@ -29,35 +30,35 @@ export const FieldLogicBadge = ({
   )
 
   const tooltipLabel = useMemo(
-    () => (!fieldMeta ? errorString : `${fieldMeta.label} field`),
-    [fieldMeta, errorString],
+    () => (!fieldMeta ? defaults.message : `${fieldMeta.label} field`),
+    [fieldMeta, defaults.message],
   )
 
   const errorIcon = useMemo(() => {
-    switch (errorType) {
+    switch (defaults.variant) {
       case 'error':
         return <Icon as={BxsErrorCircle} fontSize="1rem" color="danger.500" />
       case 'info':
         return <Icon as={BxsInfoCircle} fontSize="1rem" color="primary.500" />
     }
-  }, [errorType])
+  }, [defaults.variant])
 
   const errorText = useMemo(() => {
-    switch (errorType) {
+    switch (defaults.variant) {
       case 'error':
         return (
           <Text textColor="danger.500" noOfLines={1}>
-            {errorString}
+            {defaults.message}
           </Text>
         )
       case 'info':
         return (
           <Text textColor="primary.500" noOfLines={1}>
-            {errorString}
+            {defaults.message}
           </Text>
         )
     }
-  }, [errorType, errorString])
+  }, [defaults])
 
   return (
     <LogicBadge display="inline-flex">

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -29,36 +29,30 @@ export const FieldLogicBadge = ({
     [field],
   )
 
+  const textColor = useMemo(() => {
+    if (fieldMeta) return undefined
+    switch (defaults.variant) {
+      case 'error':
+        return 'danger.500'
+      case 'info':
+        return 'primary.500'
+    }
+  }, [defaults.variant, fieldMeta])
+
   const tooltipLabel = useMemo(
     () => (!fieldMeta ? defaults.message : `${fieldMeta.label} field`),
     [fieldMeta, defaults.message],
   )
 
-  const errorIcon = useMemo(() => {
+  const tooltipIcon = useMemo(() => {
+    if (fieldMeta) return fieldMeta.icon
     switch (defaults.variant) {
       case 'error':
-        return <Icon as={BxsErrorCircle} fontSize="1rem" color="danger.500" />
+        return BxsErrorCircle
       case 'info':
-        return <Icon as={BxsInfoCircle} fontSize="1rem" color="primary.500" />
+        return BxsInfoCircle
     }
-  }, [defaults.variant])
-
-  const errorText = useMemo(() => {
-    switch (defaults.variant) {
-      case 'error':
-        return (
-          <Text textColor="danger.500" noOfLines={1}>
-            {defaults.message}
-          </Text>
-        )
-      case 'info':
-        return (
-          <Text textColor="primary.500" noOfLines={1}>
-            {defaults.message}
-          </Text>
-        )
-    }
-  }, [defaults])
+  }, [defaults.variant, fieldMeta])
 
   return (
     <LogicBadge display="inline-flex">
@@ -68,7 +62,7 @@ export const FieldLogicBadge = ({
           label={tooltipLabel}
           wrapperStyles={{ display: 'flex' }}
         >
-          {fieldMeta ? <Icon as={fieldMeta.icon} fontSize="1rem" /> : errorIcon}
+          <Icon as={tooltipIcon} fontSize="1rem" color={textColor} />
         </Tooltip>
         {field ? (
           <>
@@ -76,7 +70,9 @@ export const FieldLogicBadge = ({
             <Text noOfLines={1}>{field.title}</Text>
           </>
         ) : (
-          errorText
+          <Text textColor={textColor} noOfLines={1}>
+            {defaults.message}
+          </Text>
         )}
       </Stack>
     </LogicBadge>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -52,18 +52,27 @@ export const InactiveLogicBlock = ({
           <>
             <Text>then show</Text>
             <Stack direction="column" spacing="0.25rem">
-              {logic.show.map((fieldId, index) => (
+              {allInvalid ? (
                 <FieldLogicBadge
-                  key={index}
-                  field={mapIdToField[fieldId]}
                   defaults={{
-                    variant: allInvalid ? 'error' : 'info',
-                    message: allInvalid
-                      ? 'All fields were deleted, please select at least one field'
-                      : 'This field was deleted and has been removed from your logic',
+                    variant: 'error',
+                    message:
+                      'All fields were deleted, please select at least one field',
                   }}
                 />
-              ))}
+              ) : (
+                logic.show.map((fieldId, index) => (
+                  <FieldLogicBadge
+                    key={index}
+                    field={mapIdToField[fieldId]}
+                    defaults={{
+                      variant: 'info',
+                      message:
+                        'This field was deleted and has been removed from your logic',
+                    }}
+                  />
+                ))
+              )}
             </Stack>
           </>
         )

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -48,8 +48,8 @@ export const InactiveLogicBlock = ({
         const allInvalid = logic.show.every(
           (fieldId) => !(fieldId in mapIdToField),
         )
-        const errorType = allInvalid ? 'error' : 'info'
-        const errorStringEnd = allInvalid
+        const defaultsVariant = allInvalid ? 'error' : 'info'
+        const defaultsMessageEnd = allInvalid
           ? '. Please select other fields.'
           : ' and has been removed from your logic.'
         return (
@@ -60,8 +60,10 @@ export const InactiveLogicBlock = ({
                 <FieldLogicBadge
                   key={index}
                   field={mapIdToField[fieldId]}
-                  errorType={errorType}
-                  errorString={`This field was deleted${errorStringEnd}`}
+                  defaults={{
+                    variant: defaultsVariant,
+                    message: `This field was deleted${defaultsMessageEnd}`,
+                  }}
                 />
               ))}
             </Stack>
@@ -129,8 +131,11 @@ export const InactiveLogicBlock = ({
                 <Text>{index === 0 ? 'If' : 'and'}</Text>
                 <FieldLogicBadge
                   field={mapIdToField[condition.field]}
-                  errorType="error"
-                  errorString="This field was deleted. Please select another field."
+                  defaults={{
+                    variant: 'error',
+                    message:
+                      'This field was deleted. Please select another field.',
+                  }}
                 />
               </Stack>
               <Stack>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -44,17 +44,30 @@ export const InactiveLogicBlock = ({
     if (!mapIdToField) return null
 
     switch (logic.logicType) {
-      case LogicType.ShowFields:
+      case LogicType.ShowFields: {
+        const allInvalid = logic.show.every(
+          (fieldId) => !(fieldId in mapIdToField),
+        )
+        const errorType = allInvalid ? 'error' : 'info'
+        const errorStringEnd = allInvalid
+          ? '. Please select other fields.'
+          : ' and has been removed from your logic.'
         return (
           <>
             <Text>then show</Text>
             <Stack direction="column" spacing="0.25rem">
               {logic.show.map((fieldId, index) => (
-                <FieldLogicBadge key={index} field={mapIdToField[fieldId]} />
+                <FieldLogicBadge
+                  key={index}
+                  field={mapIdToField[fieldId]}
+                  errorType={errorType}
+                  errorString={`This field was deleted${errorStringEnd}`}
+                />
               ))}
             </Stack>
           </>
         )
+      }
       case LogicType.PreventSubmit:
         return (
           <>
@@ -114,7 +127,11 @@ export const InactiveLogicBlock = ({
             >
               <Stack>
                 <Text>{index === 0 ? 'If' : 'and'}</Text>
-                <FieldLogicBadge field={mapIdToField[condition.field]} />
+                <FieldLogicBadge
+                  field={mapIdToField[condition.field]}
+                  errorType="error"
+                  errorString="This field was deleted. Please select another field."
+                />
               </Stack>
               <Stack>
                 <Text>{condition.state}</Text>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -48,10 +48,6 @@ export const InactiveLogicBlock = ({
         const allInvalid = logic.show.every(
           (fieldId) => !(fieldId in mapIdToField),
         )
-        const defaultsVariant = allInvalid ? 'error' : 'info'
-        const defaultsMessageEnd = allInvalid
-          ? '. Please select other fields.'
-          : ' and has been removed from your logic.'
         return (
           <>
             <Text>then show</Text>
@@ -61,8 +57,10 @@ export const InactiveLogicBlock = ({
                   key={index}
                   field={mapIdToField[fieldId]}
                   defaults={{
-                    variant: defaultsVariant,
-                    message: `This field was deleted${defaultsMessageEnd}`,
+                    variant: allInvalid ? 'error' : 'info',
+                    message: allInvalid
+                      ? 'All fields were deleted, please select at least one field'
+                      : 'This field was deleted and has been removed from your logic',
                   }}
                 />
               ))}
@@ -134,7 +132,7 @@ export const InactiveLogicBlock = ({
                   defaults={{
                     variant: 'error',
                     message:
-                      'This field was deleted. Please select another field.',
+                      'This field was deleted, please select another field',
                   }}
                 />
               </Stack>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
@@ -24,8 +24,8 @@ export const LogicContent = (): JSX.Element => {
     <Stack color="secondary.500" spacing="1rem">
       {hasError ? (
         <InlineMessage variant="error">
-          Your form's logic has errors. Please fix them before sharing your
-          form.
+          There are errors in your form's logic, please fix them before sharing
+          your form
         </InlineMessage>
       ) : null}
       <HeaderBlock />

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
@@ -1,5 +1,7 @@
 import { Stack } from '@chakra-ui/react'
 
+import InlineMessage from '~components/InlineMessage'
+
 import {
   isCreatingStateSelector,
   useAdminLogicStore,
@@ -12,7 +14,7 @@ import { NewLogicBlock } from './NewLogicBlock'
 
 export const LogicContent = (): JSX.Element => {
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
-  const { formLogics, isLoading } = useAdminFormLogic()
+  const { formLogics, isLoading, hasError } = useAdminFormLogic()
 
   if (isLoading) {
     return <div>Loading...</div>
@@ -20,6 +22,12 @@ export const LogicContent = (): JSX.Element => {
 
   return (
     <Stack color="secondary.500" spacing="1rem">
+      {hasError ? (
+        <InlineMessage variant="error">
+          Your form's logic has errors. Please fix them before sharing your
+          form.
+        </InlineMessage>
+      ) : null}
       <HeaderBlock />
       {formLogics?.map((logic) => (
         <LogicBlockFactory key={logic._id} logic={logic} />

--- a/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
+++ b/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 import { keyBy } from 'lodash'
 import pickBy from 'lodash/pickBy'
 
+import { LogicType } from '~shared/types'
+
 import { useAdminForm } from '~features/admin-form/common/queries'
 import { augmentWithQuestionNo } from '~features/form/utils/augmentWithQuestionNo'
 import { ALLOWED_LOGIC_FIELDS } from '~features/logic/constants'
@@ -21,11 +23,29 @@ export const useAdminFormLogic = () => {
     return pickBy(mapIdToField, (f) => ALLOWED_LOGIC_FIELDS.has(f.fieldType))
   }, [mapIdToField])
 
+  const hasError = useMemo(
+    () =>
+      !mapIdToField
+        ? false
+        : form?.form_logics.some(
+            (logic) =>
+              // Logic is errored if some condition does not exist, or all the
+              // show fields do not exist.
+              logic.conditions.some(
+                (condition) => !(condition.field in mapIdToField),
+              ) ||
+              (logic.logicType === LogicType.ShowFields &&
+                logic.show.every((field) => !(field in mapIdToField))),
+          ),
+    [form?.form_logics, mapIdToField],
+  )
+
   return {
     isLoading,
     formLogics: form?.form_logics,
     formFields: form?.form_fields,
     logicableFields,
     mapIdToField,
+    hasError,
   }
 }

--- a/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
+++ b/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
@@ -23,22 +23,19 @@ export const useAdminFormLogic = () => {
     return pickBy(mapIdToField, (f) => ALLOWED_LOGIC_FIELDS.has(f.fieldType))
   }, [mapIdToField])
 
-  const hasError = useMemo(
-    () =>
-      !mapIdToField
-        ? false
-        : form?.form_logics.some(
-            (logic) =>
-              // Logic is errored if some condition does not exist, or all the
-              // show fields do not exist.
-              logic.conditions.some(
-                (condition) => !(condition.field in mapIdToField),
-              ) ||
-              (logic.logicType === LogicType.ShowFields &&
-                logic.show.every((field) => !(field in mapIdToField))),
-          ),
-    [form?.form_logics, mapIdToField],
-  )
+  const hasError = useMemo(() => {
+    if (!mapIdToField || !form?.form_logics) return false
+    return form.form_logics.some(
+      (logic) =>
+        // Logic is errored if some condition does not exist, or all the
+        // show fields do not exist.
+        logic.conditions.some(
+          (condition) => !(condition.field in mapIdToField),
+        ) ||
+        (logic.logicType === LogicType.ShowFields &&
+          logic.show.every((field) => !(field in mapIdToField))),
+    )
+  }, [form?.form_logics, mapIdToField])
 
   return {
     isLoading,


### PR DESCRIPTION
## Problem
Builder logic breaks when a user deletes a field that was used in logic. This PR fixes that by adding error handling to the various components.

Closes #4341 

## Solution

`LogicFieldBadge.tsx`, `InactiveLogicBlock.tsx`
- Added error/info state props to `LogicFieldBadge` to display in case the field data cannot be found.
- `InactiveLogicBlock` provides these props to the `LogicFieldBadge` component.

`useAdminFormLogic.ts`, `LogicContent.tsx`
- Added computation to determine globally if any errors have occured within all the logics. Added an error box to display message in such case.

`EditConditionBlock.tsx`, `ThenShowBlock.tsx`
- Add effects to set form errors and values for deleted fields, as well as display info boxes where necessary.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/182070801-42e0a925-3225-41a1-9493-c953cc677113.mov


