### PR TITLE
fix(v2): close modal when removing self as collaborator

### DIFF
--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -13,7 +13,7 @@ import { CollaboratorWizardProvider } from './CollaboratorWizardContext'
 interface CollaboratorModalProps {
   isOpen: boolean
   onClose: () => void
-  formId: string
+  formId?: string
 }
 
 export const CollaboratorModal = ({
@@ -35,7 +35,7 @@ export const CollaboratorModal = ({
       >
         <ModalCloseButton />
         {isOpen && (
-          <CollaboratorWizardProvider formId={formId}>
+          <CollaboratorWizardProvider formId={formId ?? ''} onClose={onClose}>
             <CollaboratorModalContent />
           </CollaboratorWizardProvider>
         )}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorWizardContext.tsx
@@ -14,6 +14,7 @@ type CollaboratorWizardContextReturn = {
   handleForwardToTransferOwnership: (emailToTransfer: string) => void
   handleForwardToRemoveSelf: () => void
   formId: string
+  onClose: () => void
 }
 
 const CollaboratorWizardContext = createContext<
@@ -25,9 +26,13 @@ const INITIAL_STEP_STATE: [CollaboratorFlowStates, number] = [
   0 | 1 | -1,
 ]
 
-const useCollaboratorWizardContext = (
-  formId: string,
-): CollaboratorWizardContextReturn => {
+const useCollaboratorWizardContext = ({
+  formId,
+  onClose,
+}: {
+  formId: string
+  onClose: () => void
+}): CollaboratorWizardContextReturn => {
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
   const [emailToTransfer, setEmailToTransfer] = useState<string | null>(null)
@@ -57,17 +62,21 @@ const useCollaboratorWizardContext = (
     handleForwardToTransferOwnership,
     handleForwardToRemoveSelf,
     formId,
+    onClose,
   }
+}
+
+interface CollaboratorWizardProviderProps {
+  children: React.ReactNode
+  formId: string
+  onClose: () => void
 }
 
 export const CollaboratorWizardProvider = ({
   children,
-  formId,
-}: {
-  children: React.ReactNode
-  formId: string
-}): JSX.Element => {
-  const values = useCollaboratorWizardContext(formId)
+  ...props
+}: CollaboratorWizardProviderProps): JSX.Element => {
+  const values = useCollaboratorWizardContext(props)
   return (
     <CollaboratorWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/RemoveSelfScreen/RemoveSelfScreen.tsx
@@ -17,11 +17,11 @@ import { useCollaboratorWizard } from '../CollaboratorWizardContext'
 export const RemoveSelfScreen = (): JSX.Element | null => {
   const isMobile = useIsMobile()
   const { mutateRemoveSelf } = useMutateCollaborators()
-  const { handleBackToList } = useCollaboratorWizard()
+  const { handleBackToList, onClose } = useCollaboratorWizard()
 
   const handleRemoveSelf = useCallback(() => {
-    return mutateRemoveSelf.mutate()
-  }, [mutateRemoveSelf])
+    return mutateRemoveSelf.mutate(undefined, { onSuccess: onClose })
+  }, [mutateRemoveSelf, onClose])
 
   return (
     <>

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -18,6 +18,7 @@ import {
   SubmitEmailFormArgs,
   SubmitStorageFormArgs,
 } from '~features/public-form/PublicFormService'
+import { workspaceKeys } from '~features/workspace/queries'
 
 import {
   submitEmailModeFormPreview,
@@ -301,6 +302,7 @@ export const useMutateCollaborators = () => {
         navigate(DASHBOARD_ROUTE)
         // Remove all related queries from cache.
         queryClient.removeQueries(adminFormKeys.id(formId))
+        queryClient.invalidateQueries(workspaceKeys.all)
       },
       onError: (error: Error) => {
         handleError(error, FormCollaboratorAction.REMOVE_SELF)

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -299,10 +299,12 @@ export const useMutateCollaborators = () => {
           description:
             'You have removed yourself as a collaborator from the form.',
         })
-        navigate(DASHBOARD_ROUTE)
+
         // Remove all related queries from cache.
         queryClient.removeQueries(adminFormKeys.id(formId))
         queryClient.invalidateQueries(workspaceKeys.all)
+
+        navigate(DASHBOARD_ROUTE)
       },
       onError: (error: Error) => {
         handleError(error, FormCollaboratorAction.REMOVE_SELF)

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -85,13 +85,11 @@ export const WorkspaceRowsProvider = ({
         onClose={shareFormModalDisclosure.onClose}
         isFormPrivate={activeFormMeta?.status === FormStatus.Private}
       />
-      {activeFormMeta?._id && (
-        <CollaboratorModal
-          isOpen={collabModalDisclosure.isOpen}
-          formId={activeFormMeta._id}
-          onClose={collabModalDisclosure.onClose}
-        />
-      )}
+      <CollaboratorModal
+        isOpen={collabModalDisclosure.isOpen}
+        formId={activeFormMeta?._id}
+        onClose={collabModalDisclosure.onClose}
+      />
       <DeleteFormModal
         isOpen={deleteFormModalDisclosure.isOpen}
         onClose={deleteFormModalDisclosure.onClose}


### PR DESCRIPTION
## Problem
The remove self collaborator modal does not close, currently. We should close it after redirecting the user to the workspace page, and also invalidate the workspace query so that the workspace is updated with available forms to the user

Closes #4936 

## Solution
Pass `onClose` to the collaborator modal provider and access it in `RemoveSelfScreen`. Also, update the mutation on success to invalidate the workspace query.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/192448062-4a654e45-b6f6-4025-916f-477b8993e6ad.mov

