### PR TITLE
feat(v2): add duplicate form feature

### DIFF
--- a/frontend/src/features/workspace/WorkspaceService.ts
+++ b/frontend/src/features/workspace/WorkspaceService.ts
@@ -37,3 +37,23 @@ export const createStorageModeForm = async (
     ({ data }) => data,
   )
 }
+
+export const dupeEmailModeForm = async (
+  formId: string,
+  body: CreateEmailFormBodyDto,
+): Promise<FormDto> => {
+  return ApiService.post<FormDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/duplicate`,
+    body,
+  ).then(({ data }) => data)
+}
+
+export const dupeStorageModeForm = async (
+  formId: string,
+  body: CreateStorageFormBodyDto,
+): Promise<FormDto> => {
+  return ApiService.post<FormDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/duplicate`,
+    body,
+  ).then(({ data }) => data)
+}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -12,10 +12,8 @@ import { ModalCloseButton } from '~components/Modal'
 
 import { SaveSecretKeyScreen } from './CreateFormModalContent/SaveSecretKeyScreen'
 import { CreateFormModal, CreateFormModalProps } from './CreateFormModal'
-import {
-  CreateFormWizardInputProps,
-  CreateFormWizardProvider,
-} from './CreateFormWizardContext'
+import { CreateFormWizardInputProps } from './CreateFormWizardContext'
+import { CreateFormWizardProvider } from './CreateFormWizardProvider'
 
 export default {
   title: 'Pages/WorkspacePage/CreateFormModal',

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   ModalBody,
   ModalHeader,
+  Skeleton,
   Text,
 } from '@chakra-ui/react'
 
@@ -26,8 +27,13 @@ import { FormResponseOptions } from './FormResponseOptions'
 const FORM_TITLE_LENGTH_WARNING = 65
 
 export const CreateFormDetailsScreen = (): JSX.Element => {
-  const { formMethods, handleDetailsSubmit, isLoading, modalHeader } =
-    useCreateFormWizard()
+  const {
+    formMethods,
+    handleDetailsSubmit,
+    isLoading,
+    isFetching,
+    modalHeader,
+  } = useCreateFormWizard()
   const {
     register,
     control,
@@ -49,10 +55,12 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
         <Container maxW="42.5rem" p={0}>
           <FormControl isRequired isInvalid={!!errors.title} mb="2.25rem">
             <FormLabel useMarkdownForDescription>Form name</FormLabel>
-            <Input
-              autoFocus
-              {...register('title', FORM_TITLE_VALIDATION_RULES)}
-            />
+            <Skeleton isLoaded={!isFetching}>
+              <Input
+                autoFocus
+                {...register('title', FORM_TITLE_VALIDATION_RULES)}
+              />
+            </Skeleton>
             <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
             {titleInputValue?.length > FORM_TITLE_LENGTH_WARNING ? (
               <FormFieldMessage>
@@ -64,12 +72,14 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             <FormLabel>
               How do you want to receive your form responses?
             </FormLabel>
-            <Controller
-              name="responseMode"
-              control={control}
-              render={({ field }) => <FormResponseOptions {...field} />}
-              rules={{ required: 'Please select a form response mode' }}
-            />
+            <Skeleton isLoaded={!isFetching}>
+              <Controller
+                name="responseMode"
+                control={control}
+                render={({ field }) => <FormResponseOptions {...field} />}
+                rules={{ required: 'Please select a form response mode' }}
+              />
+            </Skeleton>
             <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
           </FormControl>
           {responseModeValue === FormResponseMode.Email && (
@@ -87,6 +97,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
             type="submit"
             isLoading={isLoading}
+            isDisabled={isFetching}
             onClick={handleDetailsSubmit}
             isFullWidth
           >

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -26,7 +26,8 @@ import { FormResponseOptions } from './FormResponseOptions'
 const FORM_TITLE_LENGTH_WARNING = 65
 
 export const CreateFormDetailsScreen = (): JSX.Element => {
-  const { formMethods, handleDetailsSubmit, isLoading } = useCreateFormWizard()
+  const { formMethods, handleDetailsSubmit, isLoading, modalHeader } =
+    useCreateFormWizard()
   const {
     register,
     control,
@@ -41,7 +42,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     <>
       <ModalHeader color="secondary.700">
         <Container maxW="42.5rem" p={0}>
-          Set up your form
+          {modalHeader}
         </Container>
       </ModalHeader>
       <ModalBody whiteSpace="pre-line">

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -16,6 +16,7 @@ import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormFieldMessage from '~components/FormControl/FormFieldMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import InlineMessage from '~components/InlineMessage'
 import Input from '~components/Input'
 
 import { useCreateFormWizard } from '../CreateFormWizardContext'
@@ -33,6 +34,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     isLoading,
     isFetching,
     modalHeader,
+    containsMyInfoFields,
   } = useCreateFormWizard()
   const {
     register,
@@ -76,12 +78,23 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               <Controller
                 name="responseMode"
                 control={control}
-                render={({ field }) => <FormResponseOptions {...field} />}
+                render={({ field }) => (
+                  <FormResponseOptions
+                    containsMyInfoFields={containsMyInfoFields}
+                    {...field}
+                  />
+                )}
                 rules={{ required: 'Please select a form response mode' }}
               />
             </Skeleton>
             <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
           </FormControl>
+          {containsMyInfoFields && (
+            <InlineMessage useMarkdown mt="-1rem" mb="1rem">
+              {`This form contains MyInfo fields. Only **Email** mode is supported at
+              this point.`}
+            </InlineMessage>
+          )}
           {responseModeValue === FormResponseMode.Email && (
             <FormControl isRequired isInvalid={!!errors.emails} mb="2.25rem">
               <FormLabel

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -7,6 +7,7 @@ import Badge from '~components/Badge'
 import Tile from '~components/Tile'
 
 export interface FormResponseOptionsProps {
+  containsMyInfoFields: boolean
   onChange: (option: FormResponseMode) => void
   value: FormResponseMode
 }
@@ -28,7 +29,7 @@ const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
 export const FormResponseOptions = forwardRef<
   FormResponseOptionsProps,
   'button'
->(({ value, onChange }, ref) => {
+>(({ value, onChange, containsMyInfoFields }, ref) => {
   return (
     <Stack spacing="1rem" w="100%" direction={{ base: 'column', md: 'row' }}>
       <Tile
@@ -36,6 +37,7 @@ export const FormResponseOptions = forwardRef<
         icon={BiLockAlt}
         badge={<Badge colorScheme="success">Recommended</Badge>}
         isActive={value === FormResponseMode.Encrypt}
+        isDisabled={containsMyInfoFields}
         onClick={() => onChange(FormResponseMode.Encrypt)}
         isFullWidth
         flex={1}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -31,6 +31,8 @@ export type CreateFormWizardContextReturn = {
   >
   handleBackToDetails: () => void
   keypair: ReturnType<typeof formsgSdk.crypto.generate>
+  // Whether any async operation is in progress.
+  isFetching: boolean
   isLoading: boolean
   modalHeader: string
 }

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -35,6 +35,7 @@ export type CreateFormWizardContextReturn = {
   isFetching: boolean
   isLoading: boolean
   modalHeader: string
+  containsMyInfoFields: boolean
 }
 
 export const CreateFormWizardContext = createContext<

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -1,11 +1,9 @@
-import { createContext, useContext, useMemo, useState } from 'react'
-import { useForm, UseFormHandleSubmit, UseFormReturn } from 'react-hook-form'
+import { createContext, useContext } from 'react'
+import { UseFormHandleSubmit, UseFormReturn } from 'react-hook-form'
 
 import { FormResponseMode } from '~shared/types/form/form'
 
 import formsgSdk from '~utils/formSdk'
-
-import { useCreateFormMutations } from '~features/workspace/mutations'
 
 export enum CreateFormFlowStates {
   Landing = 'landing',
@@ -21,7 +19,7 @@ export type CreateFormWizardInputProps = {
   storageAck?: boolean
 }
 
-type CreateFormWizardContextReturn = {
+export type CreateFormWizardContextReturn = {
   currentStep: CreateFormFlowStates
   direction: number
   formMethods: UseFormReturn<CreateFormWizardInputProps>
@@ -34,91 +32,12 @@ type CreateFormWizardContextReturn = {
   handleBackToDetails: () => void
   keypair: ReturnType<typeof formsgSdk.crypto.generate>
   isLoading: boolean
+  modalHeader: string
 }
 
-const CreateFormWizardContext = createContext<
+export const CreateFormWizardContext = createContext<
   CreateFormWizardContextReturn | undefined
 >(undefined)
-
-const INITIAL_STEP_STATE: [CreateFormFlowStates, number] = [
-  CreateFormFlowStates.Details,
-  0 | 1 | -1,
-]
-
-const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
-  const [[currentStep, direction], setCurrentStep] =
-    useState(INITIAL_STEP_STATE)
-
-  /**
-   * Only used for storage mode forms, but generated first so that the key is
-   * immutable per open of the modal.
-   */
-  const keypair = useMemo(() => formsgSdk.crypto.generate(), [])
-
-  const formMethods = useForm<CreateFormWizardInputProps>({
-    defaultValues: {
-      responseMode: FormResponseMode.Encrypt,
-    },
-  })
-
-  const { handleSubmit } = formMethods
-
-  const { createEmailModeFormMutation, createStorageModeFormMutation } =
-    useCreateFormMutations()
-
-  const handleCreateStorageModeForm = handleSubmit(
-    ({ title, responseMode }) => {
-      if (responseMode !== FormResponseMode.Encrypt) return
-
-      return createStorageModeFormMutation.mutate({
-        title,
-        responseMode,
-        publicKey: keypair.publicKey,
-      })
-    },
-  )
-
-  const handleDetailsSubmit = handleSubmit((inputs) => {
-    if (inputs.responseMode === FormResponseMode.Email) {
-      return createEmailModeFormMutation.mutate({
-        emails: inputs.emails.filter(Boolean),
-        title: inputs.title,
-        responseMode: inputs.responseMode,
-      })
-    }
-    setCurrentStep([CreateFormFlowStates.Landing, 1])
-  })
-
-  const handleBackToDetails = () => {
-    setCurrentStep([CreateFormFlowStates.Details, -1])
-  }
-
-  return {
-    isLoading:
-      createEmailModeFormMutation.isLoading ||
-      createStorageModeFormMutation.isLoading,
-    keypair,
-    currentStep,
-    direction,
-    formMethods,
-    handleDetailsSubmit,
-    handleCreateStorageModeForm,
-    handleBackToDetails,
-  }
-}
-
-export const CreateFormWizardProvider = ({
-  children,
-}: {
-  children: React.ReactNode
-}): JSX.Element => {
-  const values = useCreateFormWizardContext()
-  return (
-    <CreateFormWizardContext.Provider value={values}>
-      {children}
-    </CreateFormWizardContext.Provider>
-  )
-}
 
 export const useCreateFormWizard = (): CreateFormWizardContextReturn => {
   const context = useContext(CreateFormWizardContext)

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -89,6 +89,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
   }
 
   return {
+    isFetching: false,
     isLoading:
       createEmailModeFormMutation.isLoading ||
       createStorageModeFormMutation.isLoading,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -25,7 +25,7 @@ interface UseCommonFormWizardProviderProps {
 
 export const useCommonFormWizardProvider = ({
   defaultValues,
-}: UseCommonFormWizardProviderProps) => {
+}: UseCommonFormWizardProviderProps = {}) => {
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
 
@@ -101,6 +101,8 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     handleCreateStorageModeForm,
     handleBackToDetails,
     modalHeader: 'Set up your form',
+    // Creation will never contain any fields.
+    containsMyInfoFields: false,
   }
 }
 

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { FormResponseMode } from '~shared/types'
+
+import formsgSdk from '~utils/formSdk'
+
+import { useCreateFormMutations } from '~features/workspace/mutations'
+
+import {
+  CreateFormFlowStates,
+  CreateFormWizardContext,
+  CreateFormWizardContextReturn,
+  CreateFormWizardInputProps,
+} from './CreateFormWizardContext'
+
+export const INITIAL_STEP_STATE: [CreateFormFlowStates, -1 | 1 | 0] = [
+  CreateFormFlowStates.Details,
+  -1,
+]
+
+interface UseCommonFormWizardProviderProps {
+  defaultValues?: Partial<CreateFormWizardInputProps>
+}
+
+export const useCommonFormWizardProvider = ({
+  defaultValues,
+}: UseCommonFormWizardProviderProps) => {
+  const [[currentStep, direction], setCurrentStep] =
+    useState(INITIAL_STEP_STATE)
+
+  /**
+   * Only used for storage mode forms, but generated first so that the key is
+   * immutable per open of the modal.
+   */
+  const keypair = useMemo(() => formsgSdk.crypto.generate(), [])
+
+  const formMethods = useForm<CreateFormWizardInputProps>({
+    defaultValues,
+  })
+
+  return {
+    formMethods,
+    keypair,
+    currentStep,
+    direction,
+    setCurrentStep,
+  }
+}
+
+const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
+  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
+    useCommonFormWizardProvider({
+      defaultValues: {
+        responseMode: FormResponseMode.Encrypt,
+      },
+    })
+
+  const { handleSubmit } = formMethods
+
+  const { createEmailModeFormMutation, createStorageModeFormMutation } =
+    useCreateFormMutations()
+
+  const handleCreateStorageModeForm = handleSubmit(
+    ({ title, responseMode }) => {
+      if (responseMode !== FormResponseMode.Encrypt) return
+
+      return createStorageModeFormMutation.mutate({
+        title,
+        responseMode,
+        publicKey: keypair.publicKey,
+      })
+    },
+  )
+
+  const handleDetailsSubmit = handleSubmit((inputs) => {
+    if (inputs.responseMode === FormResponseMode.Email) {
+      return createEmailModeFormMutation.mutate({
+        emails: inputs.emails.filter(Boolean),
+        title: inputs.title,
+        responseMode: inputs.responseMode,
+      })
+    }
+    setCurrentStep([CreateFormFlowStates.Landing, 1])
+  })
+
+  const handleBackToDetails = () => {
+    setCurrentStep([CreateFormFlowStates.Details, -1])
+  }
+
+  return {
+    isLoading:
+      createEmailModeFormMutation.isLoading ||
+      createStorageModeFormMutation.isLoading,
+    keypair,
+    currentStep,
+    direction,
+    formMethods,
+    handleDetailsSubmit,
+    handleCreateStorageModeForm,
+    handleBackToDetails,
+    modalHeader: 'Set up your form',
+  }
+}
+
+export const CreateFormWizardProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => {
+  const values = useCreateFormWizardContext()
+  return (
+    <CreateFormWizardContext.Provider value={values}>
+      {children}
+    </CreateFormWizardContext.Provider>
+  )
+}

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -1,0 +1,78 @@
+import { FormResponseMode } from '~shared/types'
+
+import { useCreateFormMutations } from '~features/workspace/mutations'
+
+import {
+  CreateFormFlowStates,
+  CreateFormWizardContext,
+  CreateFormWizardContextReturn,
+} from '../CreateFormModal/CreateFormWizardContext'
+import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
+
+export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
+  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
+    useCommonFormWizardProvider({
+      defaultValues: {
+        responseMode: FormResponseMode.Encrypt,
+      },
+    })
+
+  const { handleSubmit } = formMethods
+
+  const { createEmailModeFormMutation, createStorageModeFormMutation } =
+    useCreateFormMutations()
+
+  const handleCreateStorageModeForm = handleSubmit(
+    ({ title, responseMode }) => {
+      if (responseMode !== FormResponseMode.Encrypt) return
+
+      return createStorageModeFormMutation.mutate({
+        title,
+        responseMode,
+        publicKey: keypair.publicKey,
+      })
+    },
+  )
+
+  const handleDetailsSubmit = handleSubmit((inputs) => {
+    if (inputs.responseMode === FormResponseMode.Email) {
+      return createEmailModeFormMutation.mutate({
+        emails: inputs.emails.filter(Boolean),
+        title: inputs.title,
+        responseMode: inputs.responseMode,
+      })
+    }
+    setCurrentStep([CreateFormFlowStates.Landing, 1])
+  })
+
+  const handleBackToDetails = () => {
+    setCurrentStep([CreateFormFlowStates.Details, -1])
+  }
+
+  return {
+    isLoading:
+      createEmailModeFormMutation.isLoading ||
+      createStorageModeFormMutation.isLoading,
+    keypair,
+    currentStep,
+    direction,
+    formMethods,
+    handleDetailsSubmit,
+    handleCreateStorageModeForm,
+    handleBackToDetails,
+    modalHeader: 'Duplicate form',
+  }
+}
+
+export const DupeFormWizardProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => {
+  const values = useDupeFormWizardContext()
+  return (
+    <CreateFormWizardContext.Provider value={values}>
+      {children}
+    </CreateFormWizardContext.Provider>
+  )
+}

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -4,7 +4,7 @@ import { FormResponseMode } from '~shared/types'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { isMyInfo } from '~features/myinfo/utils'
-import { useCreateFormMutations } from '~features/workspace/mutations'
+import { useDuplicateFormMutations } from '~features/workspace/mutations'
 import { useWorkspace } from '~features/workspace/queries'
 import { makeDuplicateFormTitle } from '~features/workspace/utils/createDuplicateFormTitle'
 
@@ -67,14 +67,16 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { handleSubmit } = formMethods
 
-  const { createEmailModeFormMutation, createStorageModeFormMutation } =
-    useCreateFormMutations()
+  const { dupeEmailModeFormMutation, dupeStorageModeFormMutation } =
+    useDuplicateFormMutations()
 
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
-      if (responseMode !== FormResponseMode.Encrypt) return
+      if (responseMode !== FormResponseMode.Encrypt || !activeFormMeta?._id)
+        return
 
-      return createStorageModeFormMutation.mutate({
+      return dupeStorageModeFormMutation.mutate({
+        formIdToDuplicate: activeFormMeta._id,
         title,
         responseMode,
         publicKey: keypair.publicKey,
@@ -83,8 +85,10 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   )
 
   const handleDetailsSubmit = handleSubmit((inputs) => {
+    if (!activeFormMeta?._id) return
     if (inputs.responseMode === FormResponseMode.Email) {
-      return createEmailModeFormMutation.mutate({
+      return dupeEmailModeFormMutation.mutate({
+        formIdToDuplicate: activeFormMeta._id,
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: inputs.responseMode,
@@ -100,8 +104,8 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   return {
     isFetching: isWorkspaceLoading || isPreviewFormLoading,
     isLoading:
-      createEmailModeFormMutation.isLoading ||
-      createStorageModeFormMutation.isLoading,
+      dupeEmailModeFormMutation.isLoading ||
+      dupeStorageModeFormMutation.isLoading,
     keypair,
     currentStep,
     direction,

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { FormResponseMode } from '~shared/types'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
+import { isMyInfo } from '~features/myinfo/utils'
 import { useCreateFormMutations } from '~features/workspace/mutations'
 import { useWorkspace } from '~features/workspace/queries'
 import { makeDuplicateFormTitle } from '~features/workspace/utils/createDuplicateFormTitle'
@@ -26,12 +27,13 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
       /* enabled= */ !!activeFormMeta,
     )
 
+  const containsMyInfoFields = useMemo(
+    () => !!previewFormData?.form.form_fields.find((ff) => isMyInfo(ff)),
+    [previewFormData?.form.form_fields],
+  )
+
   const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider({
-      defaultValues: {
-        responseMode: FormResponseMode.Encrypt,
-      },
-    })
+    useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
 
@@ -48,6 +50,9 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
     reset({
       ...getValues(),
+      responseMode: containsMyInfoFields
+        ? FormResponseMode.Email
+        : FormResponseMode.Encrypt,
       title: makeDuplicateFormTitle(previewFormData.form.title, dashboardForms),
     })
   }, [
@@ -57,6 +62,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     isPreviewFormLoading,
     isWorkspaceLoading,
     dashboardForms,
+    containsMyInfoFields,
   ])
 
   const { handleSubmit } = formMethods
@@ -103,6 +109,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     handleDetailsSubmit,
     handleCreateStorageModeForm,
     handleBackToDetails,
+    containsMyInfoFields,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -7,18 +7,19 @@ import {
 
 import { ModalCloseButton } from '~components/Modal'
 
-import { CreateFormModalContent } from './CreateFormModalContent'
-import { CreateFormWizardProvider } from './CreateFormWizardProvider'
+import { CreateFormModalContent } from '../CreateFormModal/CreateFormModalContent'
 
-export type CreateFormModalProps = Pick<
+import { DupeFormWizardProvider } from './DupeFormWizardProvider'
+
+export type DuplicateFormModalProps = Pick<
   UseDisclosureReturn,
   'onClose' | 'isOpen'
 >
 
-export const CreateFormModal = ({
+export const DuplicateFormModal = ({
   isOpen,
   onClose,
-}: CreateFormModalProps): JSX.Element => {
+}: DuplicateFormModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -29,11 +30,9 @@ export const CreateFormModal = ({
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
         <ModalCloseButton />
-        {isOpen && (
-          <CreateFormWizardProvider>
-            <CreateFormModalContent />
-          </CreateFormWizardProvider>
-        )}
+        <DupeFormWizardProvider>
+          <CreateFormModalContent />
+        </DupeFormWizardProvider>
       </ModalContent>
     </Modal>
   )

--- a/frontend/src/features/workspace/components/DuplicateFormModal/index.ts
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/index.ts
@@ -1,0 +1,1 @@
+export { DuplicateFormModal } from './DuplicateFormModal'

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActions.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActions.tsx
@@ -9,7 +9,7 @@ import { RowActionsDrawer } from './RowActionsDrawer'
 import { RowActionsDropdown } from './RowActionsDropdown'
 
 export interface RowActionsProps {
-  formMeta: Pick<AdminDashboardFormMetaDto, '_id' | 'status'>
+  formMeta: AdminDashboardFormMetaDto
   isDisabled?: boolean
 }
 

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
@@ -19,12 +19,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
-import { FormStatus } from '~shared/types'
-
 import Button, { ButtonProps } from '~components/Button'
 import IconButton from '~components/IconButton'
-
-import { ShareFormModal } from '~features/admin-form/share'
 
 import { RowActionsProps } from './RowActions'
 import { useRowActionDropdown } from './useRowActionDropdown'
@@ -44,8 +40,8 @@ export const RowActionsDrawer = ({
     handleEditForm,
     handleManageFormAccess,
     handlePreviewForm,
-    shareFormModalDisclosure,
-  } = useRowActionDropdown(formMeta._id)
+    handleShareForm,
+  } = useRowActionDropdown(formMeta)
 
   const buttonProps: Partial<ButtonProps> = useMemo(
     () => ({
@@ -59,12 +55,6 @@ export const RowActionsDrawer = ({
 
   return (
     <Box display={{ md: 'none' }}>
-      <ShareFormModal
-        isOpen={shareFormModalDisclosure.isOpen}
-        formId={formMeta._id}
-        onClose={shareFormModalDisclosure.onClose}
-        isFormPrivate={formMeta.status === FormStatus.Private}
-      />
       <IconButton
         variant="clear"
         aria-label="More options"
@@ -106,7 +96,7 @@ export const RowActionsDrawer = ({
               </Button>
               <Button
                 {...buttonProps}
-                onClick={shareFormModalDisclosure.onOpen}
+                onClick={handleShareForm}
                 leftIcon={<BiShareAlt fontSize="1.25rem" />}
               >
                 Share form

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
@@ -7,15 +7,11 @@ import {
 } from 'react-icons/bi'
 import { ButtonGroup, MenuButton, MenuDivider } from '@chakra-ui/react'
 
-import { FormStatus } from '~shared/types'
-
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
 import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
 import Button from '~components/Button'
 import IconButton from '~components/IconButton'
 import Menu from '~components/Menu'
-
-import { ShareFormModal } from '~features/admin-form/share'
 
 import { RowActionsProps } from './RowActions'
 import { useRowActionDropdown } from './useRowActionDropdown'
@@ -30,79 +26,71 @@ export const RowActionsDropdown = ({
     handleDeleteForm,
     handleDuplicateForm,
     handleManageFormAccess,
-    shareFormModalDisclosure,
-  } = useRowActionDropdown(formMeta._id)
+    handleShareForm,
+  } = useRowActionDropdown(formMeta)
 
   return (
-    <>
-      <ShareFormModal
-        isOpen={shareFormModalDisclosure.isOpen}
-        formId={formMeta._id}
-        onClose={shareFormModalDisclosure.onClose}
-        isFormPrivate={formMeta.status === FormStatus.Private}
-      />
-      <Menu
-        placement="bottom-end"
-        // Prevents massize render load when there are a ton of rows
-        isLazy
-      >
-        {({ isOpen }) => (
-          <>
-            <ButtonGroup
-              isAttached
-              variant="outline"
-              colorScheme="secondary"
-              display={{ base: 'none', md: 'flex' }}
+    <Menu
+      placement="bottom-end"
+      // Prevents massize render load when there are a ton of rows
+      isLazy
+    >
+      {({ isOpen }) => (
+        <>
+          <ButtonGroup
+            isAttached
+            variant="outline"
+            colorScheme="secondary"
+            display={{ base: 'none', md: 'flex' }}
+          >
+            <Button px="1.5rem" mr="-1px" onClick={handleEditForm}>
+              Edit
+            </Button>
+            <MenuButton
+              as={IconButton}
+              isDisabled={isDisabled}
+              _active={{ bg: 'secondary.100' }}
+              isActive={isOpen}
+              aria-label="More actions"
+              icon={isOpen ? <BxsChevronUp /> : <BxsChevronDown />}
+            />
+          </ButtonGroup>
+          <Menu.List>
+            <Menu.Item
+              onClick={handlePreviewForm}
+              icon={<BiShow fontSize="1.25rem" />}
             >
-              <Button px="1.5rem" mr="-1px" onClick={handleEditForm}>
-                Edit
-              </Button>
-              <MenuButton
-                as={IconButton}
-                isDisabled={isDisabled}
-                _active={{ bg: 'secondary.100' }}
-                isActive={isOpen}
-                aria-label="More actions"
-                icon={isOpen ? <BxsChevronUp /> : <BxsChevronDown />}
-              />
-            </ButtonGroup>
-            <Menu.List>
-              <Menu.Item
-                onClick={handlePreviewForm}
-                icon={<BiShow fontSize="1.25rem" />}
-              >
-                Preview
-              </Menu.Item>
-              <Menu.Item
-                onClick={handleDuplicateForm}
-                icon={<BiDuplicate fontSize="1.25rem" />}
-              >
-                Duplicate
-              </Menu.Item>
-              <Menu.Item
-                onClick={shareFormModalDisclosure.onOpen}
-                icon={<BiShareAlt fontSize="1.25rem" />}
-              >
-                Share form
-              </Menu.Item>
-              <Menu.Item
-                onClick={handleManageFormAccess}
-                icon={<BiUserPlus fontSize="1.25rem" />}
-              >
-                Manage form access
-              </Menu.Item>
-              <MenuDivider />
-              <Menu.Item
-                onClick={handleDeleteForm}
-                color="danger.500"
-                icon={<BiTrash fontSize="1.25rem" />}
-              >
-                Delete
-              </Menu.Item>
-            </Menu.List>
-          </>
-        )}
-      </Menu>
-    </>
+              Preview
+            </Menu.Item>
+            <Menu.Item
+              onClick={handleDuplicateForm}
+              icon={<BiDuplicate fontSize="1.25rem" />}
+            >
+              Duplicate
+            </Menu.Item>
+            <Menu.Item
+              onClick={handleShareForm}
+              icon={<BiShareAlt fontSize="1.25rem" />}
+            >
+              Share form
+            </Menu.Item>
+            <Menu.Item
+              onClick={handleManageFormAccess}
+              icon={<BiUserPlus fontSize="1.25rem" />}
+            >
+              Manage form access
+            </Menu.Item>
+            <MenuDivider />
+            <Menu.Item
+              onClick={handleDeleteForm}
+              color="danger.500"
+              icon={<BiTrash fontSize="1.25rem" />}
+            >
+              Delete
+            </Menu.Item>
+          </Menu.List>
+        </>
+      )}
+    </Menu>
   )
 }

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom'
-import { useDisclosure } from '@chakra-ui/react'
 
-import { FormId } from '~shared/types/form/form'
+import { AdminDashboardFormMetaDto } from '~shared/types/form/form'
 
 import { ADMINFORM_PREVIEW_ROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 
@@ -13,28 +12,28 @@ type UseRowActionDropdownReturn = {
   handleDuplicateForm: () => void
   handleManageFormAccess: () => void
   handleDeleteForm: () => void
-  shareFormModalDisclosure: ReturnType<typeof useDisclosure>
+  handleShareForm: () => void
 }
 
 export const useRowActionDropdown = (
-  formId: FormId,
+  formMeta: AdminDashboardFormMetaDto,
 ): UseRowActionDropdownReturn => {
   const navigate = useNavigate()
 
-  const shareFormModalDisclosure = useDisclosure()
-  const { onOpenDupeFormModal } = useWorkspaceRowsContext()
+  const { onOpenDupeFormModal, onOpenShareFormModal } =
+    useWorkspaceRowsContext()
 
   return {
-    shareFormModalDisclosure,
-    handleEditForm: () => navigate(`${ADMINFORM_ROUTE}/${formId}`),
+    handleShareForm: () => onOpenShareFormModal(formMeta),
+    handleEditForm: () => navigate(`${ADMINFORM_ROUTE}/${formMeta._id}`),
     handlePreviewForm: () =>
       window.open(
-        `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
+        `${window.location.origin}${ADMINFORM_ROUTE}/${formMeta._id}/${ADMINFORM_PREVIEW_ROUTE}`,
       ),
-    handleDuplicateForm: () => onOpenDupeFormModal(formId),
+    handleDuplicateForm: () => onOpenDupeFormModal(formMeta),
     handleManageFormAccess: () =>
-      console.log(`manage form access button clicked for ${formId}`),
+      console.log(`manage form access button clicked for ${formMeta._id}`),
     handleDeleteForm: () =>
-      console.log(`delete form  button clicked for ${formId}`),
+      console.log(`delete form  button clicked for ${formMeta._id}`),
   }
 }

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowActionDropdown.ts
@@ -5,6 +5,8 @@ import { FormId } from '~shared/types/form/form'
 
 import { ADMINFORM_PREVIEW_ROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 
+import { useWorkspaceRowsContext } from '../WorkspaceRowsContext'
+
 type UseRowActionDropdownReturn = {
   handleEditForm: () => void
   handlePreviewForm: () => void
@@ -20,6 +22,7 @@ export const useRowActionDropdown = (
   const navigate = useNavigate()
 
   const shareFormModalDisclosure = useDisclosure()
+  const { onOpenDupeFormModal } = useWorkspaceRowsContext()
 
   return {
     shareFormModalDisclosure,
@@ -28,8 +31,7 @@ export const useRowActionDropdown = (
       window.open(
         `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
       ),
-    handleDuplicateForm: () =>
-      console.log(`duplicate form button clicked for ${formId}`),
+    handleDuplicateForm: () => onOpenDupeFormModal(formId),
     handleManageFormAccess: () =>
       console.log(`manage form access button clicked for ${formId}`),
     handleDeleteForm: () =>

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -29,7 +29,7 @@ export const WorkspaceFormRow = ({
     return dayjs(formMeta.lastModified).calendar(null, RELATIVE_DATE_FORMAT)
   }, [formMeta.lastModified])
 
-  const { handleEditForm } = useRowActionDropdown(formMeta._id)
+  const { handleEditForm } = useRowActionDropdown(formMeta)
 
   return (
     <Box pos="relative">

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRows.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRows.tsx
@@ -6,6 +6,7 @@ import { CONTAINER_MAXW } from '~features/workspace/WorkspacePage'
 
 import { WorkspaceFormRow } from './WorkspaceFormRow'
 import { WorkspaceFormRowSkeleton } from './WorkspaceFormRowSkeleton'
+import { WorkspaceRowsProvider } from './WorkspaceRowsContext'
 
 export interface WorkspaceFormRowsProps {
   rows: AdminDashboardFormMetaDto[]
@@ -30,11 +31,14 @@ export const WorkspaceFormRows = ({
   if (isLoading) {
     return <WorkspaceFormRowsSkeleton />
   }
+
   return (
-    <Stack maxW={CONTAINER_MAXW} m="auto" spacing={0} divider={<Divider />}>
-      {rows.map((meta) => (
-        <WorkspaceFormRow px="2rem" key={meta._id} formMeta={meta} />
-      ))}
-    </Stack>
+    <WorkspaceRowsProvider>
+      <Stack maxW={CONTAINER_MAXW} m="auto" spacing={0} divider={<Divider />}>
+        {rows.map((meta) => (
+          <WorkspaceFormRow px="2rem" key={meta._id} formMeta={meta} />
+        ))}
+      </Stack>
+    </WorkspaceRowsProvider>
   )
 }

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -1,0 +1,60 @@
+// Context contains the current acted upon row.
+// Mostly used by actions such as duplication of form from the workspace row.
+
+import { createContext, useContext, useState } from 'react'
+import { useDisclosure } from '@chakra-ui/react'
+
+import CreateFormModal from '../CreateFormModal'
+
+interface WorkspaceRowsContextReturn {
+  activeFormId?: string
+  onOpenDupeFormModal: (id?: string) => void
+  onCloseDupeFormModal: () => void
+}
+
+const WorkspaceRowsContext = createContext<WorkspaceRowsContextReturn | null>(
+  null,
+)
+
+export const WorkspaceRowsProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const [activeFormId, setActiveFormId] = useState<string>()
+
+  const dupeFormModalDisclosure = useDisclosure()
+
+  const handleOpenDupeFormModal = (id?: string) => {
+    setActiveFormId(id)
+    if (id) {
+      dupeFormModalDisclosure.onOpen()
+    }
+  }
+
+  return (
+    <WorkspaceRowsContext.Provider
+      value={{
+        activeFormId,
+        onOpenDupeFormModal: handleOpenDupeFormModal,
+        onCloseDupeFormModal: dupeFormModalDisclosure.onClose,
+      }}
+    >
+      <CreateFormModal
+        isOpen={dupeFormModalDisclosure.isOpen}
+        onClose={dupeFormModalDisclosure.onClose}
+      />
+      {children}
+    </WorkspaceRowsContext.Provider>
+  )
+}
+
+export const useWorkspaceRowsContext = () => {
+  const context = useContext(WorkspaceRowsContext)
+  if (context === null) {
+    throw new Error(
+      'useWorkspaceRowsContext must be used within a WorkspaceRowsProvider',
+    )
+  }
+  return context
+}

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -8,7 +8,7 @@ import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types'
 
 import { ShareFormModal } from '~features/admin-form/share'
 
-import CreateFormModal from '../CreateFormModal'
+import { DuplicateFormModal } from '../DuplicateFormModal'
 
 interface WorkspaceRowsContextReturn {
   activeFormMeta?: AdminDashboardFormMetaDto
@@ -55,7 +55,7 @@ export const WorkspaceRowsProvider = ({
         onCloseDupeFormModal: dupeFormModalDisclosure.onClose,
       }}
     >
-      <CreateFormModal
+      <DuplicateFormModal
         isOpen={dupeFormModalDisclosure.isOpen}
         onClose={dupeFormModalDisclosure.onClose}
       />

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -4,12 +4,17 @@
 import { createContext, useContext, useState } from 'react'
 import { useDisclosure } from '@chakra-ui/react'
 
+import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types'
+
+import { ShareFormModal } from '~features/admin-form/share'
+
 import CreateFormModal from '../CreateFormModal'
 
 interface WorkspaceRowsContextReturn {
-  activeFormId?: string
-  onOpenDupeFormModal: (id?: string) => void
+  activeFormMeta?: AdminDashboardFormMetaDto
+  onOpenDupeFormModal: (meta?: AdminDashboardFormMetaDto) => void
   onCloseDupeFormModal: () => void
+  onOpenShareFormModal: (meta?: AdminDashboardFormMetaDto) => void
 }
 
 const WorkspaceRowsContext = createContext<WorkspaceRowsContextReturn | null>(
@@ -21,28 +26,44 @@ export const WorkspaceRowsProvider = ({
 }: {
   children: React.ReactNode
 }) => {
-  const [activeFormId, setActiveFormId] = useState<string>()
+  const [activeFormMeta, setActiveFormMeta] =
+    useState<AdminDashboardFormMetaDto>()
 
   const dupeFormModalDisclosure = useDisclosure()
+  const shareFormModalDisclosure = useDisclosure()
 
-  const handleOpenDupeFormModal = (id?: string) => {
-    setActiveFormId(id)
-    if (id) {
+  const onOpenDupeFormModal = (meta?: AdminDashboardFormMetaDto) => {
+    setActiveFormMeta(meta)
+    if (meta) {
       dupeFormModalDisclosure.onOpen()
+    }
+  }
+
+  const onOpenShareFormModal = (meta?: AdminDashboardFormMetaDto) => {
+    setActiveFormMeta(meta)
+    if (meta) {
+      shareFormModalDisclosure.onOpen()
     }
   }
 
   return (
     <WorkspaceRowsContext.Provider
       value={{
-        activeFormId,
-        onOpenDupeFormModal: handleOpenDupeFormModal,
+        activeFormMeta,
+        onOpenDupeFormModal,
+        onOpenShareFormModal,
         onCloseDupeFormModal: dupeFormModalDisclosure.onClose,
       }}
     >
       <CreateFormModal
         isOpen={dupeFormModalDisclosure.isOpen}
         onClose={dupeFormModalDisclosure.onClose}
+      />
+      <ShareFormModal
+        isOpen={shareFormModalDisclosure.isOpen}
+        formId={activeFormMeta?._id}
+        onClose={shareFormModalDisclosure.onClose}
+        isFormPrivate={activeFormMeta?.status === FormStatus.Private}
       />
       {children}
     </WorkspaceRowsContext.Provider>

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -16,16 +16,21 @@ import { useToast } from '~hooks/useToast'
 import { adminFormKeys } from '~features/admin-form/common/queries'
 
 import { workspaceKeys } from './queries'
-import { createEmailModeForm, createStorageModeForm } from './WorkspaceService'
+import {
+  createEmailModeForm,
+  createStorageModeForm,
+  dupeEmailModeForm,
+  dupeStorageModeForm,
+} from './WorkspaceService'
 
-export const useCreateFormMutations = () => {
+const useCommonHooks = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'danger', isClosable: true })
 
   const handleSuccess = useCallback(
-    (data: FormDto) => {
-      queryClient.setQueryData(adminFormKeys.id(data._id), data)
+    (data: Pick<FormDto, '_id'>) => {
+      queryClient.invalidateQueries(adminFormKeys.base)
       queryClient.invalidateQueries(workspaceKeys.all)
       navigate(`${ADMINFORM_ROUTE}/${data._id}`)
     },
@@ -40,6 +45,15 @@ export const useCreateFormMutations = () => {
     },
     [toast],
   )
+
+  return {
+    handleSuccess,
+    handleError,
+  }
+}
+
+export const useCreateFormMutations = () => {
+  const { handleSuccess, handleError } = useCommonHooks()
 
   const createEmailModeFormMutation = useMutation<
     FormDto,
@@ -62,5 +76,40 @@ export const useCreateFormMutations = () => {
   return {
     createEmailModeFormMutation,
     createStorageModeFormMutation,
+  }
+}
+
+export const useDuplicateFormMutations = () => {
+  const { handleSuccess, handleError } = useCommonHooks()
+
+  const dupeEmailModeFormMutation = useMutation<
+    FormDto,
+    ApiError,
+    CreateEmailFormBodyDto & { formIdToDuplicate: string }
+  >(
+    ({ formIdToDuplicate, ...params }) =>
+      dupeEmailModeForm(formIdToDuplicate, params),
+    {
+      onSuccess: handleSuccess,
+      onError: handleError,
+    },
+  )
+
+  const dupeStorageModeFormMutation = useMutation<
+    FormDto,
+    ApiError,
+    CreateStorageFormBodyDto & { formIdToDuplicate: string }
+  >(
+    ({ formIdToDuplicate, ...params }) =>
+      dupeStorageModeForm(formIdToDuplicate, params),
+    {
+      onSuccess: handleSuccess,
+      onError: handleError,
+    },
+  )
+
+  return {
+    dupeEmailModeFormMutation,
+    dupeStorageModeFormMutation,
   }
 }

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -15,6 +15,7 @@ import { useToast } from '~hooks/useToast'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
 
+import { workspaceKeys } from './queries'
 import { createEmailModeForm, createStorageModeForm } from './WorkspaceService'
 
 export const useCreateFormMutations = () => {
@@ -25,6 +26,7 @@ export const useCreateFormMutations = () => {
   const handleSuccess = useCallback(
     (data: FormDto) => {
       queryClient.setQueryData(adminFormKeys.id(data._id), data)
+      queryClient.invalidateQueries(workspaceKeys.all)
       navigate(`${ADMINFORM_ROUTE}/${data._id}`)
     },
     [navigate, queryClient],

--- a/frontend/src/features/workspace/queries.ts
+++ b/frontend/src/features/workspace/queries.ts
@@ -6,7 +6,7 @@ import { ApiError } from '~typings/core'
 
 import { getDashboardView } from './WorkspaceService'
 
-const workspaceKeys = {
+export const workspaceKeys = {
   all: ['workspace'] as const,
 }
 

--- a/frontend/src/features/workspace/utils/createDuplicateFormTitle.ts
+++ b/frontend/src/features/workspace/utils/createDuplicateFormTitle.ts
@@ -1,0 +1,24 @@
+import { AdminDashboardFormMetaDto } from '~shared/types'
+
+/**
+ * Determine the form title when duplicating a form. Appends copy number to the end of the title.
+ */
+export const makeDuplicateFormTitle = (
+  originalTitle: string,
+  dashboardForms: AdminDashboardFormMetaDto[],
+) => {
+  const titlePrefix = originalTitle + '_'
+  // Only appends number when original form is copied, treats duplicates as originals too
+  let copyIndex = 1
+  // Only match forms titles with same prefix
+  const formsWithTitlePrefix = new Set(
+    dashboardForms
+      .map((form) => form.title)
+      .filter((title) => title.startsWith(titlePrefix)),
+  )
+
+  while (formsWithTitlePrefix.has(`${titlePrefix}${copyIndex}`)) {
+    copyIndex++
+  }
+  return `${titlePrefix}${copyIndex}`
+}

--- a/frontend/src/theme/components/Tile.ts
+++ b/frontend/src/theme/components/Tile.ts
@@ -15,7 +15,10 @@ export const Tile: ComponentMultiStyleConfig<typeof parts> = {
       padding: '1.5rem',
       height: 'auto',
       _hover: {
-        bgColor: 'primary.100',
+        bg: 'primary.100',
+        _disabled: {
+          bg: 'initial',
+        },
       },
       _focus: {
         borderColor: 'transparent',
@@ -24,16 +27,20 @@ export const Tile: ComponentMultiStyleConfig<typeof parts> = {
         boxShadow: '0 0 0 2px var(--chakra-colors-primary-500) !important',
       },
       _active: {
-        bgColor: 'primary.200',
+        bg: 'primary.200',
         // borderColor: 'transparent',
         boxShadow: '0 0 0 3px var(--chakra-colors-primary-400)',
+        _disabled: {
+          boxShadow: 'none',
+          bg: 'initial',
+        },
         _focus: {
           // NOTE: For the boxShadow styling, due to conflicts with the focus-visible package,
           // the !important is required to display the boxShadow styling correctly.
           boxShadow: '0 0 0 3px var(--chakra-colors-primary-500) !important',
         },
       },
-      bgColor: 'white',
+      bg: 'white',
       border: '1px solid',
       borderColor: 'neutral.300',
       whiteSpace: 'pre-line',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR implements form duplication feature from the workspace. This PR also moves all workspace rows related modals into a context so they are only created once.

Closes #4300 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- add form duplication feature

**Improvements**:

- feat: move `ShareFormModal` into `WorkspaceRowsContext`
- feat: extract common form wizard context to reuse in dupe form modal


## Before & After Screenshots
Maybe...? Unless...?

