### PR TITLE
feat: prevent benign frontend errors from being sent to datadog RUM

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,8 @@ import * as React from 'react'
 import ReactDOM from 'react-dom'
 import { datadogRum } from '@datadog/browser-rum'
 
+import { ddBeforeSend } from '~utils/datadog'
+
 import { App } from './app/App'
 import * as dayjs from './utils/dayjs'
 import reportWebVitals from './reportWebVitals'
@@ -45,6 +47,7 @@ datadogRum.init({
   replaySampleRate: 100,
   trackInteractions: true,
   defaultPrivacyLevel: 'mask-user-input',
+  beforeSend: ddBeforeSend,
 })
 
 datadogRum.startSessionReplayRecording()

--- a/frontend/src/utils/datadog.ts
+++ b/frontend/src/utils/datadog.ts
@@ -1,0 +1,26 @@
+import { RumInitConfiguration } from '@datadog/browser-rum'
+
+// Discard benign RUM errors.
+export const ddBeforeSend: RumInitConfiguration['beforeSend'] = (
+  event,
+  context,
+) => {
+  if (event.type !== 'error') return
+
+  // Discard unauth'd errors
+  if (event.error.resource?.status_code === 401) {
+    return false
+  }
+  // Caused by @chakra-ui/react@latest-v1 -> @chakra-ui/modal@1.11.1 -> react-remove-scroll@2.4.1
+  // Already fixed in @chakra-ui/react@latest, but we cannot upgrade until we upgrade to React 18.
+  // See https://github.com/theKashey/react-remove-scroll/issues/8.
+  // TODO(#4889): Remove this when we update to React 18.
+  if (event.error.type === 'IgnoredEventCancel') {
+    return false
+  }
+
+  // Discard benign ResizeObserver loop limit exceeded errors
+  if (event.error.message.includes('ResizeObserver loop limit exceeded')) {
+    return false
+  }
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR prevents benign frontend errors from being sent to datadog RUM, so the errors we see on RUM can be less noisy and more useful. Do not want a repeat of Sentry in AngularJS :P.
