### PR TITLE
feat(form-v2/sgid): enable sgid storage mode

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -5,10 +5,12 @@ export type StorageFormAuthType =
   | FormAuthType.NIL
   | FormAuthType.SP
   | FormAuthType.CP
+  | FormAuthType.SGID
 
 export const STORAGE_MODE_AUTHTYPES: Record<StorageFormAuthType, string> = {
   [FormAuthType.NIL]: 'None',
   [FormAuthType.SP]: 'Singpass',
+  [FormAuthType.SGID]: 'Singpass App-only Login (Free)',
   [FormAuthType.CP]: 'Singpass (Corporate)',
 }
 


### PR DESCRIPTION
## Problem
PR #4395 implemented sgid storage mode for both the backend and the angular frontend, but since FormSG will be migrating to a React frontend soon, sgid storage mode will also need to be enabled for the new React frontend.

## Solution
This PR activates sgid storage mode on the new React frontend. 

**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Tests
Expected outcomes:
- [ ] sgID option appears in storage mode form settings on the new V2 frontend
- [ ] User is able to login with sgID for storage mode form and submit the form
- [ ] Admin is able to successfully decrypt sgID storage mode form responses
- [ ] Check that end-to-end flow for sgid email mode is unaffected