### PR TITLE
ci: use federated role

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -13,6 +13,10 @@ on:
       - staging-alt2
       - uat
 
+permissions:
+  id-token: write
+  contents: read
+  
 jobs:
   set_environment:
     outputs:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to do deployment using a federated role, similar to internal tools
 
Closes [#108](https://github.com/opengovsg/formsg-private/issues/108)

## Solution
<!-- How did you solve the problem? -->
Created a [cloud formation template `ci-actions-formsg`](https://ap-southeast-1.console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/resources?stackId=arn%3Aaws%3Acloudformation%3Aap-southeast-1%3A652261905145%3Astack%2Fci-actions-formsg%2F1ab43ca0-59ac-11ed-a1a9-06e42111fa14&filteringStatus=active&filteringText=&viewNested=true&hideStacks=false) which creates the role and associated permissions used for deployment. This template assumes the existence of an OIDC identity provider.

## Tests
Successfully [deployed](https://github.com/opengovsg/FormSG/actions/runs/3366165969) this branch to `staging-alt2` (in particular it passed the "Configure AWS credentials" step)

## Deploy Notes
**New environment variables**:

- `AWS_CI_ROLE_TO_ASSUME`: ARN of AWS role that is used in deployment of the code from Github to AWS

Completed on 19 Dec 2022:
- Deleted `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from Github secrets