### PR TITLE
feat(a11y): improvements to attachment field

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { DropzoneProps, useDropzone } from 'react-dropzone'
 import {
   Box,
@@ -173,7 +173,10 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
       colorScheme,
     })
 
-    const handleRemoveFile = useCallback(() => onChange(undefined), [onChange])
+    const handleRemoveFile = useCallback(() => {
+      onChange(undefined)
+      rootRef.current?.focus()
+    }, [onChange, rootRef])
 
     // Bunch of memoization to avoid unnecessary re-renders.
     const processedRootProps = useMemo(() => {
@@ -198,8 +201,6 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
         ...inputProps,
       })
     }, [getInputProps, inputProps, name])
-
-    useLayoutEffect(() => rootRef.current?.focus(), [rootRef, value])
 
     return (
       <StylesProvider value={styles}>

--- a/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
@@ -1,5 +1,5 @@
 import { DropzoneInputProps, DropzoneState } from 'react-dropzone'
-import { chakra, Icon, Text, useStyles } from '@chakra-ui/react'
+import { chakra, Icon, Text, useStyles, VisuallyHidden } from '@chakra-ui/react'
 
 import { BxsCloudUpload } from '~assets/icons/BxsCloudUpload'
 import Link from '~components/Link'
@@ -7,23 +7,28 @@ import Link from '~components/Link'
 interface AttachmentDropzoneProps {
   inputProps: DropzoneInputProps
   isDragActive: DropzoneState['isDragActive']
+  readableMaxSize?: string
 }
 
 export const AttachmentDropzone = ({
   inputProps,
   isDragActive,
+  readableMaxSize,
 }: AttachmentDropzoneProps): JSX.Element => {
   const styles = useStyles()
 
   return (
     <>
+      <VisuallyHidden>
+        Click to upload file, maximum file size of {readableMaxSize}
+      </VisuallyHidden>
       <chakra.input {...inputProps} data-testid={inputProps.name} />
       <Icon aria-hidden as={BxsCloudUpload} __css={styles.icon} />
 
       {isDragActive ? (
-        <Text>Drop the file here ...</Text>
+        <Text aria-hidden>Drop the file here...</Text>
       ) : (
-        <Text>
+        <Text aria-hidden>
           <Link isDisabled={inputProps.disabled}>Choose file</Link> or drag and
           drop here
         </Text>

--- a/frontend/src/components/Field/Attachment/AttachmentFileInfo.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentFileInfo.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { Flex, forwardRef, Text, VisuallyHidden } from '@chakra-ui/react'
+import { Flex, Text, VisuallyHidden } from '@chakra-ui/react'
 
 import IconButton from '~components/IconButton'
 
@@ -11,40 +11,35 @@ export interface AttachmentFileInfoProps {
   handleRemoveFile: () => void
 }
 
-export const AttachmentFileInfo = forwardRef<AttachmentFileInfoProps, 'div'>(
-  ({ file, handleRemoveFile }, ref) => {
-    const readableFileSize = useMemo(
-      () => getReadableFileSize(file.size),
-      [file.size],
-    )
+export const AttachmentFileInfo = ({
+  file,
+  handleRemoveFile,
+}: AttachmentFileInfoProps) => {
+  const readableFileSize = useMemo(
+    () => getReadableFileSize(file.size),
+    [file.size],
+  )
 
-    return (
-      <Flex
-        ref={ref}
-        justify="space-between"
-        bg="primary.100"
-        py="0.875rem"
-        px="1rem"
-      >
-        <VisuallyHidden>
-          File attached: {file.name} with file size of {readableFileSize}
-        </VisuallyHidden>
-        <Flex flexDir="column" aria-hidden>
-          <Text textStyle="subhead-1" color="secondary.500">
-            {file.name}
-          </Text>
-          <Text textStyle="caption-1" color="secondary.500">
-            {readableFileSize}
-          </Text>
-        </Flex>
-        <IconButton
-          variant="clear"
-          colorScheme="danger"
-          aria-label="remove file"
-          icon={<BiTrash />}
-          onClick={handleRemoveFile}
-        />
+  return (
+    <Flex justify="space-between" bg="primary.100" py="0.875rem" px="1rem">
+      <VisuallyHidden>
+        File attached: {file.name} with file size of {readableFileSize}
+      </VisuallyHidden>
+      <Flex flexDir="column" aria-hidden>
+        <Text textStyle="subhead-1" color="secondary.500">
+          {file.name}
+        </Text>
+        <Text textStyle="caption-1" color="secondary.500">
+          {readableFileSize}
+        </Text>
       </Flex>
-    )
-  },
-)
+      <IconButton
+        variant="clear"
+        colorScheme="danger"
+        aria-label="Click to remove file"
+        icon={<BiTrash />}
+        onClick={handleRemoveFile}
+      />
+    </Flex>
+  )
+}


### PR DESCRIPTION
## Problem
Attachment fields had a couple major issues with a11y.

1. It did not announce itself as a link or button to upload.
2. It did not refocus correctly onclick (both upload and remove).
3. It kept repeating the question title on focus of the upload field, which it should not.

Closes #4181 

## Solution
1. Added additional `VisuallyHidden` components with more descriptive sentences, and made the components that aren't super accessible `aria-hidden`.
2. When re-rendering, remove the `mergedRefs` prop from the enclosing box, so that the the focus will go onto the correct element again.
3. Remove `aria-describedby` which was causing the dropzone focus to repeat the associated formlabel. This was much too verbose because users will already have heard the form label question before scrolling to the dropzone field.

**Breaking Changes** 
- No - this PR is backwards compatible  

https://user-images.githubusercontent.com/25571626/190339466-95f31509-1728-4e50-8c6a-14d9434d870b.mov


