### PR TITLE
feat: update RUM sampleRate to match increased rollout percentage

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -43,7 +43,7 @@ datadogRum.init({
   // Specify a version number to identify the deployed version of your application in Datadog
   version: process.env.REACT_APP_VERSION,
   // TODO/RUM: Update these RUM percentages as we increase the rollout percentage!
-  sampleRate: 8,
+  sampleRate: 5,
   replaySampleRate: 100,
   trackInteractions: true,
   defaultPrivacyLevel: 'mask-user-input',


### PR DESCRIPTION
The target % of RUM sessions is 5%.

Since we're increasing rollout % for email-mode respondents to 100% and admins to 65%, increase RUM sampleRate to 5%.