### PR TITLE
feat(v2): always enable e-service id box in auth settings

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -187,7 +187,10 @@ export const AuthSettingsSection = ({
               </Radio>
             </Box>
             {esrvcidRequired(authType) && authType === settings.authType ? (
-              <EsrvcIdBox settings={settings} />
+              <EsrvcIdBox
+                settings={settings}
+                isDisabled={isDisabled(authType)}
+              />
             ) : null}
           </Fragment>
         ))}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -93,12 +93,17 @@ export const AuthSettingsSection = ({
     ],
   )
 
+  const isEsrvcIdBoxDisabled = useMemo(
+    () => isFormPublic || mutateFormAuthType.isLoading,
+    [isFormPublic, mutateFormAuthType.isLoading],
+  )
+
   const handleEnterKeyDown: KeyboardEventHandler = useCallback(
     (e) => {
       if (
-        !isDisabled &&
         (e.key === 'Enter' || e.key === ' ') &&
         focusedValue &&
+        !isDisabled(focusedValue) &&
         focusedValue !== settings.authType
       ) {
         return mutateFormAuthType.mutate(focusedValue)
@@ -143,7 +148,7 @@ export const AuthSettingsSection = ({
       ) : containsMyInfoFields ? (
         <InlineMessage mb="1.25rem">
           Authentication method cannot be changed without first removing MyInfo
-          fields.
+          fields. You can still update your e-service ID.
         </InlineMessage>
       ) : null}
       <Radio.RadioGroup
@@ -189,7 +194,7 @@ export const AuthSettingsSection = ({
             {esrvcidRequired(authType) && authType === settings.authType ? (
               <EsrvcIdBox
                 settings={settings}
-                isDisabled={isDisabled(authType)}
+                isDisabled={isEsrvcIdBoxDisabled}
               />
             ) : null}
           </Fragment>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -187,10 +187,7 @@ export const AuthSettingsSection = ({
               </Radio>
             </Box>
             {esrvcidRequired(authType) && authType === settings.authType ? (
-              <EsrvcIdBox
-                settings={settings}
-                isDisabled={isDisabled(authType)}
-              />
+              <EsrvcIdBox settings={settings} />
             ) : null}
           </Fragment>
         ))}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -23,9 +23,13 @@ import { useMutateFormSettings } from '../../mutations'
 
 interface EsrvcIdBoxProps {
   settings: FormSettings
+  isDisabled: boolean
 }
 
-export const EsrvcIdBox = ({ settings }: EsrvcIdBoxProps): JSX.Element => {
+export const EsrvcIdBox = ({
+  settings,
+  isDisabled,
+}: EsrvcIdBoxProps): JSX.Element => {
   const initialEsrvcId = useMemo(() => settings.esrvcId ?? '', [settings])
 
   const { mutateFormEsrvcId } = useMutateFormSettings()
@@ -100,6 +104,7 @@ export const EsrvcIdBox = ({ settings }: EsrvcIdBoxProps): JSX.Element => {
                       'e-service ID must not contain whitespace',
                   },
                 })}
+                isDisabled={isDisabled}
                 isReadOnly={mutateFormEsrvcId.isLoading}
                 placeholder="Enter Singpass e-service ID"
               />

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -23,13 +23,9 @@ import { useMutateFormSettings } from '../../mutations'
 
 interface EsrvcIdBoxProps {
   settings: FormSettings
-  isDisabled: boolean
 }
 
-export const EsrvcIdBox = ({
-  settings,
-  isDisabled,
-}: EsrvcIdBoxProps): JSX.Element => {
+export const EsrvcIdBox = ({ settings }: EsrvcIdBoxProps): JSX.Element => {
   const initialEsrvcId = useMemo(() => settings.esrvcId ?? '', [settings])
 
   const { mutateFormEsrvcId } = useMutateFormSettings()
@@ -104,7 +100,6 @@ export const EsrvcIdBox = ({
                       'e-service ID must not contain whitespace',
                   },
                 })}
-                isDisabled={isDisabled}
                 isReadOnly={mutateFormEsrvcId.isLoading}
                 placeholder="Enter Singpass e-service ID"
               />


### PR DESCRIPTION
## Problem
Currently, the e-service id box is disabled when the form is open and when myinfo fields are present. We want the e-service id box to be enabled. 

Closes [#4540 ]

## Solution
Change the `isDisabled` prop passed to the e-service ID Box.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshot
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/25571626/186095908-251f4cfc-0113-4b9a-bb36-e85e5dacb7df.png">
