### PR TITLE
fix: ensure admin builder page has overflow auto style for proper drawer scroll, update form view layout

### DIFF
--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -17,7 +17,9 @@ export const PreviewFormBanner = (): JSX.Element => {
       <Flex align="center" flex={1} justify="space-between" flexDir="row">
         <Text textStyle="caption-1">
           Preview{' '}
-          {form?.authType !== FormAuthType.NIL ? 'with test data' : 'mode'}
+          {form?.authType && form.authType !== FormAuthType.NIL
+            ? 'with test data'
+            : 'mode'}
         </Text>
         <Link
           variant="standalone"

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -27,7 +27,13 @@ export const CreatePage = (): JSX.Element => {
   }, [isLoading, hasAdminSeenFeatureTour])
 
   return (
-    <Flex h="100%" w="100%" overflow="auto" bg="neutral.200" direction="row">
+    <Flex
+      h="100%"
+      w="100%"
+      overflow="auto !important"
+      bg="neutral.200"
+      direction="row"
+    >
       <CreatePageSidebarProvider>
         {shouldFeatureTourRender && (
           <FeatureTour onClose={() => setHasAdminSeenFeatureTour(true)} />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
@@ -49,10 +49,11 @@ export const BuilderAndDesignPlaceholder = ({
       style={{
         top: placeholderProps.clientY,
         left: placeholderProps.clientX,
-        height: placeholderProps.clientHeight,
+        height: `calc(${placeholderProps.clientHeight}px + 1.25rem)`,
         width: placeholderProps.clientWidth,
       }}
       py={placeholderProps.droppableId === FIELD_LIST_DROP_ID ? '1.25rem' : 0}
+      pb="1.25rem"
       pos="absolute"
     >
       {renderedContents}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import {
+  Box,
   ButtonProps,
   Center,
   chakra,
@@ -32,38 +33,41 @@ export const EmptyFormPlaceholder = forwardRef<
   }, [isDraggingOver, isMobile])
 
   return (
-    <chakra.button
-      _hover={{
-        bg: 'primary.200',
-      }}
-      _focus={{
-        boxShadow: '0 0 0 2px var(--chakra-colors-neutral-500)',
-      }}
-      h="13.75rem"
-      border="1px dashed"
-      borderColor={isDraggingOver ? 'primary.700' : 'secondary.300'}
-      borderRadius="4px"
-      bg="neutral.100"
-      transitionProperty="common"
-      transitionDuration="normal"
-      onClick={onClick}
-      {...props}
-      ref={ref}
-    >
-      <Center flexDir="column" gap={'0.75rem'}>
-        <Icon
-          as={BxsWidget}
-          __css={{ color: 'secondary.500', fontSize: '1.5rem' }}
-        />
-        <Text
-          textStyle="subhead-2"
-          color="secondary.500"
-          px="1.5rem"
-          textAlign={'center'}
-        >
-          {placeholderText}
-        </Text>
-      </Center>
-    </chakra.button>
+    <Box h="13.75rem" m={{ base: '1rem', lg: '1.625rem' }}>
+      <chakra.button
+        _hover={{
+          bg: 'primary.200',
+        }}
+        _focus={{
+          boxShadow: '0 0 0 2px var(--chakra-colors-neutral-500)',
+        }}
+        h="100%"
+        w="100%"
+        border="1px dashed"
+        borderColor={isDraggingOver ? 'primary.700' : 'secondary.300'}
+        borderRadius="4px"
+        bg="neutral.100"
+        transitionProperty="common"
+        transitionDuration="normal"
+        onClick={onClick}
+        {...props}
+        ref={ref}
+      >
+        <Center flexDir="column" gap={'0.75rem'}>
+          <Icon
+            as={BxsWidget}
+            __css={{ color: 'secondary.500', fontSize: '1.5rem' }}
+          />
+          <Text
+            textStyle="subhead-2"
+            color="secondary.500"
+            px="1.5rem"
+            textAlign={'center'}
+          >
+            {placeholderText}
+          </Text>
+        </Center>
+      </chakra.button>
+    </Box>
   )
 })

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -33,7 +33,7 @@ export const EmptyFormPlaceholder = forwardRef<
   }, [isDraggingOver, isMobile])
 
   return (
-    <Box h="13.75rem" m={{ base: '1rem', lg: '1.625rem' }}>
+    <Box h="13.75rem" m={{ base: 0, lg: '1.625rem' }}>
       <chakra.button
         _hover={{
           bg: 'primary.200',

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -45,11 +45,8 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
 
   return (
     <Flex
-      m={{ base: 0, md: '2rem' }}
-      mb={0}
       flex={1}
       bg="white"
-      p={{ base: '1.5rem', md: 0 }}
       justify="center"
       overflow="auto"
       height="100%"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -45,8 +45,11 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
 
   return (
     <Flex
+      m={{ base: 0, md: '2rem' }}
+      mb={0}
       flex={1}
       bg="white"
+      p={{ base: '1.5rem', md: 0 }}
       justify="center"
       overflow="auto"
       height="100%"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -206,7 +206,6 @@ export const FieldRowContainer = ({
         <Box
           _first={{ pt: 0 }}
           _last={{ pb: 0 }}
-          m="0.75rem"
           py="0.375rem"
           {...provided.draggableProps}
           ref={provided.innerRef}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -52,8 +52,15 @@ export const FormBuilder = ({
         bg={bg}
       >
         <StartPageView />
-        <Flex flexDir="column" alignSelf="center" px="2.5rem" w="100%">
-          <Box bg="white" w="100%" maxW="57rem" alignSelf="center">
+        <Flex flexDir="column" alignSelf="center" w="100%" px="2.5rem">
+          <Box
+            bg="white"
+            w="100%"
+            maxW="57rem"
+            alignSelf="center"
+            px="1.625rem"
+            py="2.5rem"
+          >
             <Droppable droppableId={FIELD_LIST_DROP_ID}>
               {(provided, snapshot) =>
                 builderFields?.length ? (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -81,7 +81,6 @@ export const FormBuilder = ({
                   </Box>
                 ) : (
                   <EmptyFormPlaceholder
-                    m={{ base: '1.5rem', md: 0 }}
                     ref={provided.innerRef}
                     {...provided.droppableProps}
                     isDraggingOver={snapshot.isDraggingOver}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -36,6 +36,7 @@ export const FormBuilder = ({
 
   return (
     <Flex
+      m={{ base: 0, md: '2rem' }}
       mb={0}
       flex={1}
       bg={bg}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -1,5 +1,5 @@
 import { Droppable } from 'react-beautiful-dnd'
-import { Box, Flex, FlexProps, Text } from '@chakra-ui/react'
+import { Box, Flex, FlexProps, Stack } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 
@@ -36,64 +36,76 @@ export const FormBuilder = ({
 
   return (
     <Flex
-      m={{ base: 0, md: '2rem' }}
       mb={0}
       flex={1}
-      bg={bg}
-      p={{ base: '1.5rem', md: '2.5rem' }}
+      bg="neutral.200"
+      p={{ base: 0, md: '2rem' }}
       justify="center"
       overflow="auto"
       {...props}
     >
-      <Flex flexDir="column" w="100%" maxW="57rem" h="fit-content">
+      <Stack
+        direction="column"
+        w="100%"
+        h="fit-content"
+        spacing="1.5rem"
+        bg={bg}
+      >
         <StartPageView />
-        <Flex bg="white" p={{ base: 0, md: '2.5rem' }} flexDir="column">
-          <Droppable droppableId={FIELD_LIST_DROP_ID}>
-            {(provided, snapshot) =>
-              builderFields?.length ? (
-                <Box
-                  pos="relative"
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                >
-                  <BuilderFields
-                    fields={builderFields}
+        <Flex flexDir="column" alignSelf="center" px="2.5rem" w="100%">
+          <Box bg="white" w="100%" maxW="57rem" alignSelf="center">
+            <Droppable droppableId={FIELD_LIST_DROP_ID}>
+              {(provided, snapshot) =>
+                builderFields?.length ? (
+                  <Box
+                    pos="relative"
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                  >
+                    <BuilderFields
+                      fields={builderFields}
+                      isDraggingOver={snapshot.isDraggingOver}
+                    />
+                    {provided.placeholder}
+                    <BuilderAndDesignPlaceholder
+                      placeholderProps={placeholderProps}
+                      isDraggingOver={snapshot.isDraggingOver}
+                    />
+                  </Box>
+                ) : (
+                  <EmptyFormPlaceholder
+                    m={{ base: '1.5rem', md: 0 }}
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
                     isDraggingOver={snapshot.isDraggingOver}
+                    onClick={handleBuilderClick}
                   />
-                  {provided.placeholder}
-                  <BuilderAndDesignPlaceholder
-                    placeholderProps={placeholderProps}
-                    isDraggingOver={snapshot.isDraggingOver}
-                  />
-                </Box>
-              ) : (
-                <EmptyFormPlaceholder
-                  m={{ base: '1.5rem', md: 0 }}
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  isDraggingOver={snapshot.isDraggingOver}
-                  onClick={handleBuilderClick}
-                />
-              )
-            }
-          </Droppable>
+                )
+              }
+            </Droppable>
+          </Box>
         </Flex>
-        <Button
-          _hover={{ bg: 'primary.200' }}
-          py="1.5rem"
-          mt="1.5rem"
-          variant="outline"
-          borderColor="secondary.200"
-          colorScheme="secondary"
-          height="auto"
-          onClick={() => {
-            setEditEndPage()
-            handleBuilderClick()
-          }}
-        >
-          <Text textStyle="subhead-2">Customise Thank you page</Text>
-        </Button>
-      </Flex>
+        <Flex justify="center" w="100%" px="2.5rem">
+          <Button
+            _hover={{ bg: 'primary.200' }}
+            py="1.5rem"
+            mb="1.5rem"
+            variant="outline"
+            borderColor="secondary.200"
+            colorScheme="secondary"
+            height="auto"
+            maxW="57rem"
+            width="100%"
+            onClick={() => {
+              setEditEndPage()
+              handleBuilderClick()
+            }}
+            textStyle="subhead-2"
+          >
+            Customise Thank you page
+          </Button>
+        </Flex>
+      </Stack>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -36,7 +36,6 @@ export const FormBuilder = ({
 
   return (
     <Flex
-      m={{ base: 0, md: '2rem' }}
       mb={0}
       flex={1}
       bg={bg}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -81,7 +81,7 @@ export const StartPageView = () => {
   })
 
   return (
-    <>
+    <Box>
       {customLogoPending ? (
         // Show skeleton if user has chosen custom logo but not yet uploaded
         <Flex justify="center" p="1rem" bg="white">
@@ -108,12 +108,14 @@ export const StartPageView = () => {
           form?.authType !== FormAuthType.NIL ? PREVIEW_MOCK_UINFIN : undefined
         }
       />
-      <Box mt="1.5rem">
-        <FormInstructions
-          content={startPage?.paragraph}
-          colorTheme={startPage?.colorTheme}
-        />
-      </Box>
-    </>
+      {startPage?.paragraph && (
+        <Box mt="1.5rem" mx="2.5rem" mb="-1.5rem">
+          <FormInstructions
+            content={startPage?.paragraph}
+            colorTheme={startPage?.colorTheme}
+          />
+        </Box>
+      )}
+    </Box>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
@@ -26,7 +26,7 @@ export const FormFieldDrawerActions = ({
       direction={{ base: 'column', md: 'row-reverse' }}
       justifyContent="end"
       w="100%"
-      spacing="1rem"
+      spacing={{ base: '0.5rem', md: '1rem' }}
     >
       <Button
         isFullWidth={isMobile}

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/dnd.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/dnd.ts
@@ -59,11 +59,9 @@ export const getPlaceholderStartProps = ({
   return {
     droppableId: source.droppableId,
     clientHeight: draggedDOM.clientHeight,
-    clientWidth: '100%',
+    clientWidth: 'calc(100% - 3.25rem)',
     clientY,
-    clientX: parseFloat(
-      window.getComputedStyle(draggedDOM.parentElement).paddingLeft,
-    ),
+    clientX: 26, // 1.625rem in px
   }
 }
 
@@ -121,10 +119,8 @@ export const getPlaceholderUpdateProps = ({
   return {
     droppableId: source.droppableId,
     clientHeight: draggedDOM.clientHeight,
-    clientWidth: '100%',
+    clientWidth: 'calc(100% - 3.25rem)',
     clientY,
-    clientX: parseFloat(
-      window.getComputedStyle(draggedDOM.parentElement).paddingLeft,
-    ),
+    clientX: 26, // 1.625rem in px
   }
 }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
@@ -1,5 +1,5 @@
 import { BiTrash } from 'react-icons/bi'
-import { Box, ButtonGroup, Flex, Stack } from '@chakra-ui/react'
+import { Box, Flex, Stack } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -21,8 +21,8 @@ export const PreviewFormPage = (): JSX.Element => {
 
   return (
     <Flex flexDir="column" height="100vh" pos="relative">
+      <GovtMasthead />
       <PreviewFormProvider formId={formId}>
-        <GovtMasthead />
         <PreviewFormBanner />
         <FormSectionsProvider>
           <FormStartPage />

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -37,7 +37,7 @@ export const PublicFormWrapper = ({
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">
       {isAuthRequired ? null : <SectionSidebar />}
-      <Flex flexDir="column">
+      <Flex flexDir="column" maxW="57rem" w="100%">
         {/* TODO(#4279): Remove switch env message on full rollout */}
         {!isPreview && <PublicSwitchEnvMessage />}
         {children}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Something (something... i really can't find it in code) is injecting overflow='initial' into the component's styling, preventing the overflow state from being set...
This causes the 100% height drawer to be offset and thus will not be able to be scrolled to the bottom (since the real bottom is below the visible bottom) 

This PR fixes that, and the drawer can be correctly scrolled now. 

Closes #4305

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix: ensure admin builder drawer has overflow auto style
