### PR TITLE
fix(v2): add better a11y to dropdown fields

### DIFF
--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -67,7 +67,7 @@ export const MultiSelectProvider = ({
   filter = defaultFilter,
   nothingFoundLabel = 'No matching results',
   placeholder: placeholderProp,
-  clearButtonLabel = 'Clear dropdown',
+  clearButtonLabel = 'Clear selection',
   isSearchable = true,
   defaultIsOpen,
   isInvalid: isInvalidProp,

--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -14,7 +14,7 @@ export interface SharedSelectContextReturnProps<
   isClearable?: boolean
   /** Nothing found label. Defaults to "No matching results" */
   nothingFoundLabel?: string
-  /** aria-label for clear button. Defaults to "Clear dropdown" */
+  /** aria-label for clear button. Defaults to "Clear selection" */
   clearButtonLabel?: string
   /**
    * Placeholder to show in the input field.

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -51,7 +51,7 @@ export const SingleSelectProvider = ({
   filter = defaultFilter,
   nothingFoundLabel = 'No matching results',
   placeholder: placeholderProp,
-  clearButtonLabel = 'Clear dropdown input',
+  clearButtonLabel = 'Clear selection',
   isClearable = true,
   isSearchable = true,
   initialIsOpen,

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -102,6 +102,7 @@ export const SingleSelectProvider = ({
   )
 
   const virtualListRef = useRef<VirtuosoHandle>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const {
     toggleMenu,
@@ -268,6 +269,7 @@ export const SingleSelectProvider = ({
         setIsFocused,
         resetInputValue,
         inputAria,
+        inputRef,
         virtualListRef,
         virtualListHeight,
       }}

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ComboboxClearButton.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { BiX } from 'react-icons/bi'
-import { chakra } from '@chakra-ui/react'
+import { chakra, VisuallyHidden } from '@chakra-ui/react'
 
 import { useSelectContext } from '../../SelectContext'
 
@@ -13,10 +13,22 @@ export const ComboboxClearButton = (): JSX.Element | null => {
     selectItem,
     styles,
     inputValue,
+    inputRef,
     selectedItem,
   } = useSelectContext()
 
-  const handleClearSelection = useCallback(() => selectItem(null), [selectItem])
+  const [announceClearedInput, setAnnounceClearedInput] = useState(false)
+  const handleClearSelection = useCallback(() => {
+    selectItem(null)
+    inputRef?.current?.focus()
+    setAnnounceClearedInput(true)
+  }, [inputRef, selectItem])
+
+  useEffect(() => {
+    if (selectedItem) {
+      setAnnounceClearedInput(false)
+    }
+  }, [inputRef, selectedItem])
 
   if (!isClearable) return null
 
@@ -30,6 +42,11 @@ export const ComboboxClearButton = (): JSX.Element | null => {
       __css={styles.clearbutton}
       color={inputValue || selectedItem ? 'secondary.500' : undefined}
     >
+      {announceClearedInput && (
+        <VisuallyHidden aria-live="assertive">
+          Selection has been cleared
+        </VisuallyHidden>
+      )}
       <BiX fontSize="1.25rem" />
     </chakra.button>
   )

--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -5,6 +5,7 @@ import {
   InputGroup,
   Stack,
   Text,
+  useMergeRefs,
   VisuallyHidden,
 } from '@chakra-ui/react'
 
@@ -35,7 +36,10 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       isOpen,
       resetInputValue,
       inputAria,
+      inputRef,
     } = useSelectContext()
+
+    const mergedInputRef = useMergeRefs(inputRef, ref)
 
     const selectedItemMeta = useMemo(
       () => ({
@@ -101,7 +105,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             {...getInputProps({
               onClick: handleToggleMenu,
               onBlur: () => !isOpen && resetInputValue(),
-              ref,
+              ref: mergedInputRef,
               'aria-describedby': inputAria.id,
             })}
           />

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -19,7 +19,7 @@ export const ToggleChevron = (): JSX.Element => {
       {...getToggleButtonProps({
         disabled: isDisabled || isReadOnly,
         // Allow navigation to this button with screen readers.
-        tabIndex: 1,
+        tabIndex: 0,
       })}
     >
       <Icon

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -11,12 +11,21 @@ export const ToggleChevron = (): JSX.Element => {
 
   return (
     <InputRightElement
-      {...getToggleButtonProps({ disabled: isDisabled || isReadOnly })}
+      as="button"
+      type="button"
+      display="flex"
+      isDisabled={isDisabled || isReadOnly}
+      aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
+      {...getToggleButtonProps({
+        disabled: isDisabled || isReadOnly,
+        // Allow navigation to this button with screen readers.
+        tabIndex: 1,
+      })}
     >
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options icon`}
+        aria-hidden
         aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>

--- a/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/ToggleChevron.tsx
@@ -14,7 +14,9 @@ export const ToggleChevron = (): JSX.Element => {
       as="button"
       type="button"
       display="flex"
-      isDisabled={isDisabled || isReadOnly}
+      _disabled={{
+        cursor: 'not-allowed',
+      }}
       aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
       {...getToggleButtonProps({
         disabled: isDisabled || isReadOnly,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
@@ -101,9 +101,19 @@ export const FormFields = ({
     }
   }, [defaultFormValues, isDirty, reset])
 
+  const preventSubmitOnEnter = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+    }
+  }, [])
+
   return (
     <FormProvider {...formMethods}>
-      <form onSubmit={formMethods.handleSubmit(onSubmit)} noValidate>
+      <form
+        onSubmit={formMethods.handleSubmit(onSubmit)}
+        noValidate
+        onKeyDown={preventSubmitOnEnter}
+      >
         {!!formFields?.length && (
           <Box bg={'white'} py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
             <Stack spacing="2.25rem">


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a bunch of a11y tweaks to hopefully make dropdown fields a better experience.

Closes #4185 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: prevent Enter keypress from form submission (public form)
- feat: allow dropdown to be opened with screen readers by allowing focus on dropdown caret as a button
- feat(SelectCombobox): announce input cleared and refocus on input


## Before & After Screenshots
Should have no changes
