### PR TITLE
feat(form-v2/react-to-angular/3): remove infoboxes when rollout percentages hit thresholds

### DIFF
--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react'
 import { Flex, Spacer } from '@chakra-ui/react'
 
-import { FormColorTheme } from '~shared/types'
+import { FormColorTheme, FormResponseMode } from '~shared/types'
+
+import { useEnv } from '~features/env/queries'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
@@ -39,17 +41,26 @@ export const PublicFormWrapper = ({
   children,
 }: PublicFormWrapperProps): JSX.Element => {
   const { form, isLoading, isAuthRequired } = usePublicFormContext()
+  const { data: { respondentRolloutEmail, respondentRolloutStorage } = {} } =
+    useEnv()
 
   const bgColour = useBgColor({
     colorTheme: isLoading ? undefined : form?.startPage.colorTheme,
   })
-
+  const isEmailForm = form?.responseMode === FormResponseMode.Email
+  const switchEnvRolloutPercentage = isEmailForm
+    ? respondentRolloutEmail
+    : respondentRolloutStorage
+  // Remove the switch env message if the React rollout for public form respondents is >10%
+  const showSwitchEnvMessage = !!(
+    switchEnvRolloutPercentage && switchEnvRolloutPercentage <= 10
+  )
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">
       {isAuthRequired ? null : <SectionSidebar />}
       <Flex flexDir="column">
         {/* TODO(#4279): Remove switch env message on full rollout */}
-        {!isPreview && <PublicSwitchEnvMessage />}
+        {!isPreview && showSwitchEnvMessage && <PublicSwitchEnvMessage />}
         {children}
       </Flex>
       {isAuthRequired ? null : <Spacer />}

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -40,6 +40,7 @@ export const PublicFormWrapper = ({
   isPreview,
   children,
 }: PublicFormWrapperProps): JSX.Element => {
+  const REMOVE_RESPONDENTS_INFOBOX_THRESHOLD = 10
   const { form, isLoading, isAuthRequired } = usePublicFormContext()
   const { data: { respondentRolloutEmail, respondentRolloutStorage } = {} } =
     useEnv()
@@ -53,7 +54,8 @@ export const PublicFormWrapper = ({
     : respondentRolloutStorage
   // Remove the switch env message if the React rollout for public form respondents is >10%
   const showSwitchEnvMessage = !!(
-    switchEnvRolloutPercentage && switchEnvRolloutPercentage <= 10
+    switchEnvRolloutPercentage &&
+    switchEnvRolloutPercentage <= REMOVE_RESPONDENTS_INFOBOX_THRESHOLD
   )
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -5,11 +5,13 @@ import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 
 import { useEnvMutations } from '~features/env/mutations'
+import { useEnv } from '~features/env/queries'
 
 export const AdminSwitchEnvMessage = (): JSX.Element => {
   const { adminSwitchEnvMutation } = useEnvMutations()
-
-  return (
+  const { data: { adminRollout } = {} } = useEnv()
+  const showSwitchEnvMessage = adminRollout && adminRollout <= 100
+  return showSwitchEnvMessage ? (
     <InlineMessage>
       <Text>
         Welcome to the new FormSG! You can still{' '}
@@ -19,5 +21,7 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
         which is available until 28 May 2022.
       </Text>
     </InlineMessage>
+  ) : (
+    <></>
   )
 }

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -8,9 +8,11 @@ import { useEnvMutations } from '~features/env/mutations'
 import { useEnv } from '~features/env/queries'
 
 export const AdminSwitchEnvMessage = (): JSX.Element => {
+  const REMOVE_ADMIN_INFOBOX_THRESHOLD = 100
   const { adminSwitchEnvMutation } = useEnvMutations()
   const { data: { adminRollout } = {} } = useEnv()
-  const showSwitchEnvMessage = adminRollout && adminRollout <= 100
+  const showSwitchEnvMessage =
+    adminRollout && adminRollout < REMOVE_ADMIN_INFOBOX_THRESHOLD
   return showSwitchEnvMessage ? (
     <InlineMessage>
       <Text>

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -28,4 +28,5 @@ export type ClientEnvVars = {
   spcpCookieDomain: string // Cookie domain used for removing spcp cookies
   respondentRolloutEmail: number
   respondentRolloutStorage: number
+  adminRollout: number
 }

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -26,4 +26,6 @@ export type ClientEnvVars = {
   myInfoBannerContent: string // MyInfo maintenance message
   GATrackingID: string | null
   spcpCookieDomain: string // Cookie domain used for removing spcp cookies
+  respondentRolloutEmail: number
+  respondentRolloutStorage: number
 }

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -25,6 +25,10 @@ const frontendVars = {
   reactMigrationRespondentCookieName:
     config.reactMigration.respondentCookieName,
   reactMigrationAdminCookieName: config.reactMigration.adminCookieName,
+  reactMigrationRespondentRolloutEmail:
+    config.reactMigration.respondentRolloutEmail,
+  reactMigrationRespondentRolloutStorage:
+    config.reactMigration.respondentRolloutStorage,
 }
 const environment = ejs.render(
   `
@@ -51,6 +55,8 @@ const environment = ejs.render(
     // React Migration
     var reactMigrationRespondentCookieName = "<%= reactMigrationRespondentCookieName%>"
     var reactMigrationAdminCookieName = "<%= reactMigrationAdminCookieName%>"
+    var reactMigrationRespondentRolloutEmail = "<%= reactMigrationRespondentRolloutEmail%>"
+    var reactMigrationRespondentRolloutStorage = "<%= reactMigrationRespondentRolloutStorage%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -29,6 +29,7 @@ const frontendVars = {
     config.reactMigration.respondentRolloutEmail,
   reactMigrationRespondentRolloutStorage:
     config.reactMigration.respondentRolloutStorage,
+  reactMigrationAdminRollout: config.reactMigration.adminRollout,
 }
 const environment = ejs.render(
   `
@@ -57,6 +58,7 @@ const environment = ejs.render(
     var reactMigrationAdminCookieName = "<%= reactMigrationAdminCookieName%>"
     var reactMigrationRespondentRolloutEmail = "<%= reactMigrationRespondentRolloutEmail%>"
     var reactMigrationRespondentRolloutStorage = "<%= reactMigrationRespondentRolloutStorage%>"
+    var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"
   `,
   frontendVars,
 )

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -20,5 +20,8 @@ export const getClientEnvVars = (): ClientEnvVars => {
     myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
     GATrackingID: googleAnalyticsConfig.GATrackingID,
     spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
+    respondentRolloutEmail: config.reactMigration.respondentRolloutEmail,
+    respondentRolloutStorage: config.reactMigration.respondentRolloutStorage,
+    adminRollout: config.reactMigration.adminRollout,
   }
 }

--- a/src/public/utils/injectedVariables.ts
+++ b/src/public/utils/injectedVariables.ts
@@ -14,6 +14,8 @@ interface FrontendInjectedVariables {
   myInfoBannerContent: string | null
   GATrackingID: string | null
   spcpCookieDomain: string | null
+  respondentRolloutEmail: number
+  respondentRolloutStorage: number
 }
 
 // NOTE: As these variables are not injected until runtime
@@ -35,4 +37,6 @@ export const injectedVariables: FrontendInjectedVariables = {
   myInfoBannerContent: formsgWindow.myInfoBannerContent ?? null,
   GATrackingID: formsgWindow.GATrackingID ?? null,
   spcpCookieDomain: formsgWindow.spcpCookieDomain ?? null,
+  respondentRolloutEmail: formsgWindow.respondentRolloutEmail,
+  respondentRolloutStorage: formsgWindow.respondentRolloutStorage,
 }

--- a/src/public/utils/injectedVariables.ts
+++ b/src/public/utils/injectedVariables.ts
@@ -16,6 +16,7 @@ interface FrontendInjectedVariables {
   spcpCookieDomain: string | null
   respondentRolloutEmail: number
   respondentRolloutStorage: number
+  adminRollout: number
 }
 
 // NOTE: As these variables are not injected until runtime
@@ -39,4 +40,5 @@ export const injectedVariables: FrontendInjectedVariables = {
   spcpCookieDomain: formsgWindow.spcpCookieDomain ?? null,
   respondentRolloutEmail: formsgWindow.respondentRolloutEmail,
   respondentRolloutStorage: formsgWindow.respondentRolloutStorage,
+  adminRollout: formsgWindow.adminRollout,
 }


### PR DESCRIPTION
## Solution
Remove visibility of switch-back-to-AngularJS infoboxes after rollouts hit their respective % (10% for public respondents, 100% for admins)

Closes #3933 

**Details**
- Add 
`respondentRolloutEmail`, `respondentRolloutStorage`, `adminRollout` to frontend end vars
- Determine `showSwitchEnvMessage` boolean depending on whether the rollout % > the % threshold to remove the infobox

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
- [x] Set the rollout % for an email mode form below the % threshold for removal of the infobox. Infobox should be visible.
- [x] Set the rollout % for a storage mode form below the % threshold for removal of the infobox. Infobox should be visible.
- [x] Set the rollout % for admins below the % threshold for removal of the infobox. Infobox should be visible.
- [x] Repeat the 3 tests above, but set the rollout % to be above the % threshold for removal of the infobox. The infobox should no longer be seen.

