### PR TITLE
feat: add radio options to bug report form

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -77,7 +77,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
+RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add font-wqy-zenhei@edge
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 
 # Run as non-privileged user

--- a/frontend/src/components/FormControl/FormErrorMessage/FormErrorMessage.tsx
+++ b/frontend/src/components/FormControl/FormErrorMessage/FormErrorMessage.tsx
@@ -22,7 +22,7 @@ export const FormErrorMessage = ({
 }: FormErrorMessageProps): JSX.Element => {
   return (
     <ChakraFormErrorMessage alignItems="top" {...props}>
-      <FormErrorIcon h="1.5rem" as={BxsErrorCircle} />
+      {children ? <FormErrorIcon h="1.5rem" as={BxsErrorCircle} /> : null}
       {typeof children === 'string' ? (
         // Align line base height with icon (if any)
         <Box my="0.125rem">{children}</Box>

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -50,6 +50,7 @@ const createFeedbackResponsesArray = (
       fieldType === BasicField.Radio &&
       !RADIO_OPTIONS_WITHOUT_OTHERS.includes(answer)
     ) {
+      // format answer from Others to match form submission format
       answer = `Others: ${formInputs[FEEDBACK_OTHERS_INPUT_NAME]}`
     }
     return {

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -32,7 +32,7 @@ const createFeedbackResponsesArray = (
     ['feedback', 1],
     ['email', 2],
     ['rumSessionId', 3],
-    ['radio', 4],
+    ['switchReason', 4],
   ]
   const RADIO_OPTIONS_WITHOUT_OTHERS = ADMIN_RADIO_OPTIONS.concat(
     PUBLIC_RADIO_OPTIONS,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -11,6 +11,12 @@ import { ApiService } from '~services/ApiService'
 
 import { PUBLIC_FORMS_ENDPOINT } from '~features/public-form/PublicFormService'
 
+import {
+  ADMIN_RADIO_OPTIONS,
+  COMMON_RADIO_OPTIONS,
+  PUBLIC_RADIO_OPTIONS,
+} from './SwitchEnvFeedbackModal'
+
 export const getClientEnvVars = async (): Promise<ClientEnvVars> => {
   return ApiService.get<ClientEnvVars>('/client/env').then(({ data }) => data)
 }
@@ -25,7 +31,12 @@ const createFeedbackResponsesArray = (
     ['feedback', 1],
     ['email', 2],
     ['rumSessionId', 3],
+    ['radio', 4],
   ]
+  const RADIO_OPTIONS_WITHOUT_OTHERS = ADMIN_RADIO_OPTIONS.concat(
+    PUBLIC_RADIO_OPTIONS,
+    COMMON_RADIO_OPTIONS,
+  )
   const responses: {
     _id: string
     question: string
@@ -33,7 +44,13 @@ const createFeedbackResponsesArray = (
     fieldType: BasicField
   }[] = feedbackFormFieldsStructure.map(([inputKey, formFieldIndex]) => {
     const { _id, fieldType } = feedbackForm.form.form_fields[formFieldIndex]
-    const answer = formInputs[inputKey] ?? ''
+    let answer: string = formInputs[inputKey] ?? ''
+    if (
+      fieldType === BasicField.Radio &&
+      !RADIO_OPTIONS_WITHOUT_OTHERS.includes(answer)
+    ) {
+      answer = `Others: ${formInputs[inputKey]}`
+    }
     return {
       _id,
       question: inputKey,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -14,6 +14,7 @@ import { PUBLIC_FORMS_ENDPOINT } from '~features/public-form/PublicFormService'
 import {
   ADMIN_RADIO_OPTIONS,
   COMMON_RADIO_OPTIONS,
+  FEEDBACK_OTHERS_INPUT_NAME,
   PUBLIC_RADIO_OPTIONS,
 } from './SwitchEnvFeedbackModal'
 
@@ -49,7 +50,7 @@ const createFeedbackResponsesArray = (
       fieldType === BasicField.Radio &&
       !RADIO_OPTIONS_WITHOUT_OTHERS.includes(answer)
     ) {
-      answer = `Others: ${formInputs[inputKey]}`
+      answer = `Others: ${formInputs[FEEDBACK_OTHERS_INPUT_NAME]}`
     }
     return {
       _id,

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
@@ -59,8 +59,8 @@ export const PublicRespondent = PublicRespondentTemplate.bind({})
 PublicRespondent.decorators = [LoggedOutDecorator]
 
 export const MobilePublicRespondent = PublicRespondentTemplate.bind({})
-PublicRespondent.parameters = getMobileViewParameters()
-PublicRespondent.decorators = [LoggedOutDecorator]
+MobilePublicRespondent.parameters = getMobileViewParameters()
+MobilePublicRespondent.decorators = [LoggedOutDecorator]
 
 export const Admin = AdminTemplate.bind({})
 Admin.decorators = [LoggedInDecorator]

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
@@ -10,7 +10,11 @@ import {
   LoggedOutDecorator,
 } from '~utils/storybook'
 
-import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
+import {
+  ADMIN_RADIO_OPTIONS,
+  PUBLIC_RADIO_OPTIONS,
+  SwitchEnvFeedbackModal,
+} from './SwitchEnvFeedbackModal'
 
 export default {
   title: 'Pages/SwitchEnvFeedbackModal',
@@ -27,27 +31,40 @@ const onClose = () => {
   return
 }
 
-const Template: Story = () => {
+const AdminTemplate: Story = () => {
   return (
     <SwitchEnvFeedbackModal
       onChangeEnv={() => console.log('change env')}
       onSubmitFeedback={async () => console.log('submit feedback')}
       onClose={onClose}
       isOpen={true}
+      radioOptions={ADMIN_RADIO_OPTIONS}
     />
   )
 }
 
-export const NotLoggedIn = Template.bind({})
-NotLoggedIn.decorators = [LoggedOutDecorator]
+const PublicRespondentTemplate: Story = () => {
+  return (
+    <SwitchEnvFeedbackModal
+      onChangeEnv={() => console.log('change env')}
+      onSubmitFeedback={async () => console.log('submit feedback')}
+      onClose={onClose}
+      isOpen={true}
+      radioOptions={PUBLIC_RADIO_OPTIONS}
+    />
+  )
+}
 
-export const MobileNotLoggedIn = Template.bind({})
-MobileNotLoggedIn.parameters = getMobileViewParameters()
-MobileNotLoggedIn.decorators = [LoggedOutDecorator]
+export const PublicRespondent = PublicRespondentTemplate.bind({})
+PublicRespondent.decorators = [LoggedOutDecorator]
 
-export const LoggedIn = Template.bind({})
-LoggedIn.decorators = [LoggedInDecorator]
-LoggedIn.parameters = {
+export const MobilePublicRespondent = PublicRespondentTemplate.bind({})
+PublicRespondent.parameters = getMobileViewParameters()
+PublicRespondent.decorators = [LoggedOutDecorator]
+
+export const Admin = AdminTemplate.bind({})
+Admin.decorators = [LoggedInDecorator]
+Admin.parameters = {
   msw: [
     getUser({
       delay: 0,
@@ -58,8 +75,8 @@ LoggedIn.parameters = {
   ],
 }
 
-export const MobileLoggedIn = Template.bind({})
-MobileLoggedIn.parameters = {
+export const MobileAdmin = AdminTemplate.bind({})
+MobileAdmin.parameters = {
   ...getMobileViewParameters(),
   msw: [
     getUser({
@@ -70,4 +87,4 @@ MobileLoggedIn.parameters = {
     }),
   ],
 }
-MobileLoggedIn.decorators = [LoggedInDecorator]
+MobileAdmin.decorators = [LoggedInDecorator]

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -81,6 +81,7 @@ export const SwitchEnvFeedbackModal = ({
   const publicFormPath = new RegExp(`^/${formId}`)
 
   const handleFormSubmit = handleSubmit((inputs) => {
+    // Prevent submission if radio option 'I’m not used to the new FormSG' is selected
     if (!COMMON_RADIO_OPTIONS.includes(inputs.radio)) onSubmitFeedback(inputs)
     setShowThanksPage(true)
   })

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -81,8 +81,6 @@ export const SwitchEnvFeedbackModal = ({
   const publicFormPath = new RegExp(`^/${formId}`)
 
   const handleFormSubmit = handleSubmit((inputs) => {
-    // onSubmitFeedback(inputs)
-    console.log(COMMON_RADIO_OPTIONS.includes(inputs.radio))
     if (!COMMON_RADIO_OPTIONS.includes(inputs.radio)) onSubmitFeedback(inputs)
     setShowThanksPage(true)
   })

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -17,9 +17,11 @@ import {
 } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
 import { get, isEmpty } from 'lodash'
+import validator from 'validator'
 
 import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
+import { INVALID_EMAIL_ERROR } from '~constants/validation'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -228,10 +230,13 @@ export const SwitchEnvFeedbackModal = ({
                       </FormControl>
                     </Radio.OthersWrapper>
                   </Radio.RadioGroup>
-                  <FormErrorMessage>
-                    {errors['radio']?.message ??
-                      errors[FEEDBACK_OTHERS_INPUT_NAME]?.message}
-                  </FormErrorMessage>
+                  {errors['email'] ? null : (
+                    <FormErrorMessage>
+                      {errors['radio']?.message ??
+                        errors[FEEDBACK_OTHERS_INPUT_NAME]?.message ??
+                        null}
+                    </FormErrorMessage>
+                  )}
                 </FormControl>
                 {user ? (
                   <FormControl>
@@ -242,11 +247,27 @@ export const SwitchEnvFeedbackModal = ({
                     />
                   </FormControl>
                 ) : (
-                  <FormControl>
+                  <FormControl isInvalid={!!errors['email']}>
                     <FormLabel>
                       Email, if we need to contact you for details
                     </FormLabel>
-                    <Input {...register('email')} tabIndex={1} />
+                    <Input
+                      {...register('email', {
+                        validate: (value) => {
+                          if (!value) {
+                            return true
+                          }
+                          // Valid email check
+                          if (!validator.isEmail(value)) {
+                            return INVALID_EMAIL_ERROR
+                          }
+                        },
+                      })}
+                      tabIndex={1}
+                    />
+                    <FormErrorMessage>
+                      {errors['email']?.message}
+                    </FormErrorMessage>
                   </FormControl>
                 )}
                 <FormControl>

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -66,8 +66,7 @@ export const SwitchEnvFeedbackModal = ({
   const publicFormPath = new RegExp(`^/${formId}`)
 
   const handleFormSubmit = handleSubmit((inputs) => {
-    // Only submit form if there is feedback
-    if (inputs.feedback.trim()) onSubmitFeedback(inputs)
+    onSubmitFeedback(inputs)
     setShowThanksPage(true)
   })
 

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -1,7 +1,6 @@
 // TODO #4279: Remove after React rollout is complete
 import { useCallback, useRef, useState } from 'react'
 import { FieldError, useForm } from 'react-hook-form'
-import { useParams } from 'react-router-dom'
 import {
   chakra,
   FormControl,
@@ -37,6 +36,7 @@ export interface SwitchEnvModalProps {
   onClose: () => void
   onSubmitFeedback: (formInputs: SwitchEnvFeedbackFormBodyDto) => Promise<any>
   onChangeEnv: () => void
+  radioOptions: string[]
 }
 
 export const ADMIN_RADIO_OPTIONS = [
@@ -52,6 +52,7 @@ export const SwitchEnvFeedbackModal = ({
   onClose,
   onChangeEnv,
   onSubmitFeedback,
+  radioOptions,
 }: SwitchEnvModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -77,10 +78,8 @@ export const SwitchEnvFeedbackModal = ({
 
   const { user } = useUser()
   const url = window.location.href
-  const { formId } = useParams()
   const rumSessionId = datadogRum.getInternalContext()?.session_id
   const [showThanksPage, setShowThanksPage] = useState<boolean>(false)
-  const publicFormPath = new RegExp(`^/${formId}`)
 
   const handleFormSubmit = handleSubmit((inputs) => {
     // Prevent submission if radio option 'I’m not used to the new FormSG' is selected
@@ -98,8 +97,6 @@ export const SwitchEnvFeedbackModal = ({
     onClose()
     setShowThanksPage(false)
   }, [onChangeEnv, onClose])
-
-  const isPublicFormPage = window.location.pathname.match(publicFormPath)
 
   return (
     <Modal
@@ -158,37 +155,21 @@ export const SwitchEnvFeedbackModal = ({
                     Why are you switching to the previous FormSG?
                   </FormLabel>
                   <Radio.RadioGroup>
-                    {isPublicFormPage
-                      ? PUBLIC_RADIO_OPTIONS.map((option) => (
-                          <Radio
-                            {...register('switchReason', {
-                              required: {
-                                value: true,
-                                message: 'This field is required',
-                              },
-                              deps: [FEEDBACK_OTHERS_INPUT_NAME],
-                            })}
-                            value={option}
-                            key={option}
-                          >
-                            {option}
-                          </Radio>
-                        ))
-                      : ADMIN_RADIO_OPTIONS.map((option) => (
-                          <Radio
-                            {...register('switchReason', {
-                              required: {
-                                value: true,
-                                message: 'This field is required',
-                              },
-                              deps: [FEEDBACK_OTHERS_INPUT_NAME],
-                            })}
-                            value={option}
-                            key={option}
-                          >
-                            {option}
-                          </Radio>
-                        ))}
+                    {radioOptions.map((option) => (
+                      <Radio
+                        {...register('switchReason', {
+                          required: {
+                            value: true,
+                            message: 'This field is required',
+                          },
+                          deps: [FEEDBACK_OTHERS_INPUT_NAME],
+                        })}
+                        value={option}
+                        key={option}
+                      >
+                        {option}
+                      </Radio>
+                    ))}
                     {COMMON_RADIO_OPTIONS.map((option) => (
                       <Radio
                         {...register('switchReason', {

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -45,7 +45,7 @@ export const ADMIN_RADIO_OPTIONS = [
 ]
 export const PUBLIC_RADIO_OPTIONS = ['I couldn’t submit my form']
 export const COMMON_RADIO_OPTIONS = ['I’m not used to the new FormSG']
-export const FEEDBACK_OTHERS_INPUT_NAME = 'others-input'
+export const FEEDBACK_OTHERS_INPUT_NAME = 'react-feedback-others-input'
 
 export const SwitchEnvFeedbackModal = ({
   isOpen,
@@ -150,7 +150,10 @@ export const SwitchEnvFeedbackModal = ({
                 <FormControl>
                   <Input type="hidden" {...register('url')} value={url} />
                 </FormControl>
-                <FormControl isRequired={true} isInvalid={!isEmpty(errors)}>
+                <FormControl
+                  isRequired
+                  isInvalid={!isEmpty(errors) || !!othersInputError}
+                >
                   <FormLabel>
                     Why are you switching to the previous FormSG?
                   </FormLabel>
@@ -158,7 +161,7 @@ export const SwitchEnvFeedbackModal = ({
                     {isPublicFormPage
                       ? PUBLIC_RADIO_OPTIONS.map((option) => (
                           <Radio
-                            {...register('radio', {
+                            {...register('switchReason', {
                               required: {
                                 value: true,
                                 message: 'This field is required',
@@ -173,7 +176,7 @@ export const SwitchEnvFeedbackModal = ({
                         ))
                       : ADMIN_RADIO_OPTIONS.map((option) => (
                           <Radio
-                            {...register('radio', {
+                            {...register('switchReason', {
                               required: {
                                 value: true,
                                 message: 'This field is required',
@@ -188,7 +191,7 @@ export const SwitchEnvFeedbackModal = ({
                         ))}
                     {COMMON_RADIO_OPTIONS.map((option) => (
                       <Radio
-                        {...register('radio', {
+                        {...register('switchReason', {
                           required: {
                             value: true,
                             message: 'This field is required',
@@ -202,7 +205,7 @@ export const SwitchEnvFeedbackModal = ({
                       </Radio>
                     ))}
                     <Radio.OthersWrapper
-                      {...register('radio', {
+                      {...register('switchReason', {
                         required: {
                           value: true,
                           message: 'This field is required',
@@ -211,16 +214,14 @@ export const SwitchEnvFeedbackModal = ({
                       })}
                       value={othersInputValue}
                     >
-                      <FormControl
-                        isRequired={true}
-                        isInvalid={!!othersInputError}
-                      >
+                      <FormControl>
                         <OthersInput
                           aria-label='"Other" response'
                           {...register(FEEDBACK_OTHERS_INPUT_NAME, {
                             validate: (value) => {
                               return (
-                                getValues('radio') !== othersInputValue ||
+                                getValues('switchReason') !==
+                                  othersInputValue ||
                                 !!value ||
                                 'Please specify a value for the "Others" option'
                               )
@@ -230,13 +231,10 @@ export const SwitchEnvFeedbackModal = ({
                       </FormControl>
                     </Radio.OthersWrapper>
                   </Radio.RadioGroup>
-                  {errors['email'] ? null : (
-                    <FormErrorMessage>
-                      {errors['radio']?.message ??
-                        errors[FEEDBACK_OTHERS_INPUT_NAME]?.message ??
-                        null}
-                    </FormErrorMessage>
-                  )}
+                  <FormErrorMessage>
+                    {errors['switchReason']?.message ??
+                      errors[FEEDBACK_OTHERS_INPUT_NAME]?.message}
+                  </FormErrorMessage>
                 </FormControl>
                 {user ? (
                   <FormControl>

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -81,7 +81,9 @@ export const SwitchEnvFeedbackModal = ({
   const publicFormPath = new RegExp(`^/${formId}`)
 
   const handleFormSubmit = handleSubmit((inputs) => {
-    onSubmitFeedback(inputs)
+    // onSubmitFeedback(inputs)
+    console.log(COMMON_RADIO_OPTIONS.includes(inputs.radio))
+    if (!COMMON_RADIO_OPTIONS.includes(inputs.radio)) onSubmitFeedback(inputs)
     setShowThanksPage(true)
   })
 

--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -10,7 +10,10 @@ import Tooltip from '~components/Tooltip'
 
 import { useEnvMutations } from './mutations'
 import { useEnv, useSwitchEnvFeedbackFormView } from './queries'
-import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
+import {
+  ADMIN_RADIO_OPTIONS,
+  SwitchEnvFeedbackModal,
+} from './SwitchEnvFeedbackModal'
 
 export const SwitchEnvIcon = (): JSX.Element | null => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -57,6 +60,7 @@ export const SwitchEnvIcon = (): JSX.Element | null => {
           onChangeEnv={adminSwitchEnvMutation.mutate}
           isOpen={isOpen}
           onClose={onClose}
+          radioOptions={ADMIN_RADIO_OPTIONS}
         />
       </Flex>
     </Portal>

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -15,7 +15,10 @@ import InlineMessage from '~components/InlineMessage'
 
 import { useEnvMutations } from '~features/env/mutations'
 import { useSwitchEnvFeedbackFormView } from '~features/env/queries'
-import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
+import {
+  PUBLIC_RADIO_OPTIONS,
+  SwitchEnvFeedbackModal,
+} from '~features/env/SwitchEnvFeedbackModal'
 
 export const PublicSwitchEnvMessage = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -81,6 +84,7 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
         onChangeEnv={publicSwitchEnvMutation.mutate}
         isOpen={isOpen}
         onClose={onClose}
+        radioOptions={PUBLIC_RADIO_OPTIONS}
       />
     </Flex>
   )

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -9,7 +9,10 @@ import InlineMessage from '~components/InlineMessage'
 
 import { useEnvMutations } from '~features/env/mutations'
 import { useEnv, useSwitchEnvFeedbackFormView } from '~features/env/queries'
-import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
+import {
+  ADMIN_RADIO_OPTIONS,
+  SwitchEnvFeedbackModal,
+} from '~features/env/SwitchEnvFeedbackModal'
 
 export const AdminSwitchEnvMessage = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -83,6 +86,7 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
         onChangeEnv={adminSwitchEnvMutation.mutate}
         isOpen={isOpen}
         onClose={onClose}
+        radioOptions={ADMIN_RADIO_OPTIONS}
       />
     </>
   ) : (

--- a/shared/types/env.ts
+++ b/shared/types/env.ts
@@ -10,4 +10,5 @@ export interface SwitchEnvFeedbackFormBodyDto {
   feedback: string
   email: string
   rumSessionId: string
+  radio: string
 }

--- a/shared/types/env.ts
+++ b/shared/types/env.ts
@@ -10,5 +10,5 @@ export interface SwitchEnvFeedbackFormBodyDto {
   feedback: string
   email: string
   rumSessionId: string
-  radio: string
+  switchReason: string
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to get categorised feedback from users.

Closes #5185

## Solution
<!-- How did you solve the problem? -->
- Add radio options, which are required to submit the form
- Radio options differ depending on whether it's a public form or admin view
- Allow non-logged-in user to input their email, validate email

**Bug Fixes**:
- Only display `FormErrorIcon` if `children` props exist in `FormErrorMessage`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**Admin**:

https://user-images.githubusercontent.com/56983748/197731404-89573393-d4fb-45a6-b25f-616885e2c8d1.mov



**Public form**:

https://user-images.githubusercontent.com/56983748/197731414-af0832b0-ffbe-46f3-a097-7ee0cff9c31d.mov



## Tests
<!-- What tests should be run to confirm functionality? -->
Note: remember to add radio options as the last question in the bug report form before testing -

> Question: Why are you switching to the previous FormSG?
> Enable Others
> Disable Required
> Options:
> I couldn’t submit my form
> I couldn’t find a feature I needed
> The new FormSG did not function properly
> I’m not used to the new FormSG

- [x] Submit bug report form from admin view. Check that selection of a radio option is required.
- [x] Submit bug report form from public form view. Check that selection of a radio option is required, email entered should be in the correct format.

