### PR TITLE
feat(v2): hide react switch banner on AngularJS

### DIFF
--- a/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
+++ b/src/public/modules/forms/admin/controllers/list-forms.client.controller.js
@@ -36,6 +36,8 @@ function ListFormsController(
 
   vm.bannerContent = $window.siteBannerContent || $window.adminBannerContent
 
+  // Admin React rollout percentage
+  vm.reactAdminRollout = $window.reactMigrationAdminRollout
   // Hidden buttons on forms that appear after clicking more
   vm.showFormBtns = []
   // Duplicated form outline on newly dup forms

--- a/src/public/modules/forms/admin/views/list-forms.client.view.html
+++ b/src/public/modules/forms/admin/views/list-forms.client.view.html
@@ -5,9 +5,9 @@
   <div id="list-tab">
     <section data-ng-init="vm.listForms()">
       <div id="list-form" class="container" ng-if="vm.user">
-        <div id="react-switch-banner" ng-if="vm.reactAdminRollout > 0">
-          <react-switch-banner-component></react-switch-banner-component>
-        </div>
+        <react-switch-banner-component
+          ng-if="vm.reactAdminRollout > 0"
+        ></react-switch-banner-component>
         <!-- When forms have already been created -->
         <div id="list-form-exist" ng-if="vm.myforms.length > 0">
           <div

--- a/src/public/modules/forms/admin/views/list-forms.client.view.html
+++ b/src/public/modules/forms/admin/views/list-forms.client.view.html
@@ -5,7 +5,9 @@
   <div id="list-tab">
     <section data-ng-init="vm.listForms()">
       <div id="list-form" class="container" ng-if="vm.user">
-        <react-switch-banner-component></react-switch-banner-component>
+        <div id="react-switch-banner" ng-if="vm.reactAdminRollout > 0">
+          <react-switch-banner-component></react-switch-banner-component>
+        </div>
         <!-- When forms have already been created -->
         <div id="list-form-exist" ng-if="vm.myforms.length > 0">
           <div


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The banner that informs users a new FormSG is now available is still visible when the React admin rollout % is 0.

Closes #4595

## Solution
<!-- How did you solve the problem? -->
Show the banner if `reactMigrationAdminRollout > 0`