### PR TITLE
fix(v2): set default behavior for NumberInput to not focus on clicking steppers

### DIFF
--- a/frontend/src/components/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/NumberInput/NumberInput.tsx
@@ -29,7 +29,6 @@ export interface NumberInputProps extends ChakraNumberInputProps {
    * Whether to show the increment and decrement steppers. Defaults to true.
    */
   showSteppers?: boolean
-
   /**
    * Color scheme of number input.
    */
@@ -41,6 +40,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
     {
       showSteppers = true,
       clampValueOnBlur = false,
+      focusInputOnChange = false,
       isSuccess,
       isPrefilled,
       colorScheme,
@@ -70,6 +70,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
     } = useNumberInput({
       ...controlProps,
       clampValueOnBlur,
+      focusInputOnChange,
     })
 
     const inputProps = getInputProps({ placeholder: props.placeholder })


### PR DESCRIPTION
## Problem
After clicking the `- | +` steppers for minimum rows in the EditTable drawer, the number input gets highlighted, causing the associated Toggle for allowing respondents to add more rows to not work. There is currently a bug with Chakra which causes toggles to not work when something on screen is highlighted, as pointed out in the issue.

Closes #4753 

## Solution
Avoid the issue entirely by setting `focusInputOnChange` to `false`, which controls if the input is focused when the stepper is clicked. This is set as a default by changing the `NumberInput` component directly, so that the behavior of not focusing on click is consistent throughout the app. 

<img width="781" alt="image" src="https://user-images.githubusercontent.com/25571626/189562932-715ac16a-232f-4cdf-9024-4e867390760b.png">

**Breaking Changes** 
- No - this PR is backwards compatible  
