### PR TITLE
fix(form-v2): add loading state for form builder

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -93,16 +93,14 @@ export const FormBuilder = ({
             </Droppable>
           )}
         </Flex>
-        {isLoading ? (
-          <Skeleton mt="1.5rem" h="4rem" />
-        ) : (
+        <Skeleton mt="1.5rem" isLoaded={!isLoading}>
           <Button
             _hover={{ bg: 'primary.200' }}
             py="1.5rem"
-            mt="1.5rem"
             variant="outline"
             borderColor="secondary.200"
             colorScheme="secondary"
+            width="100%"
             height="auto"
             onClick={() => {
               setEditEndPage()
@@ -111,7 +109,7 @@ export const FormBuilder = ({
           >
             <Text textStyle="subhead-2">Customise Thank you page</Text>
           </Button>
-        )}
+        </Skeleton>
       </Flex>
     </Flex>
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from 'react'
 import { Droppable } from 'react-beautiful-dnd'
-import { Box, Flex, FlexProps, Skeleton, Text } from '@chakra-ui/react'
+import { Box, Flex, FlexProps, Skeleton, Stack, Text } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 
@@ -24,6 +25,15 @@ interface FormBuilderProps extends FlexProps {
   placeholderProps: DndPlaceholderProps
 }
 
+const BuilderFieldsSkeleton = (): JSX.Element => (
+  <Stack spacing="1rem">
+    <Skeleton h="2rem" mb="2rem" />
+    <Skeleton h="4rem" />
+    <Skeleton h="4rem" />
+    <Skeleton h="4rem" />
+  </Stack>
+)
+
 export const FormBuilder = ({
   placeholderProps,
   ...props
@@ -32,6 +42,7 @@ export const FormBuilder = ({
   const { handleBuilderClick } = useCreatePageSidebar()
   const setEditEndPage = useBuilderAndDesignStore(setToEditEndPageSelector)
 
+  const isLoading = useMemo(() => builderFields === null, [builderFields])
   const bg = useBgColor(useDesignColorTheme())
 
   return (
@@ -49,7 +60,7 @@ export const FormBuilder = ({
         <StartPageView />
         <Flex bg="white" p={{ base: 0, md: '2.5rem' }} flexDir="column">
           {builderFields === null ? (
-            <Skeleton h="13.75rem" m={{ base: '1.5rem', md: 0 }}></Skeleton>
+            <BuilderFieldsSkeleton />
           ) : (
             <Droppable droppableId={FIELD_LIST_DROP_ID}>
               {(provided, snapshot) =>
@@ -82,22 +93,25 @@ export const FormBuilder = ({
             </Droppable>
           )}
         </Flex>
-        <Button
-          isDisabled={builderFields === null}
-          _hover={{ bg: 'primary.200' }}
-          py="1.5rem"
-          mt="1.5rem"
-          variant="outline"
-          borderColor="secondary.200"
-          colorScheme="secondary"
-          height="auto"
-          onClick={() => {
-            setEditEndPage()
-            handleBuilderClick()
-          }}
-        >
-          <Text textStyle="subhead-2">Customise Thank you page</Text>
-        </Button>
+        {isLoading ? (
+          <Skeleton mt="1.5rem" h="4rem" />
+        ) : (
+          <Button
+            _hover={{ bg: 'primary.200' }}
+            py="1.5rem"
+            mt="1.5rem"
+            variant="outline"
+            borderColor="secondary.200"
+            colorScheme="secondary"
+            height="auto"
+            onClick={() => {
+              setEditEndPage()
+              handleBuilderClick()
+            }}
+          >
+            <Text textStyle="subhead-2">Customise Thank you page</Text>
+          </Button>
+        )}
       </Flex>
     </Flex>
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -26,7 +26,7 @@ interface FormBuilderProps extends FlexProps {
 }
 
 const BuilderFieldsSkeleton = (): JSX.Element => (
-  <Stack spacing="1rem">
+  <Stack spacing="1rem" m={{ base: '0.75rem', md: 0 }}>
     <Skeleton h="2rem" mb="2rem" />
     <Skeleton h="4rem" />
     <Skeleton h="4rem" />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -1,5 +1,5 @@
 import { Droppable } from 'react-beautiful-dnd'
-import { Box, Flex, FlexProps, Text } from '@chakra-ui/react'
+import { Box, Flex, FlexProps, Skeleton, Text } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 
@@ -48,37 +48,42 @@ export const FormBuilder = ({
       <Flex flexDir="column" w="100%" maxW="57rem" h="fit-content">
         <StartPageView />
         <Flex bg="white" p={{ base: 0, md: '2.5rem' }} flexDir="column">
-          <Droppable droppableId={FIELD_LIST_DROP_ID}>
-            {(provided, snapshot) =>
-              builderFields?.length ? (
-                <Box
-                  pos="relative"
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                >
-                  <BuilderFields
-                    fields={builderFields}
+          {builderFields === null ? (
+            <Skeleton h="13.75rem" m={{ base: '1.5rem', md: 0 }}></Skeleton>
+          ) : (
+            <Droppable droppableId={FIELD_LIST_DROP_ID}>
+              {(provided, snapshot) =>
+                builderFields.length ? (
+                  <Box
+                    pos="relative"
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                  >
+                    <BuilderFields
+                      fields={builderFields}
+                      isDraggingOver={snapshot.isDraggingOver}
+                    />
+                    {provided.placeholder}
+                    <BuilderAndDesignPlaceholder
+                      placeholderProps={placeholderProps}
+                      isDraggingOver={snapshot.isDraggingOver}
+                    />
+                  </Box>
+                ) : (
+                  <EmptyFormPlaceholder
+                    m={{ base: '1.5rem', md: 0 }}
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
                     isDraggingOver={snapshot.isDraggingOver}
+                    onClick={handleBuilderClick}
                   />
-                  {provided.placeholder}
-                  <BuilderAndDesignPlaceholder
-                    placeholderProps={placeholderProps}
-                    isDraggingOver={snapshot.isDraggingOver}
-                  />
-                </Box>
-              ) : (
-                <EmptyFormPlaceholder
-                  m={{ base: '1.5rem', md: 0 }}
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  isDraggingOver={snapshot.isDraggingOver}
-                  onClick={handleBuilderClick}
-                />
-              )
-            }
-          </Droppable>
+                )
+              }
+            </Droppable>
+          )}
         </Flex>
         <Button
+          isDisabled={builderFields === null}
           _hover={{ bg: 'primary.200' }}
           py="1.5rem"
           mt="1.5rem"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -105,7 +105,9 @@ export const StartPageView = () => {
         titleColor={titleColor}
         showHeader
         loggedInId={
-          form?.authType !== FormAuthType.NIL ? PREVIEW_MOCK_UINFIN : undefined
+          !form || form.authType === FormAuthType.NIL
+            ? undefined
+            : PREVIEW_MOCK_UINFIN
         }
       />
       <Box mt="1.5rem">


### PR DESCRIPTION
## Problem
Currently, the loading state for the form builder displays the empty form placeholder. This PR adds a proper loading screen for the form.

**Actually** closes #4371 

## Solution
In `FormBuilder.tsx`, add skeleton loading state when `builderFields` is `null`. 

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/25571626/182508280-c3a24074-fa5f-4e68-b630-155a6341008c.png">
