### PR TITLE
feat(form-v2): disable edit field drawer fields when field is being saved

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -234,7 +234,7 @@ export const DesignDrawer = (): JSX.Element | null => {
 
       <DrawerContentContainer>
         <FormControl
-          isReadOnly={isLoading}
+          isDisabled={isLoading}
           isInvalid={!isEmpty(errors.attachment)}
         >
           <FormLabel>Logo</FormLabel>
@@ -290,7 +290,7 @@ export const DesignDrawer = (): JSX.Element | null => {
         </FormControl>
 
         <FormControl
-          isReadOnly={isLoading}
+          isDisabled={isLoading}
           isInvalid={!isEmpty(errors.colorTheme)}
         >
           <FormLabel>Theme colour</FormLabel>
@@ -328,7 +328,7 @@ export const DesignDrawer = (): JSX.Element | null => {
           <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
         </FormControl>
 
-        <FormControl isReadOnly={isLoading} isInvalid={!!errors.estTimeTaken}>
+        <FormControl isDisabled={isLoading} isInvalid={!!errors.estTimeTaken}>
           <FormLabel>Time taken to complete form (minutes)</FormLabel>
           <Controller
             name="estTimeTaken"
@@ -351,7 +351,7 @@ export const DesignDrawer = (): JSX.Element | null => {
           <FormErrorMessage>{errors.estTimeTaken?.message}</FormErrorMessage>
         </FormControl>
 
-        <FormControl isReadOnly={isLoading} isInvalid={!!errors.paragraph}>
+        <FormControl isDisabled={isLoading} isInvalid={!!errors.paragraph}>
           <FormLabel>Instructions for your form</FormLabel>
           <Textarea {...register('paragraph')} />
           <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -138,20 +138,20 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.attachmentSize}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.attachmentSize}>
         <FormLabel isRequired>Attachment size</FormLabel>
         <Skeleton isLoaded={!!form}>
           <Controller

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox.tsx
@@ -198,25 +198,25 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('othersRadioButton')} label="Others" />
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.fieldOptions}
       >
         <FormLabel>Options</FormLabel>
@@ -234,8 +234,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
           description="Customise the number of options that users are allowed to select"
         />
         <FormControl
-          isDisabled={!watchedInputs.validateByValue}
-          isReadOnly={isLoading}
+          isDisabled={isLoading || !watchedInputs.validateByValue}
           isInvalid={!isEmpty(errors.ValidationOptions)}
         >
           <Stack mt="0.5rem" direction="row" spacing="0.5rem">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -155,21 +155,21 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!isEmpty(errors.dateValidation)}
       >
         <FormLabel isRequired>Date validation</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
@@ -96,25 +96,25 @@ export const EditDecimal = ({ field }: EditDecimalProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
         <Toggle

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -72,22 +72,22 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.fieldOptionsString}
       >
         <FormLabel>Options</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -152,24 +152,24 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle
           {...register('isVerifiable')}
           label="OTP verification"
@@ -177,7 +177,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         />
       </FormControl>
       <Box>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl isDisabled={isLoading}>
           <Toggle
             {...allowedEmailDomainsRegister}
             ref={mergedAllowedEmailDomainsRef}
@@ -188,7 +188,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         </FormControl>
         {watchedHasAllowedEmailDomains && (
           <FormControl
-            isReadOnly={isLoading}
+            isDisabled={isLoading}
             isRequired
             isInvalid={!!errors.allowedEmailDomains}
             mt="1.5rem"
@@ -206,7 +206,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         )}
       </Box>
       <Box>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl isDisabled={isLoading}>
           <Toggle
             {...register('autoReplyOptions.hasAutoReply')}
             label="Email confirmation"
@@ -214,7 +214,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         </FormControl>
         {watchedHasAutoReply && (
           <>
-            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
+            <FormControl isRequired isDisabled={isLoading} mt="1.5rem">
               <FormLabel>Subject</FormLabel>
               <Input
                 autoFocus
@@ -222,21 +222,21 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                 {...register('autoReplyOptions.autoReplySubject')}
               />
             </FormControl>
-            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
+            <FormControl isRequired isDisabled={isLoading} mt="1.5rem">
               <FormLabel>Sender name</FormLabel>
               <Input
                 placeholder="Default sender name is your agency name"
                 {...register('autoReplyOptions.autoReplySender')}
               />
             </FormControl>
-            <FormControl isReadOnly={isLoading} isRequired mt="1.5rem">
+            <FormControl isDisabled={isLoading} isRequired mt="1.5rem">
               <FormLabel>Content</FormLabel>
               <Textarea
                 placeholder="Default email body"
                 {...register('autoReplyOptions.autoReplyMessage')}
               />
             </FormControl>
-            <FormControl isReadOnly={isLoading} mt="1.5rem">
+            <FormControl isDisabled={isLoading} mt="1.5rem">
               <Toggle
                 {...register('autoReplyOptions.includeFormSummary')}
                 label="Include PDF response"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -44,12 +44,12 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Section header</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
@@ -52,24 +52,24 @@ export const EditHomeno = ({ field }: EditHomenoProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle
           {...register('allowIntlNumbers')}
           label="Allow international numbers"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -158,7 +158,7 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
     <DrawerContentContainer>
       <FormControl
         isRequired
-        isReadOnly={isLoading || isSubmitting}
+        isDisabled={isLoading || isSubmitting}
         isInvalid={!isEmpty(errors.attachment)}
       >
         <FormLabel>Uploaded image</FormLabel>
@@ -185,7 +185,7 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
         <FormErrorMessage>{get(errors, 'attachment.message')}</FormErrorMessage>
       </FormControl>
       <FormControl
-        isReadOnly={isLoading || isSubmitting}
+        isDisabled={isLoading || isSubmitting}
         isInvalid={!!errors.description}
       >
         <FormLabel isRequired>Description</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -130,25 +130,25 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
         <FormLabel isRequired>Number of characters allowed</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -78,7 +78,7 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
       <DrawerContentContainer>
         <FormControl
           isRequired
-          isReadOnly={isLoading}
+          isDisabled={isLoading}
           isInvalid={!!errors.title}
         >
           <FormLabel>Question</FormLabel>
@@ -87,24 +87,24 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
         </FormControl>
         <FormControl
           isRequired
-          isReadOnly={isLoading}
+          isDisabled={isLoading}
           isInvalid={!!errors.description}
         >
           <FormLabel>Description</FormLabel>
           <Textarea {...register('description')} />
           <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
         </FormControl>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl isDisabled={isLoading}>
           <Toggle {...register('required')} label="Required" />
         </FormControl>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl isDisabled={isLoading}>
           <Toggle
             {...register('allowIntlNumbers')}
             label="Allow international numbers"
           />
         </FormControl>
         <Box>
-          <FormControl isReadOnly={isLoading} isDisabled={isToggleVfnDisabled}>
+          <FormControl isDisabled={isLoading || isToggleVfnDisabled}>
             <Toggle
               {...register('isVerifiable', {
                 onChange: (e) => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
@@ -46,17 +46,17 @@ export const EditNric = ({ field }: EditNricProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormFieldDrawerActions

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -140,25 +140,25 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
         <FormLabel isRequired>Number of characters allowed</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
@@ -49,7 +49,7 @@ export const EditParagraph = ({ field }: EditParagraphProps): JSX.Element => {
     <DrawerContentContainer>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Statement</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio.tsx
@@ -77,25 +77,25 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('othersRadioButton')} label="Others" />
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.fieldOptionsString}
       >
         <FormLabel>Options</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
@@ -63,20 +63,20 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl id="ratingOptions.steps" isReadOnly={isLoading}>
+      <FormControl id="ratingOptions.steps" isDisabled={isLoading}>
         <FormLabel isRequired>Number of steps</FormLabel>
         <Controller
           control={control}
@@ -91,7 +91,7 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
           )}
         />
       </FormControl>
-      <FormControl id="ratingOptions.shape" isReadOnly={isLoading}>
+      <FormControl id="ratingOptions.shape" isDisabled={isLoading}>
         <FormLabel isRequired>Shape</FormLabel>
         <Controller
           control={control}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -153,25 +153,25 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl
         isRequired
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!!errors.description}
       >
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl
-        isReadOnly={isLoading}
+        isDisabled={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
         <FormLabel isRequired>Number of characters allowed</FormLabel>
@@ -207,7 +207,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
           {errors?.ValidationOptions?.customVal?.message}
         </FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle
           {...register('allowPrefill')}
           label="Enable pre-fill"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -6,7 +6,7 @@ import {
   UnpackNestedValue,
   useFormState,
 } from 'react-hook-form'
-import { FormControl, Stack, StackDivider } from '@chakra-ui/react'
+import { FormControl, Stack } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'
 
 import { Column, ColumnDto, TableFieldBase } from '~shared/types/field'
@@ -120,12 +120,12 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
@@ -133,7 +133,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
       <Stack spacing="2rem">
         <FormControl
           isRequired
-          isReadOnly={isLoading}
+          isDisabled={isLoading}
           isInvalid={!!errors.minimumRows}
         >
           <FormLabel>Minimum rows</FormLabel>
@@ -158,7 +158,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
           />
           <FormErrorMessage>{errors?.minimumRows?.message}</FormErrorMessage>
         </FormControl>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl isDisabled={isLoading}>
           <Toggle
             {...register('addMoreRows')}
             label="Allow respondent to add more rows"
@@ -167,7 +167,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
         {getValues('addMoreRows') ? (
           <FormControl
             isRequired
-            isReadOnly={isLoading}
+            isDisabled={isLoading}
             isInvalid={!!errors.maximumRows}
           >
             <FormLabel>Maximum rows allowed</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
@@ -46,17 +46,17 @@ export const EditUen = ({ field }: EditUenProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormFieldDrawerActions

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
@@ -49,17 +49,17 @@ export const EditYesNo = ({ field }: EditYesNoProps): JSX.Element => {
 
   return (
     <DrawerContentContainer>
-      <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
+      <FormControl isRequired isDisabled={isLoading} isInvalid={!!errors.title}>
         <FormLabel>Question</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
+      <FormControl isDisabled={isLoading} isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isDisabled={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormFieldDrawerActions


### PR DESCRIPTION
## Problem
Currently, the builder drawer does not display that the form field is in a loading state, even though it is read only. This PR changes the edit field drawers to display that the builder is in a saving state by greying out the field.

## Solution
Use `isDisabled` everywhere instead of `isReadOnly`.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
