### PR TITLE
fix(a11y): yes/no fields, formlabels

### DIFF
--- a/frontend/src/components/Field/YesNo/YesNo.tsx
+++ b/frontend/src/components/Field/YesNo/YesNo.tsx
@@ -3,14 +3,11 @@ import { BiCheck, BiX } from 'react-icons/bi'
 import {
   forwardRef,
   HStack,
-  Icon,
   useFormControlProps,
-  useMultiStyleConfig,
   useRadioGroup,
 } from '@chakra-ui/react'
 import pick from 'lodash/pick'
 
-import { YESNO_THEME_KEY } from '~theme/components/Field/YesNo'
 import { FieldColorScheme } from '~theme/foundations/colours'
 
 import { YesNoOption } from './YesNoOption'
@@ -53,7 +50,6 @@ export interface YesNoProps {
  */
 export const YesNo = forwardRef<YesNoProps, 'input'>(
   ({ colorScheme, ...props }, ref) => {
-    const styles = useMultiStyleConfig(YESNO_THEME_KEY, props)
     const formControlProps = useFormControlProps(props)
     const { getRootProps, getRadioProps } = useRadioGroup(props)
 
@@ -88,17 +84,19 @@ export const YesNo = forwardRef<YesNoProps, 'input'>(
           side="left"
           colorScheme={colorScheme}
           {...noProps}
+          leftIcon={BiX}
+          label="No"
           // Ref is set here for tracking current value, and also so any errors
           // can focus this input.
           ref={ref}
-        >
-          <Icon as={BiX} __css={styles.icon} />
-          No
-        </YesNoOption>
-        <YesNoOption side="right" colorScheme={colorScheme} {...yesProps}>
-          <Icon as={BiCheck} __css={styles.icon} />
-          Yes
-        </YesNoOption>
+        />
+        <YesNoOption
+          side="right"
+          colorScheme={colorScheme}
+          {...yesProps}
+          leftIcon={BiCheck}
+          label="Yes"
+        />
       </HStack>
     )
   },

--- a/frontend/src/components/Field/YesNo/YesNoOption.tsx
+++ b/frontend/src/components/Field/YesNo/YesNoOption.tsx
@@ -1,19 +1,28 @@
 import { KeyboardEvent, useCallback } from 'react'
+import { IconType } from 'react-icons/lib'
 import {
   Box,
   forwardRef,
+  Icon,
   useMultiStyleConfig,
   useRadio,
   UseRadioGroupReturn,
   UseRadioProps,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { YESNO_THEME_KEY } from '~theme/components/Field/YesNo'
 import { FieldColorScheme } from '~theme/foundations/colours'
 
 interface YesNoOptionProps extends UseRadioProps {
-  children: React.ReactNode
+  /**
+   * Icon to be displayed to the left of the option content.
+   */
+  leftIcon?: IconType
+
+  /**
+   * Label to be displayed as the option content.
+   */
+  label: string
 
   /**
    * Side of the option for styling to be used for styling.
@@ -37,7 +46,7 @@ interface YesNoOptionProps extends UseRadioProps {
  * Option rendering for `YesNo` component.
  */
 export const YesNoOption = forwardRef<YesNoOptionProps, 'input'>(
-  ({ children, ...props }, ref) => {
+  ({ leftIcon, label, ...props }, ref) => {
     const styles = useMultiStyleConfig(YESNO_THEME_KEY, props)
 
     const { getInputProps, getCheckboxProps } = useRadio(props)
@@ -76,17 +85,21 @@ export const YesNoOption = forwardRef<YesNoOptionProps, 'input'>(
         as="label"
         __css={styles.container}
         data-testid={`${props.name}-${props.side}`}
+        role="button"
+        ref={ref}
+        aria-label={`${label} option, ${
+          props.isChecked ? 'selected' : 'unselected'
+        }`}
       >
         <input
           {...inputProps}
           onClick={handleSelect}
           onKeyDown={handleSpacebar}
+          aria-hidden
         />
-        <VisuallyHidden>
-          "{children}" option {props.isChecked ? 'selected' : 'unselected'}
-        </VisuallyHidden>
-        <Box {...checkboxProps} __css={styles.option}>
-          {children}
+        <Box {...checkboxProps} __css={styles.option} aria-hidden>
+          {leftIcon ? <Icon as={leftIcon} __css={styles.icon} /> : null}
+          {label}
         </Box>
       </Box>
     )


### PR DESCRIPTION
## Problem
Yes/No fields currently are too verbose, as they used to say "No, selected, required invalid data, radio button, 1 of 2". Then, tabbing to the next option actually goes to "No, selected" before the yes option is read.

Also, some misc a11y fixes for the start page of the form (everything above form fields).

Closes #4176, proposes solution for #4177

## Solution
`FormLabel` - add "(required)" visually hidden component for a11y

Yes/No field - refactor component to better suit its purpose (expose only `leftIcon` and `label` props rather than generic react `children`; this is also better for a11y to easily strip away the additional cosmetic icon)

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

**Notice, importantly, that forcing `required={false} aria-required={false}` does not change the behavior of the form.**

Before:


https://user-images.githubusercontent.com/25571626/189828059-410433d4-bd73-456d-b10a-0aa9097210f2.mov



After:

https://user-images.githubusercontent.com/25571626/189827455-c7fb3840-3511-4f0f-8899-30e94ac7d45c.mov


