### PR TITLE
fix(v2): add leading zero validation to decimal fields

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -219,6 +219,11 @@ export const createDecimalValidationRules: ValidationRuleFn<
         return 'Please enter a valid decimal'
       }
 
+      // Validate leading zeros
+      if (val.match(/^0[0-9].*$/)) {
+        return 'Please enter a valid decimal without leading zeros'
+      }
+
       if (!validateByValue) return true
 
       if (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -220,7 +220,7 @@ export const createDecimalValidationRules: ValidationRuleFn<
       }
 
       // Validate leading zeros
-      if (val.match(/^0[0-9].*$/)) {
+      if (/^0[0-9]/.test(val)) {
         return 'Please enter a valid decimal without leading zeros'
       }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Server validation will reject decimal fields with leading zeros. We should add client-side validation so users do not encounter cryptic submission errors.

**Test cases**
```ts
/^0[0-9]/.test('000') // true
/^0[0-9]/.test('00') // true
/^0[0-9]/.test('0') // false

/^0[0-9]/.test('001') // true
/^0[0-9]/.test('01') // true
/^0[0-9]/.test('1') // false

/^0[0-9]/.test('0010') // true
/^0[0-9]/.test('010') // true
/^0[0-9]/.test('10') // false

/^0[0-9]/.test('0.10') // false
/^0[0-9]/.test('0.010') // false
/^0[0-9]/.test('.10') // false
/^0[0-9]/.test('00.10') // true
```

Closes #4640

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Bug Fixes**:

- fix: add leading zero validation to decimal fields

## Before & After Screenshots
Should have no change
