### PR TITLE
fix(v2): allow maximum rows for table fields to be optional

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -60,7 +60,7 @@ const transformTableFieldToEditForm = (
 
   return {
     ...pick(field, EDIT_TABLE_FIELD_KEYS),
-    addMoreRows: nextMaxRows !== '',
+    addMoreRows: field.addMoreRows,
     maximumRows: nextMaxRows,
     minimumRows: nextMinRows,
   }
@@ -175,7 +175,6 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
               name="maximumRows"
               defaultValue=""
               rules={{
-                required: REQUIRED_ERROR,
                 min: {
                   value: 1,
                   message: 'Maximum rows must be greater than 0',

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -60,7 +60,6 @@ const transformTableFieldToEditForm = (
 
   return {
     ...pick(field, EDIT_TABLE_FIELD_KEYS),
-    addMoreRows: field.addMoreRows,
     maximumRows: nextMaxRows,
     minimumRows: nextMinRows,
   }

--- a/frontend/src/templates/Field/Table/AddRowFooter.tsx
+++ b/frontend/src/templates/Field/Table/AddRowFooter.tsx
@@ -7,7 +7,7 @@ import Button from '~components/Button'
 interface AddRowFooterProps {
   handleAddRow: () => void
   currentRows: number
-  maxRows: number
+  maxRows: number | ''
 }
 
 export const AddRowFooter = ({
@@ -24,7 +24,7 @@ export const AddRowFooter = ({
       spacing="0.75rem"
     >
       <Button
-        isDisabled={currentRows >= maxRows}
+        isDisabled={!!maxRows && currentRows >= maxRows}
         leftIcon={<BiPlus fontSize="1.5rem" />}
         type="button"
         onClick={handleAddRow}
@@ -33,7 +33,9 @@ export const AddRowFooter = ({
       </Button>
 
       <Text textStyle="body-2" color="secondary.400">
-        {simplur`${currentRows} out of max ${maxRows} row[|s]`}
+        {maxRows
+          ? simplur`${currentRows} out of max ${maxRows} row[|s]`
+          : simplur`${currentRows} row[|s]`}
       </Text>
     </Stack>
   )

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -93,7 +93,11 @@ export const TableField = ({
     useTable({ columns: columnsData, data: fields })
 
   const handleAddRow = useCallback(() => {
-    if (!schema.maximumRows || fields.length >= schema.maximumRows) return
+    if (
+      !schema.addMoreRows ||
+      (!!schema.maximumRows && fields.length >= schema.maximumRows)
+    )
+      return
     return appendTableRow()
   }, [appendTableRow, fields.length, schema])
 
@@ -194,7 +198,7 @@ export const TableField = ({
       {schema.addMoreRows && schema.maximumRows !== undefined ? (
         <AddRowFooter
           currentRows={fields.length}
-          maxRows={schema.maximumRows === '' ? 0 : schema.maximumRows}
+          maxRows={schema.maximumRows}
           handleAddRow={handleAddRow}
         />
       ) : null}


### PR DESCRIPTION
## Problem
Previous version of the app allows users to not add a maximum number of rows, resulting in unlimited rows being able to be added. React did not have this feature.

Closes #4935 

## Solution
Remove requiredness for max rows in edit table, update associated components and handlers to manage this possibility.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

Admin form

https://user-images.githubusercontent.com/25571626/192338613-67a3c3e3-0568-457e-ba64-fa43038132c6.mov

Public form

https://user-images.githubusercontent.com/25571626/192338633-d2f6ca7f-46ea-413f-9def-4cfe5a18050c.mov
