### PR TITLE
fix: mock logo data in design drawer for custom logos, add key to colortheme radio selection

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
@@ -15,8 +15,8 @@ import {
   useBuilderAndDesignStore,
 } from '../useBuilderAndDesignStore'
 
-import { DesignDrawer } from './DesignDrawer/DesignDrawer'
 import { EditEndPageDrawer } from './EditEndPageDrawer/EditEndPageDrawer'
+import DesignDrawer from './DesignDrawer'
 import { EditFieldDrawer } from './EditFieldDrawer'
 import { FieldListDrawer } from './FieldListDrawer'
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -38,7 +38,6 @@ import {
   customLogoMetaSelector,
   FormStartPageInput,
   setStartPageDataSelector,
-  startPageDataSelector,
   useDesignStore,
 } from '../../useDesignStore'
 import { validateNumberInput } from '../../utils/validateNumberInput'
@@ -50,7 +49,13 @@ import {
   UploadImageInput,
 } from '../EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput'
 
-export const DesignDrawer = (): JSX.Element | null => {
+type DesignDrawerProps = {
+  startPageData: FormStartPageInput
+}
+
+export const DesignDrawer = ({
+  startPageData,
+}: DesignDrawerProps): JSX.Element | null => {
   const toast = useToast({ status: 'danger' })
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
@@ -58,10 +63,9 @@ export const DesignDrawer = (): JSX.Element | null => {
   const { startPageMutation } = useMutateFormPage()
   const { handleClose } = useCreatePageSidebar()
 
-  const { startPageData, customLogoMeta, setStartPageData } = useDesignStore(
+  const { customLogoMeta, setStartPageData } = useDesignStore(
     useCallback(
       (state) => ({
-        startPageData: startPageDataSelector(state),
         customLogoMeta: customLogoMetaSelector(state),
         setStartPageData: setStartPageDataSelector(state),
       }),
@@ -78,10 +82,7 @@ export const DesignDrawer = (): JSX.Element | null => {
     setError,
   } = useForm<FormStartPageInput>({
     mode: 'onBlur',
-    defaultValues: (() => {
-      console.log(startPageData)
-      return startPageData
-    })(),
+    defaultValues: startPageData,
   })
 
   const watchedInputs = useWatch({
@@ -265,7 +266,7 @@ export const DesignDrawer = (): JSX.Element | null => {
         </FormControl>
 
         <FormControl
-          isDisabled={startPageMutation.isLoading}
+          isReadOnly={startPageMutation.isLoading}
           isInvalid={!!errors.estTimeTaken}
         >
           <FormLabel>Time taken to complete form (minutes)</FormLabel>
@@ -291,7 +292,7 @@ export const DesignDrawer = (): JSX.Element | null => {
         </FormControl>
 
         <FormControl
-          isDisabled={startPageMutation.isLoading}
+          isReadOnly={startPageMutation.isLoading}
           isInvalid={!!errors.paragraph}
         >
           <FormLabel>Instructions for your form</FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   Controller,
   UnpackNestedValue,
@@ -14,7 +14,6 @@ import {
   Flex,
   FormControl,
   FormLabel,
-  Skeleton,
   Stack,
   Tabs,
   Text,
@@ -22,7 +21,7 @@ import {
 } from '@chakra-ui/react'
 import { cloneDeep, get, isEmpty } from 'lodash'
 
-import { CustomFormLogo, FormColorTheme, FormLogoState } from '~shared/types'
+import { FormColorTheme, FormLogoState } from '~shared/types'
 
 import { useToast } from '~hooks/useToast'
 import { uploadLogo } from '~services/FileHandlerService'
@@ -32,17 +31,12 @@ import Radio from '~components/Radio'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
-import { useEnv } from '~features/env/queries'
 import { getTitleBg } from '~features/public-form/components/FormStartPage/useFormHeader'
 
-import { useCreateTabForm } from '../../useCreateTabForm'
 import {
   CustomLogoMeta,
   customLogoMetaSelector,
   FormStartPageInput,
-  resetDesignStoreSelector,
-  setAttachmentSelector,
-  setCustomLogoMetaSelector,
   setStartPageDataSelector,
   startPageDataSelector,
   useDesignStore,
@@ -58,38 +52,18 @@ import {
 
 export const DesignDrawer = (): JSX.Element | null => {
   const toast = useToast({ status: 'danger' })
-  const { data: form } = useCreateTabForm()
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
   const { startPageMutation } = useMutateFormPage()
-  const { data: { logoBucketUrl } = {} } = useEnv()
   const { handleClose } = useCreatePageSidebar()
 
-  const [existingCustomLogoFetched, setExistingCustomLogoFetched] =
-    useState<boolean>(form?.startPage.logo.state !== FormLogoState.Custom)
-
-  const isLoading = useMemo(
-    () => startPageMutation.isLoading || !existingCustomLogoFetched,
-    [startPageMutation.isLoading, existingCustomLogoFetched],
-  )
-
-  const {
-    startPageData,
-    customLogoMeta,
-    setStartPageData,
-    setAttachment,
-    setCustomLogoMeta,
-    resetDesignStore,
-  } = useDesignStore(
+  const { startPageData, customLogoMeta, setStartPageData } = useDesignStore(
     useCallback(
       (state) => ({
         startPageData: startPageDataSelector(state),
         customLogoMeta: customLogoMetaSelector(state),
         setStartPageData: setStartPageDataSelector(state),
-        setAttachment: setAttachmentSelector(state),
-        setCustomLogoMeta: setCustomLogoMetaSelector(state),
-        resetDesignStore: resetDesignStoreSelector(state),
       }),
       [],
     ),
@@ -100,48 +74,15 @@ export const DesignDrawer = (): JSX.Element | null => {
     formState: { errors, isDirty },
     control,
     handleSubmit,
-    resetField,
     clearErrors,
     setError,
   } = useForm<FormStartPageInput>({
     mode: 'onBlur',
-    defaultValues: { ...form?.startPage, attachment: {} },
+    defaultValues: (() => {
+      console.log(startPageData)
+      return startPageData
+    })(),
   })
-
-  // On mount, fetch custom logo file to display as part of attachment field.
-  const setAttachmentOnMount = useCallback(
-    async (logo: CustomFormLogo) => {
-      const srcUrl = `${logoBucketUrl}/${logo.fileId}`
-      const customLogoBlob = await fetch(srcUrl).then((res) => res.blob())
-      setAttachment({
-        file: new File([customLogoBlob], logo.fileName),
-        srcUrl,
-      })
-      setExistingCustomLogoFetched(true)
-    },
-    [logoBucketUrl, setAttachment],
-  )
-
-  // Load existing start page and custom logo into form when user opens drawer
-  useEffect(() => {
-    setStartPageData({
-      ...form?.startPage,
-      attachment: {},
-    } as FormStartPageInput)
-    if (form?.startPage.logo.state === FormLogoState.Custom) {
-      setAttachmentOnMount(form?.startPage.logo)
-      setCustomLogoMeta(form?.startPage.logo)
-    }
-    return () => resetDesignStore()
-  }, [])
-
-  useEffect(
-    () =>
-      resetField('attachment', {
-        defaultValue: startPageData?.attachment,
-      }),
-    [existingCustomLogoFetched],
-  )
 
   const watchedInputs = useWatch({
     control: control,
@@ -234,13 +175,13 @@ export const DesignDrawer = (): JSX.Element | null => {
 
       <DrawerContentContainer>
         <FormControl
-          isReadOnly={isLoading}
+          isReadOnly={startPageMutation.isLoading}
           isInvalid={!isEmpty(errors.attachment)}
         >
           <FormLabel>Logo</FormLabel>
           <Radio.RadioGroup
             value={startPageData.logo.state}
-            isDisabled={isLoading}
+            isDisabled={startPageMutation.isLoading}
           >
             <Radio value={FormLogoState.Default} {...register('logo.state')}>
               Default
@@ -253,12 +194,7 @@ export const DesignDrawer = (): JSX.Element | null => {
             </Radio>
           </Radio.RadioGroup>
           <Box ml="45px" mt="0.5rem">
-            <Box
-              hidden={
-                startPageData.logo.state !== FormLogoState.Custom ||
-                !existingCustomLogoFetched
-              }
-            >
+            <Box hidden={startPageData.logo.state !== FormLogoState.Custom}>
               <Controller
                 name="attachment"
                 control={control}
@@ -285,22 +221,22 @@ export const DesignDrawer = (): JSX.Element | null => {
                 {get(errors, 'attachment.message')}
               </FormErrorMessage>
             </Box>
-            <Skeleton w="100%" h="4.5rem" hidden={existingCustomLogoFetched} />
           </Box>
         </FormControl>
 
         <FormControl
-          isReadOnly={isLoading}
+          isReadOnly={startPageMutation.isLoading}
           isInvalid={!isEmpty(errors.colorTheme)}
         >
           <FormLabel>Theme colour</FormLabel>
           <Radio.RadioGroup
             value={startPageData.colorTheme}
-            isDisabled={isLoading}
+            isDisabled={startPageMutation.isLoading}
           >
             <Stack spacing="0" direction="row" display="inline">
-              {Object.values(FormColorTheme).map((color) => (
+              {Object.values(FormColorTheme).map((color, idx) => (
                 <Radio
+                  key={idx}
                   display="inline"
                   width="1rem"
                   value={color}
@@ -328,7 +264,10 @@ export const DesignDrawer = (): JSX.Element | null => {
           <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
         </FormControl>
 
-        <FormControl isReadOnly={isLoading} isInvalid={!!errors.estTimeTaken}>
+        <FormControl
+          isDisabled={startPageMutation.isLoading}
+          isInvalid={!!errors.estTimeTaken}
+        >
           <FormLabel>Time taken to complete form (minutes)</FormLabel>
           <Controller
             name="estTimeTaken"
@@ -351,14 +290,17 @@ export const DesignDrawer = (): JSX.Element | null => {
           <FormErrorMessage>{errors.estTimeTaken?.message}</FormErrorMessage>
         </FormControl>
 
-        <FormControl isReadOnly={isLoading} isInvalid={!!errors.paragraph}>
+        <FormControl
+          isDisabled={startPageMutation.isLoading}
+          isInvalid={!!errors.paragraph}
+        >
           <FormLabel>Instructions for your form</FormLabel>
           <Textarea {...register('paragraph')} />
           <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>
         </FormControl>
 
         <FormFieldDrawerActions
-          isLoading={isLoading}
+          isLoading={startPageMutation.isLoading}
           isSaveEnabled={isDirty}
           handleClick={handleClick}
           handleCancel={handleClose}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useEffect } from 'react'
+
+import { FormLogoState } from '~shared/types'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+import { useEnv } from '~features/env/queries'
+
+import {
+  resetDesignStoreSelector,
+  setCustomLogoMetaSelector,
+  setStartPageDataSelector,
+  startPageDataSelector,
+  useDesignStore,
+} from '../../useDesignStore'
+
+import { DesignDrawer } from './DesignDrawer'
+
+export const DesignDrawerContainer = (): JSX.Element | null => {
+  const { data: { logoBucketUrl } = {} } = useEnv()
+  const { data: form } = useAdminForm()
+
+  const {
+    startPageData,
+    setStartPageData,
+    setCustomLogoMeta,
+    resetDesignStore,
+  } = useDesignStore(
+    useCallback(
+      (state) => ({
+        startPageData: startPageDataSelector(state),
+        setStartPageData: setStartPageDataSelector(state),
+        setCustomLogoMeta: setCustomLogoMetaSelector(state),
+        resetDesignStore: resetDesignStoreSelector(state),
+      }),
+      [],
+    ),
+  )
+
+  // Load existing start page and custom logo into drawer form
+  useEffect(() => {
+    if (!form) return
+    setStartPageData({
+      ...form.startPage,
+      estTimeTaken: !form.startPage.estTimeTaken
+        ? ''
+        : form.startPage.estTimeTaken,
+      attachment:
+        form.startPage.logo.state !== FormLogoState.Custom
+          ? {}
+          : {
+              file: Object.defineProperty(
+                new File([''], form.startPage.logo.fileName, {
+                  type: 'image/jpeg',
+                }),
+                'size',
+                { value: form.startPage.logo.fileSizeInBytes },
+              ),
+              srcUrl: `${logoBucketUrl}/${form.startPage.logo.fileId}`,
+            },
+    })
+    if (form?.startPage.logo.state === FormLogoState.Custom)
+      setCustomLogoMeta(form?.startPage.logo)
+    return resetDesignStore
+  }, [
+    form,
+    logoBucketUrl,
+    resetDesignStore,
+    setCustomLogoMeta,
+    setStartPageData,
+  ])
+
+  if (!startPageData) return null
+
+  return <DesignDrawer />
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
@@ -39,12 +39,9 @@ export const DesignDrawerContainer = (): JSX.Element | null => {
   // Load existing start page and custom logo into drawer form
   useEffect(() => {
     if (!form) return
-    console.log('set')
     setStartPageData({
       ...form.startPage,
-      estTimeTaken: !form.startPage.estTimeTaken
-        ? ''
-        : form.startPage.estTimeTaken,
+      estTimeTaken: form.startPage.estTimeTaken || '',
       attachment:
         form.startPage.logo.state !== FormLogoState.Custom
           ? {}
@@ -59,8 +56,8 @@ export const DesignDrawerContainer = (): JSX.Element | null => {
               srcUrl: `${logoBucketUrl}/${form.startPage.logo.fileId}`,
             },
     })
-    if (form?.startPage.logo.state === FormLogoState.Custom)
-      setCustomLogoMeta(form?.startPage.logo)
+    if (form.startPage.logo.state === FormLogoState.Custom)
+      setCustomLogoMeta(form.startPage.logo)
     return resetDesignStore
   }, [
     form,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
@@ -39,6 +39,7 @@ export const DesignDrawerContainer = (): JSX.Element | null => {
   // Load existing start page and custom logo into drawer form
   useEffect(() => {
     if (!form) return
+    console.log('set')
     setStartPageData({
       ...form.startPage,
       estTimeTaken: !form.startPage.estTimeTaken
@@ -71,5 +72,5 @@ export const DesignDrawerContainer = (): JSX.Element | null => {
 
   if (!startPageData) return null
 
-  return <DesignDrawer />
+  return <DesignDrawer startPageData={startPageData} />
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/index.ts
@@ -1,0 +1,1 @@
+export { DesignDrawerContainer as default } from './DesignDrawerContainer'

--- a/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
@@ -25,9 +25,7 @@ export type DesignStore = {
   startPageData?: FormStartPageInput
   customLogoMeta?: CustomLogoMeta
   setStartPageData: (startPageInput: FormStartPageInput) => void
-  setAttachment: (attachment: UploadedImage) => void
   setCustomLogoMeta: (customLogoMetaData: CustomLogoMeta) => void
-  resetCustomLogoMeta: () => void
   resetDesignStore: () => void
 }
 
@@ -38,24 +36,10 @@ export const useDesignStore = create<DesignStore>(
       if (isEqual(current.startPageData, startPageData)) return
       set({ startPageData })
     },
-    setAttachment: (attachment: UploadedImage) => {
-      const current = get()
-      if (!current.startPageData) return
-      if (isEqual(current.startPageData.attachment, attachment)) return
-      set({
-        startPageData: {
-          ...current.startPageData,
-          attachment,
-        },
-      })
-    },
     setCustomLogoMeta: (customLogoMeta: CustomLogoMeta) => {
       const current = get()
       if (isEqual(current.customLogoMeta, customLogoMeta)) return
       set({ customLogoMeta })
-    },
-    resetCustomLogoMeta: () => {
-      set({ customLogoMeta: undefined })
     },
     resetDesignStore: () => {
       set({
@@ -78,17 +62,9 @@ export const setStartPageDataSelector = (
   state: DesignStore,
 ): DesignStore['setStartPageData'] => state.setStartPageData
 
-export const setAttachmentSelector = (
-  state: DesignStore,
-): DesignStore['setAttachment'] => state.setAttachment
-
 export const setCustomLogoMetaSelector = (
   state: DesignStore,
 ): DesignStore['setCustomLogoMeta'] => state.setCustomLogoMeta
-
-export const resetCustomLogoMetaSelector = (
-  state: DesignStore,
-): DesignStore['resetCustomLogoMeta'] => state.resetCustomLogoMeta
 
 export const resetDesignStoreSelector = (
   state: DesignStore,


### PR DESCRIPTION
## Problem

Currently, we fetch the logo from s3 bucket in order to display it, but this creates some asynchrony issues in rendering the design drawer which increases the complexity of the render. Instead, we should just mock the logo data based on the information associated with the form.

Closes #4450 

## Solution
- Pull useEffect out into a container component to ensure that the useAdminForm query loads before we call useForm to render the drawer contents.
- Add keys to color theme radio to get the component to stop complaining in the console.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
