### PR TITLE
feat: improve a11y of SwitchEnvMessage, add inline flow to button

### DIFF
--- a/frontend/src/components/InlineMessage/InlineMessage.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.tsx
@@ -22,7 +22,7 @@ export const InlineMessage = ({
   const mdComponents = useMdComponents({ styles })
 
   return (
-    <Flex sx={styles.messagebox} {...flexProps} aria-label="Infobox">
+    <Flex sx={styles.messagebox} {...flexProps}>
       <Icon
         as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
         __css={styles.icon}

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -1,5 +1,12 @@
 // TODO #4279: Remove after React rollout is complete
-import { Box, Flex, Text, useDisclosure } from '@chakra-ui/react'
+import { KeyboardEventHandler, useCallback } from 'react'
+import {
+  Box,
+  Flex,
+  Text,
+  useDisclosure,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
@@ -8,6 +15,17 @@ import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
 
 export const PublicSwitchEnvMessage = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const handleKeydown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      if (event.key === 'Enter') {
+        onOpen()
+        event.preventDefault()
+      }
+    },
+    [onOpen],
+  )
+
   return (
     <Flex justify="center">
       <Box w="100%" minW={0} h="fit-content" maxW="57rem">
@@ -15,25 +33,29 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
           variant="warning"
           mb="1.5rem"
           mt={{ base: '2rem', md: '0' }}
+          id="switch-env-msg"
         >
-          {/**
-           * Hide the text and replicate it in the aria-label for the button instead,
-           * because without it, the sentence will be read as two separate parts which
-           * is confusing for those using screen readers.
-           */}
           <Text>
-            <Text as="span" aria-hidden display="inline">
-              You’re using the new FormSG design. If you have trouble
-              submitting,
-            </Text>
+            You’re using the new FormSG design. If you have trouble submitting,{' '}
             <Button
+              tabIndex={0}
+              p={0}
+              as="u"
               variant="link"
+              display="inline"
               my="-0.25rem"
               onClick={onOpen}
-              aria-label="You're using the new FormSG design. If you have trouble submitting, switch to the original one here."
+              onKeyDown={handleKeydown}
+              aria-labelledby="switch-env-msg"
             >
-              <Text as="u">switch to the original one here.</Text>
+              <VisuallyHidden>
+                Click to switch to the original FormSG
+              </VisuallyHidden>
+              <Text display="inline" aria-hidden>
+                switch to the original one here
+              </Text>
             </Button>
+            .
           </Text>
         </InlineMessage>
       </Box>

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -1,5 +1,6 @@
 // TODO #4279: Remove after React rollout is complete
-import { Text, useDisclosure } from '@chakra-ui/react'
+import { KeyboardEventHandler, useCallback } from 'react'
+import { Text, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
@@ -14,15 +15,40 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
   const { data: { angularPhaseOutDate, adminRollout } = {} } = useEnv()
   const showSwitchEnvMessage =
     adminRollout && adminRollout < REMOVE_ADMIN_INFOBOX_THRESHOLD
+
+  const handleKeydown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      if (event.key === 'Enter') {
+        onOpen()
+        event.preventDefault()
+      }
+    },
+    [onOpen],
+  )
+
   return showSwitchEnvMessage ? (
     <>
-      <InlineMessage>
+      <InlineMessage id="admin-switch-msg">
         <Text>
-          Welcome to the new FormSG! You can still
-          <Button variant="link" onClick={onOpen}>
-            <Text as="u">switch to the original one,</Text>
+          Welcome to the new FormSG! You can still{' '}
+          <Button
+            tabIndex={0}
+            p={0}
+            as="u"
+            variant="link"
+            display="inline"
+            onClick={onOpen}
+            onKeyDown={handleKeydown}
+            aria-labelledby="admin-switch-msg"
+          >
+            <VisuallyHidden>
+              Click to switch to the original FormSG
+            </VisuallyHidden>
+            <Text display="inline" aria-hidden>
+              switch to the original one
+            </Text>
           </Button>
-          which is available until {angularPhaseOutDate}.
+          , which is available until {angularPhaseOutDate}.
         </Text>
       </InlineMessage>
       <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR changes the "switch to react" link to be inline.

Closes #4932
