### PR TITLE
fix: remove "This field is required" from Home Number field preview

### DIFF
--- a/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
@@ -26,7 +26,6 @@ export const HomeNoField = ({ schema }: HomeNoFieldProps): JSX.Element => {
         control={control}
         rules={validationRules}
         name={schema._id}
-        defaultValue=""
         render={({ field }) => (
           <PhoneNumberInput
             autoComplete="tel"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Home number field (required) shows the message "This field is required" in the form builder. This message should only appear when the user tries to submit without filling in the form.

Closes #5059

## Solution
<!-- How did you solve the problem? -->
Remove `defaultValue` - this makes it consistent with the Mobile field

## Before & After Screenshots

**BEFORE**:
Refer to issue

**AFTER**:

https://user-images.githubusercontent.com/56983748/196028051-1fd1134c-1612-4da1-8c98-aae020d17553.mov


