### PR TITLE
fix(form-v2): add prop to disable date select

### DIFF
--- a/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
+++ b/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
@@ -189,6 +189,7 @@ export const BillCharges = ({
                 name={'selectDate'}
                 items={selectDateDropdownItems}
                 isClearable={false}
+                isDisabled={isLoadingOrRefetching}
               />
             </Box>
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #4650 

## Solution
<!-- How did you solve the problem? -->
add prop to disable select

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<details>
<summary> before</summary>



https://user-images.githubusercontent.com/102740235/187064068-a9d29805-afc7-4575-8e1f-be0a6e430b96.mp4
</details>

**AFTER**:
<details>
<summary> after </summary>

https://user-images.githubusercontent.com/102740235/187064002-da2d06be-36d2-4d4c-b52a-78509b10e1f5.mp4
</details>

