### PR TITLE
feat(form-v2): add collaborator modal to form row actions and refactor to use context

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -75,6 +75,7 @@ const useAdminFormNavbar = () => {
     handleBackToDashboard,
     handlePreviewForm,
     form,
+    formId,
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
     viewOnly: !isLoading && !hasEditAccess,
@@ -93,6 +94,7 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
     form,
+    formId,
     viewOnly,
   } = useAdminFormNavbar()
 
@@ -107,6 +109,7 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
       <CollaboratorModal
         isOpen={collaboratorModalDisclosure.isOpen}
         onClose={collaboratorModalDisclosure.onClose}
+        formId={formId}
       />
       <ShareFormModal
         isOpen={shareFormModalDisclosure.isOpen}

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -27,10 +27,12 @@ const ADMINFORM_ROUTES = [
 ]
 
 const useAdminFormNavbar = () => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
   const { data: form } = useAdminForm()
   const { pathname } = useLocation()
-  const { formId } = useParams()
-  const { hasEditAccess, isLoading } = useAdminFormCollaborators()
+  const { hasEditAccess, isLoading } = useAdminFormCollaborators(formId)
   const navigate = useNavigate()
 
   const calcCurrentIndex = useCallback(() => {

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
@@ -27,9 +27,9 @@ export type AddCollaboratorInputs = {
 }
 
 const useAddCollaboratorInput = () => {
-  const { handleForwardToTransferOwnership } = useCollaboratorWizard()
+  const { handleForwardToTransferOwnership, formId } = useCollaboratorWizard()
   const { isLoading, collaborators, form, isFormAdmin } =
-    useAdminFormCollaborators()
+    useAdminFormCollaborators(formId)
   const { mutateAddCollaborator } = useMutateCollaborators()
 
   const formMethods = useForm<AddCollaboratorInputs>({

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorList.tsx
@@ -39,10 +39,13 @@ const RemoveCollaboratorButton = (
 export const CollaboratorList = (): JSX.Element => {
   const isMobile = useIsMobile()
   // Admin form data required for checking for duplicate emails.
-  const { handleForwardToTransferOwnership, handleForwardToRemoveSelf } =
-    useCollaboratorWizard()
+  const {
+    handleForwardToTransferOwnership,
+    handleForwardToRemoveSelf,
+    formId,
+  } = useCollaboratorWizard()
   const { collaborators, user, isFormAdmin, form, isLoading, hasEditAccess } =
-    useAdminFormCollaborators()
+    useAdminFormCollaborators(formId)
 
   const { mutateUpdateCollaborator, mutateRemoveCollaborator } =
     useMutateCollaborators()

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/CollaboratorListScreen.tsx
@@ -2,11 +2,14 @@ import { ModalBody, ModalHeader, Stack } from '@chakra-ui/react'
 
 import { useAdminFormCollaborators } from '~features/admin-form/common/queries'
 
+import { useCollaboratorWizard } from '../CollaboratorWizardContext'
+
 import { AddCollaboratorInput } from './AddCollaboratorInput'
 import { CollaboratorList } from './CollaboratorList'
 
 export const CollaboratorListScreen = (): JSX.Element => {
-  const { hasEditAccess } = useAdminFormCollaborators()
+  const { formId } = useCollaboratorWizard()
+  const { hasEditAccess } = useAdminFormCollaborators(formId)
   return (
     <>
       <ModalHeader color="secondary.700">

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.stories.tsx
@@ -62,6 +62,7 @@ const Template: Story = () => {
     <CollaboratorModal
       {...modalProps}
       onClose={() => console.log('close modal')}
+      formId="mockStoryFormId"
     />,
     el,
   )

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -13,7 +13,7 @@ import { CollaboratorWizardProvider } from './CollaboratorWizardContext'
 interface CollaboratorModalProps {
   isOpen: boolean
   onClose: () => void
-  formId: string | undefined
+  formId: string
 }
 
 export const CollaboratorModal = ({
@@ -35,7 +35,7 @@ export const CollaboratorModal = ({
       >
         <ModalCloseButton />
         {isOpen && (
-          <CollaboratorWizardProvider formIdContext={formId}>
+          <CollaboratorWizardProvider formId={formId}>
             <CollaboratorModalContent />
           </CollaboratorWizardProvider>
         )}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -13,11 +13,13 @@ import { CollaboratorWizardProvider } from './CollaboratorWizardContext'
 interface CollaboratorModalProps {
   isOpen: boolean
   onClose: () => void
+  formId: string | undefined
 }
 
 export const CollaboratorModal = ({
   isOpen,
   onClose,
+  formId,
 }: CollaboratorModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -33,7 +35,7 @@ export const CollaboratorModal = ({
       >
         <ModalCloseButton />
         {isOpen && (
-          <CollaboratorWizardProvider>
+          <CollaboratorWizardProvider formIdContext={formId}>
             <CollaboratorModalContent />
           </CollaboratorWizardProvider>
         )}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -13,6 +13,7 @@ type CollaboratorWizardContextReturn = {
   emailToTransfer: string | null
   handleForwardToTransferOwnership: (emailToTransfer: string) => void
   handleForwardToRemoveSelf: () => void
+  formId: string | undefined
 }
 
 const CollaboratorWizardContext = createContext<
@@ -24,7 +25,9 @@ const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
   0 | 1 | -1,
 ]
 
-const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
+const useCollaboratorWizardContext = (
+  formIdContext: string | undefined,
+): CollaboratorWizardContextReturn => {
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
   const [emailToTransfer, setEmailToTransfer] = useState<string | null>(null)
@@ -46,6 +49,8 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     setCurrentStep([CollaboratorFlowStates.RemoveSelf, 1])
   }, [])
 
+  const formId = formIdContext
+
   return {
     currentStep,
     direction,
@@ -53,15 +58,18 @@ const useCollaboratorWizardContext = (): CollaboratorWizardContextReturn => {
     emailToTransfer,
     handleForwardToTransferOwnership,
     handleForwardToRemoveSelf,
+    formId,
   }
 }
 
 export const CollaboratorWizardProvider = ({
   children,
+  formIdContext,
 }: {
   children: React.ReactNode
+  formIdContext: string | undefined
 }): JSX.Element => {
-  const values = useCollaboratorWizardContext()
+  const values = useCollaboratorWizardContext(formIdContext)
   return (
     <CollaboratorWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -13,7 +13,7 @@ type CollaboratorWizardContextReturn = {
   emailToTransfer: string | null
   handleForwardToTransferOwnership: (emailToTransfer: string) => void
   handleForwardToRemoveSelf: () => void
-  formId: string | undefined
+  formId: string
 }
 
 const CollaboratorWizardContext = createContext<
@@ -26,7 +26,7 @@ const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
 ]
 
 const useCollaboratorWizardContext = (
-  formIdContext: string | undefined,
+  formId: string,
 ): CollaboratorWizardContextReturn => {
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
@@ -49,8 +49,6 @@ const useCollaboratorWizardContext = (
     setCurrentStep([CollaboratorFlowStates.RemoveSelf, 1])
   }, [])
 
-  const formId = formIdContext
-
   return {
     currentStep,
     direction,
@@ -64,12 +62,12 @@ const useCollaboratorWizardContext = (
 
 export const CollaboratorWizardProvider = ({
   children,
-  formIdContext,
+  formId,
 }: {
   children: React.ReactNode
-  formIdContext: string | undefined
+  formId: string
 }): JSX.Element => {
-  const values = useCollaboratorWizardContext(formIdContext)
+  const values = useCollaboratorWizardContext(formId)
   return (
     <CollaboratorWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -24,6 +24,7 @@ import {
   submitStorageModeFormPreview,
 } from '../common/AdminViewFormService'
 
+import { useCollaboratorWizard } from './components/CollaboratorModal/CollaboratorWizardContext'
 import { permissionsToRole } from './components/CollaboratorModal/utils'
 import { updateFormEndPage, updateFormStartPage } from './AdminFormPageService'
 import {
@@ -52,8 +53,8 @@ enum FormCollaboratorAction {
 }
 
 export const useMutateCollaborators = () => {
-  const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  const { formId } = useCollaboratorWizard()
+  if (!formId) throw new Error('No formId provided to useMutateCollaborators')
 
   const navigate = useNavigate()
   const queryClient = useQueryClient()

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -10,7 +10,6 @@ import { FORMID_REGEX } from '~constants/routes'
 
 import { useUser } from '~features/user/queries'
 
-import { useCollaboratorWizard } from './components/CollaboratorModal/CollaboratorWizardContext'
 import {
   getAdminFormView,
   getFormCollaborators,
@@ -40,9 +39,21 @@ export const useAdminForm = (
     ReturnType<typeof adminFormKeys.id>
   >,
 ): UseQueryResult<AdminFormDto, ApiError> => {
-  const { formId } = useCollaboratorWizard()
+  const { formId } = useParams()
   if (!formId) throw new Error('No formId provided to useAdminForm')
 
+  return useAdminFormWithId(formId, props)
+}
+
+export const useAdminFormWithId = (
+  formId: string,
+  props?: UseQueryOptions<
+    AdminFormDto,
+    ApiError,
+    AdminFormDto,
+    ReturnType<typeof adminFormKeys.id>
+  >,
+): UseQueryResult<AdminFormDto, ApiError> => {
   return useQuery(
     adminFormKeys.id(formId),
     () => getAdminFormView(formId),
@@ -59,14 +70,15 @@ export const useFreeSmsQuota = () => {
   )
 }
 
-export const useAdminFormCollaborators = () => {
-  const { formId } = useCollaboratorWizard()
-  if (!formId)
-    throw new Error('No formId provided to useAdminFormCollaborators')
-  console.log(formId + ' received by useAdminFormCollaborators')
-
+/**
+ * @params formId - The formId of the form to get the collaborators for.
+ * Params required as formId may come from various sources, either via url params
+ * or a context.
+ */
+export const useAdminFormCollaborators = (formId: string) => {
   const { user, isLoading: isUserLoading } = useUser()
-  const { data: form, isLoading: isAdminFormLoading } = useAdminForm()
+  const { data: form, isLoading: isAdminFormLoading } =
+    useAdminFormWithId(formId)
 
   const { data: collaborators, isLoading: isCollabLoading } = useQuery(
     adminFormKeys.collaborators(formId),

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -10,6 +10,7 @@ import { FORMID_REGEX } from '~constants/routes'
 
 import { useUser } from '~features/user/queries'
 
+import { useCollaboratorWizard } from './components/CollaboratorModal/CollaboratorWizardContext'
 import {
   getAdminFormView,
   getFormCollaborators,
@@ -39,8 +40,8 @@ export const useAdminForm = (
     ReturnType<typeof adminFormKeys.id>
   >,
 ): UseQueryResult<AdminFormDto, ApiError> => {
-  const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  const { formId } = useCollaboratorWizard()
+  if (!formId) throw new Error('No formId provided to useAdminForm')
 
   return useQuery(
     adminFormKeys.id(formId),
@@ -51,7 +52,7 @@ export const useAdminForm = (
 
 export const useFreeSmsQuota = () => {
   const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  if (!formId) throw new Error('No formId provided to useFreeSmsQuota')
 
   return useQuery(adminFormKeys.freeSmsCount(formId), () =>
     getFreeSmsQuota(formId),
@@ -59,8 +60,10 @@ export const useFreeSmsQuota = () => {
 }
 
 export const useAdminFormCollaborators = () => {
-  const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  const { formId } = useCollaboratorWizard()
+  if (!formId)
+    throw new Error('No formId provided to useAdminFormCollaborators')
+  console.log(formId + ' received by useAdminFormCollaborators')
 
   const { user, isLoading: isUserLoading } = useUser()
   const { data: form, isLoading: isAdminFormLoading } = useAdminForm()

--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -17,8 +17,10 @@ import { FeatureTour } from './featureTour/FeatureTour'
 
 export const CreatePage = (): JSX.Element => {
   const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
   const { hasEditAccess, isLoading: isCollabLoading } =
-    useAdminFormCollaborators()
+    useAdminFormCollaborators(formId)
   const navigate = useNavigate()
 
   // Redirect view-only collaborators to results screen.

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -26,8 +26,10 @@ import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
 export const SettingsPage = (): JSX.Element => {
   const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
   const { hasEditAccess, isLoading: isCollabLoading } =
-    useAdminFormCollaborators()
+    useAdminFormCollaborators(formId)
   const navigate = useNavigate()
 
   // Redirect view-only collaborators to results screen.

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
@@ -38,7 +38,7 @@ export const RowActionsDrawer = ({
     handleDeleteForm,
     handleDuplicateForm,
     handleEditForm,
-    handleManageFormAccess,
+    handleCollaborators,
     handlePreviewForm,
     handleShareForm,
   } = useRowAction(formMeta)
@@ -103,10 +103,10 @@ export const RowActionsDrawer = ({
               </Button>
               <Button
                 {...buttonProps}
-                onClick={handleManageFormAccess}
+                onClick={handleCollaborators}
                 leftIcon={<BiUserPlus fontSize="1.25rem" />}
               >
-                Manage form access
+                Manage form admins
               </Button>
               <Divider />
               <Button

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
@@ -23,7 +23,7 @@ import Button, { ButtonProps } from '~components/Button'
 import IconButton from '~components/IconButton'
 
 import { RowActionsProps } from './RowActions'
-import { useRowActionDropdown } from './useRowActionDropdown'
+import { useRowAction } from './useRowAction'
 
 /**
  * Drawer variant of form actions. Most probably used only in mobile breakpoints.
@@ -41,7 +41,7 @@ export const RowActionsDrawer = ({
     handleManageFormAccess,
     handlePreviewForm,
     handleShareForm,
-  } = useRowActionDropdown(formMeta)
+  } = useRowAction(formMeta)
 
   const buttonProps: Partial<ButtonProps> = useMemo(
     () => ({

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
@@ -14,7 +14,7 @@ import IconButton from '~components/IconButton'
 import Menu from '~components/Menu'
 
 import { RowActionsProps } from './RowActions'
-import { useRowActionDropdown } from './useRowActionDropdown'
+import { useRowAction } from './useRowAction'
 
 export const RowActionsDropdown = ({
   isDisabled,
@@ -27,7 +27,7 @@ export const RowActionsDropdown = ({
     handleDuplicateForm,
     handleManageFormAccess,
     handleShareForm,
-  } = useRowActionDropdown(formMeta)
+  } = useRowAction(formMeta)
 
   return (
     <Menu

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
@@ -25,7 +25,7 @@ export const RowActionsDropdown = ({
     handlePreviewForm,
     handleDeleteForm,
     handleDuplicateForm,
-    handleManageFormAccess,
+    handleCollaborators,
     handleShareForm,
   } = useRowAction(formMeta)
 
@@ -75,10 +75,10 @@ export const RowActionsDropdown = ({
               Share form
             </Menu.Item>
             <Menu.Item
-              onClick={handleManageFormAccess}
+              onClick={handleCollaborators}
               icon={<BiUserPlus fontSize="1.25rem" />}
             >
-              Manage form access
+              Manage form admins
             </Menu.Item>
             <MenuDivider />
             <Menu.Item

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
@@ -10,7 +10,7 @@ type UseRowActionReturn = {
   handleEditForm: () => void
   handlePreviewForm: () => void
   handleDuplicateForm: () => void
-  handleManageFormAccess: () => void
+  handleCollaborators: () => void
   handleDeleteForm: () => void
   handleShareForm: () => void
 }
@@ -20,7 +20,7 @@ export const useRowAction = (
 ): UseRowActionReturn => {
   const navigate = useNavigate()
 
-  const { onOpenDupeFormModal, onOpenShareFormModal } =
+  const { onOpenDupeFormModal, onOpenShareFormModal, onOpenCollabModal } =
     useWorkspaceRowsContext()
 
   return {
@@ -31,8 +31,7 @@ export const useRowAction = (
         `${window.location.origin}${ADMINFORM_ROUTE}/${formMeta._id}/${ADMINFORM_PREVIEW_ROUTE}`,
       ),
     handleDuplicateForm: () => onOpenDupeFormModal(formMeta),
-    handleManageFormAccess: () =>
-      console.log(`manage form access button clicked for ${formMeta._id}`),
+    handleCollaborators: () => onOpenCollabModal(formMeta),
     handleDeleteForm: () =>
       console.log(`delete form  button clicked for ${formMeta._id}`),
   }

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
@@ -6,7 +6,7 @@ import { ADMINFORM_PREVIEW_ROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 
 import { useWorkspaceRowsContext } from '../WorkspaceRowsContext'
 
-type UseRowActionDropdownReturn = {
+type UseRowActionReturn = {
   handleEditForm: () => void
   handlePreviewForm: () => void
   handleDuplicateForm: () => void
@@ -15,9 +15,9 @@ type UseRowActionDropdownReturn = {
   handleShareForm: () => void
 }
 
-export const useRowActionDropdown = (
+export const useRowAction = (
   formMeta: AdminDashboardFormMetaDto,
-): UseRowActionDropdownReturn => {
+): UseRowActionReturn => {
   const navigate = useNavigate()
 
   const { onOpenDupeFormModal, onOpenShareFormModal } =

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 
 import { AdminDashboardFormMetaDto } from '~shared/types/form/form'
 
-import { useRowActionDropdown } from './RowActions/useRowActionDropdown'
+import { useRowAction } from './RowActions/useRowAction'
 import { FormStatusLabel } from './FormStatusLabel'
 import { RowActions } from './RowActions'
 
@@ -29,7 +29,7 @@ export const WorkspaceFormRow = ({
     return dayjs(formMeta.lastModified).calendar(null, RELATIVE_DATE_FORMAT)
   }, [formMeta.lastModified])
 
-  const { handleEditForm } = useRowActionDropdown(formMeta)
+  const { handleEditForm } = useRowAction(formMeta)
 
   return (
     <Box pos="relative">

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -6,6 +6,7 @@ import { useDisclosure } from '@chakra-ui/react'
 
 import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types'
 
+import CollaboratorModal from '~features/admin-form/common/components/CollaboratorModal'
 import { ShareFormModal } from '~features/admin-form/share'
 
 import { DuplicateFormModal } from '../DuplicateFormModal'
@@ -15,6 +16,7 @@ interface WorkspaceRowsContextReturn {
   onOpenDupeFormModal: (meta?: AdminDashboardFormMetaDto) => void
   onCloseDupeFormModal: () => void
   onOpenShareFormModal: (meta?: AdminDashboardFormMetaDto) => void
+  onOpenCollabModal: (meta?: AdminDashboardFormMetaDto) => void
 }
 
 const WorkspaceRowsContext = createContext<WorkspaceRowsContextReturn | null>(
@@ -31,6 +33,7 @@ export const WorkspaceRowsProvider = ({
 
   const dupeFormModalDisclosure = useDisclosure()
   const shareFormModalDisclosure = useDisclosure()
+  const collabModalDisclosure = useDisclosure()
 
   const onOpenDupeFormModal = (meta?: AdminDashboardFormMetaDto) => {
     setActiveFormMeta(meta)
@@ -46,6 +49,13 @@ export const WorkspaceRowsProvider = ({
     }
   }
 
+  const onOpenCollabModal = (meta?: AdminDashboardFormMetaDto) => {
+    setActiveFormMeta(meta)
+    if (meta) {
+      collabModalDisclosure.onOpen()
+    }
+  }
+
   return (
     <WorkspaceRowsContext.Provider
       value={{
@@ -53,6 +63,7 @@ export const WorkspaceRowsProvider = ({
         onOpenDupeFormModal,
         onOpenShareFormModal,
         onCloseDupeFormModal: dupeFormModalDisclosure.onClose,
+        onOpenCollabModal,
       }}
     >
       <DuplicateFormModal
@@ -64,6 +75,11 @@ export const WorkspaceRowsProvider = ({
         formId={activeFormMeta?._id}
         onClose={shareFormModalDisclosure.onClose}
         isFormPrivate={activeFormMeta?.status === FormStatus.Private}
+      />
+      <CollaboratorModal
+        isOpen={collabModalDisclosure.isOpen}
+        formId={activeFormMeta?._id}
+        onClose={collabModalDisclosure.onClose}
       />
       {children}
     </WorkspaceRowsContext.Provider>

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -85,11 +85,13 @@ export const WorkspaceRowsProvider = ({
         onClose={shareFormModalDisclosure.onClose}
         isFormPrivate={activeFormMeta?.status === FormStatus.Private}
       />
-      <CollaboratorModal
-        isOpen={collabModalDisclosure.isOpen}
-        formId={activeFormMeta?._id}
-        onClose={collabModalDisclosure.onClose}
-      />
+      {activeFormMeta?._id && (
+        <CollaboratorModal
+          isOpen={collabModalDisclosure.isOpen}
+          formId={activeFormMeta._id}
+          onClose={collabModalDisclosure.onClose}
+        />
+      )}
       <DeleteFormModal
         isOpen={deleteFormModalDisclosure.isOpen}
         onClose={deleteFormModalDisclosure.onClose}


### PR DESCRIPTION
- renamed useRowActionDropdown() and useRowActionDropdown.ts to useRowAction() and useRowAction.ts for accuracy, since both RowActionDrawer and RowActionDropdown call this function
- refactored collaborator modal logic to get formId from CollaboratorWizardContext, which in turn gets formId from a CollaboratorModal param
- linked Collaborator Modal to form row actions

Related to #4298 
