### PR TITLE
feat: add logging to capture SNS notification errors

### DIFF
--- a/src/app/modules/bounce/bounce.controller.ts
+++ b/src/app/modules/bounce/bounce.controller.ts
@@ -32,6 +32,7 @@ export const handleSns: ControllerHandler<
       message: 'Unable to parse email notification request',
       meta: {
         action: 'handleSns',
+        message: req.body,
       },
       error: notificationResult.error,
     })

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -432,6 +432,7 @@ export const safeParseNotification = (
         message: 'Unable to parse SNS notification',
         meta: {
           action: 'safeParseNotification',
+          message: message,
         },
         error,
       })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, `handleSns` in `bounce.controller` does not parse SES subscription confirmation messages. 

## Solution
<!-- How did you solve the problem? -->
We want to log the confirmation message so that we're able to access the `SubscribeURL` to confirm the subscription to the endpoint
