### PR TITLE
chore(v2): remove partytown

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,6 +27,3 @@ build-storybook.log
 
 # Lint cache
 .eslintcache
-
-# Dynamic package for loading third party scripts in app.
-~partytown

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1439,11 +1439,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@builder.io/partytown": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.5.2.tgz",
-      "integrity": "sha512-DHJPs5WPVFExUuGMsuA6yZQ6OPtVVv/3JJK9pzGrNfvuGNvlip5v7xOhXwZG26HLU9ZrrOFsOGhn5FUT2H7dPw=="
-    },
     "@chakra-ui/accordion": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.11.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,6 @@
   "homepage": ".",
   "private": true,
   "dependencies": {
-    "@builder.io/partytown": "^0.5.1",
     "@chakra-ui/react": "^1.8.6",
     "@datadog/browser-rum": "^4.14.0",
     "@emotion/react": "^11.7.0",
@@ -77,11 +76,6 @@
     "zustand": "^3.6.5"
   },
   "scriptComments": {
-    "partytown": [
-      "Package that allows running of third-party scripts in a web-worker for better app performance.",
-      "Since Partytown is using a service worker, these files must be served from the same app.",
-      "Thus, the package library needs to be bundled in the final build."
-    ],
     "clean:emotion-types": [
       "Prevents injected emotion types from conflicting with ChakraUI types, such as `css`.",
       "See https://github.com/emotion-js/emotion/issues/1800"
@@ -96,9 +90,7 @@
   },
   "scripts": {
     "gen:theme-typings": "chakra-cli tokens src/theme/index.ts || true",
-    "partytown": "partytown copylib public/~partytown",
     "clean:emotion-types": "rimraf node_modules/@emotion/core/types",
-    "postinstall": "npm run gen:theme-typings && npm run clean:emotion-types && npm run partytown && npm --prefix ../shared install",
     "start": "env-cmd -f .buildtime-env craco start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test --silent",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,6 +91,7 @@
   "scripts": {
     "gen:theme-typings": "chakra-cli tokens src/theme/index.ts || true",
     "clean:emotion-types": "rimraf node_modules/@emotion/core/types",
+    "postinstall": "npm run gen:theme-typings && npm run clean:emotion-types && npm --prefix ../shared install",
     "start": "env-cmd -f .buildtime-env craco start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test --silent",


### PR DESCRIPTION
## Problem
We no longer use `partytown` to load Google Analytics 4 (related to #4665)

## Solution
<!-- How did you solve the problem? -->
Remove `partytown`.

We can explore re-enabling `partytown` with GA4 when we look into optimising our deployment pipeline.