### PR TITLE
feat(a11y): update aria-labels for icons used in public forms

### DIFF
--- a/frontend/src/components/Banner/Banner.tsx
+++ b/frontend/src/components/Banner/Banner.tsx
@@ -50,6 +50,7 @@ export const Banner = ({
           <Flex>
             <Icon
               as={variant === 'info' ? BxsInfoCircle : BxsErrorCircle}
+              aria-label={`${variant} banner icon`}
               __css={styles.icon}
             />
             {useMarkdown ? (

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -41,6 +41,7 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
           <Icon
             as={BxCheckAnimated}
             __css={iconStyles}
+            aria-label={`Checkbox icon, ${props.isChecked ? '' : 'un'}checked`}
             // This prop needs to be passed explicitly for animations
             isChecked={props.isChecked}
           />

--- a/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -117,7 +117,7 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
         >
           <Icon
             as={isOpen ? BxsChevronUp : BxsChevronDown}
-            aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
+            aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options icon`}
             aria-disabled={isDisabled}
           />
         </Box>

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -16,7 +16,7 @@ export const ToggleChevron = (): JSX.Element => {
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
+        aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options icon`}
         aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>

--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -26,7 +26,7 @@ export const InlineMessage = ({
       <Icon
         as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
         __css={styles.icon}
-        aria-label={`${variant !== 'error' ? 'Info' : 'Error'} message`}
+        aria-label={`${variant !== 'error' ? 'Info' : 'Error'} message icon`}
       />
       {useMarkdown && typeof children === 'string' ? (
         <ReactMarkdown components={mdComponents}>{children}</ReactMarkdown>

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -62,7 +62,12 @@ export const Spinner = ({
   return (
     <Flex color={color} align="center" {...flexProps}>
       {label && <VisuallyHidden>{label}</VisuallyHidden>}
-      <Icon animation={animation} as={BiLoader} fontSize={fontSize} />
+      <Icon
+        animation={animation}
+        as={BiLoader}
+        fontSize={fontSize}
+        aria-label="Spinner icon"
+      />
     </Flex>
   )
 }

--- a/frontend/src/components/Tag/Tag.tsx
+++ b/frontend/src/components/Tag/Tag.tsx
@@ -39,7 +39,9 @@ export const TagRightIcon = forwardRef<TagIconProps, 'svg'>((props, ref) => {
   )
 })
 
-const TagCloseIcon = () => <Icon as={BiX} fontSize="1.5rem" />
+const TagCloseIcon = () => (
+  <Icon as={BiX} fontSize="1.5rem" aria-label="Remove option icon" />
+)
 
 export type TagCloseButtonProps = ChakraTagCloseButtonProps
 /** Not using Chakra's TagCloseButton due to inability to override aria-label */


### PR DESCRIPTION
## Problem
Quick fix to places where icons are used in public forms to add aria-labels with the "icon" keyword, as suggested in #4183 . This definitely does not make all the a11y for associated components perfect but it should help to make sure we have the icons covered. 

## Solution

**Breaking Changes** 
- No - this PR is backwards compatible  
