### PR TITLE
fix: admin navbar links open in new tab

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -84,6 +84,7 @@ const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
       color="secondary.500"
       href={href}
       aria-label={label}
+      target="_blank"
     >
       {label}
     </Link>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #5124

## Screenshots
![Recording 2022-10-12 at 13 58 08](https://user-images.githubusercontent.com/56983748/195261772-8e696bb4-e303-412a-8b08-d77a4dcb7e92.gif)

## Tests
- [ ] links in admin navbar should open in a new tab
