### PR TITLE
feat(form-v2): ensure view-only collaborators can only see results screen

### DIFF
--- a/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
@@ -4,10 +4,12 @@ import { Meta, Story } from '@storybook/react'
 
 import {
   createFormBuilderMocks,
+  getAdminFormCollaborators,
   getAdminFormFeedback,
   getEmptyAdminFormFeedback,
   getStorageSubmissionMetadataResponse,
 } from '~/mocks/msw/handlers/admin-form'
+import { getUser } from '~/mocks/msw/handlers/user'
 
 import {
   ADMINFORM_RESULTS_SUBROUTE,
@@ -22,6 +24,8 @@ const DEFAULT_MSW_ROUTES = [
   ...createFormBuilderMocks({}, 0),
   getStorageSubmissionMetadataResponse(),
   getAdminFormFeedback(),
+  getUser(),
+  getAdminFormCollaborators(),
 ]
 
 export default {

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -8,9 +8,11 @@ import { FormResponseMode } from '~shared/types/form'
 
 import {
   createFormBuilderMocks,
+  getAdminFormCollaborators,
   getAdminFormSubmissions,
   getStorageSubmissionMetadataResponse,
 } from '~/mocks/msw/handlers/admin-form'
+import { getUser } from '~/mocks/msw/handlers/user'
 
 import {
   ADMINFORM_RESULTS_SUBROUTE,
@@ -32,7 +34,12 @@ export default {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true },
     layout: 'fullscreen',
-    msw: [...createFormBuilderMocks({}, 0), getAdminFormSubmissions()],
+    msw: [
+      ...createFormBuilderMocks({}, 0),
+      getAdminFormSubmissions(),
+      getUser(),
+      getAdminFormCollaborators(),
+    ],
   },
 } as Meta
 

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -79,6 +79,8 @@ EmailFormLoading.parameters = {
   msw: [
     ...createFormBuilderMocks({}, 0),
     getAdminFormSubmissions({ delay: 'infinite' }),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }
 
@@ -89,6 +91,8 @@ EmptyEmailForm.parameters = {
     getAdminFormSubmissions({
       override: 0,
     }),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }
 
@@ -115,6 +119,8 @@ StorageForm.parameters = {
     ),
     getAdminFormSubmissions(),
     getStorageSubmissionMetadataResponse(),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }
 
@@ -180,5 +186,7 @@ StorageFormLoading.parameters = {
     ...createFormBuilderMocks({ responseMode: FormResponseMode.Encrypt }, 0),
     getAdminFormSubmissions({ delay: 'infinite' }),
     getStorageSubmissionMetadataResponse({}, 'infinite'),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -75,6 +75,8 @@ PreventActivation.parameters = {
         esrvcId: '',
       },
     }),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }
 
@@ -116,5 +118,7 @@ StorageModeSettings.parameters = {
       mode: FormResponseMode.Encrypt,
       overrides: { publicKey: storageModeKeypair.publicKey },
     }),
+    getUser(),
+    getAdminFormCollaborators(),
   ],
 }

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -10,11 +10,13 @@ import {
 
 import {
   createFormBuilderMocks,
+  getAdminFormCollaborators,
   getAdminFormSettings,
   getAdminFormSubmissions,
   patchAdminFormSettings,
 } from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
+import { getUser } from '~/mocks/msw/handlers/user'
 
 import formsgSdk from '~utils/formSdk'
 import { viewports } from '~utils/storybook'
@@ -50,6 +52,8 @@ export default {
       getAdminFormSettings(),
       getAdminFormSubmissions(),
       patchAdminFormSettings(),
+      getUser(),
+      getAdminFormCollaborators(),
     ],
   },
 } as Meta

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.stories.tsx
@@ -36,9 +36,15 @@ const mockForm = {
 const Template: Story<AdminFormNavbarProps> = (args) => (
   <AdminFormNavbar {...args} />
 )
-export const Default = Template.bind({})
-Default.args = {
+export const DefaultEditor = Template.bind({})
+DefaultEditor.args = {
   formInfo: mockForm,
+}
+
+export const DefaultViewOnly = Template.bind({})
+DefaultViewOnly.args = {
+  formInfo: mockForm,
+  viewOnly: true,
 }
 
 export const Skeleton = Template.bind({})

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -28,8 +28,6 @@ import IconButton from '~components/IconButton'
 import { Tab } from '~components/Tabs'
 import Tooltip from '~components/Tooltip'
 
-import { useAdminFormCollaborators } from '../../queries'
-
 import { AdminFormNavbarDetails } from './AdminFormNavbarDetails'
 
 export interface AdminFormNavbarProps {
@@ -38,6 +36,8 @@ export interface AdminFormNavbarProps {
    * If not provided, the navbar will be in a loading state.
    */
   formInfo?: Pick<AdminFormDto, 'title' | 'lastModified'>
+
+  viewOnly: boolean
 
   handleBackButtonClick: () => void
   handleAddCollabButtonClick: () => void
@@ -50,6 +50,7 @@ export interface AdminFormNavbarProps {
  */
 export const AdminFormNavbar = ({
   formInfo,
+  viewOnly,
   handleAddCollabButtonClick,
   handleBackButtonClick,
   handlePreviewFormButtonClick,
@@ -57,7 +58,6 @@ export const AdminFormNavbar = ({
 }: AdminFormNavbarProps): JSX.Element => {
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
   const { isOpen, onClose, onOpen } = useDisclosure()
-  const { hasEditAccess } = useAdminFormCollaborators()
 
   const mobileDrawerExtraButtonProps: Partial<ButtonProps> = useMemo(
     () => ({
@@ -124,10 +124,10 @@ export const AdminFormNavbar = ({
         justifyContent={{ base: 'flex-start', lg: 'center' }}
         alignSelf="center"
       >
-        <Tab hidden={!hasEditAccess} isDisabled={!formInfo}>
+        <Tab hidden={viewOnly} isDisabled={!formInfo}>
           Create
         </Tab>
-        <Tab hidden={!hasEditAccess} isDisabled={!formInfo}>
+        <Tab hidden={viewOnly} isDisabled={!formInfo}>
           Settings
         </Tab>
         <Tab isDisabled={!formInfo}>Results</Tab>

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -28,6 +28,8 @@ import IconButton from '~components/IconButton'
 import { Tab } from '~components/Tabs'
 import Tooltip from '~components/Tooltip'
 
+import { useAdminFormCollaborators } from '../../queries'
+
 import { AdminFormNavbarDetails } from './AdminFormNavbarDetails'
 
 export interface AdminFormNavbarProps {
@@ -55,6 +57,7 @@ export const AdminFormNavbar = ({
 }: AdminFormNavbarProps): JSX.Element => {
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
   const { isOpen, onClose, onOpen } = useDisclosure()
+  const { hasEditAccess } = useAdminFormCollaborators()
 
   const mobileDrawerExtraButtonProps: Partial<ButtonProps> = useMemo(
     () => ({
@@ -121,8 +124,12 @@ export const AdminFormNavbar = ({
         justifyContent={{ base: 'flex-start', lg: 'center' }}
         alignSelf="center"
       >
-        <Tab isDisabled={!formInfo}>Create</Tab>
-        <Tab isDisabled={!formInfo}>Settings</Tab>
+        <Tab hidden={!hasEditAccess} isDisabled={!formInfo}>
+          Create
+        </Tab>
+        <Tab hidden={!hasEditAccess} isDisabled={!formInfo}>
+          Settings
+        </Tab>
         <Tab isDisabled={!formInfo}>Results</Tab>
       </TabList>
       <Flex

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -15,7 +15,7 @@ import {
 
 import { ShareFormModal } from '~features/admin-form/share'
 
-import { useAdminForm } from '../../queries'
+import { useAdminForm, useAdminFormCollaborators } from '../../queries'
 import CollaboratorModal from '../CollaboratorModal'
 
 import { AdminFormNavbar } from './AdminFormNavbar'
@@ -30,6 +30,7 @@ const useAdminFormNavbar = () => {
   const { data: form } = useAdminForm()
   const { pathname } = useLocation()
   const { formId } = useParams()
+  const { hasEditAccess, isLoading } = useAdminFormCollaborators()
   const navigate = useNavigate()
 
   const calcCurrentIndex = useCallback(() => {
@@ -76,6 +77,7 @@ const useAdminFormNavbar = () => {
     form,
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
+    viewOnly: !isLoading && !hasEditAccess,
   }
 }
 
@@ -91,6 +93,7 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
     form,
+    viewOnly,
   } = useAdminFormNavbar()
 
   const responsiveVariant = useBreakpointValue({
@@ -120,6 +123,7 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
       >
         <AdminFormNavbar
           formInfo={form}
+          viewOnly={viewOnly}
           handleBackButtonClick={handleBackToDashboard}
           handleAddCollabButtonClick={collaboratorModalDisclosure.onOpen}
           handlePreviewFormButtonClick={handlePreviewForm}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -41,14 +41,8 @@ export const CollaboratorList = (): JSX.Element => {
   // Admin form data required for checking for duplicate emails.
   const { handleForwardToTransferOwnership, handleForwardToRemoveSelf } =
     useCollaboratorWizard()
-  const {
-    collaborators,
-    user,
-    isFormAdmin,
-    form,
-    isLoading,
-    showEditableModal,
-  } = useAdminFormCollaborators()
+  const { collaborators, user, isFormAdmin, form, isLoading, hasEditAccess } =
+    useAdminFormCollaborators()
 
   const { mutateUpdateCollaborator, mutateRemoveCollaborator } =
     useMutateCollaborators()
@@ -153,7 +147,7 @@ export const CollaboratorList = (): JSX.Element => {
             key={row.email}
             isLoading={isLoading}
           >
-            {showEditableModal ? (
+            {hasEditAccess ? (
               <Stack
                 w="100%"
                 direction="row"

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
@@ -6,15 +6,15 @@ import { AddCollaboratorInput } from './AddCollaboratorInput'
 import { CollaboratorList } from './CollaboratorList'
 
 export const CollaboratorListScreen = (): JSX.Element => {
-  const { showEditableModal } = useAdminFormCollaborators()
+  const { hasEditAccess } = useAdminFormCollaborators()
   return (
     <>
       <ModalHeader color="secondary.700">
-        {showEditableModal ? 'Manage collaborators' : 'Collaborators'}
+        {hasEditAccess ? 'Manage collaborators' : 'Collaborators'}
       </ModalHeader>
       <ModalBody whiteSpace="pre-line">
         <Stack spacing="2.5rem" pb="2rem">
-          {showEditableModal ? <AddCollaboratorInput /> : null}
+          {hasEditAccess ? <AddCollaboratorInput /> : null}
           <CollaboratorList />
         </Stack>
       </ModalBody>

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -76,7 +76,7 @@ export const useAdminFormCollaborators = () => {
     [form, user],
   )
 
-  const showEditableModal = useMemo(() => {
+  const hasEditAccess = useMemo(() => {
     if (!form || !user) return false
     if (isFormAdmin) return true
     // Collaborators is source of truth if it has already loaded.
@@ -97,7 +97,7 @@ export const useAdminFormCollaborators = () => {
     collaborators,
     isLoading: isCollabLoading || isAdminFormLoading || isUserLoading,
     isFormAdmin,
-    showEditableModal,
+    hasEditAccess,
   }
 }
 

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -1,10 +1,14 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import { FEATURE_TOUR_KEY_PREFIX } from '~constants/localStorage'
+import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 
 import { useUser } from '~features/user/queries'
+
+import { useAdminFormCollaborators } from '../common/queries'
 
 import { CreatePageContent } from './common/CreatePageContent'
 import { CreatePageSidebar } from './common/CreatePageSidebar'
@@ -12,6 +16,15 @@ import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
 import { FeatureTour } from './featureTour/FeatureTour'
 
 export const CreatePage = (): JSX.Element => {
+  const { formId } = useParams()
+  const { hasEditAccess } = useAdminFormCollaborators()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!hasEditAccess)
+      navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
+  }, [formId, hasEditAccess, navigate])
+
   const { user, isLoading } = useUser()
   const localStorageFeatureTourKey = useMemo(() => {
     if (!user?._id) {

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -20,6 +20,7 @@ export const CreatePage = (): JSX.Element => {
   const { hasEditAccess } = useAdminFormCollaborators()
   const navigate = useNavigate()
 
+  // Redirect view-only collaborators to results screen.
   useEffect(() => {
     if (!hasEditAccess)
       navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -17,14 +17,15 @@ import { FeatureTour } from './featureTour/FeatureTour'
 
 export const CreatePage = (): JSX.Element => {
   const { formId } = useParams()
-  const { hasEditAccess } = useAdminFormCollaborators()
+  const { hasEditAccess, isLoading: isCollabLoading } =
+    useAdminFormCollaborators()
   const navigate = useNavigate()
 
   // Redirect view-only collaborators to results screen.
   useEffect(() => {
-    if (!hasEditAccess)
+    if (!isCollabLoading && !hasEditAccess)
       navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
-  }, [formId, hasEditAccess, navigate])
+  }, [formId, hasEditAccess, isCollabLoading, navigate])
 
   const { user, isLoading } = useUser()
   const localStorageFeatureTourKey = useMemo(() => {

--- a/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
+++ b/frontend/src/features/admin-form/create/featureTour/FeatureTour.stories.tsx
@@ -2,8 +2,12 @@ import { Meta, Story } from '@storybook/react'
 
 import { AdminFormDto } from '~shared/types/form'
 
-import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
+import {
+  createFormBuilderMocks,
+  getAdminFormCollaborators,
+} from '~/mocks/msw/handlers/admin-form'
 import { getFreeSmsQuota } from '~/mocks/msw/handlers/admin-form/twilio'
+import { getUser } from '~/mocks/msw/handlers/user'
 
 import { AdminFormCreatePageDecorator } from '~utils/storybook'
 
@@ -15,6 +19,8 @@ const buildMswRoutes = (
 ) => {
   return [
     ...createFormBuilderMocks(overrides, delay),
+    getUser(),
+    getAdminFormCollaborators(),
     getFreeSmsQuota({ delay }),
   ]
 }

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -26,14 +26,15 @@ import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
 export const SettingsPage = (): JSX.Element => {
   const { formId } = useParams()
-  const { hasEditAccess } = useAdminFormCollaborators()
+  const { hasEditAccess, isLoading: isCollabLoading } =
+    useAdminFormCollaborators()
   const navigate = useNavigate()
 
   // Redirect view-only collaborators to results screen.
   useEffect(() => {
-    if (!hasEditAccess)
+    if (!isCollabLoading && !hasEditAccess)
       navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
-  }, [formId, hasEditAccess, navigate])
+  }, [formId, hasEditAccess, isCollabLoading, navigate])
 
   const tabOrientation: UseTabsProps['orientation'] = useBreakpointValue({
     base: 'horizontal',

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react'
 import { BiCodeBlock, BiCog, BiKey, BiMessage } from 'react-icons/bi'
+import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
   Flex,
@@ -11,7 +13,10 @@ import {
   UseTabsProps,
 } from '@chakra-ui/react'
 
+import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
+
+import { useAdminFormCollaborators } from '../common/queries'
 
 import { SettingsTab } from './components/SettingsTab'
 import { SettingsAuthPage } from './SettingsAuthPage'
@@ -20,6 +25,16 @@ import { SettingsTwilioPage } from './SettingsTwilioPage'
 import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
 export const SettingsPage = (): JSX.Element => {
+  const { formId } = useParams()
+  const { hasEditAccess } = useAdminFormCollaborators()
+  const navigate = useNavigate()
+
+  // Redirect view-only collaborators to results screen.
+  useEffect(() => {
+    if (!hasEditAccess)
+      navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
+  }, [formId, hasEditAccess, navigate])
+
   const tabOrientation: UseTabsProps['orientation'] = useBreakpointValue({
     base: 'horizontal',
     xs: 'horizontal',


### PR DESCRIPTION
## Problem
Currently, view-only collaborators can see the create and settings tabs in the builder. They should not be able to access these, in theory.

Closes #4333 

## Solution
1. Hide create and settings tab from builder for view-only collaborators

`queries.ts`, `CollaboratorModal/`, `AdminFormNavbar`
- Change name of `showEditableModal` to `hasEditAccess` to generalize itse use.
- Use `hasEditAccess` to determine if we should show the Create and Settings tabs in the admin form navbar.

2. Redirect away on attempts to view those screens

`CreatePage.tsx`, `SettingsPage.tsx`
- Updated with a `useEffect` to automatically redirect to results screen.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/182759377-5f7a7ea3-0450-4875-9949-840de18d30f9.mov


