### PR TITLE
fix: update form guide links

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -9,31 +9,28 @@ export const OSS_README =
 export const SINGPASS_FAQ = 'https://www.singpass.gov.sg/main/html/faq.html'
 
 // FormSG guide links
-export const FORM_GUIDE = 'https://go.gov.sg/form-guide'
-export const GUIDE_WEBHOOKS =
-  'https://guide.form.gov.sg/AdvancedGuide.html#webhooks'
-export const GUIDE_EMAIL_MODE =
-  'https://guide.form.gov.sg/AdvancedGuide.html#email-mode'
-export const GUIDE_STORAGE_MODE = 'https://go.gov.sg/form-what-is-storage-mode'
-export const GUIDE_FORM_LOGIC =
-  'https://guide.form.gov.sg/AdvancedGuide.html#form-logic'
+export const FORM_GUIDE = 'https://go.gov.sg/formsg-guides'
+export const GUIDE_WEBHOOKS = 'https://go.gov.sg/formsg-guide-webhooks'
+export const GUIDE_EMAIL_MODE = 'https://go.gov.sg/formsg-guide-email-mode'
+export const GUIDE_STORAGE_MODE = 'https://go.gov.sg/formsg-guide-storage-mode'
+export const GUIDE_FORM_LOGIC = 'https://go.gov.sg/formsg-guide-logic'
 export const GUIDE_SPCP_ESRVCID =
-  'https://guide.form.gov.sg/AdvancedGuide.html#singpass-corppass-and-myinfo'
+  'https://go.gov.sg/formsg-guide-singpass-myinfo'
 export const GUIDE_ENABLE_SPCP =
-  'https://guide.form.gov.sg/AdvancedGuide.html#how-do-you-enable-singpass-or-corppass'
-export const GUIDE_TWILIO =
-  'https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-arrange-payment-for-verified-sms'
+  'https://go.gov.sg/formsg-guide-singpass-myinfo-enable'
+export const GUIDE_TWILIO = 'https://go.gov.sg/formsg-guide-verified-smses'
 export const GUIDE_ATTACHMENT_SIZE_LIMIT =
-  'https://guide.form.gov.sg/AdvancedGuide.html#how-do-i-increase-attachment-size-limit-and-what-if-there-are-many-attachments-for-my-form'
-export const GUIDE_E2EE =
-  'https://guide.form.gov.sg/AdvancedGuide.html#how-does-end-to-end-encryption-work'
+  'https://go.gov.sg/formsg-guide-attachment-size-increase'
+export const GUIDE_E2EE = 'https://go.gov.sg/formsg-guide-e2e'
 export const GUIDE_TRANSFER_OWNERSHIP =
-  'https://guide.form.gov.sg/AdvancedGuide.html#i-am-leaving-the-organisation-or-switching-over-to-a-new-email-how-do-i-transfer-ownership-of-my-forms'
-export const GUIDE_SECRET_KEY_LOSS = 'https://go.gov.sg/secretkeyloss'
+  'https://go.gov.sg/formsg-guide-transfer-ownership'
+export const GUIDE_SECRET_KEY_LOSS =
+  'https://go.gov.sg/formsg-guide-secret-key-loss'
 export const GUIDE_PREVENT_EMAIL_BOUNCE =
-  'https://go.gov.sg/form-prevent-bounce'
+  'https://go.gov.sg/formsg-guide-email-bounce'
 export const GUIDE_EMAIL_RELIABILITY =
-  'https://go.gov.sg/form-email-reliability'
+  'https://go.gov.sg/formsg-guide-email-reliability'
+export const GUIDE_PREFILL = 'https://go.gov.sg/formsg-guide-prefills'
 
 export const ACCEPTED_FILETYPES_SPREADSHEET = 'https://go.gov.sg/formsg-cwl'
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -10,6 +10,7 @@ import { extend, isEmpty, pick } from 'lodash'
 
 import { ShortTextFieldBase, TextSelectedValidation } from '~shared/types/field'
 
+import { GUIDE_PREFILL } from '~constants/links'
 import { createBaseValidationRules } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -214,7 +215,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
         <Toggle
           {...register('allowPrefill')}
           label="Enable pre-fill"
-          description="Use the Field ID to pre-populate this field for your users via an URL. [Learn how](https://go.gov.sg/form-prefill)"
+          description={`Use the Field ID to pre-populate this field for your users via an URL. [Learn how](${GUIDE_PREFILL})`}
         />
         {watchAllowPrefill ? (
           <InputGroup mt="0.5rem">

--- a/frontend/src/features/admin-form/settings/components/WebhooksSection/RetryToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/WebhooksSection/RetryToggle.tsx
@@ -1,5 +1,6 @@
 import { ChangeEventHandler, useCallback } from 'react'
 
+import { GUIDE_WEBHOOKS } from '~constants/links'
 import Toggle from '~components/Toggle'
 
 import { useMutateFormSettings } from '../../mutations'
@@ -24,7 +25,7 @@ export const RetryToggle = (): JSX.Element | null => {
       isLoading={mutateWebhookRetries.isLoading}
       isChecked={settings.webhook.isRetryEnabled}
       label="Enable retries"
-      description={`Your system must meet certain requirements before retries can be safely enabled. [Learn more](https://go.gov.sg/form-webhook-retries)`}
+      description={`Your system must meet certain requirements before retries can be safely enabled. [Learn more](${GUIDE_WEBHOOKS})`}
       onChange={handleToggleRetry}
     />
   )

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -14,6 +14,7 @@ import { TwilioCredentials } from '~shared/types/twilio'
 
 import { ApiError } from '~typings/core'
 
+import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
 import { useToast } from '~hooks/useToast'
 import { formatOrdinal } from '~utils/stringFormat'
 
@@ -98,7 +99,7 @@ export const useMutateFormSettings = () => {
         const toastStatusPublicMessage =
           newData.responseMode === FormResponseMode.Encrypt
             ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
-            : `Your form is now open.\n\nIf you expect a large number of responses,  [AutoArchive your mailbox](https://go.gov.sg/form-prevent-bounce) to avoid losing any of them.`
+            : `Your form is now open.\n\nIf you expect a large number of responses,  [AutoArchive your mailbox](${GUIDE_PREVENT_EMAIL_BOUNCE}) to avoid losing any of them.`
         const toastStatusClosedMessage = 'Your form is closed to new responses.'
         const toastStatusMessage = isNowPublic
           ? toastStatusPublicMessage

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -11,6 +11,7 @@ import {
 
 import { FormResponseMode } from '~shared/types/form/form'
 
+import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
 import { FORM_TITLE_VALIDATION_RULES } from '~utils/formValidation'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -99,7 +100,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             <FormControl isRequired isInvalid={!!errors.emails} mb="2.25rem">
               <FormLabel
                 useMarkdownForDescription
-                description="Specify up to 30 emails. [How to guard against bounce emails](https://go.gov.sg/form-prevent-bounce)."
+                description={`Specify up to 30 emails. [How to guard against bounce emails](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
               >
                 Emails where responses will be sent
               </FormLabel>

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -28,6 +28,7 @@ import FormBrandLogo from '~/assets/svgs/brand/brand-mark-colour.svg'
 import { BxlGithub } from '~assets/icons/BxlGithub'
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import {
+  CONTACT_US,
   FORM_GUIDE,
   GUIDE_ATTACHMENT_SIZE_LIMIT,
   GUIDE_E2EE,
@@ -344,7 +345,7 @@ export const LandingPage = (): JSX.Element => {
 
                   4. If you remember sending an email to share your secret key with collaborators, search the Sent folder in your email for the keyword 'secret key' and your form title. 
 
-                  5. If you still cannot find your secret key and would like our help to debug this further, contact us on our [help form](https://go.gov.sg/form-help). 
+                  5. If you still cannot find your secret key and would like our help to debug this further, contact us on our [help form](${CONTACT_US}). 
 
                   Without your secret key, you will not be able to access your existing response data. Additionally, it's not possible for us to recover your lost secret key or response data on your behalf. This is because Form does not retain your secret key or any other way to unlock your encrypted data - the only way to ensure response data is truly private to agencies only. This is an important security benefit, because that means even if our server were to be compromised, an attacker would never be able to unlock your encrypted responses.
                 `}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
- Point links to the new form guide for React
- Use link constants

Closes #5108

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Check that all links work and point to the new form guide

