### PR TITLE
feat: add extra aria text to denote the end of the form

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useFormContext, useFormState, useWatch } from 'react-hook-form'
-import { Stack } from '@chakra-ui/react'
+import { Stack, VisuallyHidden } from '@chakra-ui/react'
 
 import { FormField, LogicDto, MyInfoFormField } from '~shared/types'
 
@@ -50,6 +50,7 @@ export const PublicFormSubmitButton = ({
         isDisabled={!!preventSubmissionLogic}
         loadingText="Submitting"
       >
+        <VisuallyHidden>End of form.</VisuallyHidden>
         {preventSubmissionLogic ? 'Submission disabled' : 'Submit now'}
       </Button>
       {preventSubmissionLogic ? (

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useFormContext, useFormState, useWatch } from 'react-hook-form'
+import { useFormState, useWatch } from 'react-hook-form'
 import { Stack, VisuallyHidden } from '@chakra-ui/react'
 
 import { FormField, LogicDto, MyInfoFormField } from '~shared/types'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds extra aria-text to the submit button to denote the end of the form for extra clarity to screen reader users.

Closes #4179
