### PR TITLE
feat(datadog): connect logs and traces

### DIFF
--- a/src/app/loaders/datadog-tracer.ts
+++ b/src/app/loaders/datadog-tracer.ts
@@ -1,6 +1,8 @@
 import tracer from 'dd-trace'
 
-tracer.init()
+tracer.init({
+  logInjection: true, // https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/
+})
 
 // setup express to not track middlewares as spans
 // see documentation: https://datadoghq.dev/dd-trace-js/interfaces/plugins.express.html


### PR DESCRIPTION
## Problem
DataDog allows linkage of traces and logs, but this needs to be activated in logging

## Solution
Activate log Injection. This adds the traceid, spanid, service, env, version field to trace entries.

See documentation [here](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/)

 - [X] Tested on staging
 
 Sample Trace with Linked log:
 
![image](https://user-images.githubusercontent.com/935223/182976172-bd988ca3-a5d1-4aec-a48b-f498a66f8774.png)

