### PR TITLE
chore: drop staging-alt2 as deployment target

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS Elastic Beanstalk
 on:
   push:
     # There should be 7 environments in github actions secrets:
-    # release, release-al2, staging, staging-al2, staging-alt, staging-alt2, uat.
+    # release, release-al2, staging, staging-al2, staging-alt, uat.
     # This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name.
     branches:
       - release
@@ -10,13 +10,12 @@ on:
       - staging
       - staging-al2
       - staging-alt
-      - staging-alt2
       - uat
 
 permissions:
   id-token: write
   contents: read
-  
+
 jobs:
   set_environment:
     outputs:


### PR DESCRIPTION
We are no longer using staging-alt2. Infra and DNS records have already been updated accordingly.