### PR TITLE
feat(form-v2): update storage form activation modal UI

### DIFF
--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { BiRightArrowAlt, BiUpload } from 'react-icons/bi'
 import {
@@ -49,6 +49,7 @@ const useSecretKeyActivationModal = ({
     formState: { errors },
     setError,
     register,
+    watch,
     setValue,
     reset,
     handleSubmit,
@@ -117,11 +118,23 @@ const useSecretKeyActivationModal = ({
     return onClose()
   }, [onClose, reset])
 
+  const watchedSecretKey = watch(SECRET_KEY_NAME)
+  const watchedAck = watch('ack')
+
+  const ackHidden = useMemo(() => !watchedSecretKey, [watchedSecretKey])
+
+  const activateHidden = useMemo(
+    () => ackHidden || !watchedAck,
+    [ackHidden, watchedAck],
+  )
+
   return {
     fileUploadRef,
     handleFileSelect,
     handleVerifyKeypair,
     register,
+    ackHidden,
+    activateHidden,
     errors,
     isLoading: mutateFormStatus.isLoading,
     handleOnClose,
@@ -138,6 +151,8 @@ export const SecretKeyActivationModal = ({
     handleFileSelect,
     handleVerifyKeypair,
     register,
+    ackHidden,
+    activateHidden,
     errors,
     isLoading,
     handleOnClose,
@@ -197,7 +212,7 @@ export const SecretKeyActivationModal = ({
                 </Stack>
                 <FormErrorMessage>{errors.secretKey?.message}</FormErrorMessage>
               </FormControl>
-              <FormControl mb="1.25rem">
+              <FormControl hidden={ackHidden} mb="1.25rem">
                 <Checkbox
                   isDisabled={isLoading}
                   isInvalid={!!errors.ack}
@@ -213,6 +228,7 @@ export const SecretKeyActivationModal = ({
                 rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
                 type="submit"
                 isFullWidth
+                hidden={activateHidden}
                 isLoading={isLoading}
               >
                 Activate form

--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -121,11 +121,14 @@ const useSecretKeyActivationModal = ({
   const watchedSecretKey = watch(SECRET_KEY_NAME)
   const watchedAck = watch('ack')
 
-  const ackHidden = useMemo(() => !watchedSecretKey, [watchedSecretKey])
+  const secretKeyNotUploaded = useMemo(
+    () => !watchedSecretKey,
+    [watchedSecretKey],
+  )
 
-  const activateHidden = useMemo(
-    () => ackHidden || !watchedAck,
-    [ackHidden, watchedAck],
+  const activateDisabled = useMemo(
+    () => !watchedSecretKey || !watchedAck,
+    [watchedSecretKey, watchedAck],
   )
 
   return {
@@ -133,8 +136,8 @@ const useSecretKeyActivationModal = ({
     handleFileSelect,
     handleVerifyKeypair,
     register,
-    ackHidden,
-    activateHidden,
+    secretKeyNotUploaded,
+    activateDisabled,
     errors,
     isLoading: mutateFormStatus.isLoading,
     handleOnClose,
@@ -151,8 +154,8 @@ export const SecretKeyActivationModal = ({
     handleFileSelect,
     handleVerifyKeypair,
     register,
-    ackHidden,
-    activateHidden,
+    secretKeyNotUploaded,
+    activateDisabled,
     errors,
     isLoading,
     handleOnClose,
@@ -212,7 +215,7 @@ export const SecretKeyActivationModal = ({
                 </Stack>
                 <FormErrorMessage>{errors.secretKey?.message}</FormErrorMessage>
               </FormControl>
-              <FormControl hidden={ackHidden} mb="1.25rem">
+              <FormControl hidden={secretKeyNotUploaded} mb="1.25rem">
                 <Checkbox
                   isDisabled={isLoading}
                   isInvalid={!!errors.ack}
@@ -228,7 +231,8 @@ export const SecretKeyActivationModal = ({
                 rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
                 type="submit"
                 isFullWidth
-                hidden={activateHidden}
+                hidden={secretKeyNotUploaded}
+                isDisabled={activateDisabled}
                 isLoading={isLoading}
               >
                 Activate form


### PR DESCRIPTION
## Problem
Currently, storage form activation modal displays secret key, acknowledgement checkbox and activate button all at once. We want this to be a step-by-step process.

Closes #4355 

## Solution
Add logic to the modal to only display acknowledgement checkbox and activation button if secret key is entered, and enable activation button if secret key is entered and the acknowledgement checkbox is checked.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/182749772-0d91a485-c247-4429-9fae-de011abd00e5.mov


