### PR TITLE
fix(v2): update some buttons' colorSchemes in public form, prevent preview from triggering logout

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -72,7 +72,8 @@ export const StartPageView = () => {
   }, [form?.startPage, startPageFromStore])
 
   // Color theme options and other design stuff, identical to public form
-  const { titleColor, titleBg, estTimeString } = useFormHeader(startPage)
+  const { titleColor, titleBg, estTimeString, colorScheme } =
+    useFormHeader(startPage)
 
   const { hasLogo, logoImgSrc, logoImgAlt } = useFormBannerLogo({
     logoBucketUrl,
@@ -103,6 +104,7 @@ export const StartPageView = () => {
         estTimeString={estTimeString}
         titleBg={titleBg}
         titleColor={titleColor}
+        colorScheme={colorScheme}
         showHeader
         loggedInId={
           form?.authType !== FormAuthType.NIL ? PREVIEW_MOCK_UINFIN : undefined

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -36,6 +36,8 @@ export interface PublicFormContextProps
   /** Callback to be invoked when user submits public form. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleSubmitForm: (formInputs: any) => void
+  /** Callback to be invoked to logout of authenticated form, if user is logged in.  */
+  handleLogout?: () => void
   /** id of container to render captcha in.
    * Captcha will be instantiated if provided
    */

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -34,7 +34,7 @@ import {
 } from '~features/verifiable-fields'
 
 import { FormNotFound } from './components/FormNotFound'
-import { usePublicFormMutations } from './mutations'
+import { usePublicAuthMutations, usePublicFormMutations } from './mutations'
 import {
   PublicFormContext,
   SidebarSectionMeta,
@@ -190,6 +190,8 @@ export const PublicFormProvider = ({
   const { submitEmailModeFormMutation, submitStorageModeFormMutation } =
     usePublicFormMutations(formId, submissionData?.id ?? '')
 
+  const { handleLogoutMutation } = usePublicAuthMutations(formId)
+
   const handleSubmitForm: SubmitHandler<FormFieldValues> = useCallback(
     async (formInputs) => {
       const { form } = cachedDto ?? {}
@@ -261,6 +263,11 @@ export const PublicFormProvider = ({
 
   useTimeout(generateVfnExpiryToast, expiryInMs)
 
+  const handleLogout = useCallback(() => {
+    if (!cachedDto?.form || cachedDto.form.authType === FormAuthType.NIL) return
+    return handleLogoutMutation.mutate(cachedDto.form.authType)
+  }, [cachedDto?.form, handleLogoutMutation])
+
   const isAuthRequired = useMemo(
     () =>
       !!cachedDto?.form &&
@@ -298,6 +305,7 @@ export const PublicFormProvider = ({
     <PublicFormContext.Provider
       value={{
         handleSubmitForm,
+        handleLogout,
         formId,
         error,
         submissionData,

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -13,6 +13,7 @@ import {
 
 import { BxMenuAltLeft } from '~assets/icons/BxMenuAltLeft'
 import { BxsTimeFive } from '~assets/icons/BxsTimeFive'
+import { ThemeColorScheme } from '~theme/foundations/colours'
 import Button from '~components/Button'
 import IconButton from '~components/IconButton'
 
@@ -24,6 +25,7 @@ export type MiniHeaderProps = Pick<
   | 'activeSectionId'
   | 'miniHeaderRef'
   | 'onMobileDrawerOpen'
+  | 'colorScheme'
 > & { isOpen: boolean }
 
 export const MiniHeader = ({
@@ -33,6 +35,7 @@ export const MiniHeader = ({
   activeSectionId,
   miniHeaderRef,
   onMobileDrawerOpen,
+  colorScheme,
   isOpen,
 }: MiniHeaderProps): JSX.Element => (
   <Slide
@@ -68,8 +71,7 @@ export const MiniHeader = ({
           {activeSectionId ? (
             // Section sidebar icon should only show up if sections exist
             <IconButton
-              variant="solid"
-              colorScheme="primary"
+              colorScheme={colorScheme}
               aria-label="Mobile section sidebar"
               fontSize="1.5rem"
               icon={<BxMenuAltLeft />}
@@ -88,6 +90,7 @@ interface FormHeaderProps {
   estTimeString: string
   titleBg: string
   titleColor: string
+  colorScheme?: ThemeColorScheme
   showHeader?: boolean
   loggedInId?: string
   showMiniHeader?: boolean
@@ -102,6 +105,7 @@ export const FormHeader = ({
   estTimeString,
   titleBg,
   titleColor,
+  colorScheme,
   showHeader,
   loggedInId,
   showMiniHeader,
@@ -134,6 +138,7 @@ export const FormHeader = ({
           title={title}
           titleBg={titleBg}
           titleColor={titleColor}
+          colorScheme={colorScheme}
           activeSectionId={activeSectionId}
           miniHeaderRef={miniHeaderRef}
           onMobileDrawerOpen={onMobileDrawerOpen}
@@ -172,6 +177,7 @@ export const FormHeader = ({
           {loggedInId ? (
             <Button
               mt="2.25rem"
+              colorScheme={colorScheme}
               variant="reverse"
               aria-label="Log out"
               rightIcon={<BiLogOutCircle fontSize="1.5rem" />}

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
-import { FormAuthType, FormLogoState } from '~shared/types'
+import { FormLogoState } from '~shared/types'
 
 import { useEnv } from '~features/env/queries'
-import { usePublicAuthMutations } from '~features/public-form/mutations'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { useFormSections } from '../FormFields/FormSectionsContext'
@@ -17,10 +16,10 @@ export const FormStartPage = (): JSX.Element => {
   const {
     form,
     spcpSession,
-    formId,
     submissionData,
     miniHeaderRef,
     onMobileDrawerOpen,
+    handleLogout,
   } = usePublicFormContext()
   const { activeSectionId } = useFormSections()
 
@@ -40,12 +39,6 @@ export const FormStartPage = (): JSX.Element => {
   })
 
   const formHeaderProps = useFormHeader(form?.startPage)
-
-  const { handleLogoutMutation } = usePublicAuthMutations(formId)
-  const handleLogout = useCallback(() => {
-    if (!form || form?.authType === FormAuthType.NIL) return
-    return handleLogoutMutation.mutate(form.authType)
-  }, [form, handleLogoutMutation])
 
   return (
     <>

--- a/frontend/src/features/public-form/components/FormStartPage/useFormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/useFormHeader.tsx
@@ -3,6 +3,8 @@ import simplur from 'simplur'
 
 import { FormColorTheme, FormStartPage } from '~shared/types'
 
+import { ThemeColorScheme } from '~theme/foundations/colours'
+
 export const getTitleBg = (colorTheme?: FormColorTheme) =>
   colorTheme ? `theme-${colorTheme}.500` : `neutral.200`
 
@@ -24,5 +26,15 @@ export const useFormHeader = (startPage?: FormStartPage) => {
     return simplur`${startPage.estTimeTaken} min[|s] estimated time to complete`
   }, [startPage])
 
-  return { titleColor, titleBg, estTimeString }
+  const colorScheme: ThemeColorScheme | undefined = useMemo(() => {
+    if (!startPage?.colorTheme) return
+    return `theme-${startPage.colorTheme}` as const
+  }, [startPage?.colorTheme])
+
+  return {
+    titleColor,
+    titleBg,
+    estTimeString,
+    colorScheme,
+  }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Misc PR to make logout button and mobile section drawer button consistent with the form's color theme. Also move authed form logout function into `PublicFormProvider` so `PreviewFormProvider` cannot accidentally trigger (a benign) logout call. 


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: update colorScheme of buttons in public form view

**Improvements**:

- feat: move public form logout to PublicFormProvider


## Before & After Screenshots
Maybe the current authed stories will update the button colors. 
