### PR TITLE
fix(v2): Unable to click "Try it here!" button on Angular mobile

### DIFF
--- a/src/public/modules/forms/admin/css/list-forms.css
+++ b/src/public/modules/forms/admin/css/list-forms.css
@@ -271,6 +271,7 @@
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
+    position: relative;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     justify-content: center;


### PR DESCRIPTION
## Problem

- Unable to click `"Try it here!"` button on angular mobile due to it being blocked by an overlay

Closes #4939 
## Solution

- Set overlay's parent div to be position relative as it was tagged to its grandparent, resulting in its height to include that of the `"Try it here!"` banner.

Before:
<img width="678" alt="Screenshot 2022-09-30 at 4 37 34 PM" src="https://user-images.githubusercontent.com/52305097/193229200-f4582375-858d-46ca-ab62-c381ff4c3db8.png">


After:
<img width="578" alt="Screenshot 2022-09-30 at 4 36 54 PM" src="https://user-images.githubusercontent.com/52305097/193228989-d5bc7e2e-24c3-4c3b-80c8-fe0ee8b7bf4d.png">
