### PR TITLE
fix: return correct statuses on submission routes when sgid errors occur

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -51,6 +51,7 @@ import {
   MyInfoMissingAccessTokenError,
   MyInfoMissingHashError,
 } from '../../myinfo/myinfo.errors'
+import { SgidMissingJwtError } from '../../sgid/sgid.errors'
 import {
   InvalidJwtError,
   MissingJwtError,
@@ -420,6 +421,7 @@ export const mapRouteError: MapRouteError = (error) => {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: 'Captcha was missing. Please refresh and submit again.',
       }
+    case SgidMissingJwtError:
     case MissingJwtError:
     case VerifyJwtError:
     case InvalidJwtError:

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -51,7 +51,11 @@ import {
   MyInfoMissingAccessTokenError,
   MyInfoMissingHashError,
 } from '../../myinfo/myinfo.errors'
-import { SgidMissingJwtError } from '../../sgid/sgid.errors'
+import {
+  SgidInvalidJwtError,
+  SgidMissingJwtError,
+  SgidVerifyJwtError,
+} from '../../sgid/sgid.errors'
 import {
   InvalidJwtError,
   MissingJwtError,
@@ -422,6 +426,8 @@ export const mapRouteError: MapRouteError = (error) => {
         errorMessage: 'Captcha was missing. Please refresh and submit again.',
       }
     case SgidMissingJwtError:
+    case SgidVerifyJwtError:
+    case SgidInvalidJwtError:
     case MissingJwtError:
     case VerifyJwtError:
     case InvalidJwtError:

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.routes.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.routes.spec.ts
@@ -1,4 +1,5 @@
 import SPCPAuthClient from '@opengovsg/spcp-auth-client'
+import { err, ok } from 'neverthrow'
 import session, { Session } from 'supertest-session'
 import { mocked } from 'ts-jest/utils'
 
@@ -6,13 +7,21 @@ import { setupApp } from 'tests/integration/helpers/express-setup'
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
 import { FormAuthType, FormStatus } from '../../../../../../shared/types'
+import { SGID_COOKIE_NAME } from '../../../sgid/sgid.constants'
+import {
+  SgidInvalidJwtError,
+  SgidMissingJwtError,
+} from '../../../sgid/sgid.errors'
+import { SgidService } from '../../../sgid/sgid.service'
 import { SpOidcClient } from '../../../spcp/sp.oidc.client'
 import { EncryptSubmissionRouter } from '../encrypt-submission.routes'
 
 jest.mock('../../../spcp/sp.oidc.client')
+jest.mock('../../../sgid/sgid.service')
 
 jest.mock('@opengovsg/spcp-auth-client')
 const MockAuthClient = mocked(SPCPAuthClient, true)
+const MockSgidService = mocked(SgidService, true)
 
 const SUBMISSIONS_ENDPT_BASE = '/v2/submissions/encrypt'
 
@@ -185,7 +194,7 @@ describe('encrypt-submission.routes', () => {
     describe('CorpPass', () => {
       it('should return 200 when submission is valid', async () => {
         mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
-          cb(null, {
+          cb?.(null, {
             userName: 'S1234567A',
             userInfo: 'MyCorpPassUEN',
           }),
@@ -264,7 +273,9 @@ describe('encrypt-submission.routes', () => {
       it('should return 401 when submission has invalid JWT', async () => {
         // Mock auth client to return error when decoding JWT
         mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
-          cb(new Error()),
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          cb?.(new Error()),
         )
         const { form } = await dbHandler.insertEncryptForm({
           formOptions: {
@@ -292,7 +303,7 @@ describe('encrypt-submission.routes', () => {
       it('should return 401 when submission has JWT with the wrong shape', async () => {
         // Mock auth client to return wrong decoded JWT shape
         mockCpClient.verifyJWT.mockImplementationOnce((_jwt, cb) =>
-          cb(null, {
+          cb?.(null, {
             wrongKey: 'S1234567A',
           }),
         )
@@ -310,6 +321,157 @@ describe('encrypt-submission.routes', () => {
           .send(MOCK_SUBMISSION_BODY)
           .query({ captchaResponse: 'null' })
           .set('Cookie', ['jwtCp=mockJwt'])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+    })
+
+    describe('SGID', () => {
+      beforeEach(() => {
+        // Reset mocks
+        jest.resetAllMocks()
+      })
+      it('should return 200 when submission is valid', async () => {
+        MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+          ok({
+            userName: 'S1234567A',
+          }),
+        )
+        const { form } = await dbHandler.insertEncryptForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: FormAuthType.SGID,
+            hasCaptcha: false,
+            status: FormStatus.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .send(MOCK_SUBMISSION_BODY)
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [`${SGID_COOKIE_NAME}=mockJwt`])
+
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+          message: 'Form submission successful.',
+          submissionId: expect.any(String),
+        })
+      })
+
+      it('should return 401 when submission does not have JWT', async () => {
+        MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+          err(new SgidMissingJwtError()),
+        )
+        const { form } = await dbHandler.insertEncryptForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: FormAuthType.SGID,
+            hasCaptcha: false,
+            status: FormStatus.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .send(MOCK_SUBMISSION_BODY)
+          .query({ captchaResponse: 'null' })
+        // Note cookie is not set
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+        // Should be undefined, since there was no SGID cookie
+        expect(MockSgidService.extractSgidJwtPayload).toHaveBeenLastCalledWith(
+          undefined,
+        )
+      })
+
+      it('should return 401 when submission has the wrong JWT type', async () => {
+        MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+          err(new SgidMissingJwtError()),
+        )
+        const { form } = await dbHandler.insertEncryptForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: FormAuthType.SGID,
+            hasCaptcha: false,
+            status: FormStatus.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .send(MOCK_SUBMISSION_BODY)
+          .query({ captchaResponse: 'null' })
+          // Note cookie is for SingPass, not SGID
+          .set('Cookie', ['jwtSp=mockJwt'])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+        // Should be undefined, since there was no SGID cookie
+        expect(MockSgidService.extractSgidJwtPayload).toHaveBeenLastCalledWith(
+          undefined,
+        )
+      })
+
+      it('should return 401 when submission has invalid JWT', async () => {
+        MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+          err(new SgidInvalidJwtError()),
+        )
+        const { form } = await dbHandler.insertEncryptForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: FormAuthType.SGID,
+            hasCaptcha: false,
+            status: FormStatus.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .send(MOCK_SUBMISSION_BODY)
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [`${SGID_COOKIE_NAME}=mockJwt`])
+
+        expect(response.status).toBe(401)
+        expect(response.body).toEqual({
+          message:
+            'Something went wrong with your login. Please try logging in and submitting again.',
+          spcpSubmissionFailure: true,
+        })
+      })
+
+      it('should return 401 when submission has JWT with the wrong shape', async () => {
+        MockSgidService.extractSgidJwtPayload.mockReturnValueOnce(
+          err(new SgidInvalidJwtError()),
+        )
+        const { form } = await dbHandler.insertEncryptForm({
+          formOptions: {
+            esrvcId: 'mockEsrvcId',
+            authType: FormAuthType.SGID,
+            hasCaptcha: false,
+            status: FormStatus.Public,
+          },
+        })
+
+        const response = await request
+          .post(`${SUBMISSIONS_ENDPT_BASE}/${form._id}`)
+          .send(MOCK_SUBMISSION_BODY)
+          .query({ captchaResponse: 'null' })
+          .set('Cookie', [`${SGID_COOKIE_NAME}=mockJwt`])
 
         expect(response.status).toBe(401)
         expect(response.body).toEqual({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -247,7 +247,7 @@ const submitEncryptModeForm: ControllerHandler<
       break
     }
     case FormAuthType.SGID: {
-      const jwtPayloadResult = await SgidService.extractSgidJwtPayload(
+      const jwtPayloadResult = SgidService.extractSgidJwtPayload(
         req.cookies.jwtSgid,
       )
       if (jwtPayloadResult.isErr()) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -28,7 +28,11 @@ import {
   FormNotFoundError,
   PrivateFormError,
 } from '../../form/form.errors'
-import { SgidMissingJwtError } from '../../sgid/sgid.errors'
+import {
+  SgidInvalidJwtError,
+  SgidMissingJwtError,
+  SgidVerifyJwtError,
+} from '../../sgid/sgid.errors'
 import {
   CreateRedirectUrlError,
   FetchLoginPageError,
@@ -81,6 +85,8 @@ const errorMapper: MapRouteError = (
         errorMessage: 'Error while contacting SingPass. Please try again.',
       }
     case SgidMissingJwtError:
+    case SgidVerifyJwtError:
+    case SgidInvalidJwtError:
     case MissingJwtError:
     case VerifyJwtError:
     case InvalidJwtError:

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -28,6 +28,7 @@ import {
   FormNotFoundError,
   PrivateFormError,
 } from '../../form/form.errors'
+import { SgidMissingJwtError } from '../../sgid/sgid.errors'
 import {
   CreateRedirectUrlError,
   FetchLoginPageError,
@@ -79,6 +80,7 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.BAD_GATEWAY,
         errorMessage: 'Error while contacting SingPass. Please try again.',
       }
+    case SgidMissingJwtError:
     case MissingJwtError:
     case VerifyJwtError:
     case InvalidJwtError:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We are erroneously returning status `500`s due to default fallthrough due to unhandled SGID error mapping. This PR fixes that.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix: return correct statuses on submission routes when sgid errors occur

## Tests
<!-- What tests should be run to confirm functionality? -->
Add route-level tests to test for the returning of correct error codes
