### PR TITLE
feat: remove special touch handling on Tooltip component

### DIFF
--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -7,13 +7,13 @@ import {
   Icon,
   Text,
   TextProps,
-  Tooltip,
   useFormControlContext,
   VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import { useMdComponents } from '~hooks/useMdComponents'
+import Tooltip from '~components/Tooltip'
 
 export interface FormLabelProps extends ChakraFormLabelProps {
   /**

--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { Flex, Icon, Placement, TooltipProps, VStack } from '@chakra-ui/react'
+import { Box, Icon, Placement, TooltipProps, VStack } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
 import { BxsHelpCircle } from '~/assets/icons/BxsHelpCircle'
@@ -20,16 +20,22 @@ const TooltipStack = (
     // bottom margin just so that story snapshot does not get cut off at bottom
     <VStack align="left" spacing="4rem" mb="4rem">
       {args.labels.map(({ value, placement }, idx) => (
-        <Flex key={idx} align="center">
+        <Box key={idx}>
           {value}
           <Tooltip
             {...args}
             label="Tooltip content goes here"
             placement={placement}
           >
-            <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
+            <Icon
+              as={BxsHelpCircle}
+              aria-hidden
+              h="1.25rem"
+              ml="0.5rem"
+              verticalAlign="sub"
+            />
           </Tooltip>
-        </Flex>
+        </Box>
       ))}
     </VStack>
   )

--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon, Placement, TooltipProps, VStack } from '@chakra-ui/react'
+import { Flex, Icon, Placement, TooltipProps, VStack } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
 
 import { BxsHelpCircle } from '~/assets/icons/BxsHelpCircle'
@@ -20,7 +20,7 @@ const TooltipStack = (
     // bottom margin just so that story snapshot does not get cut off at bottom
     <VStack align="left" spacing="4rem" mb="4rem">
       {args.labels.map(({ value, placement }, idx) => (
-        <Box key={idx}>
+        <Flex key={idx} align="center">
           {value}
           <Tooltip
             {...args}
@@ -29,7 +29,7 @@ const TooltipStack = (
           >
             <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
           </Tooltip>
-        </Box>
+        </Flex>
       ))}
     </VStack>
   )

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -1,53 +1,10 @@
-import { useState } from 'react'
 import {
-  Box,
-  BoxProps,
-  CSSObject,
   Tooltip as ChakraTooltip,
   TooltipProps as ChakraTooltipProps,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
-export interface TooltipProps extends ChakraTooltipProps {
-  /**
-   * Text which appears on hover/focus.
-   */
-  label: string
-  /**
-   * Styles for the container which wraps the children.
-   */
-  wrapperStyles?: CSSObject
-  wrapperProps?: BoxProps
-}
+export type TooltipProps = ChakraTooltipProps
 
-export const Tooltip = ({
-  children,
-  wrapperStyles,
-  wrapperProps,
-  ...props
-}: TooltipProps): JSX.Element => {
-  // ChakraTooltip does not work on mobile by design. (see
-  // https://github.com/chakra-ui/chakra-ui/issues/2691)
-  // Hence adapt the tooltip to open when clicked on mobile
-  const [isLabelOpen, setIsLabelOpen] = useState(!!props.isOpen)
-  return (
-    <>
-      <ChakraTooltip {...props} hasArrow isOpen={isLabelOpen}>
-        <Box
-          as="span"
-          onMouseEnter={() => setIsLabelOpen(true)}
-          onMouseLeave={() => setIsLabelOpen(false)}
-          onClick={() => setIsLabelOpen((currentState) => !currentState)}
-          onFocus={() => setIsLabelOpen(true)}
-          onBlur={() => setIsLabelOpen(false)}
-          verticalAlign="middle"
-          __css={wrapperStyles}
-          {...wrapperProps}
-        >
-          {children}
-        </Box>
-      </ChakraTooltip>
-      <VisuallyHidden>{props.label}</VisuallyHidden>
-    </>
-  )
+export const Tooltip = (props: TooltipProps): JSX.Element => {
+  return <ChakraTooltip hasArrow {...props} />
 }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react'
-import { Icon, Stack, Text } from '@chakra-ui/react'
+import { Box, Icon, Stack, Text, Tooltip } from '@chakra-ui/react'
 
 import { BxsErrorCircle, BxsInfoCircle } from '~assets/icons'
-import Tooltip from '~components/Tooltip'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { FormFieldWithQuestionNo } from '~features/form/types'
@@ -56,13 +55,11 @@ export const FieldLogicBadge = ({
 
   return (
     <LogicBadge display="inline-flex">
-      <Stack direction="row" spacing="0.25rem" maxW="100%">
-        <Tooltip
-          placement="top"
-          label={tooltipLabel}
-          wrapperStyles={{ display: 'flex' }}
-        >
-          <Icon as={tooltipIcon} fontSize="1rem" color={textColor} />
+      <Stack direction="row" spacing="0.25rem" maxW="100%" align="center">
+        <Tooltip placement="top" label={tooltipLabel} hasArrow>
+          <Box display="inline-flex" alignItems="center">
+            <Icon as={tooltipIcon} fontSize="1rem" color={textColor} />
+          </Box>
         </Tooltip>
         {field ? (
           <>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react'
-import { Box, Icon, Stack, Text, Tooltip } from '@chakra-ui/react'
+import { Box, Icon, Stack, Text } from '@chakra-ui/react'
 
 import { BxsErrorCircle, BxsInfoCircle } from '~assets/icons'
+import Tooltip from '~components/Tooltip'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { FormFieldWithQuestionNo } from '~features/form/types'
@@ -56,7 +57,7 @@ export const FieldLogicBadge = ({
   return (
     <LogicBadge display="inline-flex">
       <Stack direction="row" spacing="0.25rem" maxW="100%" align="center">
-        <Tooltip placement="top" label={tooltipLabel} hasArrow>
+        <Tooltip placement="top" label={tooltipLabel}>
           <Box display="inline-flex" alignItems="center">
             <Icon as={tooltipIcon} fontSize="1rem" color={textColor} />
           </Box>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSection.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { Box, Icon, Skeleton } from '@chakra-ui/react'
+import { Box, Flex, Icon, Skeleton } from '@chakra-ui/react'
 
 import { FormAuthType, FormSettings, FormStatus } from '~shared/types/form'
 
@@ -160,35 +160,37 @@ export const AuthSettingsSection = ({
           <Fragment key={authType}>
             <Box onClick={handleOptionClick(authType)}>
               <Radio value={authType} isDisabled={isDisabled(authType)}>
-                {text}
-                {authType === FormAuthType.SGID ? (
-                  <>
+                <Flex align="center">
+                  {text}
+                  {authType === FormAuthType.SGID ? (
+                    <>
+                      <Tooltip
+                        label={SGID_TOOLTIP}
+                        placement="top"
+                        textAlign="center"
+                      >
+                        <Icon as={BxsHelpCircle} aria-hidden marginX="0.5rem" />
+                      </Tooltip>
+                      <Link
+                        href={OGP_SGID}
+                        isExternal
+                        // Needed for link to open since there are nested onClicks
+                        onClickCapture={(e) => e.stopPropagation()}
+                      >
+                        Contact us to find out more
+                      </Link>
+                    </>
+                  ) : null}
+                  {authType === FormAuthType.CP ? (
                     <Tooltip
-                      label={SGID_TOOLTIP}
+                      label={CP_TOOLTIP}
                       placement="top"
                       textAlign="center"
                     >
-                      <Icon as={BxsHelpCircle} aria-hidden marginX="0.5rem" />
+                      <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
                     </Tooltip>
-                    <Link
-                      href={OGP_SGID}
-                      isExternal
-                      // Needed for link to open since there are nested onClicks
-                      onClickCapture={(e) => e.stopPropagation()}
-                    >
-                      Contact us to find out more
-                    </Link>
-                  </>
-                ) : null}
-                {authType === FormAuthType.CP ? (
-                  <Tooltip
-                    label={CP_TOOLTIP}
-                    placement="top"
-                    textAlign="center"
-                  >
-                    <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
-                  </Tooltip>
-                ) : null}
+                  ) : null}
+                </Flex>
               </Radio>
             </Box>
             {esrvcidRequired(authType) && authType === settings.authType ? (

--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -23,11 +23,7 @@ export const SwitchEnvIcon = (): JSX.Element => {
       zIndex="9999"
       cursor="pointer"
     >
-      <Tooltip
-        placement="left"
-        label="Have feedback?"
-        wrapperStyles={{ display: 'flex' }}
-      >
+      <Tooltip placement="left" label="Have feedback?">
         <IconButton
           variant="outline"
           as="a"

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -152,19 +152,11 @@ export const SaveSecretKeyScreen = ({
               for safekeeping.
             </Text>
             <Stack direction={{ base: 'column', md: 'row' }}>
-              <Tooltip
-                mt={0}
-                label={hasCopiedKey ? 'Copied!' : 'Copy key'}
-                wrapperProps={{
-                  // To allow for focus styling on code element.
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore
-                  'data-group': true,
-                  tabIndex: 0,
-                  flex: 1,
-                }}
-              >
+              <Tooltip mt={0} label={hasCopiedKey ? 'Copied!' : 'Copy key'}>
                 <Code
+                  // To allow for focus styling on code element.
+                  data-group
+                  tabIndex={0}
                   transition="background 0.2s ease"
                   cursor="pointer"
                   onClick={handleCopyKey}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -157,6 +157,7 @@ export const SaveSecretKeyScreen = ({
                   // To allow for focus styling on code element.
                   data-group
                   tabIndex={0}
+                  flex={1}
                   transition="background 0.2s ease"
                   cursor="pointer"
                   onClick={handleCopyKey}
@@ -170,7 +171,7 @@ export const SaveSecretKeyScreen = ({
                   display="inline-flex"
                   alignItems="center"
                   w="100%"
-                  h="100%"
+                  h="auto"
                   px="0.75rem"
                   py="0.625rem"
                   bg="neutral.200"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Components wrapped with our `Tooltip` component was requiring doubletap on iOS devices, which is probably less ideal UX than allowing users to look at tooltips without a long hold. This PR removes that custom touch handling code.

Closes #4728 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: remove special touch handling on Tooltip component 

## Before & After Screenshots
Should have no change
