### PR TITLE
fix: set addMoreFields derived value so useEffect is stable

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -60,6 +60,7 @@ const transformTableFieldToEditForm = (
 
   return {
     ...pick(field, EDIT_TABLE_FIELD_KEYS),
+    addMoreRows: nextMaxRows !== '',
     maximumRows: nextMaxRows,
     minimumRows: nextMinRows,
   }


### PR DESCRIPTION
would throw a console error when any values for editing table fields are changed.
This commit correctly sets the initial value of the addMoreRows toggle when nextMaxRows is set

Error thrown: "The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant."
