### PR TITLE
chore: upgrade chromium

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,7 +17,7 @@ RUN apk update && apk upgrade && \
     # that is guaranteed to work. Upgrades must be done in lockstep.
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-    chromium=102.0.5005.167-r0 \
+    chromium=102.0.5005.173-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -26,7 +26,7 @@ COPY --from=node-modules-builder /opt/formsg /opt/formsg
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-    chromium=102.0.5005.167-r0 \
+    chromium=102.0.5005.173-r0 \
     nss \
     freetype \
     freetype-dev \


### PR DESCRIPTION
## Problem
The previous version of chromium was not being installed successfully (see [attempted deployment](https://github.com/opengovsg/FormSG/runs/7912837639?check_suite_focus=true))

## Solution
<!-- How did you solve the problem? -->
Update the chromium version to fix the docker build

Confirmed docker build is successful by releasing to staging

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
