### PR TITLE
feat: correctly(?) upload sourcemaps for Datadog, again

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -78,6 +78,8 @@ jobs:
           tags: ${{env.ECR_REPO}}:${{env.IMAGE_TAG}}
           build-args: |
             APP_VERSION=${{env.APP_VERSION}}
+            APP_URL=${{env.APP_URL}}
+            REPO_URL=${{github.server_url}}/${{github.repository}}
           secrets: |
             "dd_api_key=${{ secrets.DD_API_KEY }}"
 

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -78,7 +78,7 @@ jobs:
           tags: ${{env.ECR_REPO}}:${{env.IMAGE_TAG}}
           build-args: |
             APP_VERSION=${{env.APP_VERSION}}
-            APP_URL=${{env.APP_URL}}
+            APP_URL=${{secrets.APP_URL}}
             REPO_URL=${{github.server_url}}/${{github.repository}}
           secrets: |
             "dd_api_key=${{ secrets.DD_API_KEY }}"

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -39,7 +39,7 @@ RUN --mount=type=secret,id=dd_api_key \
     npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
     --service=formsg-react \
     --release-version=$APP_VERSION \
-    --minified-path-prefix=$APP_URL/static/js \
+    --minified-path-prefix=$APP_URL \
     --repository-url=$REPO_URL
 
 RUN npm prune --production

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -80,7 +80,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
+RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add font-wqy-zenhei@edge
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 
 # Run as non-privileged user

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -28,6 +28,8 @@ RUN npm run lint-ci
 RUN npm run build
 
 ARG APP_VERSION
+ARG APP_URL
+ARG REPO_URL
 
 # Upload datadog source maps from secret mount, id MUST be `id=dd_api_key` in the docker build command
 # Mount creates a file inside /run/secrets/dd_api_key, and source to load the environment variables
@@ -37,7 +39,8 @@ RUN --mount=type=secret,id=dd_api_key \
     npx @datadog/datadog-ci sourcemaps upload ./dist/frontend \
     --service=formsg-react \
     --release-version=$APP_VERSION \
-    --minified-path-prefix=/static/js
+    --minified-path-prefix=$APP_URL/static/js \
+    --repository-url=$REPO_URL
 
 RUN npm prune --production
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Fix source map URL to the exact environment, also add repository link so any errors can direct us to the offending file immediately.

Part of improving observability.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Hopefully upload source maps correctly.

## Before & After Screenshots
No changes

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
- Add new Github environment secrets `APP_URL` (not really secret, but just adding it for per-env setup)
- add new font-wqy-zenhei package package in our `Dockerfile.prod` since the one we were relying on seems to have been pulled/renamed.