### PR TITLE
perf: update to zustand 4 to prevent re-renders

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18863,7 +18863,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
@@ -23105,7 +23105,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         }
       }
@@ -25023,7 +25023,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immer": {
       "version": "9.0.12",
@@ -25808,7 +25808,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -31208,7 +31208,7 @@
     "nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
       "requires": {
         "big-integer": "^1.6.16"
       }
@@ -39587,6 +39587,11 @@
         }
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -41658,9 +41663,12 @@
       "dev": true
     },
     "zustand": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.6.9.tgz",
-      "integrity": "sha512-OvDNu/jEWpRnEC7k8xh8GKjqYog7td6FZrLMuHs/IeI8WhrCwV+FngVuwMIFhp5kysZXr6emaeReMqjLGaldAQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+      "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     },
     "zwitch": {
       "version": "1.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "uuid": "^8.3.2",
     "validator": "^13.7.0",
     "web-vitals": "^2.1.2",
-    "zustand": "^3.6.5"
+    "zustand": "^4.1.1"
   },
   "scriptComments": {
     "clean:emotion-types": [

--- a/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
@@ -40,7 +40,7 @@ export type DesignStore = {
   resetDesignStore: () => void
 }
 
-export const useDesignStore = create<DesignStore>(
+export const useDesignStore = create<DesignStore>()(
   devtools((set, get) => ({
     state: DesignState.Inactive,
     holdingState: null,

--- a/frontend/src/features/admin-form/create/builder-and-design/useDirtyFieldStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useDirtyFieldStore.tsx
@@ -6,7 +6,7 @@ export type DirtyFieldStore = {
   setIsDirty: (isDirty: boolean) => void
 }
 
-export const useDirtyFieldStore = create<DirtyFieldStore>(
+export const useDirtyFieldStore = create<DirtyFieldStore>()(
   devtools((set, _get) => ({
     isDirty: false,
     setIsDirty: (isDirty: boolean) => set({ isDirty }),

--- a/frontend/src/features/admin-form/create/builder-and-design/useEndPageBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useEndPageBuilderStore.tsx
@@ -10,7 +10,7 @@ export type EndPageBuilderStore = {
   resetEndPageData: () => void
 }
 
-export const useEndPageBuilderStore = create<EndPageBuilderStore>(
+export const useEndPageBuilderStore = create<EndPageBuilderStore>()(
   devtools((set, get) => ({
     endPageData: {
       title: 'Thank you for your response.',

--- a/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -45,7 +45,7 @@ export type FieldBuilderStore = {
   moveFromHolding: () => void
 }
 
-export const useFieldBuilderStore = create<FieldBuilderStore>(
+export const useFieldBuilderStore = create<FieldBuilderStore>()(
   devtools((set, get) => ({
     stateData: { state: FieldBuilderState.Inactive },
     holdingStateData: null,

--- a/frontend/src/features/admin-form/create/logic/adminLogicStore.ts
+++ b/frontend/src/features/admin-form/create/logic/adminLogicStore.ts
@@ -41,7 +41,7 @@ export const setToEditingSelector = (state: AdminLogicStore) =>
 export const setToInactiveSelector = (state: AdminLogicStore) =>
   state.setToInactive
 
-export const useAdminLogicStore = create<AdminLogicStore>(
+export const useAdminLogicStore = create<AdminLogicStore>()(
   devtools((set) => ({
     createOrEditData: null,
     setToCreating: () =>


### PR DESCRIPTION
## Problem
#4766 #4764 highlights some performance issues that form builder has. Both videos show that lag that occurs after changing input. (#4766 unable to scroll to bottom fully is probably a separate issue fixed in #4860). This should be caused by a long JS task blocking interaction. I also experience this lag in local development, and this issue might exist across devices as it is relatively easy to increase the lag by adding more form fields. 

## Findings
Did a bunch of random digging to see whats the problem and I try to summarise them here. Note: the numbers here are in local environment, so I'm not sure how it translates in production

- Using the chrome profiler, we can see what tasks are running and for how long. The method was to simply change one input and see what was run. Was hoping to find some rogue functions that might be causing the issue but it was mostly just react doing its thing, so it's likely due to re-renders happening
- Using the react profiler, we can see pretty much the entire page is re-rendering upon one input change which is not a good sign
- The profiler recordings unfortunately was not much help either as there every profiling session was very different even though the action was the same. Random components everywhere would take unusually long to render according to the flamegraph and that component would be different between each run. I'm not sure if this is an issue with the profiler or not, but do let me know if you guys try it and see if you get the same results.
- As such the lag seems to be not be caused by a specific component but instead is a result if just having a lot of components re-render
- Lag is not just contributed by the form fields but also the surrounding parent elements as well. A form with 8 fields, including complicated ones like Table causes a task duration of 800ms, and commenting out the return values in BuilderFields still causes the task to be 80ms. Returning an empty div in FieldRowContainer ups the duration to ~150ms meaning the hooks themselves take about 70ms? Might need to go deeper here to see if a specific component is causing problems.

## Solution
One thing I noticed from the profiler sessions is that the zustand library uses an increasing counter to [force updates](https://github.com/pmndrs/zustand/blob/4d8003b363cb06ee5b1da498300a60576419485a/src/react.ts#L80) when state has changed. That's why there's a number of components that seemingly don't need to update but still do as they call the zustand hook. It turns out that the library has already been update to v4 which uses a different way of [state management](https://github.com/pmndrs/zustand/releases/tag/v4.0.0), so I simply updated to see if it helps. 

I'm actually surprised to see how much improvement there is after the update. The JS task duration drop by about 30-40% from ~800ms to ~500ms and there is definitely less re-renders in React.

Therefore this, this PR is just a simple low-hanging fruit optimisation, but one that reaps noticeable benefit. If its worth it, there is definitely more room for improvement. Based on the findings above, I not sure if there is a simple solution to optimise performance. I'm still not too familiar with the overall state management in the app, but I feel some rejigging of the the state management should help. Maybe you guys can give your opinion on this.
