### PR TITLE
fix(v2): make emergency contact modal phone number editable again

### DIFF
--- a/frontend/src/features/user/emergency-contact/components/ContactNumberInput.tsx
+++ b/frontend/src/features/user/emergency-contact/components/ContactNumberInput.tsx
@@ -34,11 +34,7 @@ const useContactNumberInput = () => {
     handleSubmit,
     reset,
     formState: { isValid, isSubmitting, errors },
-  } = useForm<ContactNumberFormInputs>({
-    defaultValues: {
-      contact: user?.contact,
-    },
-  })
+  } = useForm<ContactNumberFormInputs>()
 
   useEffect(() => {
     if (user) {
@@ -57,12 +53,15 @@ const useContactNumberInput = () => {
 
   const { generateOtpMutation } = useUserMutations()
 
-  const handleInputChange = (nextVal?: string) => {
-    setIsVfnBoxOpen(!!contactToVerify && nextVal === contactToVerify)
-    if (isSuccess) {
-      setIsSuccess(false)
-    }
-  }
+  const handleInputChange = useCallback(
+    (nextVal?: string) => {
+      setIsVfnBoxOpen(!!contactToVerify && nextVal === contactToVerify)
+      if (isSuccess) {
+        setIsSuccess(false)
+      }
+    },
+    [contactToVerify, isSuccess],
+  )
 
   const handleVfnSuccess = useCallback(() => {
     setIsSuccess(true)


### PR DESCRIPTION
## Problem
When the user has an existing emergency contact, the phone number in the emergency contact modal was not deletable.

Closes #4651 

## Solution
The cause of this is that when the control value was undefined, the Controller would default to switch the input value back to the default value and call onChange again. But actually, we should not be passing a default value in the first place because we have to wait till the user is retrieved to set the value (which the useEffect right below it does anyway).

Also, wrapped a function that wasn't in a useCallback in a useCallback. hehe

**Breaking Changes** 
- No - this PR is backwards compatible  
