### PR TITLE
fix: add transformAllIsoStringsToDate step on form preview dto

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -51,20 +51,22 @@ export const previewForm = async (
 ): Promise<PreviewFormViewDto> => {
   return ApiService.get<PreviewFormViewDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/preview`,
-  ).then(({ data }) => {
-    // Add default mock authenticated state if previewing an authenticatable form
-    // and if server has not already sent back a mock authenticated state.
-    if (data.form.authType !== FormAuthType.NIL && !data.spcpSession) {
-      data.spcpSession = { userName: PREVIEW_MOCK_UINFIN }
-    }
+  )
+    .then(({ data }) => {
+      // Add default mock authenticated state if previewing an authenticatable form
+      // and if server has not already sent back a mock authenticated state.
+      if (data.form.authType !== FormAuthType.NIL && !data.spcpSession) {
+        data.spcpSession = { userName: PREVIEW_MOCK_UINFIN }
+      }
 
-    // Inject MyInfo preview values into form fields (if they are MyInfo fields).
-    data.form.form_fields = data.form.form_fields.map(
-      augmentWithMyInfoDisplayValue,
-    )
+      // Inject MyInfo preview values into form fields (if they are MyInfo fields).
+      data.form.form_fields = data.form.form_fields.map(
+        augmentWithMyInfoDisplayValue,
+      )
 
-    return data
-  })
+      return data
+    })
+    .then(transformAllIsoStringsToDate)
 }
 
 export const getFreeSmsQuota = async (formId: string) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Preview form was crashing due to type mismatch in the preview form DTO.
This PR fixes that :(.

No prod impact since it is not released yet.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible, but we should really get it merged in.


**Bug Fixes**:

- fix: add `transformAllIsoStringsToDate` step on form preview dto


## Tests
- [ ] Open date picker with custom date range in preview. Should work properly and dates correctly disabled if out of range. Should have no runtime errors