### PR TITLE
feat(form-v2): add builder start page hover and editing states

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -61,6 +61,11 @@ import {
   updateEditStateSelector,
   useBuilderAndDesignStore,
 } from '../../useBuilderAndDesignStore'
+import {
+  DesignState,
+  setStateSelector,
+  useDesignStore,
+} from '../../useDesignStore'
 import { useDesignColorTheme } from '../../utils/useDesignColorTheme'
 
 import { SectionFieldRow } from './SectionFieldRow'
@@ -89,6 +94,8 @@ export const FieldRowContainer = ({
         [],
       ),
     )
+
+  const setDesignState = useDesignStore(setStateSelector)
 
   const { handleBuilderClick } = useCreatePageSidebar()
 
@@ -146,13 +153,21 @@ export const FieldRowContainer = ({
   const handleFieldClick = useCallback(() => {
     if (!isActive) {
       updateEditState(field)
+      setDesignState(DesignState.Inactive)
       if (!isMobile) {
         // Do not open builder if in mobile so user can view active state without
         // drawer blocking the view.
         handleBuilderClick()
       }
     }
-  }, [isActive, updateEditState, field, isMobile, handleBuilderClick])
+  }, [
+    isActive,
+    updateEditState,
+    field,
+    setDesignState,
+    isMobile,
+    handleBuilderClick,
+  ])
 
   const handleKeydown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -108,8 +108,6 @@ export const StartPageView = () => {
     agency: form?.admin.agency,
   })
 
-  const content = useMemo(() => startPage?.paragraph, [startPage?.paragraph])
-
   const { handleDesignClick } = useCreatePageSidebar()
 
   const handleHeaderClick = useCallback(() => {
@@ -173,7 +171,7 @@ export const StartPageView = () => {
           }
         />
       </Box>
-      {content ? (
+      {startPage?.paragraph ? (
         <Flex
           flexDir="column"
           alignSelf="center"
@@ -205,7 +203,7 @@ export const StartPageView = () => {
               >
                 <Box p={{ base: '0.75rem', md: '1.5rem' }}>
                   <FormInstructions
-                    content={content}
+                    content={startPage?.paragraph}
                     colorTheme={startPage?.colorTheme}
                   />
                 </Box>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -11,6 +11,7 @@ import { FormHeader } from '~features/public-form/components/FormStartPage/FormH
 import { useFormBannerLogo } from '~features/public-form/components/FormStartPage/useFormBannerLogo'
 import { useFormHeader } from '~features/public-form/components/FormStartPage/useFormHeader'
 
+import { useCreatePageSidebar } from '../../common/CreatePageSidebarContext'
 import { useCreateTabForm } from '../useCreateTabForm'
 import {
   customLogoMetaSelector,
@@ -33,7 +34,8 @@ export const StartPageView = () => {
     form?.startPage.logo.state === FormLogoState.Custom,
   )
 
-  const [customLogoPending, setCustomLogoPending] = useState<boolean>(false)
+  const [hoverStartPage, setHoverStartPage] = useState(false)
+  const [customLogoPending, setCustomLogoPending] = useState(false)
 
   // Transform the FormStartPageInput into a FormStartPage
   const startPageFromStore: FormStartPage | null = useMemo(() => {
@@ -72,7 +74,10 @@ export const StartPageView = () => {
   }, [form?.startPage, startPageFromStore])
 
   // Color theme options and other design stuff, identical to public form
-  const { titleColor, titleBg, estTimeString } = useFormHeader(startPage)
+  const { titleColor, titleBg, estTimeString } = useFormHeader({
+    startPage,
+    hover: hoverStartPage,
+  })
 
   const { hasLogo, logoImgSrc, logoImgAlt } = useFormBannerLogo({
     logoBucketUrl,
@@ -80,34 +85,47 @@ export const StartPageView = () => {
     agency: form?.admin.agency,
   })
 
+  const { handleDesignClick } = useCreatePageSidebar()
+
   return (
     <>
-      {customLogoPending ? (
-        // Show skeleton if user has chosen custom logo but not yet uploaded
-        <Flex justify="center" p="1rem" bg="white">
-          <Skeleton w="4rem" h="4rem" />
-        </Flex>
-      ) : (
-        <FormBannerLogo
-          hasLogo={hasLogo}
-          logoImgSrc={
-            startPageData?.logo.state === FormLogoState.Custom
-              ? startPageData.attachment.srcUrl // manual override to preview custom logo
-              : logoImgSrc
+      <Box
+        onPointerEnter={() => setHoverStartPage(true)}
+        onPointerLeave={() => setHoverStartPage(false)}
+        onClick={handleDesignClick}
+        role="button"
+        cursor={hoverStartPage ? 'pointer' : 'initial'}
+      >
+        {customLogoPending ? (
+          // Show skeleton if user has chosen custom logo but not yet uploaded
+          <Flex justify="center" p="1rem" bg="white">
+            <Skeleton w="4rem" h="4rem" />
+          </Flex>
+        ) : (
+          <FormBannerLogo
+            hasLogo={hasLogo}
+            logoImgSrc={
+              startPageData?.logo.state === FormLogoState.Custom
+                ? startPageData.attachment.srcUrl // manual override to preview custom logo
+                : logoImgSrc
+            }
+            logoImgAlt={logoImgAlt}
+            logoBg={hoverStartPage ? 'neutral.200' : undefined}
+          />
+        )}
+        <FormHeader
+          title={form?.title}
+          estTimeString={estTimeString}
+          titleBg={titleBg}
+          titleColor={titleColor}
+          showHeader
+          loggedInId={
+            form?.authType !== FormAuthType.NIL
+              ? PREVIEW_MOCK_UINFIN
+              : undefined
           }
-          logoImgAlt={logoImgAlt}
         />
-      )}
-      <FormHeader
-        title={form?.title}
-        estTimeString={estTimeString}
-        titleBg={titleBg}
-        titleColor={titleColor}
-        showHeader
-        loggedInId={
-          form?.authType !== FormAuthType.NIL ? PREVIEW_MOCK_UINFIN : undefined
-        }
-      />
+      </Box>
       <Box mt="1.5rem">
         <FormInstructions
           content={startPage?.paragraph}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -173,14 +173,14 @@ export const StartPageView = () => {
           }
         />
       </Box>
-      <Flex
-        flexDir="column"
-        alignSelf="center"
-        w="100%"
-        px="2.5rem"
-        mt="1.5rem"
-      >
-        {content ? (
+      {content ? (
+        <Flex
+          flexDir="column"
+          alignSelf="center"
+          w="100%"
+          px="2.5rem"
+          mt="1.5rem"
+        >
           <Flex justify="center">
             <Box
               w="100%"
@@ -239,8 +239,8 @@ export const StartPageView = () => {
               </Box>
             </Box>
           </Flex>
-        ) : null}
-      </Flex>
+        </Flex>
+      ) : null}
     </>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
@@ -8,6 +8,12 @@ import { UploadedImage } from './BuilderAndDesignDrawer/EditFieldDrawer/edit-fie
 
 export type CustomLogoMeta = Omit<CustomFormLogo, keyof FormLogoBase>
 
+export enum DesignState {
+  EditingHeader,
+  EditingInstructions,
+  Inactive,
+}
+
 /** Design drawer form input fields. DesignStore keeps track of the data in the
  * drawer input as a single unit. Other data (specifically the logo metadata) is
  * kept separately with its own getters and setters.
@@ -22,8 +28,10 @@ export type FormStartPageInput = Omit<
 }
 
 export type DesignStore = {
+  state: DesignState
   startPageData?: FormStartPageInput
   customLogoMeta?: CustomLogoMeta
+  setState: (state: DesignState) => void
   setStartPageData: (startPageInput: FormStartPageInput) => void
   setCustomLogoMeta: (customLogoMetaData: CustomLogoMeta) => void
   resetDesignStore: () => void
@@ -31,6 +39,8 @@ export type DesignStore = {
 
 export const useDesignStore = create<DesignStore>(
   devtools((set, get) => ({
+    state: DesignState.Inactive,
+    setState: (state: DesignState) => set({ state }),
     setStartPageData: (startPageData: FormStartPageInput) => {
       const current = get()
       if (isEqual(current.startPageData, startPageData)) return
@@ -50,6 +60,9 @@ export const useDesignStore = create<DesignStore>(
   })),
 )
 
+export const stateSelector = (state: DesignStore): DesignStore['state'] =>
+  state.state
+
 export const startPageDataSelector = (
   state: DesignStore,
 ): DesignStore['startPageData'] => state.startPageData
@@ -57,6 +70,9 @@ export const startPageDataSelector = (
 export const customLogoMetaSelector = (
   state: DesignStore,
 ): DesignStore['customLogoMeta'] => state.customLogoMeta
+
+export const setStateSelector = (state: DesignStore): DesignStore['setState'] =>
+  state.setState
 
 export const setStartPageDataSelector = (
   state: DesignStore,

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -14,6 +14,11 @@ import {
   setToInactiveSelector,
   useBuilderAndDesignStore,
 } from '../../builder-and-design/useBuilderAndDesignStore'
+import {
+  DesignState,
+  setStateSelector,
+  useDesignStore,
+} from '../../builder-and-design/useDesignStore'
 
 export enum DrawerTabs {
   Builder,
@@ -53,6 +58,7 @@ export const useCreatePageSidebarContext =
       [activeTab],
     )
     const setFieldsToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+    const setDesignState = useDesignStore(setStateSelector)
 
     // Set state to inactive whenever active tab is not builder
     useEffect(() => {
@@ -60,6 +66,10 @@ export const useCreatePageSidebarContext =
         setFieldsToInactive()
       }
     }, [activeTab, setFieldsToInactive])
+
+    useEffect(() => {
+      if (activeTab !== DrawerTabs.Design) setDesignState(DesignState.Inactive)
+    }, [activeTab, setDesignState])
 
     const handleBuilderClick = useCallback(
       () => setActiveTab(DrawerTabs.Builder),

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -1,59 +1,33 @@
-import { Box, Flex, forwardRef, Text } from '@chakra-ui/react'
+import { Text } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types'
 
 import { useSectionColor } from '~templates/Field/Section/SectionField'
 
-import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
-
 interface FormInstructionsProps {
-  content?: string
+  content: string
   colorTheme?: FormColorTheme
 }
 
-export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
-  ({ content, colorTheme }, ref): JSX.Element | null => {
-    const sectionColor = useSectionColor(colorTheme)
+export const FormInstructions = ({
+  content,
+  colorTheme,
+}: FormInstructionsProps): JSX.Element => {
+  const sectionColor = useSectionColor(colorTheme)
 
-    const { handleDesignClick } = useCreatePageSidebar()
-
-    if (!content) return null
-
-    return (
-      <Flex justify="center">
-        <Box
-          w="100%"
-          minW={0}
-          h="fit-content"
-          maxW="57rem"
-          bg="white"
-          py="2.5rem"
-          px={{ base: '1rem', md: '2.5rem' }}
-          mb="1.5rem"
-        >
-          <Box
-            id="instructions"
-            ref={ref}
-            p={{ base: '0.75rem', md: '1.5rem' }}
-            transition="background 0.2s ease"
-            _hover={{ bg: 'secondary.100', cursor: 'pointer' }}
-            borderRadius="4px"
-            onClick={handleDesignClick}
-          >
-            <Text textStyle="h2" color={sectionColor}>
-              Instructions
-            </Text>
-            <Text
-              textStyle="body-1"
-              color="secondary.700"
-              mt="1rem"
-              whiteSpace="pre-line"
-            >
-              {content}
-            </Text>
-          </Box>
-        </Box>
-      </Flex>
-    )
-  },
-)
+  return (
+    <>
+      <Text textStyle="h2" color={sectionColor}>
+        Instructions
+      </Text>
+      <Text
+        textStyle="body-1"
+        color="secondary.700"
+        mt="1rem"
+        whiteSpace="pre-line"
+      >
+        {content}
+      </Text>
+    </>
+  )
+}

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -4,6 +4,8 @@ import { FormColorTheme } from '~shared/types'
 
 import { useSectionColor } from '~templates/Field/Section/SectionField'
 
+import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
+
 interface FormInstructionsProps {
   content?: string
   colorTheme?: FormColorTheme
@@ -12,6 +14,8 @@ interface FormInstructionsProps {
 export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
   ({ content, colorTheme }, ref): JSX.Element | null => {
     const sectionColor = useSectionColor(colorTheme)
+
+    const { handleDesignClick } = useCreatePageSidebar()
 
     if (!content) return null
 
@@ -27,7 +31,15 @@ export const FormInstructions = forwardRef<FormInstructionsProps, 'div'>(
           px={{ base: '1rem', md: '2.5rem' }}
           mb="1.5rem"
         >
-          <Box id="instructions" ref={ref}>
+          <Box
+            id="instructions"
+            ref={ref}
+            p={{ base: '0.75rem', md: '1.5rem' }}
+            transition="background 0.2s ease"
+            _hover={{ bg: 'secondary.100', cursor: 'pointer' }}
+            borderRadius="4px"
+            onClick={handleDesignClick}
+          >
             <Text textStyle="h2" color={sectionColor}>
               Instructions
             </Text>

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -1,3 +1,6 @@
+import { useMemo } from 'react'
+import { Box, Flex } from '@chakra-ui/react'
+
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { useFormSections } from '../FormFields/FormSectionsContext'
@@ -8,11 +11,36 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
   const { sectionRefs } = useFormSections()
   const { form, submissionData } = usePublicFormContext()
 
-  return submissionData ? null : (
-    <FormInstructions
-      content={form?.startPage.paragraph}
-      colorTheme={form?.startPage.colorTheme}
-      ref={sectionRefs['instructions']}
-    />
+  const content = useMemo(
+    () => form?.startPage.paragraph,
+    [form?.startPage.paragraph],
+  )
+
+  if (!!submissionData || !content) return null
+
+  return (
+    <Flex justify="center">
+      <Box
+        w="100%"
+        minW={0}
+        h="fit-content"
+        maxW="57rem"
+        bg="white"
+        py="2.5rem"
+        px={{ base: '1rem', md: '2.5rem' }}
+        mb="1.5rem"
+      >
+        <Box
+          id="instructions"
+          ref={sectionRefs['instructions']}
+          p={{ base: '0.75rem', md: '1.5rem' }}
+        >
+          <FormInstructions
+            content={content}
+            colorTheme={form?.startPage.colorTheme}
+          />
+        </Box>
+      </Box>
+    </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -30,11 +30,7 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
         px={{ base: '1rem', md: '2.5rem' }}
         mb="1.5rem"
       >
-        <Box
-          id="instructions"
-          ref={sectionRefs['instructions']}
-          p={{ base: '0.75rem', md: '1.5rem' }}
-        >
+        <Box id="instructions" ref={sectionRefs['instructions']}>
           <FormInstructions
             content={content}
             colorTheme={form?.startPage.colorTheme}

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Box, Flex } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
@@ -11,12 +10,7 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
   const { sectionRefs } = useFormSections()
   const { form, submissionData } = usePublicFormContext()
 
-  const content = useMemo(
-    () => form?.startPage.paragraph,
-    [form?.startPage.paragraph],
-  )
-
-  if (!!submissionData || !content) return null
+  if (submissionData || !form?.startPage.paragraph) return null
 
   return (
     <Flex justify="center">
@@ -32,7 +26,7 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
       >
         <Box id="instructions" ref={sectionRefs['instructions']}>
           <FormInstructions
-            content={content}
+            content={form?.startPage.paragraph}
             colorTheme={form?.startPage.colorTheme}
           />
         </Box>

--- a/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
@@ -17,12 +17,7 @@ export const FormBannerLogo = ({
   if (!hasLogo) return null
 
   return (
-    <Flex
-      transition="background 0.2s ease"
-      justify="center"
-      p="1rem"
-      bg="white"
-    >
+    <Flex justify="center" p="1rem" bg="white">
       <Skeleton isLoaded={hasImageLoaded}>
         <Image
           onLoad={() => setHasImageLoaded(true)}

--- a/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
@@ -5,14 +5,12 @@ interface FormBannerLogoInputProps {
   hasLogo: boolean
   logoImgSrc?: string
   logoImgAlt?: string
-  logoBg?: string
 }
 
 export const FormBannerLogo = ({
   hasLogo,
   logoImgSrc,
   logoImgAlt,
-  logoBg = 'white',
 }: FormBannerLogoInputProps): JSX.Element | null => {
   const [hasImageLoaded, setHasImageLoaded] = useState(false)
 
@@ -23,7 +21,7 @@ export const FormBannerLogo = ({
       transition="background 0.2s ease"
       justify="center"
       p="1rem"
-      bg={logoBg}
+      bg="white"
     >
       <Skeleton isLoaded={hasImageLoaded}>
         <Image

--- a/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
@@ -5,19 +5,26 @@ interface FormBannerLogoInputProps {
   hasLogo: boolean
   logoImgSrc?: string
   logoImgAlt?: string
+  logoBg?: string
 }
 
 export const FormBannerLogo = ({
   hasLogo,
   logoImgSrc,
   logoImgAlt,
+  logoBg = 'white',
 }: FormBannerLogoInputProps): JSX.Element | null => {
   const [hasImageLoaded, setHasImageLoaded] = useState(false)
 
   if (!hasLogo) return null
 
   return (
-    <Flex justify="center" p="1rem" bg="white">
+    <Flex
+      transition="background 0.2s ease"
+      justify="center"
+      p="1rem"
+      bg={logoBg}
+    >
       <Skeleton isLoaded={hasImageLoaded}>
         <Image
           onLoad={() => setHasImageLoaded(true)}

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -141,6 +141,7 @@ export const FormHeader = ({
         />
       ) : null}
       <Flex
+        transition="background 0.2s ease"
         px={{ base: '1.5rem', md: '3rem' }}
         py={{ base: '2rem', md: '3rem' }}
         justify="center"

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
@@ -39,7 +39,7 @@ export const FormStartPage = (): JSX.Element => {
     agency: form?.admin.agency,
   })
 
-  const formHeaderProps = useFormHeader(form?.startPage)
+  const formHeaderProps = useFormHeader({ startPage: form?.startPage })
 
   const { handleLogoutMutation } = usePublicAuthMutations(formId)
   const handleLogout = useCallback(() => {

--- a/frontend/src/features/public-form/components/FormStartPage/useFormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/useFormHeader.tsx
@@ -3,10 +3,15 @@ import simplur from 'simplur'
 
 import { FormColorTheme, FormStartPage } from '~shared/types'
 
-export const getTitleBg = (colorTheme?: FormColorTheme) =>
-  colorTheme ? `theme-${colorTheme}.500` : `neutral.200`
+interface UseFormHeaderProps {
+  startPage?: FormStartPage
+  hover?: boolean
+}
 
-export const useFormHeader = (startPage?: FormStartPage) => {
+export const getTitleBg = (colorTheme?: FormColorTheme, hover?: boolean) =>
+  colorTheme ? `theme-${colorTheme}.${hover ? 6 : 5}00` : `neutral.200`
+
+export const useFormHeader = ({ startPage, hover }: UseFormHeaderProps) => {
   const titleColor = useMemo(() => {
     if (startPage?.colorTheme === FormColorTheme.Orange) {
       return 'secondary.700'
@@ -15,8 +20,8 @@ export const useFormHeader = (startPage?: FormStartPage) => {
   }, [startPage?.colorTheme])
 
   const titleBg = useMemo(
-    () => getTitleBg(startPage?.colorTheme),
-    [startPage?.colorTheme],
+    () => getTitleBg(startPage?.colorTheme, hover),
+    [hover, startPage?.colorTheme],
   )
 
   const estTimeString = useMemo(() => {


### PR DESCRIPTION
## Problem
Currently, the builder start page is not clickable, when it is in AngularJS. This PR implements hover and editing states for the start page and form instructions in the builder.

Closes #4277 and #4361 

## Solution

`public-form/.../FormInstructions.tsx`, `public-form/.../FormInstructionsContainer.tsx`, `admin-form/.../StartPageView.tsx`

The design intent was for the form instructions to behave essentially identically to a form field in the builder. To add this hover state, some refactors were necessary so that the separation of concern of the form instructions component identical to that of the fields. In particular, `FormInstructions` now only contains the raw shared component between the admin form and public form (just the header and content group), since the containers for them are now different (admin form `StartPageView` has a hover and editing state, while the public form `FormInstructionsContainer` does not). 

`useFormHeader.tsx`, `FormHeader.tsx`, `FormStartPage.tsx`

Small refactors necessary to add hover state color computations and transitions.

`useDesignStore.tsx`, `CreatePageSidebarContext.tsx`, `FieldRowContainer.tsx`

Due to needing to keep track of edit states, add a new variable in the design store, `designState`. Various small addtions to set the design state appropriately upon the sidebar click and field row clicks.

`StartPageView.tsx`, `DesignDrawer.tsx`

Major changes to these two files for use of `DesignState` and link focus for design drawer form fields with the editing states in the start page view.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/183352147-f2d986c4-b524-47ca-9334-e926ace8f76f.mov


