### PR TITLE
fix(v2): align delete column button with label in table edit drawer, make Twilio credential delete a button

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Controller } from 'react-hook-form'
 import { useMutation } from 'react-query'
 import { useParams } from 'react-router-dom'
@@ -9,6 +9,7 @@ import { MB } from '~shared/constants/file'
 import { ImageFieldBase } from '~shared/types/field'
 
 import { useToast } from '~hooks/useToast'
+import { createBaseValidationRules } from '~utils/fieldValidation'
 import { uploadImage } from '~services/FileHandlerService'
 import {
   getByteFileSize,
@@ -137,6 +138,11 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
     },
   })
 
+  const requiredValidationRule = useMemo(
+    () => createBaseValidationRules({ required: true }),
+    [],
+  )
+
   // Required to override original updateField function due to possible errors
   // from the generation of presigned urls.
   const handleUpdateFieldWithCatch = useCallback(
@@ -181,8 +187,8 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
         isReadOnly={isLoading || isSubmitting}
         isInvalid={!!errors.description}
       >
-        <FormLabel>Description</FormLabel>
-        <Textarea {...register('description')} />
+        <FormLabel isRequired>Description</FormLabel>
+        <Textarea {...register('description', requiredValidationRule)} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormFieldDrawerActions

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { Controller } from 'react-hook-form'
 import { useMutation } from 'react-query'
 import { useParams } from 'react-router-dom'
@@ -9,7 +9,6 @@ import { MB } from '~shared/constants/file'
 import { ImageFieldBase } from '~shared/types/field'
 
 import { useToast } from '~hooks/useToast'
-import { createBaseValidationRules } from '~utils/fieldValidation'
 import { uploadImage } from '~services/FileHandlerService'
 import {
   getByteFileSize,
@@ -138,11 +137,6 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
     },
   })
 
-  const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
-    [],
-  )
-
   // Required to override original updateField function due to possible errors
   // from the generation of presigned urls.
   const handleUpdateFieldWithCatch = useCallback(
@@ -187,8 +181,8 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
         isReadOnly={isLoading || isSubmitting}
         isInvalid={!!errors.description}
       >
-        <FormLabel isRequired>Description</FormLabel>
-        <Textarea {...register('description', requiredValidationRule)} />
+        <FormLabel>Description</FormLabel>
+        <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormFieldDrawerActions

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
@@ -8,6 +8,7 @@ import {
 import { BiPlus, BiTrash } from 'react-icons/bi'
 import {
   FormControl,
+  Grid,
   Stack,
   StackDivider,
   VisuallyHidden,
@@ -81,10 +82,11 @@ export const EditTableColumns = ({
             isReadOnly={isLoading}
             isInvalid={!!errors?.columns?.[index]?.title}
           >
-            <Stack justify="space-between" align="center" direction="row">
+            <Grid templateColumns="1fr auto">
               <FormLabel>{`Column ${index + 1}`}</FormLabel>
               {fields.length !== 1 && (
                 <IconButton
+                  mt="-0.75rem"
                   variant="clear"
                   colorScheme="danger"
                   fontSize="1.25rem"
@@ -93,7 +95,7 @@ export const EditTableColumns = ({
                   onClick={() => remove(index)}
                 />
               )}
-            </Stack>
+            </Grid>
             <Input
               {...register(`columns.${index}.title`, requiredValidationRule)}
             />

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -191,7 +191,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
       </Stack>
       <Skeleton isLoaded={!isLoading} mt="2.5rem" w="fit-content">
         {hasExistingTwilioCreds ? (
-          <Button variant="link" colorScheme="danger" onClick={onOpen}>
+          <Button colorScheme="danger" onClick={onOpen}>
             Remove and re-enter credentials
           </Button>
         ) : (


### PR DESCRIPTION
## Problem

1. #4752 
2. #4658

## Solution
1. Need to add a negative margin for the delete icon. However, there is an issue of the margins not working due to chakra enforcing margin-top in the `Stack` component (see this [issue](https://github.com/chakra-ui/chakra-ui/issues/2578)). Therefore, switch to grid so that our negative margins work.
2. Remove `variant='link'` from button component.

**Breaking Changes** 
- No - this PR is backwards compatible  
