### PR TITLE
feat: add react-specific env var banners, grey out private form rows

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -52,7 +52,9 @@ export const AdminFormLayout = (): JSX.Element => {
   return (
     <Flex flexDir="column" css={fillHeightCss} overflow="hidden" pos="relative">
       {bannerProps ? (
-        <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+        <Banner useMarkdown variant={bannerProps.variant}>
+          {bannerProps.msg}
+        </Banner>
       ) : null}
       <AdminFormNavbar />
       <SwitchEnvIcon />

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -25,7 +25,7 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  // TODO: Revert back to non-react banners post-migration.
+  // TODO (#4279): Revert back to non-react banners post-migration.
   const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
     useEnv()
 

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -25,12 +25,14 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  // TODO: Revert back to non-react banners post-migration.
+  const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
+    useEnv()
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContent || adminBannerContent,
-    [adminBannerContent, siteBannerContent],
+    () => siteBannerContentReact || adminBannerContentReact,
+    [adminBannerContentReact, siteBannerContentReact],
   )
 
   const bannerProps = useMemo(

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -101,7 +101,7 @@ export const LoginPage = (): JSX.Element => {
   const [email, setEmail] = useState<string>()
   const { t } = useTranslation()
 
-  // TODO: Revert back to non-react banners post-migration.
+  // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContentReact || isLoginBannerReact,

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -149,7 +149,9 @@ export const LoginPage = (): JSX.Element => {
   return (
     <BackgroundBox>
       {bannerProps ? (
-        <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+        <Banner useMarkdown variant={bannerProps.variant}>
+          {bannerProps.msg}
+        </Banner>
       ) : null}
       <BaseGridLayout flex={1}>
         <NonMobileSidebarGridArea>

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -96,15 +96,16 @@ const NonMobileSidebarGridArea: FC = ({ children }) => (
 )
 
 export const LoginPage = (): JSX.Element => {
-  const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
+  const { data: { siteBannerContentReact, isLoginBannerReact } = {} } = useEnv()
   const [, setIsAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
   const [email, setEmail] = useState<string>()
   const { t } = useTranslation()
 
+  // TODO: Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContent || isLoginBanner,
-    [siteBannerContent, isLoginBanner],
+    () => siteBannerContentReact || isLoginBannerReact,
+    [siteBannerContentReact, isLoginBannerReact],
   )
 
   const bannerProps = useMemo(

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -21,7 +21,7 @@ export const FormBanner = (): JSX.Element | null => {
   } = useEnv()
   const { form } = usePublicFormContext()
 
-  // TODO: Revert back to non-react banners post-migration.
+  // TODO (#4279): Revert back to non-react banners post-migration.
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -12,8 +12,8 @@ import { usePublicFormContext } from '../PublicFormContext'
 export const FormBanner = (): JSX.Element | null => {
   const {
     data: {
-      siteBannerContent,
-      isGeneralMaintenance,
+      siteBannerContentReact,
+      isGeneralMaintenanceReact,
       isSPMaintenance,
       isCPMaintenance,
       myInfoBannerContent,
@@ -21,11 +21,13 @@ export const FormBanner = (): JSX.Element | null => {
   } = useEnv()
   const { form } = usePublicFormContext()
 
+  // TODO: Revert back to non-react banners post-migration.
+
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () =>
-      siteBannerContent ||
-      isGeneralMaintenance ||
+      siteBannerContentReact ||
+      isGeneralMaintenanceReact ||
       (form?.authType === FormAuthType.SP && isSPMaintenance) ||
       (form?.authType === FormAuthType.CP && isCPMaintenance) ||
       (form?.authType === FormAuthType.MyInfo && myInfoBannerContent) ||
@@ -33,10 +35,10 @@ export const FormBanner = (): JSX.Element | null => {
     [
       form?.authType,
       isCPMaintenance,
-      isGeneralMaintenance,
+      isGeneralMaintenanceReact,
       isSPMaintenance,
       myInfoBannerContent,
-      siteBannerContent,
+      siteBannerContentReact,
     ],
   )
 

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -49,5 +49,9 @@ export const FormBanner = (): JSX.Element | null => {
 
   if (!bannerProps) return null
 
-  return <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+  return (
+    <Banner useMarkdown variant={bannerProps.variant}>
+      {bannerProps.msg}
+    </Banner>
+  )
 }

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -78,7 +78,9 @@ export const WorkspacePage = (): JSX.Element => {
       />
       <Flex direction="column" css={fillHeightCss}>
         {bannerProps ? (
-          <Banner variant={bannerProps.variant}>{bannerProps.msg}</Banner>
+          <Banner useMarkdown variant={bannerProps.variant}>
+            {bannerProps.msg}
+          </Banner>
         ) : null}
         <AdminNavBar />
         <SwitchEnvIcon />

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -42,7 +42,7 @@ export const WorkspacePage = (): JSX.Element => {
   const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
     useEnv()
 
-  // TODO: Revert back to non-react banners post-migration.
+  // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContentReact || adminBannerContentReact,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -39,12 +39,14 @@ const useWorkspaceForms = () => {
 }
 
 export const WorkspacePage = (): JSX.Element => {
-  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
+    useEnv()
 
+  // TODO: Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContent || adminBannerContent,
-    [adminBannerContent, siteBannerContent],
+    () => siteBannerContentReact || adminBannerContentReact,
+    [adminBannerContentReact, siteBannerContentReact],
   )
 
   const bannerProps = useMemo(

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Box, ButtonProps, chakra, Flex, Text } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 
-import { AdminDashboardFormMetaDto } from '~shared/types/form/form'
+import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types/form/form'
 
 import { useRowAction } from './RowActions/useRowAction'
 import { FormStatusLabel } from './FormStatusLabel'
@@ -67,6 +67,7 @@ export const WorkspaceFormRow = ({
           gridArea="title"
           textAlign="initial"
           overflow="auto"
+          opacity={formMeta.status !== FormStatus.Public ? '30%' : '100%'}
         >
           <Text
             noOfLines={{ base: 0, md: 1 }}

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -24,7 +24,7 @@ export type ClientEnvVars = {
   isSPMaintenance: string // Singpass maintenance message
   isCPMaintenance: string // Corppass maintenance message
   myInfoBannerContent: string // MyInfo maintenance message
-  // TODO: remove after React rollout #4786
+  // TODO: remove after React rollout #4786, #4279
   GATrackingID: string | null
   isGeneralMaintenanceReact: string
   isLoginBannerReact: string

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -26,6 +26,11 @@ export type ClientEnvVars = {
   myInfoBannerContent: string // MyInfo maintenance message
   // TODO: remove after React rollout #4786
   GATrackingID: string | null
+  isGeneralMaintenanceReact: string
+  isLoginBannerReact: string
+  siteBannerContentReact: string
+  adminBannerContentReact: string
+
   spcpCookieDomain: string // Cookie domain used for removing spcp cookies
   respondentRolloutEmail: number
   respondentRolloutStorage: number

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -223,6 +223,11 @@ const config: Config = {
   isLoginBanner: basicVars.banner.isLoginBanner,
   siteBannerContent: basicVars.banner.siteBannerContent,
   adminBannerContent: basicVars.banner.adminBannerContent,
+  // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+  isGeneralMaintenanceReact: basicVars.banner.isGeneralMaintenanceReact,
+  isLoginBannerReact: basicVars.banner.isLoginBannerReact,
+  siteBannerContentReact: basicVars.banner.siteBannerContentReact,
+  adminBannerContentReact: basicVars.banner.adminBannerContentReact,
   rateLimitConfig: basicVars.rateLimit,
   reactMigration: basicVars.reactMigration,
   configureAws,

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -223,7 +223,7 @@ const config: Config = {
   isLoginBanner: basicVars.banner.isLoginBanner,
   siteBannerContent: basicVars.banner.siteBannerContent,
   adminBannerContent: basicVars.banner.adminBannerContent,
-  // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+  // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
   isGeneralMaintenanceReact: basicVars.banner.isGeneralMaintenanceReact,
   isLoginBannerReact: basicVars.banner.isLoginBannerReact,
   siteBannerContentReact: basicVars.banner.siteBannerContentReact,

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -181,6 +181,31 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: '',
       env: 'ADMIN_BANNER_CONTENT',
     },
+    // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+    isGeneralMaintenanceReact: {
+      doc: 'Load env variable with General Maintenance banner text. For React only.',
+      format: String,
+      default: '',
+      env: 'IS_GENERAL_MAINTENANCE_REACT',
+    },
+    isLoginBannerReact: {
+      doc: 'The banner message on login page. Allows for HTML. For React only.',
+      format: String,
+      default: '',
+      env: 'IS_LOGIN_BANNER_REACT',
+    },
+    siteBannerContentReact: {
+      doc: 'The banner message to show on all pages. Allows for HTML. Will supersede all other banner content if it exists. For React only.',
+      format: String,
+      default: '',
+      env: 'SITE_BANNER_CONTENT_REACT',
+    },
+    adminBannerContentReact: {
+      doc: 'The banner message to show on on admin pages. Allows for HTML. For React only.',
+      format: String,
+      default: '',
+      env: 'ADMIN_BANNER_CONTENT_REACT',
+    },
   },
   formsgSdkMode: {
     doc: 'Inform SDK which public keys are to be used to sign, encrypt, or decrypt data that is passed to it',

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -181,7 +181,7 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: '',
       env: 'ADMIN_BANNER_CONTENT',
     },
-    // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+    // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
     isGeneralMaintenanceReact: {
       doc: 'Load env variable with General Maintenance banner text. For React only.',
       format: String,

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -20,6 +20,11 @@ export const getClientEnvVars = (): ClientEnvVars => {
     myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
     // TODO: remove after React rollout #4786
     GATrackingID: googleAnalyticsConfig.GATrackingID,
+    isGeneralMaintenanceReact: config.isGeneralMaintenanceReact,
+    isLoginBannerReact: config.isLoginBannerReact,
+    siteBannerContentReact: config.siteBannerContentReact,
+    adminBannerContentReact: config.adminBannerContentReact,
+
     spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
     respondentRolloutEmail: config.reactMigration.respondentRolloutEmail,
     respondentRolloutStorage: config.reactMigration.respondentRolloutStorage,

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -18,7 +18,7 @@ export const getClientEnvVars = (): ClientEnvVars => {
     isSPMaintenance: spcpMyInfoConfig.isSPMaintenance, // Singpass maintenance message
     isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
     myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
-    // TODO: remove after React rollout #4786
+    // TODO: remove after React rollout #4786, #4279
     GATrackingID: googleAnalyticsConfig.GATrackingID,
     isGeneralMaintenanceReact: config.isGeneralMaintenanceReact,
     isLoginBannerReact: config.isLoginBannerReact,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -85,6 +85,13 @@ export type Config = {
   isLoginBanner: string
   siteBannerContent: string
   adminBannerContent: string
+
+  // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+  isGeneralMaintenanceReact: string
+  isLoginBannerReact: string
+  siteBannerContentReact: string
+  adminBannerContentReact: string
+
   rateLimitConfig: RateLimitConfig
   reactMigration: ReactMigrationConfig
   secretEnv: string
@@ -142,6 +149,11 @@ export interface IOptionalVarsSchema {
     isLoginBanner: string
     siteBannerContent: string
     adminBannerContent: string
+    // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+    isGeneralMaintenanceReact: string
+    isLoginBannerReact: string
+    siteBannerContentReact: string
+    adminBannerContentReact: string
   }
   awsConfig: {
     region: string

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -86,7 +86,7 @@ export type Config = {
   siteBannerContent: string
   adminBannerContent: string
 
-  // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+  // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
   isGeneralMaintenanceReact: string
   isLoginBannerReact: string
   siteBannerContentReact: string
@@ -149,7 +149,7 @@ export interface IOptionalVarsSchema {
     isLoginBanner: string
     siteBannerContent: string
     adminBannerContent: string
-    // TODO: Delete these when react migration is over. Revert back to original banner variables in react frontend.
+    // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
     isGeneralMaintenanceReact: string
     isLoginBannerReact: string
     siteBannerContentReact: string


### PR DESCRIPTION
## Problem
As discussed.

Also allow markdown in banners

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
- No - this PR is backwards compatible  

## Deploy Notes

**New environment variables**:

- `IS_GENERAL_MAINTENANCE_REACT`
- `IS_LOGIN_BANNER_REACT`
- `SITE_BANNER_CONTENT_REACT`
- `ADMIN_BANNER_CONTENT_REACT`
