### PR TITLE
fix: singpass decryption bug

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -43,11 +43,13 @@ jobs:
           REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
           REACT_APP_DD_RUM_ENV: ${{ secrets.DD_ENV }}
           REACT_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+          REACT_APP_FORMSG_SDK_MODE: ${{ secrets.REACT_APP_FORMSG_SDK_MODE }}
         run: |
           echo REACT_APP_DD_RUM_APP_ID=$REACT_APP_DD_RUM_APP_ID > frontend/.env
           echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env
           echo REACT_APP_DD_RUM_ENV=$REACT_APP_DD_RUM_ENV >> frontend/.env
           echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
+          echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
           npm ci
           set -e
           npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -92,6 +92,7 @@ There are also environment secrets for each environment (`staging`, `staging-alt
 |:---------|------------|
 |`APP_NAME`|Application name for the environment.|
 |`DEPLOY_ENV`|Deployment environment on elastic beanstalk.|
+|`REACT_APP_FORMSG_SDK_MODE`|Determines the keys used in the formsg SDK. Set either `production` or `staging`.|
 
 ## Environment Variables
 
@@ -259,8 +260,8 @@ Forms can be protected with [recaptcha](https://www.google.com/recaptcha/about/)
 
 [Google Analytics](https://analytics.google.com/analytics/web) is used to track website traffic. Examples of events include number of visits to various forms, number of successful submissions and number of submission failures.
 
-| Variable         | Description                   |
-| :--------------- | ----------------------------- |
+| Variable                   | Description                   |
+| :------------------------- | ----------------------------- |
 | `REACT_APP_GA_TRACKING_ID` | Google Analytics tracking ID. |
 
 #### Sentry.io

--- a/frontend/.buildtime-env
+++ b/frontend/.buildtime-env
@@ -1,7 +1,14 @@
 SKIP_PREFLIGHT_CHECK=true
+
 # This needs to be removed and replaced with a real tracking ID
+
 # in order to enable GA in a local environment
+
 REACT_APP_GA_TRACKING_ID=
 REACT_APP_DD_RUM_APP_ID=
 REACT_APP_DD_RUM_CLIENT_TOKEN=
 REACT_APP_DD_RUM_ENV=
+
+# Set `production`, `staging` or `development` for sdk mode
+
+REACT_APP_FORMSG_SDK_MODE=

--- a/frontend/src/utils/formSdk.ts
+++ b/frontend/src/utils/formSdk.ts
@@ -1,9 +1,27 @@
 import formsgPackage from '@opengovsg/formsg-sdk'
+import { PackageMode } from '@opengovsg/formsg-sdk/dist/types'
 
 import { TRANSACTION_EXPIRE_AFTER_SECONDS } from '~shared/utils/verification'
 
+/**
+ * Typeguard to check if sdkMode is valid PackageMode
+ * @param sdkMode defined in REACT_APP env var
+ * @returns true if sdkMode is valid PackageMode
+ */
+const isPackageMode = (sdkMode?: string): sdkMode is PackageMode => {
+  return (
+    !!sdkMode &&
+    ['staging', 'production', 'development', 'test'].includes(sdkMode)
+  )
+}
+
 const formsgSdk = formsgPackage({
-  mode: process.env.NODE_ENV,
+  // Either the sdk mode is set in env var, or fall back to NODE_ENV
+  // NODE_ENV is set automatically to development (when using npm start),
+  // test (when using npm test) or production (when using npm build)
+  mode: isPackageMode(process.env.REACT_APP_FORMSG_SDK_MODE)
+    ? process.env.REACT_APP_FORMSG_SDK_MODE
+    : process.env.NODE_ENV,
   verificationOptions: {
     transactionExpiry: TRANSACTION_EXPIRE_AFTER_SECONDS,
   },

--- a/frontend/src/utils/formSdk.ts
+++ b/frontend/src/utils/formSdk.ts
@@ -5,7 +5,7 @@ import { TRANSACTION_EXPIRE_AFTER_SECONDS } from '~shared/utils/verification'
 
 /**
  * Typeguard to check if sdkMode is valid PackageMode
- * @param sdkMode defined in REACT_APP env var
+ * @param sdkMode defined in REACT_APP_FORMSG_SDK_MODE env var
  * @returns true if sdkMode is valid PackageMode
  */
 const isPackageMode = (sdkMode?: string): sdkMode is PackageMode => {
@@ -16,7 +16,7 @@ const isPackageMode = (sdkMode?: string): sdkMode is PackageMode => {
 }
 
 const formsgSdk = formsgPackage({
-  // Either the sdk mode is set in env var, or fall back to NODE_ENV
+  // Either the sdk mode is set in REACT_APP_FORMSG_SDK_MODE env var, or fall back to NODE_ENV
   // NODE_ENV is set automatically to development (when using npm start),
   // test (when using npm test) or production (when using npm build)
   mode: isPackageMode(process.env.REACT_APP_FORMSG_SDK_MODE)


### PR DESCRIPTION
## Problem

Closes #4349

## Solution

- FormSG SDK mode was incorrectly set as it relied on `NODE_ENV`, which defaults to `production` if the application is built using `npm run build`
- This led to the wrong keys being used for verification of storage mode responses in staging
- This only affected verified fields, such as Singpass
- This fix introduces a new `REACT_APP_FORMSG_SDK_MODE` env var for the frontend which sets the correct FormSG SDK mode for both staging and production

## Deploy Notes


The new env var `REACT_APP_FORMSG_SDK_MODE` has already been set for all the staging environments.

Before merging into form-v2/develop:
- Set new github actions environment secret for `release-al2` branch. `REACT_APP_FORMSG_SDK_MODE` should be set to `production`