### PR TITLE
fix(v2): reset twilio settings form with empty string on deletion of credentials

### DIFF
--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -112,6 +112,17 @@ export const TwilioDetailsInputs = (): JSX.Element => {
     [hasExistingTwilioCreds, register],
   )
 
+  const onDelete = useCallback(
+    () =>
+      reset({
+        accountSid: '',
+        apiKey: '',
+        apiSecret: '',
+        messagingServiceSid: '',
+      }),
+    [reset],
+  )
+
   return (
     <>
       <Stack spacing="2rem">
@@ -192,7 +203,11 @@ export const TwilioDetailsInputs = (): JSX.Element => {
           </Button>
         )}
       </Skeleton>
-      <DeleteTwilioModal isOpen={isOpen} onClose={onClose} onDelete={reset} />
+      <DeleteTwilioModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onDelete={onDelete}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Problem
Deleting Twilio credentials does not currently clear the fields, but leaves the string `'******'` in the fields.

Closes #4933 

## Solution
This was caused by resetting the field on deletion to its default value, which was `'****'`. Instead, reset to `''` on deletion.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/192466244-f1506be8-b608-4168-94c5-a2b04e7330c4.mov
