### PR TITLE
fix(form-v2): add double negation to fix react displaying 0

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -104,7 +104,7 @@ export const FormFields = ({
   return (
     <FormProvider {...formMethods}>
       <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
-        {formFields?.length && (
+        {!!formFields?.length && (
           <Box bg={'white'} py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
             <Stack spacing="2.25rem">
               {!isEmpty(fieldPrefillMap) && (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
0 displaying in empty form @karrui 

Closes #4473 

## Solution
<!-- How did you solve the problem? -->
!!conditional. I didn't know that react will render anything even if it is falsey as long as its not undefined or bool. Sorry!

https://stackoverflow.com/questions/53048037/react-showing-0-instead-of-nothing-with-short-circuit-conditional-component


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
look at #4473 

**AFTER**:
<!-- [insert screenshot here] -->

![image](https://user-images.githubusercontent.com/102740235/182521150-4aba095b-cbff-4d7e-8550-cfb05e19d964.png)

