### PR TITLE
fix(form-v2): add default values to field templates to ensure optional fields can be submitted

### DIFF
--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 import {
   get,
   useFormContext,
@@ -55,8 +55,7 @@ export const CheckboxField = ({
     [schema],
   )
 
-  const { register, getValues, resetField } =
-    useFormContext<CheckboxFieldInputs>()
+  const { register, getValues } = useFormContext<CheckboxFieldInputs>()
   const { isValid, isSubmitting, errors } = useFormState<CheckboxFieldInputs>({
     name: schema._id,
   })
@@ -76,11 +75,6 @@ export const CheckboxField = ({
       },
     }),
     [checkboxInputName, getValues],
-  )
-
-  useEffect(
-    () => resetField(checkboxInputName, { defaultValue: '' }),
-    [checkboxInputName, resetField],
   )
 
   return (

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -84,6 +84,7 @@ export const CheckboxField = ({
           colorScheme={fieldColorScheme}
           key={idx}
           value={o}
+          defaultValue={[]}
           {...register(checkboxInputName, validationRules)}
         >
           {o}

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react'
+import { forwardRef, useEffect, useMemo } from 'react'
 import {
   get,
   useFormContext,
@@ -55,7 +55,8 @@ export const CheckboxField = ({
     [schema],
   )
 
-  const { register, getValues } = useFormContext<CheckboxFieldInputs>()
+  const { register, getValues, resetField } =
+    useFormContext<CheckboxFieldInputs>()
   const { isValid, isSubmitting, errors } = useFormState<CheckboxFieldInputs>({
     name: schema._id,
   })
@@ -75,6 +76,11 @@ export const CheckboxField = ({
       },
     }),
     [checkboxInputName, getValues],
+  )
+
+  useEffect(
+    () => resetField(checkboxInputName, { defaultValue: '' }),
+    [checkboxInputName, resetField],
   )
 
   return (

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -84,7 +84,7 @@ export const CheckboxField = ({
           colorScheme={fieldColorScheme}
           key={idx}
           value={o}
-          defaultValue={[]}
+          defaultValue=""
           {...register(checkboxInputName, validationRules)}
         >
           {o}

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -62,6 +62,7 @@ export const DateField = ({
         control={control}
         name={schema._id}
         rules={validationRules}
+        defaultValue=""
         render={({ field }) => (
           <DateInput
             colorScheme={`theme-${colorTheme}`}

--- a/frontend/src/templates/Field/Decimal/DecimalField.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.tsx
@@ -28,6 +28,7 @@ export const DecimalField = ({ schema }: DecimalFieldProps): JSX.Element => {
         control={control}
         rules={validationRules}
         name={schema._id}
+        defaultValue=""
         render={({ field }) => (
           <NumberInput
             inputMode="decimal"

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -39,6 +39,7 @@ export const EmailFieldInput = ({
       control={control}
       rules={validationRules}
       name={schema._id}
+      defaultValue={{ value: '' }}
       render={({ field: { onChange, value, ...field } }) => (
         <Input
           autoComplete="email"

--- a/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
@@ -26,6 +26,7 @@ export const HomeNoField = ({ schema }: HomeNoFieldProps): JSX.Element => {
         control={control}
         rules={validationRules}
         name={schema._id}
+        defaultValue=""
         render={({ field }) => (
           <PhoneNumberInput
             autoComplete="tel"

--- a/frontend/src/templates/Field/LongText/LongTextField.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.tsx
@@ -26,6 +26,7 @@ export const LongTextField = ({ schema }: LongTextFieldProps): JSX.Element => {
     <FieldContainer schema={schema}>
       <Textarea
         aria-label={schema.title}
+        defaultValue=""
         {...register(schema._id, validationRules)}
       />
     </FieldContainer>

--- a/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
@@ -41,6 +41,7 @@ export const MobileFieldInput = ({
       control={control}
       rules={validationRules}
       name={schema._id}
+      defaultValue={{ value: '' }}
       render={({ field: { onChange, value, ...field } }) => (
         <PhoneNumberInput
           autoComplete="tel"

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -26,6 +26,7 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
     <FieldContainer schema={schema}>
       <Input
         aria-label={schema.title}
+        defaultValue=""
         {...register(schema._id, validationRules)}
       />
     </FieldContainer>

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -30,6 +30,7 @@ export const NumberField = ({
         control={control}
         rules={validationRules}
         name={schema._id}
+        defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <NumberInput
             min={0}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Controller, useFormContext, useFormState } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
@@ -49,7 +49,8 @@ export const RadioField = ({
     [schema],
   )
 
-  const { register, getValues, trigger } = useFormContext<RadioFieldInputs>()
+  const { register, getValues, trigger, resetField } =
+    useFormContext<RadioFieldInputs>()
   const { isValid, isSubmitting, errors } = useFormState<RadioFieldInputs>({
     name: schema._id,
   })
@@ -66,6 +67,11 @@ export const RadioField = ({
       },
     }),
     [getValues, radioInputName, schema.othersRadioButton],
+  )
+
+  useEffect(
+    () => resetField(radioInputName, { defaultValue: '' }),
+    [radioInputName, resetField],
   )
 
   return (

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -73,6 +73,7 @@ export const RadioField = ({
       <Controller
         name={radioInputName}
         rules={validationRules}
+        defaultValue=""
         // `ref` omitted so the radiogroup will not have a ref and only the
         // radio themselves get the ref.
         render={({ field: { ref, onChange, value, ...rest } }) => (

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Controller, useFormContext, useFormState } from 'react-hook-form'
 import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 import { get } from 'lodash'
@@ -49,8 +49,7 @@ export const RadioField = ({
     [schema],
   )
 
-  const { register, getValues, trigger, resetField } =
-    useFormContext<RadioFieldInputs>()
+  const { register, getValues, trigger } = useFormContext<RadioFieldInputs>()
   const { isValid, isSubmitting, errors } = useFormState<RadioFieldInputs>({
     name: schema._id,
   })
@@ -67,11 +66,6 @@ export const RadioField = ({
       },
     }),
     [getValues, radioInputName, schema.othersRadioButton],
-  )
-
-  useEffect(
-    () => resetField(radioInputName, { defaultValue: '' }),
-    [radioInputName, resetField],
   )
 
   return (

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -52,7 +52,6 @@ export const RatingField = ({
         rules={validationRules}
         control={control}
         name={schema._id}
-        defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <Rating
             colorScheme={`theme-${colorTheme}`}

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -52,6 +52,7 @@ export const RatingField = ({
         rules={validationRules}
         control={control}
         name={schema._id}
+        defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <Rating
             colorScheme={`theme-${colorTheme}`}

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -31,6 +31,7 @@ export const ShortTextField = ({
       <Input
         isPrefilled={isPrefilled}
         aria-label={schema.title}
+        defaultValue=""
         {...register(schema._id, validationRules)}
       />
     </FieldContainer>

--- a/frontend/src/templates/Field/Uen/UenField.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.tsx
@@ -4,8 +4,6 @@
 import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { FormFieldWithId, UenFieldBase } from '~shared/types/field'
-
 import { createUenValidationRules } from '~utils/fieldValidation'
 import Input from '~components/Input'
 
@@ -28,6 +26,7 @@ export const UenField = ({ schema }: UenFieldProps): JSX.Element => {
     <FieldContainer schema={schema}>
       <Input
         aria-label={schema.title}
+        defaultValue=""
         {...register(schema._id, validationRules)}
       />
     </FieldContainer>


### PR DESCRIPTION
## Problem
Currently, optional radio fields left empty cannot be submitted, resulting in a `ZodError`. However, if an option is selected then deselected, the form is submittable. This indicates an issue with the default value given to the radio fields before it is touched. In particular, the default value given is undefined, which is not accepted by zod.

Closes #4508 

## Solution
Provide a default value (empty string) for radio and checkboxes.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/184061294-bf8cdd70-3a75-4d5c-b4fa-a3e472c487e7.mov
