### PR TITLE
fix(form-v2): change toast copy for storage mode form activation

### DIFF
--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -95,11 +95,14 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         // Show toast on success.
         const isNowPublic = newData.status === FormStatus.Public
-        const toastStatusMessage = isNowPublic
-          ? newData.responseMode === FormResponseMode.Encrypt
+        const toastStatusPublicMessage =
+          newData.responseMode === FormResponseMode.Encrypt
             ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
             : `Your form is now open.\n\nIf you expect a large number of responses,  [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to avoid losing any of them.`
-          : 'Your form is closed to new responses.'
+        const toastStatusClosedMessage = 'Your form is closed to new responses.'
+        const toastStatusMessage = isNowPublic
+          ? toastStatusPublicMessage
+          : toastStatusClosedMessage
 
         handleSuccess({ newData, toastDescription: toastStatusMessage })
       },

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -6,6 +6,7 @@ import simplur from 'simplur'
 import {
   AdminFormDto,
   FormAuthType,
+  FormResponseMode,
   FormSettings,
   FormStatus,
 } from '~shared/types/form/form'
@@ -95,7 +96,9 @@ export const useMutateFormSettings = () => {
         // Show toast on success.
         const isNowPublic = newData.status === FormStatus.Public
         const toastStatusMessage = isNowPublic
-          ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
+          ? newData.responseMode === FormResponseMode.Encrypt
+            ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
+            : `Your form is now open.\n\nIf you expect a large number of responses,  [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to avoid losing any of them.`
           : 'Your form is closed to new responses.'
 
         handleSuccess({ newData, toastDescription: toastStatusMessage })

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -95,7 +95,7 @@ export const useMutateFormSettings = () => {
         // Show toast on success.
         const isNowPublic = newData.status === FormStatus.Public
         const toastStatusMessage = isNowPublic
-          ? `Your form is now open.\n\nIf you expect a large number of responses,  [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to avoid losing any of them.`
+          ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
           : 'Your form is closed to new responses.'
 
         handleSuccess({ newData, toastDescription: toastStatusMessage })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
change toast message to `Your form is now open. Store your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`

Closes #4846 

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
![image](https://user-images.githubusercontent.com/102740235/189826463-75213349-c5d7-494f-8102-bd88b3c35931.png)
