### PR TITLE
feat: add rate limit to verification endpoints too

### DIFF
--- a/src/app/routes/api/v3/auth/auth.routes.ts
+++ b/src/app/routes/api/v3/auth/auth.routes.ts
@@ -46,7 +46,11 @@ AuthRouter.post(
  * @returns 422 when the OTP is invalid
  * @returns 500 when error occurred whilst verifying the OTP
  */
-AuthRouter.post('/otp/verify', AuthController.handleLoginVerifyOtp)
+AuthRouter.post(
+  '/otp/verify',
+  limitRate({ max: rateLimitConfig.sendAuthOtp }),
+  AuthController.handleLoginVerifyOtp,
+)
 
 /**
  * Sign the user out of the session by clearing the relevant session cookie

--- a/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -42,7 +42,10 @@ PublicFormsVerificationRouter.route(
  */
 PublicFormsVerificationRouter.route(
   '/:formId([a-fA-F0-9]{24})/fieldverifications/:transactionId([a-fA-F0-9]{24})/fields/:fieldId([a-fA-F0-9]{24})/otp/verify',
-).post(VerificationController.handleOtpVerification)
+).post(
+  limitRate({ max: rateLimitConfig.sendAuthOtp }),
+  VerificationController.handleOtpVerification,
+)
 
 /**
  * Route for generating a new otp for a given field

--- a/src/app/routes/api/v3/user/user.routes.ts
+++ b/src/app/routes/api/v3/user/user.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express'
 
+import { rateLimitConfig } from '../../../../config/config'
 import * as UserController from '../../../../modules/user/user.controller'
+import { limitRate } from '../../../../utils/limit-rate'
 
 export const UserRouter = Router()
 
@@ -27,7 +29,11 @@ UserRouter.get('/', UserController.handleFetchUser)
  * @returns 422 on OTP creation or SMS send failure, or if the user cannot be found
  * @returns 500 on application or database errors
  */
-UserRouter.post('/contact/otp/generate', UserController.handleContactSendOtp)
+UserRouter.post(
+  '/contact/otp/generate',
+  limitRate({ max: rateLimitConfig.sendAuthOtp }),
+  UserController.handleContactSendOtp,
+)
 
 /**
  * Verify the contact verification one-time password (OTP) for the user as part
@@ -40,6 +46,10 @@ UserRouter.post('/contact/otp/generate', UserController.handleContactSendOtp)
  * @returns 422 when OTP is invalid
  * @returns 500 when OTP is malformed or for unknown errors
  */
-UserRouter.post('/contact/otp/verify', UserController.handleContactVerifyOtp)
+UserRouter.post(
+  '/contact/otp/verify',
+  limitRate({ max: rateLimitConfig.sendAuthOtp }),
+  UserController.handleContactVerifyOtp,
+)
 
 export default UserRouter


### PR DESCRIPTION
previously only had rate limits on auth.

Verification endpoints won't invoke the super expensive hash comparisons since the verification document will not exist in the first place, but verification endpoints also invoke some database queries, might as well rate limit those too.

Fixing some CodeQL flagged issues