### PR TITLE
fix(form-v2): update CSP and image URL computation to use the correct URL

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -109,6 +109,7 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
       return uploadImageMutation
         .mutateAsync(inputs.attachment.file)
         .then((uploadedFileData) => {
+          console.log(uploadedFileData.fileId)
           return {
             ...output,
             ...uploadedFileData,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -109,7 +109,6 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
       return uploadImageMutation
         .mutateAsync(inputs.attachment.file)
         .then((uploadedFileData) => {
-          console.log(uploadedFileData.fileId)
           return {
             ...output,
             ...uploadedFileData,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput.tsx
@@ -50,7 +50,7 @@ export const UploadImageInput = forwardRef<UploadImageInputProps, 'div'>(
         maxSizeMB: MAX_UPLOAD_FILE_SIZE / MB,
         alwaysKeepResolution: true,
         initialQuality: 0.8,
-        useWebWorker: true,
+        useWebWorker: false,
       }).then((compressed) => {
         onChange({
           file: compressed,

--- a/frontend/src/services/FileHandlerService.ts
+++ b/frontend/src/services/FileHandlerService.ts
@@ -117,7 +117,7 @@ const uploadFile = async ({
   // POST generated formData to presigned url.
   const response = await postToPresignedUrl(postData.url, formData)
 
-  const encodedFileId = encodeURIComponent(fileId)
+  const encodedFileId = encodeURIComponent(postData.fields.key)
 
   const uploadedFileData: UploadedFileData = {
     url: `${response.config.url}/${encodedFileId}`,

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -29,7 +29,7 @@ const helmetMiddlewares = () => {
   const cspCoreDirectives: ContentSecurityPolicyOptions['directives'] = {
     imgSrc: [
       "'self'",
-      `blob:`,
+      'blob:',
       'data:',
       'https://www.googletagmanager.com/',
       'https://www.google-analytics.com/',
@@ -41,6 +41,7 @@ const helmetMiddlewares = () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
+      'blob:',
       'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -29,13 +29,13 @@ const helmetMiddlewares = () => {
   const cspCoreDirectives: ContentSecurityPolicyOptions['directives'] = {
     imgSrc: [
       "'self'",
+      `blob:`,
       'data:',
       'https://www.googletagmanager.com/',
       'https://www.google-analytics.com/',
       `https://s3-${config.aws.region}.amazonaws.com/agency.form.sg/`, // Agency logos
       config.aws.imageBucketUrl, // Image field
       config.aws.logoBucketUrl, // Form logo
-      `blob:${config.app.appUrl}`,
       '*', // TODO: Remove when we host our own images for Image field and Form Logo
     ],
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -35,6 +35,7 @@ const helmetMiddlewares = () => {
       `https://s3-${config.aws.region}.amazonaws.com/agency.form.sg/`, // Agency logos
       config.aws.imageBucketUrl, // Image field
       config.aws.logoBucketUrl, // Form logo
+      `blob:${config.app.appUrl}`,
       '*', // TODO: Remove when we host our own images for Image field and Form Logo
     ],
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -41,7 +41,6 @@ const helmetMiddlewares = () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
-      'blob:',
       'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',


### PR DESCRIPTION
## Problem
Image and logo uploads in general are not working in both the preview and saved mode. This occurs for two different reasons:
1. Prior to file upload, we display images and logos from local `blob:`s. However the browser refuses to load these because `blob:`s are not allowed in our CSP.
2. After files are uploaded to S3, image and logo uploads result in 403 Forbidden. They are being uploaded to S3 but the  URLs pointing to their location is not being generated correctly in `uploadFile`.

Closes #4360 

## Solution
1. Add `blob:` to our `imgSrc` CSP. 
2. Change `uploadFile` to use the correct source for the uploaded file ID.

See also:
https://stackoverflow.com/questions/28467789/content-security-policy-object-src-blob
https://csplite.com/csp105/#:~:text=The%20Content%20Security%20Policy%20controls,from%20the%20blob%3A-URI.
https://content-security-policy.com/#source_list
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots
See comment below :)