### PR TITLE
fix(form-v2): disable some MyInfo fields in builder and preview

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -120,6 +120,7 @@ export const FieldRowContainer = ({
     const augmentedField = augmentWithMyInfoDisplayValue(field)
 
     if (hasExistingFieldValue(augmentedField)) {
+      field.disabled = augmentedField.disabled
       return {
         [field._id]: extractPreviewValue(augmentedField),
       }

--- a/frontend/src/features/myinfo/utils/augmentWithMyInfoDisplayValue.ts
+++ b/frontend/src/features/myinfo/utils/augmentWithMyInfoDisplayValue.ts
@@ -13,5 +13,10 @@ export const augmentWithMyInfoDisplayValue = (
   if (!isMyInfo(field)) return field
 
   const myInfoBlock = MAP_ATTR_TO_NAME[field.myInfo.attr]
-  return { ...field, fieldValue: myInfoBlock.previewValue }
+  return {
+    ...field,
+    fieldValue: myInfoBlock.previewValue,
+    // Leave default as false, same as in MyInfoData class
+    disabled: myInfoBlock.previewIsDisabled ?? false,
+  }
 }

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -67,6 +67,7 @@ export const DateField = ({
             colorScheme={`theme-${colorTheme}`}
             {...field}
             isDateUnavailable={isDateUnavailable}
+            isDisabled={schema.disabled}
           />
         )}
       />

--- a/frontend/src/templates/Field/Dropdown/DropdownField.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.tsx
@@ -39,6 +39,7 @@ export const DropdownField = ({
           <SingleSelect
             colorScheme={`theme-${colorTheme}`}
             items={schema.fieldOptions}
+            isDisabled={schema.disabled}
             {...field}
           />
         )}

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -59,7 +59,6 @@ export const FieldContainer = ({
   return (
     <FormControl
       isRequired={schema.required}
-      isDisabled={schema.disabled}
       isReadOnly={isValid && isSubmitting}
       isInvalid={!!error}
       id={schema._id}

--- a/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
@@ -46,6 +46,7 @@ export const MobileFieldInput = ({
           autoComplete="tel"
           allowInternational={schema.allowIntlNumbers}
           value={value?.value}
+          isDisabled={schema.disabled}
           onChange={
             handleInputChange
               ? handleInputChange(onChange)

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -32,6 +32,7 @@ export const ShortTextField = ({
         isPrefilled={isPrefilled}
         aria-label={schema.title}
         {...register(schema._id, validationRules)}
+        isDisabled={schema.disabled}
       />
     </FieldContainer>
   )

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -21,6 +21,9 @@ export type MyInfoFieldBlock = {
   // for MyInfo forms. The running joke is that this is the personal
   // details of Phua Chu Kang, a famous singaporean sitcom.
   previewValue: string
+  // Refers to whether the field should be editable. The mapping is derived
+  // from MyInfoData class
+  previewIsDisabled?: boolean
 }
 
 export const types: MyInfoFieldBlock[] = [
@@ -34,6 +37,7 @@ export const types: MyInfoFieldBlock[] = [
       'The registered name of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.ShortText,
     previewValue: 'PHUA CHU KANG',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Sex,
@@ -46,6 +50,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: ['FEMALE', 'MALE', 'UNKNOWN'],
     previewValue: 'MALE',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.DateOfBirth,
@@ -57,6 +62,7 @@ export const types: MyInfoFieldBlock[] = [
       'The registered date of birth of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Date,
     previewValue: '1965-02-23',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Race,
@@ -69,6 +75,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: RACES,
     previewValue: 'CHINESE',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Nationality,
@@ -81,6 +88,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: NATIONALITIES,
     previewValue: 'SINGAPORE CITIZEN',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.BirthCountry,
@@ -93,6 +101,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: COUNTRIES,
     previewValue: 'SINGAPORE',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.ResidentialStatus,
@@ -104,6 +113,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: ['ALIEN', 'CITIZEN', 'NOT APPLICABLE', 'PR', 'UNKNOWN'],
     previewValue: 'CITIZEN',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Dialect,
@@ -115,6 +125,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: DIALECTS,
     previewValue: 'HOKKIEN',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.HousingType,
@@ -134,6 +145,7 @@ export const types: MyInfoFieldBlock[] = [
       'TERRACE HOUSE',
     ],
     previewValue: 'DETACHED HOUSE',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.HdbType,
@@ -153,6 +165,7 @@ export const types: MyInfoFieldBlock[] = [
       'STUDIO APARTMENT (HDB)',
     ],
     previewValue: 'EXECUTIVE FLAT (HDB)',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.PassportNumber,
@@ -163,6 +176,7 @@ export const types: MyInfoFieldBlock[] = [
     description: 'The passport number of the form-filler.',
     fieldType: BasicField.ShortText,
     previewValue: 'E1234567X',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.PassportExpiryDate,
@@ -173,6 +187,7 @@ export const types: MyInfoFieldBlock[] = [
     description: 'The passport expiry date of the form-filler.',
     fieldType: BasicField.Date,
     previewValue: '2022-02-23',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Marital,
@@ -185,6 +200,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: ['SINGLE', 'MARRIED', 'WIDOWED', 'DIVORCED'],
     previewValue: 'MARRIED',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.CountryOfMarriage,
@@ -197,6 +213,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: COUNTRIES,
     previewValue: 'SINGAPORE',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.RegisteredAddress,
@@ -207,6 +224,7 @@ export const types: MyInfoFieldBlock[] = [
     description: 'The registered address of the form-filler.',
     fieldType: BasicField.ShortText,
     previewValue: '411 CHUA CHU KANG AVE 3, #12-3, SINGAPORE 238823',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Occupation,
@@ -219,6 +237,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: OCCUPATIONS,
     previewValue: 'MANAGING DIRECTOR/CHIEF EXECUTIVE OFFICER',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.Employment,
@@ -230,6 +249,7 @@ export const types: MyInfoFieldBlock[] = [
       "The name of the form-filler's employer. Verified for foreigners with SingPass only.",
     fieldType: BasicField.ShortText,
     previewValue: 'PCK PTE LTD',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.VehicleNo,
@@ -240,6 +260,7 @@ export const types: MyInfoFieldBlock[] = [
     description: 'Vehicle plate number of the form-filler.',
     fieldType: BasicField.ShortText,
     previewValue: 'SHA1234X',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.MarriageCertNo,
@@ -251,6 +272,7 @@ export const types: MyInfoFieldBlock[] = [
       'Marriage Certificate Number of form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.ShortText,
     previewValue: '123456789012345',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.MarriageDate,
@@ -262,6 +284,7 @@ export const types: MyInfoFieldBlock[] = [
       'The date of marriage of the form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.Date,
     previewValue: '1999-02-02',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.DivorceDate,
@@ -273,6 +296,7 @@ export const types: MyInfoFieldBlock[] = [
       'The date of divorce of the form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.Date,
     previewValue: '2007-01-10',
+    previewIsDisabled: false,
   },
   {
     name: MyInfoAttribute.WorkpassStatus,
@@ -284,6 +308,7 @@ export const types: MyInfoFieldBlock[] = [
     fieldType: BasicField.Dropdown,
     fieldOptions: ['Live', 'Approved'],
     previewValue: 'Live',
+    previewIsDisabled: true,
   },
   {
     name: MyInfoAttribute.WorkpassExpiryDate,
@@ -304,5 +329,6 @@ export const types: MyInfoFieldBlock[] = [
     description: 'Mobile telephone number of form-filler.',
     fieldType: BasicField.Mobile,
     previewValue: '98765432',
+    previewIsDisabled: true,
   },
 ]

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -293,7 +293,7 @@ export class MyInfoServiceClass {
 
   /**
    * Prefill given current form fields with given MyInfo data.
-   * Saves the has of the prefilled fields as well because the two operations are atomic and should not be separated
+   * Saves the hash of the prefilled fields as well because the two operations are atomic and should not be separated
    * @param myInfoData
    * @param currFormFields
    * @returns currFormFields with the MyInfo fields prefilled with data from myInfoData


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
MyInfo fields appear editable in the form builder and preview. Some fields (e.g. name, DOB) should not appear editable to be consistent with public forms

Closes #4362

## Solution
<!-- How did you solve the problem? -->
Add `previewIsDisabled` prop to `MyInfoBlock`, which contains the values that are injected into the form builder's and preview's MyInfo fields. `previewIsDisabled` is determined using the mapping from `MyInfoData` class.

**Improvements**:
- Move `isDisabled` from `FieldContainer` to form components used by MyInfo. This is because `isDisabled` in `FieldContainer` is set in `FormControl`, which [disables both the form label and the form element](https://chakra-ui.com/docs/components/form-control/props). As per the [design system](https://www.figma.com/file/u00dlQLsaQfvqv6ot5ZrJZ/Form-Design-System?node-id=2153%3A4682), only the form element itself should be disabled.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<details>

![screencapture-localhost-3000-admin-form-62f366fe51036800a31c65ac-2022-08-12-10_25_58](https://user-images.githubusercontent.com/56983748/184274770-1988f6d0-0194-477c-b480-d23950ecb185.png)
</details>

**AFTER**:
<details>

![screencapture-localhost-3000-admin-form-62f366fe51036800a31c65ac-2022-08-12-10_36_10](https://user-images.githubusercontent.com/56983748/184274755-a2941e8e-81df-4c05-8f23-736b298a40cc.png)
</details>

