### PR TITLE
fix: set feedback modal's focus to be on radio options

### DIFF
--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -171,6 +171,7 @@ export const SwitchEnvFeedbackModal = ({
                         })}
                         value={option}
                         key={option}
+                        tabIndex={1}
                       >
                         {option}
                       </Radio>
@@ -247,7 +248,6 @@ export const SwitchEnvFeedbackModal = ({
                           }
                         },
                       })}
-                      tabIndex={1}
                     />
                     <FormErrorMessage>
                       {errors['email']?.message}
@@ -264,7 +264,7 @@ export const SwitchEnvFeedbackModal = ({
                   >
                     Describe your problem in detail to help us improve FormSG
                   </FormLabel>
-                  <Textarea {...register('feedback')} tabIndex={1} />
+                  <Textarea {...register('feedback')} />
                 </FormControl>
                 {rumSessionId ? (
                   <FormControl>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Feedback modal doesn't focus on radio options when it's opened. (See #5185)

## Solution
<!-- How did you solve the problem? -->
Change the focus to be on radio options


## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
**Admin**
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/56983748/198075505-00557ee3-abd9-49ed-b91a-27f8b5c2b7dc.png">

**Public form**
<img width="985" alt="image" src="https://user-images.githubusercontent.com/56983748/198075602-73f19a56-92ae-49a8-a18f-5428e29aabfa.png">
