### PR TITLE
feat: block navigation on public form page when form is dirty

### DIFF
--- a/frontend/src/features/env/PublicFeedbackModal.tsx
+++ b/frontend/src/features/env/PublicFeedbackModal.tsx
@@ -34,6 +34,7 @@ import { ModalCloseButton } from '~components/Modal'
 import Textarea from '~components/Textarea'
 
 import { useEnvMutations, useFeedbackMutation } from '~features/env/mutations'
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { usePublicFeedbackFormView } from './queries'
 import { isUsableFeedback } from './utils'
@@ -50,6 +51,7 @@ export const PublicFeedbackModal = ({
   responseMode?: FormResponseMode
   authType?: FormAuthType
 }): JSX.Element => {
+  const { setBlockNavigation } = usePublicFormContext()
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -68,7 +70,7 @@ export const PublicFeedbackModal = ({
 
   const url = window.location.href
   const rumSessionId = datadogRum.getInternalContext()?.session_id
-  const [showThanksPage, setShowThanksPage] = useState<boolean>(false)
+  const [showThanksPage, setShowThanksPage] = useState<boolean>(true)
 
   const { publicSwitchEnvMutation } = useEnvMutations()
   const { data: feedbackForm, isLoading } = usePublicFeedbackFormView()
@@ -88,8 +90,9 @@ export const PublicFeedbackModal = ({
   }, [onClose])
 
   const handleChangeEnv = useCallback(() => {
+    setBlockNavigation(false)
     publicSwitchEnvMutation.mutate()
-  }, [publicSwitchEnvMutation])
+  }, [publicSwitchEnvMutation, setBlockNavigation])
 
   const checkboxInputName = 'attachmentType'
 

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -46,6 +46,8 @@ export interface PublicFormContextProps
    */
   onMobileDrawerOpen: () => void
   onMobileDrawerClose: () => void
+  blockNavigation: boolean
+  setBlockNavigation: (val: boolean) => void
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -103,6 +103,7 @@ export const PublicFormProvider = ({
 }: PublicFormProviderProps): JSX.Element => {
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
+  const [blockNavigation, setBlockNavigation] = useState(false)
 
   const { data, isLoading, error, ...rest } = usePublicFormView(
     formId,
@@ -323,6 +324,8 @@ export const PublicFormProvider = ({
         captchaContainerId: containerId,
         expiryInMs,
         isLoading: isLoading || (!!data?.form.hasCaptcha && !hasLoaded),
+        blockNavigation,
+        setBlockNavigation,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -18,6 +18,7 @@ import {
   hasExistingFieldValue,
 } from '~features/myinfo/utils'
 import { useFetchPrefillQuery } from '~features/public-form/hooks/useFetchPrefillQuery'
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
@@ -35,6 +36,8 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
+  const { blockNavigation, setBlockNavigation } = usePublicFormContext()
+
   useFetchPrefillQuery()
   const [searchParams] = useSearchParams()
 
@@ -101,7 +104,11 @@ export const FormFields = ({
     }
   }, [defaultFormValues, isDirty, reset])
 
-  useNavigationPrompt(isDirty)
+  useEffect(() => {
+    if (isDirty) setBlockNavigation(true)
+  }, [isDirty, setBlockNavigation])
+
+  useNavigationPrompt(blockNavigation)
 
   return (
     <FormProvider {...formMethods}>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -10,6 +10,7 @@ import { FormColorTheme, LogicDto } from '~shared/types/form'
 import InlineMessage from '~components/InlineMessage'
 import { FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
+import { useNavigationPrompt } from '~templates/NavigationPrompt/useNavigationPrompt'
 
 import {
   augmentWithMyInfo,
@@ -99,6 +100,8 @@ export const FormFields = ({
       reset(defaultFormValues)
     }
   }, [defaultFormValues, isDirty, reset])
+
+  useNavigationPrompt(isDirty)
 
   return (
     <FormProvider {...formMethods}>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -7,6 +7,7 @@ import { isEmpty, times } from 'lodash'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, LogicDto } from '~shared/types/form'
 
+import { useNativeBlocker } from '~hooks/useNativeBlocker'
 import InlineMessage from '~components/InlineMessage'
 import { FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
@@ -108,7 +109,8 @@ export const FormFields = ({
     if (isDirty) setBlockNavigation(true)
   }, [isDirty, setBlockNavigation])
 
-  useNavigationPrompt(blockNavigation)
+  // useNavigationPrompt(blockNavigation)
+  useNativeBlocker(blockNavigation)
 
   return (
     <FormProvider {...formMethods}>

--- a/frontend/src/hooks/useNativeBlocker.ts
+++ b/frontend/src/hooks/useNativeBlocker.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect } from 'react'
+
+export const useNativeBlocker = (when: boolean) => {
+  const listener = useCallback(
+    (e: BeforeUnloadEvent) => {
+      if (when) e.returnValue = ''
+    },
+    [when],
+  )
+
+  useEffect(() => {
+    window?.addEventListener('beforeunload', listener)
+    return () => {
+      window?.removeEventListener('beforeunload', listener)
+    }
+  }, [listener])
+}


### PR DESCRIPTION
Closes #4793

the existing useNavigationPrompt can be used to fulfill the goal of preventing accidental navigation after form is modified.

Currently the implementation simply uses the isDirty variable provided useForm.formState to determine if navigation should be blocked. When a text field is touched and unfocused with no input change, it is considered dirty already, so if that is not the desired behaviour, further logic is needed perhaps similar to holdingStateDate in the form builder. One very important consideration here is I'm not sure if there is a situation when the isDirty=true but navigation is actually allowed.

Other than the submit button and switch to react, the public form page should not have any links that redirects the page using react-router (might be wrong here, need more context), so the only way of exiting the page is using browser functions. Thus instead of using the underlying react-router-dom functions, native web apis can be used instead for simplicity. The functionality remains the same in my testing.

The user flow for switch to react is also affected as the prompt will be shown after the feedback modal. Not sure if this is desirable and whats the best way to go about this, perhaps there is an easy way to transfer data when switching to angular? 

<img width="1145" alt="Screen Shot 2022-09-07 at 2 11 10 PM" src="https://user-images.githubusercontent.com/39296145/188801898-c8fd83ac-a4ac-496a-be98-4c2a942e8915.png">

Another solution could be to simply save responses localstorage and do away with prompts which might not be the best UX.