### PR TITLE
fix(v2): incorrect dropdown options positioning on iOS Safari when the keyboard is open

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2687,6 +2687,36 @@
         }
       }
     },
+    "@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.1.tgz",
+      "integrity": "sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==",
+      "requires": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "@floating-ui/react-dom-interactions": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.9.3.tgz",
+      "integrity": "sha512-oHwFLxySRtmhgwg7ZdWswvDDi+ld4mEtxu6ngOd7mRC5L1Rk6adjSfOBOHDxea+ItAWmds8m6A725sn1HQtUyQ==",
+      "requires": {
+        "@floating-ui/react-dom": "^1.0.0",
+        "aria-hidden": "^1.1.3"
+      }
+    },
     "@formatjs/ecma402-abstract": {
       "version": "1.11.4",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34653,15 +34653,6 @@
       "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
     },
-    "react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      }
-    },
     "react-proptype-conditional-require": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,6 @@
     "react-icons": "^4.3.1",
     "react-joyride": "^2.4.0",
     "react-markdown": "^7.1.1",
-    "react-popper": "^2.3.0",
     "react-query": "^3.34.2",
     "react-router-dom": "^6.0.2",
     "react-roving-tabindex": "^3.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -179,6 +179,7 @@
     "prettier": "^2.5.1",
     "puppeteer": "^13.0.0",
     "react-scripts": "^4.0.3",
+    "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^3.0.2",
     "storybook-addon-turbo-build": "^1.1.0",
     "storybook-preset-craco": "0.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@datadog/browser-rum": "^4.14.0",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
+    "@floating-ui/react-dom-interactions": "^0.9.3",
     "@opengovsg/formsg-sdk": "^0.9.0",
     "@stablelib/base64": "^1.0.1",
     "axios": "^0.24.0",

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -18,7 +18,11 @@ import { MultiSelectContext } from '../MultiSelectContext'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
 import { ComboboxItem } from '../types'
 import { defaultFilter } from '../utils/defaultFilter'
-import { itemToLabelString, itemToValue } from '../utils/itemUtils'
+import {
+  isItemDisabled,
+  itemToLabelString,
+  itemToValue,
+} from '../utils/itemUtils'
 
 export interface MultiSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
@@ -131,7 +135,11 @@ export const MultiSelectProvider = ({
   } = useMultipleSelection<typeof items[0]>({
     selectedItems,
     onSelectedItemsChange: ({ selectedItems }) => {
-      onChange(selectedItems?.map(itemToValue) ?? [])
+      onChange(
+        selectedItems
+          ?.filter((item) => !isItemDisabled(item))
+          .map(itemToValue) ?? [],
+      )
     },
     itemToString: itemToLabelString,
     stateReducer: (_state, { changes, type }) => {

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -14,7 +14,11 @@ import { useItems } from '../hooks/useItems'
 import { SelectContext, SharedSelectContextReturnProps } from '../SelectContext'
 import { ComboboxItem } from '../types'
 import { defaultFilter } from '../utils/defaultFilter'
-import { itemToLabelString, itemToValue } from '../utils/itemUtils'
+import {
+  isItemDisabled,
+  itemToLabelString,
+  itemToValue,
+} from '../utils/itemUtils'
 
 export interface SingleSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
@@ -124,7 +128,9 @@ export const SingleSelectProvider = ({
     selectedItem: memoizedSelectedItem,
     itemToString: itemToValue,
     onSelectedItemChange: ({ selectedItem }) => {
-      onChange(itemToValue(selectedItem))
+      if (!selectedItem || !isItemDisabled(selectedItem)) {
+        onChange(itemToValue(selectedItem))
+      }
     },
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     scrollIntoView: () => {},

--- a/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
@@ -1,9 +1,7 @@
-import { useEffect } from 'react'
 import { Virtuoso } from 'react-virtuoso'
-import { Box, List, ListItem } from '@chakra-ui/react'
+import { List, ListItem } from '@chakra-ui/react'
 
 import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
-import { useMultiSelectContext } from '../MultiSelectContext'
 import { useSelectContext } from '../SelectContext'
 import { itemToValue } from '../utils/itemUtils'
 
@@ -21,57 +19,40 @@ export const MultiSelectMenu = (): JSX.Element => {
     virtualListHeight,
   } = useSelectContext()
 
-  const { selectedItems } = useMultiSelectContext()
-
-  const { popperRef, popperStyles, popperAttributes, update } =
-    useSelectPopover()
-
-  /**
-   * Recalculate popper position when the menu opens or when selected items change.
-   **/
-  useEffect(() => {
-    if (isOpen) {
-      update?.()
-    }
-  }, [isOpen, selectedItems, update])
+  const { floatingRef, floatingStyles } = useSelectPopover()
 
   return (
-    <Box
-      ref={popperRef}
-      style={popperStyles.popper}
-      {...popperAttributes.popper}
-      w="100%"
+    <List
+      style={floatingStyles}
+      {...getMenuProps({
+        hidden: !isOpen,
+        ref: floatingRef,
+      })}
       zIndex="dropdown"
+      sx={styles.list}
     >
-      <List
-        {...getMenuProps({
-          hidden: !isOpen,
-        })}
-        sx={styles.list}
-      >
-        {isOpen && items.length > 0 && (
-          <Virtuoso
-            ref={virtualListRef}
-            data={items}
-            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
-            style={{ height: virtualListHeight }}
-            itemContent={(index, item) => {
-              return (
-                <MultiDropdownItem
-                  key={`${itemToValue(item)}${index}`}
-                  item={item}
-                  index={index}
-                />
-              )
-            }}
-          />
-        )}
-        {isOpen && items.length === 0 ? (
-          <ListItem role="option" sx={styles.emptyItem}>
-            {nothingFoundLabel}
-          </ListItem>
-        ) : null}
-      </List>
-    </Box>
+      {isOpen && items.length > 0 && (
+        <Virtuoso
+          ref={virtualListRef}
+          data={items}
+          overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+          style={{ height: virtualListHeight }}
+          itemContent={(index, item) => {
+            return (
+              <MultiDropdownItem
+                key={`${itemToValue(item)}${index}`}
+                item={item}
+                index={index}
+              />
+            )
+          }}
+        />
+      )}
+      {isOpen && items.length === 0 ? (
+        <ListItem role="option" sx={styles.emptyItem}>
+          {nothingFoundLabel}
+        </ListItem>
+      ) : null}
+    </List>
   )
 }

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -1,5 +1,5 @@
 import { Virtuoso } from 'react-virtuoso'
-import { Box, List, ListItem } from '@chakra-ui/react'
+import { List, ListItem } from '@chakra-ui/react'
 
 import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useSelectContext } from '../SelectContext'
@@ -19,44 +19,39 @@ export const SelectMenu = (): JSX.Element => {
     virtualListHeight,
   } = useSelectContext()
 
-  const { popperRef, popperStyles, popperAttributes } = useSelectPopover()
+  const { floatingRef, floatingStyles } = useSelectPopover()
 
   return (
-    <Box
-      ref={popperRef}
-      style={popperStyles.popper}
-      {...popperAttributes.popper}
+    <List
+      {...getMenuProps({
+        ref: floatingRef,
+      })}
+      style={floatingStyles}
       zIndex="dropdown"
+      sx={styles.list}
     >
-      <List
-        {...getMenuProps({
-          hidden: !isOpen,
-        })}
-        sx={styles.list}
-      >
-        {isOpen && items.length > 0 && (
-          <Virtuoso
-            ref={virtualListRef}
-            data={items}
-            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
-            style={{ height: virtualListHeight }}
-            itemContent={(index, item) => {
-              return (
-                <DropdownItem
-                  key={`${itemToValue(item)}${index}`}
-                  item={item}
-                  index={index}
-                />
-              )
-            }}
-          />
-        )}
-        {isOpen && items.length === 0 ? (
-          <ListItem role="option" sx={styles.emptyItem}>
-            {nothingFoundLabel}
-          </ListItem>
-        ) : null}
-      </List>
-    </Box>
+      {isOpen && items.length > 0 && (
+        <Virtuoso
+          ref={virtualListRef}
+          data={items}
+          overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+          style={{ height: virtualListHeight }}
+          itemContent={(index, item) => {
+            return (
+              <DropdownItem
+                key={`${itemToValue(item)}${index}`}
+                item={item}
+                index={index}
+              />
+            )
+          }}
+        />
+      )}
+      {isOpen && items.length === 0 ? (
+        <ListItem role="option" sx={styles.emptyItem}>
+          {nothingFoundLabel}
+        </ListItem>
+      ) : null}
+    </List>
   )
 }

--- a/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
+++ b/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
@@ -1,48 +1,51 @@
-import { FC, useRef, useState } from 'react'
-import { Modifier, usePopper } from 'react-popper'
+import { FC, useLayoutEffect, useMemo, useRef } from 'react'
 import { Box, useMergeRefs, useOutsideClick } from '@chakra-ui/react'
+import {
+  autoUpdate,
+  flip,
+  hide,
+  offset,
+  useFloating,
+} from '@floating-ui/react-dom-interactions'
 
 import { useSelectContext } from '~components/Dropdown/SelectContext'
 
 import { SelectPopoverContext } from './SelectPopoverContext'
 
-export const matchWidth: Modifier<'matchWidth'> = {
-  name: 'matchWidth',
-  enabled: true,
-  phase: 'beforeWrite',
-  requires: ['computeStyles'],
-  fn: ({ state }) => {
-    state.styles.popper.width = `${state.rects.reference.width}px`
-  },
-  effect:
-    ({ state }) =>
-    () => {
-      const reference = state.elements.reference as HTMLElement
-      state.elements.popper.style.width = `${reference.offsetWidth}px`
-    },
-}
-
 export const SelectPopoverProvider: FC = ({ children }): JSX.Element => {
-  const [referenceElement, setReferenceElement] =
-    useState<HTMLDivElement | null>(null)
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null,
-  )
-
-  const {
-    styles: popperStyles,
-    attributes: popperAttributes,
-    update,
-  } = usePopper(referenceElement, popperElement, {
-    placement: 'bottom-start',
-    strategy: 'fixed',
-    modifiers: [matchWidth],
-  })
-
   const { styles, setIsFocused, isOpen } = useSelectContext()
 
   const wrapperRef = useRef<HTMLDivElement | null>(null)
-  const mergedPopperRefs = useMergeRefs(setReferenceElement, wrapperRef)
+
+  const { x, y, refs, reference, floating, strategy, update } = useFloating({
+    placement: 'bottom-start',
+    strategy: 'absolute',
+    open: isOpen,
+    middleware: [
+      // offset middleware should be the first middleware
+      offset(1),
+      flip(),
+      hide(),
+    ],
+  })
+
+  const mergedReferenceRefs = useMergeRefs(reference, wrapperRef)
+
+  const floatingStyles = useMemo(
+    () => ({
+      position: strategy,
+      top: y ?? 0,
+      left: x ?? 0,
+    }),
+    [strategy, x, y],
+  )
+
+  // Allows
+  useLayoutEffect(() => {
+    if (isOpen && refs.reference.current && refs.floating.current) {
+      return autoUpdate(refs.reference.current, refs.floating.current, update)
+    }
+  }, [isOpen, update, refs.floating, refs.reference])
 
   useOutsideClick({
     ref: wrapperRef,
@@ -52,13 +55,11 @@ export const SelectPopoverProvider: FC = ({ children }): JSX.Element => {
   return (
     <SelectPopoverContext.Provider
       value={{
-        popperRef: isOpen ? setPopperElement : null,
-        popperStyles,
-        popperAttributes,
-        update,
+        floatingRef: floating,
+        floatingStyles,
       }}
     >
-      <Box ref={mergedPopperRefs} sx={styles.container}>
+      <Box ref={mergedReferenceRefs} sx={styles.container}>
         {children}
       </Box>
     </SelectPopoverContext.Provider>

--- a/frontend/src/components/Dropdown/components/SelectPopover/SelectPopoverContext.tsx
+++ b/frontend/src/components/Dropdown/components/SelectPopover/SelectPopoverContext.tsx
@@ -1,11 +1,16 @@
-import { createContext, Dispatch, SetStateAction, useContext } from 'react'
-import type { Instance as PopperInstance } from '@popperjs/core'
+import { createContext, useContext } from 'react'
+import {
+  Strategy,
+  UseFloatingReturn,
+} from '@floating-ui/react-dom-interactions'
 
 interface SelectPopoverContextReturn {
-  popperRef: Dispatch<SetStateAction<HTMLDivElement | null>> | null
-  popperStyles: { [key: string]: React.CSSProperties }
-  popperAttributes: { [key: string]: { [key: string]: string } | undefined }
-  update: PopperInstance['update'] | null
+  floatingRef: UseFloatingReturn['floating']
+  floatingStyles: {
+    position: Strategy
+    top: number
+    left: number
+  }
 }
 
 export const SelectPopoverContext = createContext<

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -326,7 +326,7 @@ export const EditConditionBlock = ({
           <BlockLabelText id={`${name}.state-label`} htmlFor={`${name}.state`}>
             IS
           </BlockLabelText>
-          <Flex flexDir="column" flex={1} as="fieldset">
+          <Flex flexDir="column" flex={1} as="fieldset" minW={0}>
             <VisuallyHidden as="legend">Logic criteria</VisuallyHidden>
             <Stack
               direction={{ base: 'column', md: 'row' }}

--- a/frontend/src/features/user/emergency-contact/EmergencyContactModal.test.tsx
+++ b/frontend/src/features/user/emergency-contact/EmergencyContactModal.test.tsx
@@ -10,9 +10,6 @@ import * as stories from './EmergencyContactModal.stories'
 
 const { NoContact, WithContact } = composeStories(stories)
 
-// Some tests take longer in this suite.
-jest.setTimeout(20000)
-
 describe('User has no verified contact number', () => {
   it('should render with empty contact number details', async () => {
     // Arrange

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -36,3 +36,5 @@ window.matchMedia =
       removeListener: jest.fn(),
     }
   }
+
+global.ResizeObserver = require('resize-observer-polyfill')

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -38,3 +38,5 @@ window.matchMedia =
   }
 
 global.ResizeObserver = require('resize-observer-polyfill')
+
+jest.setTimeout(20000)

--- a/frontend/src/templates/Field/Dropdown/DropdownField.test.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.test.tsx
@@ -8,12 +8,16 @@ import * as stories from './DropdownField.stories'
 
 const { ValidationOptional, ValidationRequired } = composeStories(stories)
 
+beforeEach(() => {
+  jest.setTimeout(10000)
+})
+
 describe('required field', () => {
   it('renders error when field is not selected before submitting', async () => {
     // Arrange
     const user = userEvent.setup()
     render(<ValidationRequired />)
-    const submitButton = screen.getByRole('button', { name: /submit/i })
+    const submitButton = screen.getByText(/submit/i)
 
     // Act
     await user.click(submitButton)
@@ -32,8 +36,10 @@ describe('required field', () => {
       ?.fieldOptions as string[]
     const expectedOption = dropdownOptions[0]
     const optionToType = expectedOption.slice(0, 6)
-    const submitButton = screen.getByRole('button', { name: /submit/i })
-    const input = screen.getByRole('textbox') as HTMLInputElement
+    const submitButton = screen.getByText(/submit/i)
+    const input = screen.getByPlaceholderText(
+      'Select an option',
+    ) as HTMLInputElement
     // Act
     // Act required due to react-hook-form usage.
     await user.type(input, `${optionToType}[enter]`)
@@ -54,8 +60,10 @@ describe('required field', () => {
     const dropdownOptions = ValidationRequired.args?.schema
       ?.fieldOptions as string[]
     const expectedOption = dropdownOptions[1]
-    const submitButton = screen.getByRole('button', { name: /submit/i })
-    const input = screen.getByRole('textbox') as HTMLInputElement
+    const submitButton = screen.getByText(/submit/i)
+    const input = screen.getByPlaceholderText(
+      'Select an option',
+    ) as HTMLInputElement
     // Act
     user.click(input)
     // Act required due to react-hook-form usage.
@@ -76,7 +84,7 @@ describe('optional field', () => {
     // Arrange
     const user = userEvent.setup()
     render(<ValidationOptional />)
-    const submitButton = screen.getByRole('button', { name: /submit/i })
+    const submitButton = screen.getByText(/submit/i)
 
     // Act
     await user.click(submitButton)
@@ -94,8 +102,10 @@ describe('optional field', () => {
     const dropdownOptions = ValidationRequired.args?.schema
       ?.fieldOptions as string[]
     const expectedOption = dropdownOptions[1]
-    const submitButton = screen.getByRole('button', { name: /submit/i })
-    const input = screen.getByRole('textbox') as HTMLInputElement
+    const submitButton = screen.getByText(/submit/i)
+    const input = screen.getByPlaceholderText(
+      'Select an option',
+    ) as HTMLInputElement
     // Act
     user.click(input)
     // Type the middle few characters of the option; dropdown should match properly,
@@ -120,20 +130,22 @@ describe('dropdown validation', () => {
 
     const dropdownOptions = ValidationRequired.args?.schema
       ?.fieldOptions as string[]
-    const submitButton = screen.getByRole('button', { name: /submit/i })
-    const inputElement = screen.getByRole('textbox') as HTMLInputElement
+    const submitButton = screen.getByText(/submit/i)
+    const input = screen.getByPlaceholderText(
+      'Select an option',
+    ) as HTMLInputElement
     const inputToType = 'this is not a valid option'
 
     expect(dropdownOptions.includes(inputToType)).toEqual(false)
 
     // Act
-    user.click(inputElement)
+    user.click(input)
     await act(() => {
-      user.type(inputElement, inputToType)
+      user.type(input, inputToType)
       return user.tab()
     })
     // Input should blur and input value should be cleared (since nothing was selected).
-    expect(inputElement.value).toEqual('')
+    expect(input.value).toEqual('')
     await userEvent.click(submitButton)
 
     // Assert

--- a/frontend/src/templates/Field/Dropdown/DropdownField.test.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.test.tsx
@@ -8,10 +8,6 @@ import * as stories from './DropdownField.stories'
 
 const { ValidationOptional, ValidationRequired } = composeStories(stories)
 
-beforeEach(() => {
-  jest.setTimeout(10000)
-})
-
 describe('required field', () => {
   it('renders error when field is not selected before submitting', async () => {
     // Arrange

--- a/frontend/src/theme/components/SingleSelect.ts
+++ b/frontend/src/theme/components/SingleSelect.ts
@@ -33,8 +33,6 @@ const itemBaseStyle: SystemStyleFunction = (props) => {
 const listBaseStyle: SystemStyleFunction = (props) => {
   const { list: menuListStyle = {} } = Menu.baseStyle(props)
   return merge(menuListStyle, {
-    // To accomodate focus ring.
-    my: '1px',
     w: '100%',
     overflowY: 'auto',
     maxH: '12rem',


### PR DESCRIPTION
> Builds on top of #4782 so the tests are fixed

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR replaces `react-popper` package usage with `@floating-ui/react-dom-interactions`. After experimentation, the layout is properly being updated on iOS Safari, which closes #4718 properly. The dev experience of using the package was also much better compared to react-popper. It is also the official successor of popperjs, which means a more updated package.

Closes #4718

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: use `@floating-ui/react-dom-interactions` instead of `react-popper` for Select components

**Bug Fixes**:

- Fixes bug where dropdown options were out of sync with the current viewport on iOS Safari.

## Before & After Screenshots
Should have no changes tbh.

## Tests
<!-- What tests should be run to confirm functionality? -->
No changes to tests

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->


**New dependencies**:

- `@floating-ui/react-dom-interactions`: replaces `react-popper` for rendering Select component's dropdown options
