### PR TITLE
fix: non-existent dates and open ended date range

### DIFF
--- a/frontend/src/components/DatePicker/DateInput.tsx
+++ b/frontend/src/components/DatePicker/DateInput.tsx
@@ -1,4 +1,10 @@
-import { KeyboardEventHandler, useCallback, useMemo, useRef } from 'react'
+import {
+  ChangeEvent,
+  KeyboardEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
 import FocusLock from 'react-focus-lock'
 import {
   Flex,
@@ -13,7 +19,7 @@ import {
   useFormControlProps,
 } from '@chakra-ui/react'
 import { ComponentWithAs, forwardRef } from '@chakra-ui/system'
-import { format } from 'date-fns'
+import { format, isValid, parse } from 'date-fns'
 
 import { BxCalendar } from '~assets/icons'
 import IconButton from '~components/IconButton'
@@ -65,6 +71,14 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
       [onChange],
     )
 
+    /**
+     * Disallow manual input of non-existant dates (e.g. 31 Sep 2022)
+     */
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+      if (isValid(parse(e.target.value, 'yyyy-MM-dd', new Date())))
+        return onChange?.(e.target.value)
+    }
+
     const datePickerDate = useMemo(() => {
       const dateFromValue = new Date(value)
       return isNaN(dateFromValue.getTime()) ? undefined : dateFromValue
@@ -110,7 +124,7 @@ export const DateInput = forwardRef<DateInputProps, 'input'>(
                       display: 'none',
                     },
                   }}
-                  onChange={(e) => onChange?.(e.target.value)}
+                  onChange={handleInputChange}
                   ref={ref}
                   value={value}
                   {...props}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -127,7 +127,7 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
     'dateValidation.customMinDate'
   > = useMemo(
     () => ({
-      // customMin is required if there is selected validation.
+      // either customMin or customMax is required if custom date range validation is selected.
       validate: {
         hasValidation: (val) => {
           const hasMaxValue =
@@ -142,6 +142,8 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
           const date = new Date(val)
           const maxDate = new Date(getValues('dateValidation.customMaxDate'))
           return (
+            !getValues('dateValidation.customMaxDate') || // Only min date
+            !val || // Only max date
             isEqual(date, maxDate) ||
             isBefore(date, maxDate) ||
             'Max date cannot be less than min date.'


### PR DESCRIPTION
## Problem
- Closes #4706 

- Problem 1: 31st dates are allowed for months that do not have it (or 29/30/31 allowed for non-leap year february too). This occurs only if you manually key in the date to the input.

  Solution: Currently, date input field already disallows invalid dates such as '31/13/2022' from being keyed in. Extends the existing functionality to disallow non-existent dates (e.g. 31/09/2022) from being keyed in as well. 

  Note: The ticket suggested that the error message displayed was wrong and we should change it. What actually happens is that when a non-existent date is keyed in to the input field, the value stored is `null`, and hence the error message corresponds to the case when no date is entered. 

- Problem 2: Open ended date ranges are not currently allowed

  Solution: Fixed code logic to allow open ended date range.