### PR TITLE
fix(v2): re-enable backend tests

### DIFF
--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -1,9 +1,5 @@
 name: CI (React)
 
-defaults:
-  run:
-    working-directory: frontend
-
 on:
   push:
     branches:
@@ -55,4 +51,26 @@ jobs:
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
-      - run: npm test
+      - run: npm run test:frontend
+
+  test-backend:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run test:backend
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,8 @@ services:
       - SES_USER
       - OTP_LIFE_SPAN
       - AWS_REGION
+      # this needs to be replaced with the ID of a feedback form that you create
+      # in your local environment
       - REACT_TO_ANGULAR_FEEDBACK_FORM_ID=62da6a569ee8e90143b5da26
       - REACT_MIGRATION_ANGULAR_END_DATE=15 September 2022
       - REACT_MIGRATION_RESP_ROLLOUT_EMAIL=1

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -19,6 +19,7 @@ describe('helmetMiddlewares', () => {
   const cspCoreDirectives = {
     imgSrc: [
       "'self'",
+      'blob:',
       'data:',
       'https://www.googletagmanager.com/',
       'https://www.google-analytics.com/',
@@ -44,6 +45,7 @@ describe('helmetMiddlewares', () => {
       "'self'",
       'https://www.google-analytics.com/',
       'https://ssl.google-analytics.com/',
+      'https://*.browser-intake-datadoghq.com',
       'https://sentry.io/api/',
       config.aws.attachmentBucketUrl,
       config.aws.imageBucketUrl,
@@ -61,6 +63,10 @@ describe('helmetMiddlewares', () => {
       'https://www.gstatic.com/recaptcha/',
       'https://www.gstatic.cn/',
       "'unsafe-inline'",
+    ],
+    workerSrc: [
+      "'self'",
+      'blob:', // DataDog RUM session replay - https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
     ],
     frameAncestors: ['*'],
   }

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -275,7 +275,7 @@ describe('public-form.controller', () => {
   describe('handleRedirect', () => {
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_REQ = expressHandler.mockRequest({
-      params: { Id: MOCK_FORM_ID },
+      params: { formId: MOCK_FORM_ID },
       others: {
         protocol: 'https',
         hostname: 'mockHostName',

--- a/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.utils.spec.ts
@@ -14,7 +14,7 @@ describe('submission.utils', () => {
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert
-      expect(modeFilter.name).toEqual('emailModeFilter')
+      expect(modeFilter.name).toEqual('emailResponseModeFilter')
       // Should filter out image and statement fields in email mode.
       const typesToBeFiltered = [BasicField.Image, BasicField.Statement]
       typesToBeFiltered.forEach((fieldType) => {
@@ -35,7 +35,7 @@ describe('submission.utils', () => {
       const actual = modeFilter(ALL_FIELD_TYPES)
 
       // Assert
-      expect(modeFilter.name).toEqual('encryptModeFilter')
+      expect(modeFilter.name).toEqual('encryptResponseModeFilter')
       // Should only return verifiable fields.
       expect(actual).toEqual(
         expect.arrayContaining([

--- a/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
@@ -1,6 +1,8 @@
 import { ok } from 'neverthrow'
 import { mocked } from 'ts-jest/utils'
 
+import formsgSdk from 'src/app/config/formsg-sdk'
+
 import {
   BasicField,
   FormResponseMode,
@@ -27,18 +29,43 @@ import IncomingEncryptSubmission from '../IncomingEncryptSubmission.class'
 jest.mock('../../../../utils/encryption')
 const mockCheckIsEncryptedEncoding = mocked(checkIsEncryptedEncoding)
 
+type VerificationMock = {
+  authenticate: () => boolean
+}
+
 describe('IncomingEncryptSubmission', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(
+        formsgSdk.verification as unknown as VerificationMock,
+        'authenticate',
+      )
+      .mockImplementation(() => true)
+  })
   it('should create an incoming encrypt submission with valid form and responses', () => {
     mockCheckIsEncryptedEncoding.mockReturnValueOnce(ok(true))
-    const mobileField = generateDefaultField(BasicField.Mobile)
-    const emailField = generateDefaultField(BasicField.Email)
+    const mobileField = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
+    const emailField = generateDefaultField(BasicField.Email, {
+      isVerifiable: true,
+      autoReplyOptions: {
+        hasAutoReply: true,
+        autoReplySubject: 'subject',
+        autoReplySender: 'sender@test.gov.sg',
+        autoReplyMessage: 'message',
+        includeFormSummary: false,
+      },
+    })
     const mobileResponse = generateSingleAnswerResponse(
       mobileField,
       '+6587654321',
+      'signature',
     )
     const emailResponse = generateSingleAnswerResponse(
       emailField,
       'test@example.com',
+      'signature',
     )
     const responses = [mobileResponse, emailResponse]
     const initResult = IncomingEncryptSubmission.init(
@@ -54,11 +81,23 @@ describe('IncomingEncryptSubmission', () => {
 
   it('should fail when responses are missing', () => {
     mockCheckIsEncryptedEncoding.mockReturnValueOnce(ok(true))
-    const mobileField = generateDefaultField(BasicField.Mobile)
-    const emailField = generateDefaultField(BasicField.Email)
+    const mobileField = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
+    const emailField = generateDefaultField(BasicField.Email, {
+      isVerifiable: true,
+      autoReplyOptions: {
+        hasAutoReply: true,
+        autoReplySubject: 'subject',
+        autoReplySender: 'sender@test.gov.sg',
+        autoReplyMessage: 'message',
+        includeFormSummary: false,
+      },
+    })
     const mobileResponse = generateSingleAnswerResponse(
       mobileField,
       '+6587654321',
+      'signature',
     )
     const responses = [mobileResponse]
     const initResult = IncomingEncryptSubmission.init(
@@ -78,32 +117,35 @@ describe('IncomingEncryptSubmission', () => {
     mockCheckIsEncryptedEncoding.mockReturnValueOnce(ok(true))
     // Only check for mobile and email fields, since the other fields are
     // e2e encrypted from the browser.
-    const mobileField = generateDefaultField(BasicField.Mobile)
-    const emailField = generateDefaultField(BasicField.Email)
+    const mobileField = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
+    const emailField = generateDefaultField(BasicField.Email, {
+      isVerifiable: true,
+      autoReplyOptions: {
+        hasAutoReply: true,
+        autoReplySubject: 'subject',
+        autoReplySender: 'sender@test.gov.sg',
+        autoReplyMessage: 'message',
+        includeFormSummary: false,
+      },
+    })
     // Add answers to both mobile and email fields
-    const mobileResponse = generateSingleAnswerResponse(
-      mobileField,
-      '+6587654321',
-    )
-
-    const emailResponse = generateSingleAnswerResponse(
-      emailField,
-      'test@example.com',
-    )
-
     const mobileProcessedResponse = generateProcessedSingleAnswerResponse(
       mobileField,
       '+6587654321',
+      'signature',
     )
     mobileProcessedResponse.isVisible = false
 
     const emailProcessedResponse = generateProcessedSingleAnswerResponse(
       emailField,
       'test@example.com',
+      'signature',
     )
     emailProcessedResponse.isVisible = false
 
-    const responses = [mobileResponse, emailResponse]
+    const responses = [mobileProcessedResponse, emailProcessedResponse]
 
     const result = IncomingEncryptSubmission.init(
       {
@@ -122,7 +164,9 @@ describe('IncomingEncryptSubmission', () => {
     mockCheckIsEncryptedEncoding.mockReturnValueOnce(ok(true))
     // Only mobile and email fields are parsed, since the other fields are
     // e2e encrypted from the browser.
-    const mobileField = generateDefaultField(BasicField.Mobile)
+    const mobileField = generateDefaultField(BasicField.Mobile, {
+      isVerifiable: true,
+    })
     const mobileResponse = generateSingleAnswerResponse(mobileField, 'invalid')
 
     const result = IncomingEncryptSubmission.init(

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -51,18 +51,9 @@ const encryptFormFieldModeFilter = <T extends FormField>(
   responses: T[] = [],
 ) => {
   // To filter for autoreply-able fields.
-  return responses.filter((response) => {
-    if ([BasicField.Mobile, BasicField.Email].includes(response.fieldType))
-      return false
-    switch (response.fieldType) {
-      case BasicField.Mobile:
-        return response.isVerifiable
-      case BasicField.Email:
-        return response.autoReplyOptions.hasAutoReply || response.isVerifiable
-      default:
-        return false
-    }
-  })
+  return responses.filter((response) =>
+    [BasicField.Mobile, BasicField.Email].includes(response.fieldType),
+  )
 }
 
 // Exported for testing.

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -51,9 +51,16 @@ const encryptFormFieldModeFilter = <T extends FormField>(
   responses: T[] = [],
 ) => {
   // To filter for autoreply-able fields.
-  return responses.filter((response) =>
-    [BasicField.Mobile, BasicField.Email].includes(response.fieldType),
-  )
+  return responses.filter((response) => {
+    switch (response.fieldType) {
+      case BasicField.Mobile:
+        return response.isVerifiable
+      case BasicField.Email:
+        return response.autoReplyOptions.hasAutoReply || response.isVerifiable
+      default:
+        return false
+    }
+  })
 }
 
 // Exported for testing.

--- a/tests/.test-env
+++ b/tests/.test-env
@@ -89,5 +89,6 @@ AWS_ENDPOINT=http://localhost:4566
 APP_URL=http://localhost:5000
 
 SECRET_ENV=development
+REACT_TO_ANGULAR_FEEDBACK_FORM_ID=62da6a569ee8e90143b5da26
 
 INTRANET_IP_LIST_PATH=tests/mock-intranet-ips.txt

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -160,6 +160,7 @@ export const generateDefaultField = (
 export const generateProcessedSingleAnswerResponse = (
   field: FormFieldSchema,
   answer = 'answer',
+  signature?: string,
 ): ProcessedSingleAnswerResponse => {
   if (
     [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
@@ -176,12 +177,14 @@ export const generateProcessedSingleAnswerResponse = (
     answer,
     fieldType: field.fieldType,
     isVisible: true,
+    signature,
   } as ProcessedSingleAnswerResponse
 }
 
 export const generateSingleAnswerResponse = (
   field: FormFieldSchema,
   answer = field.fieldType === BasicField.Section ? '' : 'answer',
+  signature?: string,
 ): SingleAnswerFieldResponse => {
   if (
     [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
@@ -196,6 +199,7 @@ export const generateSingleAnswerResponse = (
     _id: field._id,
     answer,
     fieldType: field.fieldType,
+    signature,
   } as SingleAnswerFieldResponse
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Failing backend tests are escaping our notice

Closes #4581 

## Solution
<!-- How did you solve the problem? -->

- Reinstate backend tests in `ci-react`
- Fix failing tests - `helmet.spec.ts`, `public-form.controller.spec.ts` and `submission.utils.spec.ts`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:
- `submission.util.ts`: remove redundant false check for `encryptFormFieldModeFilter`


