### PR TITLE
chore: remove dependabot triggers for react /frontend directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,4 +38,3 @@ updates:
     labels:
       - 'react'
       - 'dependencies'
-    target-branch: 'form-v2/develop'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,16 +25,3 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/frontend' # Location of package manifests
-    schedule:
-      interval: 'daily'
-      time: '05:00'
-      timezone: 'Asia/Singapore'
-    commit-message:
-      prefix: 'fix'
-      prefix-development: 'chore'
-      include: 'scope'
-    labels:
-      - 'react'
-      - 'dependencies'


### PR DESCRIPTION
Dependabot is creating new PRs to target form-v2/develop, which is pointless. Removing that.