### PR TITLE
perf(Calendar): use `cuid` instead of `uuid` to generate Calendar classnames

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15162,12 +15162,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
-    },
     "@types/validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.0.tgz",
@@ -39802,7 +39796,9 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true
     },
     "uuid-browser": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,6 @@
     "typescript": "^4.5.3",
     "use-debounce": "^7.0.1",
     "use-draggable-scroll": "^0.1.0",
-    "uuid": "^8.3.2",
     "validator": "^13.7.0",
     "web-vitals": "^2.1.2",
     "zustand": "^4.1.1"
@@ -153,7 +152,6 @@
     "@types/react-table": "^7.7.9",
     "@types/spark-md5": "^3.0.2",
     "@types/storybook-react-router": "^1.0.1",
-    "@types/uuid": "^8.3.3",
     "@types/validator": "^13.7.0",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",

--- a/frontend/src/components/Calendar/CalendarBase/CalendarContext.tsx
+++ b/frontend/src/components/Calendar/CalendarBase/CalendarContext.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react'
+import cuid from 'cuid'
 import {
   addMonths,
   differenceInCalendarMonths,
@@ -24,7 +25,6 @@ import { CalendarProps } from '../Calendar'
 import { DateRangeValue } from './types'
 import {
   generateClassNameForDate,
-  generateValidUuidClass,
   getDateFromClassName,
   getMonthOffsetFromToday,
   getNewDateFromKeyPress,
@@ -77,7 +77,7 @@ export type UseProvideCalendarProps = Pick<DayzedProps, 'monthsToDisplay'> &
   PassthroughProps
 
 interface CalendarContextProps extends CalendarProps, PassthroughProps {
-  uuid: string
+  classNameId: string
   currMonth: number
   currYear: number
   setCurrMonth: Dispatch<SetStateAction<number>>
@@ -137,7 +137,7 @@ const useProvideCalendar = ({
   // so component state doesn't suddenly jump at midnight
   const today = useMemo(() => new Date(), [])
   // Unique className for dates
-  const uuid = useMemo(() => generateValidUuidClass(), [])
+  const classNameId = useMemo(() => cuid(), [])
   const yearOptions = useMemo(() => getYearOptions(), [])
 
   // Date to focus on initial render if initialFocusRef is passed
@@ -177,7 +177,7 @@ const useProvideCalendar = ({
     // before running document.querySelector
     setTimeout(() => {
       const elementToFocus = document.querySelector(
-        `.${generateClassNameForDate(uuid, today)}`,
+        `.${generateClassNameForDate(classNameId, today)}`,
       ) as HTMLButtonElement | null
       elementToFocus?.focus()
       // Workaround because for some reason the attributes do not
@@ -185,7 +185,7 @@ const useProvideCalendar = ({
       elementToFocus?.classList.add('focus-visible')
       elementToFocus?.setAttribute('data-focus-visible-added', 'true')
     })
-  }, [uuid])
+  }, [classNameId])
 
   const updateMonthYear = useCallback(
     (newDate: Date) => {
@@ -214,10 +214,16 @@ const useProvideCalendar = ({
   const handleArrowKey = useCallback(
     (e: KeyboardEvent) => {
       const currentlyFocused = document.activeElement
-      if (!currentlyFocused || !currentlyFocused.className.includes(uuid)) {
+      if (
+        !currentlyFocused ||
+        !currentlyFocused.className.includes(classNameId)
+      ) {
         return
       }
-      const focusedDate = getDateFromClassName(currentlyFocused.className, uuid)
+      const focusedDate = getDateFromClassName(
+        currentlyFocused.className,
+        classNameId,
+      )
       if (!focusedDate) return
       // Prevent arrow key from scrolling screen
       e.preventDefault()
@@ -227,11 +233,11 @@ const useProvideCalendar = ({
       updateMonthYear(newDate)
 
       const elementToFocus = document.querySelector(
-        `.${generateClassNameForDate(uuid, newDate)}`,
+        `.${generateClassNameForDate(classNameId, newDate)}`,
       ) as HTMLButtonElement | null
       elementToFocus?.focus()
     },
-    [updateMonthYear, uuid],
+    [updateMonthYear, classNameId],
   )
   useKey(ARROW_KEY_NAMES, handleArrowKey)
 
@@ -288,7 +294,7 @@ const useProvideCalendar = ({
   )
 
   return {
-    uuid,
+    classNameId,
     currMonth,
     currYear,
     setCurrMonth,

--- a/frontend/src/components/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/frontend/src/components/Calendar/CalendarBase/CalendarPanel.tsx
@@ -19,7 +19,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
   (_props, initialFocusRef): JSX.Element => {
     const styles = useStyles()
     const {
-      uuid,
+      classNameId,
       dateToFocus,
       onMouseLeaveCalendar,
       renderProps: { calendars, getDateProps },
@@ -77,7 +77,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
                                 dateObj.date.getMonth() !== calendar.month
                               }
                               className={generateClassNameForDate(
-                                uuid,
+                                classNameId,
                                 dateObj.date,
                               )}
                               ref={

--- a/frontend/src/components/Calendar/CalendarBase/utils.ts
+++ b/frontend/src/components/Calendar/CalendarBase/utils.ts
@@ -5,7 +5,6 @@ import {
   subDays,
 } from 'date-fns'
 import range from 'lodash/range'
-import { v4 as uuidv4 } from 'uuid'
 
 /**
  * Full names of calendar months
@@ -87,17 +86,17 @@ export const getNewDateFromKeyPress = (
 /**
  * Based on a custom className given to a date element, finds the
  * date corresponding to that element.
- * The pattern used is uuid_dateTime, where dateTime corresponds to
+ * The pattern used is id_dateTime, where dateTime corresponds to
  * Date.getTime().
  * @param className Class name of element
- * @param uuid UUID to find
+ * @param id ID to find
  * @returns Date corresponding to element
  */
 export const getDateFromClassName = (
   className: string,
-  uuid: string,
+  id: string,
 ): Date | null => {
-  const timestamp = new RegExp(`${uuid}_([0-9]+)`).exec(className)
+  const timestamp = new RegExp(`${id}_([0-9]+)`).exec(className)
   if (!timestamp) return null
   return new Date(parseInt(timestamp[1]))
 }
@@ -105,20 +104,10 @@ export const getDateFromClassName = (
 /**
  * Creates a unique className for a date element, from which the corresponding
  * date can be derived.
- * @param uuid UUID to include in className
+ * @param id class name id to include in className
  * @param date Date of element
  * @returns A unique className from which the corresponding date can be derived
  */
-export const generateClassNameForDate = (uuid: string, date: Date): string => {
-  return `${uuid}_${startOfDay(date).getTime()}`
-}
-
-/**
- * Generates a UUID which is also a valid HTML class name.
- * @returns A valid UUID which can be used as a class name
- */
-export const generateValidUuidClass = (): string => {
-  // Ensure className starts with alphabet and has no hyphens
-  // followed by digits
-  return `a${uuidv4().replaceAll('-', '_')}`
+export const generateClassNameForDate = (id: string, date: Date): string => {
+  return `${id}_${startOfDay(date).getTime()}`
 }


### PR DESCRIPTION

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
`cuid` allows immediate usage in html id/classnames without transforming the output string. May also fix the error (cannot replicate) tracked in the referenced issue.

Closes #5241

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Improvements**:

- perf(Calendar): use cuid instead of uuid

## Before & After Screenshots
Should have no changes.

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Navigation of calendar by arrow keys should work as expected
- [ ] Navigation to today's date by clicking today button should work as expected.
  - [ ] In another month view
  - [ ] In another year view
  - [ ] When another date is focused
