### PR TITLE
chore: add script to automate release steps

### DIFF
--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -68,7 +68,7 @@ echo "## Tests" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
 grep -v -E -- '- [a-z]+\(deps(-dev)?\)' ${pr_body_file} | grep -v -E -- '- build: ' | while read line_item; do
   pr_id=$(echo ${line_item} | grep -o -E '\[`#\d+`\]' | grep -o -E '\d+')
-  tests=$(gh pr view ${pr_id} | awk "/## Tests/{flag=1;next}/#######/{flag=0}flag" | sed "s/\[X\]/[ ]/")
+  tests=$(gh pr view ${pr_id} | awk 'f;/## Tests/{f=1}' | sed "s/\[X\]/[ ]/")
   if [[ ${tests} =~ \S ]]; then
     echo ${line_item} | sed "s/^- /### /" >> ${pr_body_file_groupped}
     echo "${tests}" >> ${pr_body_file_groupped}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -45,17 +45,17 @@ awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md 
 
 echo "## New" > ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -v -E -- '- (fix|chore)\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -v -E -- '- [a-z]+\(deps(-dev)?\)'  ${pr_body_file} >> ${pr_body_file_groupped}
 
 echo "" >> ${pr_body_file_groupped}
 echo "## Dependencies" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -E -- '- fix\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -E -- '- [a-z]+\(deps\)'  ${pr_body_file} >> ${pr_body_file_groupped}
 
 echo "" >> ${pr_body_file_groupped}
 echo "## Dev-Dependencies" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -E -- '- chore\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -E -- '- [a-z]+\(deps-dev\)'  ${pr_body_file} >> ${pr_body_file_groupped}
 
 gh auth login
 gh pr create \

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -63,7 +63,7 @@ gh pr create \
   -H ${release_branch} \
   -B release-al2 \
   -t "build: release ${release_version}" \
-  -F ${pr_body_file}
+  -F ${pr_body_file_groupped}
 
 # cleanup
 rm ${pr_body_file}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -40,7 +40,6 @@ git push -f origin HEAD:staging-al2
 git push origin ${release_version}
 
 # extract changelog to inject into the PR
-# TODO: group changelog into sections automatically
 pr_body_file=.pr_body_${release_version}
 pr_body_file_groupped=.pr_body_${release_version}_groupped
 

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -5,6 +5,8 @@ set -x
 # pre-requisites: install github CLI
 # - github documentation: https://github.com/cli/cli#installation
 # - github is remote 'origin'
+# - PRs use test section LAST with heading "## Tests"
+# - ALL build and release PRs start with "build: "
 
 git fetch --all --tags
 git reset --hard
@@ -41,23 +43,39 @@ git push origin ${release_version}
 # TODO: group changelog into sections automatically
 pr_body_file=.pr_body_${release_version}
 pr_body_file_groupped=.pr_body_${release_version}_groupped
-awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md | sed '/^[[:space:]]*$/d' > ${pr_body_file}
+
+awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md | sed -E '/^([^-]|[[:space:]]*$)/d' > ${pr_body_file}
 
 echo "## New" > ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -v -E -- '- [a-z]+\(deps(-dev)?\)'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -v -E -- '- [a-z]+\(deps(-dev)?\)' ${pr_body_file} >> ${pr_body_file_groupped}
 
 echo "" >> ${pr_body_file_groupped}
 echo "## Dependencies" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -E -- '- [a-z]+\(deps\)'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -E -- '- [a-z]+\(deps\)' ${pr_body_file} >> ${pr_body_file_groupped}
 
 echo "" >> ${pr_body_file_groupped}
 echo "## Dev-Dependencies" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
-grep -E -- '- [a-z]+\(deps-dev\)'  ${pr_body_file} >> ${pr_body_file_groupped}
+grep -E -- '- [a-z]+\(deps-dev\)' ${pr_body_file} >> ${pr_body_file_groupped}
 
 gh auth login
+
+## Extract test procedures for feature PRs
+echo "" >> ${pr_body_file_groupped}
+echo "## Tests" >> ${pr_body_file_groupped}
+echo "" >> ${pr_body_file_groupped}
+grep -v -E -- '- [a-z]+\(deps(-dev)?\)' ${pr_body_file} | grep -v -E -- '- build: ' | while read line_item; do
+  pr_id=$(echo ${line_item} | grep -o -E '\[`#\d+`\]' | grep -o -E '\d+')
+  tests=$(gh pr view ${pr_id} | awk "/## Tests/{flag=1;next}/#######/{flag=0}flag" | sed "s/\[X\]/[ ]/")
+  if [[ ${tests} =~ \S ]]; then
+    echo ${line_item} | sed "s/^- /### /" >> ${pr_body_file_groupped}
+    echo "${tests}" >> ${pr_body_file_groupped}
+    echo "" >> ${pr_body_file_groupped}
+  fi
+done
+
 gh pr create \
   -w \
   -H ${release_branch} \

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -68,7 +68,7 @@ echo "## Tests" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
 grep -v -E -- '- [a-z]+\(deps(-dev)?\)' ${pr_body_file} | grep -v -E -- '- build: ' | while read line_item; do
   pr_id=$(echo ${line_item} | grep -o -E '\[`#\d+`\]' | grep -o -E '\d+')
-  tests=$(gh pr view ${pr_id} | awk 'f;/## Tests/{f=1}' | sed "s/\[X\]/[ ]/")
+  tests=$(gh pr view ${pr_id} | awk 'f;/^#+ Tests?/{f=1}' | sed "s/\[X\]/[ ]/")
   if [[ ${tests} =~ \S ]]; then
     echo ${line_item} | sed "s/^- /### /" >> ${pr_body_file_groupped}
     echo "${tests}" >> ${pr_body_file_groupped}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-# pre-requisites: instal github CLI
+# pre-requisites: install github CLI
 # - github documentation: https://github.com/cli/cli#installation
 # - github is remote 'origin'
 

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -x
+
+# pre-requisites: instal github CLI
+# - github documentation: https://github.com/cli/cli#installation
+# - github is remote 'origin'
+
+git reset --hard
+git pull
+git checkout develop
+git reset --hard origin/develop
+
+short_hash=$(git rev-parse --short HEAD)
+temp_release_branch=temp_${short_hash}
+
+git chekcout -b ${temp_release_branch}
+
+release_version=$(npm --no-git-tag-version version minor | tail -n 1)
+
+git commit -a -m "chore: bump version to ${release_version}"
+git tag ${release_version}
+
+release_branch=release_${release_version}
+
+git checkout -b ${release_branch}
+git branch -D ${temp_release_branch}
+
+git push origin HEAD:${release_branch}
+git push -f origin HEAD:staging-alt2
+
+# extract changelog to inject into the PR
+# TODO: group changelog into sections automatically
+pr_body_file=.pr_body_${release_version}
+awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md > ${pr_body_file}
+
+gh auth login
+gh pr create \
+  -w \
+  -H ${release_branch} \
+  -B release-al2 \
+  -t "build: release ${release_version}" \
+  -F ${pr_body_file}
+
+# cleanup
+rm ${pr_body_file}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -28,11 +28,13 @@ git branch -D ${temp_release_branch}
 
 git push origin HEAD:${release_branch}
 git push -f origin HEAD:staging-alt2
+git push origin ${release_version}
 
 # extract changelog to inject into the PR
 # TODO: group changelog into sections automatically
 pr_body_file=.pr_body_${release_version}
 awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md > ${pr_body_file}
+
 
 gh auth login
 gh pr create \
@@ -44,3 +46,4 @@ gh pr create \
 
 # cleanup
 rm ${pr_body_file}
+git branch -D ${release_branch}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -40,8 +40,22 @@ git push origin ${release_version}
 # extract changelog to inject into the PR
 # TODO: group changelog into sections automatically
 pr_body_file=.pr_body_${release_version}
-awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md > ${pr_body_file}
+pr_body_file_groupped=.pr_body_${release_version}_groupped
+awk "/#### \[${release_version}\]/{flag=1;next}/####/{flag=0}flag" CHANGELOG.md | sed '/^[[:space:]]*$/d' > ${pr_body_file}
 
+echo "## New" > ${pr_body_file_groupped}
+echo "" >> ${pr_body_file_groupped}
+grep -v -E -- '- (fix|chore)\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
+
+echo "" >> ${pr_body_file_groupped}
+echo "## Dependencies" >> ${pr_body_file_groupped}
+echo "" >> ${pr_body_file_groupped}
+grep -E -- '- fix\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
+
+echo "" >> ${pr_body_file_groupped}
+echo "## Dev-Dependencies" >> ${pr_body_file_groupped}
+echo "" >> ${pr_body_file_groupped}
+grep -E -- '- chore\(deps'  ${pr_body_file} >> ${pr_body_file_groupped}
 
 gh auth login
 gh pr create \
@@ -53,4 +67,5 @@ gh pr create \
 
 # cleanup
 rm ${pr_body_file}
+rm ${pr_body_file_groupped}
 git branch -D ${release_branch}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -15,7 +15,7 @@ git reset --hard origin/develop
 short_hash=$(git rev-parse --short HEAD)
 temp_release_branch=temp_${short_hash}
 
-git chekcout -b ${temp_release_branch}
+git checkout -b ${temp_release_branch}
 
 release_version=$(npm --no-git-tag-version version minor | tail -n 1)
 release_branch=release_${release_version}

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -6,6 +6,7 @@ set -x
 # - github documentation: https://github.com/cli/cli#installation
 # - github is remote 'origin'
 
+git fetch --all --tags
 git reset --hard
 git pull
 git checkout develop
@@ -17,16 +18,22 @@ temp_release_branch=temp_${short_hash}
 git chekcout -b ${temp_release_branch}
 
 release_version=$(npm --no-git-tag-version version minor | tail -n 1)
+release_branch=release_${release_version}
+may_force_push=
+
+if [[ "$1" == "--recut" ]]; then
+  git tag -d ${release_version}
+  git push --delete origin ${release_version}
+  git branch -D ${release_branch}
+  may_force_push=-f
+fi
 
 git commit -a -m "chore: bump version to ${release_version}"
 git tag ${release_version}
-
-release_branch=release_${release_version}
-
 git checkout -b ${release_branch}
 git branch -D ${temp_release_branch}
 
-git push origin HEAD:${release_branch}
+git push origin ${may_force_push} HEAD:${release_branch}
 git push -f origin HEAD:staging-alt2
 git push origin ${release_version}
 

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -36,7 +36,7 @@ git checkout -b ${release_branch}
 git branch -D ${temp_release_branch}
 
 git push origin ${may_force_push} HEAD:${release_branch}
-git push -f origin HEAD:staging-alt2
+git push -f origin HEAD:staging-al2
 git push origin ${release_version}
 
 # extract changelog to inject into the PR


### PR DESCRIPTION
Release steps are repetitive and systematic, we should make our life easier by automating as much as we can, such as:

- [X] version upgrade
- [X] create the release branch
- [X] push to staging
- [X] create the PR by extracting the changelog of the upgrade
- [x] sort the changelog into section
- [x] fetch test plans from the PRs being released and add to PR body