### PR TITLE
fix(v2): lock individual responses navbar, fix mobile view, add verified labels

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -22,7 +22,7 @@ type DecryptedRowProps = DecryptedRowBaseProps & {
 const DecryptedQuestionLabel = ({ row }: DecryptedRowBaseProps) => {
   return (
     <FormLabel questionNumber={`${row.questionNumber}.`} isRequired>
-      {row.question}
+      {`${row.signature ? '[verified] ' : ''}${row.question}`}
     </FormLabel>
   )
 }
@@ -36,7 +36,6 @@ const DecryptedHeaderRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
       mb="0.5rem"
       _notFirst={{ mt: '2.5rem' }}
     >
-      {row.signature ? `[verified] ` : ''}
       {row.question}
     </Text>
   )

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo } from 'react'
+import { BiChevronLeft, BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
+import {
+  Link as ReactLink,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom'
+import {
+  ButtonGroup,
+  Flex,
+  Grid,
+  Icon,
+  Link,
+  Skeleton,
+  Text,
+} from '@chakra-ui/react'
+
+import IconButton from '~components/IconButton'
+
+import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
+
+import { useIndividualSubmission } from './queries'
+
+export const IndividualResponseNavbar = (): JSX.Element => {
+  const { state } = useLocation()
+  const navigate = useNavigate()
+  const { submissionId } = useParams()
+  if (!submissionId) throw new Error('Missing submissionId')
+
+  const currentRespondentNumber = useMemo(() => {
+    return (state as { respondentNumber?: number })?.respondentNumber
+  }, [state])
+
+  const {
+    lastNavPage,
+    lastNavSubmissionId,
+    getNextSubmissionId,
+    getPreviousSubmissionId,
+    onNavNextSubmissionId,
+    onNavPreviousSubmissionId,
+    isAnyFetching,
+  } = useUnlockedResponses()
+  const { isLoading } = useIndividualSubmission()
+
+  const nextSubmissionId = useMemo(
+    () => getNextSubmissionId(submissionId),
+    [getNextSubmissionId, submissionId],
+  )
+  const prevSubmissionId = useMemo(
+    () => getPreviousSubmissionId(submissionId),
+    [getPreviousSubmissionId, submissionId],
+  )
+
+  const handleNavigateNext = useCallback(() => {
+    if (!nextSubmissionId) return
+    navigate(`../${nextSubmissionId}`, {
+      state: {
+        respondentNumber: currentRespondentNumber
+          ? currentRespondentNumber - 1
+          : undefined,
+      },
+    })
+    onNavNextSubmissionId(submissionId)
+  }, [
+    currentRespondentNumber,
+    navigate,
+    nextSubmissionId,
+    onNavNextSubmissionId,
+    submissionId,
+  ])
+
+  const handleNavigatePrev = useCallback(() => {
+    if (!prevSubmissionId) return
+    navigate(`../${prevSubmissionId}`, {
+      state: {
+        respondentNumber: currentRespondentNumber
+          ? currentRespondentNumber + 1
+          : undefined,
+      },
+    })
+    onNavPreviousSubmissionId(submissionId)
+  }, [
+    currentRespondentNumber,
+    navigate,
+    onNavPreviousSubmissionId,
+    prevSubmissionId,
+    submissionId,
+  ])
+
+  const backLink = useMemo(() => {
+    if (!lastNavPage && !lastNavSubmissionId) return `..`
+    const searchParams = new URLSearchParams()
+    if (lastNavPage) searchParams.set('page', lastNavPage.toString())
+    if (lastNavSubmissionId) {
+      searchParams.set('submissionId', lastNavSubmissionId)
+    }
+    return `..?${searchParams}`
+  }, [lastNavPage, lastNavSubmissionId])
+
+  return (
+    <Grid
+      position="sticky"
+      top={0}
+      bg="white"
+      zIndex="docked"
+      templateAreas={{
+        base: "'back navigate' 'respondent respondent'",
+        md: "'back respondent navigate'",
+      }}
+      templateColumns={{ base: '1fr auto', md: 'auto 1fr auto' }}
+      rowGap={{ base: '1.5rem', md: '2.5rem' }}
+      py={{ base: '1.5rem', md: '3rem' }}
+    >
+      <Flex gridArea="back" align="center">
+        <Link
+          display="inline-flex"
+          as={ReactLink}
+          variant="standalone"
+          to={backLink}
+        >
+          <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
+          Back to list
+        </Link>
+      </Flex>
+      <Flex gridArea="respondent" justify="center" align="center">
+        <Skeleton isLoaded={!isLoading}>
+          <Text textStyle="h2" as="h2">
+            Respondent
+            {currentRespondentNumber ? ` #${currentRespondentNumber}` : ''}
+          </Text>
+        </Skeleton>
+      </Flex>
+      <ButtonGroup gridArea="navigate">
+        <IconButton
+          isDisabled={!prevSubmissionId || isAnyFetching}
+          onClick={handleNavigatePrev}
+          icon={<BiChevronLeft />}
+          aria-label="Previous submission"
+        />
+        <IconButton
+          isDisabled={!nextSubmissionId || isAnyFetching}
+          onClick={handleNavigateNext}
+          icon={<BiChevronRight />}
+          aria-label="Next submission"
+        />
+      </ButtonGroup>
+    </Grid>
+  )
+}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,22 +1,9 @@
 import { memo, useCallback, useMemo } from 'react'
-import {
-  BiChevronLeft,
-  BiChevronRight,
-  BiDownload,
-  BiLeftArrowAlt,
-} from 'react-icons/bi'
-import {
-  Link as ReactLink,
-  useLocation,
-  useNavigate,
-  useParams,
-} from 'react-router-dom'
+import { BiDownload } from 'react-icons/bi'
+import { useParams } from 'react-router-dom'
 import {
   Box,
-  ButtonGroup,
-  Grid,
-  Icon,
-  Link,
+  Flex,
   Skeleton,
   Stack,
   StackDivider,
@@ -25,16 +12,15 @@ import {
 import simplur from 'simplur'
 
 import Button from '~components/Button'
-import IconButton from '~components/IconButton'
 import Spinner from '~components/Spinner'
 
 import {
   SecretKeyVerification,
   useStorageResponsesContext,
 } from '../ResponsesPage/storage'
-import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
 import { DecryptedRow } from './DecryptedRow'
+import { IndividualResponseNavbar } from './IndividualResponseNavbar'
 import { useMutateDownloadAttachments } from './mutations'
 import { useIndividualSubmission } from './queries'
 
@@ -60,86 +46,11 @@ const LoadingDecryption = memo(() => {
 })
 
 export const IndividualResponsePage = (): JSX.Element => {
-  const { state } = useLocation()
-  const navigate = useNavigate()
   const { submissionId } = useParams()
   if (!submissionId) throw new Error('Missing submissionId')
 
-  const currentRespondentNumber = useMemo(() => {
-    return (state as { respondentNumber?: number })?.respondentNumber
-  }, [state])
-
   const { secretKey } = useStorageResponsesContext()
-  const {
-    lastNavPage,
-    lastNavSubmissionId,
-    getNextSubmissionId,
-    getPreviousSubmissionId,
-    onNavNextSubmissionId,
-    onNavPreviousSubmissionId,
-    isAnyFetching,
-  } = useUnlockedResponses()
   const { data, isLoading, isError } = useIndividualSubmission()
-
-  const nextSubmissionId = useMemo(
-    () => getNextSubmissionId(submissionId),
-    [getNextSubmissionId, submissionId],
-  )
-  const prevSubmissionId = useMemo(
-    () => getPreviousSubmissionId(submissionId),
-    [getPreviousSubmissionId, submissionId],
-  )
-
-  const handleNavigateNext = useCallback(() => {
-    if (!nextSubmissionId) return
-    navigate(`../${nextSubmissionId}`, {
-      state: {
-        respondentNumber: currentRespondentNumber
-          ? currentRespondentNumber - 1
-          : undefined,
-      },
-    })
-    onNavNextSubmissionId(submissionId)
-  }, [
-    currentRespondentNumber,
-    navigate,
-    nextSubmissionId,
-    onNavNextSubmissionId,
-    submissionId,
-  ])
-
-  const handleNavigatePrev = useCallback(() => {
-    if (!prevSubmissionId) return
-    navigate(`../${prevSubmissionId}`, {
-      state: {
-        respondentNumber: currentRespondentNumber
-          ? currentRespondentNumber + 1
-          : undefined,
-      },
-    })
-    onNavPreviousSubmissionId(submissionId)
-  }, [
-    currentRespondentNumber,
-    navigate,
-    onNavPreviousSubmissionId,
-    prevSubmissionId,
-    submissionId,
-  ])
-
-  const backLink = useMemo(() => {
-    if (!lastNavPage && !lastNavSubmissionId) {
-      return `..`
-    }
-
-    const searchParams = new URLSearchParams()
-    if (lastNavPage) {
-      searchParams.set('page', lastNavPage.toString())
-    }
-    if (lastNavSubmissionId) {
-      searchParams.set('submissionId', lastNavSubmissionId)
-    }
-    return `..?${searchParams}`
-  }, [lastNavPage, lastNavSubmissionId])
 
   const attachmentDownloadUrls = useMemo(() => {
     const attachmentDownloadUrls = new Map()
@@ -172,43 +83,13 @@ export const IndividualResponsePage = (): JSX.Element => {
   if (!secretKey) return <SecretKeyVerification />
 
   return (
-    <Grid
-      px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
-      columnGap={{ base: '0.5rem', lg: '1rem' }}
-      templateColumns={{ base: 'repeat(4, 1fr)', md: 'repeat(12, 1fr)' }}
-    >
-      <Stack spacing="2.5rem" gridColumn="2 / -2">
-        <Stack direction="row" justify="space-between" align="center">
-          <Link
-            display="inline-flex"
-            as={ReactLink}
-            variant="standalone"
-            to={backLink}
-          >
-            <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
-            Back to list
-          </Link>
-          <Skeleton isLoaded={!isLoading}>
-            <Text textStyle="h2" as="h2">
-              Respondent
-              {currentRespondentNumber ? ` #${currentRespondentNumber}` : ''}
-            </Text>
-          </Skeleton>
-          <ButtonGroup>
-            <IconButton
-              isDisabled={!prevSubmissionId || isAnyFetching}
-              onClick={handleNavigatePrev}
-              icon={<BiChevronLeft />}
-              aria-label="Previous submission"
-            />
-            <IconButton
-              isDisabled={!nextSubmissionId || isAnyFetching}
-              onClick={handleNavigateNext}
-              icon={<BiChevronRight />}
-              aria-label="Next submission"
-            />
-          </ButtonGroup>
-        </Stack>
+    <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
+      <IndividualResponseNavbar />
+
+      <Stack
+        px={{ md: '1.75rem', lg: '2rem' }}
+        spacing={{ base: '1.5rem', md: '2.5rem' }}
+      >
         <Stack
           bg="primary.100"
           p="1.5rem"
@@ -216,27 +97,39 @@ export const IndividualResponsePage = (): JSX.Element => {
             fontFeatureSettings: "'tnum' on, 'lnum' on, 'zero' on, 'cv05' on",
           }}
         >
-          <Text display="inline-flex">
+          <Stack
+            spacing={{ base: '0', md: '0.5rem' }}
+            direction={{ base: 'column', md: 'row' }}
+          >
             <Text as="span" textStyle="subhead-1">
               Response ID:
             </Text>
-            &nbsp;{submissionId}
-          </Text>
-          <Box display="inline-flex">
+            <Text>{submissionId}</Text>
+          </Stack>
+          <Stack
+            spacing={{ base: '0', md: '0.5rem' }}
+            direction={{ base: 'column', md: 'row' }}
+          >
             <Text as="span" textStyle="subhead-1">
               Timestamp:
             </Text>
             <Skeleton isLoaded={!isLoading && !isError}>
-              &nbsp;{data?.submissionTime ?? 'Loading...'}
+              {data?.submissionTime ?? 'Loading...'}
             </Skeleton>
-          </Box>
+          </Stack>
           {attachmentDownloadUrls.size > 0 && (
-            <Box alignItems="center" display="inline-flex">
-              <Text as="span" textStyle="subhead-1">
+            <Stack
+              spacing={{ base: '0', md: '0.5rem' }}
+              direction={{ base: 'column', md: 'row' }}
+            >
+              <Text
+                as="span"
+                textStyle="subhead-1"
+                py={{ base: '0', md: '0.25rem' }}
+              >
                 Attachments:
               </Text>
               <Skeleton isLoaded={!isLoading && !isError}>
-                &nbsp;
                 <Button
                   variant="link"
                   isDisabled={downloadAttachmentsAsZipMutation.isLoading}
@@ -252,9 +145,10 @@ export const IndividualResponsePage = (): JSX.Element => {
                   {simplur`Download ${attachmentDownloadUrls.size} attachment[|s] as .zip`}
                 </Button>
               </Skeleton>
-            </Box>
+            </Stack>
           )}
         </Stack>
+
         <Stack>
           {isLoading || isError ? (
             <LoadingDecryption />
@@ -268,6 +162,6 @@ export const IndividualResponsePage = (): JSX.Element => {
           )}
         </Stack>
       </Stack>
-    </Grid>
+    </Flex>
   )
 }

--- a/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
@@ -29,7 +29,8 @@ export const FormResultsNavbar = (): JSX.Element => {
       position="sticky"
       top={0}
       flexDir="column"
-      boxShadow="0 1px 1px var(--chakra-colors-neutral-300)"
+      borderBottom="1px"
+      borderBottomColor="neutral.300"
       bg="white"
       zIndex="docked"
       flex={0}


### PR DESCRIPTION
## Problem
1. #4730 
2. #4732 
3. #4748 

## Solution
1. [verified] label was under header where it would never get used. Moved it to question which is where it actually is needed. lol
2. Created individual response navbar component and locked it in place at the top of the navbar. (Also needed to change form navbar `boxShadow` to `borderBottom`, otherwise the individual response navbar's zindex will overlap it, that's why there's a change to that file) (No changes to the computations of any of the variables, just shifted things around. Only the returned JSX elements have changes)
3. Added mobile support to all components of the individual response page.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

1. 
![image](https://user-images.githubusercontent.com/25571626/188803291-d53db631-5fa8-4515-9418-58a77929a13b.png)

2. and 3.

https://user-images.githubusercontent.com/25571626/188803560-4b910462-9c3b-4ede-b3e5-59e3cd5e24f9.mov


 