### PR TITLE
feat(v2): add clearer a11y help text to verifiable fields, add verified styling

### DIFF
--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.stories.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.stories.tsx
@@ -11,6 +11,7 @@ import {
   postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
 
+import { getMobileViewParameters } from '~utils/storybook'
 import Button from '~components/Button'
 import {
   VerifiableFieldInput,
@@ -140,6 +141,10 @@ PendingVerification.args = {
     value: 'test@example.com',
   },
 }
+
+export const PendingVerificationMobile = Template.bind({})
+PendingVerificationMobile.args = PendingVerification.args
+PendingVerificationMobile.parameters = getMobileViewParameters()
 
 export const Verified = Template.bind({})
 Verified.args = {

--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { VisuallyHidden } from '@chakra-ui/react'
 
 import { baseEmailValidationFn } from '~utils/fieldValidation'
@@ -23,7 +24,8 @@ const InnerVerifiableEmailField = ({
   schema,
   ...formContainerProps
 }: VerifiableEmailFieldProps): JSX.Element => {
-  const { handleInputChange, handleVfnButtonClick } = useVerifiableField()
+  const { handleInputChange, handleVfnButtonClick, hasSignature } =
+    useVerifiableField()
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault()
@@ -31,13 +33,18 @@ const InnerVerifiableEmailField = ({
       handleVfnButtonClick()
     }
   }
+
+  const a11yLabel = useMemo(() => {
+    if (hasSignature) {
+      return 'This input field has been successfully verified.'
+    }
+    return 'This is an input field which requires verification. After you enter the email address to be verified, please click on the Verify button. A one-time password will be sent to the entered email address, which you can then enter in the verification input field.'
+  }, [hasSignature])
+
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
       <VisuallyHidden id={`verifiable-description-${schema._id}`}>
-        This is an input field which requires verification. After you enter the
-        email address to be verified, please click on the Verify button. A
-        one-time password will be sent to the entered email address, which you
-        can then enter in the verification input field.
+        {a11yLabel}
       </VisuallyHidden>
       <EmailFieldInput
         schema={schema}

--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
@@ -1,3 +1,5 @@
+import { VisuallyHidden } from '@chakra-ui/react'
+
 import { baseEmailValidationFn } from '~utils/fieldValidation'
 import { EmailFieldInput, EmailFieldProps } from '~templates/Field/Email'
 import { EmailFieldSchema } from '~templates/Field/types'
@@ -31,11 +33,18 @@ const InnerVerifiableEmailField = ({
   }
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
+      <VisuallyHidden id={`verifiable-description-${schema._id}`}>
+        This is an input field which requires verification. After you enter the
+        email address to be verified, please click on the Verify button. A
+        one-time password will be sent to the entered email address, which you
+        can then enter in the verification input field.
+      </VisuallyHidden>
       <EmailFieldInput
         schema={schema}
         handleInputChange={handleInputChange}
         inputProps={{
           onKeyDown: handleKeyDown,
+          'aria-describedby': `verifiable-description-${schema._id}`,
         }}
       />
     </VerifiableFieldContainer>

--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { VisuallyHidden } from '@chakra-ui/react'
+import { Box, VisuallyHidden } from '@chakra-ui/react'
 
 import { baseEmailValidationFn } from '~utils/fieldValidation'
 import { EmailFieldInput, EmailFieldProps } from '~templates/Field/Email'
@@ -43,17 +43,20 @@ const InnerVerifiableEmailField = ({
 
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
-      <VisuallyHidden id={`verifiable-description-${schema._id}`}>
-        {a11yLabel}
-      </VisuallyHidden>
-      <EmailFieldInput
-        schema={schema}
-        handleInputChange={handleInputChange}
-        inputProps={{
-          onKeyDown: handleKeyDown,
-          'aria-describedby': `verifiable-description-${schema._id}`,
-        }}
-      />
+      <Box w="100%">
+        <VisuallyHidden id={`verifiable-description-${schema._id}`}>
+          {a11yLabel}
+        </VisuallyHidden>
+        <EmailFieldInput
+          schema={schema}
+          handleInputChange={handleInputChange}
+          inputProps={{
+            isSuccess: hasSignature,
+            onKeyDown: handleKeyDown,
+            'aria-describedby': `verifiable-description-${schema._id}`,
+          }}
+        />
+      </Box>
     </VerifiableFieldContainer>
   )
 }

--- a/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
+++ b/frontend/src/features/verifiable-fields/Email/VerifiableEmailField.tsx
@@ -38,7 +38,7 @@ const InnerVerifiableEmailField = ({
     if (hasSignature) {
       return 'This input field has been successfully verified.'
     }
-    return 'This is an input field which requires verification. After you enter the email address to be verified, please click on the Verify button. A one-time password will be sent to the entered email address, which you can then enter in the verification input field.'
+    return 'This is an input field which requires verification. After entering your email address, please click on the Verify button. You will receive a one-time password, which you can enter in the verification input field.'
   }, [hasSignature])
 
   return (

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.stories.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.stories.tsx
@@ -11,6 +11,7 @@ import {
   postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
 
+import { getMobileViewParameters } from '~utils/storybook'
 import Button from '~components/Button'
 import {
   VerifiableFieldInput,
@@ -132,6 +133,10 @@ PendingVerification.args = {
     value: '+6598888888',
   },
 }
+
+export const PendingVerificationMobile = Template.bind({})
+PendingVerificationMobile.args = PendingVerification.args
+PendingVerificationMobile.parameters = getMobileViewParameters()
 
 export const Verified = Template.bind({})
 Verified.args = {

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
@@ -39,7 +39,7 @@ const InnerVerifiableMobileField = ({
     if (hasSignature) {
       return 'This input field has been successfully verified.'
     }
-    return 'This is an input field which requires verification. After you enter the email address to be verified, please click on the Verify button. A one-time password will be sent to the entered email address, which you can then enter in the verification input field.'
+    return 'This is an input field which requires verification. After entering your mobile phone number, please click on the Verify button. You will receive a one-time password via SMS, which you can enter in the verification input field.'
   }, [hasSignature])
 
   return (

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { VisuallyHidden } from '@chakra-ui/react'
+import { Box, VisuallyHidden } from '@chakra-ui/react'
 
 import { baseMobileValidationFn } from '~utils/fieldValidation'
 import { MobileFieldInput, MobileFieldProps } from '~templates/Field/Mobile'
@@ -44,17 +44,20 @@ const InnerVerifiableMobileField = ({
 
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
-      <VisuallyHidden id={`verifiable-description-${schema._id}`}>
-        {a11yLabel}
-      </VisuallyHidden>
-      <MobileFieldInput
-        schema={schema}
-        handleInputChange={handleInputChange}
-        phoneNumberInputProps={{
-          onKeyDown: handleKeyDown,
-          'aria-describedby': `verifiable-description-${schema._id}`,
-        }}
-      />
+      <Box w="100%">
+        <VisuallyHidden id={`verifiable-description-${schema._id}`}>
+          {a11yLabel}
+        </VisuallyHidden>
+        <MobileFieldInput
+          schema={schema}
+          handleInputChange={handleInputChange}
+          phoneNumberInputProps={{
+            isSuccess: hasSignature,
+            onKeyDown: handleKeyDown,
+            'aria-describedby': `verifiable-description-${schema._id}`,
+          }}
+        />
+      </Box>
     </VerifiableFieldContainer>
   )
 }

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { VisuallyHidden } from '@chakra-ui/react'
 
 import { baseMobileValidationFn } from '~utils/fieldValidation'
@@ -24,7 +25,8 @@ const InnerVerifiableMobileField = ({
   schema,
   ...formContainerProps
 }: VerifiableMobileFieldProps): JSX.Element => {
-  const { handleInputChange, handleVfnButtonClick } = useVerifiableField()
+  const { handleInputChange, handleVfnButtonClick, hasSignature } =
+    useVerifiableField()
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault()
@@ -32,13 +34,18 @@ const InnerVerifiableMobileField = ({
       handleVfnButtonClick()
     }
   }
+
+  const a11yLabel = useMemo(() => {
+    if (hasSignature) {
+      return 'This input field has been successfully verified.'
+    }
+    return 'This is an input field which requires verification. After you enter the email address to be verified, please click on the Verify button. A one-time password will be sent to the entered email address, which you can then enter in the verification input field.'
+  }, [hasSignature])
+
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
       <VisuallyHidden id={`verifiable-description-${schema._id}`}>
-        This is an input field which requires verification. After you enter the
-        email address to be verified, please click on the Verify button. A
-        one-time password will be sent to the entered email address, which you
-        can then enter in the verification input field.
+        {a11yLabel}
       </VisuallyHidden>
       <MobileFieldInput
         schema={schema}

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
@@ -1,3 +1,5 @@
+import { VisuallyHidden } from '@chakra-ui/react'
+
 import { baseMobileValidationFn } from '~utils/fieldValidation'
 import { MobileFieldInput, MobileFieldProps } from '~templates/Field/Mobile'
 import { MobileFieldSchema } from '~templates/Field/types'
@@ -32,11 +34,18 @@ const InnerVerifiableMobileField = ({
   }
   return (
     <VerifiableFieldContainer schema={schema} {...formContainerProps}>
+      <VisuallyHidden id={`verifiable-description-${schema._id}`}>
+        This is an input field which requires verification. After you enter the
+        email address to be verified, please click on the Verify button. A
+        one-time password will be sent to the entered email address, which you
+        can then enter in the verification input field.
+      </VisuallyHidden>
       <MobileFieldInput
         schema={schema}
         handleInputChange={handleInputChange}
         phoneNumberInputProps={{
           onKeyDown: handleKeyDown,
+          'aria-describedby': `verifiable-description-${schema._id}`,
         }}
       />
     </VerifiableFieldContainer>

--- a/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
+++ b/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
@@ -1,8 +1,9 @@
+import { useMemo } from 'react'
 import { BiCheck } from 'react-icons/bi'
 import { Box, Stack } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types'
-import { FormFieldWithId } from '~shared/types/field'
+import { BasicField, FormFieldWithId } from '~shared/types/field'
 
 import Button from '~components/Button'
 import { BaseFieldProps, FieldContainer } from '~templates/Field/FieldContainer'
@@ -37,6 +38,19 @@ export const VerifiableFieldContainer = ({
     isSendingOtp,
   } = useVerifiableField()
 
+  const verifyButtonAriaLabel: string = useMemo(() => {
+    switch (schema.fieldType) {
+      case BasicField.Email:
+        return hasSignature
+          ? 'Given email address is verified'
+          : 'Verify email address'
+      case BasicField.Mobile:
+        return hasSignature
+          ? 'Given mobile number is verified'
+          : 'Verify mobile number'
+    }
+  }, [hasSignature, schema.fieldType])
+
   return (
     <Box>
       <FieldContainer schema={schema}>
@@ -54,6 +68,7 @@ export const VerifiableFieldContainer = ({
               leftIcon={
                 hasSignature ? <BiCheck fontSize="1.5rem" /> : undefined
               }
+              aria-label={verifyButtonAriaLabel}
             >
               {hasSignature ? 'Verified' : 'Verify'}
             </Button>

--- a/frontend/src/features/verifiable-fields/components/VerificationBox/VerificationBox.tsx
+++ b/frontend/src/features/verifiable-fields/components/VerificationBox/VerificationBox.tsx
@@ -115,7 +115,11 @@ export const VerificationBox = ({
                 onKeyDown={handleKeyDown}
               />
 
-              <Button ml="0.5rem" onClick={onSubmitForm}>
+              <Button
+                ml="0.5rem"
+                onClick={onSubmitForm}
+                aria-label="Submit OTP for verification"
+              >
                 Submit
               </Button>
             </Flex>

--- a/frontend/src/templates/ResendOtpButton/ResendOtpButton.tsx
+++ b/frontend/src/templates/ResendOtpButton/ResendOtpButton.tsx
@@ -1,3 +1,5 @@
+import { Text } from '@chakra-ui/react'
+
 import Button, { ButtonProps } from '~components/Button'
 
 export interface ResendOtpButtonProps extends ButtonProps {
@@ -26,7 +28,9 @@ export const ResendOtpButton = ({
       {...buttonProps}
     >
       Resend OTP
-      {timer > 0 && ` in ${timer}s`}
+      <Text as="span" data-chromatic="ignore">
+        {timer > 0 && ` in ${timer}s`}
+      </Text>
     </Button>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR hopefully adds clearer a11y help text to verifiable fields so screen-reader users are not as confused when they encounter such fields. Also adds verified styling to fields that has been successfully verified - stories should reflect.

Closes #4188

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: add additional screen reader help text for verifiable fields
- feat: add more descriptive aria labels for vfn buttons
- feat: add success state to input on verification success 

**Improvements**:

- fix: attempt to ignore resend button OTP countdown on chromatic

## Before & After Screenshots
Stories should be updated for verified fields and show new styling.
