### PR TITLE
fix(v2): redesign edit attachment drawer bar

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -32,6 +32,10 @@ export const GUIDE_TRANSFER_OWNERSHIP =
 export const GUIDE_SECRET_KEY_LOSS = 'https://go.gov.sg/secretkeyloss'
 export const GUIDE_PREVENT_EMAIL_BOUNCE =
   'https://go.gov.sg/form-prevent-bounce'
+export const GUIDE_EMAIL_RELIABILITY =
+  'https://go.gov.sg/form-email-reliability'
+
+export const ACCEPTED_FILETYPES_SPREADSHEET = 'https://go.gov.sg/formsg-cwl'
 
 export const APP_FOOTER_LINKS = [
   { label: 'Contact us', href: CONTACT_US },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/AttachmentStackedBar.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/AttachmentStackedBar.tsx
@@ -49,8 +49,8 @@ export const AttachmentStackedBar = ({
   )
 
   const isOverQuota = useMemo(
-    () => !!existingValues && max < totalAttachmentSize,
-    [max, totalAttachmentSize, existingValues],
+    () => max < totalAttachmentSize,
+    [max, totalAttachmentSize],
   )
 
   const barProps = useMemo(() => {
@@ -58,11 +58,12 @@ export const AttachmentStackedBar = ({
       bg: 'warning.500',
       border: 'none',
     }))
-    if (newValue > 0)
+    if (newValue > 0) {
       barProps.push({
         bg: 'success.500',
         border: '1px dashed var(--chakra-colors-success-800)',
       })
+    }
     return barProps
   }, [existingValues, newValue])
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -132,7 +132,7 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
       validate: (val) => {
         return (
           maxTotalSizeMb - otherAttachmentsSize >= Number(val) ||
-          `You have exceeded your form's attachment size limit of ${maxTotalSizeMb} MB. Kindly reduce the size of your attachments.
+          `You have exceeded your form's attachment size limit of ${maxTotalSizeMb} MB
 `
         )
       },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -168,7 +168,7 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
         <Toggle {...register('required')} label="Required" />
       </FormControl>
       <FormControl isReadOnly={isLoading} isInvalid={!!errors.attachmentSize}>
-        <FormLabel isRequired>Attachment size</FormLabel>
+        <FormLabel isRequired>Maximum size of individual attachment</FormLabel>
         <Skeleton isLoaded={!!form}>
           <Controller
             control={control}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -191,7 +191,7 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
         </Skeleton>
         <FormErrorMessage>{errors?.attachmentSize?.message}</FormErrorMessage>
         <AttachmentStackedBar
-          existingValues={form ? [otherAttachmentsSize] : undefined}
+          existingValue={form ? otherAttachmentsSize : undefined}
           newValue={Number(getValues('attachmentSize'))}
           max={maxTotalSizeMb}
         />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -11,6 +11,10 @@ import {
   FormFieldDto,
 } from '~shared/types/field'
 
+import {
+  ACCEPTED_FILETYPES_SPREADSHEET,
+  GUIDE_EMAIL_RELIABILITY,
+} from '~constants/links'
 import { createBaseValidationRules } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown'
 import type { ComboboxItem } from '~components/Dropdown/types'
@@ -143,7 +147,10 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
   // Validate on render in order to inform users when other attachments have
   // already hit the limit, so the user doesn't try to create this attachment
   // field before changing the other fields.
-  useEffect(() => validateAttachmentSize(), [validateAttachmentSize])
+  useEffect(() => {
+    if (!form) return
+    validateAttachmentSize()
+  }, [form, validateAttachmentSize])
 
   return (
     <DrawerContentContainer>
@@ -173,6 +180,8 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
                 items={attachmentSizeOptions}
                 onChange={(size) => {
                   onChange(size)
+                  // Validate on each change so that appropriate error message
+                  // is displayed when the attachment size bar also shows red
                   validateAttachmentSize()
                 }}
                 {...rest}
@@ -188,10 +197,9 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
         />
       </FormControl>
       <InlineMessage useMarkdown>
-        View our [complete list](https://go.gov.sg/formsg-cwl) of accepted file
-        types. Please also read our [FAQ on email
-        reliability](https://go.gov.sg/form-email-reliability) relating to
-        unaccepted file types.
+        {`View our [complete list](${ACCEPTED_FILETYPES_SPREADSHEET}) of accepted
+        file types. Please also read our [FAQ on email reliability](
+        ${GUIDE_EMAIL_RELIABILITY}) relating to unaccepted file types.`}
       </InlineMessage>
       <FormFieldDrawerActions
         isLoading={isLoading}


### PR DESCRIPTION
## Problem
The edit attachment drawer bar does not display correctly in cases when the existing attachments already hit the attachment limit for the form.

Closes [#4353 ]

## Solution
- Retype `AttachmentStackedBar` component to avoid implicit precondition that values has at least two elements (as well as their roles).
- Addition of `trigger` to ensure that form errors appear identically to angular.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/184340004-4cf8d880-886f-4b43-9e51-e22182da68fa.mov
