### PR TITLE
perf(v2): improve admin form performance when editing fields

### DIFF
--- a/frontend/src/features/admin-form/create/CreatePage.tsx
+++ b/frontend/src/features/admin-form/create/CreatePage.tsx
@@ -5,17 +5,13 @@ import { Flex } from '@chakra-ui/react'
 import { FEATURE_TOUR_KEY_PREFIX } from '~constants/localStorage'
 import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useLocalStorage } from '~hooks/useLocalStorage'
-import { NavigationPrompt } from '~templates/NavigationPrompt'
+import { DirtyNavigationPrompt } from '~templates/NavigationPrompt'
 
 import { useUser } from '~features/user/queries'
 
 import { DirtyModal } from '../common/components/DirtyModal'
 import { useAdminFormCollaborators } from '../common/queries'
 
-import {
-  isDirtySelector,
-  useDirtyFieldStore,
-} from './builder-and-design/useDirtyFieldStore'
 import { CreatePageContent } from './common/CreatePageContent'
 import { CreatePageSidebar } from './common/CreatePageSidebar'
 import { CreatePageSidebarProvider } from './common/CreatePageSidebarContext'
@@ -49,11 +45,9 @@ export const CreatePage = (): JSX.Element => {
     return !isLoading && !hasAdminSeenFeatureTour
   }, [isLoading, hasAdminSeenFeatureTour])
 
-  const isDirty = useDirtyFieldStore(isDirtySelector)
-
   return (
     <>
-      <NavigationPrompt when={isDirty} />
+      <DirtyNavigationPrompt />
       <CreatePageSidebarProvider>
         <DirtyModal />
         <Flex

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -1,6 +1,5 @@
 import { AdminFormDto } from '~shared/types/form'
 
-import { augmentWithQuestionNo } from '~features/form/utils'
 import { FieldIdSet } from '~features/logic/types'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
@@ -23,12 +22,11 @@ export const BuilderFields = ({
   visibleFieldIds,
   isDraggingOver,
 }: BuilderFieldsProps) => {
-  const fieldsWithQuestionNos = augmentWithQuestionNo(fields)
   const stateData = useFieldBuilderStore(stateDataSelector)
 
   return (
     <>
-      {fieldsWithQuestionNos.map((f, i) => (
+      {fields.map((f, i) => (
         <FieldRow
           index={i}
           key={f._id}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -3,6 +3,13 @@ import { AdminFormDto } from '~shared/types/form'
 import { augmentWithQuestionNo } from '~features/form/utils'
 import { FieldIdSet } from '~features/logic/types'
 
+import { PENDING_CREATE_FIELD_ID } from '../constants'
+import {
+  FieldBuilderState,
+  stateDataSelector,
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
+
 import FieldRow from './FieldRow'
 
 interface BuilderFieldsProps {
@@ -17,6 +24,8 @@ export const BuilderFields = ({
   isDraggingOver,
 }: BuilderFieldsProps) => {
   const fieldsWithQuestionNos = augmentWithQuestionNo(fields)
+  const stateData = useFieldBuilderStore(stateDataSelector)
+
   return (
     <>
       {fieldsWithQuestionNos.map((f, i) => (
@@ -26,6 +35,13 @@ export const BuilderFields = ({
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
           isDraggingOver={isDraggingOver}
+          isActive={
+            stateData.state === FieldBuilderState.EditingField
+              ? f._id === stateData.field._id
+              : stateData.state === FieldBuilderState.CreatingField
+              ? f._id === PENDING_CREATE_FIELD_ID
+              : false
+          }
         />
       ))}
     </>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -64,7 +64,7 @@ import {
   setStateSelector,
   useDesignStore,
 } from '../../useDesignStore'
-import { isDirtySelector, useDirtyFieldStore } from '../../useDirtyFieldStore'
+import { useDirtyFieldStore } from '../../useDirtyFieldStore'
 import {
   FieldBuilderState,
   fieldBuilderStateSelector,
@@ -101,7 +101,7 @@ export const FieldRowContainer = memo(
     const setToInactive = useFieldBuilderStore(setToInactiveSelector)
     const updateEditState = useFieldBuilderStore(updateEditStateSelector)
 
-    const isDirty = useDirtyFieldStore(isDirtySelector)
+    const isDirty = useDirtyFieldStore.getState().isDirty
     const toast = useToast({ status: 'danger', isClosable: true })
 
     const setDesignState = useDesignStore(setStateSelector)
@@ -233,19 +233,16 @@ export const FieldRowContainer = memo(
       [duplicateFieldMutation, deleteFieldMutation],
     )
 
-    const isDragDisabled = useMemo(() => {
-      return (
-        !isActive ||
-        isDirty ||
-        !!numFormFieldMutations ||
-        fieldBuilderState === FieldBuilderState.CreatingField
-      )
-    }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
+    const isDragDisabled = () =>
+      !isActive ||
+      isDirty ||
+      !!numFormFieldMutations ||
+      fieldBuilderState === FieldBuilderState.CreatingField
 
     return (
       <Draggable
         index={index}
-        isDragDisabled={isDragDisabled}
+        isDragDisabled={isDragDisabled()}
         disableInteractiveElementBlocking
         draggableId={field._id}
       >

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { FormProvider, useForm } from 'react-hook-form'
 import { BiCog, BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
@@ -12,7 +12,7 @@ import {
   Flex,
   Icon,
 } from '@chakra-ui/react'
-import { times } from 'lodash'
+import { isEqual, times } from 'lodash'
 
 import { FormColorTheme } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
@@ -86,314 +86,320 @@ export interface FieldRowContainerProps {
   isActive: boolean
 }
 
-export const FieldRowContainer = ({
-  field,
-  index,
-  isHiddenByLogic,
-  isDraggingOver,
-  isActive,
-}: FieldRowContainerProps): JSX.Element => {
-  const isMobile = useIsMobile()
-  const { data: form } = useCreateTabForm()
-  const numFormFieldMutations = useIsMutating(adminFormKeys.base)
-  const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
-  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
-  const updateEditState = useFieldBuilderStore(updateEditStateSelector)
-
-  const isDirty = useDirtyFieldStore(isDirtySelector)
-  const toast = useToast({ status: 'danger', isClosable: true })
-
-  const setDesignState = useDesignStore(setStateSelector)
-
-  const { handleBuilderClick } = useCreatePageSidebar()
-
-  const { duplicateFieldMutation } = useDuplicateFormField()
-  const { deleteFieldMutation } = useDeleteFormField()
-
-  const colorTheme = useDesignColorTheme()
-
-  const isMyInfoField = useMemo(() => isMyInfo(field), [field])
-
-  const defaultFieldValues = useMemo(() => {
-    if (field.fieldType === BasicField.Table) {
-      return {
-        [field._id]: times(field.minimumRows || 0, () => createTableRow(field)),
-      }
-    }
-
-    const augmentedField = augmentWithMyInfoDisplayValue(field)
-
-    if (hasExistingFieldValue(augmentedField)) {
-      return {
-        [field._id]: extractPreviewValue(augmentedField),
-      }
-    }
-  }, [field])
-
-  const formMethods = useForm<FormFieldDto>({
-    mode: 'onChange',
-    defaultValues: defaultFieldValues,
-  })
-
-  const {
-    deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
-  } = useBuilderAndDesignContext()
-
-  const ref = useRef<HTMLDivElement | null>(null)
-  useEffect(() => {
-    if (isActive) {
-      ref.current?.scrollIntoView({
-        // Avoid sudden jump when field is clicked
-        block: 'nearest',
-        // Also avoid behavior: 'smooth' as scrolling may take very long
-        // on long forms
-      })
-    }
-  }, [isActive])
-
-  const handleFieldClick = useCallback(() => {
-    if (isActive) return
-
-    if (isDirty) {
-      return updateEditState(field, true)
-    }
-    updateEditState(field)
-    setDesignState(DesignState.Inactive)
-    if (!isMobile) {
-      // Do not open builder if in mobile so user can view active state without
-      // drawer blocking the view.
-      handleBuilderClick(false)
-    }
-  }, [
-    isDirty,
-    isActive,
-    updateEditState,
+export const FieldRowContainer = memo(
+  ({
     field,
-    setDesignState,
-    isMobile,
-    handleBuilderClick,
-  ])
+    index,
+    isHiddenByLogic,
+    isDraggingOver,
+    isActive,
+  }: FieldRowContainerProps): JSX.Element => {
+    const isMobile = useIsMobile()
+    const { data: form } = useCreateTabForm()
+    const numFormFieldMutations = useIsMutating(adminFormKeys.base)
+    const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
+    const setToInactive = useFieldBuilderStore(setToInactiveSelector)
+    const updateEditState = useFieldBuilderStore(updateEditStateSelector)
 
-  const handleKeydown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault()
-        handleFieldClick()
+    const isDirty = useDirtyFieldStore(isDirtySelector)
+    const toast = useToast({ status: 'danger', isClosable: true })
+
+    const setDesignState = useDesignStore(setStateSelector)
+
+    const { handleBuilderClick } = useCreatePageSidebar()
+
+    const { duplicateFieldMutation } = useDuplicateFormField()
+    const { deleteFieldMutation } = useDeleteFormField()
+
+    const colorTheme = useDesignColorTheme()
+
+    const isMyInfoField = useMemo(() => isMyInfo(field), [field])
+
+    const defaultFieldValues = useMemo(() => {
+      if (field.fieldType === BasicField.Table) {
+        return {
+          [field._id]: times(field.minimumRows || 0, () =>
+            createTableRow(field),
+          ),
+        }
       }
-    },
-    [handleFieldClick],
-  )
 
-  const handleEditFieldClick = useCallback(() => {
-    if (isMobile) {
-      handleBuilderClick(false)
-    }
-  }, [handleBuilderClick, isMobile])
+      const augmentedField = augmentWithMyInfoDisplayValue(field)
 
-  const handleDuplicateClick = useCallback(() => {
-    if (!form) return
-    // Duplicate button should be hidden if field is not yet created, but guard here just in case
-    if (fieldBuilderState === FieldBuilderState.CreatingField) return
-    // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
-    if (field.fieldType === BasicField.Attachment) {
-      const existingAttachmentsSize = form.form_fields.reduce(
-        (sum, ff) =>
-          ff.fieldType === BasicField.Attachment
-            ? sum + Number(ff.attachmentSize)
-            : sum,
-        0,
-      )
-      const remainingAvailableSize =
-        getAttachmentSizeLimit(form.responseMode) - existingAttachmentsSize
-      const thisAttachmentSize = Number(field.attachmentSize)
-      if (thisAttachmentSize > remainingAvailableSize) {
-        toast({
-          useMarkdown: true,
-          description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${remainingAvailableSize} MB**.`,
+      if (hasExistingFieldValue(augmentedField)) {
+        return {
+          [field._id]: extractPreviewValue(augmentedField),
+        }
+      }
+    }, [field])
+
+    const formMethods = useForm<FormFieldDto>({
+      mode: 'onChange',
+      defaultValues: defaultFieldValues,
+    })
+
+    const {
+      deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
+    } = useBuilderAndDesignContext()
+
+    const ref = useRef<HTMLDivElement | null>(null)
+    useEffect(() => {
+      if (isActive) {
+        ref.current?.scrollIntoView({
+          // Avoid sudden jump when field is clicked
+          block: 'nearest',
+          // Also avoid behavior: 'smooth' as scrolling may take very long
+          // on long forms
         })
-        return
       }
-    }
-    duplicateFieldMutation.mutate(field._id)
-  }, [fieldBuilderState, field, duplicateFieldMutation, form, toast])
+    }, [isActive])
 
-  const handleDeleteClick = useCallback(() => {
-    if (fieldBuilderState === FieldBuilderState.CreatingField) {
-      setToInactive()
-    } else if (fieldBuilderState === FieldBuilderState.EditingField) {
-      onDeleteModalOpen()
-    }
-  }, [setToInactive, fieldBuilderState, onDeleteModalOpen])
+    const handleFieldClick = useCallback(() => {
+      if (isActive) return
 
-  const isAnyMutationLoading = useMemo(
-    () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
-    [duplicateFieldMutation, deleteFieldMutation],
-  )
+      if (isDirty) {
+        return updateEditState(field, true)
+      }
+      updateEditState(field)
+      setDesignState(DesignState.Inactive)
+      if (!isMobile) {
+        // Do not open builder if in mobile so user can view active state without
+        // drawer blocking the view.
+        handleBuilderClick(false)
+      }
+    }, [
+      isDirty,
+      isActive,
+      updateEditState,
+      field,
+      setDesignState,
+      isMobile,
+      handleBuilderClick,
+    ])
 
-  const isDragDisabled = useMemo(() => {
-    return (
-      !isActive ||
-      isDirty ||
-      !!numFormFieldMutations ||
-      fieldBuilderState === FieldBuilderState.CreatingField
+    const handleKeydown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleFieldClick()
+        }
+      },
+      [handleFieldClick],
     )
-  }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
 
-  return (
-    <Draggable
-      index={index}
-      isDragDisabled={isDragDisabled}
-      disableInteractiveElementBlocking
-      draggableId={field._id}
-    >
-      {(provided, snapshot) => (
-        <Box
-          _first={{ pt: 0 }}
-          _last={{ pb: 0 }}
-          py="0.375rem"
-          {...provided.draggableProps}
-          ref={provided.innerRef}
-        >
-          <Tooltip
-            hidden={!isHiddenByLogic}
-            placement="top"
-            label="This field may be hidden by your form logic"
+    const handleEditFieldClick = useCallback(() => {
+      if (isMobile) {
+        handleBuilderClick(false)
+      }
+    }, [handleBuilderClick, isMobile])
+
+    const handleDuplicateClick = useCallback(() => {
+      if (!form) return
+      // Duplicate button should be hidden if field is not yet created, but guard here just in case
+      if (fieldBuilderState === FieldBuilderState.CreatingField) return
+      // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
+      if (field.fieldType === BasicField.Attachment) {
+        const existingAttachmentsSize = form.form_fields.reduce(
+          (sum, ff) =>
+            ff.fieldType === BasicField.Attachment
+              ? sum + Number(ff.attachmentSize)
+              : sum,
+          0,
+        )
+        const remainingAvailableSize =
+          getAttachmentSizeLimit(form.responseMode) - existingAttachmentsSize
+        const thisAttachmentSize = Number(field.attachmentSize)
+        if (thisAttachmentSize > remainingAvailableSize) {
+          toast({
+            useMarkdown: true,
+            description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${remainingAvailableSize} MB**.`,
+          })
+          return
+        }
+      }
+      duplicateFieldMutation.mutate(field._id)
+    }, [fieldBuilderState, field, duplicateFieldMutation, form, toast])
+
+    const handleDeleteClick = useCallback(() => {
+      if (fieldBuilderState === FieldBuilderState.CreatingField) {
+        setToInactive()
+      } else if (fieldBuilderState === FieldBuilderState.EditingField) {
+        onDeleteModalOpen()
+      }
+    }, [setToInactive, fieldBuilderState, onDeleteModalOpen])
+
+    const isAnyMutationLoading = useMemo(
+      () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
+      [duplicateFieldMutation, deleteFieldMutation],
+    )
+
+    const isDragDisabled = useMemo(() => {
+      return (
+        !isActive ||
+        isDirty ||
+        !!numFormFieldMutations ||
+        fieldBuilderState === FieldBuilderState.CreatingField
+      )
+    }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
+
+    return (
+      <Draggable
+        index={index}
+        isDragDisabled={isDragDisabled}
+        disableInteractiveElementBlocking
+        draggableId={field._id}
+      >
+        {(provided, snapshot) => (
+          <Box
+            _first={{ pt: 0 }}
+            _last={{ pb: 0 }}
+            py="0.375rem"
+            {...provided.draggableProps}
+            ref={provided.innerRef}
           >
-            <Flex
-              // Offset for focus boxShadow
-              my="2px"
-              // Focusable
-              tabIndex={0}
-              role="button"
-              cursor={isActive ? 'initial' : 'pointer'}
-              bg="white"
-              transition="background 0.2s ease"
-              _hover={{ bg: isDraggingOver ? 'white' : 'secondary.100' }}
-              borderRadius="4px"
-              outline="none"
-              {...(isActive ? { 'data-active': true } : {})}
-              _focusWithin={{
-                boxShadow: snapshot.isDragging
-                  ? 'md'
-                  : '0 0 0 2px var(--chakra-colors-primary-500) !important',
-              }}
-              _active={{
-                bg: 'secondary.100',
-                boxShadow: snapshot.isDragging
-                  ? 'md'
-                  : '0 0 0 2px var(--chakra-colors-primary-500)',
-              }}
-              flexDir="column"
-              align="center"
-              onClick={handleFieldClick}
-              onKeyDown={handleKeydown}
-              ref={ref}
+            <Tooltip
+              hidden={!isHiddenByLogic}
+              placement="top"
+              label="This field may be hidden by your form logic"
             >
-              <Fade in={isActive}>
-                <chakra.button
-                  disabled={isDragDisabled}
-                  display="flex"
-                  tabIndex={isActive ? 0 : -1}
-                  {...provided.dragHandleProps}
-                  borderRadius="4px"
-                  _disabled={{
-                    cursor: 'not-allowed',
-                    opacity: 0.4,
-                  }}
-                  _focus={{
-                    boxShadow: snapshot.isDragging
-                      ? undefined
-                      : '0 0 0 2px var(--chakra-colors-neutral-500)',
-                  }}
-                  transition="color 0.2s ease"
-                  _hover={{
-                    color: 'secondary.300',
-                    _disabled: {
-                      color: 'secondary.200',
-                    },
-                  }}
-                  color={
-                    snapshot.isDragging ? 'secondary.300' : 'secondary.200'
-                  }
-                >
-                  {fieldBuilderState === FieldBuilderState.EditingField &&
-                  !isDragDisabled ? (
-                    <Icon as={BiGridHorizontal} fontSize="1.5rem" />
-                  ) : (
-                    <Box h="1.5rem"></Box>
-                  )}
-                </chakra.button>
-              </Fade>
-              <Box
-                px={{ base: '0.75rem', md: '1.5rem' }}
-                pb={{ base: '0.75rem', md: '1.5rem' }}
-                w="100%"
-                pointerEvents={isActive ? undefined : 'none'}
-                opacity={isActive || !isHiddenByLogic ? '100%' : '30%'}
+              <Flex
+                // Offset for focus boxShadow
+                my="2px"
+                // Focusable
+                tabIndex={0}
+                role="button"
+                cursor={isActive ? 'initial' : 'pointer'}
+                bg="white"
+                transition="background 0.2s ease"
+                _hover={{ bg: isDraggingOver ? 'white' : 'secondary.100' }}
+                borderRadius="4px"
+                outline="none"
+                {...(isActive ? { 'data-active': true } : {})}
+                _focusWithin={{
+                  boxShadow: snapshot.isDragging
+                    ? 'md'
+                    : '0 0 0 2px var(--chakra-colors-primary-500) !important',
+                }}
+                _active={{
+                  bg: 'secondary.100',
+                  boxShadow: snapshot.isDragging
+                    ? 'md'
+                    : '0 0 0 2px var(--chakra-colors-primary-500)',
+                }}
+                flexDir="column"
+                align="center"
+                onClick={handleFieldClick}
+                onKeyDown={handleKeydown}
+                ref={ref}
               >
-                <FormProvider {...formMethods}>
-                  <FieldRow
-                    field={field}
-                    colorTheme={colorTheme}
-                    showMyInfoBadge={isMyInfoField}
-                  />
-                </FormProvider>
-              </Box>
-              <Collapse in={isActive} style={{ width: '100%' }}>
-                <Flex
-                  px={{ base: '0.75rem', md: '1.5rem' }}
-                  flex={1}
-                  borderTop="1px solid var(--chakra-colors-neutral-300)"
-                  justify="flex-end"
-                >
-                  <ButtonGroup
-                    variant="clear"
-                    colorScheme="secondary"
-                    spacing={0}
-                  >
-                    {isMobile ? (
-                      <IconButton
-                        variant="clear"
-                        colorScheme="secondary"
-                        aria-label="Edit field"
-                        icon={<BiCog fontSize="1.25rem" />}
-                        onClick={handleEditFieldClick}
-                      />
-                    ) : null}
-                    {
-                      // Fields which are not yet created cannot be duplicated
-                      fieldBuilderState !== FieldBuilderState.CreatingField && (
-                        <Tooltip label="Duplicate field">
-                          <IconButton
-                            aria-label="Duplicate field"
-                            isDisabled={isAnyMutationLoading}
-                            onClick={handleDuplicateClick}
-                            isLoading={duplicateFieldMutation.isLoading}
-                            icon={<BiDuplicate fontSize="1.25rem" />}
-                          />
-                        </Tooltip>
-                      )
+                <Fade in={isActive}>
+                  <chakra.button
+                    disabled={isDragDisabled}
+                    display="flex"
+                    tabIndex={isActive ? 0 : -1}
+                    {...provided.dragHandleProps}
+                    borderRadius="4px"
+                    _disabled={{
+                      cursor: 'not-allowed',
+                      opacity: 0.4,
+                    }}
+                    _focus={{
+                      boxShadow: snapshot.isDragging
+                        ? undefined
+                        : '0 0 0 2px var(--chakra-colors-neutral-500)',
+                    }}
+                    transition="color 0.2s ease"
+                    _hover={{
+                      color: 'secondary.300',
+                      _disabled: {
+                        color: 'secondary.200',
+                      },
+                    }}
+                    color={
+                      snapshot.isDragging ? 'secondary.300' : 'secondary.200'
                     }
-                    <Tooltip label="Delete field">
-                      <IconButton
-                        colorScheme="danger"
-                        aria-label="Delete field"
-                        icon={<BiTrash fontSize="1.25rem" />}
-                        onClick={handleDeleteClick}
-                        isLoading={deleteFieldMutation.isLoading}
-                        isDisabled={isAnyMutationLoading}
-                      />
-                    </Tooltip>
-                  </ButtonGroup>
-                </Flex>
-              </Collapse>
-            </Flex>
-          </Tooltip>
-        </Box>
-      )}
-    </Draggable>
-  )
-}
+                  >
+                    {fieldBuilderState === FieldBuilderState.EditingField &&
+                    !isDragDisabled ? (
+                      <Icon as={BiGridHorizontal} fontSize="1.5rem" />
+                    ) : (
+                      <Box h="1.5rem"></Box>
+                    )}
+                  </chakra.button>
+                </Fade>
+                <Box
+                  px={{ base: '0.75rem', md: '1.5rem' }}
+                  pb={{ base: '0.75rem', md: '1.5rem' }}
+                  w="100%"
+                  pointerEvents={isActive ? undefined : 'none'}
+                  opacity={isActive || !isHiddenByLogic ? '100%' : '30%'}
+                >
+                  <FormProvider {...formMethods}>
+                    <FieldRow
+                      field={field}
+                      colorTheme={colorTheme}
+                      showMyInfoBadge={isMyInfoField}
+                    />
+                  </FormProvider>
+                </Box>
+                <Collapse in={isActive} style={{ width: '100%' }}>
+                  <Flex
+                    px={{ base: '0.75rem', md: '1.5rem' }}
+                    flex={1}
+                    borderTop="1px solid var(--chakra-colors-neutral-300)"
+                    justify="flex-end"
+                  >
+                    <ButtonGroup
+                      variant="clear"
+                      colorScheme="secondary"
+                      spacing={0}
+                    >
+                      {isMobile ? (
+                        <IconButton
+                          variant="clear"
+                          colorScheme="secondary"
+                          aria-label="Edit field"
+                          icon={<BiCog fontSize="1.25rem" />}
+                          onClick={handleEditFieldClick}
+                        />
+                      ) : null}
+                      {
+                        // Fields which are not yet created cannot be duplicated
+                        fieldBuilderState !==
+                          FieldBuilderState.CreatingField && (
+                          <Tooltip label="Duplicate field">
+                            <IconButton
+                              aria-label="Duplicate field"
+                              isDisabled={isAnyMutationLoading}
+                              onClick={handleDuplicateClick}
+                              isLoading={duplicateFieldMutation.isLoading}
+                              icon={<BiDuplicate fontSize="1.25rem" />}
+                            />
+                          </Tooltip>
+                        )
+                      }
+                      <Tooltip label="Delete field">
+                        <IconButton
+                          colorScheme="danger"
+                          aria-label="Delete field"
+                          icon={<BiTrash fontSize="1.25rem" />}
+                          onClick={handleDeleteClick}
+                          isLoading={deleteFieldMutation.isLoading}
+                          isDisabled={isAnyMutationLoading}
+                        />
+                      </Tooltip>
+                    </ButtonGroup>
+                  </Flex>
+                </Collapse>
+              </Flex>
+            </Tooltip>
+          </Box>
+        )}
+      </Draggable>
+    )
+  },
+  (prevProps, nextProps) => isEqual(prevProps, nextProps),
+)
 
 type FieldRowProps = {
   field: FormFieldDto

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -11,7 +11,7 @@ import {
 
 import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
 import { FormFieldWithQuestionNo } from '~features/form/types'
-import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
+import { addMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
 import { useCreateTabForm } from '../useCreateTabForm'
@@ -84,8 +84,8 @@ export const useBuilderFields = () => {
     } else if (stateData.state === FieldBuilderState.CreatingField) {
       mutateFormFieldsWhileCreating(draftBuilderFields, stateData)
     }
-    draftBuilderFields.map(augmentWithMyInfo)
     addQuestionNo(draftBuilderFields)
+    addMyInfo(draftBuilderFields)
   })
 
   return {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -175,7 +175,7 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
 
   useDebounce(
     () => handleChange(transform.output(clonedWatchedInputs, field)),
-    300,
+    0,
     Object.values(clonedWatchedInputs),
   )
 

--- a/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
+++ b/frontend/src/features/myinfo/utils/augmentWithMyInfo.ts
@@ -1,7 +1,12 @@
 import { keyBy } from 'lodash'
 
 import { types as myInfoTypeArray } from '~shared/constants/field/myinfo'
-import { BasicField, FormFieldDto, MyInfoFormField } from '~shared/types/field'
+import {
+  BasicField,
+  FormFieldDto,
+  MyInfoField,
+  MyInfoFormField,
+} from '~shared/types/field'
 
 const MAP_ATTR_TO_NAME = keyBy(myInfoTypeArray, 'name')
 
@@ -20,5 +25,22 @@ export const augmentWithMyInfo = ({
     }
     default:
       return field
+  }
+}
+
+// use immer array mutation pattern
+export const addMyInfo = (draftBuilderFields: FormFieldDto[]): void => {
+  for (let i = 0; i < draftBuilderFields.length; i++) {
+    if (
+      draftBuilderFields[i].fieldType === BasicField.Dropdown &&
+      (draftBuilderFields[i] as MyInfoField).myInfo?.attr
+    ) {
+      const myInfoBlock =
+        MAP_ATTR_TO_NAME[(draftBuilderFields[i] as MyInfoField).myInfo.attr]
+      draftBuilderFields[i] = {
+        ...draftBuilderFields[i],
+        fieldOptions: myInfoBlock.fieldOptions ?? [],
+      }
+    }
   }
 }

--- a/frontend/src/templates/NavigationPrompt/DirtyNavigationPrompt.tsx
+++ b/frontend/src/templates/NavigationPrompt/DirtyNavigationPrompt.tsx
@@ -1,0 +1,12 @@
+import {
+  isDirtySelector,
+  useDirtyFieldStore,
+} from '~features/admin-form/create/builder-and-design/useDirtyFieldStore'
+
+import { NavigationPrompt } from './NavigationPrompt'
+
+export const DirtyNavigationPrompt = () => {
+  const isDirty = useDirtyFieldStore(isDirtySelector)
+
+  return <NavigationPrompt when={isDirty} />
+}

--- a/frontend/src/templates/NavigationPrompt/index.ts
+++ b/frontend/src/templates/NavigationPrompt/index.ts
@@ -1,2 +1,3 @@
+export { DirtyNavigationPrompt } from './DirtyNavigationPrompt'
 export * from './NavigationPrompt'
 export * from './UnsavedChangesModal'


### PR DESCRIPTION
Continued performance optimisation from previous PR #4926 #4885. Only the the active field should re-render now, also reduces the need for debouncing input changes.

## Solution
Remove references to `useFieldBuilderStore`'s `stateData` in child components. Update builderFields using immer. Combining immer and memo seems to work to prevent FieldRowContainer from re-rendering.

Essentially builderFields is a variable dependent on `form_fields` and `useFieldBuilderStore`'s `stateData`. There is probably a cleaner way to structure it all but can't seem to put `builderFields` inside a useState without it breaking.

Form with 10 fields (local development build)
BEFORE:
<img width="975" alt="Screen Shot 2022-12-29 at 9 42 34 PM" src="https://user-images.githubusercontent.com/39296145/209962186-857f1d2f-2afc-4c11-af49-eef6d6388d76.png">

AFTER:
<img width="975" alt="Screen Shot 2022-12-29 at 9 37 50 PM" src="https://user-images.githubusercontent.com/39296145/209962207-3e1b28f2-7360-4c43-91f8-f5f0b6d646b4.png">

