### PR TITLE
feat: use MyInfo constants for title on MyInfo field creation

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/utils.ts
@@ -1,7 +1,9 @@
-import { MyInfoVerifiedType } from '~shared/constants/field/myinfo'
+import {
+  MYINFO_ATTRIBUTE_MAP,
+  MyInfoVerifiedType,
+} from '~shared/constants/field/myinfo'
 import { MyInfoAttribute, MyInfoField } from '~shared/types'
 
-import { MYINFO_FIELD_CONSTANTS } from '~features/admin-form/create/builder-and-design/constants'
 import {
   MyInfoDataSource,
   MyInfoPreviewMeta,
@@ -29,7 +31,7 @@ const convertMyInfoDataSource = (source: string): MyInfoDataSource[] => {
 const extractVerifiedFor = (
   myInfoFieldType: MyInfoAttribute,
 ): VerifiedForMappings => {
-  const verificationArray = MYINFO_FIELD_CONSTANTS[myInfoFieldType]['verified']
+  const verificationArray = MYINFO_ATTRIBUTE_MAP[myInfoFieldType]['verified']
   const baseVerifiedFor = {
     [VerifiedFor.Singaporeans]: false,
     [VerifiedFor.PermanentResidents]: false,
@@ -46,9 +48,9 @@ const extractVerifiedFor = (
 export const extendWithMyInfo = (field: MyInfoField): MyInfoPreviewMeta => {
   return {
     dataSource: convertMyInfoDataSource(
-      MYINFO_FIELD_CONSTANTS[field.myInfo.attr].source,
+      MYINFO_ATTRIBUTE_MAP[field.myInfo.attr].source,
     ),
     verifiedFor: extractVerifiedFor(field.myInfo.attr),
-    details: MYINFO_FIELD_CONSTANTS[field.myInfo.attr].description,
+    details: MYINFO_ATTRIBUTE_MAP[field.myInfo.attr].description,
   }
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -1,6 +1,3 @@
-import { keyBy } from 'lodash'
-
-import { types as MYINFO_TYPE_CONSTANTS } from '~shared/constants/field/myinfo'
 import {
   BasicField,
   DateFieldBase,
@@ -65,8 +62,6 @@ export const MYINFO_FIELDS_ORDERED: MyInfoAttribute[] = [
   MyInfoAttribute.MarriageDate,
   MyInfoAttribute.DivorceDate,
 ]
-
-export const MYINFO_FIELD_CONSTANTS = keyBy(MYINFO_TYPE_CONSTANTS, 'name')
 
 export const MYINFO_TEXTFIELD_META: MyInfoFieldMeta<ShortTextFieldBase> = {
   ValidationOptions: {

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -1,3 +1,4 @@
+import { MYINFO_ATTRIBUTE_MAP } from '~shared/constants/field/myinfo'
 import {
   AttachmentSize,
   BasicField,
@@ -11,7 +12,6 @@ import { BASICFIELD_TO_DRAWER_META } from '../../constants'
 import {
   MYINFO_DATEFIELD_META,
   MYINFO_DROPDOWNFIELD_META,
-  MYINFO_FIELD_CONSTANTS,
   MYINFO_MOBILEFIELD_META,
   MYINFO_TEXTFIELD_META,
 } from '../constants'
@@ -193,9 +193,9 @@ export const getMyInfoFieldCreationMeta = (
   > = {
     disabled: false,
     required: true,
-    title: MYINFO_FIELD_CONSTANTS[myInfoAttribute].value,
+    title: MYINFO_ATTRIBUTE_MAP[myInfoAttribute].value,
     description: '',
-    fieldType: MYINFO_FIELD_CONSTANTS[myInfoAttribute].fieldType,
+    fieldType: MYINFO_ATTRIBUTE_MAP[myInfoAttribute].fieldType,
     myInfo: {
       attr: myInfoAttribute,
     },

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -53,7 +53,7 @@ type BuilderSidebarFieldMeta = {
 }
 
 // !!! Do not use this to reference field titles for MyInfo fields. !!!
-// !!! Use MYINFO_FIELD_CONSTANTS in admin-form/create/builder-and-design/constants.ts instead !!!
+// !!! Use MYINFO_ATTRIBUTE_MAP in ~/shared/constants/field/myinfo/index.ts instead !!!
 export const BASICFIELD_TO_DRAWER_META: {
   [key in BasicField]: BuilderSidebarFieldMeta
 } = {

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -1,3 +1,4 @@
+import keyBy from 'lodash/keyBy'
 import { BasicField, MyInfoAttribute, MyInfoField } from '../../../types/field'
 import COUNTRIES from './myinfo-countries'
 import DIALECTS from './myinfo-dialects'
@@ -306,3 +307,5 @@ export const types: MyInfoFieldBlock[] = [
     previewValue: '98765432',
   },
 ]
+
+export const MYINFO_ATTRIBUTE_MAP = keyBy(types, 'name')

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -36,6 +36,12 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.186",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.2.tgz",

--- a/shared/package.json
+++ b/shared/package.json
@@ -13,6 +13,7 @@
     "zod": "^3.11.6"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.186",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
     "eslint-config-prettier": "^8.3.0",

--- a/shared/types/field/index.ts
+++ b/shared/types/field/index.ts
@@ -94,5 +94,7 @@ export type FormFieldDto<T extends FormField = FormField> =
   | MyInfoFormField<T>
   | FormFieldWithId<T>
 
-export type FieldCreateDto = FormField
+export type FieldCreateDto =
+  | (FormField & { myInfo?: MyInfoField['myInfo'] })
+  | MyInfoField
 export type FieldUpdateDto = FormFieldWithId

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -14,6 +14,7 @@ import {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
 } from '../../../../../shared/constants'
+import { MYINFO_ATTRIBUTE_MAP } from '../../../../../shared/constants/field/myinfo'
 import {
   AdminDashboardFormMetaDto,
   BasicField,
@@ -567,6 +568,12 @@ export const createFormField = (
   FormFieldSchema,
   PossibleDatabaseError | FormNotFoundError | FieldNotFoundError
 > => {
+  // If MyInfo field, override field title to stored name.
+  if (newField.myInfo?.attr) {
+    newField.title =
+      MYINFO_ATTRIBUTE_MAP[newField.myInfo.attr]?.value ?? newField.title
+  }
+
   return ResultAsync.fromPromise(
     form.insertFormField(newField, to),
     (error) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR updates MyInfo field creations to always use the shared constant values for the title for consistency.

@timotheeg this approach has a con in which IF the shared constants are incorrect, it will require a redeploy to correct. Assume that's a fair tradeoff?

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: assign myinfo title to stored constant on field creation 

## Tests
- [x] Use fetch/curl/something to create a MyInfo field with a random, non-myinfo title. The resulting title should still be what is stored in the shared constants.
