### PR TITLE
feat(express): return http errors as-is

### DIFF
--- a/src/app/loaders/express/error-handler.ts
+++ b/src/app/loaders/express/error-handler.ts
@@ -3,6 +3,7 @@ import { ErrorRequestHandler, RequestHandler } from 'express'
 import { HttpError, isHttpError } from 'http-errors'
 import { StatusCodes } from 'http-status-codes'
 import get from 'lodash/get'
+import { types } from 'util'
 
 import { createLoggerWithLabel } from '../../config/logger'
 
@@ -13,6 +14,12 @@ const isBodyParserError = (
   err: unknown,
 ): err is HttpError & { type: string } => {
   return isHttpError(err) && 'type' in err
+}
+
+const isHTTPLikeError = (
+  err: unknown,
+): err is Error & { statusCode: number } => {
+  return types.isNativeError(err) && 'statusCode' in err
 }
 
 const errorHandlerMiddlewares = (): (
@@ -37,14 +44,19 @@ const errorHandlerMiddlewares = (): (
     } else {
       const genericErrorMessage =
         'Apologies, something odd happened. Please try again later!'
+
+      const log_meta = {
+        action: 'genericErrorHandlerMiddleware',
+        // formId is only present for Joi validated routes that require it
+        formId: get(req, 'form._id', null),
+      }
+
       // Error page
       if (isCelebrateError(err)) {
         logger.error({
           message: 'Joi validation error',
           meta: {
-            action: 'genericErrorHandlerMiddleware',
-            // formId is only present for Joi validated routes that require it
-            formId: get(req, 'form._id', null),
+            ...log_meta,
             details: Object.fromEntries(err.details),
           },
           error: err,
@@ -56,9 +68,7 @@ const errorHandlerMiddlewares = (): (
         logger.error({
           message: 'Body parser error',
           meta: {
-            action: 'genericErrorHandlerMiddleware',
-            // formId is only present for Joi validated routes that require it
-            formId: get(req, 'form._id', null),
+            ...log_meta,
             details: {
               type: err.type,
               message: err.message,
@@ -74,11 +84,28 @@ const errorHandlerMiddlewares = (): (
         return res.status(err.status).json({ message: genericErrorMessage })
       }
 
+      if (isHTTPLikeError(err)) {
+        logger.error({
+          message: `HTTP Error ${err.statusCode}`,
+          meta: {
+            ...log_meta,
+            details: {
+              message: err.message,
+            },
+          },
+          error: err,
+        })
+        return res.status(err.statusCode).json({ message: err.message })
+      }
+
       // Unknown errors
       logger.error({
         message: 'Unknown error',
         meta: {
-          action: 'genericErrorHandlerMiddleware',
+          ...log_meta,
+          details: {
+            message: err.message,
+          },
         },
         error: err,
       })


### PR DESCRIPTION
## Problem
Path parsing error are returned as 500 and cause our monitoring to alert the person on call.

## Solution

Intercept HTTP-like errors in the final generic error handler and return 400 as needed.


## Tests

- [x] Very that a bad request causes a 400:

```bash
curl -v https://staging.form.gov.sg/%c0
```
