### PR TITLE
fix: correct URL of billing page in AngularJS

### DIFF
--- a/src/public/modules/users/config/users.client.routes.js
+++ b/src/public/modules/users/config/users.client.routes.js
@@ -43,7 +43,7 @@ angular.module('users').config([
         controllerAs: 'vm',
       })
       .state('billing', {
-        url: '/api/v3/billings',
+        url: '/billing',
         templateUrl: 'modules/users/views/billing.client.view.html',
         controller: 'BillingController',
         controllerAs: 'vm',


### PR DESCRIPTION
should be /billing instead of /api/v3/billings
