### PR TITLE
feat(v2): download attachments as ZIP from individual response page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -6,6 +6,7 @@ import { BasicField } from '~shared/types'
 
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
+import Spinner from '~components/Spinner'
 
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
 
@@ -85,7 +86,13 @@ const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
             aria-label="Download file"
             isDisabled={downloadAttachmentMutation.isLoading}
             onClick={handleDownload}
-            rightIcon={<BiDownload fontSize="1.5rem" />}
+            rightIcon={
+              downloadAttachmentMutation.isLoading ? (
+                <Spinner fontSize="1.5rem" />
+              ) : (
+                <BiDownload fontSize="1.5rem" />
+              )
+            }
           >
             {row.answer}
           </Button>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -1,8 +1,6 @@
 import { memo, useCallback } from 'react'
 import { BiDownload } from 'react-icons/bi'
-import { useMutation } from 'react-query'
 import { Stack, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react'
-import FileSaver from 'file-saver'
 
 import { BasicField } from '~shared/types'
 
@@ -10,7 +8,8 @@ import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
 
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
-import { downloadAndDecryptAttachment } from '../ResponsesPage/storage/utils/downloadAndDecryptAttachment'
+
+import { useMutateDownloadAttachments } from './mutations'
 
 export interface DecryptedRowBaseProps {
   row: AugmentedDecryptedResponse
@@ -64,16 +63,16 @@ const DecryptedTableRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
 }
 
 const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
-  const handleDownloadMutation = useMutation(async (url: string) => {
-    const byteArray = await downloadAndDecryptAttachment(url, secretKey)
-    if (!byteArray) throw new Error('Invalid file')
-    return FileSaver.saveAs(new Blob([byteArray]), row.answer)
-  })
+  const { downloadAttachmentMutation } = useMutateDownloadAttachments()
 
   const handleDownload = useCallback(() => {
-    if (!row.downloadUrl) return
-    return handleDownloadMutation.mutate(row.downloadUrl)
-  }, [handleDownloadMutation, row.downloadUrl])
+    if (!row.downloadUrl || !row.answer) return
+    return downloadAttachmentMutation.mutate({
+      url: row.downloadUrl,
+      secretKey,
+      fileName: row.answer,
+    })
+  }, [downloadAttachmentMutation, row, secretKey])
 
   return (
     <Stack>
@@ -84,7 +83,7 @@ const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
           <Button
             variant="link"
             aria-label="Download file"
-            isDisabled={handleDownloadMutation.isLoading}
+            isDisabled={downloadAttachmentMutation.isLoading}
             onClick={handleDownload}
             rightIcon={<BiDownload fontSize="1.5rem" />}
           >

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -26,6 +26,7 @@ import simplur from 'simplur'
 
 import Button from '~components/Button'
 import IconButton from '~components/IconButton'
+import Spinner from '~components/Spinner'
 
 import {
   SecretKeyVerification,
@@ -240,7 +241,13 @@ export const IndividualResponsePage = (): JSX.Element => {
                   variant="link"
                   isDisabled={downloadAttachmentsAsZipMutation.isLoading}
                   onClick={handleDownload}
-                  rightIcon={<BiDownload fontSize="1.5rem" />}
+                  rightIcon={
+                    downloadAttachmentsAsZipMutation.isLoading ? (
+                      <Spinner fontSize="1.5rem" />
+                    ) : (
+                      <BiDownload fontSize="1.5rem" />
+                    )
+                  }
                 >
                   {simplur`Download ${attachmentDownloadUrls.size} attachment[|s] as .zip`}
                 </Button>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/mutations.ts
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/mutations.ts
@@ -1,0 +1,81 @@
+import { useCallback } from 'react'
+import { useMutation } from 'react-query'
+import FileSaver from 'file-saver'
+
+import { useToast } from '~hooks/useToast'
+
+import { AttachmentsDownloadMap } from '../ResponsesPage/storage/types'
+import {
+  downloadAndDecryptAttachment,
+  downloadAndDecryptAttachmentsAsZip,
+} from '../ResponsesPage/storage/utils/downloadAndDecryptAttachment'
+
+export const useMutateDownloadAttachments = () => {
+  const toast = useToast({ status: 'success', isClosable: true })
+
+  const handleError = useCallback(
+    (error: Error) => {
+      toast.closeAll()
+      toast({
+        description: error.message,
+        status: 'danger',
+      })
+    },
+    [toast],
+  )
+
+  const downloadAttachmentMutation = useMutation(
+    async ({
+      url,
+      secretKey,
+      fileName,
+    }: {
+      url: string
+      secretKey: string
+      fileName: string
+    }) => {
+      const byteArray = await downloadAndDecryptAttachment(url, secretKey)
+      if (!byteArray) throw new Error('Invalid file')
+      FileSaver.saveAs(new Blob([byteArray]), fileName)
+      return fileName
+    },
+    {
+      onSuccess: (fileName) => {
+        toast.closeAll()
+        toast({ description: `Sucessfully downloaded attachment ${fileName}` })
+      },
+      onError: handleError,
+    },
+  )
+
+  const downloadAttachmentsAsZipMutation = useMutation(
+    async ({
+      attachmentDownloadUrls,
+      secretKey,
+      fileName,
+    }: {
+      attachmentDownloadUrls: AttachmentsDownloadMap
+      secretKey: string
+      fileName: string
+    }) => {
+      const byteArray = await downloadAndDecryptAttachmentsAsZip(
+        attachmentDownloadUrls,
+        secretKey,
+      )
+      if (!byteArray) throw new Error('Invalid file')
+      FileSaver.saveAs(new Blob([byteArray]), fileName)
+      return attachmentDownloadUrls.size
+    },
+    {
+      onSuccess: (numAttachments) => {
+        toast.closeAll()
+        toast({
+          description: `Successfully downloaded ${numAttachments} attachments as .zip`,
+        })
+      },
+      onError: handleError,
+    },
+  )
+
+  return { downloadAttachmentMutation, downloadAttachmentsAsZipMutation }
+}


### PR DESCRIPTION
## Problem
Download all attachments as ZIP was a feature in Angular which we missed out in React.

Closes #4645 

## Solution
Add button in header to download the attachments as ZIP

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/25571626/186089385-27372459-485e-494f-a72c-c1f70e506e34.png">
