### PR TITLE
feat(form-v2): add switch-to-react url for admins

### DIFF
--- a/frontend/src/features/env/mutations.ts
+++ b/frontend/src/features/env/mutations.ts
@@ -23,7 +23,7 @@ export const useEnvMutations = (
   const adminSwitchEnvMutation = useMutation(() => adminChooseEnvironment(), {
     onSuccess: () => {
       const previewFormReactPath = new RegExp(`^/admin/form/${formId}/preview`)
-      const adminWorkspaceReactPath = new RegExp('^/workspace')
+      const adminWorkspaceReactPath = new RegExp('^/dashboard')
       const formBuilderReactPath = new RegExp('^/admin/form/')
 
       // If on admin preview form page

--- a/frontend/src/services/EnvService.ts
+++ b/frontend/src/services/EnvService.ts
@@ -5,7 +5,7 @@ import { PUBLIC_FORMS_ENDPOINT } from '~features/public-form/PublicFormService'
 
 import { ApiService } from './ApiService'
 
-const ENV_ENDPOINT = '/environment'
+const ENV_ENDPOINT = 'environment'
 const ADMIN_ENDPOINT = '/admin'
 
 export const publicChooseEnvironment = async (): Promise<UiCookieValues> => {

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -228,7 +228,10 @@ export const adminChooseEnvironment: ControllerHandler<
   unknown,
   unknown,
   Record<string, string>
-> = (req, res) => {
+> = (req, res, next) => {
+  const redirectPath = new RegExp('^/environment')
+  const isMiddleware = req.path.match(redirectPath)
+
   const ui =
     req.params.ui === UiCookieValues.React
       ? UiCookieValues.React
@@ -240,6 +243,7 @@ export const adminChooseEnvironment: ControllerHandler<
     // chosen environment until the alternative is stable.
     ADMIN_COOKIE_OPTIONS_WITH_EXPIRY,
   )
+  if (isMiddleware) return next()
   return res.json({ ui })
 }
 
@@ -263,3 +267,19 @@ export const publicChooseEnvironment: ControllerHandler<
   )
   return res.json({ ui })
 }
+
+export const redirectToLanding: ControllerHandler<
+  SetEnvironmentParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res) => {
+  const target = '/'
+  return res.redirect(target)
+}
+
+// Redirect to landing after setting the admin cookie
+export const redirectEnvironment = [
+  adminChooseEnvironment,
+  redirectToLanding,
+] as ControllerHandler[]

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -265,16 +265,6 @@ export const publicChooseEnvironment: ControllerHandler<
   return res.json({ ui })
 }
 
-export const redirectToLanding: ControllerHandler<
-  SetEnvironmentParams,
-  unknown,
-  unknown,
-  Record<string, string>
-> = (req, res) => {
-  const target = '/'
-  return res.redirect(target)
-}
-
 // Redirect to landing after setting the admin cookie
 export const redirectAdminEnvironment: ControllerHandler<
   SetEnvironmentParams,

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -283,6 +283,5 @@ export const redirectAdminEnvironment: ControllerHandler<
     // chosen environment until the alternative is stable.
     ADMIN_COOKIE_OPTIONS_WITH_EXPIRY,
   )
-  const target = '/'
-  return res.redirect(target)
+  return res.redirect('/')
 }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -228,10 +228,7 @@ export const adminChooseEnvironment: ControllerHandler<
   unknown,
   unknown,
   Record<string, string>
-> = (req, res, next) => {
-  const redirectPath = new RegExp('^/environment')
-  const isMiddleware = req.path.match(redirectPath)
-
+> = (req, res) => {
   const ui =
     req.params.ui === UiCookieValues.React
       ? UiCookieValues.React
@@ -243,7 +240,7 @@ export const adminChooseEnvironment: ControllerHandler<
     // chosen environment until the alternative is stable.
     ADMIN_COOKIE_OPTIONS_WITH_EXPIRY,
   )
-  if (isMiddleware) return next()
+
   return res.json({ ui })
 }
 
@@ -279,7 +276,23 @@ export const redirectToLanding: ControllerHandler<
 }
 
 // Redirect to landing after setting the admin cookie
-export const redirectEnvironment = [
-  adminChooseEnvironment,
-  redirectToLanding,
-] as ControllerHandler[]
+export const redirectAdminEnvironment: ControllerHandler<
+  SetEnvironmentParams,
+  unknown,
+  unknown,
+  Record<string, string>
+> = (req, res) => {
+  const ui =
+    req.params.ui === UiCookieValues.React
+      ? UiCookieValues.React
+      : UiCookieValues.Angular
+  res.cookie(
+    config.reactMigration.adminCookieName,
+    ui,
+    // When admin chooses to switch environments, we want them to stay on their
+    // chosen environment until the alternative is stable.
+    ADMIN_COOKIE_OPTIONS_WITH_EXPIRY,
+  )
+  const target = '/'
+  return res.redirect(target)
+}

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -1,3 +1,4 @@
+// TODO #4279: Remove after React rollout is complete
 import { Router } from 'express'
 
 import * as ReactMigrationController from './react-migration.controller'
@@ -12,5 +13,11 @@ ReactMigrationRouter.get(
 ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
   res.redirect(`/${req.params.formId}`)
 })
+
+// Redirect to the landing page after setting the admin cookie
+ReactMigrationRouter.get(
+  '/environment/:ui(react|angular)',
+  ReactMigrationController.redirectEnvironment,
+)
 
 ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -17,7 +17,7 @@ ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
 // Redirect to the landing page after setting the admin cookie
 ReactMigrationRouter.get(
   '/environment/:ui(react|angular)',
-  ReactMigrationController.redirectEnvironment,
+  ReactMigrationController.redirectAdminEnvironment,
 )
 
 ReactMigrationRouter.get('*', ReactMigrationController.serveDefault)

--- a/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
+++ b/src/public/modules/forms/admin/components/react-switch-banner.client.component.js
@@ -17,9 +17,9 @@ function reactSwitchBannerController($q, $window) {
     return (
       $q
         .when(AdminService.adminChooseEnvironment(ui))
-        // Navigate to the React workspace page after changing the environment cookie
+        // Navigate to the React dashboard page after changing the environment cookie
         .then(() => {
-          $window.location.assign('/workspace')
+          $window.location.assign('/dashboard')
         })
         .catch((error) => {
           console.error('switch to react failed:', error)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to allow power users to try the new React FormSG by clicking a link which brings them to the React landing page

Closes #4289 

## Solution
<!-- How did you solve the problem? -->
Add new endpoint `/environment/:ui(react|angular)` which adds a `v2-admin-ui` cookie set to `react`, and redirects to the landing page.

**Bug Fixes**:
- Changed occurrences of `/workspace` to `/dashboard`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## After Screenshot
![Recording 2022-08-15 at 15 17 43](https://user-images.githubusercontent.com/56983748/184592617-1d1fb7d0-fb19-4faa-b65f-485f41c957b4.gif)

## Tests
- Set `v2-admin-ui` cookie to `angular`
- Navigate to [https://staging.form.gov.sg/environment/react](https://staging.form.gov.sg/environment/react)
- The page should display the react app's landing page

