### PR TITLE
fix(v2): fix redirection between React and Angular apps

### DIFF
--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import { ROOT_ROUTE } from '~constants/routes'
 
@@ -58,7 +58,7 @@ export const HashRouterElement = ({
       const match = location.hash.match(regex)
       if (match) {
         const redirectTo = getTarget(match as FormRegExpMatchArray)
-        return <Navigate replace to={redirectTo} state={{ from: location }} />
+        window.location.assign(redirectTo)
       }
     }
   }

--- a/src/app/loaders/express/logging.ts
+++ b/src/app/loaders/express/logging.ts
@@ -15,8 +15,8 @@ type LogMeta = {
   transactionId?: string
   trace?: string
   reactMigration?: {
-    respRolloutAuth: number
-    respRolloutNoAuth: number
+    respRolloutEmail: number
+    respRolloutStorage: number
     adminRollout: number
     qaCookie: string | undefined
     adminCookie: string | undefined
@@ -77,8 +77,8 @@ const loggingMiddleware = () => {
         req.cookies?.[config.reactMigration.qaCookieName]
       ) {
         meta.reactMigration = {
-          respRolloutAuth: config.reactMigration.respondentRolloutEmail,
-          respRolloutNoAuth: config.reactMigration.respondentRolloutStorage,
+          respRolloutEmail: config.reactMigration.respondentRolloutEmail,
+          respRolloutStorage: config.reactMigration.respondentRolloutStorage,
           adminRollout: config.reactMigration.adminRollout,
           qaCookie: req.cookies?.[config.reactMigration.qaCookieName],
           adminCookie: req.cookies?.[config.reactMigration.adminCookieName],

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -94,7 +94,6 @@ export const serveForm: ControllerHandler<
     // Delete existing cookies to prevent infinite redirection
     if (req.cookies) {
       res.clearCookie(config.reactMigration.respondentCookieName)
-      res.clearCookie(config.reactMigration.adminCookieName)
     }
   } else if (config.reactMigration.respondentCookieName in req.cookies) {
     // Note: the respondent cookie is for the whole session, not for a specific form.

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -16,7 +16,7 @@ export type SetEnvironmentParams = {
 
 export const RESPONDENT_COOKIE_OPTIONS = {
   httpOnly: false,
-  sameSite: 'strict' as const,
+  sameSite: 'lax' as const, // Setting to 'strict' resets the cookie after redirecting from myInfo
   secure: !config.isDev,
 }
 

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -96,21 +96,13 @@ export const serveForm: ControllerHandler<
       res.clearCookie(config.reactMigration.respondentCookieName)
       res.clearCookie(config.reactMigration.adminCookieName)
     }
-  } else if (req.cookies) {
-    if (config.reactMigration.adminCookieName in req.cookies) {
-      // Admins are dogfooders, the choice they made for the admin environment
-      // also applies to the forms they need to fill themselves
-      showReact =
-        req.cookies[config.reactMigration.adminCookieName] ===
-        UiCookieValues.React
-    } else if (config.reactMigration.respondentCookieName in req.cookies) {
-      // Note: the respondent cookie is for the whole session, not for a specific form.
-      // That means that within a session, a respondent will see the same environment
-      // for all the forms he/she fills.
-      showReact =
-        req.cookies[config.reactMigration.respondentCookieName] ===
-        UiCookieValues.React
-    }
+  } else if (config.reactMigration.respondentCookieName in req.cookies) {
+    // Note: the respondent cookie is for the whole session, not for a specific form.
+    // That means that within a session, a respondent will see the same environment
+    // for all the forms he/she fills.
+    showReact =
+      req.cookies[config.reactMigration.respondentCookieName] ===
+      UiCookieValues.React
   }
 
   if (showReact === undefined) {

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -5,13 +5,14 @@ import * as ReactMigrationController from './react-migration.controller'
 
 export const ReactMigrationRouter = Router()
 
-ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
-  res.redirect(`/${req.params.formId}`)
-})
 ReactMigrationRouter.get(
   '/:formId([a-fA-F0-9]{24})',
   ReactMigrationController.serveForm,
 )
+
+ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
+  res.redirect(`/${req.params.formId}`)
+})
 
 // Redirect to the landing page after setting the admin cookie
 ReactMigrationRouter.get(

--- a/src/app/modules/react-migration/react-migration.routes.ts
+++ b/src/app/modules/react-migration/react-migration.routes.ts
@@ -5,14 +5,13 @@ import * as ReactMigrationController from './react-migration.controller'
 
 export const ReactMigrationRouter = Router()
 
+ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
+  res.redirect(`/${req.params.formId}`)
+})
 ReactMigrationRouter.get(
   '/:formId([a-fA-F0-9]{24})',
   ReactMigrationController.serveForm,
 )
-
-ReactMigrationRouter.get('/#!/:formId([a-fA-F0-9]{24})', (req, res) => {
-  res.redirect(`/${req.params.formId}`)
-})
 
 // Redirect to the landing page after setting the admin cookie
 ReactMigrationRouter.get(

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -38,7 +38,7 @@ function SubmitFormController(
     )
 
     if (respondentCookie === 'react') {
-      $window.location.href = `/${form._id}`
+      $window.location.assign(`/${form._id}`)
       return
     }
   }

--- a/src/public/modules/forms/base/controllers/submit-form.client.controller.js
+++ b/src/public/modules/forms/base/controllers/submit-form.client.controller.js
@@ -33,17 +33,11 @@ function SubmitFormController(
 
   // React migration checker - ONLY for plain form URLs (no suffixes like /template or /preview)
   if (/^\/[0-9a-fA-F]{24}\/?$/.test($location.path())) {
-    const adminCookie = $cookies.get($window.reactMigrationAdminCookieName)
     const respondentCookie = $cookies.get(
       $window.reactMigrationRespondentCookieName,
     )
 
-    if (adminCookie) {
-      if (adminCookie === 'react') {
-        $window.location.href = `/${form._id}`
-        return
-      }
-    } else if (respondentCookie === 'react') {
+    if (respondentCookie === 'react') {
       $window.location.href = `/${form._id}`
       return
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The `v2-admin-ui` cookie takes precedence over the `v2-resp-ui` cookie on public forms, which caused a redirection loop between `/:formId` and `/#!/:formId`. We want to separate the use of both cookies - `v2-admin-ui` should only matter for admin pages, and `v2-resp-ui` for public form pages.

Closes #4639

## Solution
<!-- How did you solve the problem? -->
- Set the respondent cookie `sameSite` option to lax - this preserves the cookie choice after redirecting from the MyInfo page
- Remove the reference to admin cookie in `serveForm`, which determines which app to serve for the public form page
- In Angular, redirect the public form page to `/:formId` if the respondent cookie is `react`. We disregard the admin cookie value.

**Additional context**
An infinite redirection was occurring when the admin % was set to react + resp % was set to angular, specifically in these scenarios:
  - user opens `/#!/:formId` directly
  - admin opens up a public form page in the same window
  - user clicks "submit another form" on the public form end page

![React _ Angular Routing - Public Form Page](https://user-images.githubusercontent.com/56983748/188539983-d2f3f22a-85da-478f-ac44-7018777d149d.png)
[Lucidchart Diagram](https://lucid.app/lucidchart/63a58bd9-8f65-447c-ad0f-3cad197f844b/edit?viewport_loc=-166%2C-5%2C2290%2C1155%2C0_0&invitationId=inv_7a15f8b7-cbd3-4329-94f6-2e6585dcd79c#) (comments welcome!)

Previously, we'd decided to ignore links with `#!` because we assumed it wouldn't make up a large proportion of forms. The link provided in the share form modal does not have `#!`; the only cases where links with `#!` are shared would be when admins copy the link from their browser, or if someone bookmarks the form page. However, since we don't have the data to back up this assumption, and tackling this would make the rollout percentages more accurate, the solution deals with this edge case.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
Set rollout % as follows: Admin - 100 (react), Resp email form - 0 (angular), Resp storage form - 0 (angular). 
- [x] Open homepage, it should display react
- [x] Log in as admin, open up an **email-mode** form in another tab on the same window. Should display in angular
- [x] Same as above, for MyInfo, Singpass, CorpPass, SGID forms
- [x] Log in as admin, open up a **storage-mode** form in another tab on the same window. Should display in angular
- [x] (Not logged in as admin) On a new browser window, open up an **email-mode** form. Should display in angular.
- [x] (Not logged in as admin) Same as above, for MyInfo, Singpass, CorpPass, SGID forms
- [x] (Not logged in as admin) On a new browser window, open up a **storage-mode** form. Should display in angular.

Repeat the same tests above, but for the reverse rollout %: Admin - 0 (angular), Resp email form - 100 (react), Resp storage form - 100 (react). 
- [x] Open homepage, it should display angular
- [x] Log in as admin, open up an **email-mode** form in another tab on the same window. Should display in react
- [x] Same as above, for MyInfo, Singpass, CorpPass, SGID forms
- [x] Log in as admin, open up a **storage-mode** form in another tab on the same window. Should display in react
- [x] (Not logged in as admin) On a new browser window, open up an **email-mode** form. Should display in react.
- [x] (Not logged in as admin) Same as above, for MyInfo, Singpass, CorpPass, SGID forms
- [x] (Not logged in as admin) On a new browser window, open up a **storage-mode** form. Should display in react.