### PR TITLE
fix(a11y): improve section and form instructions focus a11y

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormSectionsContext.tsx
@@ -14,6 +14,8 @@ import { BasicField, FormFieldDto } from '~shared/types'
 import { FieldIdSet } from '~features/logic/types'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
+import { PUBLICFORM_INSTRUCTIONS_SECTIONID } from '../FormInstructions/FormInstructionsContainer'
+
 export type SidebarSectionMeta = Pick<FormFieldDto, 'title' | '_id'>
 
 interface FormSectionsContextProps {
@@ -22,8 +24,8 @@ interface FormSectionsContextProps {
   setVisibleFieldIdsForScrollData: (visibleFieldIds: FieldIdSet) => void
   sectionRefs: Record<string, RefObject<HTMLDivElement>>
   activeSectionId?: string
-  navigatedSectionTitle?: string
-  setNavigatedSectionTitle: (title: string) => void
+  navigatedSectionId?: string
+  setNavigatedSectionId: (id: string) => void
 }
 
 const FormSectionsContext = createContext<FormSectionsContextProps | undefined>(
@@ -47,7 +49,7 @@ export const FormSectionsProvider = ({
     if (form.startPage.paragraph)
       sections.push({
         title: 'Instructions',
-        _id: 'instructions',
+        _id: PUBLICFORM_INSTRUCTIONS_SECTIONID,
       })
     form.form_fields.forEach((f) => {
       if (f.fieldType !== BasicField.Section || !visibleFieldIds?.has(f._id))
@@ -73,10 +75,10 @@ export const FormSectionsProvider = ({
       .filter((f) => f.fieldType === BasicField.Section)
       .map((f) => f._id)
     return form.startPage.paragraph
-      ? ['instructions'].concat(sections)
+      ? [PUBLICFORM_INSTRUCTIONS_SECTIONID].concat(sections)
       : sections
   }, [form])
-  const [navigatedSectionTitle, setNavigatedSectionTitle] = useState<string>()
+  const [navigatedSectionId, setNavigatedSectionId] = useState<string>()
 
   useEffect(() => {
     if (!form) return
@@ -105,8 +107,8 @@ export const FormSectionsProvider = ({
         setVisibleFieldIdsForScrollData: setVisibleFieldIds,
         sectionRefs,
         activeSectionId: orderedSectionFieldIds?.[activeSection] ?? undefined,
-        navigatedSectionTitle,
-        setNavigatedSectionTitle,
+        navigatedSectionId,
+        setNavigatedSectionId,
       }}
     >
       {children}

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -6,6 +6,8 @@ import { useFormSections } from '../FormFields/FormSectionsContext'
 
 import { FormInstructions } from './FormInstructions'
 
+export const PUBLICFORM_INSTRUCTIONS_SECTIONID = 'instructions'
+
 export const FormInstructionsContainer = (): JSX.Element | null => {
   const { sectionRefs } = useFormSections()
   const { form, submissionData } = usePublicFormContext()
@@ -24,7 +26,13 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
         px={{ base: '1rem', md: '2.5rem' }}
         mb="1.5rem"
       >
-        <Box id="instructions" ref={sectionRefs['instructions']}>
+        <Box
+          id={PUBLICFORM_INSTRUCTIONS_SECTIONID}
+          ref={sectionRefs[PUBLICFORM_INSTRUCTIONS_SECTIONID]}
+          role="heading"
+          // Allow focus on instructions when sidebar link is clicked.
+          tabIndex={-1}
+        >
           <FormInstructions
             content={form?.startPage.paragraph}
             colorTheme={form?.startPage.colorTheme}

--- a/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -18,13 +18,15 @@ import { useIsMobile } from '~hooks/useIsMobile'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { useFormSections } from '../FormFields/FormSectionsContext'
+import { PUBLICFORM_INSTRUCTIONS_SECTIONID } from '../FormInstructions/FormInstructionsContainer'
 
 import { SidebarLink } from './SidebarLink'
 
 export const SectionSidebar = (): JSX.Element => {
-  const { sectionScrollData, activeSectionId, navigatedSectionTitle } =
+  const { sectionScrollData, activeSectionId, navigatedSectionId } =
     useFormSections()
   const {
+    form,
     miniHeaderRef,
     submissionData,
     isMobileDrawerOpen,
@@ -41,6 +43,14 @@ export const SectionSidebar = (): JSX.Element => {
     // will never change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [miniHeaderRef?.current?.clientHeight])
+
+  const navigatedSection = useMemo(() => {
+    if (!navigatedSectionId || !form) return
+    if (navigatedSectionId === PUBLICFORM_INSTRUCTIONS_SECTIONID) {
+      return { title: 'Instructions', description: form.startPage.paragraph }
+    }
+    return form.form_fields.find((ff) => ff._id === navigatedSectionId)
+  }, [form, navigatedSectionId])
 
   if (isMobile)
     return (
@@ -87,7 +97,7 @@ export const SectionSidebar = (): JSX.Element => {
   ) : (
     <Box
       as="nav"
-      aria-label="Form sections"
+      aria-label="Jump to form section"
       flex={1}
       d={{ base: 'none', md: 'initial' }}
       minW={sectionScrollData.length > 0 ? '20%' : undefined}
@@ -100,6 +110,7 @@ export const SectionSidebar = (): JSX.Element => {
         alignItems="flex-start"
         marginInlineStart={0}
         marginEnd="1rem"
+        aria-label="List of form section links"
       >
         {sectionScrollData?.map((d) => (
           <ListItem key={d._id} listStyleType="none">
@@ -107,9 +118,12 @@ export const SectionSidebar = (): JSX.Element => {
           </ListItem>
         ))}
       </UnorderedList>
-      {navigatedSectionTitle && (
+      {navigatedSection && (
         <VisuallyHidden aria-live="assertive" aria-atomic>
-          Navigated to {navigatedSectionTitle} section
+          Navigated to section: {navigatedSection.title}
+          {navigatedSection.description
+            ? `, ${navigatedSection.description}`
+            : ''}
         </VisuallyHidden>
       )}
     </Box>

--- a/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
+++ b/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
@@ -24,7 +24,7 @@ export const SidebarLink = ({
   isActive,
   sectionMeta,
 }: SidebarLinkProps): JSX.Element => {
-  const { sectionRefs, setNavigatedSectionTitle } = useFormSections()
+  const { sectionRefs, setNavigatedSectionId } = useFormSections()
   const { miniHeaderRef, onMobileDrawerClose } = usePublicFormContext()
 
   const sectionRef = useMemo(
@@ -49,13 +49,13 @@ export const SidebarLink = ({
     // Remove scrolling on focus to prevent app from jumping immediately to the
     // element without smooth scrolling.
     sectionRef.current.focus({ preventScroll: true })
-    setNavigatedSectionTitle(sectionMeta.title)
+    setNavigatedSectionId(sectionMeta._id)
   }, [
     sectionRef,
     miniHeaderRef,
     onMobileDrawerClose,
-    sectionMeta.title,
-    setNavigatedSectionTitle,
+    sectionMeta._id,
+    setNavigatedSectionId,
   ])
 
   const styles = useStyleConfig('Link', {


### PR DESCRIPTION
## Problem
Found some small AFIs in sections and form instructions a11y.

1. Section fields navigation was inconsistent when scrolling through the form and navigating to sections. In particular when users scroll through the form, they get to the section and it says "heading level 2, 2 items, <section name> <section description>". However when navigating, it only says "Navigated to <section name> section". We should update so that the description is also read out.
2. Form instructions did not have a11y parity with the sections (it didn't say "navigated to instructions section").

## Solution
1. Change `navigatedSectionTitle` to `navigatedSectionId` to get the title and description so it can be read out in the `VisuallyHidden` on click.
2. Refactor out instructions section id into a constant, and add support for instructions to be read out after navigation click.

**Breaking Changes** 
- No - this PR is backwards compatible  
