### PR TITLE
feat: convert most link-buttons to real links

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.stories.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.stories.tsx
@@ -20,6 +20,7 @@ export default {
   },
   args: {
     formInfo: MOCK_FORM,
+    previewFormLink: '/test',
   },
 } as Meta<AdminFormNavbarProps>
 
@@ -32,11 +33,13 @@ export const DefaultViewOnly = Template.bind({})
 DefaultViewOnly.args = {
   formInfo: MOCK_FORM,
   viewOnly: true,
+  previewFormLink: '/test',
 }
 
 export const Skeleton = Template.bind({})
 Skeleton.args = {
   formInfo: undefined,
+  previewFormLink: '/test',
 }
 
 export const Mobile = Template.bind({})
@@ -46,5 +49,6 @@ Mobile.args = {
     title:
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   },
+  previewFormLink: '/test',
 }
 Mobile.parameters = getMobileViewParameters()

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -5,7 +5,7 @@ import {
   BiShow,
   BiUserPlus,
 } from 'react-icons/bi'
-import { useLocation } from 'react-router-dom'
+import { Link as ReactLink, useLocation } from 'react-router-dom'
 import {
   Box,
   ButtonGroup,
@@ -47,12 +47,10 @@ export interface AdminFormNavbarProps {
    * If not provided, the navbar will be in a loading state.
    */
   formInfo?: Pick<AdminFormDto, 'title' | 'lastModified'>
-
   viewOnly: boolean
-
   handleAddCollabButtonClick: () => void
-  handlePreviewFormButtonClick: () => void
   handleShareButtonClick: () => void
+  previewFormLink: string
 }
 
 /**
@@ -62,8 +60,8 @@ export const AdminFormNavbar = ({
   formInfo,
   viewOnly,
   handleAddCollabButtonClick,
-  handlePreviewFormButtonClick,
   handleShareButtonClick,
+  previewFormLink,
 }: AdminFormNavbarProps): JSX.Element => {
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
   const { isOpen, onClose, onOpen } = useDisclosure()
@@ -211,9 +209,11 @@ export const AdminFormNavbar = ({
             </Tooltip>
             <Tooltip label="Preview form">
               <IconButton
+                as={ReactLink}
                 aria-label="Preview form"
                 variant="outline"
-                onClick={handlePreviewFormButtonClick}
+                to={previewFormLink}
+                target="_blank"
                 icon={<BiShow />}
               />
             </Tooltip>
@@ -236,7 +236,9 @@ export const AdminFormNavbar = ({
               w="100%"
             >
               <Button
-                onClick={handlePreviewFormButtonClick}
+                as={ReactLink}
+                to={previewFormLink}
+                target="_blank"
                 {...mobileDrawerExtraButtonProps}
                 leftIcon={<BiShow fontSize="1.25rem" />}
               >

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -50,7 +50,6 @@ export interface AdminFormNavbarProps {
 
   viewOnly: boolean
 
-  handleBackButtonClick: () => void
   handleAddCollabButtonClick: () => void
   handlePreviewFormButtonClick: () => void
   handleShareButtonClick: () => void
@@ -63,7 +62,6 @@ export const AdminFormNavbar = ({
   formInfo,
   viewOnly,
   handleAddCollabButtonClick,
-  handleBackButtonClick,
   handlePreviewFormButtonClick,
   handleShareButtonClick,
 }: AdminFormNavbarProps): JSX.Element => {
@@ -148,10 +146,7 @@ export const AdminFormNavbar = ({
         pl={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
         pr="1rem"
       >
-        <AdminFormNavbarBreadcrumbs
-          formInfo={formInfo}
-          handleBackButtonClick={handleBackButtonClick}
-        />
+        <AdminFormNavbarBreadcrumbs formInfo={formInfo} />
       </GridItem>
       <NavigationTabList
         variant={tabResponsiveVariant}

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarBreadcrumbs.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarBreadcrumbs.tsx
@@ -1,19 +1,17 @@
 import { BiHomeAlt } from 'react-icons/bi'
+import { Link as ReactLink } from 'react-router-dom'
 import { Icon, Skeleton, Stack, Text } from '@chakra-ui/react'
 
+import { DASHBOARD_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Link from '~components/Link'
 
 import { AdminFormNavbarProps } from './AdminFormNavbar'
 
-type AdminFormNavbarDetailsProps = Pick<
-  AdminFormNavbarProps,
-  'formInfo' | 'handleBackButtonClick'
->
+type AdminFormNavbarDetailsProps = Pick<AdminFormNavbarProps, 'formInfo'>
 
 export const AdminFormNavbarBreadcrumbs = ({
   formInfo,
-  handleBackButtonClick,
 }: AdminFormNavbarDetailsProps): JSX.Element => {
   const isMobile = useIsMobile()
 
@@ -29,9 +27,10 @@ export const AdminFormNavbarBreadcrumbs = ({
       spacing="0.5rem"
     >
       <Link
+        as={ReactLink}
         whiteSpace="nowrap"
         textDecorationLine="none"
-        onClick={handleBackButtonClick}
+        to={DASHBOARD_ROUTE}
       >
         {isMobile ? <Icon as={BiHomeAlt} /> : 'All forms'}
       </Link>

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 
@@ -19,18 +18,10 @@ const useAdminFormNavbar = () => {
 
   const { data: form } = useAdminForm()
   const { hasEditAccess, isLoading } = useAdminFormCollaborators(formId)
-
-  const handlePreviewForm = useCallback((): void => {
-    window.open(
-      `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`,
-    )
-  }, [formId])
-
   const collaboratorModalDisclosure = useDisclosure()
   const shareFormModalDisclosure = useDisclosure()
 
   return {
-    handlePreviewForm,
     form,
     formId,
     collaboratorModalDisclosure,
@@ -44,7 +35,6 @@ const useAdminFormNavbar = () => {
  */
 export const AdminFormNavbarContainer = (): JSX.Element => {
   const {
-    handlePreviewForm,
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
     form,
@@ -68,8 +58,8 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
       <AdminFormNavbar
         formInfo={form}
         viewOnly={viewOnly}
+        previewFormLink={`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_PREVIEW_ROUTE}`}
         handleAddCollabButtonClick={collaboratorModalDisclosure.onOpen}
-        handlePreviewFormButtonClick={handlePreviewForm}
         handleShareButtonClick={shareFormModalDisclosure.onOpen}
       />
     </>

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarContainer.tsx
@@ -1,14 +1,10 @@
 import { useCallback } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 
 import { FormStatus } from '~shared/types'
 
-import {
-  ADMINFORM_PREVIEW_ROUTE,
-  ADMINFORM_ROUTE,
-  DASHBOARD_ROUTE,
-} from '~constants/routes'
+import { ADMINFORM_PREVIEW_ROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 
 import { ShareFormModal } from '~features/admin-form/share'
 
@@ -23,12 +19,6 @@ const useAdminFormNavbar = () => {
 
   const { data: form } = useAdminForm()
   const { hasEditAccess, isLoading } = useAdminFormCollaborators(formId)
-  const navigate = useNavigate()
-
-  const handleBackToDashboard = useCallback(
-    (): void => navigate(DASHBOARD_ROUTE),
-    [navigate],
-  )
 
   const handlePreviewForm = useCallback((): void => {
     window.open(
@@ -40,7 +30,6 @@ const useAdminFormNavbar = () => {
   const shareFormModalDisclosure = useDisclosure()
 
   return {
-    handleBackToDashboard,
     handlePreviewForm,
     form,
     formId,
@@ -55,7 +44,6 @@ const useAdminFormNavbar = () => {
  */
 export const AdminFormNavbarContainer = (): JSX.Element => {
   const {
-    handleBackToDashboard,
     handlePreviewForm,
     collaboratorModalDisclosure,
     shareFormModalDisclosure,
@@ -80,7 +68,6 @@ export const AdminFormNavbarContainer = (): JSX.Element => {
       <AdminFormNavbar
         formInfo={form}
         viewOnly={viewOnly}
-        handleBackButtonClick={handleBackToDashboard}
         handleAddCollabButtonClick={collaboratorModalDisclosure.onOpen}
         handlePreviewFormButtonClick={handlePreviewForm}
         handleShareButtonClick={shareFormModalDisclosure.onOpen}

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
@@ -8,6 +8,7 @@ import {
   BiTrash,
   BiUserPlus,
 } from 'react-icons/bi'
+import { Link as ReactLink } from 'react-router-dom'
 import {
   Box,
   ButtonGroup,
@@ -35,11 +36,11 @@ export const RowActionsDrawer = ({
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const {
+    adminFormLink,
+    previewFormLink,
     handleDeleteForm,
     handleDuplicateForm,
-    handleEditForm,
     handleCollaborators,
-    handlePreviewForm,
     handleShareForm,
   } = useRowAction(formMeta)
 
@@ -74,15 +75,18 @@ export const RowActionsDrawer = ({
               colorScheme="secondary"
             >
               <Button
+                as={ReactLink}
+                to={adminFormLink}
                 {...buttonProps}
-                onClick={handleEditForm}
                 leftIcon={<BiEditAlt fontSize="1.25rem" />}
               >
                 Edit
               </Button>
               <Button
+                as={ReactLink}
+                to={previewFormLink}
+                target="_blank"
                 {...buttonProps}
-                onClick={handlePreviewForm}
                 leftIcon={<BiShow fontSize="1.25rem" />}
               >
                 Preview

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDropdown.tsx
@@ -5,6 +5,7 @@ import {
   BiTrash,
   BiUserPlus,
 } from 'react-icons/bi'
+import { Link as ReactLink } from 'react-router-dom'
 import { ButtonGroup, MenuButton, MenuDivider } from '@chakra-ui/react'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
@@ -21,8 +22,8 @@ export const RowActionsDropdown = ({
   formMeta,
 }: RowActionsProps): JSX.Element => {
   const {
-    handleEditForm,
-    handlePreviewForm,
+    adminFormLink,
+    previewFormLink,
     handleDeleteForm,
     handleDuplicateForm,
     handleCollaborators,
@@ -44,11 +45,18 @@ export const RowActionsDropdown = ({
             colorScheme="secondary"
             display={{ base: 'none', md: 'flex' }}
           >
-            <Button px="1.5rem" mr="-1px" onClick={handleEditForm}>
+            <Button
+              as={ReactLink}
+              to={adminFormLink}
+              px="1.5rem"
+              mr="-1px"
+              borderEndRadius={0}
+            >
               Edit
             </Button>
             <MenuButton
               as={IconButton}
+              borderStartRadius={0}
               isDisabled={isDisabled}
               _active={{ bg: 'secondary.100' }}
               isActive={isOpen}
@@ -58,7 +66,9 @@ export const RowActionsDropdown = ({
           </ButtonGroup>
           <Menu.List>
             <Menu.Item
-              onClick={handlePreviewForm}
+              as={ReactLink}
+              to={previewFormLink}
+              target="_blank"
               icon={<BiShow fontSize="1.25rem" />}
             >
               Preview

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/useRowAction.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import { AdminDashboardFormMetaDto } from '~shared/types/form/form'
 
@@ -10,8 +9,8 @@ import { useUser } from '~features/user/queries'
 import { useWorkspaceRowsContext } from '../WorkspaceRowsContext'
 
 type UseRowActionReturn = {
-  handleEditForm: () => void
-  handlePreviewForm: () => void
+  adminFormLink: string
+  previewFormLink: string
   handleDuplicateForm: () => void
   handleCollaborators: () => void
   handleDeleteForm: () => void
@@ -22,7 +21,6 @@ type UseRowActionReturn = {
 export const useRowAction = (
   formMeta: AdminDashboardFormMetaDto,
 ): UseRowActionReturn => {
-  const navigate = useNavigate()
   const { user } = useUser()
 
   const {
@@ -37,21 +35,20 @@ export const useRowAction = (
     [formMeta, user],
   )
 
+  const adminFormLink = useMemo(
+    () => `${ADMINFORM_ROUTE}/${formMeta._id}`,
+    [formMeta],
+  )
+
+  const previewFormLink = useMemo(
+    () => `${ADMINFORM_ROUTE}/${formMeta._id}/${ADMINFORM_PREVIEW_ROUTE}`,
+    [formMeta],
+  )
+
   const handleShareForm = useCallback(
     () => onOpenShareFormModal(formMeta),
     [formMeta, onOpenShareFormModal],
   )
-
-  const handleEditForm = useCallback(
-    () => navigate(`${ADMINFORM_ROUTE}/${formMeta._id}`),
-    [formMeta, navigate],
-  )
-
-  const handlePreviewForm = useCallback(() => {
-    return window.open(
-      `${window.location.origin}${ADMINFORM_ROUTE}/${formMeta._id}/${ADMINFORM_PREVIEW_ROUTE}`,
-    )
-  }, [formMeta])
 
   const handleDuplicateForm = useCallback(
     () => onOpenDupeFormModal(formMeta),
@@ -69,9 +66,9 @@ export const useRowAction = (
   }, [formMeta, isFormAdmin, onOpenDeleteFormModal])
 
   return {
+    adminFormLink,
+    previewFormLink,
     handleShareForm,
-    handleEditForm,
-    handlePreviewForm,
     handleDuplicateForm,
     handleCollaborators,
     handleDeleteForm,

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -7,7 +7,6 @@ import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types/form/form'
 
 import { ADMINFORM_ROUTE } from '~constants/routes'
 
-import { useRowAction } from './RowActions/useRowAction'
 import { FormStatusLabel } from './FormStatusLabel'
 import { RowActions } from './RowActions'
 

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from 'react'
+import { Link as ReactLink } from 'react-router-dom'
 import { Box, ButtonProps, chakra, Flex, Text } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 
 import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types/form/form'
+
+import { ADMINFORM_ROUTE } from '~constants/routes'
 
 import { useRowAction } from './RowActions/useRowAction'
 import { FormStatusLabel } from './FormStatusLabel'
@@ -29,14 +32,13 @@ export const WorkspaceFormRow = ({
     return dayjs(formMeta.lastModified).calendar(null, RELATIVE_DATE_FORMAT)
   }, [formMeta.lastModified])
 
-  const { handleEditForm } = useRowAction(formMeta)
-
   return (
     <Box pos="relative">
       <chakra.button
+        as={ReactLink}
         transitionProperty="common"
         transitionDuration="normal"
-        onClick={handleEditForm}
+        to={`${ADMINFORM_ROUTE}/${formMeta._id}`}
         w="100%"
         py="1.5rem"
         display="grid"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR converts most `navigate` calls to use real links instead, so users are able to open the links in new tabs instead of being confined to a single tab.

Actions converted to links:
- Opening admin form in all locations
- Preview form in all locations
- Going back to dashboard

Closes #5223 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat(workspace): update all navigation to use link tags
- feat(AdminFormNavbar): replace navigate calls to use link
- feat: convert preview button in admin form header to use link
