### PR TITLE
feat: separate admin and public environment switch

### DIFF
--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -2,7 +2,7 @@ import {
   BasicField,
   ErrorDto,
   PublicFormViewDto,
-  switchEnvFeedbackFormBodyDto,
+  SwitchEnvFeedbackFormBodyDto,
 } from '~shared/types'
 import { ClientEnvVars, SuccessMessageDto } from '~shared/types/core'
 
@@ -17,7 +17,7 @@ export const getClientEnvVars = async (): Promise<ClientEnvVars> => {
 
 // TODO #4279: Remove after React rollout is complete
 const createFeedbackResponsesArray = (
-  formInputs: switchEnvFeedbackFormBodyDto,
+  formInputs: SwitchEnvFeedbackFormBodyDto,
   feedbackForm: PublicFormViewDto,
 ) => {
   const feedbackFormFieldsStructure: [string, number][] = [
@@ -45,7 +45,7 @@ const createFeedbackResponsesArray = (
 }
 
 const createSwitchFeedbackSubmissionFormData = (
-  formInputs: switchEnvFeedbackFormBodyDto,
+  formInputs: SwitchEnvFeedbackFormBodyDto,
   feedbackForm: PublicFormViewDto,
 ) => {
   const responses = createFeedbackResponsesArray(formInputs, feedbackForm)
@@ -65,7 +65,7 @@ export const submitSwitchEnvFormFeedback = async ({
   formInputs,
   feedbackForm,
 }: {
-  formInputs: switchEnvFeedbackFormBodyDto
+  formInputs: SwitchEnvFeedbackFormBodyDto
   feedbackForm: PublicFormViewDto | undefined
 }): Promise<SuccessMessageDto | ErrorDto> => {
   if (!feedbackForm) return new Error('feedback form not provided')

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
@@ -27,9 +27,16 @@ const onClose = () => {
   return
 }
 
-const Template: Story = () => (
-  <SwitchEnvFeedbackModal onClose={onClose} isOpen={true} />
-)
+const Template: Story = () => {
+  return (
+    <SwitchEnvFeedbackModal
+      onChangeEnv={() => console.log('change env')}
+      onSubmitFeedback={async () => console.log('submit feedback')}
+      onClose={onClose}
+      isOpen={true}
+    />
+  )
+}
 
 export const NotLoggedIn = Template.bind({})
 NotLoggedIn.decorators = [LoggedOutDecorator]

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -15,7 +15,7 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react'
 
-import { switchEnvFeedbackFormBodyDto } from '~shared/types'
+import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
@@ -25,17 +25,18 @@ import Textarea from '~components/Textarea'
 
 import { useUser } from '~features/user/queries'
 
-import { useEnvMutations } from './mutations'
-import { useSwitchEnvFeedbackFormView } from './queries'
-
 export interface SwitchEnvModalProps {
   isOpen: boolean
   onClose: () => void
+  onSubmitFeedback: (formInputs: SwitchEnvFeedbackFormBodyDto) => Promise<any>
+  onChangeEnv: () => void
 }
 
 export const SwitchEnvFeedbackModal = ({
   isOpen,
   onClose,
+  onChangeEnv,
+  onSubmitFeedback,
 }: SwitchEnvModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -44,31 +45,15 @@ export const SwitchEnvFeedbackModal = ({
   })
   const isMobile = useIsMobile()
 
-  const { register, handleSubmit } = useForm<switchEnvFeedbackFormBodyDto>()
+  const { register, handleSubmit } = useForm<SwitchEnvFeedbackFormBodyDto>()
   const initialRef = useRef(null)
 
   const { user } = useUser()
   const url = window.location.href
   const [showThanksPage, setShowThanksPage] = useState<boolean>(false)
 
-  // get the feedback form data
-  const { data: feedbackForm } = useSwitchEnvFeedbackFormView(isOpen)
-
-  const {
-    submitSwitchEnvFormFeedbackMutation,
-    adminSwitchEnvMutation,
-    publicSwitchEnvMutation,
-  } = useEnvMutations(feedbackForm)
-
-  const submitFeedback = useCallback(
-    (formInputs: switchEnvFeedbackFormBodyDto) => {
-      return submitSwitchEnvFormFeedbackMutation.mutateAsync(formInputs)
-    },
-    [submitSwitchEnvFormFeedbackMutation],
-  )
-
   const handleFormSubmit = handleSubmit((inputs) => {
-    submitFeedback(inputs)
+    onSubmitFeedback(inputs)
     setShowThanksPage(true)
   })
 
@@ -76,6 +61,12 @@ export const SwitchEnvFeedbackModal = ({
     onClose()
     setShowThanksPage(false)
   }
+
+  const handleChangeEnv = useCallback(() => {
+    onChangeEnv()
+    onClose()
+    setShowThanksPage(false)
+  }, [onChangeEnv, onClose])
 
   return (
     <Modal
@@ -110,16 +101,7 @@ export const SwitchEnvFeedbackModal = ({
                 >
                   No, don’t switch
                 </Button>
-                <Button
-                  isFullWidth={isMobile}
-                  onClick={() => {
-                    user
-                      ? adminSwitchEnvMutation.mutate()
-                      : publicSwitchEnvMutation.mutate()
-                    onClose()
-                    setShowThanksPage(false)
-                  }}
-                >
+                <Button isFullWidth={isMobile} onClick={handleChangeEnv}>
                   Yes, please
                 </Button>
               </Stack>

--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -1,17 +1,34 @@
 // TODO #4279: Remove after React rollout is complete
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { BiMessage } from 'react-icons/bi'
 import { Flex, Portal, useDisclosure } from '@chakra-ui/react'
+
+import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 
-import { useEnv } from './queries'
+import { useEnvMutations } from './mutations'
+import { useEnv, useSwitchEnvFeedbackFormView } from './queries'
 import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
 
 export const SwitchEnvIcon = (): JSX.Element | null => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { data: { adminRollout, removeAdminInfoboxThreshold } = {} } = useEnv()
+
+  // get the feedback form data
+  const { data: feedbackForm } = useSwitchEnvFeedbackFormView(isOpen)
+
+  const { submitSwitchEnvFormFeedbackMutation, adminSwitchEnvMutation } =
+    useEnvMutations(feedbackForm)
+
+  const submitFeedback = useCallback(
+    (formInputs: SwitchEnvFeedbackFormBodyDto) => {
+      return submitSwitchEnvFormFeedbackMutation.mutateAsync(formInputs)
+    },
+    [submitSwitchEnvFormFeedbackMutation],
+  )
+
   // Remove the switch env message if the React rollout for admins is => threshold
   const showSwitchEnvMessage = useMemo(
     () =>
@@ -35,7 +52,12 @@ export const SwitchEnvIcon = (): JSX.Element | null => {
             onClick={onOpen}
           />
         </Tooltip>
-        <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />
+        <SwitchEnvFeedbackModal
+          onSubmitFeedback={submitFeedback}
+          onChangeEnv={adminSwitchEnvMutation.mutate}
+          isOpen={isOpen}
+          onClose={onClose}
+        />
       </Flex>
     </Portal>
   )

--- a/frontend/src/features/env/mutations.ts
+++ b/frontend/src/features/env/mutations.ts
@@ -2,7 +2,7 @@
 import { useMutation } from 'react-query'
 import { useParams } from 'react-router-dom'
 
-import { PublicFormViewDto, switchEnvFeedbackFormBodyDto } from '~shared/types'
+import { PublicFormViewDto, SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
 import {
   adminChooseEnvironment,
@@ -43,7 +43,7 @@ export const useEnvMutations = (
   })
 
   const submitSwitchEnvFormFeedbackMutation = useMutation(
-    (args: switchEnvFeedbackFormBodyDto) => {
+    (args: SwitchEnvFeedbackFormBodyDto) => {
       return submitSwitchEnvFormFeedback({
         formInputs: args,
         feedbackForm: feedbackForm,

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -8,9 +8,13 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react'
 
+import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
+
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 
+import { useEnvMutations } from '~features/env/mutations'
+import { useSwitchEnvFeedbackFormView } from '~features/env/queries'
 import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
 
 export const PublicSwitchEnvMessage = (): JSX.Element => {
@@ -24,6 +28,19 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
       }
     },
     [onOpen],
+  )
+
+  // get the feedback form data
+  const { data: feedbackForm } = useSwitchEnvFeedbackFormView(isOpen)
+
+  const { submitSwitchEnvFormFeedbackMutation, publicSwitchEnvMutation } =
+    useEnvMutations(feedbackForm)
+
+  const submitFeedback = useCallback(
+    (formInputs: SwitchEnvFeedbackFormBodyDto) => {
+      return submitSwitchEnvFormFeedbackMutation.mutateAsync(formInputs)
+    },
+    [submitSwitchEnvFormFeedbackMutation],
   )
 
   return (
@@ -59,7 +76,12 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
           </Text>
         </InlineMessage>
       </Box>
-      <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />
+      <SwitchEnvFeedbackModal
+        onSubmitFeedback={submitFeedback}
+        onChangeEnv={publicSwitchEnvMutation.mutate}
+        isOpen={isOpen}
+        onClose={onClose}
+      />
     </Flex>
   )
 }

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -2,10 +2,13 @@
 import { KeyboardEventHandler, useCallback, useMemo } from 'react'
 import { Text, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 
+import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
+
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 
-import { useEnv } from '~features/env/queries'
+import { useEnvMutations } from '~features/env/mutations'
+import { useEnv, useSwitchEnvFeedbackFormView } from '~features/env/queries'
 import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
 
 export const AdminSwitchEnvMessage = (): JSX.Element => {
@@ -36,6 +39,19 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
     [onOpen],
   )
 
+  // get the feedback form data
+  const { data: feedbackForm } = useSwitchEnvFeedbackFormView(isOpen)
+
+  const { submitSwitchEnvFormFeedbackMutation, adminSwitchEnvMutation } =
+    useEnvMutations(feedbackForm)
+
+  const submitFeedback = useCallback(
+    (formInputs: SwitchEnvFeedbackFormBodyDto) => {
+      return submitSwitchEnvFormFeedbackMutation.mutateAsync(formInputs)
+    },
+    [submitSwitchEnvFormFeedbackMutation],
+  )
+
   return showSwitchEnvMessage ? (
     <>
       <InlineMessage id="admin-switch-msg">
@@ -62,7 +78,12 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
           , which is available until {angularPhaseOutDate}.
         </Text>
       </InlineMessage>
-      <SwitchEnvFeedbackModal isOpen={isOpen} onClose={onClose} />
+      <SwitchEnvFeedbackModal
+        onSubmitFeedback={submitFeedback}
+        onChangeEnv={adminSwitchEnvMutation.mutate}
+        isOpen={isOpen}
+        onClose={onClose}
+      />
     </>
   ) : (
     <></>

--- a/shared/types/env.ts
+++ b/shared/types/env.ts
@@ -4,7 +4,7 @@ export enum UiCookieValues {
 }
 
 // TODO #4279: Remove after React rollout is complete
-export interface switchEnvFeedbackFormBodyDto {
+export interface SwitchEnvFeedbackFormBodyDto {
   [key: string]: string
   url: string
   feedback: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR fixes the edge case where switching in public form from React to AngularJS if you are logged in fails, since the admin form switch URL is used over the public form. 

