### PR TITLE
feat: detect duplicates in radio and dropdown onblur

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -62,6 +62,7 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
       input: transformDropdownFieldToEditForm,
       output: transformDropdownEditFormToField,
     },
+    mode: 'onBlur',
   })
 
   const requiredValidationRule = useMemo(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
@@ -67,6 +67,7 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
       input: transformRadioFieldToEditForm,
       output: transformRadioEditFormToField,
     },
+    mode: 'onBlur',
   })
 
   const requiredValidationRule = useMemo(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import {
   DeepPartial,
+  Mode,
   UnpackNestedValue,
   useForm,
   UseFormReturn,
@@ -53,7 +54,7 @@ type UseEditFieldFormProps<
     ) => Promise<FieldShape> | FieldShape
   }
 } & {
-  mode?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all'
+  mode?: Mode
 }
 
 export type UseEditFieldFormReturn<U> = UseFormReturn<U> & {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -52,6 +52,8 @@ type UseEditFieldFormProps<
       output: FieldShape,
     ) => Promise<FieldShape> | FieldShape
   }
+} & {
+  mode?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all'
 }
 
 export type UseEditFieldFormReturn<U> = UseFormReturn<U> & {
@@ -65,6 +67,7 @@ export type UseEditFieldFormReturn<U> = UseFormReturn<U> & {
 export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
   field,
   transform,
+  mode,
 }: UseEditFieldFormProps<
   FormShape,
   FieldShape
@@ -98,6 +101,7 @@ export const useEditFieldForm = <FormShape, FieldShape extends FormField>({
   )
   const editForm = useForm<FormShape>({
     defaultValues,
+    mode: mode,
   })
 
   const { isDirty } = editForm.formState


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #5174

## Solution
<!-- How did you solve the problem? -->
Add `mode: 'onBlur'` to `EditRadio` and `EditDropdown`


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Refer to issue

**AFTER**:
<!-- [insert screenshot here] -->
![Recording 2022-10-27 at 23 26 34](https://user-images.githubusercontent.com/56983748/198332509-3556a4b4-d572-4294-8cbf-a32bdbd10e5e.gif)

![Recording 2022-10-27 at 23 27 29](https://user-images.githubusercontent.com/56983748/198332527-170dd140-ca44-4ad6-b285-4d3df8cb2690.gif)


## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Enter a duplicate option for a radio field. Click away. The "Please remove duplicate options" error should appear
- [x] Repeat the same test for a dropdown field
