### PR TITLE
perf(v2): use modified version of useMeasure to prevent choppy animation

### DIFF
--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -7,10 +7,10 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { useMeasure } from 'react-use'
 import { UseMeasureRef } from 'react-use/lib/useMeasure'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useMeasure } from '~hooks/useMeasure'
 
 import { FieldListTabIndex } from '../../builder-and-design/constants'
 import {

--- a/frontend/src/hooks/useMeasure.ts
+++ b/frontend/src/hooks/useMeasure.ts
@@ -1,0 +1,54 @@
+// from react-use https://github.com/streamich/react-use/blob/master/src/useMeasure.ts
+// modified to debounce setRect call prevent rerenders during animation
+import { useLayoutEffect, useMemo, useState } from 'react'
+import { debounce } from 'lodash'
+
+export type UseMeasureRect = Pick<
+  DOMRectReadOnly,
+  'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
+>
+export type UseMeasureRef<E extends Element = Element> = (element: E) => void
+export type UseMeasureResult<E extends Element = Element> = [
+  UseMeasureRef<E>,
+  UseMeasureRect,
+]
+
+const defaultState: UseMeasureRect = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+}
+
+export function useMeasure<E extends Element = Element>(): UseMeasureResult<E> {
+  const [element, ref] = useState<E | null>(null)
+  const [rect, setRect] = useState<UseMeasureRect>(defaultState)
+
+  const deboucedSetRect = useMemo(() => debounce(setRect, 100), [])
+
+  const observer = useMemo(
+    () =>
+      new ResizeObserver((entries) => {
+        if (entries[0]) {
+          const { x, y, width, height, top, left, bottom, right } =
+            entries[0].contentRect
+          deboucedSetRect({ x, y, width, height, top, left, bottom, right })
+        }
+      }),
+    [deboucedSetRect],
+  )
+
+  useLayoutEffect(() => {
+    if (!element) return
+    observer.observe(element)
+    return () => {
+      observer.disconnect()
+    }
+  }, [element, observer])
+
+  return [ref, rect]
+}


### PR DESCRIPTION
## Problem
realised my previous PR #4836 causes drawer animation to be choppy as constantly changing width triggers rerenders.

## Solution
modified useMeasure to debounce setState calls so it doesnt get called so often. Animations are now smooth but there still seems to be a very slight delay when opening drawer as compared to without the useMeasure hook. maybe reverting to simple breakpoints can be considered.