### PR TITLE
fix: add multiline for dropdown items

### DIFF
--- a/frontend/src/components/Dropdown/components/DropdownItem/DropdownItem.tsx
+++ b/frontend/src/components/Dropdown/components/DropdownItem/DropdownItem.tsx
@@ -57,8 +57,7 @@ export const DropdownItem = ({
           <Text
             textStyle="body-1"
             minWidth={0}
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
+            overflowWrap="break-word"
             overflowX="hidden"
           >
             <DropdownItemTextHighlighter


### PR DESCRIPTION
## Problem
Closes #5281 

## Solution
Use overflowWrap instead of textOverflow in dropdownitem component.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/25571626/199406474-62257bc8-a396-4034-ad05-afd96cfa224e.png">
