### PR TITLE
test: add integration tests for verified field OTPs on auth forms

### DIFF
--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import bcrypt from 'bcrypt'
 import { ObjectId } from 'bson-ext'
 import { subMinutes, subYears } from 'date-fns'
@@ -60,6 +61,9 @@ jest.mock('nodemailer', () => ({
   }),
 }))
 
+jest.mock('@opengovsg/spcp-auth-client')
+const MockAuthClient = mocked(SPCPAuthClient, true)
+
 describe('public-forms.verification.routes', () => {
   let mockTransaction: IVerificationSchema
   let mockTransactionId: string
@@ -75,6 +79,10 @@ describe('public-forms.verification.routes', () => {
 
   let mockSPFormId: string
   const MOCK_EMAIL_DOMAIN_SP = 'sp.com'
+
+  let mockCPFormId: string
+  const MOCK_EMAIL_DOMAIN_CP = 'cp.com'
+  const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
 
   beforeAll(async () => {
     await dbHandler.connect()
@@ -120,6 +128,19 @@ describe('public-forms.verification.routes', () => {
       },
     })
     mockSPFormId = String(SPForm._id)
+
+    // Form with CP auth
+    const { form: CPForm } = await dbHandler.insertEmailForm({
+      mailDomain: MOCK_EMAIL_DOMAIN_CP,
+      formOptions: {
+        esrvcId: 'mockEsrvcId',
+        authType: FormAuthType.CP,
+        hasCaptcha: false,
+        status: FormStatus.Public,
+        form_fields: [emailField, mobileField],
+      },
+    })
+    mockCPFormId = String(CPForm._id)
 
     // Mock transaction with both email and mobile fields
     mockTransaction = await VerificationModel.create({
@@ -342,6 +363,33 @@ describe('public-forms.verification.routes', () => {
       expect(response.text).toEqual(getReasonPhrase(StatusCodes.CREATED))
     })
 
+    it('should return 201 when using CorpPass auth and user is logged in to CorpPass', async () => {
+      // Arrange
+      const mockJwt = 'mockJwt'
+
+      mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
+        cb(null, {
+          userName: 'S1234567A',
+          userInfo: 'MyCorpPassUEN',
+        }),
+      )
+
+      // Act
+      const response = await request
+        .post(
+          `/forms/${mockCPFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/otp/generate`,
+        )
+        .send({
+          answer: 'mail@me.com',
+        })
+        // Note cookie is for CorpPass, not SingPass
+        .set('Cookie', [`jwtCp=${mockJwt}`])
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.CREATED)
+      expect(response.text).toEqual(getReasonPhrase(StatusCodes.CREATED))
+    })
+
     it('should return 400 when fieldType is email but the provided email is not valid', async () => {
       // Arrange
       const expectedResponse = {
@@ -499,6 +547,34 @@ describe('public-forms.verification.routes', () => {
         })
         // Note cookie is for SingPass, not CorpPass
         .set('Cookie', [`jwtSp=${mockJwt}`])
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST)
+      expect(response.body).toEqual(expectedResponse)
+    })
+
+    it('should return 400 when using CorpPass auth but user is not logged in to CorpPass', async () => {
+      // Arrange
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      const mockJwt = 'mockJwt'
+
+      mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
+        cb(new Error()),
+      )
+
+      // Act
+      const response = await request
+        .post(
+          `/forms/${mockCPFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/otp/generate`,
+        )
+        .send({
+          answer: 'mail@me.com',
+        })
+        // Note cookie is for CorpPass, not SingPass
+        .set('Cookie', [`jwtCp=${mockJwt}`])
 
       // Assert
       expect(response.status).toBe(StatusCodes.BAD_REQUEST)

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -74,18 +74,6 @@ jest.mock('nodemailer', () => ({
 jest.mock('@opengovsg/spcp-auth-client')
 const MockAuthClient = mocked(SPCPAuthClient, true)
 
-jest.mock('@opengovsg/myinfo-gov-client', () => ({
-  MyInfoGovClient: jest.fn().mockReturnValue({
-    extractUinFin: jest.fn(),
-  }),
-  MyInfoMode: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoMode,
-  MyInfoSource: jest.requireActual('@opengovsg/myinfo-gov-client').MyInfoSource,
-  MyInfoAddressType: jest.requireActual('@opengovsg/myinfo-gov-client')
-    .MyInfoAddressType,
-  MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
-    .MyInfoAttribute,
-}))
-
 const MyInfoHashModel = getMyInfoHashModel(mongoose)
 
 jest.mock('jsonwebtoken')
@@ -107,15 +95,15 @@ describe('public-forms.verification.routes', () => {
   let mockSPFormId: string
   const MOCK_EMAIL_DOMAIN_SP = 'sp.com'
 
-  let mockSGIDFormId: string
-  const MOCK_EMAIL_DOMAIN_SGID = 'sgid.com'
+  let mockCPFormId: string
+  const MOCK_EMAIL_DOMAIN_CP = 'cp.com'
+  const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
 
   let mockMyInfoFormId: string
   const MOCK_EMAIL_DOMAIN_MYINFO = 'myinfo.com'
 
-  let mockCPFormId: string
-  const MOCK_EMAIL_DOMAIN_CP = 'cp.com'
-  const mockCpClient = mocked(MockAuthClient.mock.instances[1], true)
+  let mockSGIDFormId: string
+  const MOCK_EMAIL_DOMAIN_SGID = 'sgid.com'
 
   beforeAll(async () => {
     await dbHandler.connect()

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -13,6 +13,7 @@ import { MockedObjectDeep } from 'ts-jest/dist/utils/testing'
 import { mocked } from 'ts-jest/utils'
 
 import getFormModel from 'src/app/models/form.server.model'
+import { SpOidcClient } from 'src/app/modules/spcp/sp.oidc.client'
 import {
   generateFieldParams,
   MOCK_HASHED_OTP,
@@ -30,7 +31,11 @@ import MockTwilio from 'tests/integration/helpers/twilio'
 import { generateDefaultField } from 'tests/unit/backend/helpers/generate-form-data'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
-import { BasicField } from '../../../../../../../shared/types'
+import {
+  BasicField,
+  FormAuthType,
+  FormStatus,
+} from '../../../../../../../shared/types'
 import {
   NUM_OTP_RETRIES,
   WAIT_FOR_OTP_SECONDS,
@@ -68,6 +73,9 @@ describe('public-forms.verification.routes', () => {
   const MOCK_EMAIL = `mock@${MOCK_VALID_EMAIL_DOMAIN}`
   let MockTransport: MockedObjectDeep<Mail>
 
+  let mockSPFormId: string
+  const MOCK_EMAIL_DOMAIN_SP = 'sp.com'
+
   beforeAll(async () => {
     await dbHandler.connect()
     MockTransport = mocked(nodemailer.createTransport(), true)
@@ -99,6 +107,19 @@ describe('public-forms.verification.routes', () => {
       },
     })
     mockVerifiableFormId = String(verifiableForm._id)
+
+    // Form with SP auth
+    const { form: SPForm } = await dbHandler.insertEmailForm({
+      mailDomain: MOCK_EMAIL_DOMAIN_SP,
+      formOptions: {
+        esrvcId: 'mockEsrvcId',
+        authType: FormAuthType.SP,
+        hasCaptcha: false,
+        status: FormStatus.Public,
+        form_fields: [emailField, mobileField],
+      },
+    })
+    mockSPFormId = String(SPForm._id)
 
     // Mock transaction with both email and mobile fields
     mockTransaction = await VerificationModel.create({
@@ -297,6 +318,30 @@ describe('public-forms.verification.routes', () => {
       expect(response.text).toBe(getReasonPhrase(StatusCodes.CREATED))
     })
 
+    it('should return 201 when using SingPass auth and user is logged in to SingPass', async () => {
+      // Arrange
+      const mockJwt = 'mockJwt'
+
+      jest.spyOn(SpOidcClient.prototype, 'verifyJwt').mockResolvedValueOnce({
+        userName: 'S1234567A',
+      })
+
+      // Act
+      const response = await request
+        .post(
+          `/forms/${mockSPFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/otp/generate`,
+        )
+        .send({
+          answer: 'mail@me.com',
+        })
+        // Note cookie is for SingPass, not CorpPass
+        .set('Cookie', [`jwtSp=${mockJwt}`])
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.CREATED)
+      expect(response.text).toEqual(getReasonPhrase(StatusCodes.CREATED))
+    })
+
     it('should return 400 when fieldType is email but the provided email is not valid', async () => {
       // Arrange
       const expectedResponse = {
@@ -426,6 +471,34 @@ describe('public-forms.verification.routes', () => {
         .send({
           answer: 'mail@me.com',
         })
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST)
+      expect(response.body).toEqual(expectedResponse)
+    })
+
+    it('should return 400 when using SingPass auth but user is not logged in to SingPass', async () => {
+      // Arrange
+      const expectedResponse = {
+        message: 'Sorry, something went wrong. Please refresh and try again.',
+      }
+
+      const mockJwt = 'mockJwt'
+
+      jest
+        .spyOn(SpOidcClient.prototype, 'verifyJwt')
+        .mockRejectedValueOnce(new Error())
+
+      // Act
+      const response = await request
+        .post(
+          `/forms/${mockSPFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/otp/generate`,
+        )
+        .send({
+          answer: 'mail@me.com',
+        })
+        // Note cookie is for SingPass, not CorpPass
+        .set('Cookie', [`jwtSp=${mockJwt}`])
 
       // Assert
       expect(response.status).toBe(StatusCodes.BAD_REQUEST)

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import MyInfoClient, { IMyInfoConfig } from '@opengovsg/myinfo-gov-client'
 import SPCPAuthClient from '@opengovsg/spcp-auth-client'
 import bcrypt from 'bcrypt'
 import { ObjectId } from 'bson-ext'
@@ -86,11 +85,6 @@ jest.mock('@opengovsg/myinfo-gov-client', () => ({
   MyInfoAttribute: jest.requireActual('@opengovsg/myinfo-gov-client')
     .MyInfoAttribute,
 }))
-
-const MockMyInfoGovClient = mocked(
-  new MyInfoClient.MyInfoGovClient({} as IMyInfoConfig),
-  true,
-)
 
 const MyInfoHashModel = getMyInfoHashModel(mongoose)
 
@@ -457,8 +451,6 @@ describe('public-forms.verification.routes', () => {
 
     it('should return 201 when using MyInfo auth and user is logged in to MyInfo', async () => {
       // Arrange
-      MockMyInfoGovClient.extractUinFin.mockReturnValueOnce(MOCK_UINFIN)
-
       await MyInfoHashModel.updateHashes(
         MOCK_UINFIN,
         mockMyInfoFormId,
@@ -709,6 +701,11 @@ describe('public-forms.verification.routes', () => {
       const expectedResponse = {
         message: 'Sorry, something went wrong. Please refresh and try again.',
       }
+      const cookie = JSON.stringify({
+        accessToken: 'mockAccessToken',
+        usedCount: 0,
+        state: MyInfoCookieState.Error,
+      })
 
       // Act
       const response = await request
@@ -718,6 +715,10 @@ describe('public-forms.verification.routes', () => {
         .send({
           answer: 'mail@me.com',
         })
+        .set('Cookie', [
+          // The j: indicates that the cookie is in JSON
+          `${MYINFO_COOKIE_NAME}=j:${encodeURIComponent(cookie)}`,
+        ])
 
       // Assert
       expect(response.status).toBe(StatusCodes.BAD_REQUEST)


### PR DESCRIPTION
## Problem
Closes #4117 

## Solution

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

Referenced https://github.com/opengovsg/FormSG/blob/develop/src/app/modules/submission/email-submission/__tests__/email-submission.routes.spec.ts for auth setups in the tests

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Check `src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts.test.ts` passes when run locally