### PR TITLE
feat: remove contact us link from app footer

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -35,7 +35,6 @@ export const GUIDE_PREFILL = 'https://go.gov.sg/formsg-guide-prefills'
 export const ACCEPTED_FILETYPES_SPREADSHEET = 'https://go.gov.sg/formsg-cwl'
 
 export const APP_FOOTER_LINKS = [
-  { label: 'Contact us', href: CONTACT_US },
   { label: 'Guide', href: FORM_GUIDE },
   { label: 'Privacy', href: PRIVACY_POLICY_ROUTE },
   { label: 'Terms of use', href: TOU_ROUTE },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Remove Contact Us from the app footer, similar to Angular


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="1400" alt="Screenshot 2022-10-31 at 2 57 44 PM" src="https://user-images.githubusercontent.com/56983748/198949525-766dba68-9359-4f4d-9ebc-8f022e6125df.png">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1479" alt="Screenshot 2022-10-31 at 2 57 03 PM" src="https://user-images.githubusercontent.com/56983748/198949453-dabb0604-13c1-41e8-9bdd-2f6096d965c3.png">

