### PR TITLE
feat(v2): load SwitchEnvModal conditionally

### DIFF
--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -52,7 +52,7 @@ export const SwitchEnvFeedbackModal = ({
   const [showThanksPage, setShowThanksPage] = useState<boolean>(false)
 
   // get the feedback form data
-  const { data: feedbackForm } = useSwitchEnvFeedbackFormView()
+  const { data: feedbackForm } = useSwitchEnvFeedbackFormView(isOpen)
 
   const {
     submitSwitchEnvFormFeedbackMutation,

--- a/frontend/src/features/env/queries.ts
+++ b/frontend/src/features/env/queries.ts
@@ -25,7 +25,9 @@ export const useSwitchEnvFeedbackFormView = (
   /** Extra override to determine whether query is enabled */
   enabled = true,
 ): UseQueryResult<PublicFormViewDto, ApiError> => {
-  return useQuery<PublicFormViewDto, ApiError>(envKeys.viewSwitchEnvForm, () =>
-    getSwitchEnvFormView(),
+  return useQuery<PublicFormViewDto, ApiError>(
+    envKeys.viewSwitchEnvForm,
+    () => getSwitchEnvFormView(),
+    { enabled },
   )
 }


### PR DESCRIPTION
this prevents react-query from needlessly querying the switch env form until it is needed
