### PR TITLE
fix(v2): responsive layouts based on width of drawer

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
@@ -22,7 +22,7 @@ import { FieldListDrawer } from './FieldListDrawer'
 
 export const BuilderAndDesignDrawer = (): JSX.Element | null => {
   const isMobile = useIsMobile()
-  const { activeTab, isDrawerOpen } = useCreatePageSidebar()
+  const { activeTab, isDrawerOpen, drawerRef } = useCreatePageSidebar()
   const createOrEditData = useFieldBuilderStore(stateDataSelector)
 
   const drawerMotionProps = useMemo(() => {
@@ -78,7 +78,7 @@ export const BuilderAndDesignDrawer = (): JSX.Element | null => {
           overflow="hidden"
           {...drawerMotionProps}
         >
-          <Flex w="100%" h="100%" flexDir="column">
+          <Flex w="100%" h="100%" flexDir="column" ref={drawerRef}>
             {renderDrawerContent}
           </Flex>
         </MotionBox>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -23,6 +23,8 @@ import Input from '~components/Input'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
+import { useCreatePageSidebar } from '~features/admin-form/create/common'
+
 import { DrawerContentContainer } from '../common/DrawerContentContainer'
 import { FormFieldDrawerActions } from '../common/FormFieldDrawerActions'
 import { EditFieldProps } from '../common/types'
@@ -31,6 +33,8 @@ import { useEditFieldForm } from '../common/useEditFieldForm'
 type EditDateProps = EditFieldProps<DateFieldBase>
 
 const EDIT_DATE_FIELD_KEYS = ['title', 'description', 'required'] as const
+
+const MIN_WIDTH_FOR_2_COL = 405
 
 type EditDateInputs = Pick<
   DateFieldBase,
@@ -154,6 +158,8 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
     [getValues],
   )
 
+  const { drawerWidth } = useCreatePageSidebar()
+
   return (
     <DrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
@@ -196,20 +202,32 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
           {getValues('dateValidation.selectedDateValidation') ===
           DateSelectedValidation.Custom ? (
             <>
-              <Controller
-                control={control}
-                name="dateValidation.customMinDate"
-                rules={customMinValidationOptions}
-                render={({ field }) => <DateInput {...field} />}
-              />
-              <Controller
-                control={control}
-                rules={{
-                  deps: ['dateValidation.customMinDate'],
-                }}
-                name="dateValidation.customMaxDate"
-                render={({ field }) => <DateInput {...field} />}
-              />
+              <Box
+                gridColumn={
+                  drawerWidth < MIN_WIDTH_FOR_2_COL ? '1/3' : undefined
+                }
+              >
+                <Controller
+                  control={control}
+                  name="dateValidation.customMinDate"
+                  rules={customMinValidationOptions}
+                  render={({ field }) => <DateInput {...field} />}
+                />
+              </Box>
+              <Box
+                gridColumn={
+                  drawerWidth < MIN_WIDTH_FOR_2_COL ? '1/3' : undefined
+                }
+              >
+                <Controller
+                  control={control}
+                  rules={{
+                    deps: ['dateValidation.customMinDate'],
+                  }}
+                  name="dateValidation.customMaxDate"
+                  render={({ field }) => <DateInput {...field} />}
+                />
+              </Box>
             </>
           ) : null}
         </SimpleGrid>

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -7,6 +7,8 @@ import {
   useMemo,
   useState,
 } from 'react'
+import { useMeasure } from 'react-use'
+import { UseMeasureRef } from 'react-use/lib/useMeasure'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 
@@ -41,6 +43,8 @@ type CreatePageSidebarContextProps = {
   isDrawerOpen: boolean
   fieldListTabIndex: FieldListTabIndex
   setFieldListTabIndex: (tabIndex: FieldListTabIndex) => void
+  drawerRef: UseMeasureRef<HTMLDivElement>
+  drawerWidth: number
 }
 
 const CreatePageSidebarContext = createContext<
@@ -151,6 +155,8 @@ export const useCreatePageSidebarContext =
       setPendingTab(undefined)
     }, [isMobile, pendingTab, setFieldsToInactive])
 
+    const [drawerRef, { width: drawerWidth }] = useMeasure<HTMLDivElement>()
+
     return {
       activeTab,
       pendingTab,
@@ -163,6 +169,8 @@ export const useCreatePageSidebarContext =
       handleClose,
       fieldListTabIndex,
       setFieldListTabIndex,
+      drawerRef,
+      drawerWidth,
     }
   }
 


### PR DESCRIPTION
## Problem
breakpoints might not be flexible enough as the current layout allows a split drawer and content up to minimum width of 768px which means each column can get very narrow. Since breakpoints are based on the width of the entire page, it can't account for the split panels. This mainly affects the custom date range input in form builder.


## Solution
Most scenarios can be satisfied by simply setting breakpoints at `lg` instead of `md`, as per #4835. This PR adds a hook that watches the width of the drawer container then layouts can be changed at any arbitrary width.

Pros:
More flexible

Cons:
Not the cleanest code

Room for improvement:
hook could probably be optimised to give it more structure as opposed to returning the raw width?

## Before & After Screenshots

**BEFORE**
<img width="748" alt="Screen Shot 2022-09-09 at 1 47 06 PM" src="https://user-images.githubusercontent.com/39296145/189280137-e91e019a-8f25-4825-883a-1f8c8714ca33.png">

**WITH BREAKPOINTS**
<img width="1039" alt="Screen Shot 2022-09-09 at 1 46 23 PM" src="https://user-images.githubusercontent.com/39296145/189280144-aca793c9-74d9-4815-ac42-d4f5026a73a6.png">

**WITH ARBITRARY WIDTH**
<img width="1121" alt="Screen Shot 2022-09-09 at 1 47 49 PM" src="https://user-images.githubusercontent.com/39296145/189280151-5f6cdb1e-0f05-4e56-9861-63165fb77751.png">

