### PR TITLE
fix: correctly filter 401 status responses in datadog RUM

### DIFF
--- a/frontend/src/utils/datadog.ts
+++ b/frontend/src/utils/datadog.ts
@@ -5,12 +5,14 @@ export const ddBeforeSend: RumInitConfiguration['beforeSend'] = (
   event,
   context,
 ) => {
-  if (event.type !== 'error') return
-
+  // TODO(#4279): Might want to remove this once we are fully React, since then we will not need to check auth state.
   // Discard unauth'd errors
-  if (event.error.resource?.status_code === 401) {
+  if (event.type === 'resource' && event.resource.status_code === 404) {
     return false
   }
+
+  if (event.type !== 'error') return
+
   // Caused by @chakra-ui/react@latest-v1 -> @chakra-ui/modal@1.11.1 -> react-remove-scroll@2.4.1
   // Already fixed in @chakra-ui/react@latest, but we cannot upgrade until we upgrade to React 18.
   // See https://github.com/theKashey/react-remove-scroll/issues/8.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
well, 401 status responses aren't errors... so should be checking the resource object instead

Makes Datadog RUM error tracking less noisy for now, can decide whether or not to remove that filter once we remove AngularJS client for good.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
