### PR TITLE
fix(client): fix logic multiselection dropdown from not showing

### DIFF
--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelect.stories.tsx
@@ -6,7 +6,7 @@ import { Meta, Story } from '@storybook/react'
 import { get } from 'lodash'
 import difference from 'lodash/difference'
 
-import { viewports } from '~utils/storybook'
+import { fixedHeightDecorator, viewports } from '~utils/storybook'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -66,7 +66,7 @@ const INITIAL_COMBOBOX_ITEMS: ComboboxItem[] = [
 export default {
   title: 'Components/MultiSelect',
   component: MultiSelect,
-  decorators: [],
+  decorators: [fixedHeightDecorator('300px')],
   args: {
     items: INITIAL_COMBOBOX_ITEMS,
     values: [],

--- a/frontend/src/components/Dropdown/components/DropdownItem/DropdownItemTextHighlighter.tsx
+++ b/frontend/src/components/Dropdown/components/DropdownItem/DropdownItemTextHighlighter.tsx
@@ -42,7 +42,13 @@ export const DropdownItemTextHighlighter = ({
   )
 
   return (
-    <Text textStyle="body-1">
+    <Text
+      textStyle="body-1"
+      minWidth={0}
+      textOverflow="ellipsis"
+      whiteSpace="nowrap"
+      overflowX="hidden"
+    >
       <Highlighter
         searchWords={regexSearchWords}
         highlightTag={({ children }) => (

--- a/frontend/src/components/Dropdown/components/MultiDropdownItem/MultiDropdownItem.tsx
+++ b/frontend/src/components/Dropdown/components/MultiDropdownItem/MultiDropdownItem.tsx
@@ -50,10 +50,11 @@ export const MultiDropdownItem = ({
         index,
         disabled: isDisabled,
       })}
+      title={label}
     >
-      <Stack direction="row" spacing="1rem">
+      <Stack direction="row" spacing="1rem" overflowX="auto">
         <ItemCheckboxIcon isChecked={isSelected} />
-        <Flex flexDir="column">
+        <Flex flexDir="column" minW={0}>
           <Stack direction="row" spacing="0.5rem" align="center">
             {icon ? <Icon as={icon} sx={styles.icon} /> : null}
             <DropdownItemTextHighlighter

--- a/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectMenu.tsx
@@ -1,5 +1,6 @@
 import { Virtuoso } from 'react-virtuoso'
 import { List, ListItem } from '@chakra-ui/react'
+import { FloatingPortal } from '@floating-ui/react-dom-interactions'
 
 import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useSelectContext } from '../SelectContext'
@@ -22,37 +23,39 @@ export const MultiSelectMenu = (): JSX.Element => {
   const { floatingRef, floatingStyles } = useSelectPopover()
 
   return (
-    <List
-      style={floatingStyles}
-      {...getMenuProps({
-        hidden: !isOpen,
-        ref: floatingRef,
-      })}
-      zIndex="dropdown"
-      sx={styles.list}
-    >
-      {isOpen && items.length > 0 && (
-        <Virtuoso
-          ref={virtualListRef}
-          data={items}
-          overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
-          style={{ height: virtualListHeight }}
-          itemContent={(index, item) => {
-            return (
-              <MultiDropdownItem
-                key={`${itemToValue(item)}${index}`}
-                item={item}
-                index={index}
-              />
-            )
-          }}
-        />
-      )}
-      {isOpen && items.length === 0 ? (
-        <ListItem role="option" sx={styles.emptyItem}>
-          {nothingFoundLabel}
-        </ListItem>
-      ) : null}
-    </List>
+    <FloatingPortal>
+      <List
+        style={floatingStyles}
+        {...getMenuProps({
+          hidden: !isOpen,
+          ref: floatingRef,
+        })}
+        zIndex="dropdown"
+        sx={styles.list}
+      >
+        {isOpen && items.length > 0 && (
+          <Virtuoso
+            ref={virtualListRef}
+            data={items}
+            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT}
+            style={{ height: virtualListHeight }}
+            itemContent={(index, item) => {
+              return (
+                <MultiDropdownItem
+                  key={`${itemToValue(item)}${index}`}
+                  item={item}
+                  index={index}
+                />
+              )
+            }}
+          />
+        )}
+        {isOpen && items.length === 0 ? (
+          <ListItem role="option" sx={styles.emptyItem}>
+            {nothingFoundLabel}
+          </ListItem>
+        ) : null}
+      </List>
+    </FloatingPortal>
   )
 }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -264,7 +264,7 @@ const ThenLogicInput = ({
       isReadOnly={isLoading}
       isRequired
       isInvalid={!!errors.show}
-      overflow="hidden"
+      minW={0}
     >
       <Controller
         name="show"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Users were unable to select dropdown options in logic builder if the dropdown option was a multi-select. Bug was introduced in #4778 due to library and code changes in rendering of dropdown.

This PR also fixes UI overflow on dropdown menu on long dropdown options. 


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:
- feat: constrain dropdown item to a single line


**Bug Fixes**:
- fix: add floating portal to MultiSelectMenu
- fix: use minW instead of overflow=hidden to constrain width of logic dropdown
