### PR TITLE
feat: update contact email to support@form.gov.sg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ Welcome to FormSG! The following are guidelines for contribution. Use your best 
 
 To contribute, you can start by taking a look at our open issues marked 'contribute' under GitHub's 'Issues' tab. Feel free to assign yourself to any 'contribute' issue that interests you, and comment with questions or clarifications. 
 
-Otherwise, please **first discuss the change you wish to make via GitHub issue**, [email](mailto:formsg@tech.gov.sg), or any other method with the repository owners beforehand.
+Otherwise, please **first discuss the change you wish to make via GitHub issue**, [email](mailto:support@form.gov.sg), or any other method with the repository owners beforehand.
 
 ## Security reports
 
-Please do not file an open issue for ongoing security bugs. Instead, email us directly with your findings at [formsg@tech.gov.sg](mailto:formsg@tech.gov.sg).
+Please do not file an open issue for ongoing security bugs. Instead, email us directly with your findings at [support@form.gov.sg](mailto:support@form.gov.sg).
 
 ## Bug reports and feature requests
 
@@ -52,4 +52,4 @@ You generally only need to submit a CLA once, so if you've already submitted one
 
 ## Contact us
 
-Have questions? Feel free to reach out to us at [formsg@tech.gov.sg](mailto:formsg@tech.gov.sg).
+Have questions? Feel free to reach out to us at [support@form.gov.sg](mailto:support@form.gov.sg).

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ We welcome all contributions, bug reports, bug fixes, documentation improvements
 
 ## Support
 
-Please contact FormSG (formsg@tech.gov.sg) for any details.
+Please contact FormSG (support@form.gov.sg) for any details.
 
 ## Acknowledgements
 

--- a/frontend/src/pages/PrivacyPolicy/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicy/PrivacyPolicyPage.tsx
@@ -250,8 +250,8 @@ export const PrivacyPolicyPage = (): JSX.Element => {
               <SectionListItem>
                 <SectionParagraph>
                   Please contact{' '}
-                  <Link isExternal href="mailto:formsg@tech.gov.sg">
-                    formsg@tech.gov.sg
+                  <Link isExternal href="mailto:support@form.gov.sg">
+                    support@form.gov.sg
                   </Link>{' '}
                   if you:
                 </SectionParagraph>

--- a/src/public/modules/users/views/static/privacy.client.view.html
+++ b/src/public/modules/users/views/static/privacy.client.view.html
@@ -162,7 +162,7 @@
       <li seq="9">
         <span>
           Please contact
-          <a href="mailto:formsg@tech.gov.sg">formsg@tech.gov.sg</a> if you:
+          <a href="mailto:support@form.gov.sg">support@form.gov.sg</a> if you:
         </span>
         <ol>
           <li seq="9.1">


### PR DESCRIPTION
## Problem
The contact email formsg@tech.gov.sg is outdated and not read by people. 


## Solution
Use the new email address support@form.gov.sg

- [X] No - this PR is backwards compatible  

Changeset generated with:

```bash
git grep -l formsg@tech.gov.sg | while read f; do sed -i '' -e s/formsg@tech\.gov\.sg/support@form.gov.sg/g $f; done
```

