### PR TITLE
fix(form-v2): refactor to avoid repopulating design store when cache is invalidated

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -21,7 +21,7 @@ import {
 } from '@chakra-ui/react'
 import { cloneDeep, get, isEmpty } from 'lodash'
 
-import { FormColorTheme, FormLogoState } from '~shared/types'
+import { FormColorTheme, FormLogoState, FormStartPage } from '~shared/types'
 
 import { useToast } from '~hooks/useToast'
 import { uploadLogo } from '~services/FileHandlerService'
@@ -31,6 +31,7 @@ import Radio from '~components/Radio'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
+import { useEnv } from '~features/env/queries'
 import { getTitleBg } from '~features/public-form/components/FormStartPage/useFormHeader'
 
 import {
@@ -38,8 +39,11 @@ import {
   customLogoMetaSelector,
   DesignState,
   FormStartPageInput,
+  resetDesignStoreSelector,
+  setCustomLogoMetaSelector,
   setStartPageDataSelector,
   setStateSelector,
+  startPageDataSelector,
   stateSelector,
   useDesignStore,
 } from '../../useDesignStore'
@@ -53,12 +57,10 @@ import {
 } from '../EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput'
 
 type DesignDrawerProps = {
-  startPageData: FormStartPageInput
+  startPage: FormStartPage
 }
 
-export const DesignDrawer = ({
-  startPageData,
-}: DesignDrawerProps): JSX.Element | null => {
+export const DesignInput = (): JSX.Element | null => {
   const toast = useToast({ status: 'danger' })
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
@@ -66,18 +68,24 @@ export const DesignDrawer = ({
   const { startPageMutation } = useMutateFormPage()
   const { handleClose } = useCreatePageSidebar()
 
-  const { designState, setDesignState, customLogoMeta, setStartPageData } =
-    useDesignStore(
-      useCallback(
-        (state) => ({
-          designState: stateSelector(state),
-          setDesignState: setStateSelector(state),
-          customLogoMeta: customLogoMetaSelector(state),
-          setStartPageData: setStartPageDataSelector(state),
-        }),
-        [],
-      ),
-    )
+  const {
+    designState,
+    setDesignState,
+    startPageData,
+    customLogoMeta,
+    setStartPageData,
+  } = useDesignStore(
+    useCallback(
+      (state) => ({
+        designState: stateSelector(state),
+        setDesignState: setStateSelector(state),
+        startPageData: startPageDataSelector(state),
+        customLogoMeta: customLogoMetaSelector(state),
+        setStartPageData: setStartPageDataSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const setToEditingHeader = useCallback(
     () => setDesignState(DesignState.EditingHeader),
@@ -111,7 +119,7 @@ export const DesignDrawer = ({
   )
 
   useDebounce(() => setStartPageData(clonedWatchedInputs), 300, [
-    clonedWatchedInputs,
+    Object.values(clonedWatchedInputs),
   ])
 
   // Focus on paragraph field if state is editing instructions
@@ -184,6 +192,203 @@ export const DesignDrawer = ({
   if (!startPageData) return null
 
   return (
+    <DrawerContentContainer>
+      <FormControl
+        isReadOnly={startPageMutation.isLoading}
+        isInvalid={!isEmpty(errors.attachment)}
+        onFocus={setToEditingHeader}
+      >
+        <FormLabel>Logo</FormLabel>
+        <Radio.RadioGroup
+          defaultValue={startPageData.logo.state}
+          isDisabled={startPageMutation.isLoading}
+        >
+          <Radio value={FormLogoState.Default} {...register('logo.state')}>
+            Default
+          </Radio>
+          <Radio value={FormLogoState.None} {...register('logo.state')}>
+            None
+          </Radio>
+          <Radio value={FormLogoState.Custom} {...register('logo.state')}>
+            Upload custom logo (jpg, png, or gif)
+          </Radio>
+        </Radio.RadioGroup>
+        <Box ml="45px" mt="0.5rem">
+          <Box hidden={startPageData.logo.state !== FormLogoState.Custom}>
+            <Controller
+              name="attachment"
+              control={control}
+              rules={{
+                validate: (val) => {
+                  if (startPageData.logo.state !== FormLogoState.Custom)
+                    return true
+                  if (val?.file && val.srcUrl) return true
+                  return 'Please upload a logo'
+                },
+              }}
+              render={({ field: { onChange, ...rest } }) => (
+                <UploadImageInput
+                  {...rest}
+                  onChange={(event) => {
+                    clearErrors('attachment')
+                    onChange(event)
+                  }}
+                  onError={(message) => setError('attachment', { message })}
+                />
+              )}
+            />
+            <FormErrorMessage>
+              {get(errors, 'attachment.message')}
+            </FormErrorMessage>
+          </Box>
+        </Box>
+      </FormControl>
+
+      <FormControl
+        isReadOnly={startPageMutation.isLoading}
+        isInvalid={!isEmpty(errors.colorTheme)}
+        onFocus={setToEditingHeader}
+      >
+        <FormLabel>Theme colour</FormLabel>
+        <Radio.RadioGroup
+          defaultValue={startPageData.colorTheme}
+          isDisabled={startPageMutation.isLoading}
+        >
+          <Stack spacing="0" direction="row" display="inline">
+            {Object.values(FormColorTheme).map((color, idx) => (
+              <Radio
+                key={idx}
+                display="inline"
+                width="1rem"
+                value={color}
+                {...register('colorTheme')}
+                // CSS for inverted radio button
+                // TODO: anti-aliasing at interface of border and ::before?
+                border="2px solid"
+                borderRadius="50%"
+                borderColor="white"
+                background={getTitleBg(color)}
+                _checked={{ borderColor: getTitleBg(color) }}
+                _before={{
+                  content: '""',
+                  display: 'inline-block',
+                  width: '20px',
+                  height: '20px',
+                  border: '2px solid',
+                  borderColor: 'white',
+                  borderRadius: '50%',
+                }}
+              />
+            ))}
+          </Stack>
+        </Radio.RadioGroup>
+        <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
+      </FormControl>
+
+      <FormControl
+        isReadOnly={startPageMutation.isLoading}
+        isInvalid={!!errors.estTimeTaken}
+        onFocus={setToEditingHeader}
+      >
+        <FormLabel>Time taken to complete form (minutes)</FormLabel>
+        <Controller
+          name="estTimeTaken"
+          control={control}
+          rules={{
+            required: 'This field is required', //TODO: why is this field required? Seems a bit strange esp if we don't provide an initial value?
+            min: { value: 1, message: 'Cannot be less than 1' },
+            max: { value: 1000, message: 'Cannot be more than 1000' },
+          }}
+          render={({ field: { onChange, ...rest } }) => (
+            <NumberInput
+              flex={1}
+              inputMode="numeric"
+              showSteppers={false}
+              onChange={validateNumberInput(onChange)}
+              {...rest}
+            />
+          )}
+        />
+        <FormErrorMessage>{errors.estTimeTaken?.message}</FormErrorMessage>
+      </FormControl>
+
+      <FormControl
+        isReadOnly={startPageMutation.isLoading}
+        isInvalid={!!errors.paragraph}
+      >
+        <FormLabel>Instructions for your form</FormLabel>
+        <Textarea
+          onFocus={setToEditingInstructions}
+          {...register('paragraph')}
+        />
+        <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>
+      </FormControl>
+
+      <FormFieldDrawerActions
+        isLoading={startPageMutation.isLoading}
+        handleClick={handleClick}
+        handleCancel={handleClose}
+        buttonText="Save design"
+      />
+    </DrawerContentContainer>
+  )
+}
+
+export const DesignDrawer = ({
+  startPage,
+}: DesignDrawerProps): JSX.Element | null => {
+  const { data: { logoBucketUrl } = {} } = useEnv()
+
+  const {
+    startPageData,
+    setStartPageData,
+    setCustomLogoMeta,
+    resetDesignStore,
+  } = useDesignStore(
+    useCallback(
+      (state) => ({
+        startPageData: startPageDataSelector(state),
+        setStartPageData: setStartPageDataSelector(state),
+        setCustomLogoMeta: setCustomLogoMetaSelector(state),
+        resetDesignStore: resetDesignStoreSelector(state),
+      }),
+      [],
+    ),
+  )
+
+  // Load existing start page and custom logo into drawer state
+  useEffect(() => {
+    setStartPageData({
+      ...startPage,
+      estTimeTaken: startPage.estTimeTaken || '',
+      attachment:
+        startPage.logo.state !== FormLogoState.Custom
+          ? {}
+          : {
+              file: Object.defineProperty(
+                new File([''], startPage.logo.fileName, {
+                  type: 'image/jpeg',
+                }),
+                'size',
+                { value: startPage.logo.fileSizeInBytes },
+              ),
+              srcUrl: `${logoBucketUrl}/${startPage.logo.fileId}`,
+            },
+    })
+    if (startPage.logo.state === FormLogoState.Custom)
+      setCustomLogoMeta(startPage.logo)
+    return resetDesignStore
+  }, [
+    startPage,
+    logoBucketUrl,
+    resetDesignStore,
+    setCustomLogoMeta,
+    setStartPageData,
+  ])
+
+  if (!startPageData) return null
+
+  return (
     <Tabs pos="relative" h="100%" display="flex" flexDir="column">
       <Box pt="1rem" px="1.5rem" bg="white">
         <Flex justify="space-between">
@@ -194,146 +399,7 @@ export const DesignDrawer = ({
         </Flex>
         <Divider w="auto" mx="-1.5rem" />
       </Box>
-
-      <DrawerContentContainer>
-        <FormControl
-          isReadOnly={startPageMutation.isLoading}
-          isInvalid={!isEmpty(errors.attachment)}
-          onFocus={setToEditingHeader}
-        >
-          <FormLabel>Logo</FormLabel>
-          <Radio.RadioGroup
-            value={startPageData.logo.state}
-            isDisabled={startPageMutation.isLoading}
-          >
-            <Radio value={FormLogoState.Default} {...register('logo.state')}>
-              Default
-            </Radio>
-            <Radio value={FormLogoState.None} {...register('logo.state')}>
-              None
-            </Radio>
-            <Radio value={FormLogoState.Custom} {...register('logo.state')}>
-              Upload custom logo (jpg, png, or gif)
-            </Radio>
-          </Radio.RadioGroup>
-          <Box ml="45px" mt="0.5rem">
-            <Box hidden={startPageData.logo.state !== FormLogoState.Custom}>
-              <Controller
-                name="attachment"
-                control={control}
-                rules={{
-                  validate: (val) => {
-                    if (startPageData.logo.state !== FormLogoState.Custom)
-                      return true
-                    if (val?.file && val.srcUrl) return true
-                    return 'Please upload a logo'
-                  },
-                }}
-                render={({ field: { onChange, ...rest } }) => (
-                  <UploadImageInput
-                    {...rest}
-                    onChange={(event) => {
-                      clearErrors('attachment')
-                      onChange(event)
-                    }}
-                    onError={(message) => setError('attachment', { message })}
-                  />
-                )}
-              />
-              <FormErrorMessage>
-                {get(errors, 'attachment.message')}
-              </FormErrorMessage>
-            </Box>
-          </Box>
-        </FormControl>
-
-        <FormControl
-          isReadOnly={startPageMutation.isLoading}
-          isInvalid={!isEmpty(errors.colorTheme)}
-          onFocus={setToEditingHeader}
-        >
-          <FormLabel>Theme colour</FormLabel>
-          <Radio.RadioGroup
-            value={startPageData.colorTheme}
-            isDisabled={startPageMutation.isLoading}
-          >
-            <Stack spacing="0" direction="row" display="inline">
-              {Object.values(FormColorTheme).map((color, idx) => (
-                <Radio
-                  key={idx}
-                  display="inline"
-                  width="1rem"
-                  value={color}
-                  {...register('colorTheme')}
-                  // CSS for inverted radio button
-                  // TODO: anti-aliasing at interface of border and ::before?
-                  border="2px solid"
-                  borderRadius="50%"
-                  borderColor="white"
-                  background={getTitleBg(color)}
-                  _checked={{ borderColor: getTitleBg(color) }}
-                  _before={{
-                    content: '""',
-                    display: 'inline-block',
-                    width: '20px',
-                    height: '20px',
-                    border: '2px solid',
-                    borderColor: 'white',
-                    borderRadius: '50%',
-                  }}
-                />
-              ))}
-            </Stack>
-          </Radio.RadioGroup>
-          <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
-        </FormControl>
-
-        <FormControl
-          isReadOnly={startPageMutation.isLoading}
-          isInvalid={!!errors.estTimeTaken}
-          onFocus={setToEditingHeader}
-        >
-          <FormLabel>Time taken to complete form (minutes)</FormLabel>
-          <Controller
-            name="estTimeTaken"
-            control={control}
-            rules={{
-              required: 'This field is required', //TODO: why is this field required? Seems a bit strange esp if we don't provide an initial value?
-              min: { value: 1, message: 'Cannot be less than 1' },
-              max: { value: 1000, message: 'Cannot be more than 1000' },
-            }}
-            render={({ field: { onChange, ...rest } }) => (
-              <NumberInput
-                flex={1}
-                inputMode="numeric"
-                showSteppers={false}
-                onChange={validateNumberInput(onChange)}
-                {...rest}
-              />
-            )}
-          />
-          <FormErrorMessage>{errors.estTimeTaken?.message}</FormErrorMessage>
-        </FormControl>
-
-        <FormControl
-          isReadOnly={startPageMutation.isLoading}
-          isInvalid={!!errors.paragraph}
-        >
-          <FormLabel>Instructions for your form</FormLabel>
-          <Textarea
-            onFocus={setToEditingInstructions}
-            {...register('paragraph')}
-          />
-          <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>
-        </FormControl>
-
-        <FormFieldDrawerActions
-          isLoading={startPageMutation.isLoading}
-          handleClick={handleClick}
-          handleCancel={handleClose}
-          buttonText="Save design"
-        />
-      </DrawerContentContainer>
+      <DesignInput />
     </Tabs>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -134,12 +134,14 @@ export const DesignInput = (): JSX.Element | null => {
 
   const handleUploadLogo = useCallback(
     (attachment: UploadedImage): Promise<CustomLogoMeta> | CustomLogoMeta => {
-      if (!attachment.file || !attachment.srcUrl)
+      if (!attachment.file || !attachment.srcUrl) {
         throw new Error('Design pre-submit validation failed')
+      }
       if (!attachment.srcUrl.startsWith('blob:')) {
         // Logo was not changed
-        if (!customLogoMeta)
+        if (!customLogoMeta) {
           throw new Error('Design: customLogoMeta is undefined')
+        }
         return customLogoMeta
       }
       return uploadLogoMutation
@@ -160,7 +162,7 @@ export const DesignInput = (): JSX.Element | null => {
       const { logo, attachment, estTimeTaken, ...rest } = startPageData
       const estTimeTakenTransformed =
         estTimeTaken === '' ? undefined : estTimeTaken
-      if (logo.state !== FormLogoState.Custom)
+      if (logo.state !== FormLogoState.Custom) {
         startPageMutation.mutate(
           {
             logo: { state: logo.state },
@@ -169,7 +171,7 @@ export const DesignInput = (): JSX.Element | null => {
           },
           { onSuccess: handleClose },
         )
-      else {
+      } else {
         const customLogoMeta = await handleUploadLogo(attachment)
         startPageMutation.mutate(
           {
@@ -375,8 +377,9 @@ export const DesignDrawer = ({
               srcUrl: `${logoBucketUrl}/${startPage.logo.fileId}`,
             },
     })
-    if (startPage.logo.state === FormLogoState.Custom)
+    if (startPage.logo.state === FormLogoState.Custom) {
       setCustomLogoMeta(startPage.logo)
+    }
     return resetDesignStore
   }, [
     startPage,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
@@ -1,73 +1,9 @@
-import { useCallback, useEffect } from 'react'
-
-import { FormLogoState } from '~shared/types'
-
 import { useAdminForm } from '~features/admin-form/common/queries'
-import { useEnv } from '~features/env/queries'
-
-import {
-  resetDesignStoreSelector,
-  setCustomLogoMetaSelector,
-  setStartPageDataSelector,
-  startPageDataSelector,
-  useDesignStore,
-} from '../../useDesignStore'
 
 import { DesignDrawer } from './DesignDrawer'
 
 export const DesignDrawerContainer = (): JSX.Element | null => {
-  const { data: { logoBucketUrl } = {} } = useEnv()
   const { data: form } = useAdminForm()
 
-  const {
-    startPageData,
-    setStartPageData,
-    setCustomLogoMeta,
-    resetDesignStore,
-  } = useDesignStore(
-    useCallback(
-      (state) => ({
-        startPageData: startPageDataSelector(state),
-        setStartPageData: setStartPageDataSelector(state),
-        setCustomLogoMeta: setCustomLogoMetaSelector(state),
-        resetDesignStore: resetDesignStoreSelector(state),
-      }),
-      [],
-    ),
-  )
-
-  // Load existing start page and custom logo into drawer form
-  useEffect(() => {
-    if (!form) return
-    setStartPageData({
-      ...form.startPage,
-      estTimeTaken: form.startPage.estTimeTaken || '',
-      attachment:
-        form.startPage.logo.state !== FormLogoState.Custom
-          ? {}
-          : {
-              file: Object.defineProperty(
-                new File([''], form.startPage.logo.fileName, {
-                  type: 'image/jpeg',
-                }),
-                'size',
-                { value: form.startPage.logo.fileSizeInBytes },
-              ),
-              srcUrl: `${logoBucketUrl}/${form.startPage.logo.fileId}`,
-            },
-    })
-    if (form.startPage.logo.state === FormLogoState.Custom)
-      setCustomLogoMeta(form.startPage.logo)
-    return resetDesignStore
-  }, [
-    form,
-    logoBucketUrl,
-    resetDesignStore,
-    setCustomLogoMeta,
-    setStartPageData,
-  ])
-
-  if (!startPageData) return null
-
-  return <DesignDrawer startPageData={startPageData} />
+  return form ? <DesignDrawer startPage={form.startPage} /> : null
 }


### PR DESCRIPTION
## Problem
In the current implementation, design store contents is reset to the original server state upon cache invalidation. Rather, we should retain the existing design store contents. 

The reason why this occurs in the current implementation is that the effect in `DesignDrawerContainer` is run once upon invalidation (with an empty form), and then once again once the form is refetched (thus repopulating the design store with the server data).

Closes [#4547 ]

## Solution
Move the population of design store with server state data from `DesignDrawerContainer` into `DesignDrawer`, which now wraps `DesignInput`. Thus, when the cache is invalidated and the form is refetching, we don't even render the design drawer, which means we also don't re-run the effect to repopulate the store.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/184094680-80bad1ce-aa6f-49f5-9099-7c7dab58a834.mov

