### PR TITLE
fix(v2): remove accordion from end page to make response ID more discoverable

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -62,14 +62,12 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
           w="100%"
         >
           <EndPageBlock
-            formTitle={form?.title ?? 'Form Title'}
             endPage={endPage ?? { title: '', buttonText: '' }}
             submissionData={{
               id: form?._id ?? 'Submission ID',
               timeInEpochMs: Date.now(),
             }}
             colorTheme={colorTheme ?? FormColorTheme.Blue}
-            isExpandable={false}
           />
         </Box>
       </Stack>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -31,7 +31,6 @@ Default.args = {
     id: 'mockSubmissionId',
     timeInEpochMs: 1648545566989,
   },
-  formTitle: 'Test Form',
   handleSubmitFeedback: (inputs) => console.log(inputs),
 }
 

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
@@ -9,8 +9,6 @@ import { FeedbackBlock, FeedbackFormInput } from './components/FeedbackBlock'
 import { ThankYouSvgr } from './components/ThankYouSvgr'
 
 export interface FormEndPageProps {
-  /** Form title of submission for display */
-  formTitle: string
   endPage: FormDto['endPage']
   submissionData: SubmissionData
   handleSubmitFeedback: (inputs: FeedbackFormInput) => void

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -65,7 +65,6 @@ export const FormEndPageContainer = ({
       <FormEndPage
         colorTheme={form.startPage.colorTheme}
         submissionData={submissionData}
-        formTitle={form.title}
         endPage={form.endPage}
         isFeedbackSubmitted={isFeedbackSubmitted}
         handleSubmitFeedback={handleSubmitFeedback}

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -20,7 +20,7 @@ export const EndPageBlock = ({
   return (
     <Flex flexDir="column">
       <Stack spacing="1rem">
-        <Text as="h2" textStyle="h2">
+        <Text as="h2" textStyle="h2" textColor="secondary.700">
           {endPage.title}
         </Text>
         {endPage.paragraph ? (

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -1,16 +1,4 @@
-import { useMemo } from 'react'
-import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Box,
-  Flex,
-  Stack,
-  Text,
-} from '@chakra-ui/react'
-import { format } from 'date-fns'
+import { Box, Flex, Stack, Text } from '@chakra-ui/react'
 
 import { FormColorTheme, FormDto } from '~shared/types/form'
 
@@ -19,69 +7,33 @@ import Button from '~components/Button'
 import { SubmissionData } from '~features/public-form/PublicFormContext'
 
 export interface EndPageBlockProps {
-  /** Form title of submission for display */
-  formTitle: string
   endPage: FormDto['endPage']
   submissionData: SubmissionData
   colorTheme?: FormColorTheme
-  isExpandable?: boolean
 }
 
 export const EndPageBlock = ({
-  formTitle,
   endPage,
   submissionData,
   colorTheme = FormColorTheme.Blue,
-  isExpandable = true,
 }: EndPageBlockProps): JSX.Element => {
-  const prettifiedDateString = useMemo(() => {
-    return format(new Date(submissionData.timeInEpochMs), 'dd MMM yyyy, h:mm a')
-  }, [submissionData])
-
   return (
     <Flex flexDir="column">
-      <Accordion
-        {...(isExpandable ? { allowToggle: true } : { defaultIndex: [0] })}
-        m="-1rem"
-        flex={1}
-        variant="medium"
-      >
-        <AccordionItem color="secondary.500" border="none">
-          <AccordionButton>
-            <Stack
-              direction="row"
-              spacing="1rem"
-              textAlign="start"
-              justify="space-between"
-              flex={1}
-            >
-              <Stack spacing="1rem">
-                <Text as="h2" textStyle="h2">
-                  {endPage.title}
-                </Text>
-
-                {endPage.paragraph ? (
-                  <Text
-                    color="secondary.500"
-                    textStyle="subhead-1"
-                    whiteSpace="pre-line"
-                  >
-                    {endPage.paragraph}
-                  </Text>
-                ) : null}
-              </Stack>
-              <AccordionIcon />
-            </Stack>
-          </AccordionButton>
-          <AccordionPanel textStyle="body-1" color="secondary.400">
-            <Text textStyle="subhead-1" color="secondary.500">
-              {formTitle}
-            </Text>
-            <Text>{submissionData.id}</Text>
-            <Text>{prettifiedDateString}</Text>
-          </AccordionPanel>
-        </AccordionItem>
-      </Accordion>
+      <Stack spacing="1rem">
+        <Text as="h2" textStyle="h2">
+          {endPage.title}
+        </Text>
+        {endPage.paragraph ? (
+          <Text
+            color="secondary.500"
+            textStyle="subhead-1"
+            whiteSpace="pre-line"
+          >
+            {endPage.paragraph}
+          </Text>
+        ) : null}
+        <Text textColor="secondary.300">Response ID: {submissionData.id}</Text>
+      </Stack>
       <Box mt="2.25rem">
         <Button
           as="a"


### PR DESCRIPTION
## Problem
The response id is currently hidden under an accordion in the form end page. We want to make it more discoverable. 

Closes [#4593 ]

## Solution
Remove accordion from the end page as well as the information about form title and submission date and time. Also removed corresponding props from the end page type definitions.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/25571626/185025494-7634443f-ec58-466e-9f9c-a3051a979829.png">


<img width="1512" alt="image" src="https://user-images.githubusercontent.com/25571626/185025426-c38c8d8c-3d54-4ffd-a8e3-c4d3bcda94d7.png">