### PR TITLE
feat(v2): add env var banners to admin and public form pages

### DIFF
--- a/frontend/src/components/Banner/Banner.tsx
+++ b/frontend/src/components/Banner/Banner.tsx
@@ -44,7 +44,7 @@ export const Banner = ({
   }, [showCloseButton, variant])
 
   return (
-    <Collapse in={isOpen} animateOpacity>
+    <Collapse style={{ overflow: 'visible' }} in={isOpen} animateOpacity>
       <Box __css={styles.banner}>
         <Flex sx={styles.item}>
           <Flex>

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -27,6 +27,7 @@ export const AdminFormLayout = (): JSX.Element => {
   const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
   const bannerContent = useMemo(
+    // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContent || adminBannerContent,
     [adminBannerContent, siteBannerContent],
   )

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -1,9 +1,14 @@
+import { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 import { get } from 'lodash'
 
+import { getBannerProps } from '~utils/getBannerProps'
+import { Banner } from '~components/Banner'
+
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
+import { useEnv } from '~features/env/queries'
 // TODO #4279: Remove after React rollout is complete
 import { SwitchEnvIcon } from '~features/env/SwitchEnvIcon'
 
@@ -19,6 +24,18 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+
+  const bannerContent = useMemo(
+    () => siteBannerContent || adminBannerContent,
+    [adminBannerContent, siteBannerContent],
+  )
+
+  const bannerProps = useMemo(
+    () => getBannerProps(bannerContent),
+    [bannerContent],
+  )
+
   const { error } = useAdminForm()
 
   if (get(error, 'code') === 404 || get(error, 'code') === 410) {
@@ -30,6 +47,9 @@ export const AdminFormLayout = (): JSX.Element => {
 
   return (
     <Flex flexDir="column" height="100vh" overflow="hidden" pos="relative">
+      {bannerProps ? (
+        <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+      ) : null}
       <AdminFormNavbar />
       <SwitchEnvIcon />
       <StorageResponsesProvider>

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -102,6 +102,7 @@ export const LoginPage = (): JSX.Element => {
   const { t } = useTranslation()
 
   const bannerContent = useMemo(
+    // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContent || isLoginBanner,
     [siteBannerContent, isLoginBanner],
   )

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as ReactLink } from 'react-router-dom'
 import { Box, chakra, Flex, GridItem, GridProps, Text } from '@chakra-ui/react'
@@ -9,7 +9,9 @@ import { ReactComponent as BrandLogoSvg } from '~assets/svgs/brand/brand-hort-co
 import { LOGGED_IN_KEY } from '~constants/localStorage'
 import { LANDING_ROUTE } from '~constants/routes'
 import { useLocalStorage } from '~hooks/useLocalStorage'
+import { getBannerProps } from '~utils/getBannerProps'
 import { sendLoginOtp, verifyLoginOtp } from '~services/AuthService'
+import { Banner } from '~components/Banner'
 import Link from '~components/Link'
 import { AppGrid } from '~templates/AppGrid'
 
@@ -17,6 +19,7 @@ import {
   trackAdminLogin,
   trackAdminLoginFailure,
 } from '~features/analytics/AnalyticsService'
+import { useEnv } from '~features/env/queries'
 
 import { LoginForm, LoginFormInputs } from './components/LoginForm'
 import { LoginImageSvgr } from './components/LoginImageSvgr'
@@ -93,9 +96,20 @@ const NonMobileSidebarGridArea: FC = ({ children }) => (
 )
 
 export const LoginPage = (): JSX.Element => {
+  const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
   const [, setIsAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
   const [email, setEmail] = useState<string>()
   const { t } = useTranslation()
+
+  const bannerContent = useMemo(
+    () => siteBannerContent || isLoginBanner,
+    [siteBannerContent, isLoginBanner],
+  )
+
+  const bannerProps = useMemo(
+    () => getBannerProps(bannerContent),
+    [bannerContent],
+  )
 
   const handleSendOtp = async ({ email }: LoginFormInputs) => {
     const trimmedEmail = email.trim()
@@ -132,6 +146,9 @@ export const LoginPage = (): JSX.Element => {
 
   return (
     <BackgroundBox>
+      {bannerProps ? (
+        <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+      ) : null}
       <BaseGridLayout flex={1}>
         <NonMobileSidebarGridArea>
           <LoginImageSvgr maxW="100%" aria-hidden />

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
+import { FormBanner } from './components/FormBanner'
 import FormEndPage from './components/FormEndPage'
 import FormFields from './components/FormFields'
 import { FormSectionsProvider } from './components/FormFields/FormSectionsContext'
@@ -18,6 +19,7 @@ export const PublicFormPage = (): JSX.Element => {
     <PublicFormProvider formId={formId}>
       <FormSectionsProvider>
         <Flex direction="column" minH="100vh">
+          <FormBanner />
           <FormStartPage />
           <PublicFormWrapper>
             <FormInstructions />

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -22,6 +22,7 @@ export const FormBanner = (): JSX.Element | null => {
   const { form } = usePublicFormContext()
 
   const bannerContent = useMemo(
+    // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () =>
       siteBannerContent ||
       isGeneralMaintenance ||

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+
+import { FormAuthType } from '~shared/types'
+
+import { getBannerProps } from '~utils/getBannerProps'
+import { Banner } from '~components/Banner'
+
+import { useEnv } from '~features/env/queries'
+
+import { usePublicFormContext } from '../PublicFormContext'
+
+export const FormBanner = (): JSX.Element | null => {
+  const {
+    data: {
+      siteBannerContent,
+      isGeneralMaintenance,
+      isSPMaintenance,
+      isCPMaintenance,
+      myInfoBannerContent,
+    } = {},
+  } = useEnv()
+  const { form } = usePublicFormContext()
+
+  const bannerContent = useMemo(
+    () =>
+      siteBannerContent ||
+      isGeneralMaintenance ||
+      (form?.authType === FormAuthType.SP && isSPMaintenance) ||
+      (form?.authType === FormAuthType.CP && isCPMaintenance) ||
+      (form?.authType === FormAuthType.MyInfo && myInfoBannerContent) ||
+      undefined,
+    [
+      form?.authType,
+      isCPMaintenance,
+      isGeneralMaintenance,
+      isSPMaintenance,
+      myInfoBannerContent,
+      siteBannerContent,
+    ],
+  )
+
+  const bannerProps = useMemo(
+    () => getBannerProps(bannerContent),
+    [bannerContent],
+  )
+
+  if (!bannerProps) return null
+
+  return <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+}

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -5,7 +5,10 @@ import { AdminNavBar } from '~/app/AdminNavBar'
 
 import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
+import { getBannerProps } from '~utils/getBannerProps'
+import { Banner } from '~components/Banner'
 
+import { useEnv } from '~features/env/queries'
 // TODO #4279: Remove after React rollout is complete
 import { SwitchEnvIcon } from '~features/env/SwitchEnvIcon'
 import { RolloutAnnouncementModal } from '~features/rollout-announcement/RolloutAnnouncementModal'
@@ -35,6 +38,18 @@ const useWorkspaceForms = () => {
 }
 
 export const WorkspacePage = (): JSX.Element => {
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+
+  const bannerContent = useMemo(
+    () => siteBannerContent || adminBannerContent,
+    [adminBannerContent, siteBannerContent],
+  )
+
+  const bannerProps = useMemo(
+    () => getBannerProps(bannerContent),
+    [bannerContent],
+  )
+
   const { isLoading, totalFormCount, sortedForms, createFormModalDisclosure } =
     useWorkspaceForms()
   const { user, isLoading: isUserLoading } = useUser()
@@ -58,6 +73,9 @@ export const WorkspacePage = (): JSX.Element => {
         onClose={createFormModalDisclosure.onClose}
       />
       <Flex direction="column" h="100vh">
+        {bannerProps ? (
+          <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+        ) : null}
         <AdminNavBar />
         <SwitchEnvIcon />
         {totalFormCount === 0 ? (

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -41,6 +41,7 @@ export const WorkspacePage = (): JSX.Element => {
   const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
   const bannerContent = useMemo(
+    // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContent || adminBannerContent,
     [adminBannerContent, siteBannerContent],
   )

--- a/frontend/src/utils/getBannerProps.ts
+++ b/frontend/src/utils/getBannerProps.ts
@@ -1,0 +1,32 @@
+import { BannerVariant } from '~theme/components/Banner'
+
+export type BannerProps = {
+  variant: BannerVariant
+  msg: string
+}
+
+export const getBannerProps = (bannerContent?: string): BannerProps | null => {
+  if (!bannerContent) return null
+  if (bannerContent.startsWith('info:')) {
+    return {
+      variant: 'info',
+      msg: bannerContent.slice(5),
+    }
+  }
+  if (bannerContent.startsWith('warn:')) {
+    return {
+      variant: 'warn',
+      msg: bannerContent.slice(5),
+    }
+  }
+  if (bannerContent.startsWith('error:')) {
+    return {
+      variant: 'error',
+      msg: bannerContent.slice(6),
+    }
+  }
+  return {
+    variant: 'info',
+    msg: bannerContent,
+  }
+}

--- a/frontend/src/utils/getBannerProps.ts
+++ b/frontend/src/utils/getBannerProps.ts
@@ -10,23 +10,23 @@ export const getBannerProps = (bannerContent?: string): BannerProps | null => {
   if (bannerContent.startsWith('info:')) {
     return {
       variant: 'info',
-      msg: bannerContent.slice(5),
+      msg: bannerContent.slice(5).trim(),
     }
   }
   if (bannerContent.startsWith('warn:')) {
     return {
       variant: 'warn',
-      msg: bannerContent.slice(5),
+      msg: bannerContent.slice(5).trim(),
     }
   }
   if (bannerContent.startsWith('error:')) {
     return {
       variant: 'error',
-      msg: bannerContent.slice(6),
+      msg: bannerContent.slice(6).trim(),
     }
   }
   return {
     variant: 'info',
-    msg: bannerContent,
+    msg: bannerContent.trim(),
   }
 }


### PR DESCRIPTION
## Problem
Currently we do not show banners for env vars according to our [banner specification](https://github.com/opengovsg/FormSG/blob/develop/docs/DEPLOYMENT_SETUP.md#banners) in the react app.

Closes #4550 

## Solution
Add env var banners using the `Banner` component. Replicates behavior of angular app.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/25571626/185839151-c87c4310-a6fb-4ef0-a2fb-af126af68212.png">
<img width="1513" alt="image" src="https://user-images.githubusercontent.com/25571626/186102289-f6bafd26-5e36-4a8e-ad3f-130e99ce4f73.png">
<img width="1513" alt="image" src="https://user-images.githubusercontent.com/25571626/186102229-02ac48ec-5717-4e0b-ad02-a99dff4512ee.png">
