### PR TITLE
fix: add stronger model-level validation for image field URLs

### DIFF
--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -7,6 +7,8 @@ import { IFieldSchema } from 'src/types'
 
 import dbHandler from 'tests/unit/backend/helpers/jest-db'
 
+import { aws } from '../../config/config'
+
 const Form = getFormModel(mongoose)
 
 const MOCK_ADMIN_ID = new ObjectID()
@@ -112,7 +114,7 @@ const createAndReturnFormField = async (
   }
   if (formFieldParams.fieldType === 'image') {
     formFieldParams = {
-      url: 'http://example.com',
+      url: `${aws.imageBucketUrl}/test-image.jpg`,
       fileMd5Hash: 'some hash',
       name: 'test image name',
       size: 'some size',

--- a/src/app/models/field/imageField.ts
+++ b/src/app/models/field/imageField.ts
@@ -1,8 +1,8 @@
+import { escapeRegExp } from 'lodash'
 import { Schema } from 'mongoose'
-import validator from 'validator'
 
 import { IImageFieldSchema } from '../../../types'
-import { isDev } from '../../config/config'
+import { aws } from '../../config/config'
 
 const createImageFieldSchema = () => {
   return new Schema<IImageFieldSchema>({
@@ -11,12 +11,7 @@ const createImageFieldSchema = () => {
       required: true,
       validate: {
         validator: function (url: string) {
-          return validator.isURL(url, {
-            allow_underscores: true,
-            // Not require top level domain (i.e. com) for development
-            // environment where s3 is hosted on localhost.
-            require_tld: !isDev,
-          })
+          return url.match(`^${escapeRegExp(aws.imageBucketUrl)}/`) !== null
         },
         message: `Please ensure that your url is in the valid format`,
       },


### PR DESCRIPTION
## Problem
Currently, our validation for image field schema is just that the url is actually a URL. hmm

Closes #3901

## Solution

Add stronger validation for the image field URLs. We now check that the image field URL starts with the configured s3 bucket url. This will prevent any images from elsewhere on the web to be loaded.

**Breaking Changes** 
- [X] Yes - this PR contains breaking changes
   - Validation now checks more stringently for s3 urls only. There are several forms that currently fail this validation, and they have been archived (see below for details)
- [ ] No - this PR is backwards compatible  

## Tests
- [ ] Public form: images in existing forms should be able to be loaded
- [ ] Admin form: existing images should be able to be removed
- [x] Admin form: other fields should be able to be saved
- [x] Admin and public form: new images should be able to be uploaded, and then viewed in public form view
- [X] Admin form: attempt to POST a new image field with an external url. this should fail.

POST with valid URL (successful, after refreshing form page the new image shows up)
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/25571626/190565177-a1f39ae0-17ac-4c6d-b2a7-fd6128d1149c.png">

POST with invalid url (unsuccessful with correct error message, after refreshing form page the new image does not show up)
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/25571626/190565374-6db979e1-56e7-4e0b-b57c-91a5c5e957eb.png">



## Deploy Notes

Prior to opening this PR, the following query was run on staging and production DB with different values for `<bucketname>`.

```
db.getCollection("forms").find({
    "form_fields": { 
        $elemMatch : { 
            "fieldType": "image", 
            "url": { 
                $not: {
                    $regex: "^https://s3.ap-southeast-1.amazonaws.com/<bucketname>/" 
                }   
            }
        } 
    }
})
```

In production, `<bucketname> = images.form.gov.sg` was used. Only 5 forms were found. All 5 form owners were contacted, and their forms were archived. *We could upload the images to the s3 bucket manually, and then change the url in the DB, for database consistency. Is this worth it?*

In staging, `<bucketname> = images.(staging.)?form.gov.sg` yielded only 3 results. However, `<bucketname> = images.staging.form.gov.sg` yielded over 10,000 results, likely due to old forms which were copied from production to staging DB without cleaning up the image URL. If we want to clean up the DB this would not be able to be done manually. The same question applies - *should we ignore this entirely, since only we will be using staging, so the vast majority of such forms will never be edited anyway, or clean up the DB (either by archiving all the forms, or actually cleaning the data by copying the affected images to the staging bucket)?* 