### PR TITLE
feat(form-v2): hide headers in section sidebar if they are hidden by logic

### DIFF
--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -6,7 +6,6 @@ import { isEqual } from 'lodash'
 import get from 'lodash/get'
 import simplur from 'simplur'
 
-import { BasicField } from '~shared/types'
 import {
   FormAuthType,
   FormResponseMode,
@@ -17,7 +16,6 @@ import { usePreviewForm } from '~/features/admin-form/common/queries'
 import { FormNotFound } from '~/features/public-form/components/FormNotFound'
 import {
   PublicFormContext,
-  SidebarSectionMeta,
   SubmissionData,
 } from '~/features/public-form/PublicFormContext'
 import { useCommonFormProvider } from '~/features/public-form/PublicFormProvider'
@@ -128,27 +126,6 @@ export const PreviewFormProvider = ({
     [cachedDto?.form, cachedDto?.spcpSession],
   )
 
-  const sectionScrollData = useMemo(() => {
-    const { form } = cachedDto ?? {}
-    if (!form || isAuthRequired) {
-      return []
-    }
-    const sections: SidebarSectionMeta[] = []
-    if (form.startPage.paragraph)
-      sections.push({
-        title: 'Instructions',
-        _id: 'instructions',
-      })
-    form.form_fields.forEach((f) => {
-      if (f.fieldType !== BasicField.Section) return
-      sections.push({
-        title: f.title,
-        _id: f._id,
-      })
-    })
-    return sections
-  }, [cachedDto, isAuthRequired])
-
   const { submitEmailModeFormMutation, submitStorageModeFormMutation } =
     usePreviewFormMutations(formId)
 
@@ -219,7 +196,6 @@ export const PreviewFormProvider = ({
         formId,
         error,
         submissionData,
-        sectionScrollData,
         isAuthRequired,
         expiryInMs,
         isLoading,

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -2,10 +2,7 @@
 import { createContext, RefObject, useContext } from 'react'
 import { UseQueryResult } from 'react-query'
 
-import { FormFieldDto } from '~shared/types'
 import { PublicFormViewDto } from '~shared/types/form'
-
-export type SidebarSectionMeta = Pick<FormFieldDto, 'title' | '_id'>
 
 export type SubmissionData = {
   /** Submission id */
@@ -18,8 +15,6 @@ export interface PublicFormContextProps
     Omit<UseQueryResult<PublicFormViewDto>, 'data'> {
   miniHeaderRef: RefObject<HTMLDivElement>
   formId: string
-  /** Scroll data to allow form-fillers to scroll to a particular section. */
-  sectionScrollData: SidebarSectionMeta[]
   /** Whether form authentication is required. */
   isAuthRequired: boolean
   /**

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -14,7 +14,6 @@ import { isEqual } from 'lodash'
 import get from 'lodash/get'
 import simplur from 'simplur'
 
-import { BasicField } from '~shared/types'
 import {
   FormAuthType,
   FormResponseMode,
@@ -42,11 +41,7 @@ import {
 
 import { FormNotFound } from './components/FormNotFound'
 import { usePublicAuthMutations, usePublicFormMutations } from './mutations'
-import {
-  PublicFormContext,
-  SidebarSectionMeta,
-  SubmissionData,
-} from './PublicFormContext'
+import { PublicFormContext, SubmissionData } from './PublicFormContext'
 import { usePublicFormView } from './queries'
 
 interface PublicFormProviderProps {
@@ -290,27 +285,6 @@ export const PublicFormProvider = ({
     [cachedDto?.form, cachedDto?.spcpSession],
   )
 
-  const sectionScrollData = useMemo(() => {
-    const { form } = cachedDto ?? {}
-    if (!form || isAuthRequired) {
-      return []
-    }
-    const sections: SidebarSectionMeta[] = []
-    if (form.startPage.paragraph)
-      sections.push({
-        title: 'Instructions',
-        _id: 'instructions',
-      })
-    form.form_fields.forEach((f) => {
-      if (f.fieldType !== BasicField.Section) return
-      sections.push({
-        title: f.title,
-        _id: f._id,
-      })
-    })
-    return sections
-  }, [cachedDto, isAuthRequired])
-
   if (isNotFormId) {
     return <NotFoundErrorPage />
   }
@@ -323,7 +297,6 @@ export const PublicFormProvider = ({
         formId,
         error,
         submissionData,
-        sectionScrollData,
         isAuthRequired,
         captchaContainerId: containerId,
         expiryInMs,

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -19,7 +19,7 @@ export type SidebarSectionMeta = Pick<FormFieldDto, 'title' | '_id'>
 interface FormSectionsContextProps {
   /** Scroll data to allow form-fillers to scroll to a particular section. */
   sectionScrollData: SidebarSectionMeta[]
-  updateSectionScrollData: (visibleFieldIds: FieldIdSet) => void
+  setVisibleFieldIdsForScrollData: (visibleFieldIds: FieldIdSet) => void
   sectionRefs: Record<string, RefObject<HTMLDivElement>>
   activeSectionId?: string
   navigatedSectionTitle?: string
@@ -102,7 +102,7 @@ export const FormSectionsProvider = ({
     <FormSectionsContext.Provider
       value={{
         sectionScrollData,
-        updateSectionScrollData: setVisibleFieldIds,
+        setVisibleFieldIdsForScrollData: setVisibleFieldIds,
         sectionRefs,
         activeSectionId: orderedSectionFieldIds?.[activeSection] ?? undefined,
         navigatedSectionTitle,

--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -9,11 +9,17 @@ import {
 } from 'react'
 import useScrollSpy from 'react-use-scrollspy'
 
-import { BasicField } from '~shared/types/field'
+import { BasicField, FormFieldDto } from '~shared/types'
 
+import { FieldIdSet } from '~features/logic/types'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
+export type SidebarSectionMeta = Pick<FormFieldDto, 'title' | '_id'>
+
 interface FormSectionsContextProps {
+  /** Scroll data to allow form-fillers to scroll to a particular section. */
+  sectionScrollData: SidebarSectionMeta[]
+  updateSectionScrollData: (visibleFieldIds: FieldIdSet) => void
   sectionRefs: Record<string, RefObject<HTMLDivElement>>
   activeSectionId?: string
   navigatedSectionTitle?: string
@@ -31,7 +37,29 @@ interface FormSectionsProviderProps {
 export const FormSectionsProvider = ({
   children,
 }: FormSectionsProviderProps): JSX.Element => {
-  const { form } = usePublicFormContext()
+  const { form, isAuthRequired } = usePublicFormContext()
+
+  const [visibleFieldIds, setVisibleFieldIds] = useState<FieldIdSet>()
+
+  const sectionScrollData = useMemo(() => {
+    if (!form || isAuthRequired) return []
+    const sections: SidebarSectionMeta[] = []
+    if (form.startPage.paragraph)
+      sections.push({
+        title: 'Instructions',
+        _id: 'instructions',
+      })
+    form.form_fields.forEach((f) => {
+      if (f.fieldType !== BasicField.Section || !visibleFieldIds?.has(f._id))
+        return
+      sections.push({
+        title: f.title,
+        _id: f._id,
+      })
+    })
+    return sections
+  }, [form, isAuthRequired, visibleFieldIds])
+
   const [sectionRefs, setSectionRefs] = useState<
     Record<string, RefObject<HTMLDivElement>>
   >({})
@@ -73,6 +101,8 @@ export const FormSectionsProvider = ({
   return (
     <FormSectionsContext.Provider
       value={{
+        sectionScrollData,
+        updateSectionScrollData: setVisibleFieldIds,
         sectionRefs,
         activeSectionId: orderedSectionFieldIds?.[activeSection] ?? undefined,
         navigatedSectionTitle,

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -32,7 +32,7 @@ export const VisibleFormFields = ({
   fieldPrefillMap,
 }: VisibleFormFieldsProps) => {
   const watchedValues = useWatch({ control })
-  const { updateSectionScrollData } = useFormSections()
+  const { setVisibleFieldIdsForScrollData } = useFormSections()
   const [visibleFormFields, setVisibleFormFields] = useState(formFields)
 
   useEffect(() => {
@@ -40,13 +40,13 @@ export const VisibleFormFields = ({
       formFields,
       formLogics,
     })
-    updateSectionScrollData(visibleFieldIds)
+    setVisibleFieldIdsForScrollData(visibleFieldIds)
     const visibleFields = formFields.filter((field) =>
       visibleFieldIds.has(field._id),
     )
     const visibleFieldsWithQuestionNo = augmentWithQuestionNo(visibleFields)
     setVisibleFormFields(visibleFieldsWithQuestionNo)
-  }, [formFields, formLogics, updateSectionScrollData, watchedValues])
+  }, [formFields, formLogics, setVisibleFieldIdsForScrollData, watchedValues])
 
   return (
     <>

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -10,6 +10,7 @@ import { augmentWithQuestionNo } from '~features/form/utils'
 import { getVisibleFieldIds } from '~features/logic/utils'
 
 import { FieldFactory } from './FieldFactory'
+import { useFormSections } from './FormSectionsContext'
 
 interface VisibleFormFieldsProps {
   control: Control<FormFieldValues>
@@ -31,6 +32,7 @@ export const VisibleFormFields = ({
   fieldPrefillMap,
 }: VisibleFormFieldsProps) => {
   const watchedValues = useWatch({ control })
+  const { updateSectionScrollData } = useFormSections()
   const [visibleFormFields, setVisibleFormFields] = useState(formFields)
 
   useEffect(() => {
@@ -38,12 +40,13 @@ export const VisibleFormFields = ({
       formFields,
       formLogics,
     })
+    updateSectionScrollData(visibleFieldIds)
     const visibleFields = formFields.filter((field) =>
       visibleFieldIds.has(field._id),
     )
     const visibleFieldsWithQuestionNo = augmentWithQuestionNo(visibleFields)
     setVisibleFormFields(visibleFieldsWithQuestionNo)
-  }, [formFields, formLogics, watchedValues])
+  }, [formFields, formLogics, updateSectionScrollData, watchedValues])
 
   return (
     <>

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -6,13 +6,15 @@ import { AppFooter } from '~/app/AppFooter'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
+import { useFormSections } from '../FormFields/FormSectionsContext'
 import { useBgColor } from '../PublicFormWrapper'
 
 /**
  * @precondition Must be nested inside `PublicFormProvider`
  */
 export const FormFooter = (): JSX.Element => {
-  const { captchaContainerId, sectionScrollData, form } = usePublicFormContext()
+  const { captchaContainerId, form } = usePublicFormContext()
+  const { sectionScrollData } = useFormSections()
 
   const isDesktop = useBreakpointValue({ base: false, xs: false, lg: true })
   const bgColor = useBgColor({

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from 'react'
-import { Box, Flex, Spacer, Stack, useBreakpointValue } from '@chakra-ui/react'
-import { isEmpty } from 'lodash'
+import { Box, Flex, Stack } from '@chakra-ui/react'
 
 import { AppFooter } from '~/app/AppFooter'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-import { useFormSections } from '../FormFields/FormSectionsContext'
 import { useBgColor } from '../PublicFormWrapper'
 
 /**
@@ -14,18 +11,10 @@ import { useBgColor } from '../PublicFormWrapper'
  */
 export const FormFooter = (): JSX.Element => {
   const { captchaContainerId, form } = usePublicFormContext()
-  const { sectionScrollData } = useFormSections()
-
-  const isDesktop = useBreakpointValue({ base: false, xs: false, lg: true })
   const bgColor = useBgColor({
     colorTheme: form?.startPage.colorTheme,
     isFooter: true,
   })
-
-  const showSpacer = useMemo(
-    () => isDesktop && !isEmpty(sectionScrollData),
-    [isDesktop, sectionScrollData],
-  )
 
   return (
     <Flex justify="center" w="100%">
@@ -48,7 +37,6 @@ export const FormFooter = (): JSX.Element => {
           </Box>
         </Stack>
       </Box>
-      {showSpacer ? <Spacer /> : null}
     </Flex>
   )
 }

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -22,10 +22,10 @@ import { useFormSections } from '../FormFields/FormSectionsContext'
 import { SidebarLink } from './SidebarLink'
 
 export const SectionSidebar = (): JSX.Element => {
-  const { activeSectionId, navigatedSectionTitle } = useFormSections()
+  const { sectionScrollData, activeSectionId, navigatedSectionTitle } =
+    useFormSections()
   const {
     miniHeaderRef,
-    sectionScrollData,
     submissionData,
     isMobileDrawerOpen,
     onMobileDrawerClose,

--- a/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from 'react'
 import { Box, chakra, useStyleConfig, VisuallyHidden } from '@chakra-ui/react'
 
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
 import {
   SidebarSectionMeta,
-  usePublicFormContext,
-} from '~features/public-form/PublicFormContext'
-
-import { useFormSections } from '../FormFields/FormSectionsContext'
+  useFormSections,
+} from '../FormFields/FormSectionsContext'
 
 interface SidebarLinkProps {
   /**


### PR DESCRIPTION
## Problem
Currently, form headers are not hidden in the section sidebar if they are hidden in the form due to logic. This PR implements this feature. 

Closes #4506 

## Solution

`PreviewFormProvider`, `PublicFormContext`, `PublicFormProvider`, `FormSectionsContext`
- Move the scroll data computation into the Form Sections provider since it is shared between preview form and public form, and it is the same computation in either case.
- Add function to provider allowing for updating of scroll data based on visible field computation.
- Add check for visibility before adding to scroll data.

`SectionSidebar`
- Get scroll data from the form sections context rather than the form provider.

`VisibleFormFields`
- Update scroll data when visible fields are recalculated.

`SectionLink`
- Update reference to Sidebar type.

`FormFooter`
- Remove unneeded spacer component which references scroll data (was necessary before due to sidebar wrapping FormFields component, but we have since moved the sidebar to the form wrapper which also wraps the footer, thus now unnecessary).
 
**Breaking Changes** 
- [X] No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/183372600-832c86e4-44fb-4e79-b35c-baceb797c937.mov

