### PR TITLE
fix(v2): reset emails input using state to prevent erratic behavior

### DIFF
--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -5,7 +5,7 @@ import {
   useForm,
   useFormContext,
 } from 'react-hook-form'
-import { FormControl } from '@chakra-ui/react'
+import { FormControl, useToast } from '@chakra-ui/react'
 import { get, isEmpty, isEqual } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
@@ -51,6 +51,15 @@ export const EmailFormSection = ({
 
     return mutateFormEmails.mutate(nextEmails)
   }
+  const errorToast = useToast({ status: 'error', isClosable: true })
+
+  const onInvalid = () => {
+    reset({ emails: settings.emails })
+    if (get(errors, 'emails.type') === 'required') {
+      errorToast.closeAll()
+      errorToast({ description: get(errors, 'emails.message') })
+    }
+  }
 
   return (
     <FormProvider {...formMethods}>
@@ -62,7 +71,10 @@ export const EmailFormSection = ({
         >
           Emails where responses will be sent
         </FormLabel>
-        <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
+        <AdminEmailRecipientsInput
+          onSubmit={handleSubmitEmails}
+          onInvalid={onInvalid}
+        />
         <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
       </FormControl>
     </FormProvider>
@@ -71,17 +83,18 @@ export const EmailFormSection = ({
 
 interface AdminEmailRecipientsInputProps {
   onSubmit: (params: { emails: string[] }) => void
+  onInvalid?: () => void
 }
 
 const AdminEmailRecipientsInput = ({
   onSubmit,
+  onInvalid,
 }: AdminEmailRecipientsInputProps): JSX.Element => {
-  const { control, handleSubmit, reset } =
-    useFormContext<{ emails: string[] }>()
+  const { control, handleSubmit } = useFormContext<{ emails: string[] }>()
 
   const handleBlur = useCallback(() => {
-    return handleSubmit(onSubmit, () => reset())()
-  }, [handleSubmit, onSubmit, reset])
+    return handleSubmit(onSubmit, onInvalid)()
+  }, [handleSubmit, onSubmit, onInvalid])
 
   return (
     <Controller


### PR DESCRIPTION
## Problem
Emails input resets to defaultState when the one remaining email is removed. DefaultState is taken when useForm is initiated so it is whatever the original list of emails was.

Closes #4765

## Solution
Reset email input using values from store instead. Also added a error toast as previously no indication of any error if 'X' button is clicked last remaining email. 

**AFTER**:
![sr](https://user-images.githubusercontent.com/39296145/189510585-b99a21ed-d896-4f4a-bd4e-d4c90e51fb5d.gif)

## For consideration
Currently the api calls only happen onBlur however, it might be more natural to update after pressing 'Enter' key.

There is different behaviour when clicking 'X' vs pressing backspace so that might want to be improved upon. Clicking 'X' will not allow last email to be removed, whereas backspace will allow last email to be removed, but will be reset to original state onBlur. (see above video)