### PR TITLE
test(v2): extend backend tests timeout to 15s

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
       statements: 38, // Increase this percentage as test coverage improves
     },
   },
-  testTimeout: 10000, // Set timeout to be 10s to reduce test flakiness
+  testTimeout: 15000, // Set timeout to be 15s to reduce test flakiness
   globals: {
     // Revert when memory leak in ts-jest is fixed.
     // See https://github.com/kulshekhar/ts-jest/issues/1967.


### PR DESCRIPTION
## Problem
Backend tests keep failing as they time out ([example](https://github.com/opengovsg/FormSG/actions/runs/3044022382/jobs/4903994910))

This PR extends the timeout for backend tests from 10s to 15s, to reduce test flakiness.
