### PR TITLE
fix: docker port clash with control center

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run the following shell command to build the Docker image from scratch. This wil
 npm run dev
 ```
 
-After the Docker image has finished building, the application can be accessed at [localhost:5000](localhost:5000).
+After the Docker image has finished building, the application can be accessed at [localhost:5001](localhost:5001).
 
 If there are no dependency changes in `package.json` or changes in the
 `src/app/server.ts` file, you can run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./:/opt/formsg
       - /opt/formsg/node_modules
     ports:
-      - '5000:5000'
+      - '5001:5000'
       - '4566:4566' # localstack ports
       - '5156:5156' # mockpass ports
       - '9229:9229' # Node debugger port


### PR DESCRIPTION
Solving issue #4865

Changing the local port to 5001 to avoid port clash with control center in apple mac book Monterey and above.
