### PR TITLE
feat: add image compression for oversize image attachments

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -151,7 +151,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
         ) {
           return imageCompression(acceptedFile, {
             maxSizeMB: maxSize ? maxSize / MB : undefined,
-            maxWidthOrHeight: 1024,
+            maxWidthOrHeight: 1920,
             alwaysKeepResolution: true,
             initialQuality: 0.8,
             useWebWorker: false,

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -152,7 +152,6 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
           return imageCompression(acceptedFile, {
             maxSizeMB: maxSize ? maxSize / MB : undefined,
             maxWidthOrHeight: 1920,
-            alwaysKeepResolution: true,
             initialQuality: 0.8,
             useWebWorker: false,
           }).then((blob) => onChange(new File([blob], acceptedFile.name)))

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -10,8 +10,11 @@ import {
   useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
+import imageCompression from 'browser-image-compression'
 import omit from 'lodash/omit'
 import simplur from 'simplur'
+
+import { MB } from '~shared/constants/file'
 
 import { ATTACHMENT_THEME_KEY } from '~theme/components/Field/Attachment'
 import { ThemeColorScheme } from '~theme/foundations/colours'
@@ -23,6 +26,8 @@ import {
   getInvalidFileExtensionsInZip,
   getReadableFileSize,
 } from './utils'
+
+const IMAGE_UPLOAD_TYPES_TO_COMPRESS = ['image/jpeg', 'image/png']
 
 export interface AttachmentProps extends UseFormControlProps<HTMLElement> {
   /**
@@ -138,14 +143,32 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
           }
         }
 
+        // Compress images that are too large.
+        if (
+          IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(acceptedFile.type) &&
+          maxSize &&
+          acceptedFile.size > maxSize
+        ) {
+          return imageCompression(acceptedFile, {
+            maxSizeMB: maxSize ? maxSize / MB : undefined,
+            maxWidthOrHeight: 1024,
+            alwaysKeepResolution: true,
+            useWebWorker: false,
+          }).then((blob) => onChange(new File([blob], acceptedFile.name)))
+        }
+
         onChange(acceptedFile)
       },
-      [accept, onChange, onError],
+      [accept, maxSize, onChange, onError],
     )
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(
       (file) => {
-        if (maxSize && file.size > maxSize) {
+        if (
+          !IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type) &&
+          maxSize &&
+          file.size > maxSize
+        ) {
           return {
             code: 'file-too-large',
             message: `You have exceeded the limit, please upload a file below ${readableMaxSize}`,

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -153,6 +153,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             maxSizeMB: maxSize ? maxSize / MB : undefined,
             maxWidthOrHeight: 1024,
             alwaysKeepResolution: true,
+            initialQuality: 0.8,
             useWebWorker: false,
           }).then((blob) => onChange(new File([blob], acceptedFile.name)))
         }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from 'react'
 import { ControllerRenderProps } from 'react-hook-form'
 import { forwardRef } from '@chakra-ui/react'
-import imageCompression from 'browser-image-compression'
 
 import {
   MAX_UPLOAD_FILE_SIZE,
-  MB,
   VALID_UPLOAD_FILE_TYPES,
 } from '~shared/constants/file'
 
@@ -36,26 +34,9 @@ export const UploadImageInput = forwardRef<UploadImageInputProps, 'div'>(
 
     const handleChange = (file?: File) => {
       if (!file) return onChange({ file, srcUrl: undefined })
-
-      if (/\.gif$/i.test(file.name)) {
-        // No compression for gifs since they cannot be properly compressed and
-        // will just be compressed into a static image.
-        return onChange({
-          file,
-          srcUrl: URL.createObjectURL(file),
-        })
-      }
-
-      return imageCompression(file, {
-        maxSizeMB: MAX_UPLOAD_FILE_SIZE / MB,
-        alwaysKeepResolution: true,
-        initialQuality: 0.8,
-        useWebWorker: false,
-      }).then((compressed) => {
-        onChange({
-          file: compressed,
-          srcUrl: URL.createObjectURL(compressed),
-        })
+      return onChange({
+        file,
+        srcUrl: URL.createObjectURL(file),
       })
     }
 

--- a/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/DeleteFieldModal/DeleteFieldModal.tsx
@@ -77,7 +77,11 @@ export const DeleteFieldModal = (): JSX.Element => {
             ml="1.75rem"
             mt="1rem"
           >
-            <ListItem display="flex" alignItems="flex-start">
+            <ListItem
+              display="flex"
+              alignItems="flex-start"
+              wordBreak="break-word"
+            >
               <Icon
                 as={fieldIcon}
                 fontSize="1.25rem"

--- a/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -153,9 +153,9 @@ describe('attachment validation', () => {
     // Valid large file
     const mockLargeFile = new File(
       ["We're no strangers to love"],
-      'rickastley.png',
+      'rickastley.pdf',
       {
-        type: 'image/png',
+        type: 'application/pdf',
       },
     )
     Object.defineProperty(mockLargeFile, 'size', { value: 1.001 * MB })


### PR DESCRIPTION
## Problem
In angular, we promise users that we will compress images if they are oversized. We should also do this in react.

Closes #5286 

## Solution
Allow all images to pass the file size validator, since they will be processed in handleFileUpload.
Then, in handleFileUpload, if it is an oversized image file, we image compress it to maximum width/height 1024.
Remove image compression from upload image input, which calls the attachment component, to avoid calling compression twice.

Oh, also I fixed a small overflow issue in delete modal. Sorry for contaminating.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests
- [x] Respondent: Uploading a non-image attachment works in both email and storage mode.
- [x] Admin: Downloading a non-image attachment works in both email and storage mode.
- [x] Respondent: Uploading an image attachment under the size limit works in both email and storage mode.
- [x] Admin: Downloading an image attachment under the size limit works in both email and storage mode.
- [x] Respondent: Uploading an oversized image attachment works in both email and storage mode, and displays a file size smaller than the actual file size.
- [x] Admin: Downloading an oversized image attachment works in both email and storage mode, and the file size is smaller than the maximum size indicated in the attachment field.
- [x] Admin: Images and logos can be uploaded when under the size limit.
- [x] Admin: Images and logos that are oversized get compressed before being added to the form.

PM me on slack if you need a big image file, I have one :)
