### PR TITLE
feat: hopefully add robustness to mobile viewport rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1489,6 +1489,11 @@
         "@chakra-ui/utils": "1.10.4"
       }
     },
+    "@chakra-ui/breakpoint-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.4.tgz",
+      "integrity": "sha512-SUUEYnA/FCIKYDHMuEXcnBMwet+6RAAjQ+CqGD1hlwKPTfh7EK9fS8FoVAJa9KpRKAc/AawzPkgwvorzPj8NSg=="
+    },
     "@chakra-ui/button": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.5.10.tgz",
@@ -1708,12 +1713,19 @@
       }
     },
     "@chakra-ui/media-query": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
-      "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.2.7.tgz",
+      "integrity": "sha512-hbgm6JCe0kYU3PAhxASYYDopFQI26cW9kZnbp+5tRL1fykkVWNMPwoGC8FEZPur9JjXp7aoL6H4Jk7nrxY/XWw==",
       "requires": {
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/breakpoint-utils": "2.0.4",
+        "@chakra-ui/react-env": "2.0.10"
+      },
+      "dependencies": {
+        "@chakra-ui/react-env": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-2.0.10.tgz",
+          "integrity": "sha512-3Yab5EbFcCGYzEsoijy4eA3354Z/JoXyk9chYIuW7Uwd+K6g/R8C0mUSAHeTmfp6Fix9kzDgerO5MWNM87b8cA=="
+        }
       }
     },
     "@chakra-ui/menu": {
@@ -1887,6 +1899,17 @@
         "@chakra-ui/transition": "1.4.8",
         "@chakra-ui/utils": "1.10.4",
         "@chakra-ui/visually-hidden": "1.1.6"
+      },
+      "dependencies": {
+        "@chakra-ui/media-query": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
+          "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
+          "requires": {
+            "@chakra-ui/react-env": "1.1.6",
+            "@chakra-ui/utils": "1.10.4"
+          }
+        }
       }
     },
     "@chakra-ui/react-env": {
@@ -1923,6 +1946,17 @@
         "@chakra-ui/media-query": "2.0.4",
         "@chakra-ui/system": "1.12.1",
         "@chakra-ui/utils": "1.10.4"
+      },
+      "dependencies": {
+        "@chakra-ui/media-query": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
+          "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
+          "requires": {
+            "@chakra-ui/react-env": "1.1.6",
+            "@chakra-ui/utils": "1.10.4"
+          }
+        }
       }
     },
     "@chakra-ui/slider": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,18 +106,11 @@
     "test:a11y-dev": "cross-env USE_DEV_SERVER=true jest --config .storybook/storyshots/jest.config.js",
     "pre-commit": "lint-staged"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ],
   "devDependencies": {
     "@chakra-ui/cli": "^1.9.0",
     "@craco/craco": "^6.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "homepage": ".",
   "private": true,
   "dependencies": {
+    "@chakra-ui/media-query": "^3.2.7",
     "@chakra-ui/react": "^1.8.6",
     "@datadog/browser-rum": "^4.14.0",
     "@emotion/react": "^11.7.0",

--- a/frontend/src/components/Calendar/CalendarBase/CalendarHeader.tsx
+++ b/frontend/src/components/Calendar/CalendarBase/CalendarHeader.tsx
@@ -1,11 +1,11 @@
 import { ChangeEvent, memo, useCallback, useMemo } from 'react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Flex,
   HStack,
   Select,
   SelectProps,
   Text,
-  useBreakpointValue,
   useStyles,
 } from '@chakra-ui/react'
 import { addMonths } from 'date-fns'
@@ -52,11 +52,14 @@ const SelectableMonthYear = memo(() => {
   const { currMonth, setCurrMonth, currYear, setCurrYear, yearOptions } =
     useCalendar()
 
-  const shouldUseMonthFullName = useBreakpointValue({
-    base: false,
-    xs: false,
-    md: true,
-  })
+  const shouldUseMonthFullName = useBreakpointValue(
+    {
+      base: false,
+      xs: false,
+      md: true,
+    },
+    { ssr: false },
+  )
 
   const memoizedMonthOptions = useMemo(() => {
     return MONTH_NAMES.map(({ shortName, fullName }, index) => (
@@ -111,11 +114,14 @@ const SelectableMonthYear = memo(() => {
 
 const MonthYear = memo(({ monthOffset }: CalendarHeaderProps) => {
   const { currMonth, currYear } = useCalendar()
-  const shouldUseMonthFullName = useBreakpointValue({
-    base: false,
-    xs: false,
-    md: true,
-  })
+  const shouldUseMonthFullName = useBreakpointValue(
+    {
+      base: false,
+      xs: false,
+      md: true,
+    },
+    { ssr: false },
+  )
 
   const newOffsetDate = useMemo(
     () => addMonths(new Date(currYear, currMonth), monthOffset),

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
-import {
-  forwardRef,
-  Grid,
-  HStack,
-  Stack,
-  Text,
-  useBreakpointValue,
-} from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { forwardRef, Grid, HStack, Stack, Text } from '@chakra-ui/react'
 
 import { FieldColorScheme } from '~theme/foundations/colours'
 
@@ -99,12 +93,15 @@ export const Rating = forwardRef<RatingProps, 'input'>(
      * Used to check whether a new row should be created when rendering rating
      * options.
      */
-    const isSplitRows = useBreakpointValue({
-      base: true,
-      xs: true,
-      sm: true,
-      md: false,
-    })
+    const isSplitRows = useBreakpointValue(
+      {
+        base: true,
+        xs: true,
+        sm: true,
+        md: false,
+      },
+      { ssr: false },
+    )
 
     // Generate options from maxRating given, grouped by display row.
     const options = useMemo(() => {

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 
 import {
   DEFAULT_FOOTER_ICON_LINK,
@@ -16,7 +16,10 @@ export const Footer = ({
   compactMonochromeLogos,
   ...footerProps
 }: FooterProps): JSX.Element => {
-  const isDesktop = useBreakpointValue({ base: false, xs: false, lg: true })
+  const isDesktop = useBreakpointValue(
+    { base: false, xs: false, lg: true },
+    { ssr: false },
+  )
 
   if (variant === 'compact' && isDesktop) {
     return (

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 
 import { PaginationDesktop } from './PaginationDesktop'
 import { PaginationMobile } from './PaginationMobile'
@@ -37,14 +37,17 @@ export interface PaginationProps {
 }
 
 export const Pagination = (props: PaginationProps): JSX.Element => {
-  const isShowMobileVariant = useBreakpointValue({
-    base: true,
-    xs: true,
-    sm: true,
-    md: false,
-    lg: false,
-    xl: false,
-  })
+  const isShowMobileVariant = useBreakpointValue(
+    {
+      base: true,
+      xs: true,
+      sm: true,
+      md: false,
+      lg: false,
+      xl: false,
+    },
+    { ssr: false },
+  )
 
   return isShowMobileVariant ? (
     <Pagination.Mobile {...props} />

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -6,6 +6,7 @@ import {
   BiUserPlus,
 } from 'react-icons/bi'
 import { Link as ReactLink, useLocation } from 'react-router-dom'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Box,
   ButtonGroup,
@@ -20,7 +21,6 @@ import {
   GridItem,
   Skeleton,
   Text,
-  useBreakpointValue,
   useDisclosure,
 } from '@chakra-ui/react'
 import format from 'date-fns/format'
@@ -67,11 +67,14 @@ export const AdminFormNavbar = ({
   const { isOpen, onClose, onOpen } = useDisclosure()
   const { pathname } = useLocation()
 
-  const tabResponsiveVariant = useBreakpointValue({
-    base: 'line-dark',
-    xs: 'line-dark',
-    lg: 'line-light',
-  })
+  const tabResponsiveVariant = useBreakpointValue(
+    {
+      base: 'line-dark',
+      xs: 'line-dark',
+      lg: 'line-light',
+    },
+    { ssr: false },
+  )
 
   const checkTabActive = useCallback(
     (to: string) => {

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -1,9 +1,5 @@
-import {
-  Modal,
-  ModalContent,
-  ModalOverlay,
-  useBreakpointValue,
-} from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 
 import { ModalCloseButton } from '~components/Modal'
 
@@ -21,11 +17,14 @@ export const CollaboratorModal = ({
   onClose,
   formId,
 }: CollaboratorModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorModal.tsx
@@ -1,6 +1,6 @@
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { ModalCloseButton } from '~components/Modal'
 
 import { CollaboratorModalContent } from './CollaboratorModalContent'
@@ -17,14 +17,7 @@ export const CollaboratorModal = ({
   onClose,
   formId,
 }: CollaboratorModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/SmsCountsModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/SmsCountsModal.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -7,7 +8,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 
 import { SmsCountsDto } from '~shared/types/form'
@@ -33,11 +33,14 @@ export const SmsCountsModal = ({
 }: SmsCountsModalProps) => {
   const { formId } = useParams()
 
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   const isMobile = useIsMobile()
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/SmsCountsModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/SmsCountsModal.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'react-router-dom'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -14,6 +13,7 @@ import { SmsCountsDto } from '~shared/types/form'
 
 import { ADMINFORM_ROUTE, ADMINFORM_SETTINGS_SUBROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useModalSize } from '~hooks/useModalSize'
 import Badge from '~components/Badge'
 import Button from '~components/Button'
 import Link from '~components/Link'
@@ -33,14 +33,7 @@ export const SmsCountsModal = ({
 }: SmsCountsModalProps) => {
   const { formId } = useParams()
 
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   const isMobile = useIsMobile()
 

--- a/frontend/src/features/admin-form/create/logic/components/DeleteLogicModal/DeleteLogicModal.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/DeleteLogicModal/DeleteLogicModal.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -13,6 +12,7 @@ import {
 
 import { LogicDto } from '~shared/types/form'
 
+import { useModalSize } from '~hooks/useModalSize'
 import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 
@@ -35,14 +35,7 @@ export const DeleteLogicModal = ({
 }: DeleteLogicModalProps): JSX.Element => {
   const setToInactive = useAdminLogicStore(setToInactiveSelector)
   const { deleteLogicMutation } = useLogicMutations()
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   const handleDelete = useCallback(() => {
     // Cannot be put in onSuccess since this component will be unmounted by then.

--- a/frontend/src/features/admin-form/create/logic/components/DeleteLogicModal/DeleteLogicModal.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/DeleteLogicModal/DeleteLogicModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -8,7 +9,6 @@ import {
   ModalOverlay,
   Stack,
   Text,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 
 import { LogicDto } from '~shared/types/form'
@@ -35,11 +35,14 @@ export const DeleteLogicModal = ({
 }: DeleteLogicModalProps): JSX.Element => {
   const setToInactive = useAdminLogicStore(setToInactiveSelector)
   const { deleteLogicMutation } = useLogicMutations()
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   const handleDelete = useCallback(() => {
     // Cannot be put in onSuccess since this component will be unmounted by then.

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalContent,
@@ -8,6 +7,7 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { XMotionBox } from '~templates/MotionBox'
 
 import { CanceledResult, DownloadResult } from '../../types'
@@ -51,14 +51,7 @@ export const DownloadWithAttachmentModal = ({
   downloadMetadata,
   initialState = INITIAL_STEP_STATE,
 }: DownloadWithAttachmentModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
   const [[currentStep, direction], setCurrentStep] = useState(initialState)
 
   useEffect(() => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalContent,
   ModalOverlay,
   Text,
-  useBreakpointValue,
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
@@ -51,11 +51,14 @@ export const DownloadWithAttachmentModal = ({
   downloadMetadata,
   initialState = INITIAL_STEP_STATE,
 }: DownloadWithAttachmentModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
   const [[currentStep, direction], setCurrentStep] = useState(initialState)
 
   useEffect(() => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalContent,
@@ -7,6 +6,7 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { XMotionBox } from '~templates/MotionBox'
 
 import { CanceledResult, DownloadResult } from '../../types'
@@ -41,14 +41,7 @@ export const ProgressModal = ({
   downloadMetadata,
   children,
 }: ProgressModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/ProgressModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalContent,
   ModalOverlay,
-  useBreakpointValue,
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
@@ -41,11 +41,14 @@ export const ProgressModal = ({
   downloadMetadata,
   children,
 }: ProgressModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)

--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { BiRightArrowAlt, BiUpload } from 'react-icons/bi'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Container,
   FormControl,
@@ -15,6 +14,7 @@ import {
 
 import { FormStatus } from '~shared/types/form/form'
 
+import { useModalSize } from '~hooks/useModalSize'
 import formsgSdk from '~utils/formSdk'
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
@@ -161,14 +161,7 @@ export const SecretKeyActivationModal = ({
     handleOnClose,
   } = useSecretKeyActivationModal({ publicKey, onClose })
 
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'full',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize({ md: 'full' })
 
   return (
     <Modal isOpen={isOpen} onClose={handleOnClose} size={modalSize}>

--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { BiRightArrowAlt, BiUpload } from 'react-icons/bi'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Container,
   FormControl,
@@ -9,7 +10,6 @@ import {
   ModalContent,
   ModalHeader,
   Stack,
-  useBreakpointValue,
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
@@ -161,11 +161,14 @@ export const SecretKeyActivationModal = ({
     handleOnClose,
   } = useSecretKeyActivationModal({ publicKey, onClose })
 
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'full',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'full',
+    },
+    { ssr: false },
+  )
 
   return (
     <Modal isOpen={isOpen} onClose={handleOnClose} size={modalSize}>

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useParams } from 'react-router-dom'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -9,7 +10,6 @@ import {
   ModalOverlay,
   Stack,
   Text,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 
 import Button from '~components/Button'
@@ -28,11 +28,14 @@ export const DeleteTwilioModal = ({
   onClose,
   onDelete,
 }: DeleteTwilioModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   const { formId } = useParams()
   if (!formId) throw new Error('No form ID!')

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/DeleteTwilioModal.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { useParams } from 'react-router-dom'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -12,6 +11,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 
@@ -28,14 +28,7 @@ export const DeleteTwilioModal = ({
   onClose,
   onDelete,
 }: DeleteTwilioModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   const { formId } = useParams()
   if (!formId) throw new Error('No form ID!')

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { BiLinkExternal } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Box,
   FormControl,
@@ -13,7 +14,6 @@ import {
   ModalOverlay,
   Skeleton,
   Stack,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 import dedent from 'dedent'
 
@@ -45,11 +45,14 @@ export const ShareFormModal = ({
   isFormPrivate,
 }: ShareFormModalProps): JSX.Element => {
   const navigate = useNavigate()
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   const shareLink = useMemo(
     () => `${window.location.origin}/${formId}`,

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { BiLinkExternal } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Box,
   FormControl,
@@ -18,6 +17,7 @@ import {
 import dedent from 'dedent'
 
 import { ADMINFORM_ROUTE, ADMINFORM_SETTINGS_SUBROUTE } from '~constants/routes'
+import { useModalSize } from '~hooks/useModalSize'
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
 import IconButton from '~components/IconButton'
@@ -45,14 +45,7 @@ export const ShareFormModal = ({
   isFormPrivate,
 }: ShareFormModalProps): JSX.Element => {
   const navigate = useNavigate()
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   const shareLink = useMemo(
     () => `${window.location.origin}/${formId}`,

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -1,7 +1,6 @@
 // TODO #4279: Remove after React rollout is complete
 import { useCallback, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   chakra,
   FormControl,
@@ -19,6 +18,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useModalSize } from '~hooks/useModalSize'
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
 import { ModalCloseButton } from '~components/Modal'
@@ -39,14 +39,7 @@ export const SwitchEnvFeedbackModal = ({
   onChangeEnv,
   onSubmitFeedback,
 }: SwitchEnvModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
   const isMobile = useIsMobile()
 
   const { register, handleSubmit } = useForm<SwitchEnvFeedbackFormBodyDto>()

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -1,6 +1,7 @@
 // TODO #4279: Remove after React rollout is complete
 import { useCallback, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   chakra,
   FormControl,
@@ -12,7 +13,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Stack,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
 
@@ -39,11 +39,14 @@ export const SwitchEnvFeedbackModal = ({
   onChangeEnv,
   onSubmitFeedback,
 }: SwitchEnvModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
   const isMobile = useIsMobile()
 
   const { register, handleSubmit } = useForm<SwitchEnvFeedbackFormBodyDto>()

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { FormControl, Stack, useBreakpointValue } from '@chakra-ui/react'
+import { FormControl, Stack } from '@chakra-ui/react'
 import isEmail from 'validator/lib/isEmail'
 
 import { FORM_GUIDE } from '~constants/links'
 import { INVALID_EMAIL_ERROR } from '~constants/validation'
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -36,7 +37,7 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
     })
   }
 
-  const isMobile = useBreakpointValue({ base: true, xs: true, lg: false })
+  const isMobile = useIsMobile()
 
   return (
     <form onSubmit={handleSubmit(onSubmitForm)}>

--- a/frontend/src/features/login/components/OtpForm.tsx
+++ b/frontend/src/features/login/components/OtpForm.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
-import { FormControl, Stack, useBreakpointValue } from '@chakra-ui/react'
+import { FormControl, Stack } from '@chakra-ui/react'
 
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -26,7 +27,7 @@ export const OtpForm = ({
   const { handleSubmit, register, formState, setError } =
     useForm<OtpFormInputs>()
 
-  const isMobile = useBreakpointValue({ base: true, xs: true, lg: false })
+  const isMobile = useIsMobile()
 
   const validateOtp = useCallback(
     (value: string) => value.length === 6 || 'Please enter a 6 digit OTP.',

--- a/frontend/src/features/user/billing/BillingForm/BillingForm.tsx
+++ b/frontend/src/features/user/billing/BillingForm/BillingForm.tsx
@@ -1,14 +1,8 @@
 import { useForm } from 'react-hook-form'
-import {
-  Container,
-  FormControl,
-  Skeleton,
-  Stack,
-  Text,
-  useBreakpointValue,
-} from '@chakra-ui/react'
+import { Container, FormControl, Skeleton, Stack, Text } from '@chakra-ui/react'
 
 import { GUIDE_SPCP_ESRVCID } from '~constants/links'
+import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -35,7 +29,7 @@ export const BillingForm = ({
     })
   }
 
-  const isMobile = useBreakpointValue({ base: true, xs: true, lg: false })
+  const isMobile = useIsMobile()
 
   return (
     <Container p={0} maxW="42.5rem">

--- a/frontend/src/features/user/emergency-contact/EmergencyContactModal.tsx
+++ b/frontend/src/features/user/emergency-contact/EmergencyContactModal.tsx
@@ -1,4 +1,3 @@
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -8,6 +7,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { ModalCloseButton } from '~components/Modal'
 
 import { ContactNumberInput } from './components/ContactNumberInput'
@@ -21,14 +21,7 @@ export const EmergencyContactModal = ({
   isOpen,
   onClose,
 }: EmergencyContactModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
 
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>

--- a/frontend/src/features/user/emergency-contact/EmergencyContactModal.tsx
+++ b/frontend/src/features/user/emergency-contact/EmergencyContactModal.tsx
@@ -1,3 +1,4 @@
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Modal,
   ModalBody,
@@ -5,7 +6,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  useBreakpointValue,
 } from '@chakra-ui/react'
 
 import { ModalCloseButton } from '~components/Modal'
@@ -21,11 +21,14 @@ export const EmergencyContactModal = ({
   isOpen,
   onClose,
 }: EmergencyContactModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
 
   return (
     <Modal size={modalSize} isOpen={isOpen} onClose={onClose}>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
@@ -1,9 +1,5 @@
-import {
-  Modal,
-  ModalContent,
-  useBreakpointValue,
-  UseDisclosureReturn,
-} from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { Modal, ModalContent, UseDisclosureReturn } from '@chakra-ui/react'
 
 import { ModalCloseButton } from '~components/Modal'
 
@@ -19,11 +15,14 @@ export const CreateFormModal = ({
   isOpen,
   onClose,
 }: CreateFormModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'full',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'full',
+    },
+    { ssr: false },
+  )
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
@@ -1,6 +1,6 @@
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import { Modal, ModalContent, UseDisclosureReturn } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { ModalCloseButton } from '~components/Modal'
 
 import { CreateFormModalContent } from './CreateFormModalContent'
@@ -15,14 +15,7 @@ export const CreateFormModal = ({
   isOpen,
   onClose,
 }: CreateFormModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'full',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize({ md: 'full' })
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>

--- a/frontend/src/features/workspace/components/DeleteFormModal/DeleteFormModal.tsx
+++ b/frontend/src/features/workspace/components/DeleteFormModal/DeleteFormModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { BiFileBlank } from 'react-icons/bi'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Container,
   Icon,
@@ -13,7 +14,6 @@ import {
   Stack,
   Text,
   UnorderedList,
-  useBreakpointValue,
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
@@ -35,11 +35,14 @@ export const DeleteFormModal = ({
   onClose,
   formToDelete,
 }: DeleteFormModalProps): JSX.Element | null => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'md',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'md',
+    },
+    { ssr: false },
+  )
   const isMobile = useIsMobile()
 
   const { deleteFormMutation } = useDeleteFormMutation()

--- a/frontend/src/features/workspace/components/DeleteFormModal/DeleteFormModal.tsx
+++ b/frontend/src/features/workspace/components/DeleteFormModal/DeleteFormModal.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { BiFileBlank } from 'react-icons/bi'
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import {
   Container,
   Icon,
@@ -20,6 +19,7 @@ import {
 import { AdminDashboardFormMetaDto } from '~shared/types'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { useModalSize } from '~hooks/useModalSize'
 import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 
@@ -35,14 +35,7 @@ export const DeleteFormModal = ({
   onClose,
   formToDelete,
 }: DeleteFormModalProps): JSX.Element | null => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'md',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize()
   const isMobile = useIsMobile()
 
   const { deleteFormMutation } = useDeleteFormMutation()

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -1,6 +1,6 @@
-import { useBreakpointValue } from '@chakra-ui/media-query'
 import { Modal, ModalContent, UseDisclosureReturn } from '@chakra-ui/react'
 
+import { useModalSize } from '~hooks/useModalSize'
 import { ModalCloseButton } from '~components/Modal'
 
 import { CreateFormModalContent } from '../CreateFormModal/CreateFormModalContent'
@@ -16,14 +16,7 @@ export const DuplicateFormModal = ({
   isOpen,
   onClose,
 }: DuplicateFormModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue(
-    {
-      base: 'mobile',
-      xs: 'mobile',
-      md: 'full',
-    },
-    { ssr: false },
-  )
+  const modalSize = useModalSize({ md: 'full' })
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -1,9 +1,5 @@
-import {
-  Modal,
-  ModalContent,
-  useBreakpointValue,
-  UseDisclosureReturn,
-} from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { Modal, ModalContent, UseDisclosureReturn } from '@chakra-ui/react'
 
 import { ModalCloseButton } from '~components/Modal'
 
@@ -20,11 +16,14 @@ export const DuplicateFormModal = ({
   isOpen,
   onClose,
 }: DuplicateFormModalProps): JSX.Element => {
-  const modalSize = useBreakpointValue({
-    base: 'mobile',
-    xs: 'mobile',
-    md: 'full',
-  })
+  const modalSize = useBreakpointValue(
+    {
+      base: 'mobile',
+      xs: 'mobile',
+      md: 'full',
+    },
+    { ssr: false },
+  )
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -7,7 +7,7 @@ export const useIsMobile = (): boolean => {
       xs: true,
       md: false,
     },
-    { ssr: false, fallback: false },
+    { ssr: false },
   )
 
   return isMobile ?? false

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,11 +1,14 @@
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
 
 export const useIsMobile = (): boolean => {
-  const isMobile = useBreakpointValue({
-    base: true,
-    xs: true,
-    md: false,
-  })
+  const isMobile = useBreakpointValue(
+    {
+      base: true,
+      xs: true,
+      md: false,
+    },
+    { ssr: false },
+  )
 
   return isMobile ?? false
 }

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -7,7 +7,7 @@ export const useIsMobile = (): boolean => {
       xs: true,
       md: false,
     },
-    { ssr: false },
+    { ssr: false, fallback: false },
   )
 
   return isMobile ?? false

--- a/frontend/src/hooks/useModalSize.ts
+++ b/frontend/src/hooks/useModalSize.ts
@@ -16,7 +16,7 @@ export const useModalSize = ({
       md,
       ...rest,
     },
-    { ssr: false, fallback: md },
+    { ssr: false },
   )
 
   return modalSize

--- a/frontend/src/hooks/useModalSize.ts
+++ b/frontend/src/hooks/useModalSize.ts
@@ -1,0 +1,23 @@
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { ThemingProps } from '@chakra-ui/react'
+
+type ModalSize = ThemingProps<'Modal'>['size']
+
+export const useModalSize = ({
+  base = 'mobile',
+  xs = 'mobile',
+  md = 'md',
+  ...rest
+}: Partial<Record<string, ModalSize>> = {}): ThemingProps<'Modal'>['size'] => {
+  const modalSize = useBreakpointValue<ThemingProps<'Modal'>['size']>(
+    {
+      base,
+      xs,
+      md,
+      ...rest,
+    },
+    { ssr: false, fallback: md },
+  )
+
+  return modalSize
+}

--- a/frontend/src/templates/Field/Image/ImageField.tsx
+++ b/frontend/src/templates/Field/Image/ImageField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Box, Image, Skeleton, useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { Box, Image, Skeleton } from '@chakra-ui/react'
 
 import { useMdComponents } from '~hooks/useMdComponents'
 import { MarkdownText } from '~components/MarkdownText'
@@ -20,10 +21,13 @@ export const ImageField = ({ schema }: ImageFieldProps): JSX.Element => {
   const [fallbackType, setFallbackType] = useState<'loading' | 'error'>(
     'loading',
   )
-  const responsiveTextStyle = useBreakpointValue({
-    base: 'caption-2',
-    md: 'body-2',
-  })
+  const responsiveTextStyle = useBreakpointValue(
+    {
+      base: 'caption-2',
+      md: 'body-2',
+    },
+    { ssr: false },
+  )
 
   const mdComponents = useMdComponents({
     styles: {

--- a/frontend/src/templates/PublicHeader/PublicHeader.tsx
+++ b/frontend/src/templates/PublicHeader/PublicHeader.tsx
@@ -1,11 +1,5 @@
-import {
-  As,
-  chakra,
-  Flex,
-  FlexProps,
-  HStack,
-  useBreakpointValue,
-} from '@chakra-ui/react'
+import { useBreakpointValue } from '@chakra-ui/media-query'
+import { As, chakra, Flex, FlexProps, HStack } from '@chakra-ui/react'
 
 import { ReactComponent as BrandHortSvg } from '~assets/svgs/brand/brand-hort-colour.svg'
 import { ReactComponent as BrandMarkSvg } from '~assets/svgs/brand/brand-mark-colour.svg'
@@ -71,10 +65,13 @@ export const PublicHeader = ({
   publicHeaderLinks,
   ctaElement: ctaButton,
 }: PublicHeaderProps): JSX.Element => {
-  const logoToRender = useBreakpointValue({
-    base: <BrandSmallLogo w="2.5rem" />,
-    sm: <BrandHortLogo w="7.75rem" />,
-  })
+  const logoToRender = useBreakpointValue(
+    {
+      base: <BrandSmallLogo w="2.5rem" />,
+      sm: <BrandHortLogo w="7.75rem" />,
+    },
+    { ssr: false },
+  )
 
   return (
     <PublicHeader.Container>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Not sure if this will solve it, but maybe? The later versions of `@chakra-ui/media-query` allow for base default breakpoints??? we can try using media queries if this does not help still. 

Closes #5244 hopefully

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- refactor: use new useBreakpointValue import,
- refactor: add useModalSize hook to reduce repeated code
- build: update browserlist to be same in dev and prod  (loader seems to break on esm modules if using development profile)


## Before & After Screenshots
Should have no changes

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->


**New dependencies**:

- `@chakra-ui/media-query` : separate, newer version than the one bundled with our current `@chakra-ui/react` version (that we can't update yet since we are on a lower version of react)
