### PR TITLE
feat(form-v2): guide button in builder

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import {
   BiDotsHorizontalRounded,
+  BiHelpCircle,
   BiLeftArrowAlt,
   BiShareAlt,
   BiShow,
@@ -142,6 +143,17 @@ export const AdminFormNavbar = ({
         />
         <Box display={{ base: 'none', md: 'flex' }}>
           <ButtonGroup spacing="0.5rem" isDisabled={!formInfo}>
+            <Tooltip label="Help">
+              <IconButton
+                aria-label="Help"
+                variant="outline"
+                onClick={(e) => {
+                  e.preventDefault()
+                  window.open('https://guide.form.gov.sg/')
+                }}
+                icon={<BiHelpCircle />}
+              />
+            </Tooltip>
             <Tooltip label="Manage collaborators">
               <IconButton
                 aria-label="Manage collaborators"

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -23,6 +23,7 @@ import {
 
 import { AdminFormDto } from '~shared/types/form/form'
 
+import { FORM_GUIDE } from '~constants/links'
 import { useDraggable } from '~hooks/useDraggable'
 import Button, { ButtonProps } from '~components/Button'
 import IconButton from '~components/IconButton'
@@ -149,7 +150,7 @@ export const AdminFormNavbar = ({
                 variant="outline"
                 onClick={(e) => {
                   e.preventDefault()
-                  window.open('https://guide.form.gov.sg/')
+                  window.open(FORM_GUIDE)
                 }}
                 icon={<BiHelpCircle />}
               />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
add link to guide in builder

Closes #4478 

## Solution
<!-- How did you solve the problem? -->
observed where help buttons to the form guide are placed in the workspace page as well as the landing page. placed button on the navbar following the pattern above.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<details>

![image](https://user-images.githubusercontent.com/102740235/183233202-4d5f094e-c7d5-46fa-b439-bc2f623d2915.png)
</details>

**AFTER**:
<!-- [insert screenshot here] -->
<details>


https://user-images.githubusercontent.com/102740235/183233175-e242bb56-7772-4c7d-8ff8-65c300f9cd9f.mp4
</details>

