### PR TITLE
fix(form-v2): add isClearable to attachment size dropdown

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -158,7 +158,11 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
             rules={attachmentSizeValidationRule}
             name="attachmentSize"
             render={({ field }) => (
-              <SingleSelect items={attachmentSizeOptions} {...field} />
+              <SingleSelect
+                isClearable={false}
+                items={attachmentSizeOptions}
+                {...field}
+              />
             )}
           />
         </Skeleton>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Attachment size is a clearable field, which leads to an error when the attachment size is cleared and the field submitted

Closes #4354 

## Solution
<!-- How did you solve the problem? -->
add `isClearable={false}` to `SingleSelect`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

