### PR TITLE
fix(v2): extend empty workspace flexbox to fill screen

### DIFF
--- a/frontend/src/features/workspace/components/EmptyWorkspace/EmptyWorkspace.tsx
+++ b/frontend/src/features/workspace/components/EmptyWorkspace/EmptyWorkspace.tsx
@@ -22,9 +22,10 @@ export const EmptyWorkspace = ({
 
   return (
     <Flex
-      justify="center"
+      justify="flex-start"
       flexDir="column"
       align="center"
+      h="100vh"
       px="2rem"
       py="1rem"
       bg="neutral.100"
@@ -40,7 +41,7 @@ export const EmptyWorkspace = ({
         color="secondary.500"
         mb={{ base: '2.5rem', md: '2rem' }}
       >
-        Get started by creating a new form.
+        Get started by creating a new form
       </Text>
       <Button
         isFullWidth={isMobile}

--- a/frontend/src/features/workspace/components/EmptyWorkspace/EmptyWorkspace.tsx
+++ b/frontend/src/features/workspace/components/EmptyWorkspace/EmptyWorkspace.tsx
@@ -2,6 +2,7 @@ import { BiPlus } from 'react-icons/bi'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { fillHeightCss } from '~utils/fillHeightCss'
 import Button from '~components/Button'
 
 // TODO #4279: Remove after React rollout is complete
@@ -25,10 +26,10 @@ export const EmptyWorkspace = ({
       justify="flex-start"
       flexDir="column"
       align="center"
-      h="100vh"
       px="2rem"
       py="1rem"
       bg="neutral.100"
+      css={fillHeightCss}
     >
       <Box pb="1.5rem">
         <AdminSwitchEnvMessage />


### PR DESCRIPTION
There was a weird break in the background color for empty workspace because the height wasn't 100vh. This PR fixes that.

Before
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/25571626/192673311-66359394-a9fc-42f8-aa61-0a9f1bb5fada.png">

After
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/25571626/192673335-d22671aa-48f5-406a-be13-dfedbf4d669b.png">
