### PR TITLE
chore: update readme for monterey

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ If you are on macOS Monetery or higher, port 5000 is now used by the system. Thi
   - `docker-compose.yml`
     - Introduce a new env var `PORT`
     - Update `APP_URL`
+  - `frontend/package.json`
+    - Update the proxy URL
 - [Disable control center](https://apple.stackexchange.com/a/431164)
 
 ### Running Locally

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Notable features include:
 - (Singapore government agencies only) Citizen authentication with [SingPass](https://www.singpass.gov.sg/singpass/common/aboutus)
 - (Singapore government agencies only) Corporate authentication with [CorpPass](https://www.corppass.gov.sg/corppass/common/aboutus)
 - (Singapore government agencies only) Automatic prefill of verified data with [MyInfo](https://www.singpass.gov.sg/myinfo/common/aboutus)
-- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK] (<https://github.com/opengovsg/formsg-ruby-sdk>)
+- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK](<https://github.com/opengovsg/formsg-ruby-sdk>)
 
 The current product roadmap includes:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ If you are on macOS Monetery or higher, port 5000 is now used by the system. Thi
 
 - Update the backend ports in these environment variables:
   - `Dockerfile.development`
+    - Update exposed port
   - `docker-compose.yml`
+    - Introduce a new env var `PORT`
+    - Update `APP_URL`
 - [Disable control center](https://apple.stackexchange.com/a/431164)
 
 ### Running Locally

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
   - [Features](#features)
   - [Local Development (Docker)](#local-development-docker)
     - [Prerequisites](#prerequisites)
+    - [First Setup](#first-setup)
     - [Running Locally](#running-locally)
+    - [Accessing email locally](#accessing-email-locally)
     - [Environment variables](#environment-variables)
     - [Trouble-shooting](#trouble-shooting)
   - [Testing](#testing)
@@ -20,9 +22,9 @@
       - [End-to-end tests](#end-to-end-tests)
   - [Architecture](#architecture)
   - [MongoDB Scripts](#mongodb-scripts)
-  - [Maintenance Banners](#maintenance-banners)
   - [Contributing](#contributing)
   - [Support](#support)
+  - [Acknowledgements](#acknowledgements)
 
 ## Features
 
@@ -37,7 +39,7 @@ Notable features include:
 - (Singapore government agencies only) Citizen authentication with [SingPass](https://www.singpass.gov.sg/singpass/common/aboutus)
 - (Singapore government agencies only) Corporate authentication with [CorpPass](https://www.corppass.gov.sg/corppass/common/aboutus)
 - (Singapore government agencies only) Automatic prefill of verified data with [MyInfo](https://www.singpass.gov.sg/myinfo/common/aboutus)
-- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK] (https://github.com/opengovsg/formsg-ruby-sdk)
+- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK] (<https://github.com/opengovsg/formsg-ruby-sdk>)
 
 The current product roadmap includes:
 
@@ -62,6 +64,13 @@ npm install
 ```
 
 If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of 4GB) by clicking on the Docker icon on the toolbar, clicking on the "Preferences" menu item, then clicking on the "Resources" link on the left.
+
+If you are on macOS Monetery or higher, port 5000 is now used by the system. This conflicts with the default port used by the backend. You could either:
+
+- Update the backend ports in these environment variables:
+  - `Dockerfile.development`
+  - `docker-compose.yml`
+- [Disable control center](https://apple.stackexchange.com/a/431164)
 
 ### Running Locally
 


### PR DESCRIPTION
## Problem

Port 5000 conflicts with macOS Monterey system ports but is not documented in setup guide.

## Solution

Document in README

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  