### PR TITLE
fix(v2): use Portals instead of setting arbitrary zIndices

### DIFF
--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -1,6 +1,7 @@
 // TODO #4279: Remove after React rollout is complete
+import { useMemo } from 'react'
 import { BiMessage } from 'react-icons/bi'
-import { Flex, useDisclosure } from '@chakra-ui/react'
+import { Flex, Portal, useDisclosure } from '@chakra-ui/react'
 
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
@@ -10,31 +11,30 @@ import { REMOVE_ADMIN_INFOBOX_THRESHOLD } from '~features/workspace/components/A
 import { useEnv } from './queries'
 import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
 
-export const SwitchEnvIcon = (): JSX.Element => {
+export const SwitchEnvIcon = (): JSX.Element | null => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { data: { adminRollout } = {} } = useEnv()
-  const showSwitchEnvMessage =
-    adminRollout && adminRollout < REMOVE_ADMIN_INFOBOX_THRESHOLD
-  return showSwitchEnvMessage ? (
-    <Flex
-      position="fixed"
-      bottom="2.75rem"
-      right="2.75rem"
-      zIndex="9999"
-      cursor="pointer"
-    >
-      <Tooltip placement="left" label="Have feedback?">
-        <IconButton
-          variant="outline"
-          as="a"
-          aria-label="switch environments"
-          icon={<BiMessage color="primary.500" />}
-          onClick={onOpen}
-        />
-      </Tooltip>
-      <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />
-    </Flex>
-  ) : (
-    <></>
+  const showSwitchEnvMessage = useMemo(
+    () => adminRollout && adminRollout < REMOVE_ADMIN_INFOBOX_THRESHOLD,
+    [adminRollout],
+  )
+
+  if (!showSwitchEnvMessage) return null
+
+  return (
+    <Portal>
+      <Flex position="fixed" bottom="2.75rem" right="2.75rem" cursor="pointer">
+        <Tooltip placement="left" label="Have feedback?">
+          <IconButton
+            variant="outline"
+            as="a"
+            aria-label="switch environments"
+            icon={<BiMessage color="primary.500" />}
+            onClick={onOpen}
+          />
+        </Tooltip>
+        <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />
+      </Flex>
+    </Portal>
   )
 }

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Flex,
   Icon,
+  Portal,
   Skeleton,
   Slide,
   Text,
@@ -38,58 +39,59 @@ export const MiniHeader = ({
   colorScheme,
   isOpen,
 }: MiniHeaderProps): JSX.Element => (
-  <Slide
-    // Screen readers do not need to know of the existence of this component.
-    aria-hidden
-    ref={miniHeaderRef}
-    direction="top"
-    in={isOpen}
-    style={{ zIndex: 1000 }}
-  >
-    <Box
-      bg={titleBg}
-      px={{ base: '1.5rem', md: '2rem' }}
-      py={{ base: '0.5rem', md: '1rem' }}
+  <Portal>
+    <Slide
+      // Screen readers do not need to know of the existence of this component.
+      aria-hidden
+      ref={miniHeaderRef}
+      direction="top"
+      in={isOpen}
     >
-      <Skeleton isLoaded={!!title}>
-        <Flex
-          align="center"
-          flex={1}
-          gap="0.5rem"
-          justify="space-between"
-          flexDir="row"
-        >
+      <Box
+        bg={titleBg}
+        px={{ base: '1.5rem', md: '2rem' }}
+        py={{ base: '0.5rem', md: '1rem' }}
+      >
+        <Skeleton isLoaded={!!title}>
           <Flex
-            alignItems="center"
-            minH={{ base: '4rem', md: '0' }}
-            flex="1 1 0"
-            w="100%"
-            overflow="hidden"
+            align="center"
+            flex={1}
+            gap="0.5rem"
+            justify="space-between"
+            flexDir="row"
           >
-            <Text
-              textStyle={{ base: 'h4', md: 'h2' }}
-              textAlign="start"
-              color={titleColor}
-              noOfLines={2}
+            <Flex
+              alignItems="center"
+              minH={{ base: '4rem', md: '0' }}
+              flex="1 1 0"
+              w="100%"
+              overflow="hidden"
             >
-              {title ?? 'Loading title'}
-            </Text>
+              <Text
+                textStyle={{ base: 'h4', md: 'h2' }}
+                textAlign="start"
+                color={titleColor}
+                noOfLines={2}
+              >
+                {title ?? 'Loading title'}
+              </Text>
+            </Flex>
+            {activeSectionId ? (
+              // Section sidebar icon should only show up if sections exist
+              <IconButton
+                colorScheme={colorScheme}
+                aria-label="Mobile section sidebar"
+                fontSize="1.5rem"
+                icon={<BxMenuAltLeft />}
+                d={{ base: 'flex', md: 'none' }}
+                onClick={onMobileDrawerOpen}
+              />
+            ) : null}
           </Flex>
-          {activeSectionId ? (
-            // Section sidebar icon should only show up if sections exist
-            <IconButton
-              colorScheme={colorScheme}
-              aria-label="Mobile section sidebar"
-              fontSize="1.5rem"
-              icon={<BxMenuAltLeft />}
-              d={{ base: 'flex', md: 'none' }}
-              onClick={onMobileDrawerOpen}
-            />
-          ) : null}
-        </Flex>
-      </Skeleton>
-    </Box>
-  </Slide>
+        </Skeleton>
+      </Box>
+    </Slide>
+  </Portal>
 )
 
 interface FormHeaderProps {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Instead of hoping no sibling component's zIndex values are higher in their render stack, use the `Portal` component to guarantee always on top of the stacking layout.

This PR only affects two components that were using arbitrary zIndex values - public form `MiniHeader` and the `SwitchEnvIcon` components.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Improvements**:

- feat: use Portal instead of zIndex values for `SwitchEnvIcon` and `FormHeader` components
  - fixes the bug where dropdown options may appear in front of the mini header.
