### PR TITLE
chore(ci): set default working directory of chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,10 @@
 # Workflow name
 name: 'Chromatic'
 
+defaults:
+  run:
+    working-directory: frontend
+
 # Event for the workflow
 on: push
 


### PR DESCRIPTION
so chromatic's  `npm i` step does not take unnecessary runtime (and also reduces chance of Turbosnap not working properly due to root's `package.lock` changes)
