### PR TITLE
feat: use new TagInput component for email respondents input

### DIFF
--- a/frontend/src/components/TagInput/TagInput.stories.tsx
+++ b/frontend/src/components/TagInput/TagInput.stories.tsx
@@ -43,7 +43,7 @@ export const InvalidFieldWithInvalidTags = Template.bind({})
 InvalidFieldWithInvalidTags.args = {
   isInvalid: true,
   defaultValue: ['foo', 'bar', 'bazinvalid'],
-  tagInvalidation: (tag) => tag.length > 3,
+  tagValidation: (tag) => tag.length <= 3,
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/components/TagInput/TagInput.tsx
+++ b/frontend/src/components/TagInput/TagInput.tsx
@@ -39,9 +39,10 @@ export interface TagInputProps
   keyDownKeys?: string[]
   /**
    * Optional function to call to validate created tags.
-   * Should return `true` if tag is invalid
+   * Should return `true` if tag is valid.
+   * If no function is provided, all tags are considered valid.
    */
-  tagInvalidation?: (tag: string) => boolean
+  tagValidation?: (tag: string) => boolean
 
   /**
    * Optional function to call when input is blurred.
@@ -63,7 +64,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
       onBlur,
       keyDownKeys = ['Enter', ',', ' '],
       tagColorScheme = 'secondary',
-      tagInvalidation,
+      tagValidation = () => true,
       size,
       preventDuplicates = true,
       ...props
@@ -172,7 +173,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
                 isDisabled={inputProps.disabled}
                 key={index}
                 colorScheme={tagColorScheme}
-                isInvalid={tagInvalidation?.(tag)}
+                isInvalid={!tagValidation(tag)}
                 label={tag}
                 onClearTag={handleRemoveTag(index)}
                 onBlur={onBlur}

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -7,14 +7,15 @@ import {
 } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 import { get, isEmpty, isEqual } from 'lodash'
+import isEmail from 'validator/lib/isEmail'
 
 import { EmailFormSettings } from '~shared/types/form/form'
 
 import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
-import { createAdminEmailValidationTransform } from '~utils/formValidation'
+import { ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
-import Input from '~components/Input'
+import { TagInput } from '~components/TagInput'
 
 import { useMutateFormSettings } from '../mutations'
 
@@ -78,11 +79,6 @@ const AdminEmailRecipientsInput = ({
   const { control, handleSubmit, reset } =
     useFormContext<{ emails: string[] }>()
 
-  const { rules, transform } = useMemo(
-    () => createAdminEmailValidationTransform(),
-    [],
-  )
-
   const handleBlur = useCallback(() => {
     return handleSubmit(onSubmit, () => reset())()
   }, [handleSubmit, onSubmit, reset])
@@ -91,12 +87,16 @@ const AdminEmailRecipientsInput = ({
     <Controller
       control={control}
       name="emails"
-      rules={rules}
+      rules={ADMIN_EMAIL_VALIDATION_RULES}
       render={({ field }) => (
-        <Input
-          value={transform.input(field.value)}
-          onChange={(e) => field.onChange(transform.output(e.target.value))}
-          onBlur={handleBlur}
+        <TagInput
+          placeholder="Separate emails with a comma"
+          {...field}
+          tagInvalidation={(tag) => !isEmail(tag)}
+          onBlur={() => {
+            console.log('blurring')
+            return handleBlur()
+          }}
         />
       )}
     />

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -93,10 +93,7 @@ const AdminEmailRecipientsInput = ({
           placeholder="Separate emails with a comma"
           {...field}
           tagInvalidation={(tag) => !isEmail(tag)}
-          onBlur={() => {
-            console.log('blurring')
-            return handleBlur()
-          }}
+          onBlur={handleBlur}
         />
       )}
     />

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -92,7 +92,7 @@ const AdminEmailRecipientsInput = ({
         <TagInput
           placeholder="Separate emails with a comma"
           {...field}
-          tagInvalidation={(tag) => !isEmail(tag)}
+          tagValidation={isEmail}
           onBlur={handleBlur}
         />
       )}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
@@ -40,7 +40,7 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
           <TagInput
             placeholder="Separate emails with a comma"
             {...field}
-            tagInvalidation={(tag) => !isEmail(tag)}
+            tagValidation={isEmail}
           />
         )}
       />

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
@@ -1,11 +1,12 @@
-import { useMemo } from 'react'
 import { Controller } from 'react-hook-form'
 import { Skeleton } from '@chakra-ui/react'
 import { get } from 'lodash'
+import isEmail from 'validator/lib/isEmail'
 
-import { createAdminEmailValidationTransform } from '~utils/formValidation'
+import { ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Input from '~components/Input'
+import { TagInput } from '~components/TagInput'
 
 import { useUser } from '~features/user/queries'
 
@@ -18,11 +19,6 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
     control,
     formState: { errors },
   } = formMethods
-
-  const emailTransformRules = useMemo(
-    () => createAdminEmailValidationTransform(),
-    [],
-  )
 
   // Add loading skeleton
   if (!user || isLoading) {
@@ -39,14 +35,12 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
         control={control}
         defaultValue={[user.email]}
         name="emails"
-        rules={emailTransformRules.rules}
-        render={({ field: { value, onChange, ...rest } }) => (
-          <Input
-            value={emailTransformRules.transform.input(value)}
-            onChange={(e) =>
-              onChange(emailTransformRules.transform.output(e.target.value))
-            }
-            {...rest}
+        rules={ADMIN_EMAIL_VALIDATION_RULES}
+        render={({ field }) => (
+          <TagInput
+            placeholder="Separate emails with a comma"
+            {...field}
+            tagInvalidation={(tag) => !isEmail(tag)}
           />
         )}
       />

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -30,49 +30,31 @@ export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
   },
 }
 
-export const createAdminEmailValidationTransform = () => {
-  const transform = {
-    // Combine and display all emails in a single string in the input field.
-    input: (value: string[]) => value.join(','),
-    // Convert joined email string into an array of emails.
-    output: (value: string) =>
-      value
-        .replace(/\s/g, '')
-        .split(',')
-        .map((v) => v.trim()),
-  }
-
-  const rules: UseControllerProps['rules'] = {
-    validate: {
-      required: (emails: string[]) => {
-        return (
-          emails.filter(Boolean).length > 0 ||
-          'You must at least enter one email to receive responses'
-        )
-      },
-      valid: (emails: string[]) => {
-        return (
-          emails.filter(Boolean).every((e) => validator.isEmail(e)) ||
-          'Please enter valid email(s) (e.g. me@example.com) separated by commas.'
-        )
-      },
-      duplicate: (emails: string[]) => {
-        return (
-          new Set(emails).size === emails.length ||
-          'Please remove duplicate emails.'
-        )
-      },
-      maxLength: (emails: string[]) => {
-        return (
-          emails.length <= MAX_EMAIL_LENGTH ||
-          'Please limit number of emails to 30.'
-        )
-      },
+export const ADMIN_EMAIL_VALIDATION_RULES: UseControllerProps['rules'] = {
+  validate: {
+    required: (emails: string[]) => {
+      return (
+        emails.filter(Boolean).length > 0 ||
+        'You must at least enter one email to receive responses'
+      )
     },
-  }
-
-  return {
-    rules,
-    transform,
-  }
+    valid: (emails: string[]) => {
+      return (
+        emails.filter(Boolean).every((e) => validator.isEmail(e)) ||
+        'Please enter valid email(s) (e.g. me@example.com) separated by commas.'
+      )
+    },
+    duplicate: (emails: string[]) => {
+      return (
+        new Set(emails).size === emails.length ||
+        'Please remove duplicate emails.'
+      )
+    },
+    maxLength: (emails: string[]) => {
+      return (
+        emails.length <= MAX_EMAIL_LENGTH ||
+        'Please limit number of emails to 30.'
+      )
+    },
+  },
 }

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -45,15 +45,16 @@ export const ADMIN_EMAIL_VALIDATION_RULES: UseControllerProps['rules'] = {
       )
     },
     duplicate: (emails: string[]) => {
+      const truthyEmails = emails.filter(Boolean)
       return (
-        new Set(emails).size === emails.length ||
+        new Set(truthyEmails).size === truthyEmails.length ||
         'Please remove duplicate emails.'
       )
     },
     maxLength: (emails: string[]) => {
       return (
-        emails.length <= MAX_EMAIL_LENGTH ||
-        'Please limit number of emails to 30.'
+        emails.filter(Boolean).length <= MAX_EMAIL_LENGTH ||
+        `Please limit number of emails to ${MAX_EMAIL_LENGTH}.`
       )
     },
   },


### PR DESCRIPTION
> This PR builds on #4509 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Updates the email respondents input to use newly created `TagInput` component. 

Also closes #4335

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: use new TagInput component for email respondents input


## Before & After Screenshots
Stories should update
