### PR TITLE
fix(v2): set cookie expiration to 12 months

### DIFF
--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -22,7 +22,7 @@ export const RESPONDENT_COOKIE_OPTIONS = {
 
 export const RESPONDENT_COOKIE_OPTIONS_WITH_EXPIRY = {
   ...RESPONDENT_COOKIE_OPTIONS,
-  maxAge: 31 * 2 * 24 * 60 * 60, // 2 months
+  maxAge: 31 * 12 * 24 * 60 * 60, // 12 months
 }
 
 export const ADMIN_COOKIE_OPTIONS = {
@@ -33,7 +33,7 @@ export const ADMIN_COOKIE_OPTIONS = {
 
 export const ADMIN_COOKIE_OPTIONS_WITH_EXPIRY = {
   ...ADMIN_COOKIE_OPTIONS,
-  maxAge: 31 * 2 * 24 * 60 * 60, // 2 months
+  maxAge: 31 * 12 * 24 * 60 * 60, // 12 months
 }
 
 const logger = createLoggerWithLabel(module)


### PR DESCRIPTION
## Problem
Routing will no longer work when the admin and respondent cookies expire, because the user might be served the other app and the routes for the angular and react apps are different.

Closes #4345 

## Solution
<!-- How did you solve the problem? -->
Set the cookie `maxAge` to 12 months. This should be long enough to account for the full rollout duration.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
