### PR TITLE
feat: add retry/refresh when chunk loading fails

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -17,6 +17,7 @@ import {
   TOU_ROUTE,
 } from '~constants/routes'
 import { fillHeightCss } from '~utils/fillHeightCss'
+import { lazyRetry } from '~utils/lazyRetry'
 
 import NotFoundErrorPage from '~pages/NotFoundError'
 import { AdminFormLayout } from '~features/admin-form/common/AdminFormLayout'
@@ -35,15 +36,19 @@ import { HashRouterElement } from './HashRouterElement'
 import { PrivateElement } from './PrivateElement'
 import { PublicElement } from './PublicElement'
 
-const PublicFormPage = lazy(
-  () => import('~features/public-form/PublicFormPage'),
+const PublicFormPage = lazy(() =>
+  lazyRetry(() => import('~features/public-form/PublicFormPage')),
 )
-const WorkspacePage = lazy(() => import('~features/workspace'))
-const LandingPage = lazy(() => import('~pages/Landing'))
-const LoginPage = lazy(() => import('~features/login'))
-const PrivacyPolicyPage = lazy(() => import('~pages/PrivacyPolicy'))
-const TermsOfUsePage = lazy(() => import('~pages/TermsOfUse'))
-const PreviewFormPage = lazy(() => import('~features/admin-form/preview'))
+const WorkspacePage = lazy(() => lazyRetry(() => import('~features/workspace')))
+const LandingPage = lazy(() => lazyRetry(() => import('~pages/Landing')))
+const LoginPage = lazy(() => lazyRetry(() => import('~features/login')))
+const PrivacyPolicyPage = lazy(() =>
+  lazyRetry(() => import('~pages/PrivacyPolicy')),
+)
+const TermsOfUsePage = lazy(() => lazyRetry(() => import('~pages/TermsOfUse')))
+const PreviewFormPage = lazy(() =>
+  lazyRetry(() => import('~features/admin-form/preview')),
+)
 
 const WithSuspense = ({ children }: { children: React.ReactNode }) => (
   <Suspense fallback={<Box bg="neutral.100" css={fillHeightCss} w="100vw" />}>

--- a/frontend/src/utils/lazyRetry.ts
+++ b/frontend/src/utils/lazyRetry.ts
@@ -1,0 +1,36 @@
+import { ComponentType } from 'react'
+
+/**
+ * Retry React.lazy calls on error, or refresh the page if it was a chunk load
+ * error to hopefully retrieve the correct version of the chunk to due
+ * no-cache header.
+ *
+ * Retrieved from https://www.codemzy.com/blog/fix-chunkloaderror-react.
+ *
+ * @note this only works for route based code splitting https://reactjs.org/docs/code-splitting.html#route-based-code-splitting
+ * Will cause infinite loop if used for normal code splitting since multiple lazy calls may be triggered in a single component.
+ */
+export const lazyRetry = <T extends ComponentType>(
+  componentImport: () => Promise<{ default: T }>,
+) => {
+  return new Promise<{ default: T }>((resolve, reject) => {
+    // check if the window has already been refreshed
+    const hasRefreshed = JSON.parse(
+      window.sessionStorage.getItem('retry-lazy-refreshed') || 'false',
+    )
+    // try to import the component
+    componentImport()
+      .then((component) => {
+        window.sessionStorage.setItem('retry-lazy-refreshed', 'false') // success so reset the refresh
+        resolve(component)
+      })
+      .catch((error) => {
+        if (!hasRefreshed) {
+          // not been refreshed yet
+          window.sessionStorage.setItem('retry-lazy-refreshed', 'true') // we are now going to refresh
+          return window.location.reload() // refresh the page
+        }
+        reject(error) // Default error behaviour as already tried refresh
+      })
+  })
+}

--- a/frontend/src/utils/lazyRetry.ts
+++ b/frontend/src/utils/lazyRetry.ts
@@ -13,21 +13,23 @@ import { ComponentType } from 'react'
 export const lazyRetry = <T extends ComponentType>(
   componentImport: () => Promise<{ default: T }>,
 ) => {
+  const sessionStorageKey = `retry-lazy-${process.env.REACT_APP_VERSION}-refreshed`
+
   return new Promise<{ default: T }>((resolve, reject) => {
     // check if the window has already been refreshed
     const hasRefreshed = JSON.parse(
-      window.sessionStorage.getItem('retry-lazy-refreshed') || 'false',
+      window.sessionStorage.getItem(sessionStorageKey) || 'false',
     )
     // try to import the component
     componentImport()
       .then((component) => {
-        window.sessionStorage.setItem('retry-lazy-refreshed', 'false') // success so reset the refresh
+        window.sessionStorage.setItem(sessionStorageKey, 'false') // success so reset the refresh
         resolve(component)
       })
       .catch((error) => {
         if (!hasRefreshed) {
           // not been refreshed yet
-          window.sessionStorage.setItem('retry-lazy-refreshed', 'true') // we are now going to refresh
+          window.sessionStorage.setItem(sessionStorageKey, 'true') // we are now going to refresh
           return window.location.reload() // refresh the page
         }
         reject(error) // Default error behaviour as already tried refresh


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Seeing a small amount of chunk loading errors due to older clients.

Forcing a refresh on lazy loading errors (on first refresh) should get latest the `index.html` from the server (which references new chunks), reducing chunk errors

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- feat: add retry/refresh when lazy loading fails

## Before & After Screenshots
Should have no changes
