### PR TITLE
feat: use lowercased string operations when setting/getting emails from db

### DIFF
--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -105,7 +105,8 @@ export const useAdminFormCollaborators = (formId: string) => {
     }
     // Else use permissionList first
     return form.permissionList.some(
-      (perms) => perms.write && perms.email === user.email,
+      (perms) =>
+        perms.write && perms.email.toLowerCase() === user.email.toLowerCase(),
     )
   }, [collaborators, form, isFormAdmin, user])
 

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -99,7 +99,8 @@ export const useAdminFormCollaborators = (formId: string) => {
     // Collaborators is source of truth if it has already loaded.
     if (collaborators) {
       return collaborators.some(
-        (perms) => perms.write && perms.email === user.email,
+        (perms) =>
+          perms.write && perms.email.toLowerCase() === user.email.toLowerCase(),
       )
     }
     // Else use permissionList first

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -271,6 +271,13 @@ describe('Form Model', () => {
           MOCK_FORM_PARAMS,
         )
         expect(actualSavedObject).toEqual(expectedObject)
+        // Should become lowercased email.
+        const expectedPermissionList = permissionList.map((permission) => {
+          return {
+            ...permission,
+            email: permission.email.toLowerCase(),
+          }
+        })
 
         // Remove indeterministic id from actual permission list
         const actualPermissionList = saved
@@ -278,7 +285,7 @@ describe('Form Model', () => {
           .permissionList?.map((permission: FormPermission) =>
             omit(permission, '_id'),
           )
-        expect(actualPermissionList).toEqual(permissionList)
+        expect(actualPermissionList).toEqual(expectedPermissionList)
       })
 
       it('should save new admin successfully but remove new admin from permissionList', async () => {
@@ -533,12 +540,19 @@ describe('Form Model', () => {
           MOCK_ENCRYPTED_FORM_PARAMS,
         )
         expect(actualSavedObject).toEqual(expectedObject)
+        // Should become lowercased email.
+        const expectedPermissionList = permissionList.map((permission) => {
+          return {
+            ...permission,
+            email: permission.email.toLowerCase(),
+          }
+        })
 
         // Remove indeterministic id from actual permission list
         const actualPermissionList = (
           saved.toObject() as unknown as IEncryptedForm
         ).permissionList?.map((permission) => omit(permission, '_id'))
-        expect(actualPermissionList).toEqual(permissionList)
+        expect(actualPermissionList).toEqual(expectedPermissionList)
       })
 
       it('should save new admin successfully but remove new admin from permissionList', async () => {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -269,6 +269,8 @@ const compileFormModel = (db: Mongoose): IFormModel => {
               type: String,
               trim: true,
               required: true,
+              // Set email to lowercase for consistency
+              set: (v: string) => v.toLowerCase(),
             },
             write: {
               type: Boolean,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -734,7 +734,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     return (
       this.find()
         // List forms when either the user is an admin or collaborator.
-        .or([{ 'permissionList.email': userEmail }, { admin: userId }])
+        .or([
+          { 'permissionList.email': userEmail.toLowerCase() },
+          { admin: userId },
+        ])
         // Filter out archived forms.
         .where('status')
         .ne(FormStatus.Archived)

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -22,6 +22,8 @@ const compileUserModel = (db: Mongoose) => {
     {
       email: {
         type: String,
+        // Ensure lowercase email addresses are stored in the database.
+        set: (v: string) => v.toLowerCase(),
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         trim: true,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -319,7 +319,7 @@ export const transferFormOwnership = (
       .andThen((currentOwner) => {
         // No need to transfer form ownership if new and current owners are
         // the same.
-        if (newOwnerEmail === currentOwner.email) {
+        if (newOwnerEmail.toLowerCase() === currentOwner.email.toLowerCase()) {
           return errAsync(
             new TransferOwnershipError(
               'You are already the owner of this form',

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -195,7 +195,8 @@ export const assertHasReadPermissions: AssertFormFn = (user, form) => {
 
   // Check if user email is currently in form's allowed list.
   const hasReadPermissions = !!form.permissionList?.find(
-    (allowedUser) => allowedUser.email === user.email,
+    (allowedUser) =>
+      allowedUser.email.toLowerCase() === user.email.toLowerCase(),
   )
 
   return hasReadPermissions
@@ -238,7 +239,9 @@ export const assertHasWritePermissions: AssertFormFn = (user, form) => {
   // Check if user email is currently in form's allowed list, and has write
   // permissions.
   const hasWritePermissions = !!form.permissionList?.find(
-    (allowedUser) => allowedUser.email === user.email && allowedUser.write,
+    (allowedUser) =>
+      allowedUser.email.toLowerCase() === user.email.toLowerCase() &&
+      allowedUser.write,
   )
 
   return hasWritePermissions

--- a/src/app/modules/user/__tests__/user.service.spec.ts
+++ b/src/app/modules/user/__tests__/user.service.spec.ts
@@ -437,7 +437,8 @@ describe('user.service', () => {
       // Assert
       const expectedUser: Partial<LeanDocument<IPopulatedUser>> = {
         agency: defaultAgency.toObject(),
-        email: newUserEmail,
+        // Should be transformed to lowercased due to schema.
+        email: newUserEmail.toLowerCase(),
         lastAccessed: MOCKED_DATE,
       }
       expect(actualResult.isOk()).toBe(true)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR uses lowercased email equality to determine ownership of forms. Moves email cased-ness responsibility to the server instead of the client.

Related to #5239

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible, even though there are schema changes. Moved email cased-ness responsibility to the server instead of the client.

**Features**:
- feat: update form and user models to set to lowercased automatically

**Improvements**:

- feat: add email case insensitivity when checking form permissions
- feat: add case insensitive email check when transferring ownership
- feat: search permission list with lowercased emails


## Before & After Screenshots
Should have no changes.

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Add collaborator with mixed case email. Return response should correctly be lowercased.
- [ ] In the staging DB (pls don't do on prod), edit a form in which you are a collaborator to your email, but in mixed case. You should still have access to the form.
- [ ] Transfer ownership of your form with a mixed case email. Should correctly transfer (if the lowercased version of the email exists) (can just add <your-email>+1@open.gov.sg (log in once to create the user) for ease of testing.
