### PR TITLE
feat(v2): prevent attachment field duplication if size limit exceeded, add toasts for duplication

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -18,6 +18,7 @@ import { FormColorTheme } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useToast } from '~hooks/useToast'
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 import {
@@ -56,6 +57,7 @@ import { useBuilderAndDesignContext } from '../../BuilderAndDesignContext'
 import { PENDING_CREATE_FIELD_ID } from '../../constants'
 import { useDeleteFormField } from '../../mutations/useDeleteFormField'
 import { useDuplicateFormField } from '../../mutations/useDuplicateFormField'
+import { useCreateTabForm } from '../../useCreateTabForm'
 import {
   DesignState,
   setStateSelector,
@@ -68,6 +70,7 @@ import {
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '../../useFieldBuilderStore'
+import { getAttachmentSizeLimit } from '../../utils/getAttachmentSizeLimit'
 import { useDesignColorTheme } from '../../utils/useDesignColorTheme'
 
 import { SectionFieldRow } from './SectionFieldRow'
@@ -86,6 +89,7 @@ export const FieldRowContainer = ({
   isDraggingOver,
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
+  const { data: form } = useCreateTabForm()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
   const { stateData, setToInactive, updateEditState } = useFieldBuilderStore(
     useCallback(
@@ -97,6 +101,8 @@ export const FieldRowContainer = ({
       [],
     ),
   )
+
+  const toast = useToast({ status: 'danger', isClosable: true })
 
   const setDesignState = useDesignStore(setStateSelector)
 
@@ -191,12 +197,31 @@ export const FieldRowContainer = ({
   }, [handleBuilderClick, isMobile])
 
   const handleDuplicateClick = useCallback(() => {
-    // Duplicate button should be hidden if field
-    // is not yet created, but guard here just in case
-    if (stateData.state !== FieldBuilderState.CreatingField) {
-      duplicateFieldMutation.mutate(field._id)
+    // Duplicate button should be hidden if field is not yet created, but guard here just in case
+    if (stateData.state === FieldBuilderState.CreatingField) return
+    // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
+    if (field.fieldType === BasicField.Attachment) {
+      if (!form) return
+      const existingAttachmentsSize = form.form_fields.reduce(
+        (sum, ff) =>
+          ff.fieldType === BasicField.Attachment
+            ? sum + Number(ff.attachmentSize)
+            : sum,
+        0,
+      )
+      const remainingAvailableSize =
+        getAttachmentSizeLimit(form.responseMode) - existingAttachmentsSize
+      const thisAttachmentSize = Number(field.attachmentSize)
+      if (thisAttachmentSize > remainingAvailableSize) {
+        toast({
+          useMarkdown: true,
+          description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${remainingAvailableSize} MB**.`,
+        })
+        return
+      }
     }
-  }, [stateData.state, duplicateFieldMutation, field._id])
+    duplicateFieldMutation.mutate(field._id)
+  }, [stateData.state, field, duplicateFieldMutation, form, toast])
 
   const handleDeleteClick = useCallback(() => {
     if (stateData.state === FieldBuilderState.CreatingField) {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -197,11 +197,11 @@ export const FieldRowContainer = ({
   }, [handleBuilderClick, isMobile])
 
   const handleDuplicateClick = useCallback(() => {
+    if (!form) return
     // Duplicate button should be hidden if field is not yet created, but guard here just in case
     if (stateData.state === FieldBuilderState.CreatingField) return
     // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
     if (field.fieldType === BasicField.Attachment) {
-      if (!form) return
       const existingAttachmentsSize = form.form_fields.reduce(
         (sum, ff) =>
           ff.fieldType === BasicField.Attachment

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -26,6 +26,7 @@ import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
 import { useCreateTabForm } from '~features/admin-form/create/builder-and-design/useCreateTabForm'
+import { getAttachmentSizeLimit } from '~features/admin-form/create/builder-and-design/utils/getAttachmentSizeLimit'
 
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
@@ -95,15 +96,10 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
       .reduce((sum, ff) => sum + Number(ff.attachmentSize), 0)
   }, [field._id, form?.form_fields])
 
-  const maxTotalSizeMb: number = useMemo(() => {
-    if (!form?.responseMode) return 0
-    switch (form.responseMode) {
-      case FormResponseMode.Email:
-        return Number(AttachmentSize.SevenMb)
-      case FormResponseMode.Encrypt:
-        return Number(AttachmentSize.TwentyMb)
-    }
-  }, [form?.responseMode])
+  const maxTotalSizeMb: number = useMemo(
+    () => getAttachmentSizeLimit(form?.responseMode),
+    [form?.responseMode],
+  )
 
   const attachmentSizeOptions: ComboboxItem[] = useMemo(() => {
     if (!form) return []

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useCreateFormField.ts
@@ -47,7 +47,7 @@ export const useCreateFormField = () => {
         return
       }
       toast({
-        description: `Field "${newField.title}" created`,
+        description: `The field "${newField.title}" was created.`,
       })
       queryClient.setQueryData<AdminFormDto>(adminFormKey, (oldForm) => {
         // Should not happen, should not be able to update field if there is no

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
@@ -45,7 +45,7 @@ export const useDeleteFormField = () => {
       return
     }
     toast({
-      description: `Field "${stateData.field.title}" deleted`,
+      description: `The field "${stateData.field.title}" was deleted.`,
     })
     queryClient.setQueryData<AdminFormDto>(adminFormKey, (oldForm) => {
       // Should not happen, should not be able to update field if there is no

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
@@ -38,7 +38,7 @@ export const useEditFormField = () => {
         return
       }
       toast({
-        description: `Field "${newField.title}" updated`,
+        description: `The field "${newField.title}" was updated.`,
       })
       queryClient.setQueryData<AdminFormDto>(adminFormKey, (oldForm) => {
         // Should not happen, should not be able to update field if there is no

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/getAttachmentSizeLimit.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/getAttachmentSizeLimit.ts
@@ -1,0 +1,15 @@
+import { AttachmentSize, FormResponseMode } from '~shared/types'
+
+export const getAttachmentSizeLimit = (
+  responseMode?: FormResponseMode,
+): number => {
+  if (!responseMode) return 0
+  switch (responseMode) {
+    case FormResponseMode.Email:
+      return Number(AttachmentSize.SevenMb)
+    case FormResponseMode.Encrypt:
+      return Number(AttachmentSize.TwentyMb)
+    default:
+      return 0
+  }
+}

--- a/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
+++ b/frontend/src/features/admin-form/create/logic/hooks/useAdminFormLogic.ts
@@ -23,6 +23,18 @@ export const useAdminFormLogic = () => {
     return pickBy(mapIdToField, (f) => ALLOWED_LOGIC_FIELDS.has(f.fieldType))
   }, [mapIdToField])
 
+  const logicedFieldIdsSet = useMemo(
+    () =>
+      form?.form_logics.reduce((set, logic) => {
+        logic.conditions.map((cond) => cond.field).forEach((id) => set.add(id))
+        if (logic.logicType === LogicType.ShowFields) {
+          logic.show.forEach((id) => set.add(id))
+        }
+        return set
+      }, new Set()),
+    [form?.form_logics],
+  )
+
   const hasError = useMemo(() => {
     if (!mapIdToField || !form?.form_logics) return false
     return form.form_logics.some(
@@ -41,8 +53,9 @@ export const useAdminFormLogic = () => {
     isLoading,
     formLogics: form?.form_logics,
     formFields: form?.form_fields,
-    logicableFields,
     mapIdToField,
+    logicableFields,
+    logicedFieldIdsSet,
     hasError,
   }
 }


### PR DESCRIPTION
## Problem
Attachment fields can be duplicated even if the size limit ends up being exceeded which is a bug. In Angular, a modal pops up showing that the attachment can't be duplicated.

Simultaneously, found a difference between angular and react in that we don't notify users when logiced fields are duplicated. Added as part of the toast, as agreed on slack.

Closes #4648 

## Solution
1. Improve language of all the field update toasts.
2. Prevent attachment dupe:
a. In field row container, add check prior to dupe.
b. Factor out function getting max attachment size.
3. Add `logicedFieldIdsSet` to admin form logic, and access it in order to determine whether to show logic sentence in dupe toast.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/186885100-d0890702-3ee8-40a5-a35e-061d84dc74fd.mov

