### PR TITLE
feat(v2): enable refetch on mount for storage responses

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -24,14 +24,14 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 100, // maxWidth is only used as a limit for resizing
   },
   {
-    Header: 'Reference ID',
+    Header: 'Response ID',
     accessor: 'refNo',
     minWidth: 200,
     width: 300,
     maxWidth: 240, // maxWidth is only used as a limit for resizing
   },
   {
-    Header: 'Submission time',
+    Header: 'Timestamp',
     accessor: 'submissionTime',
     minWidth: 200,
     width: 300,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/SubmissionSearchbar.tsx
@@ -29,7 +29,7 @@ export const SubmissionSearchbar = ({
       onChange={setInputValue}
       onCollapseIconClick={() => setSubmissionId(null)}
       onSearch={setSubmissionId}
-      placeholder="Search by reference ID"
+      placeholder="Search by response ID"
     />
   )
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponses.tsx
@@ -45,11 +45,11 @@ export const UnlockedResponses = (): JSX.Element => {
         mb="1rem"
         alignItems="end"
         color="secondary.500"
-        gridTemplateColumns={{ base: 'auto', md: 'auto 1fr' }}
-        gridGap={{ base: '0.5rem', md: '1.5rem' }}
+        gridTemplateColumns={{ base: 'auto 1fr', lg: 'auto 1fr auto' }}
+        gridGap="0.5rem"
         gridTemplateAreas={{
-          base: "'submissions' 'export'",
-          md: "'submissions export'",
+          base: "'submissions search' 'export export'",
+          lg: "'submissions search export'",
         }}
       >
         <Stack
@@ -67,19 +67,29 @@ export const UnlockedResponses = (): JSX.Element => {
             </Text>
           </Skeleton>
         </Stack>
-        <Stack direction="row" gridArea="export" justifySelf="end">
+
+        <Flex gridArea="search" justifySelf="end">
           <SubmissionSearchbar
             submissionId={submissionId}
             setSubmissionId={setSubmissionId}
             isAnyFetching={isAnyFetching}
           />
+        </Flex>
+
+        <Stack
+          direction={{ base: 'column', sm: 'row' }}
+          justifySelf={{ base: 'start', sm: 'end' }}
+          gridArea="export"
+        >
           <DateRangeInput value={dateRange} onChange={setDateRange} />
           <DownloadButton />
         </Stack>
       </Grid>
+
       <Box mb="3rem" overflow="auto" flex={1}>
         <ResponsesTable />
       </Box>
+
       <Box display={isLoading || countToUse === 0 ? 'none' : ''}>
         <Pagination
           totalCount={countToUse ?? 0}

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -90,6 +90,7 @@ export const useFormResponses = ({
     adminFormResponsesKeys.metadata(formId, params),
     () => getFormSubmissionsMetadata(formId, params),
     {
+      staleTime: 0,
       keepPreviousData: !submissionId,
       enabled: !!secretKey && (page > 0 || !!submissionId),
     },

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -90,11 +90,6 @@ export const useFormResponses = ({
     adminFormResponsesKeys.metadata(formId, params),
     () => getFormSubmissionsMetadata(formId, params),
     {
-      refetchOnMount: true,
-      // Consider data stale after 10s, prevent admins from initiating too many
-      // fetches by continuously clicking out and in of the results tab to
-      // refetch data
-      staleTime: 10000,
       keepPreviousData: !submissionId,
       enabled: !!secretKey && (page > 0 || !!submissionId),
     },

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -91,9 +91,10 @@ export const useFormResponses = ({
     () => getFormSubmissionsMetadata(formId, params),
     {
       refetchOnMount: true,
-      refetchOnWindowFocus: false,
-      // Data will never change.
-      staleTime: Infinity,
+      // Consider data stale after 10s, prevent admins from initiating too many
+      // fetches by continuously clicking out and in of the results tab to
+      // refetch data
+      staleTime: 10000,
       keepPreviousData: !submissionId,
       enabled: !!secretKey && (page > 0 || !!submissionId),
     },


### PR DESCRIPTION
## Problem
Storage responses was not refetching until the admin refreshed the page. But once they refresh the page, they need to upload their secret key again, creating higher friction for admins to see their updated form responses.

Closes #4737 

## Solution
Remove custom refetch settings.

Also made some changes to the storage responses page for mobile responsiveness.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/189083049-fed255c0-cb18-4606-81e9-c2c02ec78bdf.mov
