### PR TITLE
fix(v2): update hashbang routing

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -21,7 +21,7 @@ import {
   EMERGENCY_CONTACT_KEY_PREFIX,
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
 } from '~constants/localStorage'
-import { ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { logout } from '~services/AuthService'
@@ -235,7 +235,7 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   return (
     <>
       <AdminNavBar.Container>
-        <ReactLink title="Form Logo" to={ROOT_ROUTE}>
+        <ReactLink title="Form Logo" to={DASHBOARD_ROUTE}>
           {<BrandSmallLogo w="2rem" />}
         </ReactLink>
         <HStack

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -8,12 +8,12 @@ import {
   ADMINFORM_ROUTE,
   ADMINFORM_SETTINGS_SUBROUTE,
   BILLING_ROUTE,
+  DASHBOARD_ROUTE,
   LANDING_ROUTE,
   LOGIN_ROUTE,
   PRIVACY_POLICY_ROUTE,
   PUBLICFORM_ROUTE,
   RESULTS_FEEDBACK_SUBROUTE,
-  ROOT_ROUTE,
   TOU_ROUTE,
 } from '~constants/routes'
 
@@ -59,7 +59,7 @@ export const AppRouter = (): JSX.Element => {
           element={<HashRouterElement element={<LandingPage />} />}
         />
         <Route
-          path={ROOT_ROUTE}
+          path={DASHBOARD_ROUTE}
           element={<PrivateElement element={<WorkspacePage />} />}
         />
         <Route

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom'
 
-import { ROOT_ROUTE } from '~constants/routes'
+import { LANDING_ROUTE, ROOT_ROUTE } from '~constants/routes'
 
 import { PublicElement } from './PublicElement'
 
@@ -31,17 +31,20 @@ const hashRouteMapper = [
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
-    getTarget: (m: FormRegExpMatchArray) =>
-      `${ROOT_ROUTE}/admin/form/${m.groups.formid}`,
+    getTarget: (m: FormRegExpMatchArray) => `/admin/form/${m.groups.formid}`,
   },
   {
     regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
     getTarget: (m: FormRegExpMatchArray) =>
-      `${ROOT_ROUTE}/admin/form/${m.groups.formid}/preview`,
+      `/admin/form/${m.groups.formid}/preview`,
   },
   {
     regex: /^#!\/examples$/,
-    getTarget: (m: FormRegExpMatchArray) => `${ROOT_ROUTE}/admin`,
+    getTarget: (m: FormRegExpMatchArray) => `${LANDING_ROUTE}`,
+  },
+  {
+    regex: /^#!\/forms$/,
+    getTarget: (m: FormRegExpMatchArray) => `${ROOT_ROUTE}`,
   },
 ]
 

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom'
 
-import { LANDING_ROUTE, ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 
 import { PublicElement } from './PublicElement'
 
@@ -39,12 +39,12 @@ const hashRouteMapper = [
       `/admin/form/${m.groups.formid}/preview`,
   },
   {
-    regex: /^#!\/examples$/,
-    getTarget: (m: FormRegExpMatchArray) => `${LANDING_ROUTE}`,
+    regex: /^#!\/forms$/,
+    getTarget: (m: FormRegExpMatchArray) => `${DASHBOARD_ROUTE}`,
   },
   {
-    regex: /^#!\/forms$/,
-    getTarget: (m: FormRegExpMatchArray) => `${ROOT_ROUTE}`,
+    regex: /^#!\/examples$/,
+    getTarget: (m: FormRegExpMatchArray) => `/examples`,
   },
 ]
 

--- a/frontend/src/app/PublicElement.tsx
+++ b/frontend/src/app/PublicElement.tsx
@@ -2,7 +2,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import { useAuth } from '~contexts/AuthContext'
-import { ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import GovtMasthead from '~components/GovtMasthead'
 
 interface PublicElementProps {
@@ -28,7 +28,7 @@ export const PublicElement = ({
   const { isAuthenticated } = useAuth()
 
   if (isAuthenticated && strict) {
-    return <Navigate to={state?.from.pathname ?? ROOT_ROUTE} replace />
+    return <Navigate to={state?.from.pathname ?? DASHBOARD_ROUTE} replace />
   }
 
   return (

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,5 +1,5 @@
 export const LANDING_ROUTE = '/'
-export const ROOT_ROUTE = '/dashboard'
+export const DASHBOARD_ROUTE = '/dashboard'
 export const LOGIN_ROUTE = '/login'
 
 export const TOU_ROUTE = '/terms'

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -7,7 +7,7 @@ import { FormStatus } from '~shared/types'
 import {
   ADMINFORM_PREVIEW_ROUTE,
   ADMINFORM_ROUTE,
-  ROOT_ROUTE,
+  DASHBOARD_ROUTE,
 } from '~constants/routes'
 
 import { ShareFormModal } from '~features/admin-form/share'
@@ -26,7 +26,7 @@ const useAdminFormNavbar = () => {
   const navigate = useNavigate()
 
   const handleBackToDashboard = useCallback(
-    (): void => navigate(ROOT_ROUTE),
+    (): void => navigate(DASHBOARD_ROUTE),
     [navigate],
   )
 

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -10,7 +10,7 @@ import {
   StartPageUpdateDto,
 } from '~shared/types/form/form'
 
-import { ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import { useToast } from '~hooks/useToast'
 import { HttpError } from '~services/ApiService'
 
@@ -298,7 +298,7 @@ export const useMutateCollaborators = () => {
           description:
             'You have removed yourself as a collaborator from the form.',
         })
-        navigate(ROOT_ROUTE)
+        navigate(DASHBOARD_ROUTE)
         // Remove all related queries from cache.
         queryClient.removeQueries(adminFormKeys.id(formId))
       },

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 import { getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
 
-import { ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import {
   getMobileViewParameters,
   LoggedInDecorator,
@@ -61,8 +61,8 @@ export default {
   decorators: [
     ViewedRolloutDecorator,
     StoryRouter({
-      initialEntries: [ROOT_ROUTE],
-      path: ROOT_ROUTE,
+      initialEntries: [DASHBOARD_ROUTE],
+      path: DASHBOARD_ROUTE,
     }),
     mockDateDecorator,
     LoggedInDecorator,

--- a/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.tsx
+++ b/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Stack, Text } from '@chakra-ui/react'
 import { AppFooter } from '~/app/AppFooter'
 
 import { useAuth } from '~contexts/AuthContext'
-import { LOGIN_ROUTE, ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE, LOGIN_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import Link from '~components/Link'
@@ -80,7 +80,7 @@ export const AdminForbiddenErrorPage = ({
               <Link
                 variant="standalone"
                 as={ReactLink}
-                to={isAuthenticated ? ROOT_ROUTE : LOGIN_ROUTE}
+                to={isAuthenticated ? DASHBOARD_ROUTE : LOGIN_ROUTE}
               >
                 {isAuthenticated ? 'Go to dashboard' : 'Log in'}
               </Link>

--- a/frontend/src/pages/NotFoundError/NotFoundErrorPage.tsx
+++ b/frontend/src/pages/NotFoundError/NotFoundErrorPage.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Stack, Text } from '@chakra-ui/react'
 import { AppFooter } from '~/app/AppFooter'
 
 import { useAuth } from '~contexts/AuthContext'
-import { ROOT_ROUTE } from '~constants/routes'
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import Link from '~components/Link'
@@ -57,7 +57,7 @@ export const NotFoundErrorPage = (): JSX.Element => {
                 Back
               </Button>
               {isAuthenticated ? (
-                <Link variant="standalone" as={ReactLink} to={ROOT_ROUTE}>
+                <Link variant="standalone" as={ReactLink} to={DASHBOARD_ROUTE}>
                   Go to dashboard
                 </Link>
               ) : null}

--- a/src/app/routes/api/v3/user/__tests__/user.routes.spec.ts
+++ b/src/app/routes/api/v3/user/__tests__/user.routes.spec.ts
@@ -600,7 +600,7 @@ describe('user.routes', () => {
         .send({ version: MOCK_UPDATE_VERSION })
 
       // Assert
-      expect(retrieveUserSpy).toBeCalled()
+      expect(retrieveUserSpy).toHaveBeenCalled()
       expect(response.status).toEqual(500)
       expect(response.body).toEqual(mockErrorString)
     })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Hashbanged admin URL was not routing correctly
 
Closes #4809

## Solution
- Update routing for admin form and preview
- Add routing for examples page

**Bug fixes**
- Updated `user.routes` test

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
Each of the following routes should redirect to the non-hangbang React version - (remember to replace `formId`)
https://staging.form.gov.sg/#!/63033f67721bbb0012521e2d
https://staging.form.gov.sg/#!/${formId}/admin
https://staging.form.gov.sg/#!/${formId}/preview
https://staging.form.gov.sg/#!/forms
https://staging.form.gov.sg/#!/examples => 404
