### PR TITLE
fix(v2): handle null errors for table fields

### DIFF
--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -59,9 +59,7 @@ export const TableField = ({
     // would not need to be shown in the table field itself.
     if (isMobile) return
     // Get first available error amongst all column cell errors.
-    return head(
-      uniq(tableErrors?.flatMap((err = {}) => Object.values(err)))
-    )
+    return head(uniq(tableErrors?.flatMap((err = {}) => Object.values(err))))
   }, [isMobile, tableErrors])
 
   const { fields, append, remove } = useFieldArray<TableFieldInputs>({

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -59,7 +59,9 @@ export const TableField = ({
     // would not need to be shown in the table field itself.
     if (isMobile) return
     // Get first available error amongst all column cell errors.
-    return head(uniq(tableErrors?.flatMap(Object.values)))
+    return head(
+      uniq(tableErrors?.flatMap((errs) => (errs ? Object.values(errs) : []))),
+    )
   }, [isMobile, tableErrors])
 
   const { fields, append, remove } = useFieldArray<TableFieldInputs>({
@@ -67,13 +69,18 @@ export const TableField = ({
     name: schema._id,
   })
 
+  const appendTableRow = useCallback(
+    () => append(createTableRow(schema), { shouldFocus: false }),
+    [append, schema],
+  )
+
   useEffect(() => {
     // Update field array when min rows changes.
     if (hasMinRowsChanged) {
       const prevRowLength = fields.length
       if (schema.minimumRows > prevRowLength) {
         for (let i = prevRowLength; i < schema.minimumRows; i++) {
-          append(createTableRow(schema), { shouldFocus: false })
+          appendTableRow()
         }
       } else {
         // Remove rows from field array
@@ -82,15 +89,15 @@ export const TableField = ({
         }
       }
     }
-  }, [append, fields.length, hasMinRowsChanged, remove, schema])
+  }, [appendTableRow, fields.length, hasMinRowsChanged, remove, schema])
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable({ columns: columnsData, data: fields })
 
   const handleAddRow = useCallback(() => {
     if (!schema.maximumRows || fields.length >= schema.maximumRows) return
-    return append(createTableRow(schema))
-  }, [append, fields.length, schema])
+    return appendTableRow()
+  }, [appendTableRow, fields.length, schema])
 
   const handleRemoveRow = useCallback(
     (rowIndex: number) => {

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -60,7 +60,7 @@ export const TableField = ({
     if (isMobile) return
     // Get first available error amongst all column cell errors.
     return head(
-      uniq(tableErrors?.flatMap((errs) => (errs ? Object.values(errs) : []))),
+      uniq(tableErrors?.flatMap((err = {}) => Object.values(err)))
     )
   }, [isMobile, tableErrors])
 


### PR DESCRIPTION
## Problem
Currently, if table fields have no error, the app crashes because we try to call `Object.values` on `null`.

Also, clicking Add more rows the first time works, but the second time it causes the required error to show up. This is because we autofocus on the new row on the first time we Add more rows. Then, the second time, the click blurs the input, triggering validation.

Closes [#4717]

## Solution
Add "error handling" for the case where the field has no errors (lmaoo)

Don't autofocus on Adding more rows to prevent triggering validation

**Breaking Changes** 
- No - this PR is backwards compatible  
