### PR TITLE
feat(v2): clear user query cache on logout, disable query retries on 4xx errors

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -84,7 +84,7 @@ export interface AdminNavBarProps {
 }
 
 export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
-  const { user } = useUser()
+  const { user, removeQuery } = useUser()
 
   const ROLLOUT_ANNOUNCEMENT_KEY = useMemo(
     () => ROLLOUT_ANNOUNCEMENT_KEY_PREFIX + user?._id,
@@ -125,6 +125,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
 
   const handleLogout = () => {
     logout()
+    removeQuery()
     if (emergencyContactKey) {
       localStorage.removeItem(emergencyContactKey)
     }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -17,11 +17,8 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 60 * 1000, // 60 seconds,
       retry: (failureCount, error) => {
-        // Do not retry if 404 or 410.
-        if (
-          error instanceof HttpError &&
-          [404, 403, 410].includes(error.code)
-        ) {
+        // Do not retry on 4xx error codes.
+        if (error instanceof HttpError && String(error.code).startsWith('4')) {
           return false
         }
         return failureCount !== 3

--- a/frontend/src/features/user/queries.ts
+++ b/frontend/src/features/user/queries.ts
@@ -12,12 +12,17 @@ export const userKeys = {
 type UseUserReturn = {
   user: UserDto | undefined
   isLoading: boolean
+  removeQuery: () => void
 }
 
 export const useUser = (): UseUserReturn => {
   const { isAuthenticated } = useAuth()
 
-  const { data: user, isLoading } = useQuery<UserDto>(
+  const {
+    data: user,
+    isLoading,
+    remove,
+  } = useQuery<UserDto>(
     userKeys.base,
     () => fetchUser(),
     // 10 minutes staletime, do not need to retrieve so often.
@@ -27,5 +32,6 @@ export const useUser = (): UseUserReturn => {
   return {
     user: isAuthenticated ? user : undefined,
     isLoading,
+    removeQuery: remove,
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR correctly clears user cache on logout, triggering a reload to /login page. Also disables query retries on 4xx errors.

Closes #4536
