### PR TITLE
fix: set inline display on all markdown links

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -120,7 +120,7 @@ WithLongInstructions.parameters = {
           startPage: {
             paragraph: dedent`
             Fill in this mock form in this story. 
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt orci. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. Praesent mattis ligula egestas magna sagittis, non aliquet mauris sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est risus.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ac tincidunt orci. Go watch this funny video of a cat https://www.youtube.com/watch?v=dQw4w9WgXcQ. Vivamus id nisl tellus. Aliquam ullamcorper nec diam id ornare. Praesent mattis ligula egestas magna sagittis, non aliquet mauris sollicitudin. In maximus euismod nunc eget pellentesque. Maecenas sollicitudin lobortis consectetur. Suspendisse potenti. Nam a est risus.
 
             Aliquam egestas diam in velit pellentesque lacinia. Praesent nunc ex, fermentum sed nunc nec, laoreet dignissim nisi. Vivamus et lorem non velit facilisis luctus. Sed et luctus magna, sed tincidunt odio. Fusce quis pretium eros. Mauris in est ornare, aliquam odio quis, porttitor lacus. Aliquam dignissim laoreet libero, sed pharetra enim. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
           

--- a/frontend/src/hooks/useMdComponents.tsx
+++ b/frontend/src/hooks/useMdComponents.tsx
@@ -48,6 +48,7 @@ export const useMdComponents = ({
     () => ({
       sx: {
         whiteSpace: 'pre-wrap',
+        display: 'initial',
         ...(styles.link ?? {}),
       },
     }),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Links were rendering as inline-flex in react-markdown due to the `Link` stylings in the default theme, causing unwarranted layout shifts. Set to default to inline display so text flows.

Added a new story to ensure no regression.