### PR TITLE
feat: update copy for the 'submit other responses' button

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -74,7 +74,7 @@ const FORM_DEFAULTS = {
   },
   endPage: {
     title: 'Thank you for filling out the form.',
-    buttonText: 'Submit another form',
+    buttonText: 'Submit another response',
   },
   hasCaptcha: true,
   form_fields: [],
@@ -1589,7 +1589,7 @@ describe('Form Model', () => {
           endPage: {
             ...updatedEndPage,
             // Defaults should be populated and returned
-            buttonText: 'Submit another form',
+            buttonText: 'Submit another response',
             title: 'Thank you for filling out the form.',
           },
         })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -323,7 +323,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         buttonLink: String,
         buttonText: {
           type: String,
-          default: 'Submit another form',
+          default: 'Submit another response',
         },
       },
 


### PR DESCRIPTION
( Taking over https://github.com/opengovsg/FormSG/pull/5086 for release )

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
End page default button copy
Closes #5064

## Solution
Change from "Submit another form" to "Submit another response" in 2 files

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
