### PR TITLE
feat(v2): move settings tabs for mobile to left side

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -45,8 +45,8 @@ export const SettingsPage = (): JSX.Element => {
         isManual
         orientation="vertical"
         variant="line"
-        py={{ base: '3.5rem', lg: '4rem' }}
-        px={{ base: '1.75rem', lg: '2rem' }}
+        py={{ base: '2.5rem', lg: '3.125rem' }}
+        px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
       >
         <Flex
           h="max-content"
@@ -56,8 +56,6 @@ export const SettingsPage = (): JSX.Element => {
           onMouseDown={onMouseDown}
           position="sticky"
           zIndex={0}
-          // Height align text with start of tab panel.
-          mt={{ base: '-1rem', lg: '-0.875rem' }}
           top={{ base: '2.5rem', lg: '3.125rem' }}
           borderTopColor="neutral.300"
           w={{ base: 'auto', lg: '21rem' }}
@@ -83,7 +81,11 @@ export const SettingsPage = (): JSX.Element => {
             <SettingsTab label="Webhooks" icon={BiCodeBlock} />
           </TabList>
         </Flex>
-        <TabPanels maxW="42.5rem">
+        <TabPanels
+          maxW="42.5rem"
+          // Offset start of tabpanel text from tablist.
+          mt={{ md: '1rem' }}
+        >
           <TabPanel>
             <SettingsGeneralPage />
           </TabPanel>

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -38,28 +38,17 @@ export const SettingsPage = (): JSX.Element => {
       navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
   }, [formId, hasEditAccess, isCollabLoading, navigate])
 
-  const tabOrientation: UseTabsProps['orientation'] = useBreakpointValue({
-    base: 'horizontal',
-    xs: 'horizontal',
-    md: 'vertical',
-  })
-
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
 
   return (
-    <Box
-      overflow="auto"
-      flex={1}
-      // Buffer for bottom navbar in mobile breakpoints.
-      mb={{ base: '4rem', md: 'initial' }}
-    >
+    <Box overflow="auto" flex={1}>
       <Tabs
         isLazy
         isManual
-        orientation={tabOrientation}
+        orientation="vertical"
         variant="line"
-        py={{ base: '2.5rem', md: '3.5rem', lg: '4rem' }}
-        px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
+        py={{ base: '3.5rem', lg: '4rem' }}
+        px={{ base: '1.75rem', lg: '2rem' }}
       >
         <Flex
           h="max-content"
@@ -67,18 +56,13 @@ export const SettingsPage = (): JSX.Element => {
           flexShrink={0}
           ref={ref}
           onMouseDown={onMouseDown}
-          overflowX={{ base: 'auto', md: 'initial' }}
-          position={{ base: 'fixed', md: 'sticky' }}
-          zIndex={{ base: 'docked', md: 0 }}
-          bg={{ base: 'neutral.100', md: 'inherit' }}
+          position="sticky"
+          zIndex={0}
           // Height align text with start of tab panel.
-          mt={{ md: '-1rem', lg: '-0.875rem' }}
-          top={{ base: 'initial', md: '2.5rem', lg: '3.125rem' }}
-          bottom={{ base: 0, md: 'initial' }}
-          left={{ base: 0, md: 'initial' }}
-          borderTop={{ base: '1px solid', md: 'none' }}
+          mt={{ base: '-1rem', lg: '-0.875rem' }}
+          top={{ base: '2.5rem', lg: '3.125rem' }}
           borderTopColor="neutral.300"
-          w={{ base: '100vw', md: 'auto', lg: '21rem' }}
+          w={{ base: 'auto', lg: '21rem' }}
           __css={{
             scrollbarWidth: 0,
             /* Scrollbar for Chrome, Safari, Opera and Microsoft Edge */
@@ -92,7 +76,6 @@ export const SettingsPage = (): JSX.Element => {
             overflowX="initial"
             display="inline-flex"
             w="max-content"
-            ml={{ base: '1.5rem', md: 0 }}
             mr={{ base: '1.5rem', md: '4rem', lg: '2rem' }}
             mb="calc(0.5rem - 2px)"
           >

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -9,8 +9,6 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
-  useBreakpointValue,
-  UseTabsProps,
 } from '@chakra-ui/react'
 
 import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'


### PR DESCRIPTION
## Problem
Settings page tabs currently exist at the bottom of the page. We want them to exist on the left side instead, to be consistent with desktop.

Closes #4744 

## Solution
Remove the custom CSS for creating the sidebar at the bottom of the page.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/188815476-56bdba19-766b-46f0-bfc8-0dea539f9467.mov


