### PR TITLE
fix: harden ssh server

### DIFF
--- a/.ebextensions/harden_sshd.config
+++ b/.ebextensions/harden_sshd.config
@@ -1,9 +1,9 @@
-container_commands:
+commands:
     harden_sshd_remove_weak_ciphers_and_key_exchange_algos:
         command:
-            - "sudo sed -i -E '/ciphers|kexalgorithms/d' /etc/ssh/sshd_config"
-            - "echo '' | sudo tee -a /etc/ssh/sshd_config"
-            - "echo 'ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com' | sudo tee -a /etc/ssh/sshd_config"
-            - "echo '' | sudo tee -a /etc/ssh/sshd_config"
-            - "echo 'kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256' | sudo tee -a /etc/ssh/sshd_config"
-            - "sudo systemctl restart sshd"
+            - "sed -i -r '/ciphers|kexalgorithms/d' /etc/ssh/sshd_config"
+            - "echo '' >> /etc/ssh/sshd_config"
+            - "echo 'ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com' >> /etc/ssh/sshd_config"
+            - "echo '' >> /etc/ssh/sshd_config"
+            - "echo 'kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256' >> /etc/ssh/sshd_config"
+            - "systemctl restart sshd"

--- a/.ebextensions/harden_sshd.config
+++ b/.ebextensions/harden_sshd.config
@@ -1,0 +1,9 @@
+container_commands:
+    harden_sshd_remove_weak_ciphers_and_key_exchange_algos:
+        command:
+            - "sudo sed -i -E '/ciphers|kexalgorithms/d' /etc/ssh/sshd_config"
+            - "echo '' | sudo tee -a /etc/ssh/sshd_config"
+            - "echo 'ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com' | sudo tee -a /etc/ssh/sshd_config"
+            - "echo '' | sudo tee -a /etc/ssh/sshd_config"
+            - "echo 'kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256' | sudo tee -a /etc/ssh/sshd_config"
+            - "sudo systemctl restart sshd"

--- a/.ebextensions/harden_sshd.config
+++ b/.ebextensions/harden_sshd.config
@@ -1,9 +1,10 @@
 commands:
     harden_sshd_remove_weak_ciphers_and_key_exchange_algos:
-        command:
-            - "sed -i -r '/ciphers|kexalgorithms/d' /etc/ssh/sshd_config"
-            - "echo '' >> /etc/ssh/sshd_config"
-            - "echo 'ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com' >> /etc/ssh/sshd_config"
-            - "echo '' >> /etc/ssh/sshd_config"
-            - "echo 'kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256' >> /etc/ssh/sshd_config"
-            - "systemctl restart sshd"
+        command: |
+            echo "Hardening sshd server now"
+            sed -i -r '/ciphers|kexalgorithms/d' /etc/ssh/sshd_config
+            echo '' >> /etc/ssh/sshd_config
+            echo 'ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com' >> /etc/ssh/sshd_config
+            echo '' >> /etc/ssh/sshd_config
+            echo 'kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256' >> /etc/ssh/sshd_config
+            systemctl restart sshd


### PR DESCRIPTION
## Problem
FormSG runs in Elastic BeanStalk and SSH is not opened by default. Occasionally we do ssh in for some inspection (run traceroutes, inspect EFS and shared files), this is done with access control limited to VPN.

Even though the SSH access scheme is locked down pretty well, the ssh server itself should disallow weak ciphers and weak key exchange algorithms, in particular CBC ciphers, and weak diffie_helman variant of key exchange algorithms.


## Solution
Rather than building a custom image that we have to maintain, we let the EB deployment harden the SSH server on deployment through the use of an ebextension file.

We cannot just removed ciphers and algos we don't want, but instead we must state the ciphers and algos we specifically allow. 

- [x] Tested on staging and verified by pairing with @justynoh 


