### PR TITLE
fix: add explicit type label for compressed file to ensure image upload validation works

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -154,7 +154,13 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             maxWidthOrHeight: 1920,
             initialQuality: 0.8,
             useWebWorker: false,
-          }).then((blob) => onChange(new File([blob], acceptedFile.name)))
+          }).then((blob) =>
+            onChange(
+              new File([blob], acceptedFile.name, {
+                type: blob.type,
+              }),
+            ),
+          )
         }
 
         onChange(acceptedFile)


### PR DESCRIPTION
## Problem
#5287 added compression for oversized image attachments, but that broke image and logo uploads in the builder. The reason is because while the attachment field allows files of any type, the builder allows only uploads of png and jpeg, and requires an explicit annotation for the file type. This was not included in the File object that was created after the image was compressed.

## Solution
Add an explicit filetype annotation.

**Breaking Changes** 
- No - this PR is backwards compatible  
