### PR TITLE
chore: remove the double build-step for EB deployment

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -32,13 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'npm'
       - name: Build
         env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
           REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
           REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
           REACT_APP_DD_RUM_ENV: ${{ secrets.DD_ENV }}
@@ -50,11 +45,6 @@ jobs:
           echo REACT_APP_DD_RUM_ENV=$REACT_APP_DD_RUM_ENV >> frontend/.env
           echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
           echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
-          npm ci
-          set -e
-          npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
-          npm run lint-ci
-          npm run build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -17,8 +17,10 @@ RUN npm ci
 
 COPY . ./
 
-ENV NODE_OPTIONS=--max-old-space-size=3072
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
+RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
+RUN npm run lint-ci
 RUN npm run build
 RUN npm prune --production
 


### PR DESCRIPTION
## Problem
Our deployments are slow because we build twice:
- once as a github action step
- once in the docker image creation

That should be unnecessary. If the docker image building fails, the overall github action should also fails.

## Solution
Drop build step from github action

TODO:
- [x] Test on staging that a deployment is successful with a single build step
- [x] Test on staging that, say, a compilation error, causes the overall github workflow to fail when the docker build step fails
