### PR TITLE
feat(form-workspaces-be/7): add move forms from multiple source workspaces functionality

### DIFF
--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -81,7 +81,7 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
       {
         _id: workspaceId,
       },
-      { session },
+      { session, new: true },
     )
   }
 

--- a/src/app/models/workspace.server.model.ts
+++ b/src/app/models/workspace.server.model.ts
@@ -1,6 +1,11 @@
 import { ClientSession, Mongoose, Schema } from 'mongoose'
 
-import { IUserSchema, IWorkspaceModel, IWorkspaceSchema } from '../../types'
+import {
+  IFormSchema,
+  IUserSchema,
+  IWorkspaceModel,
+  IWorkspaceSchema,
+} from '../../types'
 
 export const WORKSPACE_SCHEMA_ID = 'Workspace'
 
@@ -81,6 +86,38 @@ const compileWorkspaceModel = (db: Mongoose): IWorkspaceModel => {
       {
         _id: workspaceId,
       },
+      { session, new: true },
+    )
+  }
+
+  WorkspaceSchema.statics.removeFormIdsFromAllWorkspaces = async function ({
+    admin,
+    formIds,
+    session,
+  }: {
+    admin: IUserSchema['_id']
+    formIds: IFormSchema['_id'][]
+    session?: ClientSession
+  }) {
+    return await this.updateMany(
+      { admin },
+      { $pullAll: { formIds } },
+      { session },
+    )
+  }
+
+  WorkspaceSchema.statics.addFormIdsToWorkspace = async function ({
+    workspaceId,
+    formIds,
+    session,
+  }: {
+    workspaceId: IWorkspaceSchema['_id']
+    formIds: IFormSchema['_id'][]
+    session?: ClientSession
+  }) {
+    return await this.findOneAndUpdate(
+      { _id: workspaceId },
+      { $addToSet: { formIds: { $each: formIds } } },
       { session, new: true },
     )
   }

--- a/src/app/routes/api/v3/admin/workspaces/workspaces.form.routes.ts
+++ b/src/app/routes/api/v3/admin/workspaces/workspaces.form.routes.ts
@@ -4,7 +4,7 @@ import * as WorkspaceController from '../../../../../modules/workspace/workspace
 
 export const WorkspacesFormRouter = Router()
 
-WorkspacesFormRouter.route('/')
+WorkspacesFormRouter.route('/:workspaceId([a-fA-F0-9]{24})/forms')
   /**
    * Gets all the forms belonging to the workspace
    * @security session
@@ -28,16 +28,3 @@ WorkspacesFormRouter.route('/')
    * @returns 500 when database errors occur
    */
   .delete(WorkspaceController.deleteForms)
-
-WorkspacesFormRouter.route('/move')
-  /**
-   * Move forms from source workspace to destination workspace
-   * @security session
-   *
-   * @returns 200 with a list of remaining forms in the source workspace
-   * @returns 401 when user is not logged in
-   * @returns 404 when the source or destination workspace does not exist or belong to the user
-   * @returns 422 when user of given id cannnot be found in the database
-   * @returns 500 when database errors occur
-   */
-  .post(WorkspaceController.moveForms)

--- a/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
+++ b/src/app/routes/api/v3/admin/workspaces/workspaces.routes.ts
@@ -12,10 +12,7 @@ export const WorkspacesRouter = Router()
 WorkspacesRouter.use(withUserAuthentication)
 WorkspacesRouter.use(logAdminAction)
 
-WorkspacesRouter.use(
-  '/:workspaceId([a-fA-F0-9]{24})/forms',
-  WorkspacesFormRouter,
-)
+WorkspacesRouter.use(WorkspacesFormRouter)
 
 WorkspacesRouter.route('/')
   /**
@@ -69,3 +66,18 @@ WorkspacesRouter.route('/:workspaceId([a-fA-F0-9]{24})/title')
    * @returns 500 when database error occurs
    */
   .put(WorkspaceController.updateWorkspaceTitle)
+
+WorkspacesRouter.route('/move')
+  /**
+   * Move forms from to destination workspace. Forms may come from one source workspace, or from
+   * multiple different source workspaces.
+   * @security session
+   *
+   * @returns 200 with a list of remaining forms in the source workspace
+   * @returns 401 when user is not logged in
+   * @returns 403 when user does not have permissions to update the source or destination workspace
+   * @returns 404 when the source or destination workspace does not exist
+   * @returns 422 when user of given id cannnot be found in the database
+   * @returns 500 when database errors occur
+   */
+  .post(WorkspaceController.moveFormsToWorkspace)

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -42,4 +42,24 @@ export interface IWorkspaceModel extends Model<IWorkspaceSchema> {
      */
     session?: ClientSession
   }): Promise<WorkspaceDto | null>
+
+  removeFormIdsFromAllWorkspaces({
+    admin,
+    formIds,
+    session,
+  }: {
+    admin: IUserSchema['_id']
+    formIds: IFormSchema['_id'][]
+    session?: ClientSession
+  }): Promise<void>
+
+  addFormIdsToWorkspace({
+    workspaceId,
+    formIds,
+    session,
+  }: {
+    workspaceId: IWorkspaceSchema['_id']
+    formIds: IFormSchema['_id'][]
+    session?: ClientSession
+  }): Promise<WorkspaceDto | null>
 }


### PR DESCRIPTION
Builds on #4254 

Part of #4039 

## Solution
Add endpoint logic for POST `api/v3/admin/forms/move` for moving forms that could be in multiple different workspaces, to one destination workspace. This API will likely be used in the "All forms" workspace that could have forms from different workspaces

**Breaking Changes** 
- [x] No - this PR is backwards compatible  