### PR TITLE
perf: preload inter fonts from app directory in storybook preview-head

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,10 +1,85 @@
-<!-- Preloading fonts to prevent flakiness in snapshots caused by font changing.
-This is not a complete solution as our own fonts contain font feature settings
-Google Fonts do not provide, but will likely be enough. -->
-
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<!-- Preloading fonts to prevent flakiness in snapshots caused by font changing. -->
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-  rel="stylesheet"
+  rel="preload"
+  href="../src/assets/fonts/Inter-Light.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-LightItalic.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-Regular.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-Italic.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-Medium.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-MediumItalic.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-SemiBold.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-SemiBoldItalic.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-Bold.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-BoldItalic.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-roman.var.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+<link
+  rel="preload"
+  href="../src/assets/fonts/Inter-italic.var.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
 />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Trying this to further reduce flakiness in story by directly loading fonts used in the app before stories even gets rendered.
 

## Solution
**Improvements**:

- preload with app's font files instead of using Google Fonts.

