### PR TITLE
feat: use media queries for `useIsMobile` hook

### DIFF
--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,11 +1,9 @@
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useMediaQuery } from '@chakra-ui/react'
+
+import { BREAKPOINT_VALS } from '~theme/foundations/breakpoints'
 
 export const useIsMobile = (): boolean => {
-  const isMobile = useBreakpointValue({
-    base: true,
-    xs: true,
-    md: false,
-  })
+  const [isLargerThanMd] = useMediaQuery(`(min-width: ${BREAKPOINT_VALS.md})`)
 
-  return isMobile ?? false
+  return !isLargerThanMd
 }

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,9 +1,9 @@
-import { useMediaQuery } from '@chakra-ui/react'
+import { useMediaMatch } from 'rooks'
 
 import { BREAKPOINT_VALS } from '~theme/foundations/breakpoints'
 
 export const useIsMobile = (): boolean => {
-  const [isLargerThanMd] = useMediaQuery(`(min-width: ${BREAKPOINT_VALS.md})`)
+  const isLargerThanMd = useMediaMatch(`(min-width: ${BREAKPOINT_VALS.md})`)
 
   return !isLargerThanMd
 }

--- a/frontend/src/theme/foundations/breakpoints.ts
+++ b/frontend/src/theme/foundations/breakpoints.ts
@@ -1,9 +1,11 @@
 import { createBreakpoints } from '@chakra-ui/theme-tools'
 
-export const breakpoints = createBreakpoints({
+export const BREAKPOINT_VALS = {
   xs: '22.5em',
   sm: '30em',
   md: '48em',
   lg: '64em',
   xl: '90em',
-})
+}
+
+export const breakpoints = createBreakpoints(BREAKPOINT_VALS)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Use media queries instead of the result of `useBreakpointValue` to trigger layout changes.  May break on virtual browsers, we should test before releasing if we can our hands on such devices.



Supercedes #5247
Closes #5244 hopefully

## Solution
<!-- How did you solve the problem? -->

Documentation for [chakra's useMediaQuery()](https://chakra-ui.com/docs/hooks/use-media-query)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
