### PR TITLE
fix: add frontend validation for duplicate Others

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
@@ -107,6 +107,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   const optionsValidation = useCallback(
     (opts: string) => {
       const textareaValidation = SPLIT_TEXTAREA_VALIDATION.validate(opts)
+      // Explicit check for !== true, since the error strings returned by the validator will also be truthy.
       if (textareaValidation !== true) return textareaValidation
       return DUPLICATE_OTHERS_VALIDATION(
         watchedInputs.othersRadioButton,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { Controller, RegisterOptions } from 'react-hook-form'
 import { Box, FormControl, SimpleGrid } from '@chakra-ui/react'
 import { extend, isEmpty, pick } from 'lodash'
@@ -17,6 +17,7 @@ import { validateNumberInput } from '~features/admin-form/create/builder-and-des
 
 import { CreatePageDrawerContentContainer } from '../../../../../common'
 import {
+  DUPLICATE_OTHERS_VALIDATION,
   SPLIT_TEXTAREA_TRANSFORM,
   SPLIT_TEXTAREA_VALIDATION,
 } from '../common/constants'
@@ -102,6 +103,17 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   )
 
   const watchedInputs = watch()
+
+  const optionsValidation = useCallback(
+    (opts: string) => {
+      const textareaValidation = SPLIT_TEXTAREA_VALIDATION.validate(opts)
+      if (textareaValidation !== true) return textareaValidation
+      return DUPLICATE_OTHERS_VALIDATION(
+        watchedInputs.othersRadioButton,
+      ).validate(opts)
+    },
+    [watchedInputs.othersRadioButton],
+  )
 
   const customMinValidationOptions: RegisterOptions = useMemo(
     () => ({
@@ -222,7 +234,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         <Textarea
           placeholder="Enter one option per line"
           {...register('fieldOptions', {
-            validate: SPLIT_TEXTAREA_VALIDATION,
+            validate: optionsValidation,
           })}
         />
         <FormErrorMessage>{errors?.fieldOptions?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
@@ -81,6 +81,7 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
   const optionsValidation = useCallback(
     (opts: string) => {
       const textareaValidation = SPLIT_TEXTAREA_VALIDATION.validate(opts)
+      // Explicit check for !== true, since the error strings returned by the validator will also be truthy.
       if (textareaValidation !== true) return textareaValidation
       return DUPLICATE_OTHERS_VALIDATION(hasRadio).validate(opts)
     },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { FormControl } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'
 
@@ -13,6 +13,7 @@ import Toggle from '~components/Toggle'
 
 import { CreatePageDrawerContentContainer } from '../../../../../common'
 import {
+  DUPLICATE_OTHERS_VALIDATION,
   SPLIT_TEXTAREA_TRANSFORM,
   SPLIT_TEXTAREA_VALIDATION,
 } from '../common/constants'
@@ -61,6 +62,7 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
     handleUpdateField,
     isLoading,
     handleCancel,
+    watch,
   } = useEditFieldForm<EditRadioInputs, RadioFieldBase>({
     field,
     transform: {
@@ -73,6 +75,16 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
   const requiredValidationRule = useMemo(
     () => createBaseValidationRules({ required: true }),
     [],
+  )
+
+  const hasRadio = watch('othersRadioButton')
+  const optionsValidation = useCallback(
+    (opts: string) => {
+      const textareaValidation = SPLIT_TEXTAREA_VALIDATION.validate(opts)
+      if (textareaValidation !== true) return textareaValidation
+      return DUPLICATE_OTHERS_VALIDATION(hasRadio).validate(opts)
+    },
+    [hasRadio],
   )
 
   return (
@@ -102,7 +114,7 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
         <Textarea
           placeholder="Enter one option per line"
           {...register('fieldOptionsString', {
-            validate: SPLIT_TEXTAREA_VALIDATION,
+            validate: optionsValidation,
           })}
         />
         <FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/constants.ts
@@ -17,3 +17,13 @@ export const SPLIT_TEXTAREA_VALIDATION = {
     )
   },
 }
+
+export const DUPLICATE_OTHERS_VALIDATION = (hasOthers: boolean) => ({
+  validate: (opts: string) => {
+    if (!hasOthers) return true
+    const optsArr = SPLIT_TEXTAREA_TRANSFORM.output(opts)
+    return (
+      !optsArr.includes('Others') || "Please remove duplicate 'Others' options."
+    )
+  },
+})

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -338,7 +338,7 @@ const isConditionFulfilled = (
     // TODO: An option that is named "Others: Something..." will also pass this test,
     // even if the field has not been configured to set othersRadioButton=true
     if (conditionValues.indexOf('Others') > -1) {
-      // TODO: This is used for angular's client. There's no need to push these magic values, as they are never seen by the server.
+      // TODO: This is used for angular's client. The server has no need for these magic values, as they are never seen by the server.
       if (field.fieldType === 'radiobutton') {
         conditionValues.push('radioButtonOthers')
       } else if (field.fieldType === 'checkbox') {

--- a/src/shared/util/logic.ts
+++ b/src/shared/util/logic.ts
@@ -317,7 +317,7 @@ const isConditionFulfilled = (
     condition.state === LogicConditionState.Equal ||
     condition.state === LogicConditionState.Either
   ) {
-    // condition.value can be a string (is equals to), or an array (is either)
+    // condition.value can be a string (is equals to), or an array (is either) (not strictly true either...)
     const conditionValues = ([] as unknown[])
       .concat(condition.value)
       .map(String)
@@ -338,20 +338,24 @@ const isConditionFulfilled = (
     // TODO: An option that is named "Others: Something..." will also pass this test,
     // even if the field has not been configured to set othersRadioButton=true
     if (conditionValues.indexOf('Others') > -1) {
+      // TODO: This is used for angular's client. There's no need to push these magic values, as they are never seen by the server.
       if (field.fieldType === 'radiobutton') {
         conditionValues.push('radioButtonOthers')
       } else if (field.fieldType === 'checkbox') {
         conditionValues.push('checkboxOthers') // Checkbox currently doesn't have logic, but the 'Others' will work in the future if it in implemented
       }
+      // This needs to work for manual "Others" options created by users as well.
+      // The only reason this works is that manual "Others" will satisfy the client-side
+      // condition, albeit on the server. See #5318 for more info.
       return (
         conditionValues.indexOf(currentValue) > -1 || // Client-side
         currentValue.startsWith('Others: ')
       ) // Server-side
     }
     return conditionValues.indexOf(currentValue) > -1
-  } else if (condition.state === 'is less than or equal to') {
+  } else if (condition.state === LogicConditionState.Lte) {
     return Number(currentValue) <= Number(condition.value)
-  } else if (condition.state === 'is more than or equal to') {
+  } else if (condition.state === LogicConditionState.Gte) {
     return Number(currentValue) >= Number(condition.value)
   } else {
     return false


### PR DESCRIPTION
## Problem

Closes #5315

## Solution
Add frontend validation to ensure that there is no "Others" option in radio and checkbox options, if the others toggle is already on.

**Breaking changes**
- No - this PR is backwards compatible  

## Tests
For both radio and checkbox:
- [ ] New field should be addable if there is "Others" toggled.
- [ ] New field should be addable if there is manual "Others".
- [ ] New field should not be addable if there is both "Others" toggled and manual "Others".
- [ ] Existing field should not be updatable if there is both "Others" toggled and manual "Others".