### PR TITLE
fix: change sidebar copy

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -44,7 +44,7 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
   return (
     <DrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
-        <FormLabel>Section header</FormLabel>
+        <FormLabel>Section heading</FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -61,7 +61,7 @@ export const FieldListDrawer = (): JSX.Element => {
       <Box pt="1rem" px="1.5rem" bg="white">
         <Flex justify="space-between">
           <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
-            Builder
+            Fields
           </Text>
           <CreatePageDrawerCloseButton />
         </Flex>

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
@@ -65,7 +65,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
     >
       <Stack spacing="0.5rem">
         <DrawerTabIcon
-          label="Build your form"
+          label="Add fields"
           icon={<BxsWidget fontSize="1.5rem" />}
           onClick={handleDrawerBuilderClick}
           isActive={activeTab === DrawerTabs.Builder}
@@ -79,7 +79,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
           id={FEATURE_TOUR[1].id}
         />
         <DrawerTabIcon
-          label="Add conditional logic"
+          label="Add logic"
           icon={<BiGitMerge fontSize="1.5rem" />}
           onClick={handleDrawerLogicClick}
           isActive={activeTab === DrawerTabs.Logic}

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -69,7 +69,7 @@ export const BASICFIELD_TO_DRAWER_META: {
   },
 
   [BasicField.Section]: {
-    label: 'Header',
+    label: 'Heading',
     icon: BiHeading,
     isSubmitted: false,
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR makes different copy changes, based on the results from user tests. 

Closes #5017

## Solution
<!-- How did you solve the problem? -->
Changes made:

- Change Builder button tooltip to 'Add fields'
- Change Logic button tooltip to 'Add logic'
- Change BUILDER Widget drawer title to 'FIELDS'
- Change Header field to 'Heading'

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

