### PR TITLE
feat(form-v2/whats-new): add What's new tab on admin nav bar

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
@@ -79,3 +79,17 @@ WhatsNewFeatureNotificationNotShown.parameters = {
     }),
   ],
 }
+
+export const WhatsNewFeatureMobileNotificationShown = Template.bind({})
+WhatsNewFeatureMobileNotificationShown.parameters = {
+  ...Mobile.parameters,
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        flags: {},
+      },
+    }),
+  ],
+}

--- a/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
@@ -53,3 +53,29 @@ MobileExpanded.args = Expanded.args
 
 export const Tablet = Template.bind({})
 Tablet.parameters = getTabletViewParameters()
+
+export const WhatsNewFeatureNotificationShown = Template.bind({})
+WhatsNewFeatureNotificationShown.parameters = {
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        flags: {},
+      },
+    }),
+  ],
+}
+
+export const WhatsNewFeatureNotificationNotShown = Template.bind({})
+WhatsNewFeatureNotificationNotShown.parameters = {
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        flags: { lastSeenFeatureUpdateDate: new Date() },
+      },
+    }),
+  ],
+}

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -105,12 +105,23 @@ const WhatsNewNavBarTab = ({
 
   if (isMobile && MobileIcon) {
     return (
-      <IconButton
-        variant="clear"
-        as="a"
-        aria-label={label}
-        icon={<MobileIcon fontSize="1.25rem" color="primary.500" />}
-      />
+      <Box position="relative">
+        <IconButton
+          variant="clear"
+          as="a"
+          aria-label={label}
+          icon={<MobileIcon fontSize="1.25rem" color="primary.500" />}
+          onClick={onClick}
+        />
+        {shouldShowNotiifcation && (
+          <Icon
+            as={GoPrimitiveDot}
+            color="danger.500"
+            position="absolute"
+            ml="-15px"
+          />
+        )}
+      </Box>
     )
   }
 

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -1,16 +1,21 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { BiCommentDetail } from 'react-icons/bi'
+import { GoPrimitiveDot } from 'react-icons/go'
 import { Link as ReactLink } from 'react-router-dom'
 import {
   As,
+  Box,
   chakra,
   Flex,
   FlexProps,
   HStack,
+  Icon,
+  Text,
   useDisclosure,
 } from '@chakra-ui/react'
 
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
+import { BxsRocket } from '~assets/icons/BxsRocket'
 import { ReactComponent as BrandMarkSvg } from '~assets/svgs/brand/brand-mark-colour.svg'
 import { FEATURE_REQUEST, FORM_GUIDE } from '~constants/links'
 import {
@@ -20,12 +25,16 @@ import {
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { logout } from '~services/AuthService'
+import Button from '~components/Button'
 import IconButton from '~components/IconButton'
 import Link from '~components/Link'
 import { AvatarMenu, AvatarMenuDivider } from '~templates/AvatarMenu/AvatarMenu'
 
 import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
+import { useUserMutations } from '~features/user/mutations'
 import { useUser } from '~features/user/queries'
+import { getShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
+import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
 import Menu from '../../components/Menu'
 
@@ -49,6 +58,8 @@ const NAV_LINKS: AdminNavBarLinkProps[] = [
     MobileIcon: BxsHelpCircle,
   },
 ]
+
+const WHATS_NEW_LABEL = "What's new"
 
 const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
   const isMobile = useIsMobile()
@@ -78,13 +89,66 @@ const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
   )
 }
 
+interface WhatsNewNavBarTabProps {
+  onClick: () => void
+  label: string
+  shoudlShowNotiifcation: boolean
+  MobileIcon?: As
+}
+
+const WhatsNewNavBarTab = ({
+  onClick,
+  label,
+  MobileIcon,
+  shoudlShowNotiifcation,
+}: WhatsNewNavBarTabProps) => {
+  const isMobile = useIsMobile()
+
+  if (isMobile && MobileIcon) {
+    return (
+      <IconButton
+        variant="clear"
+        as="a"
+        aria-label={label}
+        icon={<MobileIcon fontSize="1.25rem" color="primary.500" />}
+      />
+    )
+  }
+
+  return (
+    <Box position="relative">
+      <Button
+        w="fit-content"
+        variant="link"
+        color="secondary.500"
+        onClick={onClick}
+        aria-label={label}
+        textStyle="subhead-1"
+      >
+        {label}
+      </Button>
+      {shoudlShowNotiifcation && (
+        <Icon
+          as={GoPrimitiveDot}
+          color="danger.500"
+          position="absolute"
+          ml="-5px"
+        />
+      )}
+    </Box>
+  )
+}
+
 export interface AdminNavBarProps {
   /* This prop is only for testing to show expanded menu state */
   isMenuOpen?: boolean
 }
 
 export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
-  const { user } = useUser()
+  const { user, isLoading: isUserLoading } = useUser()
+  const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
+
+  const whatsNewFeatureDrawerDisclosure = useDisclosure()
 
   const ROLLOUT_ANNOUNCEMENT_KEY = useMemo(
     () => ROLLOUT_ANNOUNCEMENT_KEY_PREFIX + user?._id,
@@ -116,6 +180,19 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     },
   })
 
+  const shouldShowFeatureUpdateNotification = useMemo(() => {
+    if (isUserLoading || !user) return false
+    return getShowLatestFeatureUpdateNotification(user)
+  }, [isUserLoading, user])
+
+  const onWhatsNewDrawerOpen = useCallback(() => {
+    whatsNewFeatureDrawerDisclosure.onOpen()
+    updateUserLastSeenFeatureUpdateDateMutation.mutate()
+  }, [
+    updateUserLastSeenFeatureUpdateDateMutation,
+    whatsNewFeatureDrawerDisclosure,
+  ])
+
   // Emergency contact modal appears after the rollout announcement modal
   useEffect(() => {
     if (!hasSeenContactModal && user && !user?.contact && hasSeenAnnouncement) {
@@ -143,6 +220,12 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
           {NAV_LINKS.map((link, index) => (
             <AdminNavBarLink key={index} {...link} />
           ))}
+          <WhatsNewNavBarTab
+            label={WHATS_NEW_LABEL}
+            onClick={onWhatsNewDrawerOpen}
+            MobileIcon={BxsRocket}
+            shoudlShowNotiifcation={shouldShowFeatureUpdateNotification}
+          />
           <AvatarMenu
             name={user?.email}
             menuUsername={user?.email}
@@ -160,6 +243,10 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
           </AvatarMenu>
         </HStack>
       </AdminNavBar.Container>
+      <WhatsNewDrawer
+        isOpen={whatsNewFeatureDrawerDisclosure.isOpen}
+        onClose={whatsNewFeatureDrawerDisclosure.onClose}
+      />
       <EmergencyContactModal
         onClose={onContactModalClose}
         isOpen={isContactModalOpen}

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -10,7 +10,6 @@ import {
   FlexProps,
   HStack,
   Icon,
-  Text,
   useDisclosure,
 } from '@chakra-ui/react'
 

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -90,27 +90,22 @@ const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
 
 interface WhatsNewNavBarTabProps {
   onClick: () => void
-  label: string
   shouldShowNotiifcation: boolean
-  MobileIcon?: As
 }
 
 const WhatsNewNavBarTab = ({
   onClick,
-  label,
-  MobileIcon,
   shouldShowNotiifcation,
 }: WhatsNewNavBarTabProps) => {
   const isMobile = useIsMobile()
 
-  if (isMobile && MobileIcon) {
+  if (isMobile) {
     return (
       <Box position="relative">
         <IconButton
           variant="clear"
-          as="a"
-          aria-label={label}
-          icon={<MobileIcon fontSize="1.25rem" color="primary.500" />}
+          aria-label={WHATS_NEW_LABEL}
+          icon={<BxsRocket fontSize="1.25rem" color="primary.500" />}
           onClick={onClick}
         />
         {shouldShowNotiifcation && (
@@ -132,10 +127,9 @@ const WhatsNewNavBarTab = ({
         variant="link"
         color="secondary.500"
         onClick={onClick}
-        aria-label={label}
-        textStyle="subhead-1"
+        aria-label={WHATS_NEW_LABEL}
       >
-        {label}
+        {WHATS_NEW_LABEL}
       </Button>
       {shouldShowNotiifcation && (
         <Icon
@@ -231,9 +225,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
             <AdminNavBarLink key={index} {...link} />
           ))}
           <WhatsNewNavBarTab
-            label={WHATS_NEW_LABEL}
             onClick={onWhatsNewDrawerOpen}
-            MobileIcon={BxsRocket}
             shouldShowNotiifcation={shouldShowFeatureUpdateNotification}
           />
           <AvatarMenu

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -92,7 +92,7 @@ const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
 interface WhatsNewNavBarTabProps {
   onClick: () => void
   label: string
-  shoudlShowNotiifcation: boolean
+  shouldShowNotiifcation: boolean
   MobileIcon?: As
 }
 
@@ -100,7 +100,7 @@ const WhatsNewNavBarTab = ({
   onClick,
   label,
   MobileIcon,
-  shoudlShowNotiifcation,
+  shouldShowNotiifcation,
 }: WhatsNewNavBarTabProps) => {
   const isMobile = useIsMobile()
 
@@ -127,7 +127,7 @@ const WhatsNewNavBarTab = ({
       >
         {label}
       </Button>
-      {shoudlShowNotiifcation && (
+      {shouldShowNotiifcation && (
         <Icon
           as={GoPrimitiveDot}
           color="danger.500"

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -224,7 +224,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
             label={WHATS_NEW_LABEL}
             onClick={onWhatsNewDrawerOpen}
             MobileIcon={BxsRocket}
-            shoudlShowNotiifcation={shouldShowFeatureUpdateNotification}
+            shouldShowNotiifcation={shouldShowFeatureUpdateNotification}
           />
           <AvatarMenu
             name={user?.email}

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -128,6 +128,7 @@ const WhatsNewNavBarTab = ({
         color="secondary.500"
         onClick={onClick}
         aria-label={WHATS_NEW_LABEL}
+        fontWeight="500"
       >
         {WHATS_NEW_LABEL}
       </Button>

--- a/frontend/src/features/whats-new/WhatsNewContent.tsx
+++ b/frontend/src/features/whats-new/WhatsNewContent.tsx
@@ -35,11 +35,11 @@ export const WhatsNewContent = ({
   })
   const formattedDate = format(date, DATE_FORMAT)
   return (
-    <Box paddingX="2.5rem" paddingY="1.25">
+    <Box>
       <Text textStyle="caption-1" color="secondary.400">
         {formattedDate}
       </Text>
-      <Text textStyle="h4" mb="0.5rem" mt="1rem" color="secondary.700">
+      <Text as="h4" textStyle="h4" mb="0.5rem" mt="1rem" color="secondary.700">
         {title}
       </Text>
       <ReactMarkdown components={mdComponents} remarkPlugins={[gfm]}>

--- a/frontend/src/features/whats-new/WhatsNewContent.tsx
+++ b/frontend/src/features/whats-new/WhatsNewContent.tsx
@@ -30,6 +30,7 @@ export const WhatsNewContent = ({
       },
       list: {
         color: 'secondary.500',
+        marginInlineStart: '1.25em',
       },
     },
   })

--- a/frontend/src/features/whats-new/WhatsNewContent.tsx
+++ b/frontend/src/features/whats-new/WhatsNewContent.tsx
@@ -25,19 +25,21 @@ export const WhatsNewContent = ({
   const mdComponents = useMdComponents({
     styles: {
       text: {
-        color: 'secondary.700',
+        color: 'secondary.500',
         textStyle: 'body-1',
       },
       list: {
-        color: 'secondary.700',
+        color: 'secondary.500',
       },
     },
   })
   const formattedDate = format(date, DATE_FORMAT)
   return (
     <Box paddingX="2.5rem" paddingY="1.25">
-      <Text textStyle="caption-1">{formattedDate}</Text>
-      <Text textStyle="h4" mb="0.5rem" mt="1rem">
+      <Text textStyle="caption-1" color="secondary.400">
+        {formattedDate}
+      </Text>
+      <Text textStyle="h4" mb="0.5rem" mt="1rem" color="secondary.700">
         {title}
       </Text>
       <ReactMarkdown components={mdComponents} remarkPlugins={[gfm]}>

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -50,12 +50,13 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
     <Drawer isOpen={isOpen} onClose={onClose} placement="right" size="lg">
       <DrawerOverlay />
       <DrawerContent>
-        <DrawerCloseButton top="2rem" />
+        <DrawerCloseButton top="1.25rem" />
         <DrawerHeader
           textStyle="h2"
           fontSize="24px"
-          paddingTop="2rem"
-          paddingLeft="1.5rem"
+          paddingTop="1.25rem"
+          paddingLeft="2.5rem"
+          color="secondary.700"
         >
           What’s new
         </DrawerHeader>

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -50,23 +50,18 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
     <Drawer isOpen={isOpen} onClose={onClose} placement="right" size="lg">
       <DrawerOverlay />
       <DrawerContent>
-        <DrawerCloseButton top="1.25rem" />
-        <DrawerHeader
-          textStyle="h2"
-          fontSize="24px"
-          paddingTop="1.25rem"
-          paddingLeft="2.5rem"
-          color="secondary.700"
-        >
+        <DrawerCloseButton
+          variant="clear"
+          colorScheme="secondary"
+          top="1.25rem"
+        />
+        <DrawerHeader textStyle="h2" color="secondary.700">
           What’s new
         </DrawerHeader>
         <DrawerBody
-          py={0}
-          px={0}
-          mt="1.25rem"
-          display="flex"
-          alignItems="center"
-          flexDirection="column"
+          whiteSpace="pre-line"
+          color="secondary.500"
+          textStyle="body-2"
         >
           <Stack divider={<StackDivider />} spacing="2rem">
             {listOfFeatureUpdatesShown.map((featureUpdate, key) => {

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Drawer,
   DrawerBody,
@@ -26,24 +26,19 @@ const EXTENDED_LIST_LINK_TEXT = 'Show less'
 const DEFAULT_FEATURE_UPDATE_COUNT = 10
 
 export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
-  const [numberOfFeatureUpdatesShown, setNumberOfFeatureUpdatesShown] =
-    useState<number>(DEFAULT_FEATURE_UPDATE_COUNT)
-  const [linkText, setLinkText] = useState<string>(UNEXTENDED_LIST_LINK_TEXT)
   const [isListExtended, setIsListExtended] = useState<boolean>(false)
 
-  const listOfFeatureUpdatesShown: FeatureUpdate[] = FEATURE_UPDATE_LIST.filter(
-    (featureUpdate) => featureUpdate.id <= numberOfFeatureUpdatesShown,
-  )
+  const listOfFeatureUpdatesShown: FeatureUpdate[] = useMemo(() => {
+    return isListExtended
+      ? FEATURE_UPDATE_LIST
+      : FEATURE_UPDATE_LIST.slice(0, DEFAULT_FEATURE_UPDATE_COUNT)
+  }, [isListExtended])
+
+  const showExtendListButton = useMemo(() => {
+    return FEATURE_UPDATE_LIST.length > DEFAULT_FEATURE_UPDATE_COUNT
+  }, [])
 
   const handleOnViewAllUpdatesClick = () => {
-    setNumberOfFeatureUpdatesShown(
-      isListExtended
-        ? DEFAULT_FEATURE_UPDATE_COUNT
-        : FEATURE_UPDATE_LIST.length,
-    )
-    setLinkText(
-      isListExtended ? UNEXTENDED_LIST_LINK_TEXT : EXTENDED_LIST_LINK_TEXT,
-    )
     setIsListExtended(!isListExtended)
   }
 
@@ -57,7 +52,7 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
           top="1.25rem"
         />
         <DrawerHeader textStyle="h2" color="secondary.700">
-          What’s new
+          What's new
         </DrawerHeader>
         <DrawerBody
           whiteSpace="pre-line"
@@ -68,14 +63,18 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
             {listOfFeatureUpdatesShown.map((featureUpdate, key) => {
               return <WhatsNewContent {...featureUpdate} key={key} />
             })}
-            <Button
-              variant="link"
-              textDecoration="underline"
-              alignSelf="center"
-              onClick={handleOnViewAllUpdatesClick}
-            >
-              {linkText}
-            </Button>
+            {showExtendListButton && (
+              <Button
+                variant="link"
+                textDecoration="underline"
+                alignSelf="center"
+                onClick={handleOnViewAllUpdatesClick}
+              >
+                {isListExtended
+                  ? EXTENDED_LIST_LINK_TEXT
+                  : UNEXTENDED_LIST_LINK_TEXT}
+              </Button>
+            )}
           </Stack>
         </DrawerBody>
       </DrawerContent>

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -6,11 +6,12 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerOverlay,
-  Link,
   Stack,
   StackDivider,
   UseDisclosureReturn,
 } from '@chakra-ui/react'
+
+import Button from '~components/Button'
 
 import { FEATURE_UPDATE_LIST, FeatureUpdate } from './FeatureUpdateList'
 import { WhatsNewContent } from './WhatsNewContent'
@@ -63,14 +64,19 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
           color="secondary.500"
           textStyle="body-2"
         >
-          <Stack divider={<StackDivider />} spacing="2rem">
+          <Stack divider={<StackDivider />} spacing="2rem" mb="2rem">
             {listOfFeatureUpdatesShown.map((featureUpdate, key) => {
               return <WhatsNewContent {...featureUpdate} key={key} />
             })}
+            <Button
+              variant="link"
+              textDecoration="underline"
+              alignSelf="center"
+              onClick={handleOnViewAllUpdatesClick}
+            >
+              {linkText}
+            </Button>
           </Stack>
-          <Link mt="2rem" mb="5.75rem" onClick={handleOnViewAllUpdatesClick}>
-            {linkText}
-          </Link>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -12,18 +12,12 @@ import { chunk } from 'lodash'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
 
-import {
-  EMERGENCY_CONTACT_KEY_PREFIX,
-  ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
-} from '~constants/localStorage'
+import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import Pagination from '~components/Pagination'
 
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
-import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
-import { useUserMutations } from '~features/user/mutations'
 import { useUser } from '~features/user/queries'
-import { getShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
 import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
 // TODO #4279: Remove after React rollout is complete
@@ -48,7 +42,6 @@ const useWorkspaceForms = () => {
   const [isManipulating, setIsManipulating] = useState(false)
 
   const createFormModalDisclosure = useDisclosure()
-  const whatsNewFeatureDrawerDisclosure = useDisclosure()
 
   const topRef = useRef<HTMLDivElement>(null)
 
@@ -107,7 +100,6 @@ const useWorkspaceForms = () => {
     setSortOrder,
     topRef,
     createFormModalDisclosure,
-    whatsNewFeatureDrawerDisclosure,
   }
 }
 
@@ -120,10 +112,8 @@ export const WorkspacePage = (): JSX.Element => {
     setPageNumber,
     topRef,
     createFormModalDisclosure,
-    whatsNewFeatureDrawerDisclosure,
   } = useWorkspaceForms()
   const { user, isLoading: isUserLoading } = useUser()
-  const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
 
   const ROLLOUT_ANNOUNCEMENT_KEY = useMemo(
     () => ROLLOUT_ANNOUNCEMENT_KEY_PREFIX + user?._id,
@@ -137,47 +127,12 @@ export const WorkspacePage = (): JSX.Element => {
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const emergencyContactKey = useMemo(
-    () => (user?._id ? EMERGENCY_CONTACT_KEY_PREFIX + user._id : null),
-    [user],
-  )
-
-  const [hasSeenEmergencyContact, setHasSeenEmergencyContact] =
-    useLocalStorage<boolean>(emergencyContactKey)
-
-  const isEmergencyContactModalOpen = useMemo(
-    () =>
-      !isUserLoading &&
-      // Open emergency contact modal after the rollout announcement modal
-      Boolean(hasSeenAnnouncement) &&
-      !hasSeenEmergencyContact &&
-      !user?.contact,
-    [isUserLoading, hasSeenAnnouncement, hasSeenEmergencyContact, user],
-  )
-
-  const shouldShowFeatureUpdateNotification = useMemo(() => {
-    if (isUserLoading || !user) return false
-    return getShowLatestFeatureUpdateNotification(user)
-  }, [isUserLoading, user])
-
-  const onWhatsNewDrawerOpen = useCallback(() => {
-    whatsNewFeatureDrawerDisclosure.onOpen()
-    updateUserLastSeenFeatureUpdateDateMutation.mutate()
-  }, [
-    updateUserLastSeenFeatureUpdateDateMutation,
-    whatsNewFeatureDrawerDisclosure,
-  ])
-
   return (
     <>
       <AdminNavBar />
       <CreateFormModal
         isOpen={createFormModalDisclosure.isOpen}
         onClose={createFormModalDisclosure.onClose}
-      />
-      <WhatsNewDrawer
-        isOpen={whatsNewFeatureDrawerDisclosure.isOpen}
-        onClose={whatsNewFeatureDrawerDisclosure.onClose}
       />
       {totalFormCount === 0 ? (
         <EmptyWorkspace
@@ -206,8 +161,6 @@ export const WorkspacePage = (): JSX.Element => {
               isLoading={isLoading}
               totalFormCount={totalFormCount}
               handleOpenCreateFormModal={createFormModalDisclosure.onOpen}
-              handleOpenWhatsNewDrawer={onWhatsNewDrawerOpen}
-              isWhatsNewButtonSolid={shouldShowFeatureUpdateNotification}
             />
           </Container>
           <Box gridArea="main">

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -18,7 +18,6 @@ import Pagination from '~components/Pagination'
 
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
 import { useUser } from '~features/user/queries'
-import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
 // TODO #4279: Remove after React rollout is complete
 import { AdminSwitchEnvMessage } from './components/AdminSwitchEnvMessage'

--- a/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
@@ -17,8 +17,6 @@ export interface WorkspaceHeaderProps {
   totalFormCount?: number | '---'
   isLoading: boolean
   handleOpenCreateFormModal: () => void
-  handleOpenWhatsNewDrawer: () => void
-  isWhatsNewButtonSolid: boolean
 }
 
 /**
@@ -28,13 +26,9 @@ export const WorkspaceHeader = ({
   totalFormCount = '---',
   isLoading,
   handleOpenCreateFormModal,
-  handleOpenWhatsNewDrawer,
-  isWhatsNewButtonSolid,
 }: WorkspaceHeaderProps): JSX.Element => {
   const [sortOption, setSortOption] = useState(SortOption.LastUpdated)
   const isMobile = useIsMobile()
-
-  const whatsNewButtonVariant = isWhatsNewButtonSolid ? 'solid' : 'outline'
 
   return (
     <Stack
@@ -70,15 +64,6 @@ export const WorkspaceHeader = ({
           leftIcon={<BiPlus fontSize="1.5rem" />}
         >
           Create form
-        </Button>
-        {/* TODO: Button with button variant prop is used temporarily to represent the what's new tab functionality in the admin header. 
-        Shift this to admin header once admin header is implemented.*/}
-        <Button
-          isFullWidth={isMobile}
-          onClick={handleOpenWhatsNewDrawer}
-          variant={whatsNewButtonVariant}
-        >
-          What's New
         </Button>
       </Stack>
     </Stack>

--- a/frontend/src/hooks/useMdComponents.tsx
+++ b/frontend/src/hooks/useMdComponents.tsx
@@ -61,7 +61,9 @@ export const useMdComponents = ({
           {...textStyles}
         />
       ),
-      ul: ({ node, ...props }) => <UnorderedList {...props} {...listStyles} />,
+      ul: ({ node, ordered, ...props }) => (
+        <UnorderedList {...props} {...listStyles} />
+      ),
       li: ({ node, ordered, ...props }) => (
         <ListItem {...props} {...textStyles} />
       ),

--- a/frontend/src/theme/components/Drawer.ts
+++ b/frontend/src/theme/components/Drawer.ts
@@ -1,24 +1,35 @@
-import { ComponentMultiStyleConfig } from '~theme/types'
+import { drawerAnatomy as parts } from '@chakra-ui/anatomy'
+import type {
+  PartsStyleFunction,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from '@chakra-ui/theme-tools'
+
+import { textStyles } from '~theme/textStyles'
 
 import { Modal } from './Modal'
 
-// Default parts.
-const parts = [
-  'overlay',
-  'dialogContainer',
-  'dialog',
-  'header',
-  'closeButton',
-  'body',
-  'footer',
-]
+const baseStyleOverlay: SystemStyleFunction = (props) => {
+  return Modal.baseStyle(props).overlay ?? {}
+}
 
-export const Drawer: ComponentMultiStyleConfig = {
-  parts,
-  baseStyle: (props) => ({
-    overlay:
-      Modal.baseStyle instanceof Function
-        ? Modal.baseStyle(props).overlay
-        : undefined,
-  }),
+const baseStyleHeader: SystemStyleObject = {
+  ...textStyles['h2'],
+  py: '1.25rem',
+  px: '2.5rem',
+}
+
+const baseStyleBody: SystemStyleObject = {
+  px: '2.5rem',
+}
+
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  overlay: baseStyleOverlay(props),
+  header: baseStyleHeader,
+  body: baseStyleBody,
+})
+
+export const Drawer = {
+  parts: parts.keys,
+  baseStyle,
 }

--- a/frontend/src/theme/components/Modal.ts
+++ b/frontend/src/theme/components/Modal.ts
@@ -6,12 +6,11 @@ import {
   SystemStyleObject,
 } from '@chakra-ui/theme-tools'
 
-import { ComponentMultiStyleConfig } from '~theme/types'
-
 import { textStyles } from '../textStyles'
 
 const baseStyleOverlay: SystemStyleObject = {
   bg: 'rgba(0, 0, 0, 0.65)',
+  zIndex: 'overlay',
 }
 
 const baseStyleDialog: SystemStyleFunction = (props) => {
@@ -103,7 +102,7 @@ const sizes = {
   full: getSize('full'),
 }
 
-export const Modal: ComponentMultiStyleConfig<typeof parts> = {
+export const Modal = {
   parts: parts.keys,
   baseStyle,
   sizes,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently there is a button placeholder used to open the drawer containing the list of feature updates. As the admin nav bar is implemented, removed button placeholder and added What's new tab on admin nav bar.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

## Before & After Screenshots
New stories added under `App/AdminNavBar` to show the What's new tab UI when there is notification and when there is no user notification.