### PR TITLE
fix(form-v2): remove additional log in step when switching from AngularJS to React

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -41,14 +41,18 @@ export const useAuth = (): AuthContextProps => {
 
 // Provider hook that creates auth object and handles state
 const useProvideAuth = () => {
+  const [isLocalStorageAuthenticated, setIsLocalStorageAuthenticated] =
+    useLocalStorage<boolean>(LOGGED_IN_KEY)
   // TODO #4279: Remove after React rollout is complete
   const { data: user } = useQuery<UserDto>(
     userKeys.base,
     () => fetchUser(),
     // 10 minutes staletime, do not need to retrieve so often.
-    { staleTime: 600000 },
+    {
+      staleTime: 600000,
+      onSuccess: () => setIsLocalStorageAuthenticated(true),
+    },
   )
-  const [isLocalStorageAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
   const isAuthenticated = isLocalStorageAuthenticated || !!user
 
   // Return the user object and auth methods

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,7 +1,13 @@
 import { createContext, FC, useContext } from 'react'
+import { useQuery } from 'react-query'
+
+import { UserDto } from '~shared/types'
 
 import { LOGGED_IN_KEY } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
+import { fetchUser } from '~services/UserService'
+
+import { userKeys } from '~features/user/queries'
 
 type AuthContextProps = {
   isAuthenticated?: boolean
@@ -35,7 +41,15 @@ export const useAuth = (): AuthContextProps => {
 
 // Provider hook that creates auth object and handles state
 const useProvideAuth = () => {
-  const [isAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
+  // TODO #4279: Remove after React rollout is complete
+  const { data: user } = useQuery<UserDto>(
+    userKeys.base,
+    () => fetchUser(),
+    // 10 minutes staletime, do not need to retrieve so often.
+    { staleTime: 600000 },
+  )
+  const [isLocalStorageAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
+  const isAuthenticated = isLocalStorageAuthenticated || !!user
 
   // Return the user object and auth methods
   return {

--- a/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
+++ b/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
@@ -19,7 +19,8 @@ function reactSwitchBannerController($q, $window) {
         .when(AdminService.adminChooseEnvironment(ui))
         // Refresh the page after changing the environment cookie
         .then(() => {
-          $window.location.reload(true)
+          $window.location.assign('/workspace')
+          // $window.location.reload(true)
         })
         .catch((error) => {
           console.error('switch to react failed:', error)

--- a/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
+++ b/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
@@ -17,10 +17,9 @@ function reactSwitchBannerController($q, $window) {
     return (
       $q
         .when(AdminService.adminChooseEnvironment(ui))
-        // Refresh the page after changing the environment cookie
+        // Navigate to the React workspace page after changing the environment cookie
         .then(() => {
           $window.location.assign('/workspace')
-          // $window.location.reload(true)
         })
         .catch((error) => {
           console.error('switch to react failed:', error)


### PR DESCRIPTION
## Problem
User appears logged out after switching from AngularJS to React

Closes #4287 

## Solution
- Instead of refreshing the `/#!/forms` page, navigate to `/workspace`
- Query for `user` to ascertain logged in state

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
**Features**:

## Before & After Screenshots

**BEFORE**:
![Recording 2022-08-02 at 12 16 09](https://user-images.githubusercontent.com/56983748/182290762-4d9cd1a0-e4d4-4482-b01b-b4d6aa45b691.gif)


**AFTER**:
![Recording 2022-08-02 at 13 04 42](https://user-images.githubusercontent.com/56983748/182296026-bb114da1-a111-47a8-8b82-ff36cd67da6d.gif)



## Tests
- [x] Make sure `is-logged-in` is not present in localStorage. 
Log in to the AngularJS app. Click the banner message to switch to React. 
You should be brought to the Workspace page (`/workspace`) on the React app and remain logged in.
`is-logged-in` in localStorage should have the value `true`
`v2-admin-ui` cookie should have the value `react`.
