### PR TITLE
fix: add myinfo attribute to parsed responses if MyInfo field

### DIFF
--- a/src/app/modules/submission/email-submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/email-submission/ParsedResponsesObject.class.ts
@@ -151,6 +151,11 @@ export default class ParsedResponsesObject {
         processingResponse.isUserVerified = formField.isVerifiable
       }
 
+      // Inject myinfo to response if field is a myinfo field for downstream processing.
+      if (formField.myInfo?.attr) {
+        processingResponse.myInfo = formField.myInfo
+      }
+
       // Error will be returned if the processed response is not valid.
       const validateFieldResult = validateField(
         form._id,

--- a/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
@@ -131,18 +131,18 @@ describe('IncomingEncryptSubmission', () => {
       },
     })
     // Add answers to both mobile and email fields
-    const mobileProcessedResponse = generateProcessedSingleAnswerResponse(
-      mobileField,
-      '+6587654321',
-      'signature',
-    )
+    const mobileProcessedResponse = generateProcessedSingleAnswerResponse({
+      field: mobileField,
+      answer: '+6587654321',
+      signature: 'signature',
+    })
     mobileProcessedResponse.isVisible = false
 
-    const emailProcessedResponse = generateProcessedSingleAnswerResponse(
-      emailField,
-      'test@example.com',
-      'signature',
-    )
+    const emailProcessedResponse = generateProcessedSingleAnswerResponse({
+      field: emailField,
+      answer: 'test@example.com',
+      signature: 'signature',
+    })
     emailProcessedResponse.isVisible = false
 
     const responses = [mobileProcessedResponse, emailProcessedResponse]

--- a/tests/unit/backend/helpers/generate-form-data.ts
+++ b/tests/unit/backend/helpers/generate-form-data.ts
@@ -25,6 +25,7 @@ import {
 } from 'src/types'
 
 import {
+  AllowMyInfoBase,
   AttachmentSize,
   BasicField,
   CheckboxResponse,
@@ -157,11 +158,17 @@ export const generateDefaultField = (
   }
 }
 
-export const generateProcessedSingleAnswerResponse = (
-  field: FormFieldSchema,
+export const generateProcessedSingleAnswerResponse = ({
+  field,
   answer = 'answer',
-  signature?: string,
-): ProcessedSingleAnswerResponse => {
+  signature,
+  myInfo,
+}: {
+  field: FormFieldSchema
+  answer: string
+  signature?: string
+  myInfo?: AllowMyInfoBase['myInfo']
+}): ProcessedSingleAnswerResponse => {
   if (
     [BasicField.Attachment, BasicField.Table, BasicField.Checkbox].includes(
       field.fieldType,
@@ -178,6 +185,7 @@ export const generateProcessedSingleAnswerResponse = (
     fieldType: field.fieldType,
     isVisible: true,
     signature,
+    myInfo,
   } as ProcessedSingleAnswerResponse
 }
 
@@ -300,7 +308,7 @@ export const generateTableResponse = (
           rowAnswer.push(col.fieldOptions[0])
       }
     })
-    answerArray = Array(field.minimumRows).fill(rowAnswer)
+    answerArray = Array(field.minimumRows || 0).fill(rowAnswer)
   }
   return {
     _id: field._id,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Instead of relying on response object, MyInfo state should ultimately come from server/db. This PR ensures that if a form field is a MyInfo field, the attribute is added to the response.

Closes https://github.com/opengovsg/formsg-private/issues/111

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

- fix: add myinfo attribute to parsed responses if MyInfo field

### Tests
- [x] Submit myinfo **email** mode form on _React_ client. MyInfo responses should be correctly prefixed (and thus validated)
- [x] Submit myinfo **email** mode form on _AngularJS_ client. MyInfo responses should be correctly prefixed (and thus validated)