### PR TITLE
chore(ci): update chromatic workflow to ignore non-frontend directory changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -56,3 +56,5 @@ jobs:
           onlyChanged: true
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
+          # Only run when the frontend directory has changes
+          untraced: '!(frontend)/**'

--- a/frontend/src/components/Badge/Badge.stories.tsx
+++ b/frontend/src/components/Badge/Badge.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Badge',
   component: Badge,
   decorators: [],
-} as Meta
+} as Meta<BadgeProps>
 
 const Template: Story<BadgeProps> = (args) => <Badge {...args} />
 


### PR DESCRIPTION
Chromatic's Turbosnap keeps detecting root `package.json` as having changes, wasting our snapshots by rebuilding all stories when it is not needed.

This PR attempts to only trigger snapshots when the frontend directory has changes.