### PR TITLE
fix: decimal field validation allows 0 to be the min or max

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -250,22 +250,21 @@ export const createDecimalValidationRules: ValidationRuleFn<
       if (!validateByValue) return true
 
       if (
-        customMin &&
-        customMax &&
+        customMin !== null &&
+        customMax !== null &&
         (numVal < customMin || numVal > customMax)
       ) {
         return `Please enter a decimal between ${formatNumberToLocaleString(
           customMin,
         )} and ${formatNumberToLocaleString(customMax)} (inclusive)`
       }
-
-      if (customMin && numVal < customMin) {
+      if (customMin !== null && numVal < customMin) {
         return `Please enter a decimal greater than or equal to ${formatNumberToLocaleString(
           customMin,
         )}`
       }
 
-      if (customMax && numVal > customMax) {
+      if (customMax !== null && numVal > customMax) {
         return `Please enter a decimal less than or equal to ${formatNumberToLocaleString(
           customMax,
         )}`


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Frontend validation checks for the decimal field were failing when 0 was set as the min or max value.

## Solution
<!-- How did you solve the problem? -->
As identified by @justynoh , when 0 was set as the min/max value, it was not being registered by the checks since this was based on a boolean. To solve this, set `customMax` / `customMin` `!== null` instead of relying on just `customMax` / `customMin`

## Screenshots
*Before*
![image](https://user-images.githubusercontent.com/56983748/199686374-f2766112-f3b0-43ee-bf74-7d24c3a89592.png)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a decimal field. Set 0 as the min value. In the public form, enter -5. A validation message should pop up and you should not be able to submit the form. 
- [ ] Create a decimal field. Set 0 as the max value. In the public form, enter 5. A validation message should pop up and you should not be able to submit the form. 

