### PR TITLE
fix(a11y): improved public form start page, env switch banner, yes/no field

### DIFF
--- a/frontend/src/components/Field/YesNo/YesNo.tsx
+++ b/frontend/src/components/Field/YesNo/YesNo.tsx
@@ -3,14 +3,11 @@ import { BiCheck, BiX } from 'react-icons/bi'
 import {
   forwardRef,
   HStack,
-  Icon,
   useFormControlProps,
-  useMultiStyleConfig,
   useRadioGroup,
 } from '@chakra-ui/react'
 import pick from 'lodash/pick'
 
-import { YESNO_THEME_KEY } from '~theme/components/Field/YesNo'
 import { FieldColorScheme } from '~theme/foundations/colours'
 
 import { YesNoOption } from './YesNoOption'
@@ -53,19 +50,13 @@ export interface YesNoProps {
  */
 export const YesNo = forwardRef<YesNoProps, 'input'>(
   ({ colorScheme, ...props }, ref) => {
-    const styles = useMultiStyleConfig(YESNO_THEME_KEY, props)
     const formControlProps = useFormControlProps(props)
     const { getRootProps, getRadioProps } = useRadioGroup(props)
 
     const groupProps = getRootProps()
     const [noProps, yesProps] = useMemo(() => {
       const baseProps = {
-        ...pick(formControlProps, [
-          'isDisabled',
-          'isReadOnly',
-          'isRequired',
-          'isInvalid',
-        ]),
+        ...pick(formControlProps, ['isDisabled', 'isReadOnly', 'isInvalid']),
         name: props.name,
       }
 
@@ -91,14 +82,16 @@ export const YesNo = forwardRef<YesNoProps, 'input'>(
           // Ref is set here for tracking current value, and also so any errors
           // can focus this input.
           ref={ref}
-        >
-          <Icon as={BiX} __css={styles.icon} />
-          No
-        </YesNoOption>
-        <YesNoOption side="right" colorScheme={colorScheme} {...yesProps}>
-          <Icon as={BiCheck} __css={styles.icon} />
-          Yes
-        </YesNoOption>
+          leftIcon={BiX}
+          label="No"
+        />
+        <YesNoOption
+          side="right"
+          colorScheme={colorScheme}
+          {...yesProps}
+          leftIcon={BiCheck}
+          label="Yes"
+        />
       </HStack>
     )
   },

--- a/frontend/src/components/Field/YesNo/YesNoOption.tsx
+++ b/frontend/src/components/Field/YesNo/YesNoOption.tsx
@@ -1,19 +1,28 @@
 import { KeyboardEvent, useCallback } from 'react'
+import { IconType } from 'react-icons/lib'
 import {
   Box,
   forwardRef,
+  Icon,
   useMultiStyleConfig,
   useRadio,
   UseRadioGroupReturn,
   UseRadioProps,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { YESNO_THEME_KEY } from '~theme/components/Field/YesNo'
 import { FieldColorScheme } from '~theme/foundations/colours'
 
 interface YesNoOptionProps extends UseRadioProps {
-  children: React.ReactNode
+  /**
+   * Icon to be displayed to the left of the option content.
+   */
+  leftIcon?: IconType
+
+  /**
+   * Label to be displayed as the option content.
+   */
+  label: string
 
   /**
    * Side of the option for styling to be used for styling.
@@ -37,7 +46,7 @@ interface YesNoOptionProps extends UseRadioProps {
  * Option rendering for `YesNo` component.
  */
 export const YesNoOption = forwardRef<YesNoOptionProps, 'input'>(
-  ({ children, ...props }, ref) => {
+  ({ leftIcon, label, ...props }, ref) => {
     const styles = useMultiStyleConfig(YESNO_THEME_KEY, props)
 
     const { getInputProps, getCheckboxProps } = useRadio(props)
@@ -81,12 +90,16 @@ export const YesNoOption = forwardRef<YesNoOptionProps, 'input'>(
           {...inputProps}
           onClick={handleSelect}
           onKeyDown={handleSpacebar}
+          // Override inputProps default settings for required and aria-required for a11y
+          required={false}
+          aria-required={false}
+          aria-label={label}
         />
-        <VisuallyHidden>
-          "{children}" option {props.isChecked ? 'selected' : 'unselected'}
-        </VisuallyHidden>
         <Box {...checkboxProps} __css={styles.option}>
-          {children}
+          {leftIcon ? (
+            <Icon as={leftIcon} __css={styles.icon} aria-hidden />
+          ) : null}
+          {label}
         </Box>
       </Box>
     )

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -176,7 +176,7 @@ FormLabel.QuestionNumber = ({ children, ...props }: TextProps): JSX.Element => {
 FormLabel.OptionalIndicator = ({
   isRequired,
   ...props
-}: TextProps & { isRequired?: boolean }): JSX.Element | null => {
+}: TextProps & { isRequired?: boolean }): JSX.Element => {
   // useFormControlContext is a ChakraUI hook that returns props passed down
   // from a parent ChakraUI's `FormControl` component.
   // Valid hook usage since composited component is still a component.
@@ -184,7 +184,10 @@ FormLabel.OptionalIndicator = ({
   const field = useFormControlContext()
 
   // If isRequired is explicitly provided, ignore form control context value.
-  if (isRequired ?? field?.isRequired) return null
+  if (isRequired ?? field?.isRequired) {
+    // Don't display required label, but say it out loud for screen readers.
+    return <VisuallyHidden>&nbsp;(required)</VisuallyHidden>
+  }
 
   return (
     <Text

--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -22,10 +22,13 @@ export const InlineMessage = ({
   const mdComponents = useMdComponents({ styles })
 
   return (
-    <Flex sx={styles.messagebox} {...flexProps}>
+    <Flex sx={styles.messagebox} {...flexProps} role="banner">
       <Icon
         as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
         __css={styles.icon}
+        aria-label={
+          variant !== 'error' ? 'Informational message' : 'Error message'
+        }
       />
       {useMarkdown && typeof children === 'string' ? (
         <ReactMarkdown components={mdComponents}>{children}</ReactMarkdown>

--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -22,13 +22,11 @@ export const InlineMessage = ({
   const mdComponents = useMdComponents({ styles })
 
   return (
-    <Flex sx={styles.messagebox} {...flexProps} role="banner">
+    <Flex sx={styles.messagebox} {...flexProps} aria-label="Infobox">
       <Icon
         as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
         __css={styles.icon}
-        aria-label={
-          variant !== 'error' ? 'Informational message' : 'Error message'
-        }
+        aria-label={`${variant !== 'error' ? 'Info' : 'Error'} message`}
       />
       {useMarkdown && typeof children === 'string' ? (
         <ReactMarkdown components={mdComponents}>{children}</ReactMarkdown>

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -135,8 +135,7 @@ export const StorageFormUnlocked = Template.bind({})
 StorageFormUnlocked.parameters = StorageForm.parameters
 StorageFormUnlocked.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
-  const inputName =
-    /enter or upload secret key your secret key was downloaded when you created your form/i
+  const inputName = /enter or upload secret key/i
 
   await waitFor(
     async () => {

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -179,7 +179,12 @@ export const FormHeader = ({
           </Skeleton>
           {estTimeString && (
             <Flex align="flex-start" justify="center" mt="0.875rem">
-              <Icon as={BxsTimeFive} fontSize="1.5rem" mr="0.5rem" />
+              <Icon
+                as={BxsTimeFive}
+                fontSize="1.5rem"
+                mr="0.5rem"
+                aria-hidden
+              />
               <Text textStyle="body-2" mt="0.125rem">
                 {estTimeString}
               </Text>

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -161,6 +161,7 @@ export const FormHeader = ({
         wordBreak="break-word"
         justify="center"
         bg={titleBg}
+        role="banner"
       >
         <Flex
           maxW="57rem"

--- a/frontend/src/features/public-form/components/FormStartPage/useFormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/useFormBannerLogo.tsx
@@ -34,7 +34,7 @@ export const useFormBannerLogo = ({
       case FormLogoState.Default:
         return agency ? `Logo for ${agency.fullName}` : undefined
       case FormLogoState.Custom:
-        return `Custom Logo`
+        return `Custom form logo`
     }
   }, [agency, logo])
 

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -17,8 +17,15 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
           mt={{ base: '2rem', md: '0' }}
         >
           <Text>
-            You’re using the new FormSG design. If you have trouble submitting,
-            <Button variant="link" onClick={onOpen}>
+            <span aria-hidden>
+              You’re using the new FormSG design. If you have trouble
+              submitting,
+            </span>
+            <Button
+              variant="link"
+              onClick={onOpen}
+              aria-label="You're using the new FormSG design. If you have trouble submitting, switch to the original one here."
+            >
               <Text as="u">switch to the original one here.</Text>
             </Button>
           </Text>

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -16,6 +16,10 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
           mb="1.5rem"
           mt={{ base: '2rem', md: '0' }}
         >
+          {/* Hide the text and replicate it in the aria-label for the button instead,
+           because without it, the sentence will be read as two separate parts which
+          is confusing for those using screen readers. */}
+
           <Text>
             <span aria-hidden>
               You’re using the new FormSG design. If you have trouble


### PR DESCRIPTION
## Problem
Yes/No fields currently are too verbose, as they used to say "No, selected, required invalid data, radio button, 1 of 2". Then, tabbing to the next option actually goes to "No, selected" before the yes option is read.

Also, some misc a11y fixes for the start page of the form (everything above form fields).

Closes #4176, proposes solution for #4177

## Solution
`FormLabel` - add "(required)" visually hidden component for a11y

>*Aside: why add required at the field label level?*
>While we don't display the "required" tag visually, it's obvious to form respondents that they are required to fill in a form field if there is another optional field on the screen (thus contextually, they know that unlabelled = required). But those who use screen readers lose this context. Required-ness is associated with the questions, not the answer choices. Thus we should say whether the field is required or not at the fieldlabel level, not the field options level.
>Alternatively, we can get rid of the visually hidden "required" in the field label, and rely on errors on submission to show up, but that seems like a hassle for respondents especially since navigating back to errored fields is already pretty taxing... 

Yes/No field - refactor component to better suit its purpose (expose only `leftIcon` and `label` props rather than generic react `children`; this is also better for a11y to easily strip away the additional cosmetic icon)

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

**Notice, importantly, that forcing `required={false} aria-required={false}` does not change the behavior of the form.**

Before:


https://user-images.githubusercontent.com/25571626/189828059-410433d4-bd73-456d-b10a-0aa9097210f2.mov



After:

https://user-images.githubusercontent.com/25571626/189827455-c7fb3840-3511-4f0f-8899-30e94ac7d45c.mov


