### PR TITLE
style(v2): reduce modal's default margin-y to 4rem from 8rem

### DIFF
--- a/frontend/src/theme/components/Modal.ts
+++ b/frontend/src/theme/components/Modal.ts
@@ -18,7 +18,7 @@ const baseStyleDialog: SystemStyleFunction = (props) => {
   const { scrollBehavior } = props
   return {
     borderRadius: '0.25rem',
-    my: '8rem',
+    my: '4rem',
     maxH: scrollBehavior === 'inside' ? 'calc(100% - 16rem)' : undefined,
     boxShadow: 'md',
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Updates modal margins to better fit GSIB's default zoom.

Closes #4707
