### PR TITLE
fix: set staletime to 0 for response count, feedback and free SMS queries

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16566,7 +16566,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
@@ -23844,7 +23844,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -24253,7 +24253,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         }
       }
@@ -27015,7 +27015,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
@@ -36084,7 +36084,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "strip-ansi": {
@@ -40578,7 +40578,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "anymatch": {
@@ -41069,7 +41069,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "strip-ansi": {

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -65,8 +65,10 @@ export const useFreeSmsQuota = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided to useFreeSmsQuota')
 
-  return useQuery(adminFormKeys.freeSmsCount(formId), () =>
-    getFreeSmsQuota(formId),
+  return useQuery(
+    adminFormKeys.freeSmsCount(formId),
+    () => getFreeSmsQuota(formId),
+    { staleTime: 0 },
   )
 }
 

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -60,7 +60,7 @@ export const useFormResponsesCount = (
   return useQuery(
     adminFormResponsesKeys.count(formId, dateParams),
     () => countFormSubmissions({ formId, dates }),
-    { staleTime: 10 * 60 * 1000 },
+    { staleTime: 0 },
   )
 }
 
@@ -104,7 +104,9 @@ export const useFormFeedback = (): UseQueryResult<FormFeedbackMetaDto> => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  return useQuery(adminFormFeedbackKeys.id(formId), () =>
-    getFormFeedback(formId),
+  return useQuery(
+    adminFormFeedbackKeys.id(formId),
+    () => getFormFeedback(formId),
+    { staleTime: 0 },
   )
 }

--- a/frontend/src/features/admin-form/settings/queries.ts
+++ b/frontend/src/features/admin-form/settings/queries.ts
@@ -22,6 +22,6 @@ export const useAdminFormSettings = (): UseQueryResult<FormSettings> => {
   return useQuery(
     adminFormSettingsKeys.id(formId),
     () => getFormSettings(formId),
-    { staleTime: 10 * 60 * 1000 },
+    { staleTime: 0 },
   )
 }


### PR DESCRIPTION
## Problem

Email response count, Form feedback and free SMS verification count does not get updated. They should, since they are real-time data influenced by user responses.

Closes #5053 

## Solution
Set staletime to 0 for these queries.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/195236594-55260cd6-2446-47ee-99fc-10c86e914437.mov
