### PR TITLE
fix: sgid eserviceid bug

### DIFF
--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -31,7 +31,10 @@ export const FormStatusToggle = (): JSX.Element => {
       // But only if form is not already public
       // (so admin can toggle to private mode when that happens somehow).
       status === FormStatus.Private &&
-      authType !== FormAuthType.NIL &&
+      authType &&
+      [FormAuthType.CP, FormAuthType.SP, FormAuthType.MyInfo].includes(
+        authType,
+      ) &&
       !esrvcId,
     [authType, esrvcId, status],
   )


### PR DESCRIPTION
## Problem
- Fixes bug where admins were required to provide an eservice id for sgid forms before activation
- Closes #4624
