### PR TITLE
feat(v2): add single quote to CSV output

### DIFF
--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
@@ -41,7 +41,9 @@ export class FeedbackCsvGenerator extends CsvGenerator {
       // prefix it with a single quote to prevent formula injection
       if (!isPureNumber && hasFormulaChars) {
         feedbackComment = `'${feedback.comment}`
-      } else feedbackComment = feedback.comment
+      } else {
+        feedbackComment = feedback.comment
+      }
     }
 
     this.addLine([createdAt, feedbackComment, feedback.rating])

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
@@ -4,10 +4,7 @@ import { formatInTimeZone } from 'date-fns-tz'
 import { FormFeedbackDto } from '~shared/types'
 
 import { CsvGenerator } from '../../common/utils/CsvGenerator'
-import {
-  FORMULA_INJECTION_REGEXP,
-  PURE_NUMBER_REGEXP,
-} from '../../ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator'
+import { processFormulaInjectionText } from '../../ResponsesPage/storage/utils/processFormulaInjection'
 /**
  * Class to encapsulate the FeedbackCsv and its attributes
  */
@@ -31,20 +28,9 @@ export class FeedbackCsvGenerator extends CsvGenerator {
       'dd MMM yyyy hh:mm:ss a',
     ) // Format in SG timezone
 
-    let feedbackComment = ''
-    if (feedback.comment) {
-      // Check if fieldRecord is a pure number
-      const isPureNumber = PURE_NUMBER_REGEXP.test(feedback.comment)
-      // Check if fieldRecord starts with formula characters
-      const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(feedback.comment)
-      // if fieldRecord is not a pure number, and starts with formula characters,
-      // prefix it with a single quote to prevent formula injection
-      if (!isPureNumber && hasFormulaChars) {
-        feedbackComment = `'${feedback.comment}`
-      } else {
-        feedbackComment = feedback.comment
-      }
-    }
+    const feedbackComment = feedback.comment
+      ? processFormulaInjectionText(feedback.comment)
+      : ''
 
     this.addLine([createdAt, feedbackComment, feedback.rating])
   }

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
@@ -4,7 +4,10 @@ import { formatInTimeZone } from 'date-fns-tz'
 import { FormFeedbackDto } from '~shared/types'
 
 import { CsvGenerator } from '../../common/utils/CsvGenerator'
-import { FORMULA_INJECTION_REGEXP } from '../../ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator'
+import {
+  FORMULA_INJECTION_REGEXP,
+  PURE_NUMBER_REGEXP,
+} from '../../ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator'
 /**
  * Class to encapsulate the FeedbackCsv and its attributes
  */
@@ -28,19 +31,19 @@ export class FeedbackCsvGenerator extends CsvGenerator {
       'dd MMM yyyy hh:mm:ss a',
     ) // Format in SG timezone
 
-    let feedbackComment
-    // Check if fieldRecord is a pure number
-    const isNonNumber = isNaN(Number(feedback.comment))
-    // Check if fieldRecord starts with formula characters
-    const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(
-      feedback.comment || '',
-    )
-    // if fieldRecord is not a pure number, and starts with formula characters,
-    // prefix it with a single quote to prevent formula injection
-    if (isNonNumber && hasFormulaChars) {
-      feedbackComment = `'${feedback.comment}`
-    } else feedbackComment = feedback.comment
+    let feedbackComment = ''
+    if (feedback.comment) {
+      // Check if fieldRecord is a pure number
+      const isPureNumber = PURE_NUMBER_REGEXP.test(feedback.comment)
+      // Check if fieldRecord starts with formula characters
+      const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(feedback.comment)
+      // if fieldRecord is not a pure number, and starts with formula characters,
+      // prefix it with a single quote to prevent formula injection
+      if (!isPureNumber && hasFormulaChars) {
+        feedbackComment = `'${feedback.comment}`
+      } else feedbackComment = feedback.comment
+    }
 
-    this.addLine([createdAt, feedbackComment ?? '', feedback.rating])
+    this.addLine([createdAt, feedbackComment, feedback.rating])
   }
 }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -18,12 +18,13 @@ const BOM_LENGTH = 1
 /**
  * Generates a mock decrypted row object.
  * @param append the text to append to the back of all keys.
- * @param answerArray If given, the answer key will be changed to answerArray and this will be assigned to that key.
+ * @param customAnswer If given and if this is an array, the answer key will be changed to answerArray
+ * and this will be assigned to that key. Otherwise, this will be assigned to answer.
  * @param fieldType Used as fieldType of record if given.
  */
 const generateRecord = (
   append: string | number,
-  answerArray?: string[] | string[][],
+  customAnswer?: string | string[] | string[][],
   fieldType?: FieldType,
 ): CsvRecordData => {
   const generated: SetOptional<CsvRecordData, 'answer' | 'answerArray'> = {
@@ -32,8 +33,12 @@ const generateRecord = (
     fieldType: fieldType ?? 'textfield',
   }
 
-  if (answerArray) {
-    generated.answerArray = answerArray
+  if (customAnswer) {
+    if (Array.isArray(customAnswer)) {
+      generated.answerArray = customAnswer
+    } else {
+      generated.answer = customAnswer
+    }
   } else {
     generated.answer = `mockAnswer${append}`
   }
@@ -549,6 +554,74 @@ describe('EncryptedResponseCsvGenerator', () => {
           expectedHeaderRow,
           expectedSubmissionRow1,
           expectedSubmissionRow2,
+        ])
+      })
+
+      it('should handle submissions with entries that start with a formula character', () => {
+        // Arrange
+        const mockAnswerWithFormulaChars = [generateRecord(1, '=formula')]
+        const mockAnswerWithFormulaCharsRecord = {
+          record: mockAnswerWithFormulaChars,
+          created: mockCreatedEarly,
+          submissionId: 'mockSubmissionIdAnswer',
+        }
+        generator.addRecord(mockAnswerWithFormulaCharsRecord)
+
+        // Act
+        generator.process()
+
+        // Assert
+        // Should have 1 header row and 1 submission row
+        expect(generator.records.length).toEqual(2 + BOM_LENGTH)
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          'Timestamp',
+          mockAnswerWithFormulaChars[0].question,
+        ])
+        // Answer should be prefixed with a single quote
+        const expectedSubmissionRow1 = stringify([
+          mockAnswerWithFormulaCharsRecord.submissionId,
+          getFormattedDate(mockAnswerWithFormulaCharsRecord.created),
+          `'${mockAnswerWithFormulaChars[0].answer}`,
+        ])
+        expect(generator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedSubmissionRow1,
+        ])
+      })
+
+      it('should handle submissions with pure number entries prefixed with +', () => {
+        // Arrange
+        const mockAnswer = [generateRecord(1, '+5')]
+        const mockAnswerRecord = {
+          record: mockAnswer,
+          created: mockCreatedEarly,
+          submissionId: 'mockSubmissionIdAnswer',
+        }
+        generator.addRecord(mockAnswerRecord)
+
+        // Act
+        generator.process()
+
+        // Assert
+        // Should have 1 header row and 1 submission row
+        expect(generator.records.length).toEqual(2 + BOM_LENGTH)
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          'Timestamp',
+          mockAnswer[0].question,
+        ])
+        // Answer should NOT be prefixed with a single quote
+        const expectedSubmissionRow1 = stringify([
+          mockAnswerRecord.submissionId,
+          getFormattedDate(mockAnswerRecord.created),
+          mockAnswer[0].answer,
+        ])
+        expect(generator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedSubmissionRow1,
         ])
       })
     })

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -624,6 +624,40 @@ describe('EncryptedResponseCsvGenerator', () => {
           expectedSubmissionRow1,
         ])
       })
+
+      it('should handle submissions that start with +digit and contain other alphabets', () => {
+        // Arrange
+        const mockAnswer = [generateRecord(1, '+3*SUM(A1)')]
+        const mockAnswerRecord = {
+          record: mockAnswer,
+          created: mockCreatedEarly,
+          submissionId: 'mockSubmissionIdAnswer',
+        }
+        generator.addRecord(mockAnswerRecord)
+
+        // Act
+        generator.process()
+
+        // Assert
+        // Should have 1 header row and 1 submission row
+        expect(generator.records.length).toEqual(2 + BOM_LENGTH)
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          'Timestamp',
+          mockAnswer[0].question,
+        ])
+        // Answer should be prefixed with a single quote
+        const expectedSubmissionRow1 = stringify([
+          mockAnswerRecord.submissionId,
+          getFormattedDate(mockAnswerRecord.created),
+          `'${mockAnswer[0].answer}`,
+        ])
+        expect(generator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedSubmissionRow1,
+        ])
+      })
     })
 
     describe('submissions with answerArray key', () => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -14,6 +14,7 @@ type UnprocessedRecord = Merge<
   { record: Dictionary<Response> }
 >
 
+export const PURE_NUMBER_REGEXP = new RegExp('^[+-][0-9]+')
 export const FORMULA_INJECTION_REGEXP = new RegExp('^[+=@-].*')
 export class EncryptedResponseCsvGenerator extends CsvGenerator {
   hasBeenProcessed: boolean
@@ -135,14 +136,16 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
     // Check if fieldRecord is a pure number
-    const isNonNumber = isNaN(Number(fieldRecord.getAnswer(colIndex)))
+    const isPureNumber = PURE_NUMBER_REGEXP.test(
+      fieldRecord.getAnswer(colIndex),
+    )
     // Check if fieldRecord starts with formula characters
     const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(
       fieldRecord.getAnswer(colIndex),
     )
     // if fieldRecord is not a pure number, and starts with formula characters,
     // prefix it with a single quote to prevent formula injection
-    if (isNonNumber && hasFormulaChars) {
+    if (!isPureNumber && hasFormulaChars) {
       return `'${fieldRecord.getAnswer(colIndex)}`
     }
     return fieldRecord.getAnswer(colIndex)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -133,7 +133,10 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
   ): string {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
-    return fieldRecord.getAnswer(colIndex)
+    const fieldAnswer = fieldRecord.getAnswer(colIndex)
+    const asciiBELCharacter = String.fromCharCode(7)
+    const answer = asciiBELCharacter.concat(fieldAnswer)
+    return answer
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -8,14 +8,13 @@ import { CsvGenerator } from '../../../../common/utils'
 import type { DecryptedSubmissionData } from '../../types'
 import type { Response } from '../csv-response-classes'
 import { getDecryptedResponseInstance } from '../getDecryptedResponseInstance'
+import { processFormulaInjectionText } from '../processFormulaInjection'
 
 type UnprocessedRecord = Merge<
   DecryptedSubmissionData,
   { record: Dictionary<Response> }
 >
 
-export const PURE_NUMBER_REGEXP = new RegExp('^[+-][0-9]+')
-export const FORMULA_INJECTION_REGEXP = new RegExp('^[+=@-].*')
 export class EncryptedResponseCsvGenerator extends CsvGenerator {
   hasBeenProcessed: boolean
   hasBeenSorted: boolean
@@ -135,20 +134,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
   ): string {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
-    // Check if fieldRecord is a pure number
-    const isPureNumber = PURE_NUMBER_REGEXP.test(
-      fieldRecord.getAnswer(colIndex),
-    )
-    // Check if fieldRecord starts with formula characters
-    const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(
-      fieldRecord.getAnswer(colIndex),
-    )
-    // if fieldRecord is not a pure number, and starts with formula characters,
-    // prefix it with a single quote to prevent formula injection
-    if (!isPureNumber && hasFormulaChars) {
-      return `'${fieldRecord.getAnswer(colIndex)}`
-    }
-    return fieldRecord.getAnswer(colIndex)
+    return processFormulaInjectionText(fieldRecord.getAnswer(colIndex))
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -14,6 +14,7 @@ type UnprocessedRecord = Merge<
   { record: Dictionary<Response> }
 >
 
+export const FORMULA_INJECTION_REGEXP = new RegExp('^[+=@-].*')
 export class EncryptedResponseCsvGenerator extends CsvGenerator {
   hasBeenProcessed: boolean
   hasBeenSorted: boolean
@@ -133,10 +134,18 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
   ): string {
     const fieldRecord = unprocessedRecord[fieldId]
     if (!fieldRecord) return ''
-    const fieldAnswer = fieldRecord.getAnswer(colIndex)
-    const asciiBELCharacter = String.fromCharCode(7)
-    const answer = asciiBELCharacter.concat(fieldAnswer)
-    return answer
+    // Check if fieldRecord is a pure number
+    const isNonNumber = isNaN(Number(fieldRecord.getAnswer(colIndex)))
+    // Check if fieldRecord starts with formula characters
+    const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(
+      fieldRecord.getAnswer(colIndex),
+    )
+    // if fieldRecord is not a pure number, and starts with formula characters,
+    // prefix it with a single quote to prevent formula injection
+    if (isNonNumber && hasFormulaChars) {
+      return `'${fieldRecord.getAnswer(colIndex)}`
+    }
+    return fieldRecord.getAnswer(colIndex)
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
@@ -1,5 +1,5 @@
-const PURE_NUMBER_REGEXP = new RegExp('^[+-][0-9]+')
-const FORMULA_INJECTION_REGEXP = new RegExp('^[+=@-].*')
+const PURE_NUMBER_REGEXP = /^[+-.\d]*$/
+const FORMULA_INJECTION_REGEXP = /^[+=@-]/
 
 export const processFormulaInjectionText = (input: string): string => {
   // Check if input is a pure number

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
@@ -1,14 +1,14 @@
-const PURE_NUMBER_REGEXP = /^[+-.\d]*$/
+const NUMBERS_ONLY_REGEXP = /^[+-.\d]+$/
 const FORMULA_INJECTION_REGEXP = /^[+=@-]/
 
 export const processFormulaInjectionText = (input: string): string => {
-  // Check if input is a pure number
-  const isPureNumber = PURE_NUMBER_REGEXP.test(input)
+  // Check if input contains only + | - | digits
+  const hasNumbersOnly = NUMBERS_ONLY_REGEXP.test(input)
   // Check if input starts with formula characters
   const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(input)
   // if the input is not a pure number, and starts with formula characters,
   // prefix it with a single quote to prevent formula injection
-  if (hasFormulaChars && !isPureNumber) {
+  if (hasFormulaChars && !hasNumbersOnly) {
     return `'${input}`
   } else {
     return input

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
@@ -1,0 +1,16 @@
+const PURE_NUMBER_REGEXP = new RegExp('^[+-][0-9]+')
+const FORMULA_INJECTION_REGEXP = new RegExp('^[+=@-].*')
+
+export const processFormulaInjectionText = (input: string): string => {
+  // Check if input is a pure number
+  const isPureNumber = PURE_NUMBER_REGEXP.test(input)
+  // Check if input starts with formula characters
+  const hasFormulaChars = FORMULA_INJECTION_REGEXP.test(input)
+  // if the input is not a pure number, and starts with formula characters,
+  // prefix it with a single quote to prevent formula injection
+  if (hasFormulaChars && !isPureNumber) {
+    return `'${input}`
+  } else {
+    return input
+  }
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processFormulaInjection.ts
@@ -1,4 +1,4 @@
-const NUMBERS_ONLY_REGEXP = /^[+-.\d]+$/
+const NUMBERS_ONLY_REGEXP = /^[+.\d-]+$/
 const FORMULA_INJECTION_REGEXP = /^[+=@-]/
 
 export const processFormulaInjectionText = (input: string): string => {

--- a/src/public/modules/forms/helpers/__tests__/FeedbackCsvGenerator.spec.ts
+++ b/src/public/modules/forms/helpers/__tests__/FeedbackCsvGenerator.spec.ts
@@ -65,5 +65,33 @@ describe('FeedbackCsvGenerator', () => {
         expect.stringContaining(todaysDate),
       )
     })
+
+    it('should add single quote before comment if comment starts with a formula character', () => {
+      // Arrange
+      const feedbackCsv = new FeedbackCsvGenerator(1)
+      const feedback: FormFeedbackDto = {
+        rating: 3,
+        comment: '=formula',
+        formId: new ObjectId().toHexString(),
+        created: new Date('2019-11-05T13:12:14').toISOString() as DateString,
+        lastModified: new Date(
+          '2019-11-05T13:12:14',
+        ).toISOString() as DateString,
+      }
+      const insertedCreatedDate = moment(feedback.created)
+        .tz('Asia/Singapore')
+        .format('DD MMM YYYY hh:mm:ss A')
+
+      const insertedLine = `${insertedCreatedDate},'${feedback.comment},${feedback.rating}`
+
+      // Act
+      feedbackCsv.addLineFromFeedback(feedback)
+
+      //Assert
+      expect(feedbackCsv.idx).toEqual(3)
+      expect(feedbackCsv.records[2]).toEqual(
+        expect.stringContaining(insertedLine),
+      )
+    })
   })
 })


### PR DESCRIPTION
## Problem
Works towards [#133](https://github.com/datagovsg/formsg-private/issues/133)

## Solution
<!-- How did you solve the problem? -->
Use regex expressions to determine if the field value starts with a formula character. If so, prefix it with a single quote. The only exceptions to this are field values that only contain numbers, + or - e.g. +65, -1.

[Design doc here](https://docs.google.com/document/d/1M5kc5IckkhLjA9bZ_WI9gHq3WIuSUFCo4JFzuPEsB50/edit)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - Downloaded CSVs might have cells that start with an additional single quote, if any of their field values start with a formula character

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Enter a value starting with a formula character into a **storage form**'s short text, long text and table fields. Download the responses. These values should be prefixed with a single quote.
- [x]  Repeat the same for a **form's feedback**.