### PR TITLE
feat(whats-new): update whats new API to use version flag instead of date flag

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.stories.tsx
@@ -10,6 +10,8 @@ import {
   ViewedEmergencyContactDecorator,
 } from '~utils/storybook'
 
+import { FEATURE_UPDATE_LIST } from '~features/whats-new/FeatureUpdateList'
+
 import { AdminNavBar, AdminNavBarProps } from './AdminNavBar'
 
 export default {
@@ -74,7 +76,7 @@ WhatsNewFeatureNotificationNotShown.parameters = {
       delay: 0,
       mockUser: {
         ...MOCK_USER,
-        flags: { lastSeenFeatureUpdateDate: new Date() },
+        flags: { lastSeenFeatureUpdateVersion: FEATURE_UPDATE_LIST.version },
       },
     }),
   ],

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -32,6 +32,7 @@ import { AvatarMenu, AvatarMenuDivider } from '~templates/AvatarMenu/AvatarMenu'
 import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUserMutations } from '~features/user/mutations'
 import { useUser } from '~features/user/queries'
+import { FEATURE_UPDATE_LIST } from '~features/whats-new/FeatureUpdateList'
 import { getShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
 import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
@@ -151,7 +152,7 @@ export interface AdminNavBarProps {
 
 export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   const { user, isLoading: isUserLoading } = useUser()
-  const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
+  const { updateLastSeenFeatureVersionMutation } = useUserMutations()
 
   const whatsNewFeatureDrawerDisclosure = useDisclosure()
 
@@ -191,10 +192,21 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [isUserLoading, user])
 
   const onWhatsNewDrawerOpen = useCallback(() => {
+    if (isUserLoading || !user) return
+    // Update version if current user version is not set or is less than the latest version.
+    if (
+      user.flags?.lastSeenFeatureUpdateVersion === undefined ||
+      user.flags?.lastSeenFeatureUpdateVersion < FEATURE_UPDATE_LIST.version
+    ) {
+      updateLastSeenFeatureVersionMutation.mutateAsync(
+        FEATURE_UPDATE_LIST.version,
+      )
+    }
     whatsNewFeatureDrawerDisclosure.onOpen()
-    updateUserLastSeenFeatureUpdateDateMutation.mutate()
   }, [
-    updateUserLastSeenFeatureUpdateDateMutation,
+    isUserLoading,
+    updateLastSeenFeatureVersionMutation,
+    user,
     whatsNewFeatureDrawerDisclosure,
   ])
 

--- a/frontend/src/features/user/mutations.ts
+++ b/frontend/src/features/user/mutations.ts
@@ -11,7 +11,7 @@ import { ApiError } from '~typings/core'
 import { useToast } from '~hooks/useToast'
 import {
   generateUserContactOtp,
-  updateUserLastSeenFeatureUpdateDate,
+  updateUserLastSeenFeatureUpdateVersion,
   verifyUserContactOtp,
 } from '~services/UserService'
 
@@ -40,11 +40,11 @@ export const useUserMutations = () => {
     },
   })
 
-  const updateUserLastSeenFeatureUpdateDateMutation = useMutation<
+  const updateLastSeenFeatureVersionMutation = useMutation<
     UserDto,
     ApiError,
-    void
-  >(() => updateUserLastSeenFeatureUpdateDate(), {
+    number
+  >((version: number) => updateUserLastSeenFeatureUpdateVersion(version), {
     onSuccess: (newData) => {
       queryClient.setQueryData(userKeys.base, newData)
     },
@@ -53,6 +53,6 @@ export const useUserMutations = () => {
   return {
     generateOtpMutation,
     verifyOtpMutation,
-    updateUserLastSeenFeatureUpdateDateMutation,
+    updateLastSeenFeatureVersionMutation,
   }
 }

--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -6,173 +6,167 @@ export interface FeatureUpdateImage {
   alt: string
 }
 export interface FeatureUpdate {
-  id: number
   date: Date
   title: string
   description: string
   image?: FeatureUpdateImage
 }
 
+export interface FeatureUpdateList {
+  features: FeatureUpdate[]
+  version: number
+}
+
 // TODO: Confirm the actual features which will be showcased in the What's New section
-export const FEATURE_UPDATE_LIST: FeatureUpdate[] = [
-  {
-    id: 1,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'UI Improvements',
-    description: `
+// New features should be added at the top of the list.
+export const FEATURE_UPDATE_LIST: FeatureUpdateList = {
+  // Update version whenever a new feature is added.
+  version: 1,
+  features: [
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'UI Improvements',
+      description: `
   * Cool new datepicker with day, month, and year views
   * Loading indicators for verified field OTPs
   * Consistent mobile field styling
   `,
-  },
-  {
-    id: 2,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'No more hangups',
-    description:
-      'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
-    image: {
-      url: PhoneFieldFeatureUpdateImg,
-      alt: 'Phone Field Feature Update',
     },
-  },
-  {
-    id: 3,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'Introducing Workspaces',
-    description:
-      "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
-    image: {
-      url: WorkspaceFeatureUpdateImg,
-      alt: 'Workspace Feature Update',
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'No more hangups',
+      description:
+        'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
+      image: {
+        url: PhoneFieldFeatureUpdateImg,
+        alt: 'Phone Field Feature Update',
+      },
     },
-  },
-  {
-    id: 4,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'UI Improvements',
-    description: `
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'Introducing Workspaces',
+      description:
+        "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
+      image: {
+        url: WorkspaceFeatureUpdateImg,
+        alt: 'Workspace Feature Update',
+      },
+    },
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'UI Improvements',
+      description: `
 * Cool new datepicker with day, month, and year views
 * Loading indicators for verified field OTPs
 * Consistent mobile field styling
     `,
-  },
-  {
-    id: 5,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'No more hangups',
-    description:
-      'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
-    image: {
-      url: PhoneFieldFeatureUpdateImg,
-      alt: 'Phone Field Feature Update',
     },
-  },
-  {
-    id: 6,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'Introducing Workspaces',
-    description:
-      "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
-    image: {
-      url: WorkspaceFeatureUpdateImg,
-      alt: 'Workspace Feature Update',
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'No more hangups',
+      description:
+        'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
+      image: {
+        url: PhoneFieldFeatureUpdateImg,
+        alt: 'Phone Field Feature Update',
+      },
     },
-  },
-  {
-    id: 7,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'UI Improvements',
-    description: `
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'Introducing Workspaces',
+      description:
+        "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
+      image: {
+        url: WorkspaceFeatureUpdateImg,
+        alt: 'Workspace Feature Update',
+      },
+    },
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'UI Improvements',
+      description: `
 * Cool new datepicker with day, month, and year views
 * Loading indicators for verified field OTPs
 * Consistent mobile field styling
     `,
-  },
-  {
-    id: 8,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'No more hangups',
-    description:
-      'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
-    image: {
-      url: PhoneFieldFeatureUpdateImg,
-      alt: 'Phone Field Feature Update',
     },
-  },
-  {
-    id: 9,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'Introducing Workspaces',
-    description:
-      "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
-    image: {
-      url: WorkspaceFeatureUpdateImg,
-      alt: 'Workspace Feature Update',
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'No more hangups',
+      description:
+        'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
+      image: {
+        url: PhoneFieldFeatureUpdateImg,
+        alt: 'Phone Field Feature Update',
+      },
     },
-  },
-  {
-    id: 10,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'UI Improvements',
-    description: `
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'Introducing Workspaces',
+      description:
+        "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
+      image: {
+        url: WorkspaceFeatureUpdateImg,
+        alt: 'Workspace Feature Update',
+      },
+    },
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'UI Improvements',
+      description: `
 * Cool new datepicker with day, month, and year views
 * Loading indicators for verified field OTPs
 * Consistent mobile field styling
     `,
-  },
-  {
-    id: 11,
-    date: new Date('17 June 2022 GMT+8'),
-    title: 'No more hangups',
-    description:
-      'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
-    image: {
-      url: PhoneFieldFeatureUpdateImg,
-      alt: 'Phone Field Feature Update',
     },
-  },
-  {
-    id: 12,
-    date: new Date('10 June 2022 GMT+8'),
-    title: 'Introducing Workspaces',
-    description:
-      "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
-    image: {
-      url: WorkspaceFeatureUpdateImg,
-      alt: 'Workspace Feature Update',
+    {
+      date: new Date('17 June 2022 GMT+8'),
+      title: 'No more hangups',
+      description:
+        'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
+      image: {
+        url: PhoneFieldFeatureUpdateImg,
+        alt: 'Phone Field Feature Update',
+      },
     },
-  },
-  {
-    id: 13,
-    date: new Date('10 June 2022 GMT+8'),
-    title: 'UI Improvements',
-    description: `
+    {
+      date: new Date('10 June 2022 GMT+8'),
+      title: 'Introducing Workspaces',
+      description:
+        "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
+      image: {
+        url: WorkspaceFeatureUpdateImg,
+        alt: 'Workspace Feature Update',
+      },
+    },
+    {
+      date: new Date('10 June 2022 GMT+8'),
+      title: 'UI Improvements',
+      description: `
 * Cool new datepicker with day, month, and year views
 * Loading indicators for verified field OTPs
 * Consistent mobile field styling
     `,
-  },
-  {
-    id: 14,
-    date: new Date('10 June 2022 GMT+8'),
-    title: 'No more hangups',
-    description:
-      'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
-    image: {
-      url: PhoneFieldFeatureUpdateImg,
-      alt: 'Phone Field Feature Update',
     },
-  },
-  {
-    id: 15,
-    date: new Date('10 June 2022 GMT+8'),
-    title: 'Introducing Workspaces',
-    description:
-      "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
-    image: {
-      url: WorkspaceFeatureUpdateImg,
-      alt: 'Workspace Feature Update',
+    {
+      date: new Date('10 June 2022 GMT+8'),
+      title: 'No more hangups',
+      description:
+        'With the new Phone Number field, you can quickly collect people’s digits. Local and international validation available.',
+      image: {
+        url: PhoneFieldFeatureUpdateImg,
+        alt: 'Phone Field Feature Update',
+      },
     },
-  },
-]
+    {
+      date: new Date('10 June 2022 GMT+8'),
+      title: 'Introducing Workspaces',
+      description:
+        "A workspace that's never messy. The first thing you see when you log into FormSG is your Workspace. This is where you store and organize all of your forms. Create multiple Workspaces and move your forms into them to stay organised.",
+      image: {
+        url: WorkspaceFeatureUpdateImg,
+        alt: 'Workspace Feature Update',
+      },
+    },
+  ],
+}

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Drawer,
   DrawerBody,
@@ -25,24 +25,15 @@ const EXTENDED_LIST_LINK_TEXT = 'Show less'
 const DEFAULT_FEATURE_UPDATE_COUNT = 10
 
 export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
-  const [numberOfFeatureUpdatesShown, setNumberOfFeatureUpdatesShown] =
-    useState<number>(DEFAULT_FEATURE_UPDATE_COUNT)
-  const [linkText, setLinkText] = useState<string>(UNEXTENDED_LIST_LINK_TEXT)
   const [isListExtended, setIsListExtended] = useState<boolean>(false)
 
-  const listOfFeatureUpdatesShown: FeatureUpdate[] = FEATURE_UPDATE_LIST.filter(
-    (featureUpdate) => featureUpdate.id <= numberOfFeatureUpdatesShown,
-  )
+  const listOfFeatureUpdatesShown: FeatureUpdate[] = useMemo(() => {
+    return isListExtended
+      ? FEATURE_UPDATE_LIST.features
+      : FEATURE_UPDATE_LIST.features.slice(0, DEFAULT_FEATURE_UPDATE_COUNT)
+  }, [isListExtended])
 
   const handleOnViewAllUpdatesClick = () => {
-    setNumberOfFeatureUpdatesShown(
-      isListExtended
-        ? DEFAULT_FEATURE_UPDATE_COUNT
-        : FEATURE_UPDATE_LIST.length,
-    )
-    setLinkText(
-      isListExtended ? UNEXTENDED_LIST_LINK_TEXT : EXTENDED_LIST_LINK_TEXT,
-    )
     setIsListExtended(!isListExtended)
   }
 
@@ -73,7 +64,9 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
             })}
           </Stack>
           <Link mt="2rem" mb="5.75rem" onClick={handleOnViewAllUpdatesClick}>
-            {linkText}
+            {isListExtended
+              ? UNEXTENDED_LIST_LINK_TEXT
+              : EXTENDED_LIST_LINK_TEXT}
           </Link>
         </DrawerBody>
       </DrawerContent>

--- a/frontend/src/features/whats-new/WhatsNewDrawer.tsx
+++ b/frontend/src/features/whats-new/WhatsNewDrawer.tsx
@@ -65,8 +65,8 @@ export const WhatsNewDrawer = ({ isOpen, onClose }: WhatsNewDrawerProps) => {
           </Stack>
           <Link mt="2rem" mb="5.75rem" onClick={handleOnViewAllUpdatesClick}>
             {isListExtended
-              ? UNEXTENDED_LIST_LINK_TEXT
-              : EXTENDED_LIST_LINK_TEXT}
+              ? EXTENDED_LIST_LINK_TEXT
+              : UNEXTENDED_LIST_LINK_TEXT}
           </Link>
         </DrawerBody>
       </DrawerContent>

--- a/frontend/src/features/whats-new/utils/utils.ts
+++ b/frontend/src/features/whats-new/utils/utils.ts
@@ -1,23 +1,13 @@
-import { compareDesc, isAfter } from 'date-fns'
-
-import { UserDto } from '~shared/types/user'
+import { UserDto } from '~shared/types'
 
 import { FEATURE_UPDATE_LIST } from '../FeatureUpdateList'
 
 export const getShowLatestFeatureUpdateNotification = (
   user: UserDto | undefined,
 ): boolean => {
-  if (!user?.flags?.lastSeenFeatureUpdateDate) {
+  if (user?.flags?.lastSeenFeatureUpdateVersion === undefined) {
     return true
   }
 
-  const latestFeatureUpdate = FEATURE_UPDATE_LIST.sort((a, b) =>
-    compareDesc(a.date, b.date),
-  ).shift()
-
-  if (!latestFeatureUpdate) {
-    return false
-  }
-
-  return isAfter(latestFeatureUpdate.date, user.flags.lastSeenFeatureUpdateDate)
+  return user.flags.lastSeenFeatureUpdateVersion < FEATURE_UPDATE_LIST.version
 }

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -12,17 +12,14 @@ import { chunk } from 'lodash'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
 
-import {
-  EMERGENCY_CONTACT_KEY_PREFIX,
-  ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
-} from '~constants/localStorage'
+import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import Pagination from '~components/Pagination'
 
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
-import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUserMutations } from '~features/user/mutations'
 import { useUser } from '~features/user/queries'
+import { FEATURE_UPDATE_LIST } from '~features/whats-new/FeatureUpdateList'
 import { getShowLatestFeatureUpdateNotification } from '~features/whats-new/utils/utils'
 import { WhatsNewDrawer } from '~features/whats-new/WhatsNewDrawer'
 
@@ -123,7 +120,7 @@ export const WorkspacePage = (): JSX.Element => {
     whatsNewFeatureDrawerDisclosure,
   } = useWorkspaceForms()
   const { user, isLoading: isUserLoading } = useUser()
-  const { updateUserLastSeenFeatureUpdateDateMutation } = useUserMutations()
+  const { updateLastSeenFeatureVersionMutation } = useUserMutations()
 
   const ROLLOUT_ANNOUNCEMENT_KEY = useMemo(
     () => ROLLOUT_ANNOUNCEMENT_KEY_PREFIX + user?._id,
@@ -137,34 +134,27 @@ export const WorkspacePage = (): JSX.Element => {
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const emergencyContactKey = useMemo(
-    () => (user?._id ? EMERGENCY_CONTACT_KEY_PREFIX + user._id : null),
-    [user],
-  )
-
-  const [hasSeenEmergencyContact, setHasSeenEmergencyContact] =
-    useLocalStorage<boolean>(emergencyContactKey)
-
-  const isEmergencyContactModalOpen = useMemo(
-    () =>
-      !isUserLoading &&
-      // Open emergency contact modal after the rollout announcement modal
-      Boolean(hasSeenAnnouncement) &&
-      !hasSeenEmergencyContact &&
-      !user?.contact,
-    [isUserLoading, hasSeenAnnouncement, hasSeenEmergencyContact, user],
-  )
-
   const shouldShowFeatureUpdateNotification = useMemo(() => {
     if (isUserLoading || !user) return false
     return getShowLatestFeatureUpdateNotification(user)
   }, [isUserLoading, user])
 
-  const onWhatsNewDrawerOpen = useCallback(() => {
+  const handleWhatsNewDrawerOpen = useCallback(() => {
     whatsNewFeatureDrawerDisclosure.onOpen()
-    updateUserLastSeenFeatureUpdateDateMutation.mutate()
+
+    // Update user last seen version if needed.
+    if (isUserLoading || !user) return
+    // Update version if current user version is not set or is less than the latest version.
+    if (
+      user.flags?.lastSeenFeatureUpdateVersion === undefined ||
+      user.flags?.lastSeenFeatureUpdateVersion < FEATURE_UPDATE_LIST.version
+    ) {
+      updateLastSeenFeatureVersionMutation.mutate(FEATURE_UPDATE_LIST.version)
+    }
   }, [
-    updateUserLastSeenFeatureUpdateDateMutation,
+    isUserLoading,
+    updateLastSeenFeatureVersionMutation,
+    user,
     whatsNewFeatureDrawerDisclosure,
   ])
 
@@ -206,7 +196,7 @@ export const WorkspacePage = (): JSX.Element => {
               isLoading={isLoading}
               totalFormCount={totalFormCount}
               handleOpenCreateFormModal={createFormModalDisclosure.onOpen}
-              handleOpenWhatsNewDrawer={onWhatsNewDrawerOpen}
+              handleOpenWhatsNewDrawer={handleWhatsNewDrawerOpen}
               isWhatsNewButtonSolid={shouldShowFeatureUpdateNotification}
             />
           </Container>

--- a/frontend/src/services/UserService.ts
+++ b/frontend/src/services/UserService.ts
@@ -32,9 +32,11 @@ export const verifyUserContactOtp = (
   ).then(({ data }) => data)
 }
 
-export const updateUserLastSeenFeatureUpdateDate =
-  async (): Promise<UserDto> => {
-    return ApiService.post<UserDto>(
-      `${USER_ENDPOINT}/flag/new-features-last-seen`,
-    ).then(({ data }) => data)
-  }
+export const updateUserLastSeenFeatureUpdateVersion = async (
+  version: number,
+): Promise<UserDto> => {
+  return ApiService.post<UserDto>(
+    `${USER_ENDPOINT}/flag/new-features-last-seen`,
+    { version },
+  ).then(({ data }) => data)
+}

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -17,7 +17,7 @@ export const UserBase = z.object({
     })
     .optional(),
   flags: z
-    .object({ lastSeenFeatureUpdateDate: z.date().optional() })
+    .object({ lastSeenFeatureUpdateVersion: z.number().optional() })
     .optional(),
   created: z.date(),
   lastAccessed: z.date().optional(),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -72,7 +72,7 @@ const compileUserModel = (db: Mongoose) => {
         sgid: Boolean,
       },
       flags: {
-        lastSeenFeatureUpdateDate: Date,
+        lastSeenFeatureUpdateVersion: Number,
       },
     },
     {

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -177,7 +177,7 @@ describe('user.controller', () => {
       agency: 'mockAgency',
       email: 'mockEmail',
       _id: VALID_SESSION_USER_ID,
-    } as IPopulatedUser
+    } as unknown as IPopulatedUser
 
     const MOCK_REQ = expressHandler.mockRequest({
       body: {
@@ -432,12 +432,16 @@ describe('user.controller', () => {
     })
   })
 
-  describe('handleUpdateUserLastSeenFeatureUpdateDate', () => {
+  describe('handleUpdateUserLastSeenFeatureUpdateVersion', () => {
+    const MOCK_UPDATE_VERSION = 10
     const MOCK_REQ = expressHandler.mockRequest({
       session: {
         user: {
           _id: VALID_SESSION_USER_ID,
         },
+      },
+      body: {
+        version: MOCK_UPDATE_VERSION,
       },
     })
 
@@ -451,12 +455,12 @@ describe('user.controller', () => {
       }
 
       // Mock all UserService calls to pass.
-      MockUserService.updateUserLastSeenFeatureUpdateDate.mockReturnValueOnce(
+      MockUserService.updateUserLastSeenFeatureUpdateVersion.mockReturnValueOnce(
         okAsync(mockPopulatedUser as IPopulatedUser),
       )
 
       // Act
-      await UserController.handleUpdateUserLastSeenFeatureUpdateDate(
+      await UserController._handleUpdateUserLastSeenFeatureUpdateVersion(
         MOCK_REQ,
         mockRes,
         jest.fn(),
@@ -465,8 +469,8 @@ describe('user.controller', () => {
       // Assert
       // Expect services to be called with correct arguments.
       expect(
-        MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id)
+        MockUserService.updateUserLastSeenFeatureUpdateVersion,
+      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_UPDATE_VERSION)
       expect(mockRes.status).toBeCalledWith(200)
       expect(mockRes.json).toBeCalledWith(mockPopulatedUser)
     })
@@ -475,18 +479,21 @@ describe('user.controller', () => {
       // Arrange
       const MOCK_REQ_WITH_NO_USER_ID_IN_SESSION = expressHandler.mockRequest({
         session: {},
+        body: {
+          version: MOCK_UPDATE_VERSION,
+        },
       })
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await UserController.handleUpdateUserLastSeenFeatureUpdateDate(
+      await UserController._handleUpdateUserLastSeenFeatureUpdateVersion(
         MOCK_REQ_WITH_NO_USER_ID_IN_SESSION,
         mockRes,
         jest.fn(),
       )
 
       expect(
-        MockUserService.updateUserLastSeenFeatureUpdateDate,
+        MockUserService.updateUserLastSeenFeatureUpdateVersion,
       ).not.toHaveBeenCalled()
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNAUTHORIZED)
       expect(mockRes.json).toBeCalledWith(UNAUTHORIZED_USER_MESSAGE)
@@ -498,20 +505,20 @@ describe('user.controller', () => {
       const expectedError = new MissingUserError('mock missing user error')
 
       // Mock all UserService calls to pass.
-      MockUserService.updateUserLastSeenFeatureUpdateDate.mockReturnValueOnce(
+      MockUserService.updateUserLastSeenFeatureUpdateVersion.mockReturnValueOnce(
         errAsync(expectedError),
       )
 
       // Act
-      await UserController.handleUpdateUserLastSeenFeatureUpdateDate(
+      await UserController._handleUpdateUserLastSeenFeatureUpdateVersion(
         MOCK_REQ,
         mockRes,
         jest.fn(),
       )
 
       expect(
-        MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id)
+        MockUserService.updateUserLastSeenFeatureUpdateVersion,
+      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_UPDATE_VERSION)
       expect(mockRes.status).toBeCalledWith(StatusCodes.UNPROCESSABLE_ENTITY)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })
@@ -522,20 +529,20 @@ describe('user.controller', () => {
       const expectedError = new DatabaseError('mock error')
 
       // Mock all UserService calls to pass.
-      MockUserService.updateUserLastSeenFeatureUpdateDate.mockReturnValueOnce(
+      MockUserService.updateUserLastSeenFeatureUpdateVersion.mockReturnValueOnce(
         errAsync(expectedError),
       )
 
       // Act
-      await UserController.handleUpdateUserLastSeenFeatureUpdateDate(
+      await UserController._handleUpdateUserLastSeenFeatureUpdateVersion(
         MOCK_REQ,
         mockRes,
         jest.fn(),
       )
 
       expect(
-        MockUserService.updateUserLastSeenFeatureUpdateDate,
-      ).toBeCalledWith(MOCK_REQ.session.user?._id)
+        MockUserService.updateUserLastSeenFeatureUpdateVersion,
+      ).toBeCalledWith(MOCK_REQ.session.user?._id, MOCK_UPDATE_VERSION)
       expect(mockRes.status).toBeCalledWith(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(mockRes.json).toBeCalledWith(expectedError.message)
     })

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -311,25 +311,29 @@ describe('user.service', () => {
     })
   })
 
-  describe('updateUserLastSeenFeatureUpdateDate', () => {
+  describe('updateUserLastSeenFeatureUpdateVersion', () => {
+    const MOCK_FEATURE_VERSION = 10
+
     it('should update user successfully', async () => {
       const user = await dbHandler.insertUser({
         agencyId: defaultAgency._id,
-        mailName: 'updateUserLastSeenFeatureUpdateDate',
+        mailName: 'updateUserLastSeenFeatureUpdateVersion',
       })
-      const MOCK_DATE = new Date()
 
-      expect(user.flags?.lastSeenFeatureUpdateDate).toBeUndefined()
+      expect(user.flags?.lastSeenFeatureUpdateVersion).toBeUndefined()
 
       const actualResult =
-        await UserService.updateUserLastSeenFeatureUpdateDate(user._id)
+        await UserService.updateUserLastSeenFeatureUpdateVersion(
+          user._id,
+          MOCK_FEATURE_VERSION,
+        )
 
       const updatedUser = await UserService.getPopulatedUserById(user._id)
       expect(actualResult.isOk()).toEqual(true)
       expect(
         updatedUser._unsafeUnwrap()?.toObject().flags
-          ?.lastSeenFeatureUpdateDate,
-      ).toEqual(MOCK_DATE)
+          ?.lastSeenFeatureUpdateVersion,
+      ).toEqual(MOCK_FEATURE_VERSION)
     })
 
     it('should return MissingUserError if userId is invalid', async () => {
@@ -338,7 +342,10 @@ describe('user.service', () => {
 
       // Act
       const actualResult =
-        await UserService.updateUserLastSeenFeatureUpdateDate(invalidUserId)
+        await UserService.updateUserLastSeenFeatureUpdateVersion(
+          invalidUserId,
+          MOCK_FEATURE_VERSION,
+        )
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(MissingUserError)
     })
@@ -360,13 +367,13 @@ describe('user.service', () => {
       expect(actualResult._unsafeUnwrap()?.toObject()).toEqual(expected)
     })
 
-    it('should return populated user with last seen feature update date successfully', async () => {
+    it('should return populated user with last seen feature update version successfully', async () => {
       const mockUserIdWithLastSeenFeatureUpdate = new ObjectID()
       const { agency, user } = await dbHandler.insertFormCollectionReqs({
         userId: mockUserIdWithLastSeenFeatureUpdate,
         mailName: 'userWithLastSeenFeatureUpdate',
         mailDomain: ALLOWED_DOMAIN,
-        flags: { lastSeenFeatureUpdateDate: MOCKED_DATE },
+        flags: { lastSeenFeatureUpdateVersion: 3 },
       })
 
       const defaultUserWithLastSeenFeatureUpdate: IUserSchema = user

--- a/src/app/modules/user/user.middleware.ts
+++ b/src/app/modules/user/user.middleware.ts
@@ -25,3 +25,9 @@ export const validateContactOtpVerificationParams = celebrate({
     contact: Joi.string().required(),
   }),
 })
+
+export const validateUpdateUserLastSeenFeatureUpdateVersion = celebrate({
+  [Segments.BODY]: Joi.object({
+    version: Joi.number().required(),
+  }),
+})

--- a/src/app/modules/user/user.service.ts
+++ b/src/app/modules/user/user.service.ts
@@ -170,10 +170,10 @@ export const updateUserContact = (
  * @returns err(MissingUserError) if user document cannot be found
  * @returns err(DatabaseError) if any error occurs whilst querying the database
  */
-export const updateUserLastSeenFeatureUpdateDate = (
+export const updateUserLastSeenFeatureUpdateVersion = (
   userId: IUserSchema['_id'],
+  version: number,
 ): ResultAsync<IPopulatedUser, MissingUserError | DatabaseError> => {
-  const currentDate = new Date()
   // Retrieve user from database and
   // update user's last seen feature update date attribute.
   return ResultAsync.fromPromise(
@@ -181,7 +181,7 @@ export const updateUserLastSeenFeatureUpdateDate = (
       userId,
       {
         $set: {
-          flags: { lastSeenFeatureUpdateDate: currentDate },
+          flags: { lastSeenFeatureUpdateVersion: version },
         },
       },
       { new: true },
@@ -194,8 +194,8 @@ export const updateUserLastSeenFeatureUpdateDate = (
     (error) => {
       logger.error({
         message:
-          'Database error when updating user last seen feature update date',
-        meta: { action: 'updateUserLastSeenFeatureUpdateDate', userId },
+          'Database error when updating user last seen feature update version',
+        meta: { action: 'updateUserLastSeenFeatureUpdateVersion', userId },
         error,
       })
 

--- a/src/app/routes/api/v3/user/user.routes.ts
+++ b/src/app/routes/api/v3/user/user.routes.ts
@@ -54,7 +54,7 @@ UserRouter.post('/contact/otp/verify', UserController.handleContactVerifyOtp)
  */
 UserRouter.post(
   '/flag/new-features-last-seen',
-  UserController.handleUpdateUserLastSeenFeatureUpdateDate,
+  UserController.handleUpdateUserLastSeenFeatureUpdateVersion,
 )
 
 export default UserRouter

--- a/tests/unit/backend/helpers/jest-db.ts
+++ b/tests/unit/backend/helpers/jest-db.ts
@@ -74,12 +74,12 @@ const insertAgency = async ({
   shortName?: string
 } = {}): Promise<AgencyDocument> => {
   const Agency = getAgencyModel(mongoose)
-  const agency = await Agency.create({
+  const agency = (await Agency.create({
     shortName,
     fullName: `Government Testing Agency (${shortName})`,
     emailDomain: [mailDomain],
     logo: `/invalid-path/test-${shortName}.jpg`,
-  })
+  })) as AgencyDocument
 
   return agency
 }
@@ -121,7 +121,7 @@ const insertFormCollectionReqs = async ({
   mailName?: string
   mailDomain?: string
   shortName?: string
-  flags?: { lastSeenFeatureUpdateDate: Date }
+  flags?: { lastSeenFeatureUpdateVersion: number }
 } = {}): Promise<{
   agency: AgencyDocument
   user: IUserSchema


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Date flag seemed a little too brittle and needed additional processing for the What's New feature. As discussed, we can probably add an identifier every time we update the hardcoded what's new object.

This PR updates the user's last seen feature flag to store the version instead of a Date.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - Change in User model flag to store last seen state to `flags.lastSeenFeatureUpdateVersion`
- [ ] No - this PR is backwards compatible  

**Features**:

- feat: update whats new API to use version flag instead of date flag
