### PR TITLE
fix: add option 2 to radio, checkbox and dropdown options

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -91,6 +91,7 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
       >
         <FormLabel>Options</FormLabel>
         <Textarea
+          placeholder="Enter one option per line"
           {...register('fieldOptionsString', {
             validate: SPLIT_TEXTAREA_VALIDATION,
           })}

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -62,7 +62,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
           customMin: null,
         },
         validateByValue: false,
-        fieldOptions: ['Option 1'],
+        fieldOptions: ['Option 1', 'Option 2'],
         othersRadioButton: false,
       }
     }
@@ -107,7 +107,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
       return {
         fieldType,
         ...baseMeta,
-        fieldOptions: ['Option 1'],
+        fieldOptions: ['Option 1', 'Option 2'],
       }
     }
     case BasicField.Image: {
@@ -151,7 +151,7 @@ export const getFieldCreationMeta = (fieldType: BasicField): FieldCreateDto => {
       return {
         fieldType,
         ...baseMeta,
-        fieldOptions: ['Option 1'],
+        fieldOptions: ['Option 1', 'Option 2'],
         othersRadioButton: false,
       }
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #5126

## Solution
<!-- How did you solve the problem? -->
- Add 'Option 2' to the Options textbox
- Add placeholder text to Dropdown textbox

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

