### PR TITLE
refactor(v2): reuse public end page component in builder

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { Flex } from '@chakra-ui/react'
 
-import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
-
 import { DndPlaceholderProps } from '../types'
 import {
   BuildFieldState,
@@ -10,7 +8,6 @@ import {
   stateDataSelector,
   useBuilderAndDesignStore,
 } from '../useBuilderAndDesignStore'
-import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import { EndPageView } from './EndPageView'
 import { FormBuilder } from './FormBuilder'
@@ -35,10 +32,8 @@ export const BuilderAndDesignContent = ({
 
   useEffect(() => setFieldsToInactive, [setFieldsToInactive])
 
-  const bg = useBgColor({ colorTheme: useDesignColorTheme() })
-
   return (
-    <Flex flex={1} bg={bg} overflow="auto">
+    <Flex flex={1} overflow="auto">
       <EndPageView
         display={
           // Don't conditionally render EndPageView and FormBuilder because it

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from 'react'
-import { Box, Flex, FlexProps, Stack, Text } from '@chakra-ui/react'
-import { format } from 'date-fns'
+import { Box, Flex, FlexProps, Stack } from '@chakra-ui/react'
 
 import { FormColorTheme, FormLogoState } from '~shared/types'
 
-import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
-import Button from '~components/Button'
-
 import { useAdminForm } from '~features/admin-form/common/queries'
 import { useEnv } from '~features/env/queries'
+import { EndPageBlock } from '~features/public-form/components/FormEndPage/components/EndPageBlock'
 import { ThankYouSvgr } from '~features/public-form/components/FormEndPage/components/ThankYouSvgr'
 import { FormBannerLogo } from '~features/public-form/components/FormStartPage/FormBannerLogo'
 import { useFormBannerLogo } from '~features/public-form/components/FormStartPage/useFormBannerLogo'
@@ -45,58 +42,35 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
 
   return (
     <Flex
-      m={{ base: 0, md: '2rem' }}
       mb={0}
       flex={1}
-      bg="white"
-      p={{ base: '1.5rem', md: 0 }}
+      bg="neutral.200"
+      p={{ base: 0, md: '2rem' }}
       justify="center"
       overflow="auto"
-      height="100%"
       {...props}
     >
-      <Stack w="100%">
+      <Stack w="100%" bg="white">
         <FormBannerLogo {...formBannerLogoProps} />
         <Flex backgroundColor={backgroundColor} justifyContent="center">
           <ThankYouSvgr h="100%" pt="2.5rem" />
         </Flex>
 
-        <Box px="4rem" pt="3rem">
-          <Flex justifyContent="space-between" alignItems="center">
-            <Text textStyle="h2" color="secondary.500">
-              {endPage?.title}
-            </Text>
-            <BxsChevronUp color="secondary.500" />
-          </Flex>
-
-          <Text
-            textStyle="subhead-1"
-            color="secondary.500"
-            mt="1rem"
-            whiteSpace="pre-line"
-          >
-            {endPage?.paragraph}
-          </Text>
-
-          <Text textStyle="subhead-1" color="secondary.500" mt="2.25rem">
-            {form?.title ?? 'Form Title'}
-          </Text>
-          <Text textStyle="body-1" color="neutral.500">
-            {form?._id ?? 'Form Identification Number'}
-            <br />
-            {format(new Date(), 'dd MMM yyyy, h:m aa')}
-          </Text>
-
-          <Box mt="2.25rem">
-            <Button
-              variant="solid"
-              colorScheme={`theme-${
-                colorTheme ? colorTheme : FormColorTheme.Blue
-              }`}
-            >
-              {endPage?.buttonText}
-            </Button>
-          </Box>
+        <Box
+          py={{ base: '1.5rem', md: '3rem' }}
+          px={{ base: '1.5rem', md: '4rem' }}
+          w="100%"
+        >
+          <EndPageBlock
+            formTitle={form?.title ?? 'Form Title'}
+            endPage={endPage ?? { title: '', buttonText: '' }}
+            submissionData={{
+              id: form?._id ?? 'Submission ID',
+              timeInEpochMs: Date.now(),
+            }}
+            colorTheme={colorTheme ?? FormColorTheme.Blue}
+            isExpandable={false}
+          />
         </Box>
       </Stack>
     </Flex>

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -24,6 +24,7 @@ export interface EndPageBlockProps {
   endPage: FormDto['endPage']
   submissionData: SubmissionData
   colorTheme?: FormColorTheme
+  isExpandable?: boolean
 }
 
 export const EndPageBlock = ({
@@ -31,6 +32,7 @@ export const EndPageBlock = ({
   endPage,
   submissionData,
   colorTheme = FormColorTheme.Blue,
+  isExpandable = true,
 }: EndPageBlockProps): JSX.Element => {
   const prettifiedDateString = useMemo(() => {
     return format(new Date(submissionData.timeInEpochMs), 'dd MMM yyyy, h:mm a')
@@ -38,7 +40,12 @@ export const EndPageBlock = ({
 
   return (
     <Flex flexDir="column">
-      <Accordion allowToggle m="-1rem" flex={1} variant="medium">
+      <Accordion
+        {...(isExpandable ? { allowToggle: true } : { defaultIndex: [0] })}
+        m="-1rem"
+        flex={1}
+        variant="medium"
+      >
         <AccordionItem color="secondary.500" border="none">
           <AccordionButton>
             <Stack


### PR DESCRIPTION
## Problem
End page view recreates the public form end page from scratch. This PR refactors it to make use of the public end page component for better modularity.

## Solution
To account for the accordion being expanded, add an optional `isExpandable` to `EndPageBlock` which defaults to `true`. Other than that, some layout simplifications to improve readability while retaining the existing design.

**Breaking Changes** 
- No - this PR is backwards compatible  