### PR TITLE
chore: update docker tooling for local dev

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -44,8 +44,10 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # Chinese fonts
 RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
 
-COPY . ./
+COPY package*.json ./
 RUN npm install
+
+COPY . ./
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of
 
 ### Running Locally
 
-Run the following shell command to build the Docker image from scratch. This will usually take 10 or so minutes.
+Run the following shell command to build the Docker image from scratch. This will usually take 10 or so minutes. This command runs the backend services specified under [docker-compose.yml](docker-compose.yml) and the React frontend on the native host.
 
 ```bash
 npm run dev
@@ -82,6 +82,20 @@ docker-compose up
 
 which does **not** rebuild the Docker image from scratch. This command usually
 only takes ~15 seconds to finish starting up the image.
+
+### Adding dependencies
+
+Run `npm install` as per usual.
+
+For backend, run
+
+```
+docker-compose up --build --renew-anon-volumes
+```
+
+which will rebuild the backend Docker image and not reuse the existing node_modules volume.
+
+As frontend project is currently not using Docker, no other steps are required.
 
 ### Accessing email locally
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "copyfiles:backend": "copyfiles -e src/public/**/*.html -u 1 src/**/*.html dist/backend/src",
     "clean": "rimraf dist/",
     "start": "node -r dotenv/config src/app/server.js",
-    "dev": "concurrently -k -p \"[{name}]\" -n \"api,client\" -c  \"yellow.bold,green.bold\" \"docker-compose up --build\" \"npm run dev:frontend\"",
+    "dev": "concurrently -k -p \"[{name}]\" -n \"api,client\" -c  \"yellow.bold,green.bold\" \"docker-compose up\" \"npm run dev:frontend\"",
     "dev:backend": "npm run dev:angularjs & tsnd --poll --respawn --transpile-only --inspect=0.0.0.0 --exit-child -r dotenv/config -- src/app/server.ts",
     "dev:frontend": "npm run --prefix frontend start",
     "test": "npm run test:backend && npm run test:frontend",


### PR DESCRIPTION
## Changes

1. npm run dev no longer rebuilds images
Images shouldn't need to be rebuilt for every time for development. For first time run, docker compose will build the necessary images if they do not exist

2. Update development Dockerfile to copy only package.json files before npm run install.
Take advantage of docker cached layers as explained [here](http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/). If there are no dependency changes, docker will just used the cached layer from previous runs. Note that if you don't run docker compose with the --build flag, this change doesn't do much as npm install will not even be run.

3. Update documentation with info on how to add dependencies
docker compose up will not take into account dependency changes so, the node_modules volume needs to be updated.
--build will rebuild the backend image and run npm install, --renew-anon-volumes is also needed as docker will reuse the previous node_modules volume and dependencies will not get updated. This update should help with #3934
