### PR TITLE
feat(v2): add question titles to delete field modal, conditionally render message based on logic

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
@@ -1,18 +1,23 @@
 import { useCallback, useMemo } from 'react'
 import {
   ButtonGroup,
+  Icon,
+  ListItem,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
+  UnorderedList,
 } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 
 import { BASICFIELD_TO_DRAWER_META } from '../../constants'
+import { useAdminFormLogic } from '../../logic/hooks/useAdminFormLogic'
 import { useBuilderAndDesignContext } from '../BuilderAndDesignContext'
 import { useDeleteFormField } from '../mutations/useDeleteFormField'
 import {
@@ -26,13 +31,19 @@ export const DeleteFieldModal = (): JSX.Element => {
   const {
     deleteFieldModalDisclosure: { isOpen, onClose },
   } = useBuilderAndDesignContext()
+  const { mapIdToField, logicedFieldIdsSet } = useAdminFormLogic()
 
-  const fieldTypeLabel = useMemo(() => {
-    if (stateData.state === FieldBuilderState.EditingField) {
-      return BASICFIELD_TO_DRAWER_META[stateData.field.fieldType].label
-    }
-    return null
-  }, [stateData])
+  const { fieldIsInLogic, fieldIcon, fieldTitleWithQuestionNumber } =
+    useMemo(() => {
+      if (stateData.state !== FieldBuilderState.EditingField) return {}
+      const questionNumber = mapIdToField?.[stateData.field._id].questionNumber
+      const fieldTitle = stateData.field.title
+      return {
+        fieldIsInLogic: logicedFieldIdsSet?.has(stateData.field._id),
+        fieldIcon: BASICFIELD_TO_DRAWER_META[stateData.field.fieldType].icon,
+        fieldTitleWithQuestionNumber: `${questionNumber}. ${fieldTitle}`,
+      }
+    }, [mapIdToField, stateData, logicedFieldIdsSet])
 
   const { deleteFieldMutation } = useDeleteFormField()
 
@@ -49,10 +60,33 @@ export const DeleteFieldModal = (): JSX.Element => {
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />
-        <ModalHeader>Delete {fieldTypeLabel} field</ModalHeader>
+        <ModalHeader>Delete field</ModalHeader>
         <ModalBody>
-          This field will be deleted permanently. Are you sure you want to
-          proceed?
+          <Text color="secondary.500">
+            {fieldIsInLogic
+              ? `This field is used in your form logic, so deleting it may cause
+                your logic to stop working correctly. Are you sure you want to 
+                delete this field?`
+              : `Are you sure you want to delete this field? This action
+                cannot be undone.`}
+          </Text>
+          <UnorderedList
+            spacing="0.5rem"
+            listStyleType="none"
+            ml="1.75rem"
+            mt="1rem"
+          >
+            <ListItem display="flex" alignItems="flex-start">
+              <Icon
+                as={fieldIcon}
+                fontSize="1.25rem"
+                h="1.5rem"
+                ml="-1.75rem"
+                mr="0.5rem"
+              />
+              {fieldTitleWithQuestionNumber}
+            </ListItem>
+          </UnorderedList>
         </ModalBody>
         <ModalFooter>
           <ButtonGroup>


### PR DESCRIPTION
## Problem
Currently the delete field modal doesn't match the delete modal format.

Closes #4644 

## Solution
Use `logicedFieldIdsSet` from admin logic to determine if the field is in logic. Also access the question numbers and titles from `useAdminFormLogic`.

_As a side note, actually `mapIdToFields` should be in `useCreateTabForm`, not `useAdminFormLogic` right..._

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

Nonlogiced field
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/25571626/187151553-2b1c6875-714f-4ada-8b9d-88b342dbfd21.png">

Logiced field
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/25571626/187151631-3252ba2f-1ed8-4ffb-94a6-acb2cb308c9b.png">
