### PR TITLE
perf(v2): narrow slice selection and remove memo

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -8,6 +8,7 @@ import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 import { DndPlaceholderProps } from '../types'
 import {
   FieldBuilderState,
+  fieldBuilderStateSelector,
   setToInactiveSelector,
   stateDataSelector,
   useFieldBuilderStore,
@@ -25,16 +26,8 @@ export const BuilderAndDesignContent = ({
 }: BuilderAndDesignContentProps): JSX.Element => {
   const { data: settings } = useAdminFormSettings()
 
-  const { stateData, setToInactive: setFieldsToInactive } =
-    useFieldBuilderStore(
-      useCallback(
-        (state) => ({
-          stateData: stateDataSelector(state),
-          setToInactive: setToInactiveSelector(state),
-        }),
-        [],
-      ),
-    )
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
+  const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
 
   useEffect(() => {
     setFieldsToInactive()
@@ -58,7 +51,7 @@ export const BuilderAndDesignContent = ({
           display={
             // Don't conditionally render EndPageView and FormBuilder because it
             // is expensive and takes time.
-            stateData.state === FieldBuilderState.EditingEndPage
+            fieldBuilderState === FieldBuilderState.EditingEndPage
               ? 'flex'
               : 'none'
           }
@@ -66,7 +59,7 @@ export const BuilderAndDesignContent = ({
         <FormBuilder
           placeholderProps={placeholderProps}
           display={
-            stateData.state === FieldBuilderState.EditingEndPage
+            fieldBuilderState === FieldBuilderState.EditingEndPage
               ? 'none'
               : 'flex'
           }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -1,5 +1,3 @@
-import { memo, useMemo } from 'react'
-
 import { AdminFormDto } from '~shared/types/form'
 
 import { augmentWithQuestionNo } from '~features/form/utils'
@@ -13,27 +11,23 @@ interface BuilderFieldsProps {
   isDraggingOver: boolean
 }
 
-export const BuilderFields = memo(
-  ({ fields, visibleFieldIds, isDraggingOver }: BuilderFieldsProps) => {
-    const fieldsWithQuestionNos = useMemo(
-      () => augmentWithQuestionNo(fields),
-      [fields],
-    )
-
-    return (
-      <>
-        {fieldsWithQuestionNos.map((f, i) => (
-          <FieldRow
-            index={i}
-            key={f._id}
-            field={f}
-            isHiddenByLogic={!visibleFieldIds.has(f._id)}
-            isDraggingOver={isDraggingOver}
-          />
-        ))}
-      </>
-    )
-  },
-  (prev, next) =>
-    prev.fields === next.fields && prev.isDraggingOver === next.isDraggingOver,
-)
+export const BuilderFields = ({
+  fields,
+  visibleFieldIds,
+  isDraggingOver,
+}: BuilderFieldsProps) => {
+  const fieldsWithQuestionNos = augmentWithQuestionNo(fields)
+  return (
+    <>
+      {fieldsWithQuestionNos.map((f, i) => (
+        <FieldRow
+          index={i}
+          key={f._id}
+          field={f}
+          isHiddenByLogic={!visibleFieldIds.has(f._id)}
+          isDraggingOver={isDraggingOver}
+        />
+      ))}
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { FormProvider, useForm } from 'react-hook-form'
 import { BiCog, BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
@@ -340,7 +340,7 @@ export const FieldRowContainer = ({
                 opacity={isActive || !isHiddenByLogic ? '100%' : '30%'}
               >
                 <FormProvider {...formMethods}>
-                  <MemoFieldRow
+                  <FieldRow
                     field={field}
                     colorTheme={colorTheme}
                     showMyInfoBadge={isMyInfoField}
@@ -403,13 +403,13 @@ export const FieldRowContainer = ({
   )
 }
 
-type MemoFieldRowProps = {
+type FieldRowProps = {
   field: FormFieldDto
   colorTheme?: FormColorTheme
   showMyInfoBadge?: boolean
 }
 
-const MemoFieldRow = memo(({ field, ...rest }: MemoFieldRowProps) => {
+const FieldRow = ({ field, ...rest }: FieldRowProps) => {
   switch (field.fieldType) {
     case BasicField.Section:
       return <SectionFieldRow field={field} {...rest} />
@@ -464,4 +464,4 @@ const MemoFieldRow = memo(({ field, ...rest }: MemoFieldRowProps) => {
     case BasicField.Table:
       return <TableField schema={field} {...rest} />
   }
-})
+}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/BuilderAndDesignDrawer.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../common/CreatePageSidebarContext'
 import {
   FieldBuilderState,
-  stateDataSelector,
+  fieldBuilderStateSelector,
   useFieldBuilderStore,
 } from '../useFieldBuilderStore'
 
@@ -23,7 +23,7 @@ import { FieldListDrawer } from './FieldListDrawer'
 export const BuilderAndDesignDrawer = (): JSX.Element | null => {
   const isMobile = useIsMobile()
   const { activeTab, isDrawerOpen, drawerRef } = useCreatePageSidebar()
-  const createOrEditData = useFieldBuilderStore(stateDataSelector)
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
 
   const drawerMotionProps = useMemo(() => {
     return {
@@ -49,7 +49,7 @@ export const BuilderAndDesignDrawer = (): JSX.Element | null => {
   const renderDrawerContent: JSX.Element | null = useMemo(() => {
     switch (activeTab) {
       case DrawerTabs.Builder:
-        switch (createOrEditData.state) {
+        switch (fieldBuilderState) {
           case FieldBuilderState.EditingField:
           case FieldBuilderState.CreatingField:
             return <EditFieldDrawer />
@@ -65,7 +65,7 @@ export const BuilderAndDesignDrawer = (): JSX.Element | null => {
         // Logic drawer open
         return null
     }
-  }, [createOrEditData, activeTab])
+  }, [fieldBuilderState, activeTab])
 
   return (
     <AnimatePresence>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
@@ -8,7 +8,7 @@ import Link from '~components/Link'
 
 import {
   FieldBuilderState,
-  stateDataSelector,
+  fieldBuilderStateSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
 
@@ -33,7 +33,7 @@ type EditMyInfoProps = EditFieldProps<MyInfoField>
 
 export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
   const extendedField = extendWithMyInfo(field)
-  const stateData = useFieldBuilderStore(stateDataSelector)
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
   const { buttonText, handleUpdateField, isLoading, handleCancel } =
     useEditFieldForm<EditMyInfoProps, MyInfoField>({
       field,
@@ -84,7 +84,7 @@ export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
         <Text textStyle="subhead-1">Field details</Text>
         <Text>{extendedField.details}</Text>
       </VStack>
-      {stateData.state === FieldBuilderState.CreatingField && (
+      {fieldBuilderState === FieldBuilderState.CreatingField && (
         <FormFieldDrawerActions
           isLoading={isLoading}
           buttonText={buttonText}

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDuplicateFormField.ts
@@ -13,7 +13,7 @@ import { useAdminFormLogic } from '../../logic/hooks/useAdminFormLogic'
 import { duplicateSingleFormField } from '../UpdateFormFieldService'
 import {
   FieldBuilderState,
-  stateDataSelector,
+  fieldBuilderStateSelector,
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '../useFieldBuilderStore'
@@ -22,16 +22,8 @@ import { getMutationErrorMessage } from '../utils/getMutationErrorMessage'
 export const useDuplicateFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
-
-  const { stateData, updateEditState } = useFieldBuilderStore(
-    useCallback(
-      (state) => ({
-        stateData: stateDataSelector(state),
-        updateEditState: updateEditStateSelector(state),
-      }),
-      [],
-    ),
-  )
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
+  const updateEditState = useFieldBuilderStore(updateEditStateSelector)
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -42,7 +34,7 @@ export const useDuplicateFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto, fieldId: string) => {
       toast.closeAll()
-      if (stateData.state !== FieldBuilderState.EditingField) {
+      if (fieldBuilderState !== FieldBuilderState.EditingField) {
         toast({
           status: 'warning',
           description:
@@ -71,7 +63,7 @@ export const useDuplicateFormField = () => {
     },
     [
       toast,
-      stateData.state,
+      fieldBuilderState,
       logicedFieldIdsSet,
       queryClient,
       adminFormKey,

--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useEditFormField.ts
@@ -12,7 +12,7 @@ import { adminFormKeys } from '~features/admin-form/common/queries'
 import { updateSingleFormField } from '../UpdateFormFieldService'
 import {
   FieldBuilderState,
-  stateDataSelector,
+  fieldBuilderStateSelector,
   useFieldBuilderStore,
 } from '../useFieldBuilderStore'
 import { getMutationErrorMessage } from '../utils/getMutationErrorMessage'
@@ -21,7 +21,7 @@ export const useEditFormField = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const stateData = useFieldBuilderStore(stateDataSelector)
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -30,7 +30,7 @@ export const useEditFormField = () => {
   const handleSuccess = useCallback(
     (newField: FormFieldDto) => {
       toast.closeAll()
-      if (stateData.state !== FieldBuilderState.EditingField) {
+      if (fieldBuilderState !== FieldBuilderState.EditingField) {
         toast({
           status: 'warning',
           description:
@@ -52,7 +52,7 @@ export const useEditFormField = () => {
         return oldForm
       })
     },
-    [adminFormKey, stateData, queryClient, toast],
+    [adminFormKey, fieldBuilderState, queryClient, toast],
   )
 
   const handleError = useCallback(

--- a/frontend/src/features/admin-form/create/builder-and-design/useCreateTabForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/useCreateTabForm.ts
@@ -2,14 +2,14 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import {
   FieldBuilderState,
-  stateDataSelector,
+  fieldBuilderStateSelector,
   useFieldBuilderStore,
 } from './useFieldBuilderStore'
 
 export const useCreateTabForm = () => {
-  const stateData = useFieldBuilderStore(stateDataSelector)
+  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
   return useAdminForm({
     // Only fetch data if no field is being created or edited
-    enabled: stateData.state === FieldBuilderState.Inactive,
+    enabled: fieldBuilderState === FieldBuilderState.Inactive,
   })
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -125,6 +125,10 @@ export const stateDataSelector = (
   state: FieldBuilderStore,
 ): FieldBuilderStore['stateData'] => state.stateData
 
+export const fieldBuilderStateSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['stateData']['state'] => state.stateData.state
+
 export const updateCreateStateSelector = (
   state: FieldBuilderStore,
 ): FieldBuilderStore['updateCreateState'] => state.updateCreateState

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -20,8 +20,8 @@ import {
 } from '../../builder-and-design/useDesignStore'
 import {
   FieldBuilderState,
+  fieldBuilderStateSelector,
   setToInactiveSelector,
-  stateDataSelector,
   useFieldBuilderStore,
 } from '../../builder-and-design/useFieldBuilderStore'
 
@@ -74,15 +74,9 @@ export const useCreatePageSidebarContext =
       () => activeTab !== null && activeTab !== DrawerTabs.Logic,
       [activeTab],
     )
-    const { fieldState, setFieldsToInactive } = useFieldBuilderStore(
-      useCallback(
-        (state) => ({
-          fieldState: stateDataSelector(state),
-          setFieldsToInactive: setToInactiveSelector(state),
-        }),
-        [],
-      ),
-    )
+    const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
+    const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
+
     const setDesignState = useDesignStore(setStateSelector)
 
     const [fieldListTabIndex, setFieldListTabIndex] =
@@ -108,13 +102,13 @@ export const useCreatePageSidebarContext =
           if (
             tab === null &&
             // Always want to set to inactive if the state was creating, even in mobile
-            (fieldState.state === FieldBuilderState.CreatingField || !isMobile)
+            (fieldBuilderState === FieldBuilderState.CreatingField || !isMobile)
           ) {
             setFieldsToInactive()
           }
         }
       },
-      [fieldState.state, isMobile, setFieldsToInactive],
+      [fieldBuilderState, isMobile, setFieldsToInactive],
     )
 
     const clearPendingTab = useCallback(() => {


### PR DESCRIPTION
## Problem
This PR should further alleviate performance issues as mentioned PR #4885 and issues #4766 #4764.

## Solution
The first commit seems to yield significant gains (>40%) by only selecting the necessary slice from `useFieldBuilderStore` `stateData`. `stateData.field` will change when editing field, causing components to update frequently. Following the suggested pattern in [zustand recipes](https://docs.pmnd.rs/zustand/recipes/recipes) to select multiple slices.

Need some help to verify if this translates into production by testing on a form with many table fields as it seems table fields are pretty render intensive. There should be a reduction in task duration when editing a field.

Currently, all fields will still rerender on input change but it seems either react/zustand is handling it much better perhaps because its doing less comparisons(?)

Second commit does not really do seem to have much impact but the additional `memo` is definitely overhead. The BuilderFields component will always rerender whenever `stateData` changes as the `fields` prop it receives will always change on input.

To verify, add a console.log to the comparison function of `memo` and it should not get printed out.

**BEFORE**
<img width="465" alt="Screen Shot 2022-09-25 at 3 47 03 PM" src="https://user-images.githubusercontent.com/39296145/192133597-05663e13-c5f5-4da0-a9fe-4e6201c85490.png">

**AFTER**
<img width="465" alt="Screen Shot 2022-09-25 at 3 46 20 PM" src="https://user-images.githubusercontent.com/39296145/192133587-a60b9968-ed2e-4625-aa52-3df74a24163d.png">
