### PR TITLE
feat: set login state correctly between AngularJS and React, remove redundant /user calls

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,13 +1,7 @@
 import { createContext, FC, useContext } from 'react'
-import { useQuery } from 'react-query'
-
-import { UserDto } from '~shared/types'
 
 import { LOGGED_IN_KEY } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
-import { fetchUser } from '~services/UserService'
-
-import { userKeys } from '~features/user/queries'
 
 type AuthContextProps = {
   isAuthenticated?: boolean
@@ -41,19 +35,7 @@ export const useAuth = (): AuthContextProps => {
 
 // Provider hook that creates auth object and handles state
 const useProvideAuth = () => {
-  const [isLocalStorageAuthenticated, setIsLocalStorageAuthenticated] =
-    useLocalStorage<boolean>(LOGGED_IN_KEY)
-  // TODO #4279: Remove after React rollout is complete
-  const { data: user } = useQuery<UserDto>(
-    userKeys.base,
-    () => fetchUser(),
-    // 10 minutes staletime, do not need to retrieve so often.
-    {
-      staleTime: 600000,
-      onSuccess: () => setIsLocalStorageAuthenticated(true),
-    },
-  )
-  const isAuthenticated = isLocalStorageAuthenticated || !!user
+  const [isAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
 
   // Return the user object and auth methods
   return {

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
@@ -1,7 +1,7 @@
 // TODO #4279: Remove after React rollout is complete
 import { Meta, Story } from '@storybook/react'
 
-import { getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
+import { getUnauthedUser, getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
 
 import {
   fullScreenDecorator,
@@ -57,9 +57,15 @@ const PublicRespondentTemplate: Story = () => {
 
 export const PublicRespondent = PublicRespondentTemplate.bind({})
 PublicRespondent.decorators = [LoggedOutDecorator]
+PublicRespondent.parameters = {
+  msw: [getUnauthedUser()],
+}
 
 export const MobilePublicRespondent = PublicRespondentTemplate.bind({})
-MobilePublicRespondent.parameters = getMobileViewParameters()
+MobilePublicRespondent.parameters = {
+  ...getMobileViewParameters(),
+  msw: [getUnauthedUser()],
+}
 MobilePublicRespondent.decorators = [LoggedOutDecorator]
 
 export const Admin = AdminTemplate.bind({})

--- a/frontend/src/features/user/queries.ts
+++ b/frontend/src/features/user/queries.ts
@@ -1,8 +1,11 @@
 import { useQuery } from 'react-query'
+import { StatusCodes } from 'http-status-codes'
 
 import { UserDto } from '~shared/types/user'
 
-import { useAuth } from '~contexts/AuthContext'
+import { LOGGED_IN_KEY } from '~constants/localStorage'
+import { useLocalStorage } from '~hooks/useLocalStorage'
+import { HttpError } from '~services/ApiService'
 import { fetchUser } from '~services/UserService'
 
 export const userKeys = {
@@ -16,21 +19,26 @@ type UseUserReturn = {
 }
 
 export const useUser = (): UseUserReturn => {
-  const { isAuthenticated } = useAuth()
+  const [, setIsLocalStorageAuthenticated] =
+    useLocalStorage<boolean>(LOGGED_IN_KEY)
 
   const {
     data: user,
     isLoading,
     remove,
-  } = useQuery<UserDto>(
-    userKeys.base,
-    () => fetchUser(),
+  } = useQuery(userKeys.base, () => fetchUser(), {
+    onSuccess: () => setIsLocalStorageAuthenticated(true),
+    onError: (err) => {
+      if (err instanceof HttpError && err.code === StatusCodes.UNAUTHORIZED) {
+        setIsLocalStorageAuthenticated(undefined)
+      }
+    },
     // 10 minutes staletime, do not need to retrieve so often.
-    { staleTime: 600000, enabled: !!isAuthenticated },
-  )
+    staleTime: 600000,
+  })
 
   return {
-    user: isAuthenticated ? user : undefined,
+    user,
     isLoading,
     removeQuery: remove,
   }

--- a/frontend/src/mocks/msw/handlers/user.ts
+++ b/frontend/src/mocks/msw/handlers/user.ts
@@ -25,6 +25,12 @@ export const MOCK_USER = {
   updatedAt: '2021-08-24T09:10:03.295Z' as DateString,
 }
 
+export const getUnauthedUser = ({ delay = 0 }: WithDelayProps = {}) => {
+  return rest.get<never, never, UserDto>('/api/v3/user', (_req, res, ctx) => {
+    return res(ctx.delay(delay), ctx.status(401))
+  })
+}
+
 export const getUser = ({
   delay,
   mockUser = MOCK_USER,

--- a/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.stories.tsx
+++ b/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
+import { getUnauthedUser } from '~/mocks/msw/handlers/user'
+
 import {
   getMobileViewParameters,
   LoggedInDecorator,
@@ -31,6 +33,9 @@ const Template: Story = (args: AdminForbiddenErrorPageProps) => (
 )
 export const NotLoggedIn = Template.bind({})
 NotLoggedIn.decorators = [LoggedOutDecorator]
+NotLoggedIn.parameters = {
+  msw: [getUnauthedUser()],
+}
 
 export const WithMessage = Template.bind({})
 WithMessage.args = {

--- a/frontend/src/pages/NotFoundError/NotFoundErrorPage.stories.tsx
+++ b/frontend/src/pages/NotFoundError/NotFoundErrorPage.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
+import { getUnauthedUser } from '~/mocks/msw/handlers/user'
+
 import {
   getMobileViewParameters,
   LoggedInDecorator,
@@ -26,6 +28,9 @@ export default {
 const Template: Story = () => <NotFoundErrorPage />
 export const NotLoggedIn = Template.bind({})
 NotLoggedIn.decorators = [LoggedOutDecorator]
+NotLoggedIn.parameters = {
+  msw: [getUnauthedUser()],
+}
 
 export const MobileNotLoggedIn = Template.bind({})
 MobileNotLoggedIn.parameters = getMobileViewParameters()

--- a/src/public/modules/users/config/users.client.config.js
+++ b/src/public/modules/users/config/users.client.config.js
@@ -14,6 +14,7 @@ angular.module('users').config([
           responseError: function (response) {
             if (response.status === HttpStatus.UNAUTHORIZED) {
               $window.localStorage.removeItem('user')
+              $window.localStorage.removeItem('is-logged-in')
               $window.location.assign('/#!/signin')
             } else if (response.status === HttpStatus.FORBIDDEN) {
               $window.location.assign('/#!/forms')

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -4,6 +4,8 @@ import { UserDto } from '../../../shared/types'
 
 /** Exported for testing */
 export const STORAGE_USER_KEY = 'user'
+// For React redirect compatibility
+export const LOGGED_IN_KEY = 'is-logged-in'
 /** Exported for testing */
 export const USER_ENDPOINT = '/api/v3/user'
 
@@ -36,6 +38,7 @@ export const getUserFromLocalStorage = (): UserDto | null => {
  */
 export const saveUserToLocalStorage = (user: UserDto): void => {
   localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(user))
+  localStorage.setItem(LOGGED_IN_KEY, 'true')
 }
 
 /**
@@ -44,6 +47,7 @@ export const saveUserToLocalStorage = (user: UserDto): void => {
  */
 export const clearUserFromLocalStorage = (): void => {
   localStorage.removeItem(STORAGE_USER_KEY)
+  localStorage.removeItem(LOGGED_IN_KEY)
 }
 
 /**

--- a/src/public/services/UserService.ts
+++ b/src/public/services/UserService.ts
@@ -19,6 +19,7 @@ export const getUserFromLocalStorage = (): UserDto | null => {
   const userStringified = localStorage.getItem(STORAGE_USER_KEY)
 
   if (userStringified) {
+    localStorage.setItem(LOGGED_IN_KEY, 'true')
     try {
       return UserDto.parse(JSON.parse(userStringified))
     } catch (error) {

--- a/src/public/services/__tests__/UserService.test.ts
+++ b/src/public/services/__tests__/UserService.test.ts
@@ -4,7 +4,7 @@ import { mocked } from 'ts-jest/utils'
 import { DateString, UserDto } from '../../../../shared/types'
 import * as UserService from '../UserService'
 
-const { STORAGE_USER_KEY, USER_ENDPOINT } = UserService
+const { STORAGE_USER_KEY, USER_ENDPOINT, LOGGED_IN_KEY } = UserService
 
 jest.mock('axios')
 
@@ -58,7 +58,11 @@ describe('UserService', () => {
       // Assert
       expect(localStorage.getItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
       expect(actual).toEqual(null)
-      expect(localStorage.removeItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(
+        1,
+        STORAGE_USER_KEY,
+      )
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(2, LOGGED_IN_KEY)
     })
 
     it('should return null and clear user from localStorage when JSON.parse throws', async () => {
@@ -71,7 +75,12 @@ describe('UserService', () => {
       // Assert
       expect(localStorage.getItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
       expect(actual).toEqual(null)
-      expect(localStorage.removeItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
+
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(
+        1,
+        STORAGE_USER_KEY,
+      )
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(2, LOGGED_IN_KEY)
     })
   })
 
@@ -81,10 +90,16 @@ describe('UserService', () => {
       UserService.saveUserToLocalStorage(MOCK_USER)
 
       // Assert
-      expect(localStorage.setItem).toHaveBeenLastCalledWith(
+      expect(localStorage.setItem).toHaveBeenNthCalledWith(
+        1,
         STORAGE_USER_KEY,
         // Should be stringified.
         JSON.stringify(MOCK_USER),
+      )
+      expect(localStorage.setItem).toHaveBeenNthCalledWith(
+        2,
+        LOGGED_IN_KEY,
+        'true',
       )
     })
   })
@@ -95,7 +110,11 @@ describe('UserService', () => {
       UserService.clearUserFromLocalStorage()
 
       // Assert
-      expect(localStorage.removeItem).toHaveBeenLastCalledWith(STORAGE_USER_KEY)
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(
+        1,
+        STORAGE_USER_KEY,
+      )
+      expect(localStorage.removeItem).toHaveBeenNthCalledWith(2, LOGGED_IN_KEY)
     })
   })
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
A more canonically correct way to sync logged in state between angularjs and react. Will also cut down 401s!!!

Fixes bug where there may be a race condition between logging out and /user query which may lead to a desynchronisation of true logged in state. This PR uses localStorage as the source of truth so such race conditions will not happen anymore
