### PR TITLE
build: use new CD pipeline to allow for datadog source maps, add cache control

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -34,9 +34,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup secrets for datadog sourcemap deployment
         run: |
-          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_ENV
-          echo "DATADOG_API_KEY=${{ secrets.DD_API_KEY }}" >> $GITHUB_ENV
-      - name: Build
+          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_EN
+      - name: Inject frontend build env vars
         env:
           REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
           REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
@@ -62,13 +61,31 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        env:
+          ECR_REPO: ${{ secrets.ECR_REPO }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_ENV: ${{ secrets.DD_ENV }}
+        with:
+          context: .
+          file: ./Dockerfile.production
+          push: false
+          tags: $ECR_REPO:$IMAGE_TAG
+          build-args: |
+            APP_VERSION=${{env.APP_VERSION}}
+          secrets: |
+            "dd_api_key=${{ secrets.DD_API_KEY }}"
+
+      - name: Push image to Amazon ECR
         env:
           ECR_REPOSITORY: ${{ secrets.ECR_REPO }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_ENV: ${{ secrets.DD_ENV }}
         run: |
-          DOCKER_BUILDKIT=1 docker build --secret id=env_secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
           docker push -a $ECR_REPOSITORY
           sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -23,6 +23,9 @@ jobs:
         run: echo "::set-output name=current_env::${{github.ref_name}}"
 
   deploy_dd_sourcemaps:
+    needs: set_environment
+    environment:
+      name: ${{ needs.set_environment.outputs.current_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup secrets for datadog sourcemap deployment
         run: |
-          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_EN
+          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_ENV
       - name: Inject frontend build env vars
         env:
           REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -74,7 +74,7 @@ jobs:
           context: .
           file: ./Dockerfile.production
           push: false
-          tags: $ECR_REPO:$IMAGE_TAG
+          tags: ${{env.ECR_REPO}}:${{env.IMAGE_TAG}}
           build-args: |
             APP_VERSION=${{env.APP_VERSION}}
           secrets: |

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -22,47 +22,6 @@ jobs:
       - id: set-environment
         run: echo "::set-output name=current_env::${{github.ref_name}}"
 
-  deploy_dd_sourcemaps:
-    needs: set_environment
-    environment:
-      name: ${{ needs.set_environment.outputs.current_env }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - name: Set datadog app version for branch
-        run: |
-          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> "$GITHUB_ENV"
-      - name: Set runtime env vars # Should be same as what is set in EB deployment so same static files are generated!
-        env:
-          REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
-          REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
-          REACT_APP_DD_RUM_ENV: ${{ secrets.DD_ENV }}
-          REACT_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
-          REACT_APP_FORMSG_SDK_MODE: ${{ secrets.REACT_APP_FORMSG_SDK_MODE }}
-        run: |
-          echo REACT_APP_VERSION=${{env.APP_VERSION}} > frontend/.env
-          echo REACT_APP_DD_RUM_APP_ID=$REACT_APP_DD_RUM_APP_ID >> frontend/.env
-          echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env
-          echo REACT_APP_DD_RUM_ENV=$REACT_APP_DD_RUM_ENV >> frontend/.env
-          echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
-          echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
-      - run: npm ci
-      - run: npm run build:frontend
-      - name: Upload source maps
-        env:
-          DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
-        run: |
-          npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
-          --service=formsg-react \
-          --release-version=${{env.APP_VERSION}} \
-          --minified-path-prefix=/static/js
-
   build_deploy_application:
     needs: set_environment
     environment:
@@ -73,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set datadog app version for branch
-        # Should be consistent with the app version in deploy_dd_sourcemaps
+      - name: Setup secrets for datadog sourcemap deployment
         run: |
-          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_ENV
+          echo "DATADOG_API_KEY=${{ secrets.DD_API_KEY }}" >> $GITHUB_ENV
       - name: Build
         env:
           REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
@@ -109,7 +68,7 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_ENV: ${{ secrets.DD_ENV }}
         run: |
-          docker build -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --secret id=secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
           docker push -a $ECR_REPOSITORY
           sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -35,6 +35,20 @@ jobs:
       - name: Set datadog app version for branch
         run: |
           echo "APP_VERSION=$(jq -r .version package.json)-$(echo ${GITHUB_REF##*/})-$(echo ${GITHUB_SHA} | cut -c1-8)" >> "$GITHUB_ENV"
+      - name: Set runtime env vars # Should be same as what is set in EB deployment so same static files are generated!
+        env:
+          REACT_APP_DD_RUM_APP_ID: ${{ secrets.DD_RUM_APP_ID }}
+          REACT_APP_DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
+          REACT_APP_DD_RUM_ENV: ${{ secrets.DD_ENV }}
+          REACT_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+          REACT_APP_FORMSG_SDK_MODE: ${{ secrets.REACT_APP_FORMSG_SDK_MODE }}
+        run: |
+          echo REACT_APP_VERSION=${{env.APP_VERSION}} > frontend/.env
+          echo REACT_APP_DD_RUM_APP_ID=$REACT_APP_DD_RUM_APP_ID >> frontend/.env
+          echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env
+          echo REACT_APP_DD_RUM_ENV=$REACT_APP_DD_RUM_ENV >> frontend/.env
+          echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
+          echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
       - run: npm ci
       - run: npm run build:frontend
       - name: Upload source maps

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -74,6 +74,7 @@ jobs:
           context: .
           file: ./Dockerfile.production
           push: false
+          load: true # Load image into local docker daemon so we can tag and push in later steps
           tags: ${{env.ECR_REPO}}:${{env.IMAGE_TAG}}
           build-args: |
             APP_VERSION=${{env.APP_VERSION}}

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -68,7 +68,7 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_ENV: ${{ secrets.DD_ENV }}
         run: |
-          DOCKER_BUILDKIT=1 docker build --secret id=secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
+          DOCKER_BUILDKIT=1 docker build --secret id=env_secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
           docker push -a $ECR_REPOSITORY
           sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -68,7 +68,7 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_ENV: ${{ secrets.DD_ENV }}
         run: |
-          docker build --secret id=secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
+          DOCKER_BUILDKIT=1 docker build --secret id=secrets,src=$GITHUB_ENV -f Dockerfile.production -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
           docker push -a $ECR_REPOSITORY
           sed -i -e "s/@TAG/$IMAGE_TAG/g" Dockerrun.aws.json

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -2,6 +2,10 @@
 # Docker 1.2 allows for usage of secrets without baking them into the image.
 
 FROM node:fermium-alpine3.16 as build
+
+# TODO: Remove, this is for early failure whilst debugging
+RUN --mount=type=secret,id=env_secrets,required source /run/secrets/env_secrets
+
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
 RUN apk update && apk upgrade && \
@@ -26,11 +30,11 @@ RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --valid
 RUN npm run lint-ci
 RUN npm run build
 
-# Upload datadog source maps from secret mount, id MUST be `id=secrets` in the docker build command
-# Mount creates a file inside /run/secrets/secrets, and source to load the environment variables
+# Upload datadog source maps from secret mount, id MUST be `id=env_secrets` in the docker build command
+# Mount creates a file inside /run/secrets/env_secrets, and source to load the environment variables
 # Assume secret file contains APP_VERSION and DATADOG_API_KEY environment variables for datadog sourcemap upload.
 # For the content of the mounted file is only accessible in the RUN command where it’s referred in, use && command.
-RUN --mount=type=secret,id=secrets source /run/secrets/secrets \
+RUN --mount=type=secret,id=env_secrets source /run/secrets/env_secrets \
     && npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
     --service=formsg-react \
     --release-version=${APP_VERSION} \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1.2
+# Docker 1.2 allows for usage of secrets without baking them into the image.
+
 FROM node:fermium-alpine3.16 as build
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
@@ -22,6 +25,17 @@ ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
 RUN npm run lint-ci
 RUN npm run build
+
+# Upload datadog source maps from secret mount, id MUST be `id=secrets` in the docker build command
+# Mount creates a file inside /run/secrets/secrets, and source to load the environment variables
+# Assume secret file contains APP_VERSION and DATADOG_API_KEY environment variables for datadog sourcemap upload.
+# For the content of the mounted file is only accessible in the RUN command where it’s referred in, use && command.
+RUN --mount=type=secret,id=secrets source /run/secrets/secrets \
+    && npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
+    --service=formsg-react \
+    --release-version=${APP_VERSION} \
+    --minified-path-prefix=/static/js
+
 RUN npm prune --production
 
 # This stage builds the final container

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -33,7 +33,7 @@ ARG APP_VERSION
 # Mount creates a file inside /run/secrets/dd_api_key, and source to load the environment variables
 # For the content of the mounted file is only accessible in the RUN command where it’s referred in, use && command.
 RUN --mount=type=secret,id=dd_api_key \
-    export DATADOG_API_KEY=(cat /run/secrets/dd_api_key) && \
+    export DATADOG_API_KEY=$(cat /run/secrets/dd_api_key) && \
     npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
     --service=formsg-react \
     --release-version=$APP_VERSION \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -12,7 +12,8 @@ WORKDIR /build
 
 COPY package.json package-lock.json ./
 COPY shared/package.json shared/package-lock.json ./shared/
-COPY frontend/package.json frontend/package-lock.json frontend/patches ./frontend/
+COPY frontend/package.json frontend/package-lock.json ./frontend/
+COPY frontend/patches ./frontend/patches
 
 # Allow running of postinstall scripts
 RUN npm config set unsafe-perm true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,10 +1,6 @@
-# syntax=docker/dockerfile:1.2
-# Docker 1.2 allows for usage of secrets without baking them into the image.
+# syntax=docker/dockerfile:1
 
 FROM node:fermium-alpine3.16 as build
-
-# TODO: Remove, this is for early failure whilst debugging
-RUN --mount=type=secret,id=env_secrets,required source /run/secrets/env_secrets
 
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
@@ -16,7 +12,7 @@ WORKDIR /build
 
 COPY package.json package-lock.json ./
 COPY shared/package.json shared/package-lock.json ./shared/
-COPY frontend/package.json frontend/package-lock.json ./frontend/
+COPY frontend/package.json frontend/package-lock.json frontend/patches ./frontend/
 
 # Allow running of postinstall scripts
 RUN npm config set unsafe-perm true
@@ -30,14 +26,16 @@ RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --valid
 RUN npm run lint-ci
 RUN npm run build
 
-# Upload datadog source maps from secret mount, id MUST be `id=env_secrets` in the docker build command
-# Mount creates a file inside /run/secrets/env_secrets, and source to load the environment variables
-# Assume secret file contains APP_VERSION and DATADOG_API_KEY environment variables for datadog sourcemap upload.
+ARG APP_VERSION
+
+# Upload datadog source maps from secret mount, id MUST be `id=dd_api_key` in the docker build command
+# Mount creates a file inside /run/secrets/dd_api_key, and source to load the environment variables
 # For the content of the mounted file is only accessible in the RUN command where it’s referred in, use && command.
-RUN --mount=type=secret,id=env_secrets source /run/secrets/env_secrets \
-    && npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
+RUN --mount=type=secret,id=dd_api_key \
+    export DATADOG_API_KEY=(cat /run/secrets/dd_api_key) && \
+    npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
     --service=formsg-react \
-    --release-version=${APP_VERSION} \
+    --release-version=$APP_VERSION \
     --minified-path-prefix=/static/js
 
 RUN npm prune --production

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/datagovsg/formsg.git"
+    "url": "https://github.com/opengovsg/formsg.git"
   },
   "engines": {
     "node": "~14",

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -102,7 +102,7 @@ export const handleRedirect: ControllerHandler<
   }
 
   // Metatags creation successful.
-  return res.render('index', {
+  return res.setHeader('Cache-Control', 'no-cache').render('index', {
     ...createMetatagsResult.value,
     redirectPath,
   })

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -102,7 +102,7 @@ export const handleRedirect: ControllerHandler<
   }
 
   // Metatags creation successful.
-  return res.setHeader('Cache-Control', 'no-cache').render('index', {
+  return res.render('index', {
     ...createMetatagsResult.value,
     redirectPath,
   })

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -49,7 +49,12 @@ const serveFormReact: ControllerHandler = (_req, res) => {
       reactFrontendPath,
     },
   })
-  return res.sendFile(path.join(reactFrontendPath, 'index.html'))
+  return (
+    res
+      // Prevent index.html from being cached by browsers.
+      .setHeader('Cache-Control', 'no-cache')
+      .sendFile(path.join(reactFrontendPath, 'index.html'))
+  )
 }
 
 const serveFormAngular: ControllerHandler<


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Updated pipeline to build and upload React source maps to Datadog in a secure manner. The previous build pipeline had discrepancies with what Docker build output (probably due to `chakra-ui/cli` not running (since the source files were not copied into the docker build yet, and `patch-package` not running properly).

Also update express to apply no-cache headers to our served React's `index.html` so we can hopefully lessen chunk 404 errors.

Should hopefully work now. Source maps are now uploading properly inside the docker build.

Ignore the bunch of commits where I flailed around like a headless monkey. But we should really clean up our docker/CD pipeline lol it seems like bandaids on top of bandaids.

Closes https://github.com/opengovsg/formsg-private/issues/112 (again)

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

- Update CD pipeline
- Correctly copy frontend/patches in Dockerfile.production so patches actually get applied