### PR TITLE
fix(v2): add numerical comparison for decimal equality in logic

### DIFF
--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -78,6 +78,11 @@ export const isConditionFulfilled = (
         }
         return condition.value === currentValue.value
       }
+      // In angular, number equality is string=== but decimal equality is number===.
+      // Need to replicate this behavior for backward-compatibility.
+      if (fieldType === BasicField.Decimal) {
+        return Number(currentValue) === Number(condition.value)
+      }
       return String(condition.value) === currentValue
     }
   }


### PR DESCRIPTION
## Problem
For logic blocks requiring equality on decimals, we use string comparison when angular uses numerical comparison. We should mimic angular behavior for backward compatibility.

Closes [#4711] 

## Solution
Cast values to numbers before checking equality for blocks relying on decimal conditions.

**Breaking Changes** 
- No - this PR is backwards compatible  

