### PR TITLE
fix(v2): fix radio aria-required inconsistency

### DIFF
--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -266,7 +266,12 @@ const OthersRadio = forwardRef<RadioProps, 'input'>((props, ref) => {
   }, [isChecked, othersInputRef])
 
   return (
-    <Radio ref={mergedRadioRef} {...props} __css={styles.othersRadio}>
+    <Radio
+      ref={mergedRadioRef}
+      {...props}
+      __css={styles.othersRadio}
+      isRequired={false}
+    >
       Other
     </Radio>
   )
@@ -299,6 +304,7 @@ export const OthersInput = forwardRef<InputProps, 'input'>(
         ref={mergedInputRef}
         {...props}
         onChange={handleInputChange}
+        isRequired={othersRadioRef.current?.checked}
       />
     )
   },

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -215,7 +215,11 @@ export const Radio = forwardRef<RadioProps, 'input'>(
         {...labelProps}
         __css={rootStyles}
       >
-        <input className="chakra-radio__input" {...inputProps} />
+        <input
+          className="chakra-radio__input"
+          {...inputProps}
+          aria-invalid={false}
+        />
         <chakra.span
           className="chakra-radio__control"
           {...checkboxProps}

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -270,7 +270,7 @@ const OthersRadio = forwardRef<RadioProps, 'input'>((props, ref) => {
       ref={mergedRadioRef}
       {...props}
       __css={styles.othersRadio}
-      // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
+      // Required should apply to radio group rather than individual radio.
       isRequired={false}
     >
       Other
@@ -305,7 +305,7 @@ export const OthersInput = forwardRef<InputProps, 'input'>(
         ref={mergedInputRef}
         {...props}
         onChange={handleInputChange}
-        // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
+        // Required only when other radio is checked.
         isRequired={othersRadioRef.current?.checked}
       />
     )

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -270,6 +270,7 @@ const OthersRadio = forwardRef<RadioProps, 'input'>((props, ref) => {
       ref={mergedRadioRef}
       {...props}
       __css={styles.othersRadio}
+      // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
       isRequired={false}
     >
       Other
@@ -304,6 +305,7 @@ export const OthersInput = forwardRef<InputProps, 'input'>(
         ref={mergedInputRef}
         {...props}
         onChange={handleInputChange}
+        // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
         isRequired={othersRadioRef.current?.checked}
       />
     )

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -97,6 +97,7 @@ export const RadioField = ({
                 key={idx}
                 value={option}
                 {...(idx === 0 ? { ref } : {})}
+                // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
                 isRequired={false}
               >
                 {option}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -97,7 +97,7 @@ export const RadioField = ({
                 key={idx}
                 value={option}
                 {...(idx === 0 ? { ref } : {})}
-                // This is to enhance radio a11y: https://github.com/opengovsg/FormSG/pull/4925
+                // Required should apply to radio group rather than individual radio.
                 isRequired={false}
               >
                 {option}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -87,6 +87,9 @@ export const RadioField = ({
               if (value === RADIO_OTHERS_INPUT_VALUE) trigger(othersInputName)
             }}
             aria-label={schema.title}
+            aria-invalid={
+              !!get(errors, radioInputName) || !!get(errors, othersInputName)
+            }
           >
             {schema.fieldOptions.map((option, idx) => (
               <Radio key={idx} value={option} {...(idx === 0 ? { ref } : {})}>

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -90,9 +90,15 @@ export const RadioField = ({
             aria-invalid={
               !!get(errors, radioInputName) || !!get(errors, othersInputName)
             }
+            aria-required={schema.required}
           >
             {schema.fieldOptions.map((option, idx) => (
-              <Radio key={idx} value={option} {...(idx === 0 ? { ref } : {})}>
+              <Radio
+                key={idx}
+                value={option}
+                {...(idx === 0 ? { ref } : {})}
+                isRequired={false}
+              >
                 {option}
               </Radio>
             ))}


### PR DESCRIPTION
## Problem

Closes #4190 

## Solution

Although the automatic injection of `required` props by Chakra's `useFormControl` has been disabled by this [PR](https://github.com/opengovsg/FormSG/pull/4916), they are still injected by radio-related Chakra hooks eg. `useRadio`. Hence, the `required` prop still has to be disabled manually to produce the desired behaviour.

After some discussion with @justynoh, the desired behaviour of radio field's a11y is as such:

- Radio Group
  - aria-invalid
    - `true` when error message is displayed (either for radio group or other input)
  - aria-required
    - `true` when required option is checked

- Radio + Other Radio
  - aria-invalid
    - never `true`
  - aria-required
    - never `true`

- Other Input
  - aria-invalid
    - `true` when error message is displayed (for other input)
  - aria-required
    - `true` when other option is checked
