### PR TITLE
feat: remove default value on Mobile field admin form preview

### DIFF
--- a/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
@@ -41,7 +41,6 @@ export const MobileFieldInput = ({
       control={control}
       rules={validationRules}
       name={schema._id}
-      defaultValue={{ value: '' }}
       render={({ field: { onChange, value, ...field } }) => (
         <PhoneNumberInput
           autoComplete="tel"


### PR DESCRIPTION
does not seem compatible with `PhoneNumberInput`, will trigger validation immediately in admin form builder preview.


