### PR TITLE
feat: add patch-package to remove `required` prop in useFormControl

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15907,6 +15907,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -23279,6 +23285,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -29004,6 +29019,15 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -32186,6 +32210,76 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
     },
     "path-browserify": {
       "version": "0.0.1",
@@ -38566,6 +38660,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
   "scripts": {
     "gen:theme-typings": "chakra-cli tokens src/theme/index.ts || true",
     "clean:emotion-types": "rimraf node_modules/@emotion/core/types",
-    "postinstall": "npm run gen:theme-typings && npm run clean:emotion-types && npm --prefix ../shared install",
+    "postinstall": "patch-package && npm run gen:theme-typings && npm run clean:emotion-types && npm --prefix ../shared install",
     "start": "env-cmd -f .buildtime-env craco start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test --silent",
@@ -170,6 +170,7 @@
     "mockdate": "^3.0.5",
     "msw": "^0.36.3",
     "msw-storybook-addon": "^1.6.3",
+    "patch-package": "^6.4.7",
     "prettier": "^2.5.1",
     "puppeteer": "^13.0.0",
     "react-scripts": "^4.0.3",

--- a/frontend/patches/@chakra-ui+form-control+1.6.0.patch
+++ b/frontend/patches/@chakra-ui+form-control+1.6.0.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.cjs.prod.js b/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.cjs.prod.js
+index 7e61813..7f48c08 100644
+--- a/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.cjs.prod.js
++++ b/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.cjs.prod.js
+@@ -308,7 +308,6 @@ function useFormControl(props) {
+   return _extends({}, rest, {
+     disabled: isDisabled,
+     readOnly: isReadOnly,
+-    required: isRequired,
+     "aria-invalid": utils.ariaAttr(isInvalid),
+     "aria-required": utils.ariaAttr(isRequired),
+     "aria-readonly": utils.ariaAttr(isReadOnly)
+diff --git a/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.esm.js b/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.esm.js
+index dabd0ad..4e7a57f 100644
+--- a/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.esm.js
++++ b/node_modules/@chakra-ui/form-control/dist/chakra-ui-form-control.esm.js
+@@ -281,7 +281,6 @@ function useFormControl(props) {
+   return _extends({}, rest, {
+     disabled: isDisabled,
+     readOnly: isReadOnly,
+-    required: isRequired,
+     "aria-invalid": ariaAttr(isInvalid),
+     "aria-required": ariaAttr(isRequired),
+     "aria-readonly": ariaAttr(isReadOnly)
+diff --git a/node_modules/@chakra-ui/form-control/src/use-form-control.ts b/node_modules/@chakra-ui/form-control/src/use-form-control.ts
+index a74417d..bcf30e2 100644
+--- a/node_modules/@chakra-ui/form-control/src/use-form-control.ts
++++ b/node_modules/@chakra-ui/form-control/src/use-form-control.ts
+@@ -36,7 +36,6 @@ export function useFormControl<T extends HTMLElement>(
+     ...rest,
+     disabled: isDisabled,
+     readOnly: isReadOnly,
+-    required: isRequired,
+     "aria-invalid": ariaAttr(isInvalid),
+     "aria-required": ariaAttr(isRequired),
+     "aria-readonly": ariaAttr(isReadOnly),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Known issue of various screen readers to read out input as "invalid" even when there has not been any action taken by the user. This is tEcHniCaLLy cOrReCt since an empty required field is technically invalid, though it is very unintuitive to a screen-reader user.

The most correct (and convenient) way is to remove the `required` prop from the input and use `aria-required` instead, but  ChakraUI injects the `required` prop without allowances for overrides.

Thus, require monkey-patching the underlying package to remove the assignment of `required` prop.

Closes #4177
