### PR TITLE
refactor(v2): rename `BuilderAndDesignStore` to `FieldBuilderStore`

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -5,11 +5,11 @@ import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
 
 import { DndPlaceholderProps } from '../types'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   setToInactiveSelector,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import { EndPageView } from './EndPageView'
@@ -23,7 +23,7 @@ export const BuilderAndDesignContent = ({
   placeholderProps,
 }: BuilderAndDesignContentProps): JSX.Element => {
   const { stateData, setToInactive: setFieldsToInactive } =
-    useBuilderAndDesignStore(
+    useFieldBuilderStore(
       useCallback(
         (state) => ({
           stateData: stateDataSelector(state),
@@ -43,13 +43,13 @@ export const BuilderAndDesignContent = ({
         display={
           // Don't conditionally render EndPageView and FormBuilder because it
           // is expensive and takes time.
-          stateData.state === BuildFieldState.EditingEndPage ? 'flex' : 'none'
+          stateData.state === FieldBuilderState.EditingEndPage ? 'flex' : 'none'
         }
       />
       <FormBuilder
         placeholderProps={placeholderProps}
         display={
-          stateData.state === BuildFieldState.EditingEndPage ? 'none' : 'flex'
+          stateData.state === FieldBuilderState.EditingEndPage ? 'none' : 'flex'
         }
       />
     </Flex>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -57,17 +57,17 @@ import { PENDING_CREATE_FIELD_ID } from '../../constants'
 import { useDeleteFormField } from '../../mutations/useDeleteFormField'
 import { useDuplicateFormField } from '../../mutations/useDuplicateFormField'
 import {
-  BuildFieldState,
-  setToInactiveSelector,
-  stateDataSelector,
-  updateEditStateSelector,
-  useBuilderAndDesignStore,
-} from '../../useBuilderAndDesignStore'
-import {
   DesignState,
   setStateSelector,
   useDesignStore,
 } from '../../useDesignStore'
+import {
+  FieldBuilderState,
+  setToInactiveSelector,
+  stateDataSelector,
+  updateEditStateSelector,
+  useFieldBuilderStore,
+} from '../../useFieldBuilderStore'
 import { useDesignColorTheme } from '../../utils/useDesignColorTheme'
 
 import { SectionFieldRow } from './SectionFieldRow'
@@ -87,17 +87,16 @@ export const FieldRowContainer = ({
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
-  const { stateData, setToInactive, updateEditState } =
-    useBuilderAndDesignStore(
-      useCallback(
-        (state) => ({
-          stateData: stateDataSelector(state),
-          setToInactive: setToInactiveSelector(state),
-          updateEditState: updateEditStateSelector(state),
-        }),
-        [],
-      ),
-    )
+  const { stateData, setToInactive, updateEditState } = useFieldBuilderStore(
+    useCallback(
+      (state) => ({
+        stateData: stateDataSelector(state),
+        setToInactive: setToInactiveSelector(state),
+        updateEditState: updateEditStateSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const setDesignState = useDesignStore(setStateSelector)
 
@@ -132,9 +131,9 @@ export const FieldRowContainer = ({
   })
 
   const isActive = useMemo(() => {
-    if (stateData.state === BuildFieldState.EditingField) {
+    if (stateData.state === FieldBuilderState.EditingField) {
       return field._id === stateData.field._id
-    } else if (stateData.state === BuildFieldState.CreatingField) {
+    } else if (stateData.state === FieldBuilderState.CreatingField) {
       return field._id === PENDING_CREATE_FIELD_ID
     }
     return false
@@ -194,15 +193,15 @@ export const FieldRowContainer = ({
   const handleDuplicateClick = useCallback(() => {
     // Duplicate button should be hidden if field
     // is not yet created, but guard here just in case
-    if (stateData.state !== BuildFieldState.CreatingField) {
+    if (stateData.state !== FieldBuilderState.CreatingField) {
       duplicateFieldMutation.mutate(field._id)
     }
   }, [stateData.state, duplicateFieldMutation, field._id])
 
   const handleDeleteClick = useCallback(() => {
-    if (stateData.state === BuildFieldState.CreatingField) {
+    if (stateData.state === FieldBuilderState.CreatingField) {
       setToInactive()
-    } else if (stateData.state === BuildFieldState.EditingField) {
+    } else if (stateData.state === FieldBuilderState.EditingField) {
       onDeleteModalOpen()
     }
   }, [setToInactive, stateData.state, onDeleteModalOpen])
@@ -218,7 +217,7 @@ export const FieldRowContainer = ({
       isDragDisabled={
         !isActive ||
         !!numFormFieldMutations ||
-        stateData.state === BuildFieldState.CreatingField
+        stateData.state === FieldBuilderState.CreatingField
       }
       disableInteractiveElementBlocking
       draggableId={field._id}
@@ -329,7 +328,7 @@ export const FieldRowContainer = ({
                     ) : null}
                     {
                       // Fields which are not yet created cannot be duplicated
-                      stateData.state !== BuildFieldState.CreatingField && (
+                      stateData.state !== FieldBuilderState.CreatingField && (
                         <IconButton
                           aria-label="Duplicate field"
                           isDisabled={isAnyMutationLoading}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -13,8 +13,8 @@ import { FIELD_LIST_DROP_ID } from '../constants'
 import { DndPlaceholderProps } from '../types'
 import {
   setToEditEndPageSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import { EmptyFormPlaceholder } from './BuilderAndDesignPlaceholder/EmptyFormPlaceholder'
@@ -34,7 +34,7 @@ export const FormBuilder = ({
   const { builderFields } = useBuilderFields()
   const { formLogics } = useAdminFormLogic()
   const { handleBuilderClick } = useCreatePageSidebar()
-  const setEditEndPage = useBuilderAndDesignStore(setToEditEndPageSelector)
+  const setEditEndPage = useFieldBuilderStore(setToEditEndPageSelector)
   const visibleFieldIds = useMemo(
     () =>
       getVisibleFieldIds(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -22,10 +22,6 @@ import { useFormBannerLogo } from '~features/public-form/components/FormStartPag
 import { useFormHeader } from '~features/public-form/components/FormStartPage/useFormHeader'
 
 import { useCreatePageSidebar } from '../../common/CreatePageSidebarContext'
-import {
-  setToInactiveSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
 import { useCreateTabForm } from '../useCreateTabForm'
 import {
   customLogoMetaSelector,
@@ -35,11 +31,15 @@ import {
   stateSelector,
   useDesignStore,
 } from '../useDesignStore'
+import {
+  setToInactiveSelector,
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const StartPageView = () => {
   const isMobile = useIsMobile()
   const { data: form } = useCreateTabForm()
-  const setToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
   const { designState, startPageData, customLogoMeta, setDesignState } =
     useDesignStore(
       useCallback(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -12,12 +12,12 @@ import { insertAt, replaceAt } from '~shared/utils/immutable-array-fns'
 import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
-import {
-  BuildFieldState,
-  stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
 import { useCreateTabForm } from '../useCreateTabForm'
+import {
+  FieldBuilderState,
+  stateDataSelector,
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 const getFormFieldsWhileCreating = (
   formFields: FormFieldDto[],
@@ -53,16 +53,16 @@ const getFormFieldsWhileEditing = (
 
 export const useBuilderFields = () => {
   const { data: formData } = useCreateTabForm()
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const stateData = useFieldBuilderStore(stateDataSelector)
   const builderFields = useMemo(() => {
     let existingFields = formData?.form_fields
     if (!existingFields) return null
-    if (stateData.state === BuildFieldState.EditingField) {
+    if (stateData.state === FieldBuilderState.EditingField) {
       existingFields = getFormFieldsWhileEditing(
         existingFields,
         stateData.field,
       )
-    } else if (stateData.state === BuildFieldState.CreatingField) {
+    } else if (stateData.state === FieldBuilderState.CreatingField) {
       existingFields = getFormFieldsWhileCreating(existingFields, stateData)
     }
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
@@ -10,10 +10,10 @@ import {
   useCreatePageSidebar,
 } from '../../common/CreatePageSidebarContext'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 import { EditEndPageDrawer } from './EditEndPageDrawer/EditEndPageDrawer'
 import DesignDrawer from './DesignDrawer'
@@ -23,7 +23,7 @@ import { FieldListDrawer } from './FieldListDrawer'
 export const BuilderAndDesignDrawer = (): JSX.Element | null => {
   const isMobile = useIsMobile()
   const { activeTab, isDrawerOpen } = useCreatePageSidebar()
-  const createOrEditData = useBuilderAndDesignStore(stateDataSelector)
+  const createOrEditData = useFieldBuilderStore(stateDataSelector)
 
   const drawerMotionProps = useMemo(() => {
     return {
@@ -50,10 +50,10 @@ export const BuilderAndDesignDrawer = (): JSX.Element | null => {
     switch (activeTab) {
       case DrawerTabs.Builder:
         switch (createOrEditData.state) {
-          case BuildFieldState.EditingField:
-          case BuildFieldState.CreatingField:
+          case FieldBuilderState.EditingField:
+          case FieldBuilderState.CreatingField:
             return <EditFieldDrawer />
-          case BuildFieldState.EditingEndPage:
+          case FieldBuilderState.EditingEndPage:
             return <EditEndPageDrawer />
           default:
             // Inactive state

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
@@ -25,14 +25,14 @@ import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'
 
 import {
-  setToInactiveSelector,
-  useBuilderAndDesignStore,
-} from '../../useBuilderAndDesignStore'
-import {
   resetEndPageDataSelector,
   setEndPageDataSelector,
   useEndPageBuilderStore,
 } from '../../useEndPageBuilderStore'
+import {
+  setToInactiveSelector,
+  useFieldBuilderStore,
+} from '../../useFieldBuilderStore'
 import { DrawerContentContainer } from '../EditFieldDrawer/edit-fieldtype/common/DrawerContentContainer'
 
 const buttonLinkRules: RegisterOptions<FormEndPage, 'buttonLink'> = {
@@ -55,7 +55,7 @@ export const EndPageBuilderInput = ({
   const isMobile = useIsMobile()
   const { endPageMutation } = useMutateFormPage()
 
-  const closeBuilderDrawer = useBuilderAndDesignStore(setToInactiveSelector)
+  const closeBuilderDrawer = useFieldBuilderStore(setToInactiveSelector)
   const { setEndPageBuilderState, resetEndPageBuilderState } =
     useEndPageBuilderStore((state) => ({
       setEndPageBuilderState: setEndPageDataSelector(state),

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -8,10 +8,10 @@ import { isMyInfo } from '~features/myinfo/utils'
 import { useBuilderFields } from '../../BuilderAndDesignContent/useBuilderFields'
 import { MYINFO_FIELD_CONSTANTS } from '../../constants'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../../useFieldBuilderStore'
 import { BuilderDrawerContainer } from '../common/BuilderDrawerContainer'
 
 import {
@@ -39,12 +39,12 @@ import {
 } from './edit-fieldtype'
 
 export const EditFieldDrawer = (): JSX.Element | null => {
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const stateData = useFieldBuilderStore(stateDataSelector)
 
   const fieldToEdit: FieldCreateDto | undefined = useMemo(() => {
     if (
-      stateData.state === BuildFieldState.EditingField ||
-      stateData.state === BuildFieldState.CreatingField
+      stateData.state === FieldBuilderState.EditingField ||
+      stateData.state === FieldBuilderState.CreatingField
     ) {
       return stateData.field
     }
@@ -68,9 +68,9 @@ export const EditFieldDrawer = (): JSX.Element | null => {
   // then fieldIndex changes.
   const { builderFields } = useBuilderFields()
   const fieldIndex = useMemo(() => {
-    if (stateData.state === BuildFieldState.CreatingField) {
+    if (stateData.state === FieldBuilderState.CreatingField) {
       return stateData.insertionIndex
-    } else if (stateData.state === BuildFieldState.EditingField) {
+    } else if (stateData.state === FieldBuilderState.EditingField) {
       return builderFields?.findIndex(
         (field) => field._id === stateData.field._id,
       )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -19,13 +19,13 @@ import {
 import { useCreateFormField } from '~features/admin-form/create/builder-and-design/mutations/useCreateFormField'
 import { useEditFormField } from '~features/admin-form/create/builder-and-design/mutations/useEditFormField'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   setToInactiveSelector,
   stateDataSelector,
   updateCreateStateSelector,
   updateEditStateSelector,
-  useBuilderAndDesignStore,
-} from '~features/admin-form/create/builder-and-design/useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
 
 import { EditFieldProps } from './types'
 
@@ -66,7 +66,7 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
   FieldShape
 >): UseEditFieldFormReturn<FormShape> => {
   const { stateData, setToInactive, updateEditState, updateCreateState } =
-    useBuilderAndDesignStore(
+    useFieldBuilderStore(
       useCallback(
         (state) => ({
           stateData: stateDataSelector(state),
@@ -82,7 +82,7 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
   const { createFieldMutation } = useCreateFormField()
 
   const isPendingField = useMemo(
-    () => stateData.state === BuildFieldState.CreatingField,
+    () => stateData.state === FieldBuilderState.CreatingField,
     [stateData.state],
   )
 
@@ -122,11 +122,11 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
     if (transform.preSubmit) {
       updatedFormField = await transform.preSubmit(inputs, updatedFormField)
     }
-    if (stateData.state === BuildFieldState.CreatingField) {
+    if (stateData.state === FieldBuilderState.CreatingField) {
       return createFieldMutation.mutate(updatedFormField, {
         onSuccess: onSaveSuccess,
       })
-    } else if (stateData.state === BuildFieldState.EditingField) {
+    } else if (stateData.state === FieldBuilderState.EditingField) {
       return editFieldMutation.mutate(
         { ...updatedFormField, _id: stateData.field._id } as FormFieldDto,
         { onSuccess: onSaveSuccess },
@@ -136,9 +136,9 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
 
   const handleChange = useCallback(
     (field: FieldCreateDto | FormFieldDto) => {
-      if (stateData.state === BuildFieldState.CreatingField) {
+      if (stateData.state === FieldBuilderState.CreatingField) {
         updateCreateState(field, stateData.insertionIndex)
-      } else if (stateData.state === BuildFieldState.EditingField) {
+      } else if (stateData.state === FieldBuilderState.EditingField) {
         updateEditState({
           ...(field as FormFieldDto),
           _id: stateData.field._id,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
@@ -13,11 +13,11 @@ import {
   MYINFO_FIELD_TO_DRAWER_META,
 } from '~features/admin-form/create/constants'
 
+import { useCreateTabForm } from '../../useCreateTabForm'
 import {
   updateCreateStateSelector,
-  useBuilderAndDesignStore,
-} from '../../useBuilderAndDesignStore'
-import { useCreateTabForm } from '../../useCreateTabForm'
+  useFieldBuilderStore,
+} from '../../useFieldBuilderStore'
 import {
   getFieldCreationMeta,
   getMyInfoFieldCreationMeta,
@@ -155,9 +155,7 @@ export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
       [fieldType],
     )
 
-    const updateCreateState = useBuilderAndDesignStore(
-      updateCreateStateSelector,
-    )
+    const updateCreateState = useFieldBuilderStore(updateCreateStateSelector)
 
     const handleClick = useCallback(() => {
       if (!isDisabled) {
@@ -193,9 +191,7 @@ export const MyInfoFieldOption = forwardRef<MyInfoFieldOptionProps, 'button'>(
       [fieldType],
     )
 
-    const updateCreateState = useBuilderAndDesignStore(
-      updateCreateStateSelector,
-    )
+    const updateCreateState = useFieldBuilderStore(updateCreateStateSelector)
 
     const handleClick = useCallback(() => {
       if (!isDisabled) updateCreateState(newFieldMeta, numFields)

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/common/BuilderDrawerContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/common/BuilderDrawerContainer.tsx
@@ -6,8 +6,8 @@ import IconButton from '~components/IconButton'
 
 import {
   setToInactiveSelector,
-  useBuilderAndDesignStore,
-} from '../../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../../useFieldBuilderStore'
 import { CreatePageDrawerCloseButton } from '../CreatePageDrawerCloseButton'
 
 interface BuilderDrawerContainerProps {
@@ -19,7 +19,7 @@ export const BuilderDrawerContainer = ({
   title,
   children,
 }: BuilderDrawerContainerProps): JSX.Element | null => {
-  const setToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
 
   return (
     <>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignTab.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignTab.tsx
@@ -37,14 +37,14 @@ import {
 } from './constants'
 import { DeleteFieldModal } from './DeleteFieldModal'
 import { DndPlaceholderProps } from './types'
+import { useCreateTabForm } from './useCreateTabForm'
 import {
   updateCreateStateSelector,
-  useBuilderAndDesignStore,
-} from './useBuilderAndDesignStore'
-import { useCreateTabForm } from './useCreateTabForm'
+  useFieldBuilderStore,
+} from './useFieldBuilderStore'
 
 export const BuilderAndDesignTab = (): JSX.Element => {
-  const setToCreating = useBuilderAndDesignStore(updateCreateStateSelector)
+  const setToCreating = useFieldBuilderStore(updateCreateStateSelector)
   const { data } = useCreateTabForm()
 
   const { reorderFieldMutation } = useReorderFormField()

--- a/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
@@ -16,19 +16,19 @@ import { BASICFIELD_TO_DRAWER_META } from '../../constants'
 import { useBuilderAndDesignContext } from '../BuilderAndDesignContext'
 import { useDeleteFormField } from '../mutations/useDeleteFormField'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const DeleteFieldModal = (): JSX.Element => {
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const stateData = useFieldBuilderStore(stateDataSelector)
   const {
     deleteFieldModalDisclosure: { isOpen, onClose },
   } = useBuilderAndDesignContext()
 
   const fieldTypeLabel = useMemo(() => {
-    if (stateData.state === BuildFieldState.EditingField) {
+    if (stateData.state === FieldBuilderState.EditingField) {
       return BASICFIELD_TO_DRAWER_META[stateData.field.fieldType].label
     }
     return null
@@ -37,7 +37,7 @@ export const DeleteFieldModal = (): JSX.Element => {
   const { deleteFieldMutation } = useDeleteFormField()
 
   const handleDeleteConfirmation = useCallback(() => {
-    if (stateData.state === BuildFieldState.EditingField) {
+    if (stateData.state === FieldBuilderState.EditingField) {
       deleteFieldMutation.mutate(stateData.field._id, {
         onSuccess: onClose,
       })

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
@@ -11,18 +11,25 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 
 import { createSingleFormField } from '../UpdateFormFieldService'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
   updateEditStateSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const useCreateFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const updateEditState = useBuilderAndDesignStore(updateEditStateSelector)
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const { stateData, updateEditState } = useFieldBuilderStore(
+    useCallback(
+      (state) => ({
+        stateData: stateDataSelector(state),
+        updateEditState: updateEditStateSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -31,7 +38,7 @@ export const useCreateFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (stateData.state !== BuildFieldState.CreatingField) {
+      if (stateData.state !== FieldBuilderState.CreatingField) {
         toast({
           status: 'warning',
           description:
@@ -67,7 +74,7 @@ export const useCreateFormField = () => {
   )
 
   const insertionIndex = useMemo(() => {
-    if (stateData.state === BuildFieldState.CreatingField) {
+    if (stateData.state === FieldBuilderState.CreatingField) {
       return stateData.insertionIndex
     }
   }, [stateData])

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
@@ -10,18 +10,25 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 
 import { deleteSingleFormField } from '../UpdateFormFieldService'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   setToInactiveSelector,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const useDeleteFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const setToInactive = useBuilderAndDesignStore(setToInactiveSelector)
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const { stateData, setToInactive } = useFieldBuilderStore(
+    useCallback(
+      (state) => ({
+        stateData: stateDataSelector(state),
+        setToInactive: setToInactiveSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -29,7 +36,7 @@ export const useDeleteFormField = () => {
 
   const handleSuccess = useCallback(() => {
     toast.closeAll()
-    if (stateData.state !== BuildFieldState.EditingField) {
+    if (stateData.state !== FieldBuilderState.EditingField) {
       toast({
         status: 'warning',
         description:

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
@@ -11,18 +11,25 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 
 import { duplicateSingleFormField } from '../UpdateFormFieldService'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
   updateEditStateSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const useDuplicateFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const updateEditState = useBuilderAndDesignStore(updateEditStateSelector)
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const { stateData, updateEditState } = useFieldBuilderStore(
+    useCallback(
+      (state) => ({
+        stateData: stateDataSelector(state),
+        updateEditState: updateEditStateSelector(state),
+      }),
+      [],
+    ),
+  )
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -31,7 +38,7 @@ export const useDuplicateFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (stateData.state !== BuildFieldState.EditingField) {
+      if (stateData.state !== FieldBuilderState.EditingField) {
         toast({
           status: 'warning',
           description:

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
@@ -11,16 +11,16 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 
 import { updateSingleFormField } from '../UpdateFormFieldService'
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from '../useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 export const useEditFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const stateData = useFieldBuilderStore(stateDataSelector)
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -29,7 +29,7 @@ export const useEditFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (stateData.state !== BuildFieldState.EditingField) {
+      if (stateData.state !== FieldBuilderState.EditingField) {
         toast({
           status: 'warning',
           description:

--- a/frontend/src/features/admin-form/create/builder-and-design/useCreateTabForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/useCreateTabForm.ts
@@ -1,15 +1,15 @@
 import { useAdminForm } from '~features/admin-form/common/queries'
 
 import {
-  BuildFieldState,
+  FieldBuilderState,
   stateDataSelector,
-  useBuilderAndDesignStore,
-} from './useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from './useFieldBuilderStore'
 
 export const useCreateTabForm = () => {
-  const stateData = useBuilderAndDesignStore(stateDataSelector)
+  const stateData = useFieldBuilderStore(stateDataSelector)
   return useAdminForm({
     // Only fetch data if no field is being created or edited
-    enabled: stateData.state === BuildFieldState.Inactive,
+    enabled: stateData.state === FieldBuilderState.Inactive,
   })
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -4,40 +4,40 @@ import { devtools } from 'zustand/middleware'
 
 import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
 
-export enum BuildFieldState {
+export enum FieldBuilderState {
   CreatingField,
   EditingField,
   EditingEndPage,
   Inactive,
 }
 
-export type BuilderAndDesignStore = {
+export type FieldBuilderStore = {
   updateCreateState: (field: FieldCreateDto, insertionIndex: number) => void
   updateEditState: (field: FormFieldDto) => void
   setEditEndPage: () => void
   setToInactive: () => void
   stateData:
     | {
-        state: BuildFieldState.CreatingField
+        state: FieldBuilderState.CreatingField
         field: FieldCreateDto
         insertionIndex: number
       }
     | {
-        state: BuildFieldState.EditingField
+        state: FieldBuilderState.EditingField
         field: FormFieldDto
       }
-    | { state: BuildFieldState.EditingEndPage }
-    | { state: BuildFieldState.Inactive }
+    | { state: FieldBuilderState.EditingEndPage }
+    | { state: FieldBuilderState.Inactive }
 }
 
-export const useBuilderAndDesignStore = create<BuilderAndDesignStore>(
+export const useFieldBuilderStore = create<FieldBuilderStore>(
   devtools((set, get) => ({
-    stateData: { state: BuildFieldState.Inactive },
+    stateData: { state: FieldBuilderState.Inactive },
     updateCreateState: (field, insertionIndex) => {
       // perf: prevent store update if field is the same
       const current = get()
       if (
-        current.stateData.state === BuildFieldState.CreatingField &&
+        current.stateData.state === FieldBuilderState.CreatingField &&
         current.stateData.insertionIndex === insertionIndex &&
         isEqual(current.stateData.field, field)
       ) {
@@ -45,7 +45,7 @@ export const useBuilderAndDesignStore = create<BuilderAndDesignStore>(
       }
       set({
         stateData: {
-          state: BuildFieldState.CreatingField,
+          state: FieldBuilderState.CreatingField,
           field,
           insertionIndex,
         },
@@ -55,40 +55,40 @@ export const useBuilderAndDesignStore = create<BuilderAndDesignStore>(
       // perf: prevent store update if field is the same
       const current = get()
       if (
-        current.stateData.state === BuildFieldState.EditingField &&
+        current.stateData.state === FieldBuilderState.EditingField &&
         isEqual(current.stateData.field, field)
       ) {
         return
       }
       set({
-        stateData: { state: BuildFieldState.EditingField, field },
+        stateData: { state: FieldBuilderState.EditingField, field },
       })
     },
     setEditEndPage: () => {
-      set({ stateData: { state: BuildFieldState.EditingEndPage } })
+      set({ stateData: { state: FieldBuilderState.EditingEndPage } })
     },
     setToInactive: () => {
-      set({ stateData: { state: BuildFieldState.Inactive } })
+      set({ stateData: { state: FieldBuilderState.Inactive } })
     },
   })),
 )
 
 export const stateDataSelector = (
-  state: BuilderAndDesignStore,
-): BuilderAndDesignStore['stateData'] => state.stateData
+  state: FieldBuilderStore,
+): FieldBuilderStore['stateData'] => state.stateData
 
 export const updateCreateStateSelector = (
-  state: BuilderAndDesignStore,
-): BuilderAndDesignStore['updateCreateState'] => state.updateCreateState
+  state: FieldBuilderStore,
+): FieldBuilderStore['updateCreateState'] => state.updateCreateState
 
 export const updateEditStateSelector = (
-  state: BuilderAndDesignStore,
-): BuilderAndDesignStore['updateEditState'] => state.updateEditState
+  state: FieldBuilderStore,
+): FieldBuilderStore['updateEditState'] => state.updateEditState
 
 export const setToInactiveSelector = (
-  state: BuilderAndDesignStore,
-): BuilderAndDesignStore['setToInactive'] => state.setToInactive
+  state: FieldBuilderStore,
+): FieldBuilderStore['setToInactive'] => state.setToInactive
 
 export const setToEditEndPageSelector = (
-  state: BuilderAndDesignStore,
-): BuilderAndDesignStore['setEditEndPage'] => state.setEditEndPage
+  state: FieldBuilderStore,
+): FieldBuilderStore['setEditEndPage'] => state.setEditEndPage

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
@@ -13,15 +13,15 @@ import {
 
 import {
   setToInactiveSelector,
-  useBuilderAndDesignStore,
-} from '../../builder-and-design/useBuilderAndDesignStore'
+  useFieldBuilderStore,
+} from '../../builder-and-design/useFieldBuilderStore'
 import { FEATURE_TOUR } from '../../featureTour/constants'
 
 import { DrawerTabIcon } from './DrawerTabIcon'
 
 export const CreatePageSidebar = (): JSX.Element | null => {
   const isMobile = useIsMobile()
-  const setFieldsToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+  const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
   const { activeTab, handleBuilderClick, handleDesignClick, handleLogicClick } =
     useCreatePageSidebar()
 

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -12,14 +12,14 @@ import { useIsMobile } from '~hooks/useIsMobile'
 
 import { FieldListTabIndex } from '../../builder-and-design/constants'
 import {
-  setToInactiveSelector,
-  useBuilderAndDesignStore,
-} from '../../builder-and-design/useBuilderAndDesignStore'
-import {
   DesignState,
   setStateSelector,
   useDesignStore,
 } from '../../builder-and-design/useDesignStore'
+import {
+  setToInactiveSelector,
+  useFieldBuilderStore,
+} from '../../builder-and-design/useFieldBuilderStore'
 
 export enum DrawerTabs {
   Builder,
@@ -60,7 +60,7 @@ export const useCreatePageSidebarContext =
       () => activeTab !== null && activeTab !== DrawerTabs.Logic,
       [activeTab],
     )
-    const setFieldsToInactive = useBuilderAndDesignStore(setToInactiveSelector)
+    const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
     const setDesignState = useDesignStore(setStateSelector)
 
     const [fieldListTabIndex, setFieldListTabIndex] =


### PR DESCRIPTION
## Problem
`BuilderAndDesignStore` does not accurately reflect its use in the code anymore. In particular, end page and design have their own stores, so we should rename this to `FieldBuilderStore`.

## Solution
Rename `BuilderAndDesignStore` to `FieldBuilderStore` everywhere.

**Breaking Changes** 
- No - this PR is backwards compatible  
