### PR TITLE
fix: augment myinfo data only after admin field state is added

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -55,15 +55,18 @@ export const useBuilderFields = () => {
   const { data: formData } = useCreateTabForm()
   const stateData = useBuilderAndDesignStore(stateDataSelector)
   const builderFields = useMemo(() => {
-    const existingFields = formData?.form_fields?.map(augmentWithMyInfo)
+    let existingFields = formData?.form_fields
     if (!existingFields) return null
     if (stateData.state === BuildFieldState.EditingField) {
-      return getFormFieldsWhileEditing(existingFields, stateData.field)
+      existingFields = getFormFieldsWhileEditing(
+        existingFields,
+        stateData.field,
+      )
+    } else if (stateData.state === BuildFieldState.CreatingField) {
+      existingFields = getFormFieldsWhileCreating(existingFields, stateData)
     }
-    if (stateData.state === BuildFieldState.CreatingField) {
-      return getFormFieldsWhileCreating(existingFields, stateData)
-    }
-    return existingFields
+
+    return existingFields.map(augmentWithMyInfo)
   }, [formData, stateData])
 
   return {


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, fields to be created will not be augmented with their myinfo dropdown options as the augmentation of myinfo dropdown options were already done prior to the creation of the new field.

This PR fixes that by only augmenting after all edit/creation data has been added to the builder fields.

Closes #4363.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix: augment myinfo data only after admin field state is added 
