### PR TITLE
feat(v2): add better error messages for submission and network errors 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "file-saver": "^2.0.5",
     "focus-visible": "^5.2.0",
     "framer-motion": "^5.4.5",
+    "http-status-codes": "^2.2.0",
     "i18next": "^21.6.16",
     "i18next-browser-languagedetector": "^6.1.4",
     "i18next-icu": "^2.0.3",

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -80,13 +80,18 @@ export function useCommonFormProvider(formId: string) {
     return differenceInMilliseconds(vfnTransaction.expireAt, Date.now())
   }, [vfnTransaction])
 
-  const showErrorToast = useCallback(() => {
-    toast({
-      status: 'danger',
-      description:
-        'An error occurred whilst processing your submission. Please refresh and try again.',
-    })
-  }, [toast])
+  const showErrorToast = useCallback(
+    (error) => {
+      toast({
+        status: 'danger',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'An error occurred whilst processing your submission. Please refresh and try again.',
+      })
+    },
+    [toast],
+  )
 
   return {
     isNotFormId,
@@ -212,7 +217,7 @@ export const PublicFormProvider = ({
           // Do nothing if recaptcha is closed.
           return
         }
-        return showErrorToast()
+        return showErrorToast(error)
       }
 
       switch (form.responseMode) {

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -63,7 +63,7 @@ export const usePublicFormMutations = (
   formId: string,
   submissionId: string,
 ) => {
-  const toast = useToast({ status: 'success', isClosable: true })
+  const toast = useToast({ isClosable: true })
 
   const submitEmailModeFormMutation = useMutation(
     (args: Omit<SubmitEmailFormArgs, 'formId'>) => {
@@ -82,10 +82,7 @@ export const usePublicFormMutations = (
       submitFormFeedback(formId, submissionId, args),
     {
       onError: (error: Error) => {
-        toast({
-          description: error.message,
-          status: 'danger',
-        })
+        toast({ status: 'danger', description: error.message })
       },
     },
   )

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -39,7 +39,7 @@ export const transformAxiosError = (e: Error): ApiError => {
       return new Error(
         'There was a problem with your internet connection. Please check your network and try again.',
       )
-    }
+    } else return e
   }
   return e
 }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -19,22 +19,27 @@ export class HttpError extends Error {
  * @returns HttpError if AxiosError, else original error
  */
 export const transformAxiosError = (e: Error): ApiError => {
-  if (axios.isAxiosError(e) && e.response) {
-    const statusCode = e.response.status
-    if (statusCode === 429) {
-      return new HttpError('Please try again later.', statusCode)
+  if (axios.isAxiosError(e)) {
+    if (e.response) {
+      const statusCode = e.response.status
+      if (statusCode === 429) {
+        return new HttpError('Please try again later.', statusCode)
+      }
+      if (typeof e.response.data === 'string') {
+        return new HttpError(e.response.data, statusCode)
+      }
+      if (e.response.data?.message) {
+        return new HttpError(e.response.data.message, statusCode)
+      }
+      if (e.response.statusText) {
+        return new HttpError(e.response.statusText, statusCode)
+      }
+      return new HttpError(`Http ${statusCode} error`, statusCode)
+    } else if (e.request) {
+      return new Error(
+        'There was a problem with your internet connection. Please check your network and try again.',
+      )
     }
-    if (typeof e.response.data === 'string') {
-      return new HttpError(e.response.data, statusCode)
-    }
-    if (e.response.data?.message) {
-      return new HttpError(e.response.data.message, statusCode)
-    }
-    if (e.response.statusText) {
-      return new HttpError(e.response.statusText, statusCode)
-    }
-
-    return new HttpError(`Http ${statusCode} error`, statusCode)
   }
   return e
 }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -40,7 +40,7 @@ export const transformAxiosError = (e: Error): ApiError => {
       return new Error(
         'There was a problem with your internet connection. Please check your network and try again.',
       )
-    } else return e
+    }
   }
   return e
 }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios'
+import { StatusCodes } from 'http-status-codes'
 
 import { ApiError } from '~typings/core'
 
@@ -22,7 +23,7 @@ export const transformAxiosError = (e: Error): ApiError => {
   if (axios.isAxiosError(e)) {
     if (e.response) {
       const statusCode = e.response.status
-      if (statusCode === 429) {
+      if (statusCode === StatusCodes.TOO_MANY_REQUESTS) {
         return new HttpError('Please try again later.', statusCode)
       }
       if (typeof e.response.data === 'string') {


### PR DESCRIPTION
## Problem
1. Currently, for submission errors we do not display the error message returned by the server, but a generic error message. Closes #4389 
2. Also, our offline error message just says "Network Error" which is not very informative. Closes #4316 

## Solution
1. Modify the submission handler to use the network error message if it exists, and fallback to the generic error message otherwise.
2. Add a network error check a la https://stackabuse.com/handling-errors-with-axios/#:~:text=in%20Node.js.-,Other,-Errors

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Screenshots

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/25571626/185824011-977a0f29-8700-4786-be50-39e5bba2ea39.png">
