### PR TITLE
feat: make feedback compulsory for public respondents

### DIFF
--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -15,7 +15,6 @@ import {
   ADMIN_RADIO_OPTIONS,
   COMMON_RADIO_OPTIONS,
   FEEDBACK_OTHERS_INPUT_NAME,
-  PUBLIC_RADIO_OPTIONS,
 } from './SwitchEnvFeedbackModal'
 
 export const getClientEnvVars = async (): Promise<ClientEnvVars> => {
@@ -34,10 +33,8 @@ const createFeedbackResponsesArray = (
     ['rumSessionId', 3],
     ['switchReason', 4],
   ]
-  const RADIO_OPTIONS_WITHOUT_OTHERS = ADMIN_RADIO_OPTIONS.concat(
-    PUBLIC_RADIO_OPTIONS,
-    COMMON_RADIO_OPTIONS,
-  )
+  const RADIO_OPTIONS_WITHOUT_OTHERS =
+    ADMIN_RADIO_OPTIONS.concat(COMMON_RADIO_OPTIONS)
   const responses: {
     _id: string
     question: string

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.stories.tsx
@@ -10,11 +10,7 @@ import {
   LoggedOutDecorator,
 } from '~utils/storybook'
 
-import {
-  ADMIN_RADIO_OPTIONS,
-  PUBLIC_RADIO_OPTIONS,
-  SwitchEnvFeedbackModal,
-} from './SwitchEnvFeedbackModal'
+import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
 
 export default {
   title: 'Pages/SwitchEnvFeedbackModal',
@@ -38,7 +34,7 @@ const AdminTemplate: Story = () => {
       onSubmitFeedback={async () => console.log('submit feedback')}
       onClose={onClose}
       isOpen={true}
-      radioOptions={ADMIN_RADIO_OPTIONS}
+      isAdminView={true}
     />
   )
 }
@@ -50,7 +46,7 @@ const PublicRespondentTemplate: Story = () => {
       onSubmitFeedback={async () => console.log('submit feedback')}
       onClose={onClose}
       isOpen={true}
-      radioOptions={PUBLIC_RADIO_OPTIONS}
+      isAdminView={false}
     />
   )
 }

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -254,7 +254,6 @@ export const SwitchEnvFeedbackModal = ({
                     })}
                   />
                   <FormErrorMessage>
-                    {console.log(errors['feedback']?.message)}
                     {errors['feedback']?.message}
                   </FormErrorMessage>
                 </FormControl>

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -157,10 +157,8 @@ export const SwitchEnvFeedbackModal = ({
                 </FormControl>
                 {user && isAdminView ? (
                   <FormControl
-                    isRequired={isAdminView}
-                    isInvalid={
-                      isAdminView && (!isEmpty(errors) || !!othersInputError)
-                    }
+                    isRequired
+                    isInvalid={!isEmpty(errors) || !!othersInputError}
                   >
                     <FormLabel>
                       Why are you switching to the previous FormSG?

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -157,8 +157,10 @@ export const SwitchEnvFeedbackModal = ({
                 </FormControl>
                 {user && isAdminView ? (
                   <FormControl
-                    isRequired
-                    isInvalid={!isEmpty(errors) || !!othersInputError}
+                    isRequired={isAdminView}
+                    isInvalid={
+                      isAdminView && (!isEmpty(errors) || !!othersInputError)
+                    }
                   >
                     <FormLabel>
                       Why are you switching to the previous FormSG?
@@ -228,19 +230,33 @@ export const SwitchEnvFeedbackModal = ({
                     </FormErrorMessage>
                   </FormControl>
                 ) : null}
-                <FormControl>
+                <FormControl
+                  isRequired={!isAdminView}
+                  isInvalid={!isAdminView && !isEmpty(errors)}
+                >
                   <FormLabel
                     description={
-                      user
+                      isAdminView
                         ? ''
                         : 'Any fields you’ve filled in your form so far will be cleared'
                     }
                   >
-                    {user
+                    {isAdminView
                       ? 'Describe your problem in detail to help us improve FormSG'
                       : 'Please tell us about the issue(s) you’re facing. It’ll help us improve FormSG.'}
                   </FormLabel>
-                  <Textarea {...register('feedback')} />
+                  <Textarea
+                    {...register('feedback', {
+                      required: {
+                        value: !isAdminView,
+                        message: 'This field is required',
+                      },
+                    })}
+                  />
+                  <FormErrorMessage>
+                    {console.log(errors['feedback']?.message)}
+                    {errors['feedback']?.message}
+                  </FormErrorMessage>
                 </FormControl>
                 {user ? (
                   <FormControl>

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -36,14 +36,13 @@ export interface SwitchEnvModalProps {
   onClose: () => void
   onSubmitFeedback: (formInputs: SwitchEnvFeedbackFormBodyDto) => Promise<any>
   onChangeEnv: () => void
-  radioOptions: string[]
+  isAdminView: boolean
 }
 
 export const ADMIN_RADIO_OPTIONS = [
   'I couldn’t find a feature I needed',
   'The new FormSG did not function properly',
 ]
-export const PUBLIC_RADIO_OPTIONS = ['I couldn’t submit my form']
 export const COMMON_RADIO_OPTIONS = ['I’m not used to the new FormSG']
 export const FEEDBACK_OTHERS_INPUT_NAME = 'react-feedback-others-input'
 
@@ -52,7 +51,7 @@ export const SwitchEnvFeedbackModal = ({
   onClose,
   onChangeEnv,
   onSubmitFeedback,
-  radioOptions,
+  isAdminView,
 }: SwitchEnvModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -147,83 +146,101 @@ export const SwitchEnvFeedbackModal = ({
         ) : (
           <chakra.form noValidate onSubmit={handleFormSubmit}>
             <ModalHeader pr="48px">
-              Something not right on the new FormSG?
+              {user
+                ? 'Something not right on the new FormSG?'
+                : "Can't submit this form?"}
             </ModalHeader>
             <ModalBody mt="0" pt="0">
               <Stack spacing="1rem">
                 <FormControl>
                   <Input type="hidden" {...register('url')} value={url} />
                 </FormControl>
-                <FormControl
-                  isRequired
-                  isInvalid={!isEmpty(errors) || !!othersInputError}
-                >
-                  <FormLabel>
-                    Why are you switching to the previous FormSG?
-                  </FormLabel>
-                  <Radio.RadioGroup>
-                    {COMMON_RADIO_OPTIONS.map((option) => (
-                      <Radio
-                        {...register('switchReason', {
-                          required: {
-                            value: true,
-                            message: 'This field is required',
-                          },
-                          deps: [FEEDBACK_OTHERS_INPUT_NAME],
-                        })}
-                        value={'I’m not used to the new FormSG'}
-                        key={option}
-                        tabIndex={1}
-                      >
-                        {option}
-                      </Radio>
-                    ))}
-                    {radioOptions.map((option) => (
-                      <Radio
-                        {...register('switchReason', {
-                          required: {
-                            value: true,
-                            message: 'This field is required',
-                          },
-                          deps: [FEEDBACK_OTHERS_INPUT_NAME],
-                        })}
-                        value={option}
-                        key={option}
-                      >
-                        {option}
-                      </Radio>
-                    ))}
-                    <Radio.OthersWrapper
-                      {...register('switchReason', {
-                        required: {
-                          value: true,
-                          message: 'This field is required',
-                        },
-                        deps: [FEEDBACK_OTHERS_INPUT_NAME],
-                      })}
-                      value={othersInputValue}
-                    >
-                      <FormControl>
-                        <OthersInput
-                          aria-label='"Other" response'
-                          {...register(FEEDBACK_OTHERS_INPUT_NAME, {
-                            validate: (value) => {
-                              return (
-                                getValues('switchReason') !==
-                                  othersInputValue ||
-                                !!value ||
-                                'Please specify a value for the "Others" option'
-                              )
+                {user && isAdminView ? (
+                  <FormControl
+                    isRequired
+                    isInvalid={!isEmpty(errors) || !!othersInputError}
+                  >
+                    <FormLabel>
+                      Why are you switching to the previous FormSG?
+                    </FormLabel>
+                    <Radio.RadioGroup>
+                      {COMMON_RADIO_OPTIONS.map((option) => (
+                        <Radio
+                          {...register('switchReason', {
+                            required: {
+                              value: true,
+                              message: 'This field is required',
                             },
+                            deps: [FEEDBACK_OTHERS_INPUT_NAME],
                           })}
-                        />
-                      </FormControl>
-                    </Radio.OthersWrapper>
-                  </Radio.RadioGroup>
-                  <FormErrorMessage>
-                    {errors['switchReason']?.message ??
-                      errors[FEEDBACK_OTHERS_INPUT_NAME]?.message}
-                  </FormErrorMessage>
+                          value={'I’m not used to the new FormSG'}
+                          key={option}
+                          tabIndex={1}
+                        >
+                          {option}
+                        </Radio>
+                      ))}
+                      {ADMIN_RADIO_OPTIONS.map((option) => (
+                        <Radio
+                          {...register('switchReason', {
+                            required: {
+                              value: true,
+                              message: 'This field is required',
+                            },
+                            deps: [FEEDBACK_OTHERS_INPUT_NAME],
+                          })}
+                          value={option}
+                          key={option}
+                        >
+                          {option}
+                        </Radio>
+                      ))}
+                      <Radio.OthersWrapper
+                        {...register('switchReason', {
+                          required: {
+                            value: true,
+                            message: 'This field is required',
+                          },
+                          deps: [FEEDBACK_OTHERS_INPUT_NAME],
+                        })}
+                        value={othersInputValue}
+                      >
+                        <FormControl>
+                          <OthersInput
+                            aria-label='"Other" response'
+                            {...register(FEEDBACK_OTHERS_INPUT_NAME, {
+                              validate: (value) => {
+                                return (
+                                  getValues('switchReason') !==
+                                    othersInputValue ||
+                                  !!value ||
+                                  'Please specify a value for the "Others" option'
+                                )
+                              },
+                            })}
+                          />
+                        </FormControl>
+                      </Radio.OthersWrapper>
+                    </Radio.RadioGroup>
+                    <FormErrorMessage>
+                      {errors['switchReason']?.message ??
+                        errors[FEEDBACK_OTHERS_INPUT_NAME]?.message}
+                    </FormErrorMessage>
+                  </FormControl>
+                ) : null}
+                <FormControl>
+                  <FormLabel
+                    description={
+                      user
+                        ? ''
+                        : 'Any fields you’ve filled in your form so far will be cleared'
+                    }
+                  >
+                    {user
+                      ? 'Describe your problem in detail to help us improve FormSG'
+                      : 'Please tell us about the issue(s) you’re facing. It’ll help us improve FormSG.'}
+                  </FormLabel>
+                  <Textarea {...register('feedback')} />
                 </FormControl>
                 {user ? (
                   <FormControl>
@@ -256,18 +273,6 @@ export const SwitchEnvFeedbackModal = ({
                     </FormErrorMessage>
                   </FormControl>
                 )}
-                <FormControl>
-                  <FormLabel
-                    description={
-                      user
-                        ? ''
-                        : 'Any fields you’ve filled in your form so far will be cleared'
-                    }
-                  >
-                    Describe your problem in detail to help us improve FormSG
-                  </FormLabel>
-                  <Textarea {...register('feedback')} />
-                </FormControl>
                 {rumSessionId ? (
                   <FormControl>
                     <Input

--- a/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
+++ b/frontend/src/features/env/SwitchEnvFeedbackModal.tsx
@@ -173,7 +173,7 @@ export const SwitchEnvFeedbackModal = ({
                             },
                             deps: [FEEDBACK_OTHERS_INPUT_NAME],
                           })}
-                          value={'I’m not used to the new FormSG'}
+                          value={option}
                           key={option}
                           tabIndex={1}
                         >

--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -10,10 +10,7 @@ import Tooltip from '~components/Tooltip'
 
 import { useEnvMutations } from './mutations'
 import { useEnv, useSwitchEnvFeedbackFormView } from './queries'
-import {
-  ADMIN_RADIO_OPTIONS,
-  SwitchEnvFeedbackModal,
-} from './SwitchEnvFeedbackModal'
+import { SwitchEnvFeedbackModal } from './SwitchEnvFeedbackModal'
 
 export const SwitchEnvIcon = (): JSX.Element | null => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -60,7 +57,7 @@ export const SwitchEnvIcon = (): JSX.Element | null => {
           onChangeEnv={adminSwitchEnvMutation.mutate}
           isOpen={isOpen}
           onClose={onClose}
-          radioOptions={ADMIN_RADIO_OPTIONS}
+          isAdminView={true}
         />
       </Flex>
     </Portal>

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -15,10 +15,7 @@ import InlineMessage from '~components/InlineMessage'
 
 import { useEnvMutations } from '~features/env/mutations'
 import { useSwitchEnvFeedbackFormView } from '~features/env/queries'
-import {
-  PUBLIC_RADIO_OPTIONS,
-  SwitchEnvFeedbackModal,
-} from '~features/env/SwitchEnvFeedbackModal'
+import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
 
 export const PublicSwitchEnvMessage = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -84,7 +81,7 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
         onChangeEnv={publicSwitchEnvMutation.mutate}
         isOpen={isOpen}
         onClose={onClose}
-        radioOptions={PUBLIC_RADIO_OPTIONS}
+        isAdminView={false}
       />
     </Flex>
   )

--- a/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
+++ b/frontend/src/features/workspace/components/AdminSwitchEnvMessage.tsx
@@ -9,10 +9,7 @@ import InlineMessage from '~components/InlineMessage'
 
 import { useEnvMutations } from '~features/env/mutations'
 import { useEnv, useSwitchEnvFeedbackFormView } from '~features/env/queries'
-import {
-  ADMIN_RADIO_OPTIONS,
-  SwitchEnvFeedbackModal,
-} from '~features/env/SwitchEnvFeedbackModal'
+import { SwitchEnvFeedbackModal } from '~features/env/SwitchEnvFeedbackModal'
 
 export const AdminSwitchEnvMessage = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -86,7 +83,7 @@ export const AdminSwitchEnvMessage = (): JSX.Element => {
         onChangeEnv={adminSwitchEnvMutation.mutate}
         isOpen={isOpen}
         onClose={onClose}
-        radioOptions={ADMIN_RADIO_OPTIONS}
+        isAdminView={true}
       />
     </>
   ) : (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

For public form respondents: Remove radio options and make feedback field compulsory in the feedback modal

Closes #5336

**Details**
- Added `isAdminView` prop to differentiate admin and public form modals

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Submit a feedback form from a public form view
- [x] Submit a feedback form from an admin view

