### PR TITLE
Revert "perf: preload inter fonts from app directory in storybook preview-head"

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,85 +1,10 @@
-<!-- Preloading fonts to prevent flakiness in snapshots caused by font changing. -->
+<!-- Preloading fonts to prevent flakiness in snapshots caused by font changing.
+This is not a complete solution as our own fonts contain font feature settings
+Google Fonts do not provide, but will likely be enough. -->
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  rel="preload"
-  href="../src/assets/fonts/Inter-Light.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-LightItalic.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-Regular.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-Italic.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-Medium.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-MediumItalic.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-SemiBold.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-SemiBoldItalic.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-Bold.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-BoldItalic.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-roman.var.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="../src/assets/fonts/Inter-italic.var.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+  rel="stylesheet"
 />


### PR DESCRIPTION
Reverts opengovsg/FormSG#4458

Actually didn't help, and chrome now throws a bunch of console errors due to not using the preloaded fonts.