### PR TITLE
fix(form-v2): use publicform context to selectively render components in form end page

### DIFF
--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -6,9 +6,9 @@ import { FormInstructions } from './FormInstructions'
 
 export const FormInstructionsContainer = (): JSX.Element | null => {
   const { sectionRefs } = useFormSections()
-  const { form } = usePublicFormContext()
+  const { form, submissionData } = usePublicFormContext()
 
-  return (
+  return submissionData ? null : (
     <FormInstructions
       content={form?.startPage.paragraph}
       colorTheme={form?.startPage.colorTheme}

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -21,11 +21,12 @@ import { useFormSections } from '../FormFields/FormSectionsContext'
 
 import { SidebarLink } from './SidebarLink'
 
-export const SectionSidebar = (): JSX.Element => {
+export const SectionSidebar = (): JSX.Element | null => {
   const { activeSectionId, navigatedSectionTitle } = useFormSections()
   const {
     miniHeaderRef,
     sectionScrollData,
+    submissionData,
     isMobileDrawerOpen,
     onMobileDrawerClose,
   } = usePublicFormContext()
@@ -77,7 +78,13 @@ export const SectionSidebar = (): JSX.Element => {
       </Drawer>
     )
 
-  return (
+  return submissionData ? (
+    <Box
+      flex={1}
+      d={{ base: 'none', md: 'initial' }}
+      minW={sectionScrollData.length > 0 ? '20%' : undefined}
+    ></Box>
+  ) : (
     <Box
       as="nav"
       aria-label="Form sections"

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -21,7 +21,7 @@ import { useFormSections } from '../FormFields/FormSectionsContext'
 
 import { SidebarLink } from './SidebarLink'
 
-export const SectionSidebar = (): JSX.Element | null => {
+export const SectionSidebar = (): JSX.Element => {
   const { activeSectionId, navigatedSectionTitle } = useFormSections()
   const {
     miniHeaderRef,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We should only show the form end page without other public form components such as sections and instructions.

Closes [#4453]

## Solution
<!-- How did you solve the problem? -->
public form context provider has property `submissionData` which is not null when form is submitted successfully. utilized that to selectively render components at form end page.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<details>


https://user-images.githubusercontent.com/102740235/182192377-49430351-6958-4189-a2e8-e2e3ee40a536.mp4
</details>

**AFTER**:
<!-- [insert screenshot here] -->
<details>

https://user-images.githubusercontent.com/102740235/182192398-16320d6f-65cc-4f7c-a31e-eacfa5dcafd8.mp4
</details>

