### PR TITLE
feat: copy changes to label and error message

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -285,8 +285,7 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         <FormControl>
           <Toggle
             {...register('addParticularDayRestriction')}
-            label="Customize days of the week"
-            description="Checking a day will disable all the same days in the calendar"
+            label="Custom availability during the week"
           />
         </FormControl>
         {watchAddParticularDayRestriction ? (
@@ -296,7 +295,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               name="invalidDays"
               rules={{
                 validate: (val) => {
-                  return !!val.length || 'Error placeholder'
+                  return (
+                    !!val.length || 'Please select available days of the week'
+                  )
                 },
               }}
               render={({ field: { ref, ...field } }) => (

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -8,13 +8,13 @@ export enum DateSelectedValidation {
 }
 
 export enum InvalidDaysOptions {
-  Sunday = 'Sunday',
-  Monday = 'Monday',
-  Tuesday = 'Tuesday',
-  Wednesday = 'Wednesday',
-  Thursday = 'Thursday',
-  Friday = 'Friday',
-  Saturday = 'Saturday',
+  Sunday = 'Sundays',
+  Monday = 'Mondays',
+  Tuesday = 'Tuesdays',
+  Wednesday = 'Wednesdays',
+  Thursday = 'Thursdays',
+  Friday = 'Fridays',
+  Saturday = 'Saturdays',
 }
 
 export type DateValidationOptions = {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Add copy changes to form section label and error message for restricting days of the week for form admin users.

For reference:
Label:
<img width="310" alt="Screenshot 2022-08-11 at 11 17 31 AM" src="https://user-images.githubusercontent.com/48427064/184059402-6cf99e55-874a-4347-af39-b6889b4af058.png">

Error Message:
<img width="321" alt="Screenshot 2022-08-11 at 11 18 34 AM" src="https://user-images.githubusercontent.com/48427064/184059487-955a9bb0-4fb7-4778-877c-a37401540440.png">

I only added the label and error message for days of the week and not for public holidays as the feature for restricting Singapore public holidays has not been implemented yet.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] Yes - this PR contains breaking changes
    - Previous `InvalidDaysOption` was days of the week that were singular. This change would make the days of the weeks plural. Hence previous values stored in the `InvalidDays` option would be invalid and cause an error during server side validation.
- [ ] No - this PR is backwards compatible  
