### PR TITLE
fix(client): remove duplicate selectable date field in Builder drawer

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -31,7 +31,6 @@ export const BASIC_FIELDS_ORDERED = [
   BasicField.Attachment,
   BasicField.Number,
   BasicField.Decimal,
-  BasicField.Date,
   BasicField.Nric,
   BasicField.Uen,
 ]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR removes a duplicate Date field entry in the form builder drawer

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


@wanlingt check if this is the correct order? I removed the "older" entry.