### PR TITLE
fix: add correct parsing for myinfo dates

### DIFF
--- a/frontend/src/features/myinfo/utils/extractPreviewValue.ts
+++ b/frontend/src/features/myinfo/utils/extractPreviewValue.ts
@@ -1,6 +1,12 @@
+import { format, parse } from 'date-fns'
+
 import { BasicField, MyInfoPrefilledFormField } from '~shared/types'
 
+import { DATE_PARSE_FORMAT } from '~templates/Field/Date/DateField'
+
 type PrefilledMyInfoValue = string | { value: string }
+
+const MYINFO_DATE_FORMAT = 'yyyy-mm-dd'
 
 export const extractPreviewValue = ({
   fieldType,
@@ -9,10 +15,17 @@ export const extractPreviewValue = ({
   // NOTE: The mobile number field uses value?.value to inject the input.
   // Hence, we have to return an object in order for the mobile number field
   // to read the default value correctly.
-  if (fieldType === BasicField.Mobile) {
-    return {
-      value: fieldValue,
-    }
+  switch (fieldType) {
+    case BasicField.Mobile:
+      return {
+        value: fieldValue,
+      }
+    case BasicField.Date:
+      return format(
+        parse(fieldValue, MYINFO_DATE_FORMAT, new Date()),
+        DATE_PARSE_FORMAT,
+      )
+    default:
+      return fieldValue
   }
-  return fieldValue
 }

--- a/frontend/src/features/myinfo/utils/extractPreviewValue.ts
+++ b/frontend/src/features/myinfo/utils/extractPreviewValue.ts
@@ -6,7 +6,7 @@ import { DATE_PARSE_FORMAT } from '~templates/Field/Date/DateField'
 
 type PrefilledMyInfoValue = string | { value: string }
 
-const MYINFO_DATE_FORMAT = 'yyyy-mm-dd'
+const MYINFO_DATE_FORMAT = 'yyyy-MM-dd'
 
 export const extractPreviewValue = ({
   fieldType,

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -56,7 +56,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The registered date of birth of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Date,
-    previewValue: '23/02/1965',
+    previewValue: '1965-02-23',
   },
   {
     name: MyInfoAttribute.Race,
@@ -172,7 +172,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Immigration & Checkpoints Authority',
     description: 'The passport expiry date of the form-filler.',
     fieldType: BasicField.Date,
-    previewValue: '23/02/2022',
+    previewValue: '2022-02-23',
   },
   {
     name: MyInfoAttribute.Marital,
@@ -261,7 +261,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The date of marriage of the form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.Date,
-    previewValue: '02/02/1999',
+    previewValue: '1999-02-02',
   },
   {
     name: MyInfoAttribute.DivorceDate,
@@ -272,7 +272,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The date of divorce of the form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.Date,
-    previewValue: '10/01/2007',
+    previewValue: '2007-01-10',
   },
   {
     name: MyInfoAttribute.WorkpassStatus,
@@ -293,7 +293,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Ministry of Manpower',
     description: 'The workpass expiry date of the form-filler.',
     fieldType: BasicField.Date,
-    previewValue: '22/01/2023',
+    previewValue: '2023-01-23',
   },
   {
     name: MyInfoAttribute.MobileNo,


### PR DESCRIPTION
## Problem

Myinfo dates were not getting parsed correctly. This PR adds it as a hotfix.

## Solution
Parse myinfo dates with the format yyyy-MM-dd prior to passing it to the date field.

**Breaking Changes** 
- No - this PR is backwards compatible  
