### PR TITLE
fix(v2): fix if/then show fields logic for number/decimal fields

### DIFF
--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -40,7 +40,8 @@ export const isConditionFulfilled = (
   if (
     currentValue === null ||
     currentValue === undefined ||
-    currentValue.toString().length === 0
+    // check if currentValue is empty for Decimal and Number fields
+    (typeof currentValue === 'string' && currentValue.length === 0)
   ) {
     return false
   }

--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -37,23 +37,19 @@ export const isConditionFulfilled = (
   if (!isLogicableField(args)) return false
 
   const currentValue = getCurrentFieldValue(args.input, args.fieldType)
-  if (currentValue === undefined) return false
+  if (
+    currentValue === null ||
+    currentValue === undefined ||
+    currentValue.toString().length === 0
+  ) {
+    return false
+  }
 
   switch (condition.state) {
     case LogicConditionState.Lte:
-      if (!currentValue)
-        // currentValue must be populated for the condition to be checked
-        return false
-      else {
-        return Number(currentValue) <= Number(condition.value)
-      }
+      return Number(currentValue) <= Number(condition.value)
     case LogicConditionState.Gte:
-      if (!currentValue)
-        // currentValue must be populated for the condition to be checked
-        return false
-      else {
-        return Number(currentValue) >= Number(condition.value)
-      }
+      return Number(currentValue) >= Number(condition.value)
     case LogicConditionState.Either: {
       // currentValue must be in a value in condition.value
       const condValuesArray = Array.isArray(condition.value)

--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -41,9 +41,19 @@ export const isConditionFulfilled = (
 
   switch (condition.state) {
     case LogicConditionState.Lte:
-      return Number(currentValue) <= Number(condition.value)
+      if (!currentValue)
+        // currentValue must be populated for the condition to be checked
+        return false
+      else {
+        return Number(currentValue) <= Number(condition.value)
+      }
     case LogicConditionState.Gte:
-      return Number(currentValue) >= Number(condition.value)
+      if (!currentValue)
+        // currentValue must be populated for the condition to be checked
+        return false
+      else {
+        return Number(currentValue) >= Number(condition.value)
+      }
     case LogicConditionState.Either: {
       // currentValue must be in a value in condition.value
       const condValuesArray = Array.isArray(condition.value)

--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -37,12 +37,7 @@ export const isConditionFulfilled = (
   if (!isLogicableField(args)) return false
 
   const currentValue = getCurrentFieldValue(args.input, args.fieldType)
-  if (
-    currentValue === null ||
-    currentValue === undefined ||
-    // check if currentValue is empty for Decimal and Number fields
-    (typeof currentValue === 'string' && currentValue.length === 0)
-  ) {
+  if (currentValue === '') {
     return false
   }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Hidden fields were showing even though the logic conditions were not being fulfilled

Closes #4617 

## Solution
<!-- How did you solve the problem? -->
`Number(currentValue)` returns 0 when `currentValue` is empty. Hence, the less than equals to logic condition was always returning `true`. To fix this, we do a check for `currentValue` first and return `false` if it's empty, before checking the logic condition.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**AFTER**:
<!-- [insert screenshot here] -->
![Recording 2022-08-23 at 17 01 35](https://user-images.githubusercontent.com/56983748/186117853-e9ccee8f-d74c-49ea-8839-9d93e477c269.gif)

