### PR TITLE
chore: update RUM percentages for 10% rollout

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -40,7 +40,8 @@ datadogRum.init({
 
   // Specify a version number to identify the deployed version of your application in Datadog
   // version: '1.0.0',
-  sampleRate: 100,
+  // TODO/RUM: Update these RUM percentages as we increase the rollout percentage!
+  sampleRate: 50,
   replaySampleRate: 100,
   trackInteractions: true,
   defaultPrivacyLevel: 'mask-user-input',


### PR DESCRIPTION
## Problem
We need to update the RUM percentages for 10% rollout.

As a note, in the future we can just search for `TODO/RUM` to update the percentages.

## Solution
Update to 50% sample, 100% replay.
