### PR TITLE
feat(form-v2): add MyInfo badge to form builder for MyInfo fields

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -64,7 +64,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200, layout: 'fullscreen' },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
     userId: 'adminFormTestUserId',

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -64,7 +64,11 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 200, layout: 'fullscreen' },
+    chromatic: {
+      pauseAnimationAtEnd: true,
+      delay: 200,
+      viewports: [1500, 8000],
+    },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
     userId: 'adminFormTestUserId',

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -64,11 +64,7 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: {
-      pauseAnimationAtEnd: true,
-      delay: 200,
-      viewports: [1500, 8000],
-    },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
     layout: 'fullscreen',
     msw: buildMswRoutes(),
     userId: 'adminFormTestUserId',

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -48,6 +48,7 @@ import {
   augmentWithMyInfoDisplayValue,
   extractPreviewValue,
   hasExistingFieldValue,
+  isMyInfo,
 } from '~features/myinfo/utils'
 
 import { useBuilderAndDesignContext } from '../../BuilderAndDesignContext'
@@ -272,7 +273,11 @@ export const FieldRowContainer = ({
               pointerEvents={isActive ? undefined : 'none'}
             >
               <FormProvider {...formMethods}>
-                <MemoFieldRow field={field} colorTheme={colorTheme} />
+                <MemoFieldRow
+                  field={field}
+                  colorTheme={colorTheme}
+                  showMyInfoBadge={isMyInfo(field)}
+                />
               </FormProvider>
             </Box>
             <Collapse in={isActive} style={{ width: '100%' }}>
@@ -329,6 +334,7 @@ export const FieldRowContainer = ({
 type MemoFieldRowProps = {
   field: FormFieldDto
   colorTheme?: FormColorTheme
+  showMyInfoBadge?: boolean
 }
 
 const MemoFieldRow = memo(({ field, ...rest }: MemoFieldRowProps) => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -98,6 +98,8 @@ export const FieldRowContainer = ({
 
   const colorTheme = useDesignColorTheme()
 
+  const isMyInfoField = useMemo(() => isMyInfo(field), [field])
+
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {
       return {
@@ -276,7 +278,7 @@ export const FieldRowContainer = ({
                 <MemoFieldRow
                   field={field}
                   colorTheme={colorTheme}
-                  showMyInfoBadge={isMyInfo(field)}
+                  showMyInfoBadge={isMyInfoField}
                 />
               </FormProvider>
             </Box>

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -25,6 +25,7 @@ export interface DateFieldProps extends BaseFieldProps {
 export const DateField = ({
   schema,
   colorTheme = FormColorTheme.Blue,
+  ...fieldContainerProps
 }: DateFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDateValidationRules(schema),
@@ -56,7 +57,7 @@ export const DateField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema}>
+    <FieldContainer schema={schema} {...fieldContainerProps}>
       <Controller
         control={control}
         name={schema._id}

--- a/frontend/src/templates/Field/Dropdown/DropdownField.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.tsx
@@ -19,6 +19,7 @@ export interface DropdownFieldProps extends BaseFieldProps {
 export const DropdownField = ({
   schema,
   colorTheme = FormColorTheme.Blue,
+  ...fieldContainerProps
 }: DropdownFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createDropdownValidationRules(schema),
@@ -28,7 +29,7 @@ export const DropdownField = ({
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema}>
+    <FieldContainer schema={schema} {...fieldContainerProps}>
       <Controller
         control={control}
         rules={validationRules}

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -5,11 +5,12 @@
  * provides.
  */
 import { FieldError, useFormState } from 'react-hook-form'
-import { FormControl } from '@chakra-ui/react'
+import { Box, FormControl, Grid } from '@chakra-ui/react'
 import { get } from 'lodash'
 
 import { FormColorTheme } from '~shared/types/form'
 
+import Badge from '~components/Badge'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 
@@ -34,6 +35,11 @@ export type BaseFieldProps = {
    * Whether or not the field was prefilled.
    */
   isPrefilled?: boolean
+
+  /**
+   * Whether the MyInfo badge should be shown next to the question name.
+   */
+  showMyInfoBadge?: boolean
 }
 
 export interface FieldContainerProps extends BaseFieldProps {
@@ -44,6 +50,7 @@ export const FieldContainer = ({
   schema,
   children,
   errorKey,
+  showMyInfoBadge,
 }: FieldContainerProps): JSX.Element => {
   const { errors, isSubmitting, isValid } = useFormState({ name: schema._id })
 
@@ -57,14 +64,25 @@ export const FieldContainer = ({
       isInvalid={!!error}
       id={schema._id}
     >
-      <FormLabel
-        questionNumber={
-          schema.questionNumber ? `${schema.questionNumber}.` : undefined
-        }
-        description={schema.description}
+      <Grid
+        gridTemplateAreas={"'formlabel myinfobadge'"}
+        gridTemplateColumns={'1fr auto'}
       >
-        {schema.title}
-      </FormLabel>
+        <FormLabel
+          gridArea="formlabel"
+          questionNumber={
+            schema.questionNumber ? `${schema.questionNumber}.` : undefined
+          }
+          description={schema.description}
+        >
+          {schema.title}
+        </FormLabel>
+        <Box hidden={!showMyInfoBadge} gridArea="myinfobadge">
+          <Badge variant="subtle" colorScheme="secondary">
+            MyInfo
+          </Badge>
+        </Box>
+      </Grid>
       {children}
       <FormErrorMessage>{error?.message}</FormErrorMessage>
     </FormControl>

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -17,6 +17,7 @@ export interface ShortTextFieldProps extends BaseFieldProps {
 export const ShortTextField = ({
   schema,
   isPrefilled,
+  ...fieldContainerProps
 }: ShortTextFieldProps): JSX.Element => {
   const validationRules = useMemo(
     () => createTextValidationRules(schema),
@@ -26,7 +27,7 @@ export const ShortTextField = ({
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
-    <FieldContainer schema={schema}>
+    <FieldContainer schema={schema} {...fieldContainerProps}>
       <Input
         isPrefilled={isPrefilled}
         aria-label={schema.title}


### PR DESCRIPTION
## Problem
MyInfo fields currently are not distinguished from normal fields in the form builder. This PR adds the MyInfo badge to the relevant fields in the form builder.

Closes #4441 

## Solution
Add an additional base field prop, `showMyInfoBadge` (not called `isMyInfo` because we explicitly don't want to show the badge in the public form, only in the form builder). `FieldRowContainer` adds the badge itself. Also updates to props for Short Text, Dropdown and Date fields to accommodate additional field container props.

**Breaking Changes** 
No - this PR is backwards compatible  

## Screenshots

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/25571626/183839900-fdc40f9f-fb97-4474-8d75-48ee08e2e07e.png">

<img width="512" alt="image" src="https://user-images.githubusercontent.com/25571626/183840000-4f5d46f1-dea7-4217-9229-78af1e182923.png">

