### PR TITLE
fix(a11y): improvements to radio, checkbox and form labels, refactor rating to reduce screen reader garbage

### DIFF
--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -48,6 +48,7 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
         colorScheme={colorScheme}
         ref={ref}
         {...props}
+        aria-label={children?.toString()}
       >
         {children}
       </ChakraCheckbox>

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -48,7 +48,6 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
         colorScheme={colorScheme}
         ref={ref}
         {...props}
-        aria-label={children?.toString()}
       >
         {children}
       </ChakraCheckbox>
@@ -107,6 +106,7 @@ const OthersCheckbox = forwardRef<CheckboxProps, 'input'>((props, ref) => {
     <Checkbox
       ref={mergedCheckboxRef}
       __css={styles.othersCheckbox}
+      aria-label="Other"
       {...props}
       onChange={handleCheckboxChange}
     >

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -149,7 +149,7 @@ export const Rating = forwardRef<RatingProps, 'input'>(
         >
           <Stack spacing={ratingLayout.spacing}>
             {options.map((row, i) => (
-              <HStack spacing={ratingLayout.spacing}>
+              <HStack spacing={ratingLayout.spacing} key={i}>
                 {row.map((value) => (
                   <RatingOption
                     name={name}

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -135,15 +135,15 @@ export const Rating = forwardRef<RatingProps, 'input'>(
         rowGap="0.5rem"
         templateAreas={{
           base: "'caption' 'rating'",
-          lg: "'rating' 'caption'",
+          md: "'rating' 'caption'",
         }}
       >
         <Stack
           gridArea="rating"
           as="fieldset"
-          direction={{ base: 'column', lg: 'row' }}
-          spacing={{ base: '0.5rem', lg: '1rem' }}
-          align={{ base: 'flex-start', lg: 'center' }}
+          direction={{ base: 'column', md: 'row' }}
+          spacing={{ base: '0.5rem', md: '1rem' }}
+          align={{ base: 'flex-start', md: 'center' }}
         >
           <Stack spacing={ratingLayout.spacingY}>
             {options.map((row, i) => (

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -124,32 +124,30 @@ export const Rating = forwardRef<RatingProps, 'input'>(
     const ratingLayout = useMemo(() => {
       switch (variant) {
         case 'number':
-          return { spacing: '-1px', rowHeight: '0.5rem' }
+          return { spacingX: '-1px', spacingY: '0.5rem' }
         default:
-          return { spacing: 0, rowHeight: 0 }
+          return { spacingX: 0, spacingY: 0 }
       }
     }, [variant])
 
     return (
       <Grid
         rowGap="0.5rem"
-        templateAreas={[
-          `'caption' 'rating'`,
-          `'caption' 'rating'`,
-          `'caption' 'rating'`,
-          `'rating' 'caption'`,
-        ]}
+        templateAreas={{
+          base: "'caption' 'rating'",
+          lg: "'rating' 'caption'",
+        }}
       >
         <Stack
           gridArea="rating"
           as="fieldset"
-          direction={['column', 'column', 'column', 'row']}
-          spacing={['0.5rem', '0.5rem', '0.5rem', '1rem']}
-          align={['flex-start', 'flex-start', 'flex-start', 'center']}
+          direction={{ base: 'column', lg: 'row' }}
+          spacing={{ base: '0.5rem', lg: '1rem' }}
+          align={{ base: 'flex-start', lg: 'center' }}
         >
-          <Stack spacing={ratingLayout.spacing}>
+          <Stack spacing={ratingLayout.spacingY}>
             {options.map((row, i) => (
-              <HStack spacing={ratingLayout.spacing} key={i}>
+              <HStack spacing={ratingLayout.spacingX} key={i}>
                 {row.map((value) => (
                   <RatingOption
                     name={name}

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -121,12 +121,12 @@ export const Rating = forwardRef<RatingProps, 'input'>(
       return options
     }, [isSplitRows, numberOfRatings, wrapComponentsPerRow])
 
-    const ratingLayout = useMemo(() => {
+    const optionSpacing = useMemo(() => {
       switch (variant) {
         case 'number':
-          return { spacingX: '-1px', spacingY: '0.5rem' }
+          return { column: '-1px', row: '0.5rem' }
         default:
-          return { spacingX: 0, spacingY: 0 }
+          return { column: 0, row: 0 }
       }
     }, [variant])
 
@@ -145,9 +145,9 @@ export const Rating = forwardRef<RatingProps, 'input'>(
           spacing={{ base: '0.5rem', md: '1rem' }}
           align={{ base: 'flex-start', md: 'center' }}
         >
-          <Stack spacing={ratingLayout.spacingY}>
+          <Stack spacing={optionSpacing.row}>
             {options.map((row, i) => (
-              <HStack spacing={ratingLayout.spacingX} key={i}>
+              <HStack spacing={optionSpacing.column} key={i}>
                 {row.map((value) => (
                   <RatingOption
                     name={name}

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -1,13 +1,11 @@
-import { Fragment, useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
-  Box,
   forwardRef,
   Grid,
+  HStack,
   Stack,
   Text,
   useBreakpointValue,
-  Wrap,
-  WrapItem,
 } from '@chakra-ui/react'
 
 import { FieldColorScheme } from '~theme/foundations/colours'
@@ -108,11 +106,20 @@ export const Rating = forwardRef<RatingProps, 'input'>(
       md: false,
     })
 
-    // Generate options from maxRating given.
-    const options = useMemo(
-      () => Array.from({ length: numberOfRatings }, (_, i) => i + 1),
-      [numberOfRatings],
-    )
+    // Generate options from maxRating given, grouped by display row.
+    const options = useMemo(() => {
+      const options = []
+      let suboptions = []
+      for (let i = 1; i <= numberOfRatings; i++) {
+        suboptions.push(i)
+        if (isSplitRows && i % wrapComponentsPerRow === 0) {
+          options.push(suboptions)
+          suboptions = []
+        }
+      }
+      if (suboptions.length > 0) options.push(suboptions)
+      return options
+    }, [isSplitRows, numberOfRatings, wrapComponentsPerRow])
 
     const ratingLayout = useMemo(() => {
       switch (variant) {
@@ -140,38 +147,27 @@ export const Rating = forwardRef<RatingProps, 'input'>(
           spacing={['0.5rem', '0.5rem', '0.5rem', '1rem']}
           align={['flex-start', 'flex-start', 'flex-start', 'center']}
         >
-          <Wrap spacing={ratingLayout.spacing}>
-            {options.map((value, i) => {
-              return (
-                <Fragment key={value}>
-                  <WrapItem>
-                    <RatingOption
-                      name={name}
-                      variant={variant}
-                      colorScheme={colorScheme}
-                      value={value}
-                      onChange={handleRatingChange}
-                      selectedValue={currentValue}
-                      isDisabled={isDisabled}
-                      {...(i === 0 ? { ref } : {})}
-                    >
-                      {value}
-                    </RatingOption>
-                  </WrapItem>
-                  {
-                    // Force component to begin on a new line.
-                    value !== numberOfRatings &&
-                      value % wrapComponentsPerRow === 0 &&
-                      isSplitRows && (
-                        <WrapItem display="contents" aria-hidden>
-                          <Box flexBasis="100%" h={ratingLayout.rowHeight} />
-                        </WrapItem>
-                      )
-                  }
-                </Fragment>
-              )
-            })}
-          </Wrap>
+          <Stack spacing={ratingLayout.spacing}>
+            {options.map((row, i) => (
+              <HStack spacing={ratingLayout.spacing}>
+                {row.map((value) => (
+                  <RatingOption
+                    name={name}
+                    variant={variant}
+                    colorScheme={colorScheme}
+                    value={value}
+                    onChange={handleRatingChange}
+                    selectedValue={currentValue}
+                    isDisabled={isDisabled}
+                    key={value}
+                    {...(value === 1 ? { ref } : {})}
+                  >
+                    {value}
+                  </RatingOption>
+                ))}
+              </HStack>
+            ))}
+          </Stack>
           {currentValue && variant !== 'number' && (
             <Text color="secondary.700" textStyle="subhead-2">
               {currentValue} selected

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -3,10 +3,8 @@ import {
   Box,
   forwardRef,
   Icon,
-  Text,
   useMultiStyleConfig,
   useRadio,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { BxHeart, BxsHeart, BxsStar, BxStar } from '~assets/icons'
@@ -61,14 +59,10 @@ const NumberRating = ({
       {...radioProps}
       as="label"
       htmlFor={inputId}
-      aria-hidden={false}
       {...(isChecked ? { 'data-checked': '' } : {})}
       __css={styles.option}
     >
-      <VisuallyHidden>
-        {value} {isChecked ? 'selected' : 'unselected'}
-      </VisuallyHidden>
-      <Text aria-hidden>{value}</Text>
+      {value}
     </Box>
   )
 }
@@ -94,14 +88,15 @@ const IconRating = ({
       {...radioProps}
       as="label"
       htmlFor={inputId}
-      aria-hidden={false}
+      aria-label={`${value}`}
       {...(isChecked ? { 'data-checked': '' } : {})}
       __css={styles.option}
     >
-      <VisuallyHidden>
-        {value} {isChecked ? 'selected' : 'unselected'}
-      </VisuallyHidden>
-      <Icon as={isChecked ? fullIcon : emptyIcon} fontSize="2.5rem" />
+      <Icon
+        as={isChecked ? fullIcon : emptyIcon}
+        fontSize="2.5rem"
+        aria-hidden
+      />
     </Box>
   )
 }

--- a/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   TextProps,
   useFormControlContext,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
@@ -167,7 +166,6 @@ FormLabel.QuestionNumber = ({ children, ...props }: TextProps): JSX.Element => {
       lineHeight={0}
       {...props}
     >
-      <VisuallyHidden>Question number:</VisuallyHidden>
       {children}
     </Text>
   )

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -86,6 +86,7 @@ export const CheckboxField = ({
             key={idx}
             value={o}
             defaultValue=""
+            aria-label={o}
             {...register(checkboxInputName, validationRules)}
           >
             {o}

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -5,7 +5,7 @@ import {
   UseFormRegisterReturn,
   useFormState,
 } from 'react-hook-form'
-import { FormControl, useMultiStyleConfig } from '@chakra-ui/react'
+import { Box, FormControl, useMultiStyleConfig } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types'
 
@@ -79,53 +79,55 @@ export const CheckboxField = ({
 
   return (
     <FieldContainer schema={schema} errorKey={checkboxInputName}>
-      {schema.fieldOptions.map((o, idx) => (
-        <Checkbox
-          colorScheme={fieldColorScheme}
-          key={idx}
-          value={o}
-          defaultValue=""
-          {...register(checkboxInputName, validationRules)}
-        >
-          {o}
-        </Checkbox>
-      ))}
-      {schema.fieldOptions.length === 1 ? (
-        // React-hook-form quirk where the value will not be set in an array if there is only a single checkbox option.
-        // This is a workaround to set the value in an array by registering a hidden checkbox with the same id.
-        // See https://github.com/react-hook-form/react-hook-form/issues/7834#issuecomment-1040735711.
-        <input
-          type="checkbox"
-          hidden
-          value=""
-          {...register(checkboxInputName)}
-        />
-      ) : null}
-      {schema.othersRadioButton ? (
-        <Checkbox.OthersWrapper colorScheme={fieldColorScheme}>
-          <FormControl
-            isRequired={schema.required}
-            isDisabled={schema.disabled}
-            isReadOnly={isValid && isSubmitting}
-            isInvalid={!!get(errors, othersInputName)}
+      <Box aria-label={schema.title} role="list">
+        {schema.fieldOptions.map((o, idx) => (
+          <Checkbox
+            colorScheme={fieldColorScheme}
+            key={idx}
+            value={o}
+            defaultValue=""
+            {...register(checkboxInputName, validationRules)}
           >
-            <OtherCheckboxField
-              colorScheme={fieldColorScheme}
-              value={CHECKBOX_OTHERS_INPUT_VALUE}
-              isInvalid={!!get(errors, checkboxInputName)}
-              {...register(checkboxInputName, validationRules)}
-            />
-            <Checkbox.OthersInput
-              colorScheme={fieldColorScheme}
-              aria-label='Enter value for "Others" option'
-              {...register(othersInputName, othersValidationRules)}
-            />
-            <FormErrorMessage ml={styles.othersInput?.ml as string} mb={0}>
-              {get(errors, `${othersInputName}.message`)}
-            </FormErrorMessage>
-          </FormControl>
-        </Checkbox.OthersWrapper>
-      ) : null}
+            {o}
+          </Checkbox>
+        ))}
+        {schema.fieldOptions.length === 1 ? (
+          // React-hook-form quirk where the value will not be set in an array if there is only a single checkbox option.
+          // This is a workaround to set the value in an array by registering a hidden checkbox with the same id.
+          // See https://github.com/react-hook-form/react-hook-form/issues/7834#issuecomment-1040735711.
+          <input
+            type="checkbox"
+            hidden
+            value=""
+            {...register(checkboxInputName)}
+          />
+        ) : null}
+        {schema.othersRadioButton ? (
+          <Checkbox.OthersWrapper colorScheme={fieldColorScheme}>
+            <FormControl
+              isRequired={schema.required}
+              isDisabled={schema.disabled}
+              isReadOnly={isValid && isSubmitting}
+              isInvalid={!!get(errors, othersInputName)}
+            >
+              <OtherCheckboxField
+                colorScheme={fieldColorScheme}
+                value={CHECKBOX_OTHERS_INPUT_VALUE}
+                isInvalid={!!get(errors, checkboxInputName)}
+                {...register(checkboxInputName, validationRules)}
+              />
+              <Checkbox.OthersInput
+                colorScheme={fieldColorScheme}
+                aria-label='"Other" response'
+                {...register(othersInputName, othersValidationRules)}
+              />
+              <FormErrorMessage ml={styles.othersInput?.ml as string} mb={0}>
+                {get(errors, `${othersInputName}.message`)}
+              </FormErrorMessage>
+            </FormControl>
+          </Checkbox.OthersWrapper>
+        ) : null}
+      </Box>
     </FieldContainer>
   )
 }

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -86,6 +86,7 @@ export const RadioField = ({
               // Trigger validation of others input if Other radio is selected.
               if (value === RADIO_OTHERS_INPUT_VALUE) trigger(othersInputName)
             }}
+            aria-label={schema.title}
           >
             {schema.fieldOptions.map((option, idx) => (
               <Radio key={idx} value={option} {...(idx === 0 ? { ref } : {})}>
@@ -104,7 +105,7 @@ export const RadioField = ({
                   isInvalid={!!get(errors, othersInputName)}
                 >
                   <OthersInput
-                    aria-label='Enter value for "Others" option'
+                    aria-label='"Other" response'
                     {...register(othersInputName, othersValidationRules)}
                   />
                   <FormErrorMessage


### PR DESCRIPTION
## Problem
Rating field was saying "1 unselected, required invalid data, radio button, 1 of 5, 1 of 5" for unselected ratings, and selected ratings will say "3 selected, required selected invalid data, radio button, 3 of 5, 3 of 5", along with other stuff when scrolling through focus referring to the text and the star/heart icon. 

Key reason for this is that the Wrap component generates a list element (accounting for one of the "3 of 5"), and then radio button accounts for the other "3 of 5". Also, HTML input natively announces selected-ness, so there's no need for us to add our own check at the start. The fact that it's selected is kinda hidden by the fact that "invalid data" is read out everywhere but once that's fixed later on this should be good to go.

Additionally, radio and checkbox fields were slightly inconsistent, and form labels sounded weird. (Form label screen reader says "Question number (long pause) 4. Rating". Better to just get rid of the "question number" prefix, google forms doesn't even show question numbers anyway. Given that it's a form page i would think it's quite obvious that the prefix number is the question number.

Closes #4184 

## Solution
Refactor rating to make use of stack and hstacks instead.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/191166855-4c9962ea-4faa-4596-a6f7-d09de8a5fac0.mov

