### PR TITLE
feat(v2): highlight response table row on hover

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -166,6 +166,12 @@ export const ResponsesTable = () => {
               onClick={() =>
                 handleRowClick(row.values.refNo, row.values.number)
               }
+              _hover={{
+                bg: 'primary.100',
+              }}
+              _active={{
+                bg: 'primary.200',
+              }}
             >
               {row.cells.map((cell) => {
                 return (

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -166,6 +166,7 @@ export const ResponsesTable = () => {
               onClick={() =>
                 handleRowClick(row.values.refNo, row.values.number)
               }
+              cursor="pointer"
               _hover={{
                 bg: 'primary.100',
               }}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
It's not apparent to users that they can click into each row of the storage mode responses table

Closes #4128

## Solution
<!-- How did you solve the problem? -->
- Add `_hover` and `_active` states
- Change pointer to `cursor`

## Screenshots
**After**
![Recording 2022-09-06 at 14 35 46](https://user-images.githubusercontent.com/56983748/188563614-bf4a46d1-eac6-477d-89fb-db9db489a809.gif)
