### PR TITLE
fix: handle query strings in url hashes when doing angular redirect

### DIFF
--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -59,7 +59,8 @@ export const HashRouterElement = ({
   useLayoutEffect(() => {
     let hasRedirect = false
 
-    // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
+    // we capture angular links where the path is in the url hash. e.g. starting with #!/
+    // the angular links may have a query string in the hash too 🤮😭🙄, so we must do our own extraction of the hash
     const matches = location.hash.match(/^#!(\/[^?]*)(\?.*)?$/)
 
     // Retire this custom routing after July 2024

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -25,26 +25,26 @@ type FormRegExpMatchArray = RegExpMatchArray & {
   }
 }
 
-const hashRouteMapper = [
+const pathMapper = [
   {
-    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})$/,
     getTarget: (m: FormRegExpMatchArray) => `/${m.groups.formid}`,
   },
   {
-    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
     getTarget: (m: FormRegExpMatchArray) => `/admin/form/${m.groups.formid}`,
   },
   {
-    regex: /^#!\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
     getTarget: (m: FormRegExpMatchArray) =>
       `/admin/form/${m.groups.formid}/preview`,
   },
   {
-    regex: /^#!\/forms$/,
+    regex: /^\/forms$/,
     getTarget: (m: FormRegExpMatchArray) => `${DASHBOARD_ROUTE}`,
   },
   {
-    regex: /^#!\/examples$/,
+    regex: /^\/examples$/,
     getTarget: (m: FormRegExpMatchArray) => `/examples`,
   },
 ]
@@ -60,17 +60,19 @@ export const HashRouterElement = ({
     let hasRedirect = false
     // Retire this custom routing after July 2024
     if (location.hash.startsWith('#!/')) {
-      // angular routes that need to be mapped
-      for (const { regex, getTarget } of hashRouteMapper) {
-        // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
-        const urlHash = location.hash.replace(/\?.*$/, '')
-        const hashQueryString = location.hash.replace(/^[^?]+/, '')
+      // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
+      const [path, querystring] = location.hash.match(/^#!([^?]+)(\?.*)?$/) || [
+        '/',
+        '',
+      ]
 
-        const match = urlHash.match(regex)
+      // angular routes that need to be mapped
+      for (const { regex, getTarget } of pathMapper) {
+        const match = path.match(regex)
         if (match) {
           const redirectTo = getTarget(match as FormRegExpMatchArray)
           hasRedirect = true
-          window.location.assign(`${redirectTo}${hashQueryString}`)
+          window.location.assign(`${redirectTo}${querystring}`)
           break
         }
       }

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -58,13 +58,14 @@ export const HashRouterElement = ({
 
   useLayoutEffect(() => {
     let hasRedirect = false
+
+    // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
+    const matches = location.hash.match(/^#!(\/[^?]*)(\?.*)?$/)
+
     // Retire this custom routing after July 2024
-    if (location.hash.startsWith('#!/')) {
-      // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
-      const [path, querystring] = location.hash.match(/^#!([^?]+)(\?.*)?$/) || [
-        '/',
-        '',
-      ]
+    if (matches) {
+      const path = matches[1]
+      const querystring = matches[2]
 
       // angular routes that need to be mapped
       for (const { regex, getTarget } of pathMapper) {

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -62,11 +62,15 @@ export const HashRouterElement = ({
     if (location.hash.startsWith('#!/')) {
       // angular routes that need to be mapped
       for (const { regex, getTarget } of hashRouteMapper) {
-        const match = location.hash.match(regex)
+        // angular links may have a query string in the hash 🤮😭🙄, so we must do our own extraction of the hash
+        const urlHash = location.hash.replace(/\?.*$/, '')
+        const hashQueryString = location.hash.replace(/^[^?]+/, '')
+
+        const match = urlHash.match(regex)
         if (match) {
           const redirectTo = getTarget(match as FormRegExpMatchArray)
           hasRedirect = true
-          window.location.assign(redirectTo)
+          window.location.assign(`${redirectTo}${hashQueryString}`)
           break
         }
       }


### PR DESCRIPTION
## Problem
We do URL redirection from the old "bad" angular urls (with path in url hash) to the new "clean" react urls.

The url hash inspection broke when prefill argument are supplied as a query string into the hash.

## Solution

1. split the url hash into its path and querystring components
2. do redirection match on the path alone
3. pass the query string through into the redirection url
