### PR TITLE
fix(client): correctly display transfer ownership error from the server

### DIFF
--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -87,11 +87,15 @@ export const useMutateCollaborators = () => {
 
   const getMappedBadRequestErrorMessage = (
     formCollaboratorAction: FormCollaboratorAction,
+    originalErrorMessage: string,
   ): string => {
     let badRequestErrorMessage
     switch (formCollaboratorAction) {
       case FormCollaboratorAction.ADD:
         badRequestErrorMessage = `The collaborator was unable to be added or edited. Please try again or refresh the page.`
+        break
+      case FormCollaboratorAction.TRANSFER_OWNERSHIP:
+        badRequestErrorMessage = originalErrorMessage
         break
       default:
         badRequestErrorMessage = `Sorry, an error occurred. Please refresh the page and try again later.`
@@ -145,6 +149,7 @@ export const useMutateCollaborators = () => {
           case 400:
             errorMessage = getMappedBadRequestErrorMessage(
               formCollaboratorAction,
+              error.message,
             )
             break
           default:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When 400 status code errors occur when transferring ownership of a form, a vague error message is displayed to the user. This PR updates the error message displayed to the one returned from the server, reducing confusion.

Closes #5147

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:
- fix: correctly display transfer ownership error from the server

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
![Screenshot 2022-10-13 at 11 00 22 AM](https://user-images.githubusercontent.com/22133008/195489330-bc3f0793-dfb4-499f-a022-00389873fcbc.png)
