### PR TITLE
feat: bunch of table field (a11y) improvements, misc public form fixes

### DIFF
--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelect.stories.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelect.stories.tsx
@@ -5,6 +5,7 @@ import { FormControl } from '@chakra-ui/react'
 import { useArgs } from '@storybook/client-api'
 import { Meta, Story } from '@storybook/react'
 
+import { fixedHeightDecorator } from '~utils/storybook'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -68,7 +69,7 @@ const INITIAL_COMBOBOX_ITEMS: ComboboxItem[] = [
 export default {
   title: 'Components/SingleSelect',
   component: SingleSelect,
-  decorators: [],
+  decorators: [fixedHeightDecorator('300px')],
   args: {
     items: INITIAL_COMBOBOX_ITEMS,
     value: '',

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -32,7 +32,6 @@ export const SelectMenu = (): JSX.Element => {
           { suppressRefError: true },
         )}
         style={floatingStyles}
-        zIndex="dropdown"
         sx={styles.list}
       >
         {isOpen && items.length > 0 && (

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -25,9 +25,12 @@ export const SelectMenu = (): JSX.Element => {
   return (
     <FloatingPortal>
       <List
-        {...getMenuProps({
-          ref: floatingRef,
-        })}
+        {...getMenuProps(
+          { ref: floatingRef },
+          // Suppressing ref error since this will be in a portal and will be conditionally rendered.
+          // See https://github.com/downshift-js/downshift/issues/1272#issuecomment-1063244446
+          { suppressRefError: true },
+        )}
         style={floatingStyles}
         zIndex="dropdown"
         sx={styles.list}

--- a/frontend/src/components/Dropdown/components/SelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/SelectMenu.tsx
@@ -1,5 +1,6 @@
 import { Virtuoso } from 'react-virtuoso'
 import { List, ListItem } from '@chakra-ui/react'
+import { FloatingPortal } from '@floating-ui/react-dom-interactions'
 
 import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useSelectContext } from '../SelectContext'
@@ -22,36 +23,38 @@ export const SelectMenu = (): JSX.Element => {
   const { floatingRef, floatingStyles } = useSelectPopover()
 
   return (
-    <List
-      {...getMenuProps({
-        ref: floatingRef,
-      })}
-      style={floatingStyles}
-      zIndex="dropdown"
-      sx={styles.list}
-    >
-      {isOpen && items.length > 0 && (
-        <Virtuoso
-          ref={virtualListRef}
-          data={items}
-          overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
-          style={{ height: virtualListHeight }}
-          itemContent={(index, item) => {
-            return (
-              <DropdownItem
-                key={`${itemToValue(item)}${index}`}
-                item={item}
-                index={index}
-              />
-            )
-          }}
-        />
-      )}
-      {isOpen && items.length === 0 ? (
-        <ListItem role="option" sx={styles.emptyItem}>
-          {nothingFoundLabel}
-        </ListItem>
-      ) : null}
-    </List>
+    <FloatingPortal>
+      <List
+        {...getMenuProps({
+          ref: floatingRef,
+        })}
+        style={floatingStyles}
+        zIndex="dropdown"
+        sx={styles.list}
+      >
+        {isOpen && items.length > 0 && (
+          <Virtuoso
+            ref={virtualListRef}
+            data={items}
+            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+            style={{ height: virtualListHeight }}
+            itemContent={(index, item) => {
+              return (
+                <DropdownItem
+                  key={`${itemToValue(item)}${index}`}
+                  item={item}
+                  index={index}
+                />
+              )
+            }}
+          />
+        )}
+        {isOpen && items.length === 0 ? (
+          <ListItem role="option" sx={styles.emptyItem}>
+            {nothingFoundLabel}
+          </ListItem>
+        ) : null}
+      </List>
+    </FloatingPortal>
   )
 }

--- a/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
+++ b/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
@@ -5,6 +5,7 @@ import {
   flip,
   hide,
   offset,
+  size,
   useFloating,
 } from '@floating-ui/react-dom-interactions'
 
@@ -26,6 +27,14 @@ export const SelectPopoverProvider: FC = ({ children }): JSX.Element => {
       offset(1),
       flip(),
       hide(),
+      // Set width to be the same as the reference element.
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          })
+        },
+      }),
     ],
   })
 

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
@@ -101,19 +101,9 @@ export const FormFields = ({
     }
   }, [defaultFormValues, isDirty, reset])
 
-  const preventSubmitOnEnter = useCallback((event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-    }
-  }, [])
-
   return (
     <FormProvider {...formMethods}>
-      <form
-        onSubmit={formMethods.handleSubmit(onSubmit)}
-        noValidate
-        onKeyDown={preventSubmitOnEnter}
-      >
+      <form noValidate>
         {!!formFields?.length && (
           <Box bg={'white'} py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
             <Stack spacing="2.25rem">
@@ -136,6 +126,7 @@ export const FormFields = ({
           </Box>
         )}
         <PublicFormSubmitButton
+          onSubmit={formMethods.handleSubmit(onSubmit)}
           formFields={augmentedFormFields}
           formLogics={formLogics}
           colorTheme={colorTheme}

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { MouseEventHandler, useMemo } from 'react'
 import { useFormState, useWatch } from 'react-hook-form'
 import { Stack, VisuallyHidden } from '@chakra-ui/react'
 
@@ -16,6 +16,7 @@ interface PublicFormSubmitButtonProps {
   formFields: MyInfoFormField<FormField>[]
   formLogics: LogicDto[]
   colorTheme: string
+  onSubmit: MouseEventHandler<HTMLButtonElement>
 }
 
 /**
@@ -26,6 +27,7 @@ export const PublicFormSubmitButton = ({
   formFields,
   formLogics,
   colorTheme,
+  onSubmit,
 }: PublicFormSubmitButtonProps): JSX.Element => {
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
@@ -45,10 +47,11 @@ export const PublicFormSubmitButton = ({
         isFullWidth={isMobile}
         w="100%"
         colorScheme={`theme-${colorTheme}` as ThemeColorScheme}
-        type="submit"
+        type="button"
         isLoading={isSubmitting}
         isDisabled={!!preventSubmissionLogic}
         loadingText="Submitting"
+        onClick={onSubmit}
       >
         <VisuallyHidden>End of form.</VisuallyHidden>
         {preventSubmissionLogic ? 'Submission disabled' : 'Submit now'}

--- a/frontend/src/templates/Field/Table/AddRowFooter.tsx
+++ b/frontend/src/templates/Field/Table/AddRowFooter.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { BiPlus } from 'react-icons/bi'
-import { Stack, Text, VisuallyHidden } from '@chakra-ui/react'
+import { Box, Stack, Text, VisuallyHidden } from '@chakra-ui/react'
 import simplur from 'simplur'
 
 import Button from '~components/Button'
@@ -14,8 +14,10 @@ interface AddRowFooterProps {
 export const AddRowFooter = ({
   currentRows,
   maxRows,
-  handleAddRow,
+  handleAddRow: handleAddRowProp,
 }: AddRowFooterProps): JSX.Element => {
+  // State to decide whether to announce row changes to screen readers
+  const [hasAddedRows, setHasAddedRows] = useState(false)
   const maxRowDescription = useMemo(() => {
     return maxRows
       ? simplur`${currentRows} out of max ${maxRows} row[|s]`
@@ -27,6 +29,11 @@ export const AddRowFooter = ({
       ? simplur`There [is|are] currently ${currentRows} out of max ${maxRows} row[|s].`
       : simplur`There [is|are] currently ${currentRows} row[|s].`
   }, [currentRows, maxRows])
+
+  const handleAddRow = useCallback(() => {
+    handleAddRowProp()
+    setHasAddedRows(true)
+  }, [handleAddRowProp])
 
   return (
     <Stack
@@ -48,10 +55,15 @@ export const AddRowFooter = ({
         </VisuallyHidden>
       </Button>
 
-      <Text textStyle="body-2" color="secondary.400">
-        <VisuallyHidden>The table field currently has </VisuallyHidden>
-        {maxRowDescription}
-      </Text>
+      <Box>
+        <VisuallyHidden aria-live={hasAddedRows ? 'polite' : 'off'} aria-atomic>
+          The table field currently has {maxRowDescription}
+        </VisuallyHidden>
+
+        <Text aria-hidden textStyle="body-2" color="secondary.400">
+          {maxRowDescription}
+        </Text>
+      </Box>
     </Stack>
   )
 }

--- a/frontend/src/templates/Field/Table/AddRowFooter.tsx
+++ b/frontend/src/templates/Field/Table/AddRowFooter.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from 'react'
 import { BiPlus } from 'react-icons/bi'
-import { Stack, Text } from '@chakra-ui/react'
+import { Stack, Text, VisuallyHidden } from '@chakra-ui/react'
 import simplur from 'simplur'
 
 import Button from '~components/Button'
@@ -15,6 +16,18 @@ export const AddRowFooter = ({
   maxRows,
   handleAddRow,
 }: AddRowFooterProps): JSX.Element => {
+  const maxRowDescription = useMemo(() => {
+    return maxRows
+      ? simplur`${currentRows} out of max ${maxRows} row[|s]`
+      : simplur`${currentRows} row[|s]`
+  }, [currentRows, maxRows])
+
+  const maxRowAriaDescription = useMemo(() => {
+    return maxRows
+      ? simplur`There [is|are] currently ${currentRows} out of max ${maxRows} row[|s].`
+      : simplur`There [is|are] currently ${currentRows} row[|s].`
+  }, [currentRows, maxRows])
+
   return (
     <Stack
       mt="0.75rem"
@@ -30,12 +43,14 @@ export const AddRowFooter = ({
         onClick={handleAddRow}
       >
         Add another row
+        <VisuallyHidden>
+          to the table field. {maxRowAriaDescription}
+        </VisuallyHidden>
       </Button>
 
       <Text textStyle="body-2" color="secondary.400">
-        {maxRows
-          ? simplur`${currentRows} out of max ${maxRows} row[|s]`
-          : simplur`${currentRows} row[|s]`}
+        <VisuallyHidden>The table field currently has </VisuallyHidden>
+        {maxRowDescription}
       </Text>
     </Stack>
   )

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -2,7 +2,16 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { useFieldArray, useFormContext, useFormState } from 'react-hook-form'
 import { BiTrash } from 'react-icons/bi'
 import { useTable } from 'react-table'
-import { Box, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import {
+  Box,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 import { get, head, uniq } from 'lodash'
 
 import { FormColorTheme } from '~shared/types'
@@ -111,6 +120,20 @@ export const TableField = ({
     [fields.length, remove, schema.minimumRows],
   )
 
+  const ariaTableDescription = useMemo(() => {
+    let description = 'This is a table field.'
+    if (schema.addMoreRows) {
+      description += ` You can add more rows if you'd like by clicking the "Add another row" button below`
+      if (schema.maximumRows) {
+        description += `, up to ${schema.maximumRows} rows`
+      } else {
+        description += '.'
+      }
+    }
+
+    return description
+  }, [schema.addMoreRows, schema.maximumRows])
+
   return (
     <TableFieldContainer schema={schema}>
       <Box
@@ -127,8 +150,13 @@ export const TableField = ({
           },
         }}
       >
+        <VisuallyHidden id={`table-desc-${schema._id}`}>
+          {ariaTableDescription}
+        </VisuallyHidden>
         <Table
           {...getTableProps()}
+          aria-describedby={`table-desc-${schema._id}`}
+          aria-labelledby={`${schema._id}-label`}
           variant="column-stripe"
           size="sm"
           colorScheme={`theme-${colorTheme}`}

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -13,6 +13,7 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react'
 import { get, head, uniq } from 'lodash'
+import simplur from 'simplur'
 
 import { FormColorTheme } from '~shared/types'
 
@@ -121,7 +122,7 @@ export const TableField = ({
   )
 
   const ariaTableDescription = useMemo(() => {
-    let description = 'This is a table field.'
+    let description = simplur`This is a table field. There [is|are] ${fields.length} row[|s], excluding the header row.`
     if (schema.addMoreRows) {
       description += ` You can add more rows if you'd like by clicking the "Add another row" button below`
       if (schema.maximumRows) {
@@ -132,7 +133,7 @@ export const TableField = ({
     }
 
     return description
-  }, [schema.addMoreRows, schema.maximumRows])
+  }, [fields.length, schema.addMoreRows, schema.maximumRows])
 
   return (
     <TableFieldContainer schema={schema}>
@@ -167,6 +168,7 @@ export const TableField = ({
                 {headerGroup.headers.map((column, _idx, array) => (
                   <Th
                     {...column.getHeaderProps()}
+                    scope="col"
                     w={{ base: 'initial', md: `calc(100%/${array.length})` }}
                     minW="15rem"
                     display={{ base: 'block', md: 'table-cell' }}

--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -25,6 +25,7 @@ export const TableFieldContainer = ({
 
   return (
     <FormControl
+      id={schema._id}
       isRequired={schema.required}
       isDisabled={schema.disabled}
       isReadOnly={isValid && isSubmitting}

--- a/frontend/src/utils/storybook.tsx
+++ b/frontend/src/utils/storybook.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { Box, Center, useDisclosure } from '@chakra-ui/react'
+import { Box, BoxProps, Center, useDisclosure } from '@chakra-ui/react'
 import { DecoratorFn } from '@storybook/react'
 import dayjs from 'dayjs'
 import mockdate from 'mockdate'
@@ -23,6 +23,15 @@ import { fillHeightCss } from './fillHeightCss'
 export const centerDecorator: DecoratorFn = (storyFn) => (
   <Center>{storyFn()}</Center>
 )
+
+export const fixedHeightDecorator =
+  (height: BoxProps['h']): DecoratorFn =>
+  (Story) =>
+    (
+      <Box h={height}>
+        <Story />
+      </Box>
+    )
 
 export const fullScreenDecorator: DecoratorFn = (storyFn) => (
   <Box w="100vw" css={fillHeightCss}>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds a bunch of table field a11y improvements. 
Also some public form submission fixes. See changelog below.

Hopefully closes #4192, but probably need more user tests.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: add accessible table field description and label


**Bug Fixes**:

- fix(Select): use Portal for dropdown menu so Table field container does not constrain dropdown dimensions.
- fix: move onSubmit to submit button click, remove incorrect handling of "enter" keypresses on the form level
  - previous implementation of preventing enter keypresses was affecting the whole form, where enter can no longer be used to trigger buttons.
  - however, we still do want to prevent erroneous form submissions with the enter keypress, and thus should only trigger form submission on button click.
- feat: add slightly more context to table aria descriptions and when table row changes have occurred

## Before & After Screenshots
No change, all purely on the aria level.
