### PR TITLE
fix(v2): update react dev proxy port to port 5001, fix invalid dom tag nesting 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -182,7 +182,7 @@
     "ts-jest": "^27.1.1",
     "worker-loader": "^3.0.8"
   },
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:5001",
   "msw": {
     "workerDirectory": "public"
   }

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -51,7 +51,7 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
               <VisuallyHidden>
                 Click to switch to the original FormSG
               </VisuallyHidden>
-              <Text display="inline" aria-hidden>
+              <Text as="span" display="inline" aria-hidden>
                 switch to the original one here
               </Text>
             </Button>

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -44,7 +44,7 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
             <VisuallyHidden>
               Click to switch to the original FormSG
             </VisuallyHidden>
-            <Text display="inline" aria-hidden>
+            <Text as="span" display="inline" aria-hidden>
               switch to the original one
             </Text>
           </Button>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR fixes two issues.

- React app would not proxy correctly due to not updating proxy port on the React side, introduced in #4954
- Invalid nested `<p>` tags in the DOM, introduced in #4959

