### PR TITLE
fix: reload form on logout

### DIFF
--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -45,10 +45,8 @@ export const usePublicAuthMutations = (formId: string) => {
       logoutPublicForm(authType),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(publicFormKeys.base)
-        toast({
-          description: 'Logged out successfully',
-        })
+        // Refresh browser to reset form state.
+        window.location.reload()
       },
     },
   )

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useMutation } from 'react-query'
 
 import { FormAuthType, SubmitFormFeedbackBodyDto } from '~shared/types/form'
 
@@ -14,11 +14,9 @@ import {
   SubmitStorageFormArgs,
   submitStorageModeForm,
 } from './PublicFormService'
-import { publicFormKeys } from './queries'
 
 export const usePublicAuthMutations = (formId: string) => {
   const { storePrefillQuery } = useStorePrefillQuery()
-  const queryClient = useQueryClient()
 
   const toast = useToast({ status: 'success', isClosable: true })
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR reloads the public form page when user logs out of public form authentication. 

The current double toast behaviour flagged in #4649 is due to the caching of the current public form (to prevent sudden changes to form viewed by the form filler when form is updated by the form admin), which results in the outdated toast being shown (since there was a `spcpSession` prop in the previous logged in state which is no longer present in the logged out state).

By reloading the page on logout, a fresh form is now loaded.

Closes #4649 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix: reload form on logout
