### PR TITLE
fix: remove "Confidential responses" from email mode features in copy

### DIFF
--- a/src/public/modules/forms/admin/directiveViews/configure-form.client.view.html
+++ b/src/public/modules/forms/admin/directiveViews/configure-form.client.view.html
@@ -59,7 +59,6 @@
           <p>However, choose Email mode if you need any of these features:</p>
           <ul>
             <li>MyInfo</li>
-            <li>Confidential responses</li>
             <li>Emailed copy of response to respondent</li>
           </ul>
         </span>
@@ -85,7 +84,6 @@
           </p>
           <ul>
             <li>MyInfo</li>
-            <li>Confidential responses</li>
             <li>Emailed copy of response to respondent</li>
           </ul>
         </span>


### PR DESCRIPTION
## Problem
Currently, "Confidential responses" is listed as an email mode advantage in copy which we should remove. 

## Solution
**Breaking Changes** 
- [X] No - this PR is backwards compatible 

## Tests

- [X] Create a new form. Selecting storage mode or email mode should only list MyInfo and email responses as advantages of email mode, and not Confidential responses.