### PR TITLE
feat: add tooltip description to field actions

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -372,23 +372,27 @@ export const FieldRowContainer = ({
                     {
                       // Fields which are not yet created cannot be duplicated
                       stateData.state !== FieldBuilderState.CreatingField && (
-                        <IconButton
-                          aria-label="Duplicate field"
-                          isDisabled={isAnyMutationLoading}
-                          onClick={handleDuplicateClick}
-                          isLoading={duplicateFieldMutation.isLoading}
-                          icon={<BiDuplicate fontSize="1.25rem" />}
-                        />
+                        <Tooltip label="Duplicate field">
+                          <IconButton
+                            aria-label="Duplicate field"
+                            isDisabled={isAnyMutationLoading}
+                            onClick={handleDuplicateClick}
+                            isLoading={duplicateFieldMutation.isLoading}
+                            icon={<BiDuplicate fontSize="1.25rem" />}
+                          />
+                        </Tooltip>
                       )
                     }
-                    <IconButton
-                      colorScheme="danger"
-                      aria-label="Delete field"
-                      icon={<BiTrash fontSize="1.25rem" />}
-                      onClick={handleDeleteClick}
-                      isLoading={deleteFieldMutation.isLoading}
-                      isDisabled={isAnyMutationLoading}
-                    />
+                    <Tooltip label="Delete field">
+                      <IconButton
+                        colorScheme="danger"
+                        aria-label="Delete field"
+                        icon={<BiTrash fontSize="1.25rem" />}
+                        onClick={handleDeleteClick}
+                        isLoading={deleteFieldMutation.isLoading}
+                        isDisabled={isAnyMutationLoading}
+                      />
+                    </Tooltip>
                   </ButtonGroup>
                 </Flex>
               </Collapse>


### PR DESCRIPTION
a very small PR that adds tooltips to the form field actions row in the form builder. The trash and settings button is pretty clear what it does but the duplicate button not as much. Could have added a title attribute instead but since chakra makes it easy to add a tooltip, a tooltip might be visually better.

## Before & After Screenshots
**AFTER**:
<img width="493" alt="Screen Shot 2022-09-04 at 10 17 50 PM" src="https://user-images.githubusercontent.com/39296145/188318367-c6ce41c2-fc71-4b40-9e6d-da098abab718.png">

<img width="493" alt="Screen Shot 2022-09-04 at 10 17 44 PM" src="https://user-images.githubusercontent.com/39296145/188318372-0d4cdfca-5bc7-4a95-8820-9d5acb884384.png">