### PR TITLE
feat: add tag input component 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34751,6 +34751,14 @@
         "react-router": "6.0.2"
       }
     },
+    "react-roving-tabindex": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-roving-tabindex/-/react-roving-tabindex-3.2.0.tgz",
+      "integrity": "sha512-WY5d46Y/QuS2zgXs4MgYJlmi3uIyq7M9UD4l3SWim8ClnyV1L3r84brxElLxEBXdKuWFUbll9mOBpxfcDZsCVQ==",
+      "requires": {
+        "warning": "^4.0.3"
+      }
+    },
     "react-scripts": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.3.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react-popper": "^2.3.0",
     "react-query": "^3.34.2",
     "react-router-dom": "^6.0.2",
+    "react-roving-tabindex": "^3.2.0",
     "react-swipeable": "^7.0.0",
     "react-table": "^7.7.0",
     "react-textarea-autosize": "^8.3.3",

--- a/frontend/src/components/TagInput/TagInput.stories.tsx
+++ b/frontend/src/components/TagInput/TagInput.stories.tsx
@@ -16,3 +16,20 @@ export const WithValue = Template.bind({})
 WithValue.args = {
   defaultValue: ['foo', 'bar'],
 }
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  isDisabled: true,
+}
+
+export const DisabledWithValue = Template.bind({})
+DisabledWithValue.args = {
+  ...WithValue.args,
+  ...Disabled.args,
+}
+
+export const Invalid = Template.bind({})
+Invalid.args = {
+  ...WithValue.args,
+  isInvalid: true,
+}

--- a/frontend/src/components/TagInput/TagInput.stories.tsx
+++ b/frontend/src/components/TagInput/TagInput.stories.tsx
@@ -1,11 +1,16 @@
 import { Meta, Story } from '@storybook/react'
 
+import { getMobileViewParameters } from '~utils/storybook'
+
 import { TagInput, TagInputProps } from './TagInput'
 
 export default {
   title: 'Components/TagInput',
   component: TagInput,
   decorators: [],
+  parameters: {
+    actions: { argTypesRegex: '^on.*' },
+  },
 } as Meta<TagInputProps>
 
 const Template: Story<TagInputProps> = (args) => <TagInput {...args} />
@@ -33,3 +38,12 @@ Invalid.args = {
   ...WithValue.args,
   isInvalid: true,
 }
+
+export const Mobile = Template.bind({})
+Mobile.args = {
+  defaultValue: [
+    'somethingreallylong_that_should_overflow_the_input@example.com',
+    'test@example.com',
+  ],
+}
+Mobile.parameters = getMobileViewParameters()

--- a/frontend/src/components/TagInput/TagInput.stories.tsx
+++ b/frontend/src/components/TagInput/TagInput.stories.tsx
@@ -33,10 +33,17 @@ DisabledWithValue.args = {
   ...Disabled.args,
 }
 
-export const Invalid = Template.bind({})
-Invalid.args = {
+export const InvalidField = Template.bind({})
+InvalidField.args = {
   ...WithValue.args,
   isInvalid: true,
+}
+
+export const InvalidFieldWithInvalidTags = Template.bind({})
+InvalidFieldWithInvalidTags.args = {
+  isInvalid: true,
+  defaultValue: ['foo', 'bar', 'bazinvalid'],
+  tagInvalidation: (tag) => tag.length > 3,
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/components/TagInput/TagInput.stories.tsx
+++ b/frontend/src/components/TagInput/TagInput.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from '@storybook/react'
+
+import { TagInput, TagInputProps } from './TagInput'
+
+export default {
+  title: 'Components/TagInput',
+  component: TagInput,
+  decorators: [],
+} as Meta<TagInputProps>
+
+const Template: Story<TagInputProps> = (args) => <TagInput {...args} />
+export const Default = Template.bind({})
+Default.args = {}
+
+export const WithValue = Template.bind({})
+WithValue.args = {
+  defaultValue: ['foo', 'bar'],
+}

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -3,6 +3,7 @@ import {
   KeyboardEvent,
   SyntheticEvent,
   useCallback,
+  useRef,
 } from 'react'
 import { RovingTabIndexProvider } from 'react-roving-tabindex'
 import {
@@ -10,6 +11,7 @@ import {
   forwardRef,
   StylesProvider,
   useControllableState,
+  useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
@@ -50,13 +52,23 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
     },
     ref,
   ): JSX.Element => {
-    const styles = useMultiStyleConfig('TagInput', { size, ...props })
+    const styles = useMultiStyleConfig('TagInput', {
+      size,
+      ...props,
+    })
 
     const [value, onChange] = useControllableState({
       value: valueProp,
       onChange: onChangeProp,
       defaultValue,
     })
+
+    const inputRef = useRef<HTMLInputElement>(null)
+    const mergedInputRefs = useMergeRefs(ref, inputRef)
+
+    const handleFieldClick = useCallback(() => {
+      inputRef.current?.focus()
+    }, [])
 
     const addTag = useCallback(
       (event: SyntheticEvent, tag: string) => {
@@ -130,7 +142,13 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
     return (
       <RovingTabIndexProvider>
         <StylesProvider value={styles}>
-          <Box sx={styles.container}>
+          <Box
+            sx={styles.container}
+            onClick={handleFieldClick}
+            aria-disabled={props.isDisabled}
+            aria-invalid={props.isInvalid}
+            aria-readonly={props.isReadOnly}
+          >
             {value.map((tag, index) => (
               <TagInputTag
                 key={index}
@@ -143,7 +161,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
               {...props}
               onKeyDown={handleKeyDown}
               onBlur={handleBlur}
-              ref={ref}
+              ref={mergedInputRefs}
             />
           </Box>
         </StylesProvider>

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -1,0 +1,181 @@
+import {
+  FocusEventHandler,
+  KeyboardEvent,
+  SyntheticEvent,
+  useCallback,
+} from 'react'
+import { RovingTabIndexProvider } from 'react-roving-tabindex'
+import {
+  Box,
+  Flex,
+  forwardRef,
+  useControllableState,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
+
+import { InputProps } from '~components/Input'
+import { TagProps } from '~components/Tag/Tag'
+
+import { TagInputInput } from './TagInputInput'
+import { TagInputTag } from './TagInputTag'
+
+export interface TagInputProps
+  extends Omit<InputProps, 'value' | 'onChange' | 'defaultValue'> {
+  /** Value of the controlled input. */
+  value?: string[]
+  /**
+   * Callback for when the value changes.
+   * @param value - The new value.
+   */
+  onChange?: (value: string[]) => void
+  /** Default value of the uncontrolled input. */
+  defaultValue?: string[]
+  /** Color scheme to assign to the created tags  */
+  tagColorScheme?: TagProps['colorScheme']
+  /** Keys that will trigger the creation of new tags. Defaults to `['Enter', ',', ' ']` */
+  keyDownKeys?: string[]
+}
+
+export const TagInput = forwardRef<TagInputProps, 'input'>(
+  (
+    {
+      value: valueProp,
+      defaultValue = [],
+      onChange: onChangeProp,
+      onKeyDown,
+      keyDownKeys = ['Enter', ',', ' '],
+      tagColorScheme = 'secondary',
+      size,
+      ...props
+    },
+    ref,
+  ): JSX.Element => {
+    const inputStyle = useMultiStyleConfig('Input', { size, ...props })
+
+    const [value, onChange] = useControllableState({
+      value: valueProp,
+      onChange: onChangeProp,
+      defaultValue,
+    })
+
+    const addTag = useCallback(
+      (event: SyntheticEvent, tag: string) => {
+        if (event.isDefaultPrevented()) return
+
+        onChange(value.concat([tag]))
+      },
+      [onChange, value],
+    )
+    const removeTag = useCallback(
+      (event: SyntheticEvent, index: number) => {
+        if (event.isDefaultPrevented()) return
+
+        onChange([...value.slice(0, index), ...value.slice(index + 1)])
+      },
+      [onChange, value],
+    )
+    const handleRemoveTag = useCallback(
+      (index: number) => (event: SyntheticEvent) => {
+        removeTag(event, index)
+      },
+      [removeTag],
+    )
+
+    const handleBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+      (event) => {
+        const currentValue = event.target.value
+        // No value to add a tag to.
+        if (!currentValue.trim()) {
+          event.target.value = ''
+        } else {
+          addTag(event, currentValue)
+          if (!event.isDefaultPrevented()) {
+            event.target.value = ''
+          }
+          event.preventDefault()
+        }
+      },
+      [addTag],
+    )
+
+    const handleKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLInputElement>) => {
+        onKeyDown?.(event)
+
+        if (event.isDefaultPrevented()) return
+        if (event.isPropagationStopped()) return
+
+        const { currentTarget, key } = event
+        const { selectionStart, selectionEnd } = currentTarget
+        if (
+          key === 'Delete' &&
+          value.length > 0 &&
+          selectionStart === 0 &&
+          selectionEnd === 0
+        ) {
+          return removeTag(event, value.length - 1)
+        }
+        if (!currentTarget.value.trim()) return // No value to add a tag to.
+        if (keyDownKeys.indexOf(key) > -1 && currentTarget.value) {
+          addTag(event, currentTarget.value)
+          if (!event.isDefaultPrevented()) {
+            currentTarget.value = ''
+          }
+          event.preventDefault()
+        }
+      },
+      [onKeyDown, keyDownKeys, value.length, addTag, removeTag],
+    )
+
+    return (
+      <RovingTabIndexProvider>
+        <Box
+          sx={{
+            ...inputStyle.field,
+            display: 'flex',
+            flexWrap: 'wrap',
+            p: '0.375rem',
+            minH: '2.75rem',
+            cursor: 'pointer',
+            _disabled: {
+              cursor: 'not-allowed',
+            },
+            transitionProperty: 'common',
+            transitionDuration: 'normal',
+            borderRadius: '4px',
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            _focusWithin: inputStyle.field._focus,
+            height: 'auto',
+            maxW: '100%',
+            w: '100%',
+          }}
+        >
+          <Flex
+            flexWrap="wrap"
+            align="center"
+            maxW="inherit"
+            w="100%"
+            gap="0.25rem"
+          >
+            {value.map((tag, index) => (
+              <TagInputTag
+                key={index}
+                colorScheme={tagColorScheme}
+                label={tag}
+                onClose={handleRemoveTag(index)}
+              />
+            ))}
+            <TagInputInput
+              flexGrow={1}
+              {...props}
+              onKeyDown={handleKeyDown}
+              onBlur={handleBlur}
+              ref={ref}
+            />
+          </Flex>
+        </Box>
+      </RovingTabIndexProvider>
+    )
+  },
+)

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -138,7 +138,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
         const { currentTarget, key } = event
         const { selectionStart, selectionEnd } = currentTarget
         if (
-          key === 'Delete' &&
+          key === 'Backspace' &&
           value.length > 0 &&
           selectionStart === 0 &&
           selectionEnd === 0

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -36,6 +36,11 @@ export interface TagInputProps
   tagColorScheme?: TagProps['colorScheme']
   /** Keys that will trigger the creation of new tags. Defaults to `['Enter', ',', ' ']` */
   keyDownKeys?: string[]
+  /**
+   * Optional function to call to validate created tags.
+   * Should return `true` if tag is invalid
+   */
+  tagInvalidation?: (tag: string) => boolean
 }
 
 export const TagInput = forwardRef<TagInputProps, 'input'>(
@@ -47,6 +52,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
       onKeyDown,
       keyDownKeys = ['Enter', ',', ' '],
       tagColorScheme = 'secondary',
+      tagInvalidation,
       size,
       ...props
     },
@@ -154,6 +160,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
                 isDisabled={props.isDisabled}
                 key={index}
                 colorScheme={tagColorScheme}
+                isInvalid={tagInvalidation?.(tag)}
                 label={tag}
                 onClose={handleRemoveTag(index)}
               />

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -43,7 +43,14 @@ export interface TagInputProps
    */
   tagInvalidation?: (tag: string) => boolean
 
+  /**
+   * Optional function to call when input is blurred.
+   */
   onBlur?: (event: SyntheticEvent) => void
+  /**
+   * If true, duplicate tags will not be created. Defaults to `true`.
+   */
+  preventDuplicates?: boolean
 }
 
 export const TagInput = forwardRef<TagInputProps, 'input'>(
@@ -58,6 +65,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
       tagColorScheme = 'secondary',
       tagInvalidation,
       size,
+      preventDuplicates = true,
       ...props
     },
     ref,
@@ -81,10 +89,11 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
     const addTag = useCallback(
       (event: SyntheticEvent, tag: string) => {
         if (event.isDefaultPrevented()) return
+        if (preventDuplicates && value.includes(tag)) return
 
         onChange(value.concat([tag]))
       },
-      [onChange, value],
+      [onChange, preventDuplicates, value],
     )
     const removeTag = useCallback(
       (event: SyntheticEvent, index: number) => {

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -51,6 +51,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
       defaultValue = [],
       onChange: onChangeProp,
       onKeyDown,
+      onBlur,
       keyDownKeys = ['Enter', ',', ' '],
       tagColorScheme = 'secondary',
       tagInvalidation,
@@ -111,8 +112,9 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
           }
           event.preventDefault()
         }
+        onBlur?.(event)
       },
-      [addTag],
+      [addTag, onBlur],
     )
 
     const handleKeyDown = useCallback(
@@ -162,6 +164,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
                 isInvalid={tagInvalidation?.(tag)}
                 label={tag}
                 onClose={handleRemoveTag(index)}
+                onBlur={onBlur}
               />
             ))}
             <TagInputInput

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -151,6 +151,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
           >
             {value.map((tag, index) => (
               <TagInputTag
+                isDisabled={props.isDisabled}
                 key={index}
                 colorScheme={tagColorScheme}
                 label={tag}

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -11,6 +11,7 @@ import {
   forwardRef,
   StylesProvider,
   useControllableState,
+  useFormControl,
   useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
@@ -58,10 +59,8 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
     },
     ref,
   ): JSX.Element => {
-    const styles = useMultiStyleConfig('TagInput', {
-      size,
-      ...props,
-    })
+    const inputProps = useFormControl<HTMLInputElement>(props)
+    const styles = useMultiStyleConfig('TagInput', inputProps)
 
     const [value, onChange] = useControllableState({
       value: valueProp,
@@ -151,13 +150,13 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
           <Box
             sx={styles.container}
             onClick={handleFieldClick}
-            aria-disabled={props.isDisabled}
-            aria-invalid={props.isInvalid}
-            aria-readonly={props.isReadOnly}
+            aria-disabled={inputProps.disabled}
+            aria-invalid={inputProps['aria-invalid']}
+            aria-readonly={inputProps.readOnly}
           >
             {value.map((tag, index) => (
               <TagInputTag
-                isDisabled={props.isDisabled}
+                isDisabled={inputProps.disabled}
                 key={index}
                 colorScheme={tagColorScheme}
                 isInvalid={tagInvalidation?.(tag)}
@@ -166,7 +165,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
               />
             ))}
             <TagInputInput
-              {...props}
+              {...inputProps}
               onKeyDown={handleKeyDown}
               onBlur={handleBlur}
               ref={mergedInputRefs}

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -7,8 +7,8 @@ import {
 import { RovingTabIndexProvider } from 'react-roving-tabindex'
 import {
   Box,
-  Flex,
   forwardRef,
+  StylesProvider,
   useControllableState,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
@@ -50,7 +50,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
     },
     ref,
   ): JSX.Element => {
-    const inputStyle = useMultiStyleConfig('Input', { size, ...props })
+    const styles = useMultiStyleConfig('TagInput', { size, ...props })
 
     const [value, onChange] = useControllableState({
       value: valueProp,
@@ -129,35 +129,8 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
 
     return (
       <RovingTabIndexProvider>
-        <Box
-          sx={{
-            ...inputStyle.field,
-            display: 'flex',
-            flexWrap: 'wrap',
-            p: '0.375rem',
-            minH: '2.75rem',
-            cursor: 'pointer',
-            _disabled: {
-              cursor: 'not-allowed',
-            },
-            transitionProperty: 'common',
-            transitionDuration: 'normal',
-            borderRadius: '4px',
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            //@ts-ignore
-            _focusWithin: inputStyle.field._focus,
-            height: 'auto',
-            maxW: '100%',
-            w: '100%',
-          }}
-        >
-          <Flex
-            flexWrap="wrap"
-            align="center"
-            maxW="inherit"
-            w="100%"
-            gap="0.25rem"
-          >
+        <StylesProvider value={styles}>
+          <Box sx={styles.container}>
             {value.map((tag, index) => (
               <TagInputTag
                 key={index}
@@ -167,14 +140,13 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
               />
             ))}
             <TagInputInput
-              flexGrow={1}
               {...props}
               onKeyDown={handleKeyDown}
               onBlur={handleBlur}
               ref={ref}
             />
-          </Flex>
-        </Box>
+          </Box>
+        </StylesProvider>
       </RovingTabIndexProvider>
     )
   },

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -42,6 +42,8 @@ export interface TagInputProps
    * Should return `true` if tag is invalid
    */
   tagInvalidation?: (tag: string) => boolean
+
+  onBlur?: (event: SyntheticEvent) => void
 }
 
 export const TagInput = forwardRef<TagInputProps, 'input'>(
@@ -163,7 +165,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
                 colorScheme={tagColorScheme}
                 isInvalid={tagInvalidation?.(tag)}
                 label={tag}
-                onClose={handleRemoveTag(index)}
+                onClearTag={handleRemoveTag(index)}
                 onBlur={onBlur}
               />
             ))}

--- a/frontend/src/components/TagInput/TagInputInput.tsx
+++ b/frontend/src/components/TagInput/TagInputInput.tsx
@@ -1,11 +1,12 @@
 import { KeyboardEventHandler, useCallback, useRef } from 'react'
 import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
-import { chakra, forwardRef, useMergeRefs } from '@chakra-ui/react'
+import { chakra, forwardRef, useMergeRefs, useStyles } from '@chakra-ui/react'
 
 import { InputProps } from '~components/Input'
 
 export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
   ({ onKeyDown, ...props }, ref) => {
+    const styles = useStyles()
     // The ref of the input to be controlled.
     const focusedRef = useRef<HTMLElement>(null)
 
@@ -33,9 +34,7 @@ export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
 
     return (
       <chakra.input
-        flexGrow={1}
-        py="0.25rem"
-        pl="0.5rem"
+        sx={styles.field}
         {...props}
         ref={mergedRefs}
         tabIndex={tabIndex}

--- a/frontend/src/components/TagInput/TagInputInput.tsx
+++ b/frontend/src/components/TagInput/TagInputInput.tsx
@@ -1,0 +1,47 @@
+import { KeyboardEventHandler, useCallback, useRef } from 'react'
+import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
+import { chakra, forwardRef, useMergeRefs } from '@chakra-ui/react'
+
+import { InputProps } from '~components/Input'
+
+export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
+  ({ onKeyDown, ...props }, ref) => {
+    // The ref of the input to be controlled.
+    const focusedRef = useRef<HTMLElement>(null)
+
+    const mergedRefs = useMergeRefs(ref, focusedRef)
+
+    // handleKeyDown and handleClick are stable for the lifetime of the component:
+    const [tabIndex, focused, handleRovingKeyDown, handleClick] =
+      useRovingTabIndex(
+        focusedRef,
+        /* disabled= */ false, // But change this as you like throughout the lifetime of the component.
+      )
+    // Set focus on the input if it gets focus
+    useFocusEffect(focused, focusedRef)
+
+    const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+      (event) => {
+        onKeyDown?.(event)
+        // Only allow roving if the input is empty.
+        if (!event.currentTarget.value) {
+          handleRovingKeyDown(event)
+        }
+      },
+      [handleRovingKeyDown, onKeyDown],
+    )
+
+    return (
+      <chakra.input
+        flexGrow={1}
+        py="0.25rem"
+        pl="0.5rem"
+        {...props}
+        ref={mergedRefs}
+        tabIndex={tabIndex}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
+      />
+    )
+  },
+)

--- a/frontend/src/components/TagInput/TagInputInput.tsx
+++ b/frontend/src/components/TagInput/TagInputInput.tsx
@@ -5,7 +5,7 @@ import { chakra, forwardRef, useMergeRefs, useStyles } from '@chakra-ui/react'
 import { InputProps } from '~components/Input'
 
 export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
-  ({ onKeyDown, ...props }, ref) => {
+  ({ onKeyDown, isDisabled = false, isReadOnly, isInvalid, ...props }, ref) => {
     const styles = useStyles()
     // The ref of the input to be controlled.
     const focusedRef = useRef<HTMLElement>(null)
@@ -14,10 +14,8 @@ export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
 
     // handleKeyDown and handleClick are stable for the lifetime of the component:
     const [tabIndex, focused, handleRovingKeyDown, handleClick] =
-      useRovingTabIndex(
-        focusedRef,
-        /* disabled= */ false, // But change this as you like throughout the lifetime of the component.
-      )
+      useRovingTabIndex(focusedRef, isDisabled)
+
     // Set focus on the input if it gets focus
     useFocusEffect(focused, focusedRef)
 
@@ -34,6 +32,9 @@ export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
 
     return (
       <chakra.input
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        aria-invalid={isInvalid}
         sx={styles.field}
         {...props}
         ref={mergedRefs}

--- a/frontend/src/components/TagInput/TagInputInput.tsx
+++ b/frontend/src/components/TagInput/TagInputInput.tsx
@@ -1,11 +1,19 @@
-import { KeyboardEventHandler, useCallback, useRef } from 'react'
+import {
+  KeyboardEventHandler,
+  MouseEventHandler,
+  useCallback,
+  useRef,
+} from 'react'
 import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
 import { chakra, forwardRef, useMergeRefs, useStyles } from '@chakra-ui/react'
 
 import { InputProps } from '~components/Input'
 
 export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
-  ({ onKeyDown, isDisabled = false, isReadOnly, isInvalid, ...props }, ref) => {
+  (
+    { onKeyDown, isDisabled = false, isReadOnly, isInvalid, onClick, ...props },
+    ref,
+  ) => {
     const styles = useStyles()
     // The ref of the input to be controlled.
     const focusedRef = useRef<HTMLElement>(null)
@@ -13,7 +21,7 @@ export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
     const mergedRefs = useMergeRefs(ref, focusedRef)
 
     // handleKeyDown and handleClick are stable for the lifetime of the component:
-    const [tabIndex, focused, handleRovingKeyDown, handleClick] =
+    const [tabIndex, focused, handleRovingKeyDown, handleRovingClick] =
       useRovingTabIndex(focusedRef, isDisabled)
 
     // Set focus on the input if it gets focus
@@ -28,6 +36,14 @@ export const TagInputInput = forwardRef<Omit<InputProps, 'size'>, 'input'>(
         }
       },
       [handleRovingKeyDown, onKeyDown],
+    )
+
+    const handleClick: MouseEventHandler<HTMLInputElement> = useCallback(
+      (event) => {
+        onClick?.(event)
+        handleRovingClick()
+      },
+      [handleRovingClick, onClick],
     )
 
     return (

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -11,6 +11,7 @@ import { Tag, TagCloseButton, TagProps } from '~components/Tag/Tag'
 
 export interface TagInputTagProps extends TagProps {
   isDisabled?: boolean
+  isInvalid?: boolean
   label: string
   onClose: (event: SyntheticEvent) => void
 }
@@ -19,6 +20,8 @@ export const TagInputTag = ({
   label,
   onClose,
   isDisabled = false,
+  isInvalid,
+  colorScheme,
   ...props
 }: TagInputTagProps) => {
   // The ref of the input to be controlled.
@@ -55,6 +58,8 @@ export const TagInputTag = ({
     <Tag
       cursor="pointer"
       aria-disabled={isDisabled}
+      aria-invalid={isInvalid}
+      colorScheme={isInvalid ? 'danger' : colorScheme}
       {...props}
       ref={focusedRef}
       tabIndex={tabIndex}

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -45,7 +45,9 @@ export const TagInputTag = ({ label, onClose, ...props }: TagInputTagProps) => {
       onKeyDown={handleKeyDown}
       onClick={handleClick}
     >
-      <TagLabel noOfLines={1}>{label}</TagLabel>
+      <TagLabel title={label} isTruncated>
+        {label}
+      </TagLabel>
       <TagCloseButton tabIndex={-1} onClick={onClose} />
     </Tag>
   )

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -1,0 +1,52 @@
+import {
+  KeyboardEventHandler,
+  SyntheticEvent,
+  useCallback,
+  useRef,
+} from 'react'
+import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
+import { TagLabel } from '@chakra-ui/react'
+
+import { Tag, TagCloseButton, TagProps } from '~components/Tag/Tag'
+
+export interface TagInputTagProps extends TagProps {
+  label: string
+  onClose: (event: SyntheticEvent) => void
+}
+
+export const TagInputTag = ({ label, onClose, ...props }: TagInputTagProps) => {
+  // The ref of the input to be controlled.
+  const focusedRef = useRef<HTMLElement>(null)
+
+  // handleKeyDown and handleClick are stable for the lifetime of the component:
+  const [tabIndex, focused, handleRovingKeyDown, handleClick] =
+    useRovingTabIndex(focusedRef, /* disabled= */ false)
+
+  // Set focus on the tag if it gets focus.
+  useFocusEffect(focused, focusedRef)
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      switch (event.key) {
+        case 'Delete':
+        case 'Backspace':
+          return onClose(event)
+      }
+      handleRovingKeyDown(event)
+    },
+    [handleRovingKeyDown, onClose],
+  )
+
+  return (
+    <Tag
+      {...props}
+      ref={focusedRef}
+      tabIndex={tabIndex}
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+    >
+      <TagLabel noOfLines={1}>{label}</TagLabel>
+      <TagCloseButton tabIndex={-1} onClick={onClose} />
+    </Tag>
+  )
+}

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -13,15 +13,17 @@ export interface TagInputTagProps extends TagProps {
   isDisabled?: boolean
   isInvalid?: boolean
   label: string
-  onClose: (event: SyntheticEvent) => void
+  onClearTag: (event: SyntheticEvent) => void
+  onBlur?: (event: SyntheticEvent) => void
 }
 
 export const TagInputTag = ({
   label,
-  onClose,
   isDisabled = false,
   isInvalid,
   colorScheme,
+  onClearTag,
+  onBlur,
   ...props
 }: TagInputTagProps) => {
   // The ref of the input to be controlled.
@@ -42,16 +44,25 @@ export const TagInputTag = ({
     [handleRovingClick],
   )
 
+  const handleCloseButtonClick = useCallback(
+    (event: SyntheticEvent) => {
+      onClearTag(event)
+      onBlur?.(event)
+      event.stopPropagation()
+    },
+    [onBlur, onClearTag],
+  )
+
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
       switch (event.key) {
         case 'Delete':
         case 'Backspace':
-          return onClose(event)
+          return onClearTag(event)
       }
       handleRovingKeyDown(event)
     },
-    [handleRovingKeyDown, onClose],
+    [handleRovingKeyDown, onClearTag],
   )
 
   return (
@@ -69,7 +80,11 @@ export const TagInputTag = ({
       <TagLabel title={label} isTruncated>
         {label}
       </TagLabel>
-      <TagCloseButton tabIndex={-1} isDisabled={isDisabled} onClick={onClose} />
+      <TagCloseButton
+        tabIndex={-1}
+        isDisabled={isDisabled}
+        onClick={handleCloseButtonClick}
+      />
     </Tag>
   )
 }

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -10,20 +10,34 @@ import { TagLabel } from '@chakra-ui/react'
 import { Tag, TagCloseButton, TagProps } from '~components/Tag/Tag'
 
 export interface TagInputTagProps extends TagProps {
+  isDisabled?: boolean
   label: string
   onClose: (event: SyntheticEvent) => void
 }
 
-export const TagInputTag = ({ label, onClose, ...props }: TagInputTagProps) => {
+export const TagInputTag = ({
+  label,
+  onClose,
+  isDisabled = false,
+  ...props
+}: TagInputTagProps) => {
   // The ref of the input to be controlled.
   const focusedRef = useRef<HTMLElement>(null)
 
   // handleKeyDown and handleClick are stable for the lifetime of the component:
-  const [tabIndex, focused, handleRovingKeyDown, handleClick] =
-    useRovingTabIndex(focusedRef, /* disabled= */ false)
+  const [tabIndex, focused, handleRovingKeyDown, handleRovingClick] =
+    useRovingTabIndex(focusedRef, isDisabled)
 
   // Set focus on the tag if it gets focus.
   useFocusEffect(focused, focusedRef)
+
+  const handleClick = useCallback(
+    (event: SyntheticEvent) => {
+      handleRovingClick()
+      event.stopPropagation()
+    },
+    [handleRovingClick],
+  )
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
@@ -39,6 +53,7 @@ export const TagInputTag = ({ label, onClose, ...props }: TagInputTagProps) => {
 
   return (
     <Tag
+      cursor="pointer"
       {...props}
       ref={focusedRef}
       tabIndex={tabIndex}

--- a/frontend/src/components/TagInput/TagInputTag.tsx
+++ b/frontend/src/components/TagInput/TagInputTag.tsx
@@ -54,6 +54,7 @@ export const TagInputTag = ({
   return (
     <Tag
       cursor="pointer"
+      aria-disabled={isDisabled}
       {...props}
       ref={focusedRef}
       tabIndex={tabIndex}
@@ -63,7 +64,7 @@ export const TagInputTag = ({
       <TagLabel title={label} isTruncated>
         {label}
       </TagLabel>
-      <TagCloseButton tabIndex={-1} onClick={onClose} />
+      <TagCloseButton tabIndex={-1} isDisabled={isDisabled} onClick={onClose} />
     </Tag>
   )
 }

--- a/frontend/src/components/TagInput/index.ts
+++ b/frontend/src/components/TagInput/index.ts
@@ -1,0 +1,2 @@
+export type { TagInputProps } from './TagInput'
+export { TagInput } from './TagInput'

--- a/frontend/src/theme/components/TagInput.ts
+++ b/frontend/src/theme/components/TagInput.ts
@@ -1,0 +1,72 @@
+import {
+  anatomy,
+  PartsStyleFunction,
+  PartsStyleObject,
+} from '@chakra-ui/theme-tools'
+
+import { Input } from './Input'
+
+export const parts = anatomy('taginput').parts('container', 'field')
+
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
+  return {
+    container: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      cursor: 'pointer',
+      height: 'auto',
+      maxW: '100%',
+      w: '100%',
+      _disabled: {
+        cursor: 'not-allowed',
+      },
+      transitionProperty: 'common',
+      transitionDuration: 'normal',
+    },
+    field: {
+      flexGrow: 1,
+    },
+  }
+}
+
+const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
+  const inputFieldVariantOutline = Input.variants.outline(props).field
+
+  return {
+    container: {
+      borderRadius: '4px',
+      _focusWithin: inputFieldVariantOutline._focus,
+      ...inputFieldVariantOutline,
+    },
+  }
+}
+
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
+  md: {
+    container: {
+      p: '0.375rem',
+      minH: '2.75rem',
+      gap: '0.25rem',
+    },
+    field: {
+      py: '0.25rem',
+      pl: '0.5rem',
+    },
+  },
+}
+
+export const TagInput = {
+  parts: parts.keys,
+  baseStyle,
+  variants: {
+    outline: variantOutline,
+  },
+  sizes,
+  defaultProps: {
+    size: 'md',
+    variant: 'outline',
+    focusBorderColor: Input.defaultProps.focusBorderColor,
+    errorBorderColor: Input.defaultProps.errorBorderColor,
+    colorScheme: 'primary',
+  },
+}

--- a/frontend/src/theme/components/TagInput.ts
+++ b/frontend/src/theme/components/TagInput.ts
@@ -13,7 +13,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
     container: {
       display: 'flex',
       flexWrap: 'wrap',
-      cursor: 'pointer',
+      cursor: 'text',
       height: 'auto',
       maxW: '100%',
       w: '100%',
@@ -25,6 +25,9 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
     },
     field: {
       flexGrow: 1,
+      _disabled: {
+        cursor: 'not-allowed',
+      },
     },
   }
 }

--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -32,6 +32,7 @@ import { SingleSelect } from './SingleSelect'
 import { Table } from './Table'
 import { Tabs } from './Tabs'
 import { Tag } from './Tag'
+import { TagInput } from './TagInput'
 import { Textarea } from './Textarea'
 import { Tile } from './Tile'
 import { Toast } from './Toast'
@@ -67,6 +68,7 @@ export const components = {
   Table,
   Tabs,
   Tag,
+  TagInput,
   [ATTACHMENT_THEME_KEY]: Attachment,
   [PAGINATION_THEME_KEY]: Pagination,
   [CHECKBOX_THEME_KEY]: Checkbox,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds the primitive `TagInput` component, which can also be added to the design system (later).
Mostly used for creating tags in an array format via an input. Keys that create a tag defaults to the Enter, Comma, and Space keys.

Part 1 of updating email mode recipient list for better input handling, and to be closer to the design.

Related to #4335

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Add `TagInput` component and theme.


## Before & After Screenshots
New stories have been added for the component

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `react-roving-tabindex` : for adding roving tab index to navigate between created tags in the input
