### PR TITLE
fix(v2): bunch of fixes in admin builder styling

### DIFF
--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -86,10 +86,16 @@ export interface RadioProps
 
   /**
    * Function called when checked state of the input changes
-   * If provided, will be called with empty string when user attempts to
+   * If provided (and if @param allowDeselect is `true`), will be called with empty string when user attempts to
    * deselect the radio.
    */
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void
+
+  /**
+   * Whether the radio button can be deselected once radio group has a value.
+   * @default true
+   */
+  allowDeselect?: boolean
 }
 
 type RadioWithSubcomponentProps = ComponentWithAs<'input', RadioProps> & {
@@ -104,124 +110,126 @@ type RadioWithSubcomponentProps = ComponentWithAs<'input', RadioProps> & {
  *
  * @see Docs https://chakra-ui.com/radio
  */
-export const Radio = forwardRef<RadioProps, 'input'>((props, ref) => {
-  const { onChange: onChangeProp, value: valueProp } = props
+export const Radio = forwardRef<RadioProps, 'input'>(
+  ({ allowDeselect = true, ...props }, ref) => {
+    const { onChange: onChangeProp, value: valueProp } = props
 
-  const group = useRadioGroupContext()
-  const styles = useMultiStyleConfig(RADIO_THEME_KEY, { ...group, ...props })
+    const group = useRadioGroupContext()
+    const styles = useMultiStyleConfig(RADIO_THEME_KEY, { ...group, ...props })
 
-  const {
-    spacing = '0.5rem',
-    children,
-    isFullWidth,
-    ...rest
-  } = omitThemingProps(props)
+    const {
+      spacing = '0.5rem',
+      children,
+      isFullWidth,
+      ...rest
+    } = omitThemingProps(props)
 
-  let isChecked = props.isChecked
-  if (group?.value != null && valueProp != null) {
-    isChecked = group.value === valueProp
-  }
+    let isChecked = props.isChecked
+    if (group?.value != null && valueProp != null) {
+      isChecked = group.value === valueProp
+    }
 
-  let onChange = onChangeProp
-  if (group?.onChange && valueProp != null) {
-    onChange = callAll(group.onChange, onChangeProp)
-  }
+    let onChange = onChangeProp
+    if (group?.onChange && valueProp != null) {
+      onChange = callAll(group.onChange, onChangeProp)
+    }
 
-  const name = props?.name ?? group?.name
+    const name = props?.name ?? group?.name
 
-  const { getInputProps, getCheckboxProps, getLabelProps, htmlProps } =
-    useRadio({
-      ...rest,
-      isDisabled: props.isDisabled,
-      isChecked,
-      onChange,
-      name,
-    })
+    const { getInputProps, getCheckboxProps, getLabelProps, htmlProps } =
+      useRadio({
+        ...rest,
+        isDisabled: props.isDisabled,
+        isChecked,
+        onChange,
+        name,
+      })
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [layoutProps, otherProps] = split(htmlProps, layoutPropNames as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [layoutProps, otherProps] = split(htmlProps, layoutPropNames as any)
 
-  const checkboxProps = getCheckboxProps(otherProps)
-  const inputProps = getInputProps({}, ref)
+    const checkboxProps = getCheckboxProps(otherProps)
+    const inputProps = getInputProps({}, ref)
 
-  const handleSelect = useCallback(
-    (e: SyntheticEvent) => {
-      if (isChecked) {
-        e.preventDefault()
-        // Toggle off if onChange is given.
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        onChange?.({ target: { value: '' } })
-      }
-    },
-    [isChecked, onChange],
-  )
+    const handleSelect = useCallback(
+      (e: SyntheticEvent) => {
+        if (isChecked && allowDeselect) {
+          e.preventDefault()
+          // Toggle off if onChange is given.
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          onChange?.({ target: { value: '' } })
+        }
+      },
+      [allowDeselect, isChecked, onChange],
+    )
 
-  const handleSpacebar = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key !== ' ') return
-      if (isChecked) {
-        handleSelect(e)
-      }
-    },
-    [handleSelect, isChecked],
-  )
+    const handleSpacebar = useCallback(
+      (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key !== ' ') return
+        if (isChecked && allowDeselect) {
+          handleSelect(e)
+        }
+      },
+      [allowDeselect, handleSelect, isChecked],
+    )
 
-  // Update labelProps to include props to allow deselection of radio value if
-  // available
-  const labelProps = useMemo(() => {
-    return getLabelProps({
-      onClick: handleSelect,
-      onKeyDown: handleSpacebar,
-    })
-  }, [getLabelProps, handleSelect, handleSpacebar])
+    // Update labelProps to include props to allow deselection of radio value if
+    // available
+    const labelProps = useMemo(() => {
+      return getLabelProps({
+        onClick: handleSelect,
+        onKeyDown: handleSpacebar,
+      })
+    }, [getLabelProps, handleSelect, handleSpacebar])
 
-  const rootStyles = {
-    width: isFullWidth ? 'full' : undefined,
-    display: 'inline-flex',
-    alignItems: 'center',
-    verticalAlign: 'top',
-    ...styles.container,
-    ...props.__css,
-  }
+    const rootStyles = {
+      width: isFullWidth ? 'full' : undefined,
+      display: 'inline-flex',
+      alignItems: 'center',
+      verticalAlign: 'top',
+      ...styles.container,
+      ...props.__css,
+    }
 
-  const checkboxStyles = {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    ...styles.control,
-  }
+    const checkboxStyles = {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+      ...styles.control,
+    }
 
-  const labelStyles: SystemStyleObject = {
-    userSelect: 'none',
-    marginStart: spacing,
-    ...styles.label,
-  }
+    const labelStyles: SystemStyleObject = {
+      userSelect: 'none',
+      marginStart: spacing,
+      ...styles.label,
+    }
 
-  return (
-    <chakra.label
-      className="chakra-radio"
-      {...layoutProps}
-      // This is the adapted line of code which applies the internal label styles
-      // to the whole container
-      {...labelProps}
-      __css={rootStyles}
-    >
-      <input className="chakra-radio__input" {...inputProps} />
-      <chakra.span
-        className="chakra-radio__control"
-        {...checkboxProps}
-        __css={checkboxStyles}
-      />
-      {children && (
-        <chakra.span className="chakra-radio__label" __css={labelStyles}>
-          {children}
-        </chakra.span>
-      )}
-    </chakra.label>
-  )
-}) as RadioWithSubcomponentProps
+    return (
+      <chakra.label
+        className="chakra-radio"
+        {...layoutProps}
+        // This is the adapted line of code which applies the internal label styles
+        // to the whole container
+        {...labelProps}
+        __css={rootStyles}
+      >
+        <input className="chakra-radio__input" {...inputProps} />
+        <chakra.span
+          className="chakra-radio__control"
+          {...checkboxProps}
+          __css={checkboxStyles}
+        />
+        {children && (
+          <chakra.span className="chakra-radio__label" __css={labelStyles}>
+            {children}
+          </chakra.span>
+        )}
+      </chakra.label>
+    )
+  },
+) as RadioWithSubcomponentProps
 
 /**
  * Components to support the "Others" option.

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect } from 'react'
-import { Flex } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
+
+import InlineMessage from '~components/InlineMessage'
+
+import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 
 import { DndPlaceholderProps } from '../types'
 import {
@@ -19,6 +23,8 @@ interface BuilderAndDesignContentProps {
 export const BuilderAndDesignContent = ({
   placeholderProps,
 }: BuilderAndDesignContentProps): JSX.Element => {
+  const { data: settings } = useAdminFormSettings()
+
   const { stateData, setToInactive: setFieldsToInactive } =
     useFieldBuilderStore(
       useCallback(
@@ -34,19 +40,35 @@ export const BuilderAndDesignContent = ({
 
   return (
     <Flex flex={1} overflow="auto">
-      <EndPageView
-        display={
-          // Don't conditionally render EndPageView and FormBuilder because it
-          // is expensive and takes time.
-          stateData.state === FieldBuilderState.EditingEndPage ? 'flex' : 'none'
-        }
-      />
-      <FormBuilder
-        placeholderProps={placeholderProps}
-        display={
-          stateData.state === FieldBuilderState.EditingEndPage ? 'none' : 'flex'
-        }
-      />
+      <Box w="100%">
+        {settings?.webhook?.url ? (
+          <InlineMessage
+            mx={{ base: 0, md: '2rem' }}
+            mt={{ base: 0, md: '2rem' }}
+            mb={{ base: 0, md: '-1rem' }}
+          >
+            Webhooks are enabled on this form. Please ensure the webhook server
+            is able to handle any field changes.
+          </InlineMessage>
+        ) : null}
+        <EndPageView
+          display={
+            // Don't conditionally render EndPageView and FormBuilder because it
+            // is expensive and takes time.
+            stateData.state === FieldBuilderState.EditingEndPage
+              ? 'flex'
+              : 'none'
+          }
+        />
+        <FormBuilder
+          placeholderProps={placeholderProps}
+          display={
+            stateData.state === FieldBuilderState.EditingEndPage
+              ? 'none'
+              : 'flex'
+          }
+        />
+      </Box>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/EndPageView.tsx
@@ -45,7 +45,11 @@ export const EndPageView = ({ ...props }: FlexProps): JSX.Element => {
       mb={0}
       flex={1}
       bg="neutral.200"
-      p={{ base: 0, md: '2rem' }}
+      // Using margin for margin collapse when there are inline messages above.
+      mt={{ base: 0, md: '1rem' }}
+      pt={{ base: 0, md: '1rem' }}
+      pb={{ base: 0, md: '2rem' }}
+      px={{ base: 0, md: '2rem' }}
       justify="center"
       overflow="auto"
       {...props}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FormBuilder.tsx
@@ -3,9 +3,7 @@ import { Droppable } from 'react-beautiful-dnd'
 import { Box, Flex, FlexProps, Skeleton, Stack } from '@chakra-ui/react'
 
 import Button from '~components/Button'
-import InlineMessage from '~components/InlineMessage'
 
-import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 import { getVisibleFieldIds } from '~features/logic/utils'
 import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
 
@@ -35,7 +33,6 @@ export const FormBuilder = ({
   ...props
 }: FormBuilderProps): JSX.Element => {
   const { builderFields, isLoading } = useBuilderFields()
-  const { data: settings } = useAdminFormSettings()
   const { formLogics } = useAdminFormLogic()
   const { handleBuilderClick } = useCreatePageSidebar()
   const setEditEndPage = useFieldBuilderStore(setToEditEndPageSelector)
@@ -56,115 +53,99 @@ export const FormBuilder = ({
   const bg = useBgColor({ colorTheme: useDesignColorTheme() })
 
   return (
-    <Box w="100%">
-      {settings?.webhook?.url ? (
-        <InlineMessage
-          mx={{ base: 0, md: '2rem' }}
-          mt={{ base: 0, md: '2rem' }}
-          mb={{ base: 0, md: '-1rem' }}
-        >
-          Webhooks are enabled on this form. Please ensure the webhook server is
-          able to handle any field changes.
-        </InlineMessage>
-      ) : null}
-      <Flex
-        mb={0}
-        flex={1}
-        bg="neutral.200"
-        // Using margin for margin collapse when there are inline messages above.
-        mt={{ base: 0, md: '2rem' }}
-        pb={{ base: 0, md: '2rem' }}
-        px={{ base: 0, md: '2rem' }}
-        justify="center"
-        overflow="auto"
-        {...props}
+    <Flex
+      mb={0}
+      flex={1}
+      bg="neutral.200"
+      // Using margin for margin collapse when there are inline messages above.
+      mt={{ base: 0, md: '1rem' }}
+      pt={{ base: 0, md: '1rem' }}
+      pb={{ base: 0, md: '2rem' }}
+      px={{ base: 0, md: '2rem' }}
+      justify="center"
+      overflow="auto"
+      {...props}
+    >
+      <Stack
+        direction="column"
+        w="100%"
+        h="fit-content"
+        spacing={{ base: 0, md: '1.5rem' }}
+        bg={bg}
       >
-        <Stack
-          direction="column"
+        <StartPageView />
+        <Flex
+          flexDir="column"
+          alignSelf="center"
           w="100%"
-          h="fit-content"
-          spacing={{ base: 0, md: '1.5rem' }}
-          bg={bg}
+          px={{ base: 0, md: '1.5rem', lg: '2.5rem' }}
         >
-          <StartPageView />
-          <Flex
-            flexDir="column"
+          <Box
+            bg="white"
+            w="100%"
+            maxW="57rem"
             alignSelf="center"
-            w="100%"
-            px={{ base: 0, md: '1.5rem', lg: '2.5rem' }}
+            px={{ base: '1.5rem', md: '1.625rem' }}
+            py={{ base: '1.5rem', md: '2.5rem' }}
           >
-            <Box
-              bg="white"
-              w="100%"
-              maxW="57rem"
-              alignSelf="center"
-              px={{ base: '1.5rem', md: '1.625rem' }}
-              py={{ base: '1.5rem', md: '2.5rem' }}
-            >
-              {isLoading || !builderFields ? (
-                <FormBuilderFieldsSkeleton />
-              ) : (
-                <Droppable droppableId={FIELD_LIST_DROP_ID}>
-                  {(provided, snapshot) =>
-                    builderFields?.length ? (
-                      <Box
-                        pos="relative"
-                        ref={provided.innerRef}
-                        {...provided.droppableProps}
-                      >
-                        <BuilderFields
-                          fields={builderFields}
-                          visibleFieldIds={visibleFieldIds}
-                          isDraggingOver={snapshot.isDraggingOver}
-                        />
-                        {provided.placeholder}
-                        <BuilderAndDesignPlaceholder
-                          placeholderProps={placeholderProps}
-                          isDraggingOver={snapshot.isDraggingOver}
-                        />
-                      </Box>
-                    ) : (
-                      <EmptyFormPlaceholder
-                        ref={provided.innerRef}
-                        {...provided.droppableProps}
+            {isLoading || !builderFields ? (
+              <FormBuilderFieldsSkeleton />
+            ) : (
+              <Droppable droppableId={FIELD_LIST_DROP_ID}>
+                {(provided, snapshot) =>
+                  builderFields?.length ? (
+                    <Box
+                      pos="relative"
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                    >
+                      <BuilderFields
+                        fields={builderFields}
+                        visibleFieldIds={visibleFieldIds}
                         isDraggingOver={snapshot.isDraggingOver}
-                        onClick={handleBuilderClick}
                       />
-                    )
-                  }
-                </Droppable>
-              )}
-            </Box>
-          </Flex>
-          <Flex
-            justify="center"
-            w="100%"
-            pt={{ base: '1rem', md: 0 }}
-            px={{ base: '1rem', md: '1.5rem', lg: '2.5rem' }}
-          >
-            <Skeleton
-              isLoaded={!isLoading}
-              mb="1.5rem"
-              maxW="57rem"
+                      {provided.placeholder}
+                      <BuilderAndDesignPlaceholder
+                        placeholderProps={placeholderProps}
+                        isDraggingOver={snapshot.isDraggingOver}
+                      />
+                    </Box>
+                  ) : (
+                    <EmptyFormPlaceholder
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      isDraggingOver={snapshot.isDraggingOver}
+                      onClick={handleBuilderClick}
+                    />
+                  )
+                }
+              </Droppable>
+            )}
+          </Box>
+        </Flex>
+        <Flex
+          justify="center"
+          w="100%"
+          pt={{ base: '1rem', md: 0 }}
+          px={{ base: '1rem', md: '1.5rem', lg: '2.5rem' }}
+        >
+          <Skeleton isLoaded={!isLoading} mb="1.5rem" maxW="57rem" width="100%">
+            <Button
+              _hover={{ bg: 'primary.200' }}
+              py="1.5rem"
               width="100%"
+              variant="outline"
+              borderColor="secondary.200"
+              colorScheme="secondary"
+              height="auto"
+              onClick={handleEditEndPageClick}
+              textStyle="subhead-2"
             >
-              <Button
-                _hover={{ bg: 'primary.200' }}
-                py="1.5rem"
-                width="100%"
-                variant="outline"
-                borderColor="secondary.200"
-                colorScheme="secondary"
-                height="auto"
-                onClick={handleEditEndPageClick}
-                textStyle="subhead-2"
-              >
-                Customise Thank you page
-              </Button>
-            </Skeleton>
-          </Flex>
-        </Stack>
-      </Flex>
-    </Box>
+              Customise Thank you page
+            </Button>
+          </Skeleton>
+        </Flex>
+      </Stack>
+    </Flex>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BiCog } from 'react-icons/bi'
-import {
-  Box,
-  ButtonGroup,
-  Collapse,
-  Flex,
-  IconButton,
-  Skeleton,
-} from '@chakra-ui/react'
+import { Box, ButtonGroup, Collapse, Flex, IconButton } from '@chakra-ui/react'
 
 import { FormAuthType, FormLogoState, FormStartPage } from '~shared/types'
 
@@ -58,7 +51,6 @@ export const StartPageView = () => {
   )
 
   const [hoverStartPage, setHoverStartPage] = useState(false)
-  const [customLogoPending, setCustomLogoPending] = useState(false)
 
   // Transform the FormStartPageInput into a FormStartPage
   const startPageFromStore: FormStartPage | null = useMemo(() => {
@@ -67,14 +59,12 @@ export const StartPageView = () => {
     const estTimeTakenTransformed =
       estTimeTaken === '' ? undefined : estTimeTaken
     if (logo.state !== FormLogoState.Custom) {
-      setCustomLogoPending(false)
       return {
         logo: { state: logo.state },
         estTimeTaken: estTimeTakenTransformed,
         ...rest,
       }
     }
-    setCustomLogoPending(!startPageData?.attachment.srcUrl)
     return {
       logo: {
         state: FormLogoState.Custom,
@@ -92,7 +82,6 @@ export const StartPageView = () => {
   // to be previewed, so when the store is populated, prioritize that setting.
   const startPage = useMemo(() => {
     if (startPageFromStore) return startPageFromStore
-    setCustomLogoPending(false)
     return form?.startPage
   }, [form?.startPage, startPageFromStore])
 
@@ -157,21 +146,14 @@ export const StartPageView = () => {
         overflow="hidden"
         ref={headerRef}
       >
-        {customLogoPending ? (
-          // Show skeleton if user has chosen custom logo but not yet uploaded
-          <Flex justify="center" p="1rem" bg="white">
-            <Skeleton w="4rem" h="4rem" />
-          </Flex>
-        ) : (
-          <FormBannerLogo
-            logoImgSrc={
-              startPageData?.logo.state === FormLogoState.Custom
-                ? startPageData.attachment.srcUrl // manual override to preview custom logo
-                : logoImgSrc
-            }
-            {...formBannerLogoProps}
-          />
-        )}
+        <FormBannerLogo
+          logoImgSrc={
+            startPageData?.logo.state === FormLogoState.Custom
+              ? startPageData.attachment.srcUrl // manual override to preview custom logo
+              : logoImgSrc
+          }
+          {...formBannerLogoProps}
+        />
         <FormHeader
           title={form?.title}
           showHeader

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -134,6 +134,17 @@ export const StartPageView = () => {
     if (isMobile) handleDesignClick()
   }, [handleDesignClick, isMobile])
 
+  const headerWrapperEditProps = useMemo(() => {
+    switch (designState) {
+      case DesignState.EditingHeader:
+        return {
+          border: '2px solid var(--chakra-colors-primary-500)',
+          m: '-2px',
+          borderRadius: '4px',
+        }
+    }
+  }, [designState])
+
   return (
     <>
       <Box
@@ -141,14 +152,9 @@ export const StartPageView = () => {
         onPointerLeave={() => setHoverStartPage(false)}
         onClick={handleHeaderClick}
         role="button"
-        cursor={hoverStartPage ? 'pointer' : 'initial'}
-        {...(designState === DesignState.EditingHeader
-          ? { border: '2px solid var(--chakra-colors-primary-500)' }
-          : {
-              borderTop: '2px solid var(--chakra-colors-neutral-200)',
-              borderBottom: '2px solid transparent',
-            })}
-        borderRadius="4px"
+        cursor="pointer"
+        {...headerWrapperEditProps}
+        overflow="hidden"
         ref={headerRef}
       >
         {customLogoPending ? (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -255,34 +255,36 @@ export const DesignInput = (): JSX.Element | null => {
         <Radio.RadioGroup
           defaultValue={startPageData.colorTheme}
           isDisabled={startPageMutation.isLoading}
+          flexDirection="row"
+          display="inline-flex"
+          flexWrap="wrap"
+          maxW="100%"
         >
-          <Stack spacing="0" direction="row" display="inline">
-            {Object.values(FormColorTheme).map((color, idx) => (
-              <Radio
-                key={idx}
-                display="inline"
-                width="1rem"
-                value={color}
-                {...register('colorTheme')}
-                // CSS for inverted radio button
-                // TODO: anti-aliasing at interface of border and ::before?
-                border="2px solid"
-                borderRadius="50%"
-                borderColor="white"
-                background={getTitleBg(color)}
-                _checked={{ borderColor: getTitleBg(color) }}
-                _before={{
-                  content: '""',
-                  display: 'inline-block',
-                  width: '20px',
-                  height: '20px',
-                  border: '2px solid',
-                  borderColor: 'white',
-                  borderRadius: '50%',
-                }}
-              />
-            ))}
-          </Stack>
+          {Object.values(FormColorTheme).map((color, idx) => (
+            <Radio
+              key={idx}
+              flex={0}
+              allowDeselect={false}
+              value={color}
+              {...register('colorTheme')}
+              // CSS for inverted radio button
+              // TODO: anti-aliasing at interface of border and ::before?
+              border="2px solid"
+              borderRadius="50%"
+              borderColor="white"
+              background={getTitleBg(color)}
+              _checked={{ borderColor: getTitleBg(color) }}
+              _before={{
+                content: '""',
+                display: 'inline-block',
+                width: '20px',
+                height: '20px',
+                border: '2px solid',
+                borderColor: 'white',
+                borderRadius: '50%',
+              }}
+            />
+          ))}
         </Radio.RadioGroup>
         <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -14,7 +14,6 @@ import {
   Flex,
   FormControl,
   FormLabel,
-  Stack,
   Tabs,
   Text,
   Textarea,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -231,6 +231,7 @@ export const DesignInput = (): JSX.Element | null => {
             hidden={startPageData.logo.state !== FormLogoState.Custom}
             isInvalid={!isEmpty(errors.attachment)}
             ml="2.625rem"
+            mt="0.5rem"
             w="auto"
           >
             <Controller

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -196,6 +196,7 @@ export const DesignInput = (): JSX.Element | null => {
   return (
     <DrawerContentContainer>
       <FormControl
+        id="logo.state"
         isReadOnly={startPageMutation.isLoading}
         isInvalid={!isEmpty(errors.attachment)}
         onFocus={setToEditingHeader}
@@ -205,18 +206,34 @@ export const DesignInput = (): JSX.Element | null => {
           defaultValue={startPageData.logo.state}
           isDisabled={startPageMutation.isLoading}
         >
-          <Radio value={FormLogoState.Default} {...register('logo.state')}>
+          <Radio
+            allowDeselect={false}
+            value={FormLogoState.Default}
+            {...register('logo.state')}
+          >
             Default
           </Radio>
-          <Radio value={FormLogoState.None} {...register('logo.state')}>
+          <Radio
+            allowDeselect={false}
+            value={FormLogoState.None}
+            {...register('logo.state')}
+          >
             None
           </Radio>
-          <Radio value={FormLogoState.Custom} {...register('logo.state')}>
+          <Radio
+            allowDeselect={false}
+            value={FormLogoState.Custom}
+            {...register('logo.state')}
+          >
             Upload custom logo (jpg, png, or gif)
           </Radio>
-        </Radio.RadioGroup>
-        <Box ml="45px" mt="0.5rem">
-          <Box hidden={startPageData.logo.state !== FormLogoState.Custom}>
+          <FormControl
+            id="attachment"
+            hidden={startPageData.logo.state !== FormLogoState.Custom}
+            isInvalid={!isEmpty(errors.attachment)}
+            ml="2.625rem"
+            w="auto"
+          >
             <Controller
               name="attachment"
               control={control}
@@ -242,8 +259,8 @@ export const DesignInput = (): JSX.Element | null => {
             <FormErrorMessage>
               {get(errors, 'attachment.message')}
             </FormErrorMessage>
-          </Box>
-        </Box>
+          </FormControl>
+        </Radio.RadioGroup>
       </FormControl>
 
       <FormControl

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditEndPageDrawer/EditEndPage.tsx
@@ -99,24 +99,33 @@ export const EndPageBuilderInput = ({
   ])
 
   const handleUpdateEndPage = handleSubmit((endPage) =>
-    endPageMutation.mutate(endPage),
+    endPageMutation.mutate(endPage, { onSuccess: closeBuilderDrawer }),
   )
 
   return (
     <DrawerContentContainer>
       <Stack gap="2rem">
-        <FormControl isInvalid={!!errors.title}>
+        <FormControl
+          isReadOnly={endPageMutation.isLoading}
+          isInvalid={!!errors.title}
+        >
           <FormLabel isRequired>Title</FormLabel>
           <Input {...register('title', { required: REQUIRED_ERROR })} />
           <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
         </FormControl>
-        <FormControl isInvalid={!!errors.paragraph}>
+        <FormControl
+          isReadOnly={endPageMutation.isLoading}
+          isInvalid={!!errors.paragraph}
+        >
           <FormLabel isRequired>Follow-up instructions</FormLabel>
           <Textarea {...register('paragraph')} />
           <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>
         </FormControl>
         <Stack direction={['column', 'row']} gap={['2rem', '1rem']}>
-          <FormControl isInvalid={!!errors.buttonText}>
+          <FormControl
+            isReadOnly={endPageMutation.isLoading}
+            isInvalid={!!errors.buttonText}
+          >
             <FormLabel isRequired>Button text</FormLabel>
             <Input
               placeholder="Submit another form"
@@ -124,7 +133,10 @@ export const EndPageBuilderInput = ({
             />
             <FormErrorMessage>{errors.buttonText?.message}</FormErrorMessage>
           </FormControl>
-          <FormControl isInvalid={!!errors.buttonLink}>
+          <FormControl
+            isReadOnly={endPageMutation.isLoading}
+            isInvalid={!!errors.buttonLink}
+          >
             <FormLabel isRequired>Button redirect link</FormLabel>
             <Input
               placeholder="Default form link"
@@ -142,10 +154,8 @@ export const EndPageBuilderInput = ({
       >
         <Button
           isFullWidth={isMobile}
-          onClick={() => {
-            handleUpdateEndPage()
-            closeBuilderDrawer()
-          }}
+          onClick={handleUpdateEndPage}
+          isLoading={endPageMutation.isLoading}
         >
           Save field
         </Button>
@@ -153,6 +163,7 @@ export const EndPageBuilderInput = ({
           isFullWidth={isMobile}
           variant="clear"
           colorScheme="secondary"
+          isDisabled={endPageMutation.isLoading}
           onClick={closeBuilderDrawer}
         >
           Cancel

--- a/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormBannerLogo.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
-import { Flex, Image, Skeleton } from '@chakra-ui/react'
+import { useEffect, useMemo, useState } from 'react'
+import { BiImage } from 'react-icons/bi'
+import { Box, Flex, Icon, Image, Skeleton, Stack, Text } from '@chakra-ui/react'
 
 interface FormBannerLogoInputProps {
   hasLogo: boolean
@@ -7,28 +8,63 @@ interface FormBannerLogoInputProps {
   logoImgAlt?: string
 }
 
+export const InvalidLogo = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <Box bg="neutral.200" p="0.5rem">
+      <Stack spacing="1rem" justify="center" align="center">
+        <Icon as={BiImage} size="1.5rem" color="secondary.500" />
+        <Text
+          textStyle="caption-1"
+          color="secondary.400"
+          whiteSpace="pre-line"
+          textAlign="center"
+        >
+          {message}
+        </Text>
+      </Stack>
+    </Box>
+  )
+}
+
 export const FormBannerLogo = ({
   hasLogo,
   logoImgSrc,
   logoImgAlt,
 }: FormBannerLogoInputProps): JSX.Element | null => {
-  const [hasImageLoaded, setHasImageLoaded] = useState(false)
+  const [fallbackType, setFallbackType] = useState<
+    'loading' | 'error' | 'loaded'
+  >('loading')
+  // Reset fallback type to `loading` whenever src changes.
+  useEffect(() => {
+    if (logoImgSrc) {
+      setFallbackType('loading')
+    }
+  }, [logoImgSrc])
+
+  const fallback = useMemo(() => {
+    if (!logoImgSrc && fallbackType !== 'loading') {
+      return <InvalidLogo message="Image not provided" />
+    }
+    if (fallbackType === 'error') {
+      return <InvalidLogo message="Image not found" />
+    }
+    if (fallbackType !== 'loaded') {
+      return <Skeleton h="4rem" w="4rem" />
+    }
+  }, [fallbackType, logoImgSrc])
 
   if (!hasLogo) return null
 
   return (
     <Flex justify="center" p="1rem" bg="white">
-      <Skeleton isLoaded={hasImageLoaded}>
-        <Image
-          onLoad={() => setHasImageLoaded(true)}
-          ignoreFallback
-          src={logoImgSrc}
-          alt={logoImgAlt}
-          // Define minimum height and width of skeleton before image has loaded.
-          {...(hasImageLoaded ? {} : { h: '4rem', w: '4rem' })}
-          maxH="4rem"
-        />
-      </Skeleton>
+      <Image
+        fallback={fallback}
+        onLoad={() => setFallbackType('loaded')}
+        onError={() => setFallbackType('error')}
+        src={logoImgSrc}
+        alt={logoImgAlt}
+        maxH="4rem"
+      />
     </Flex>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR started off cleaning up webhook infomessage mislayout in admin form builder's edit endpage view. 
But found a bunch of places where things could be improved and made those fixes after all.


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat(Radio): add `allowDeselect` prop so users can set radio deselection
  - allows prevention of radio deselection in places where we do not need deselection (start page logo type, theme color, etc)

**Improvements**:

- feat: update focus styling when start page is being edited
- feat: update theme color radio styling to be more canonical
- feat(EditEndPage): add pending update handling
- feat: add image fallback handling for startpage


**Bug Fixes**:

- fix: move webhook info message to BuilderAndDesignContent for correct layout due to flex direction
- fix: prevent file selection window from opening on logo label click

## Before & After Screenshots
Should be updated
