### PR TITLE
fix(a11y): start page, inline message and public switch message

### DIFF
--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -22,10 +22,11 @@ export const InlineMessage = ({
   const mdComponents = useMdComponents({ styles })
 
   return (
-    <Flex sx={styles.messagebox} {...flexProps}>
+    <Flex sx={styles.messagebox} {...flexProps} aria-label="Infobox">
       <Icon
         as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
         __css={styles.icon}
+        aria-label={`${variant !== 'error' ? 'Info' : 'Error'} message`}
       />
       {useMarkdown && typeof children === 'string' ? (
         <ReactMarkdown components={mdComponents}>{children}</ReactMarkdown>

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -161,6 +161,7 @@ export const FormHeader = ({
         wordBreak="break-word"
         justify="center"
         bg={titleBg}
+        role="banner"
       >
         <Flex
           maxW="57rem"
@@ -179,7 +180,12 @@ export const FormHeader = ({
           </Skeleton>
           {estTimeString && (
             <Flex align="flex-start" justify="center" mt="0.875rem">
-              <Icon as={BxsTimeFive} fontSize="1.5rem" mr="0.5rem" />
+              <Icon
+                as={BxsTimeFive}
+                fontSize="1.5rem"
+                mr="0.5rem"
+                aria-hidden
+              />
               <Text textStyle="body-2" mt="0.125rem">
                 {estTimeString}
               </Text>

--- a/frontend/src/features/public-form/components/FormStartPage/useFormBannerLogo.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/useFormBannerLogo.tsx
@@ -34,7 +34,7 @@ export const useFormBannerLogo = ({
       case FormLogoState.Default:
         return agency ? `Logo for ${agency.fullName}` : undefined
       case FormLogoState.Custom:
-        return `Custom Logo`
+        return `Form logo`
     }
   }, [agency, logo])
 

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -20,10 +20,10 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
            because without it, the sentence will be read as two separate parts which
           is confusing for those using screen readers. */}
           <Text>
-            <span aria-hidden>
+            <Text aria-hidden display="inline">
               You’re using the new FormSG design. If you have trouble
               submitting,
-            </span>
+            </Text>
             <Button
               variant="link"
               onClick={onOpen}

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -16,9 +16,19 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
           mb="1.5rem"
           mt={{ base: '2rem', md: '0' }}
         >
+          {/* Hide the text and replicate it in the aria-label for the button instead,
+           because without it, the sentence will be read as two separate parts which
+          is confusing for those using screen readers. */}
           <Text>
-            You’re using the new FormSG design. If you have trouble submitting,
-            <Button variant="link" onClick={onOpen}>
+            <span aria-hidden>
+              You’re using the new FormSG design. If you have trouble
+              submitting,
+            </span>
+            <Button
+              variant="link"
+              onClick={onOpen}
+              aria-label="You're using the new FormSG design. If you have trouble submitting, switch to the original one here."
+            >
               <Text as="u">switch to the original one here.</Text>
             </Button>
           </Text>


### PR DESCRIPTION
## Problem
Form start page needs some a11y improvement.

Closes #4180

## Solution
add better `logoImgAlt`, remove screen reading for `X estimated time time to complete` icon, improve `InlineMessage` a11y

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/189843733-4efe415a-396e-4869-bc78-5be166eb7564.mov
