### PR TITLE
fix(v2): update rendering of start page theme radio selection

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -14,7 +14,6 @@ import {
   Flex,
   FormControl,
   FormLabel,
-  Stack,
   Tabs,
   Text,
   Textarea,
@@ -31,7 +30,6 @@ import Radio from '~components/Radio'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
-import { getTitleBg } from '~features/public-form/components/FormStartPage/useFormHeader'
 
 import {
   CustomLogoMeta,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -259,6 +259,7 @@ export const DesignDrawer = ({
           >
             {Object.values(FormColorTheme).map((color) => (
               <Radio
+                key={color}
                 {...register('colorTheme')}
                 colorScheme={`theme-${color}`}
                 value={color}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -254,36 +254,17 @@ export const DesignDrawer = ({
         >
           <FormLabel>Theme colour</FormLabel>
           <Radio.RadioGroup
-            value={startPageData.colorTheme}
+            defaultValue={startPageData.colorTheme}
             isDisabled={startPageMutation.isLoading}
           >
-            <Stack spacing="0" direction="row" display="inline">
-              {Object.values(FormColorTheme).map((color, idx) => (
-                <Radio
-                  key={idx}
-                  display="inline"
-                  width="1rem"
-                  value={color}
-                  {...register('colorTheme')}
-                  // CSS for inverted radio button
-                  // TODO: anti-aliasing at interface of border and ::before?
-                  border="2px solid"
-                  borderRadius="50%"
-                  borderColor="white"
-                  background={getTitleBg(color)}
-                  _checked={{ borderColor: getTitleBg(color) }}
-                  _before={{
-                    content: '""',
-                    display: 'inline-block',
-                    width: '20px',
-                    height: '20px',
-                    border: '2px solid',
-                    borderColor: 'white',
-                    borderRadius: '50%',
-                  }}
-                />
-              ))}
-            </Stack>
+            {Object.values(FormColorTheme).map((color) => (
+              <Radio
+                {...register('colorTheme')}
+                colorScheme={`theme-${color}`}
+                value={color}
+                w="auto"
+              />
+            ))}
           </Radio.RadioGroup>
           <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
         </FormControl>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR simplifies the styling and semantics of the radio buttons used to select the current color theme of the form. 
