### PR TITLE
fix: add frontend and backend validation for empty field titles

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -75,12 +75,19 @@ type ValidationRuleFnEmailAndMobile<T extends FieldBase = FieldBase> = (
   schema: MinimumFieldValidationPropsEmailAndMobile<T>,
 ) => RegisterOptions
 
-const createRequiredValidationRules = (
+const requiredValidationFn =
+  (schema: Pick<FieldBase, 'required'>) => (value: unknown) => {
+    if (!schema.required) return true
+    // Trim strings before checking for emptiness
+    const trimmedValue = typeof value === 'string' ? value.trim() : value
+    return !!trimmedValue || REQUIRED_ERROR
+  }
+
+const createRequiredInValidationRules = (
   schema: Pick<FieldBase, 'required'>,
-): RegisterOptions['required'] => {
+): RegisterOptions['validate'] => {
   return {
-    value: schema.required,
-    message: REQUIRED_ERROR,
+    required: requiredValidationFn(schema),
   }
 }
 
@@ -91,12 +98,11 @@ const createRequiredValidationRules = (
  */
 const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   VerifiableFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return {
     validate: {
       required: (value?: VerifiableFieldValues) => {
-        if (!schema.required) return true
-        return !!value?.value || REQUIRED_ERROR
+        return requiredValidationFn(schema)(value?.value)
       },
       hasSignature: (val?: VerifiableFieldValues) => {
         if (!schema.isVerifiable) return true
@@ -115,22 +121,11 @@ const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   }
 }
 
-const createRequiredInValidationRules = (
-  schema: Pick<FieldBase, 'required'>,
-): RegisterOptions['validate'] => {
-  return {
-    required: (value: unknown) => {
-      if (!schema.required) return true
-      return !!value || REQUIRED_ERROR
-    },
-  }
-}
-
 export const createBaseValidationRules = (
   schema: Pick<FieldBase, 'required'>,
 ): RegisterOptions => {
   return {
-    required: createRequiredValidationRules(schema),
+    validate: createRequiredInValidationRules(schema),
   }
 }
 
@@ -139,8 +134,8 @@ export const createDropdownValidationRules: ValidationRuleFn<
 > = (schema): RegisterOptions => {
   // TODO(#3360): Handle MyInfo dropdown validation
   return {
-    ...createBaseValidationRules(schema),
     validate: {
+      ...createRequiredInValidationRules(schema),
       validOptions: (value: string) => {
         if (!value) return
         return (
@@ -154,34 +149,32 @@ export const createDropdownValidationRules: ValidationRuleFn<
 export const createRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
   schema,
 ): RegisterOptions => {
-  return {
-    validate: {
-      ...createRequiredInValidationRules(schema),
-    },
-  }
+  return createBaseValidationRules(schema)
 }
 
 export const createAttachmentValidationRules: ValidationRuleFn<
   AttachmentFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return createBaseValidationRules(schema)
 }
 
 export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string) => {
-      if (!val) return true
-      return isHomePhoneNumber(val) || 'Please enter a valid landline number'
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validHomeNo: (val?: string) => {
+        if (!val) return true
+        return isHomePhoneNumber(val) || 'Please enter a valid landline number'
+      },
     },
   }
 }
 
 export const createMobileValidationRules: ValidationRuleFnEmailAndMobile<
   MobileFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return {
     validate: {
       baseValidations: (val?: VerifiableFieldValues) => {
@@ -194,177 +187,188 @@ export const createMobileValidationRules: ValidationRuleFnEmailAndMobile<
 
 export const createNumberValidationRules: ValidationRuleFn<NumberFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   const { selectedValidation, customVal } = schema.ValidationOptions
 
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string) => {
-      if (!val || !customVal) return true
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validNumber: (val?: string) => {
+        if (!val || !customVal) return true
 
-      const currLen = val.length
+        const currLen = val.length
 
-      switch (selectedValidation) {
-        case NumberSelectedValidation.Exact:
-          return (
-            currLen === customVal ||
-            simplur`Please enter ${customVal} digit[|s] (${currLen}/${customVal})`
-          )
-        case NumberSelectedValidation.Min:
-          return (
-            currLen >= customVal ||
-            simplur`Please enter at least ${customVal} digit[|s] (${currLen}/${customVal})`
-          )
-        case NumberSelectedValidation.Max:
-          return (
-            currLen <= customVal ||
-            simplur`Please enter at most ${customVal} digit[|s] (${currLen}/${customVal})`
-          )
-      }
+        switch (selectedValidation) {
+          case NumberSelectedValidation.Exact:
+            return (
+              currLen === customVal ||
+              simplur`Please enter ${customVal} digit[|s] (${currLen}/${customVal})`
+            )
+          case NumberSelectedValidation.Min:
+            return (
+              currLen >= customVal ||
+              simplur`Please enter at least ${customVal} digit[|s] (${currLen}/${customVal})`
+            )
+          case NumberSelectedValidation.Max:
+            return (
+              currLen <= customVal ||
+              simplur`Please enter at most ${customVal} digit[|s] (${currLen}/${customVal})`
+            )
+        }
+      },
     },
   }
 }
 
 export const createDecimalValidationRules: ValidationRuleFn<
   DecimalFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val: string) => {
-      const {
-        ValidationOptions: { customMax, customMin },
-        validateByValue,
-      } = schema
-      if (!val) return true
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validDecimal: (val: string) => {
+        const {
+          ValidationOptions: { customMax, customMin },
+          validateByValue,
+        } = schema
+        if (!val) return true
 
-      const numVal = Number(val)
-      if (isNaN(numVal)) {
-        return 'Please enter a valid decimal'
-      }
+        const numVal = Number(val)
+        if (isNaN(numVal)) {
+          return 'Please enter a valid decimal'
+        }
 
-      // Validate leading zeros
-      if (/^0[0-9]/.test(val)) {
-        return 'Please enter a valid decimal without leading zeros'
-      }
+        // Validate leading zeros
+        if (/^0[0-9]/.test(val)) {
+          return 'Please enter a valid decimal without leading zeros'
+        }
 
-      if (!validateByValue) return true
+        if (!validateByValue) return true
 
-      if (
-        customMin !== null &&
-        customMax !== null &&
-        (numVal < customMin || numVal > customMax)
-      ) {
-        return `Please enter a decimal between ${formatNumberToLocaleString(
-          customMin,
-        )} and ${formatNumberToLocaleString(customMax)} (inclusive)`
-      }
-      if (customMin !== null && numVal < customMin) {
-        return `Please enter a decimal greater than or equal to ${formatNumberToLocaleString(
-          customMin,
-        )}`
-      }
+        if (
+          customMin !== null &&
+          customMax !== null &&
+          (numVal < customMin || numVal > customMax)
+        ) {
+          return `Please enter a decimal between ${formatNumberToLocaleString(
+            customMin,
+          )} and ${formatNumberToLocaleString(customMax)} (inclusive)`
+        }
+        if (customMin !== null && numVal < customMin) {
+          return `Please enter a decimal greater than or equal to ${formatNumberToLocaleString(
+            customMin,
+          )}`
+        }
+        if (customMax !== null && numVal > customMax) {
+          return `Please enter a decimal less than or equal to ${formatNumberToLocaleString(
+            customMax,
+          )}`
+        }
 
-      if (customMax !== null && numVal > customMax) {
-        return `Please enter a decimal less than or equal to ${formatNumberToLocaleString(
-          customMax,
-        )}`
-      }
-
-      return true
+        return true
+      },
     },
   }
 }
 
 export const createTextValidationRules: ValidationRuleFn<
   ShortTextFieldBase | LongTextFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   const { selectedValidation, customVal } = schema.ValidationOptions
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string) => {
-      if (!val || !customVal) return true
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validText: (val?: string) => {
+        if (!val || !customVal) return true
 
-      const currLen = val.length
+        const currLen = val.length
 
-      switch (selectedValidation) {
-        case TextSelectedValidation.Exact:
-          return (
-            currLen === customVal ||
-            simplur`Please enter ${customVal} character[|s] (${currLen}/${customVal})`
-          )
-        case TextSelectedValidation.Minimum:
-          return (
-            currLen >= customVal ||
-            simplur`Please enter at least ${customVal} character[|s] (${currLen}/${customVal})`
-          )
-        case TextSelectedValidation.Maximum:
-          return (
-            currLen <= customVal ||
-            simplur`Please enter at most ${customVal} character[|s] (${currLen}/${customVal})`
-          )
-      }
+        switch (selectedValidation) {
+          case TextSelectedValidation.Exact:
+            return (
+              currLen === customVal ||
+              simplur`Please enter ${customVal} character[|s] (${currLen}/${customVal})`
+            )
+          case TextSelectedValidation.Minimum:
+            return (
+              currLen >= customVal ||
+              simplur`Please enter at least ${customVal} character[|s] (${currLen}/${customVal})`
+            )
+          case TextSelectedValidation.Maximum:
+            return (
+              currLen <= customVal ||
+              simplur`Please enter at most ${customVal} character[|s] (${currLen}/${customVal})`
+            )
+        }
+      },
     },
   }
 }
 
 export const createUenValidationRules: ValidationRuleFn<UenFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string) => {
-      if (!val) return true
-      return isUenValid(val) || 'Please enter a valid UEN'
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validUen: (val?: string) => {
+        if (!val) return true
+        return isUenValid(val) || 'Please enter a valid UEN'
+      },
     },
   }
 }
 
 export const createNricValidationRules: ValidationRuleFn<NricFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string) => {
-      if (!val) return true
-      return (
-        isNricValid(val) ||
-        isMFinSeriesValid(val) ||
-        'Please enter a valid NRIC'
-      )
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validNric: (val?: string) => {
+        if (!val) return true
+        return (
+          isNricValid(val) ||
+          isMFinSeriesValid(val) ||
+          'Please enter a valid NRIC'
+        )
+      },
     },
   }
 }
 
 export const createCheckboxValidationRules: ValidationRuleFn<
   CheckboxFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
-    validate: (val?: string[]) => {
-      const {
-        ValidationOptions: { customMin, customMax },
-        validateByValue,
-      } = schema
-      if (!val || val.length === 0 || !validateByValue) return true
+    validate: {
+      ...createRequiredInValidationRules(schema),
+      validOptions: (val?: string[]) => {
+        const {
+          ValidationOptions: { customMin, customMax },
+          validateByValue,
+        } = schema
+        if (!val || val.length === 0 || !validateByValue) return true
 
-      if (
-        customMin &&
-        customMax &&
-        customMin === customMax &&
-        val.length !== customMin
-      ) {
-        return simplur`Please select exactly ${customMin} option[|s] (${val.length}/${customMin})`
-      }
+        if (
+          customMin &&
+          customMax &&
+          customMin === customMax &&
+          val.length !== customMin
+        ) {
+          return simplur`Please select exactly ${customMin} option[|s] (${val.length}/${customMin})`
+        }
 
-      if (customMin && val.length < customMin) {
-        return simplur`Please select at least ${customMin} option[|s] (${val.length}/${customMin})`
-      }
+        if (customMin && val.length < customMin) {
+          return simplur`Please select at least ${customMin} option[|s] (${val.length}/${customMin})`
+        }
 
-      if (customMax && val.length > customMax) {
-        return simplur`Please select at most ${customMax} option[|s] (${val.length}/${customMax})`
-      }
+        if (customMax && val.length > customMax) {
+          return simplur`Please select at most ${customMax} option[|s] (${val.length}/${customMax})`
+        }
 
-      return true
+        return true
+      },
     },
   }
 }
@@ -375,10 +379,10 @@ const parseDate = (val: string) => {
 
 export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   return {
-    ...createBaseValidationRules(schema),
     validate: {
+      ...createRequiredInValidationRules(schema),
       validDate: (val) => {
         if (!val) return true
         if (val === DATE_PARSE_FORMAT.toLowerCase()) {
@@ -436,13 +440,13 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
 
 export const createRadioValidationRules: ValidationRuleFn<RadioFieldBase> = (
   schema,
-) => {
+): RegisterOptions => {
   return createBaseValidationRules(schema)
 }
 
 export const createEmailValidationRules: ValidationRuleFnEmailAndMobile<
   EmailFieldBase
-> = (schema) => {
+> = (schema): RegisterOptions => {
   return {
     validate: {
       baseValidations: (val?: VerifiableFieldValues) => {
@@ -460,26 +464,22 @@ export const createEmailValidationRules: ValidationRuleFnEmailAndMobile<
 export const baseEmailValidationFn =
   (schema: MinimumFieldValidationProps<EmailFieldBase>) =>
   (inputValue?: string) => {
-    if (!inputValue) {
-      return true
-    }
+    if (!inputValue) return true
 
     // Valid email check
-    if (!validator.isEmail(inputValue)) {
-      return INVALID_EMAIL_ERROR
-    }
+    if (!validator.isEmail(inputValue)) return INVALID_EMAIL_ERROR
 
+    // Valid domain check
     const allowedDomains = schema.isVerifiable
       ? new Set(schema.allowedEmailDomains)
       : new Set()
-
-    // Valid domain check
     if (allowedDomains.size !== 0) {
       const domainInValue = inputValue.split('@')[1]
       if (domainInValue && !allowedDomains.has(`@${domainInValue}`)) {
         return INVALID_EMAIL_DOMAIN_ERROR
       }
     }
+
     // Passed all error validation.
     return true
   }
@@ -487,14 +487,10 @@ export const baseEmailValidationFn =
 export const baseMobileValidationFn =
   (_schema: MinimumFieldValidationProps<MobileFieldBase>) =>
   (inputValue?: string) => {
-    if (!inputValue) {
-      return true
-    }
+    if (!inputValue) return true
 
     // Valid mobile check
-    if (!isMobilePhoneNumber(inputValue)) {
-      return 'Please enter a valid mobile number'
-    }
-
-    return true
+    return (
+      isMobilePhoneNumber(inputValue) || 'Please enter a valid mobile number'
+    )
   }

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1690,7 +1690,7 @@ export const handleUpdateFormField = [
           .required(),
         description: Joi.string().allow('').required(),
         required: Joi.boolean().required(),
-        title: Joi.string().required(),
+        title: Joi.string().trim().required(),
         disabled: Joi.boolean().required(),
         // Allow other field related key-values to be provided and let the model
         // layer handle the validation.
@@ -1958,7 +1958,7 @@ export const handleCreateFormField = [
       fieldType: Joi.string()
         .valid(...Object.values(BasicField))
         .required(),
-      title: Joi.string().required(),
+      title: Joi.string().trim().required(),
       description: Joi.string().allow(''),
       required: Joi.boolean(),
       disabled: Joi.boolean(),


### PR DESCRIPTION
## Problem

We did not perform empty string validation for field titles correctly. In particular, field titles were not trimmed before being validated.

Closes #5345 

## Solution
Backend: Add `.trim()` to validator for field creation and updation middlewares.

Frontend (react): Add custom validator for required fields to trim input before checking non-emptiness. This required a bit of refactoring for the entire field validation util file, so we will need to retest all the validators again, especially for public forms.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

Backend
- [x] PUT a field with `"title":"field title"`. This should succeed, and the field should appear in the form with title `field title`.
- [x] PUT a field with `"title":"  field title "`. This should succeed, and the field should appear in the form with title `field title`.
- [x] PUT a field with `"title":""`. This should fail with status code 400. The field should not appear in the form.
- [x] PUT a field with `"title":"  "`. This should fail with status code 400. The field should not appear in the form.

Sample failure and success cases:
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/25571626/200719388-35c1bb5e-c94a-4e2d-838d-d0d5310d0c9d.png">


Frontend
- [x] Attempt to create a field with title just containing a single space. The frontend should display an error that the title field is required.
- [x] Attempt to create a field with title ` field title  `. This should succeed, and the field title should be `field title`.
- [x] Test that the validators for all fields work correctly in public forms
   - yes/no: required
   - home no, mobile no, email: required, valid home no / mobile no / email entered*
   - number, decimal: required, custom min/max value
   - short text, long text: required, custom min/max/exact length*
   - uen, nric: required, valid uen/nric entered
   - checkbox: required, custom min/max number of options
   - date: required, custom date validations
   - radio: required
   - tables: columns required (both short text and dropdowns)

* It's important in this case to check that the behavior re: leading/trailing whitespace should continue to be the same as current behavior. (e.g. does `a b c ` count as 5 or 6 characters, for short/long text input length custom validation)