### PR TITLE
fix: update builder drawer design

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -85,25 +85,23 @@ const BasicFieldPanelContent = () => {
   const { isLoading } = useCreateTabForm()
 
   return (
-    <>
-      <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
-        {(provided) => (
-          <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection>
-              {BASIC_FIELDS_ORDERED.map((fieldType, index) => (
-                <DraggableBasicFieldListOption
-                  index={index}
-                  isDisabled={isLoading}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              ))}
-              <Box display="none">{provided.placeholder}</Box>
-            </FieldSection>
-          </Box>
-        )}
-      </Droppable>
-    </>
+    <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
+      {(provided) => (
+        <Box ref={provided.innerRef} {...provided.droppableProps}>
+          <FieldSection>
+            {BASIC_FIELDS_ORDERED.map((fieldType, index) => (
+              <DraggableBasicFieldListOption
+                index={index}
+                isDisabled={isLoading}
+                key={index}
+                fieldType={fieldType}
+              />
+            ))}
+            <Box display="none">{provided.placeholder}</Box>
+          </FieldSection>
+        </Box>
+      )}
+    </Droppable>
   )
 }
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -21,8 +21,8 @@ import Link from '~components/Link'
 import { Tab } from '~components/Tabs'
 
 import {
+  BASIC_FIELDS_ORDERED,
   CREATE_FIELD_DROP_ID,
-  CREATE_FIELD_FIELDS_ORDERED,
   CREATE_MYINFO_CONTACT_DROP_ID,
   CREATE_MYINFO_CONTACT_FIELDS_ORDERED,
   CREATE_MYINFO_MARRIAGE_DROP_ID,
@@ -31,8 +31,6 @@ import {
   CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED,
   CREATE_MYINFO_PERSONAL_DROP_ID,
   CREATE_MYINFO_PERSONAL_FIELDS_ORDERED,
-  CREATE_PAGE_DROP_ID,
-  CREATE_PAGE_FIELDS_ORDERED,
 } from '~features/admin-form/create/builder-and-design/constants'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
 import { isMyInfo } from '~features/myinfo/utils'
@@ -88,28 +86,11 @@ const BasicFieldPanelContent = () => {
 
   return (
     <>
-      <Droppable isDropDisabled droppableId={CREATE_PAGE_DROP_ID}>
-        {(provided) => (
-          <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Page">
-              {CREATE_PAGE_FIELDS_ORDERED.map((fieldType, index) => (
-                <DraggableBasicFieldListOption
-                  index={index}
-                  isDisabled={isLoading}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              ))}
-            </FieldSection>
-            <Box display="none">{provided.placeholder}</Box>
-          </Box>
-        )}
-      </Droppable>
       <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Fields">
-              {CREATE_FIELD_FIELDS_ORDERED.map((fieldType, index) => (
+            <FieldSection>
+              {BASIC_FIELDS_ORDERED.map((fieldType, index) => (
                 <DraggableBasicFieldListOption
                   index={index}
                   isDisabled={isLoading}
@@ -117,8 +98,8 @@ const BasicFieldPanelContent = () => {
                   fieldType={fieldType}
                 />
               ))}
+              <Box display="none">{provided.placeholder}</Box>
             </FieldSection>
-            <Box display="none">{provided.placeholder}</Box>
           </Box>
         )}
       </Droppable>
@@ -275,7 +256,7 @@ const FieldSection = ({
   label,
   children,
 }: {
-  label: string
+  label?: string
   children: React.ReactNode
 }) => {
   return (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -259,19 +259,21 @@ const FieldSection = ({
 }) => {
   return (
     <Box mb="0.5rem">
-      <Text
-        px="1.5rem"
-        pt="1rem"
-        pb="0.75rem"
-        textStyle="subhead-2"
-        color="secondary.500"
-        pos="sticky"
-        top={0}
-        bg="white"
-        zIndex="docked"
-      >
-        {label}
-      </Text>
+      {label ? (
+        <Text
+          px="1.5rem"
+          pt="1rem"
+          pb="0.75rem"
+          textStyle="subhead-2"
+          color="secondary.500"
+          pos="sticky"
+          top={0}
+          bg="white"
+          zIndex="docked"
+        >
+          {label}
+        </Text>
+      ) : null}
       <Stack divider={<StackDivider />} spacing={0}>
         {children}
       </Stack>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignTab.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignTab.tsx
@@ -21,8 +21,8 @@ import { BuilderAndDesignContent } from './BuilderAndDesignContent'
 import { BuilderAndDesignContext } from './BuilderAndDesignContext'
 import { BuilderAndDesignDrawer } from './BuilderAndDesignDrawer'
 import {
+  BASIC_FIELDS_ORDERED,
   CREATE_FIELD_DROP_ID,
-  CREATE_FIELD_FIELDS_ORDERED,
   CREATE_MYINFO_CONTACT_DROP_ID,
   CREATE_MYINFO_CONTACT_FIELDS_ORDERED,
   CREATE_MYINFO_MARRIAGE_DROP_ID,
@@ -31,8 +31,6 @@ import {
   CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED,
   CREATE_MYINFO_PERSONAL_DROP_ID,
   CREATE_MYINFO_PERSONAL_FIELDS_ORDERED,
-  CREATE_PAGE_DROP_ID,
-  CREATE_PAGE_FIELDS_ORDERED,
   FIELD_LIST_DROP_ID,
 } from './constants'
 import { DeleteFieldModal } from './DeleteFieldModal'
@@ -80,16 +78,9 @@ export const BuilderAndDesignTab = (): JSX.Element => {
       if (!data || !destination) return
 
       switch (source.droppableId) {
-        case CREATE_PAGE_DROP_ID: {
-          return setToCreating(
-            getFieldCreationMeta(CREATE_PAGE_FIELDS_ORDERED[source.index]),
-            destination.index,
-          )
-        }
-
         case CREATE_FIELD_DROP_ID: {
           return setToCreating(
-            getFieldCreationMeta(CREATE_FIELD_FIELDS_ORDERED[source.index]),
+            getFieldCreationMeta(BASIC_FIELDS_ORDERED[source.index]),
             destination.index,
           )
         }

--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -92,9 +92,6 @@ export const MYINFO_DATEFIELD_META: MyInfoFieldMeta<DateFieldBase> = {
   },
 }
 
-export const CREATE_PAGE_FIELDS_ORDERED = BASIC_FIELDS_ORDERED.slice(0, 3)
-export const CREATE_FIELD_FIELDS_ORDERED = BASIC_FIELDS_ORDERED.slice(3)
-
 export const CREATE_MYINFO_PERSONAL_FIELDS_ORDERED =
   MYINFO_FIELDS_ORDERED.slice(0, 13)
 
@@ -109,7 +106,6 @@ export const CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED =
 export const CREATE_MYINFO_MARRIAGE_FIELDS_ORDERED =
   MYINFO_FIELDS_ORDERED.slice(19, 24)
 
-export const CREATE_PAGE_DROP_ID = 'create-fields-page'
 export const CREATE_FIELD_DROP_ID = 'create-fields-field'
 
 export const CREATE_MYINFO_PERSONAL_DROP_ID = 'create-myinfo-personal'

--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -13,26 +13,25 @@ import {
 import { MyInfoFieldMeta } from '~features/myinfo/types'
 
 export const BASIC_FIELDS_ORDERED = [
-  // Page section
-  BasicField.Section,
-  BasicField.Statement,
-  BasicField.Image,
-  // Fields section
   BasicField.ShortText,
   BasicField.LongText,
   BasicField.Radio,
   BasicField.Checkbox,
-  BasicField.Mobile,
-  BasicField.Email,
-  BasicField.HomeNo,
   BasicField.Dropdown,
+  BasicField.Section,
+  BasicField.Statement,
   BasicField.YesNo,
   BasicField.Rating,
+  BasicField.Email,
+  BasicField.Mobile,
+  BasicField.HomeNo,
+  BasicField.Date,
+  BasicField.Image,
+  BasicField.Table,
+  BasicField.Attachment,
   BasicField.Number,
   BasicField.Decimal,
-  BasicField.Attachment,
   BasicField.Date,
-  BasicField.Table,
   BasicField.Nric,
   BasicField.Uen,
 ]


### PR DESCRIPTION
## Solution
<!-- What problem are you trying to solve? What issue does this close? -->
The builder drawer has been redesigned. This PR
- rearranges the fields
- removes 'Page' and 'Field' sections from the drawer

Additionally, `FieldSection`'s `label` prop is now optional.

Closes #5016

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Drag and drop a field that was previously under the 'Page' section. Field should appear in the builder, in preview and in the public form.
- [x] Repeat the same for a field that was previously under the 'Field' section. Field should appear in the builder, in preview and in the public form.
- [x] Repeat the same 2 tests above, but instead of drag and drop, click the field. Field should appear in the builder, in preview and in the public form.
