### PR TITLE
feat: record feedback ratings for instrumentation

### DIFF
--- a/src/app/modules/feedback/feedback.controller.ts
+++ b/src/app/modules/feedback/feedback.controller.ts
@@ -2,6 +2,7 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { ErrorDto, PrivateFormErrorDto } from 'shared/types'
 
+import config from '../../config/config'
 import { statsdClient } from '../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
@@ -58,6 +59,10 @@ const submitFormFeedback: ControllerHandler<
     .andThen((form) => {
       statsdClient.distribution('formsg.feedback.rating', rating, 1, {
         rating: `${rating}`,
+        ui:
+          req.cookies?.[config.reactMigration.respondentCookieName] === 'react'
+            ? 'react'
+            : 'angular',
       })
 
       return PublicFormService.insertFormFeedback({

--- a/src/app/modules/feedback/feedback.controller.ts
+++ b/src/app/modules/feedback/feedback.controller.ts
@@ -2,6 +2,7 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { ErrorDto, PrivateFormErrorDto } from 'shared/types'
 
+import { statsdClient } from '../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
@@ -55,6 +56,10 @@ const submitFormFeedback: ControllerHandler<
     .andThen(() => FormService.retrieveFullFormById(formId))
     .andThen((form) => FormService.isFormPublic(form).map(() => form))
     .andThen((form) => {
+      statsdClient.distribution('formsg.feedback.rating', rating, 1, {
+        rating: `${rating}`,
+      })
+
       return PublicFormService.insertFormFeedback({
         formId: form._id,
         submissionId: submissionId,


### PR DESCRIPTION
## Problem
We don't have a live view of feedback ratings in datadog. Feedback ratings are tracked in our product charts but the view is limited to the past 30 days.

![image](https://user-images.githubusercontent.com/935223/196822052-9974f58d-8419-4eea-9682-53e12ab857cc.png)


## Solution
Record feedback events to datadog. Those will allow very granular view in to the feedback ratings for any time period.

The metric type [distribution](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types) is used, such that we can track counts, and average.

Note 1: a counter metric would be suitable for a distribution graph (if the ratings are tracked as tags to the metric), but average wouldn't be available. a metric type `distribution` gives us what we need (in fact, more than what we need, sadly).

Note 2: We are not tagging the feedback by form id because tag cardinality too high.

View in DataDog:
![image](https://user-images.githubusercontent.com/935223/196828280-ff4ff0cb-bbcd-47a1-bde4-2955693542fd.png)

