### PR TITLE
fix(v2): page scrolls completely to bottom on mobile

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -47,7 +47,7 @@ export const AdminFormLayout = (): JSX.Element => {
   }
 
   return (
-    <Flex flexDir="column" height="100vh" overflow="hidden" pos="relative">
+    <Flex flexDir="column" height="100%" overflow="hidden" pos="relative">
       {bannerProps ? (
         <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
       ) : null}

--- a/frontend/src/features/user/billing/BillingPage.tsx
+++ b/frontend/src/features/user/billing/BillingPage.tsx
@@ -22,7 +22,7 @@ export const BillingPage = (): JSX.Element => {
     setEsrvcId(esrvcId?.trim())
 
   return (
-    <Flex direction="column" h="100vh">
+    <Flex direction="column" h="100%">
       <AdminNavBar />
       <Container
         overflowY="auto"

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -73,7 +73,7 @@ export const WorkspacePage = (): JSX.Element => {
         isOpen={createFormModalDisclosure.isOpen}
         onClose={createFormModalDisclosure.onClose}
       />
-      <Flex direction="column" h="100vh">
+      <Flex direction="column" h="100%">
         {bannerProps ? (
           <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
         ) : null}


### PR DESCRIPTION
## Problem
page does not scroll all the way to the bottom on mobile browsers on first scroll. Issue is better described in these articles.
[https://dev.to/nirazanbasnet/dont-use-100vh-for-mobile-responsive-3o97](https://dev.to/nirazanbasnet/dont-use-100vh-for-mobile-responsive-3o97)
[https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html](https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html)
[https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile](https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile)

Closes #4767

## Solution
simplest solution seems to be replacing 100vh with 100% instead.

**AFTER**
![iosgif](https://user-images.githubusercontent.com/39296145/189526012-10d4d29f-338d-4f7c-8551-f7f4acd3b727.gif)
#
![android](https://user-images.githubusercontent.com/39296145/189525966-c4f383aa-5a33-4083-8cd6-1210b99cfe7b.gif)


## Considerations
One side effect is now the address bar on mobile browsers will not scroll away, limiting screen height for content. Removing height property completely will fix this issue but position: sticky for headers will stop working. To get both sticky headers, and address bar to scroll away, an option is to set fixed header height and equal padding: top to the content. However, as the headers are currently not fixed in height, this is not so straightforward as well.
