### PR TITLE
fix: make custom field validations consistent between angular and react

### DIFF
--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -38,33 +38,43 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
     'preventDefaultOnEnter',
   ])
 
-  const chakraInputProps: ChakraInputProps = useMemo(
-    () => ({
-      ref,
-      ...inputProps,
-      sx: props.sx ?? inputStyles.field,
+  const preventDefault = useMemo(
+    () =>
       // This flag should be set for form input fields, to prevent refresh on enter if form only has one input
-      onKeyDown: props.preventDefaultOnEnter
-        ? (e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-            }
+      props.preventDefaultOnEnter
+        ? {
+            onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+              }
+            },
           }
-        : undefined,
-    }),
-    [inputProps, inputStyles.field, props, ref],
+        : {},
+    [props.preventDefaultOnEnter],
   )
 
   // Return normal input component if not success state.
   if (!props.isSuccess) {
-    return <ChakraInput {...chakraInputProps} />
+    return (
+      <ChakraInput
+        ref={ref}
+        {...preventDefault}
+        {...inputProps}
+        sx={props.sx ?? inputStyles.field}
+      />
+    )
   }
 
   return (
     // InputGroup is required for InputRightElement to retrieve the correct
     // style props. Will crash if not included.
     <InputGroup>
-      <ChakraInput {...chakraInputProps} />
+      <ChakraInput
+        ref={ref}
+        {...preventDefault}
+        {...inputProps}
+        sx={props.sx ?? inputStyles.field}
+      />
       <InputRightElement sx={inputStyles.success}>
         <Icon as={BxsCheckCircle} />
       </InputRightElement>

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   forwardRef,
   Icon,
@@ -37,36 +38,33 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
     'preventDefaultOnEnter',
   ])
 
+  const chakraInputProps: ChakraInputProps = useMemo(
+    () => ({
+      ref,
+      ...inputProps,
+      sx: props.sx ?? inputStyles.field,
+      // This flag should be set for form input fields, to prevent refresh on enter if form only has one input
+      onKeyDown: props.preventDefaultOnEnter
+        ? (e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+            }
+          }
+        : undefined,
+    }),
+    [inputProps, inputStyles.field, props, ref],
+  )
+
   // Return normal input component if not success state.
   if (!props.isSuccess) {
-    return (
-      <ChakraInput
-        ref={ref}
-        // This flag should be set for form input fields, to prevent refresh on enter if form only has one input
-        {...(props.preventDefaultOnEnter
-          ? {
-              onKeyDown: (e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                }
-              },
-            }
-          : {})}
-        {...inputProps}
-        sx={props.sx ?? inputStyles.field}
-      />
-    )
+    return <ChakraInput {...chakraInputProps} />
   }
 
   return (
     // InputGroup is required for InputRightElement to retrieve the correct
     // style props. Will crash if not included.
     <InputGroup>
-      <ChakraInput
-        ref={ref}
-        {...inputProps}
-        sx={props.sx ?? inputStyles.field}
-      />
+      <ChakraInput {...chakraInputProps} />
       <InputRightElement sx={inputStyles.success}>
         <Icon as={BxsCheckCircle} />
       </InputRightElement>

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -67,7 +67,7 @@ const transformToSingleAnswerOutput = <F extends FormFieldDto>(
 ): SingleAnswerOutput<F> => {
   return {
     ...pickBaseOutputFromSchema(schema),
-    answer: (input ?? '').trim(),
+    answer: input?.trim() ?? '',
   }
 }
 
@@ -105,8 +105,8 @@ const transformToTableOutput = (
   const orderedColumnIds = schema.columns.map((col) => col._id)
   const answerArray = populatedInput.map(
     (rowResponse) =>
-      orderedColumnIds.map((colId) =>
-        (rowResponse[colId] ?? '').trim(),
+      orderedColumnIds.map(
+        (colId) => rowResponse[colId]?.trim() ?? '',
       ) as TableRow,
   )
   return {

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -67,7 +67,7 @@ const transformToSingleAnswerOutput = <F extends FormFieldDto>(
 ): SingleAnswerOutput<F> => {
   return {
     ...pickBaseOutputFromSchema(schema),
-    answer: input ?? '',
+    answer: (input ?? '').trim(),
   }
 }
 
@@ -105,7 +105,9 @@ const transformToTableOutput = (
   const orderedColumnIds = schema.columns.map((col) => col._id)
   const answerArray = populatedInput.map(
     (rowResponse) =>
-      orderedColumnIds.map((colId) => rowResponse[colId] ?? '') as TableRow,
+      orderedColumnIds.map((colId) =>
+        (rowResponse[colId] ?? '').trim(),
+      ) as TableRow,
   )
   return {
     ...pickBaseOutputFromSchema(schema),

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -196,7 +196,7 @@ export const createNumberValidationRules: ValidationRuleFn<NumberFieldBase> = (
       validNumber: (val?: string) => {
         if (!val || !customVal) return true
 
-        const currLen = val.length
+        const currLen = val.trim().length
 
         switch (selectedValidation) {
           case NumberSelectedValidation.Exact:
@@ -281,7 +281,7 @@ export const createTextValidationRules: ValidationRuleFn<
       validText: (val?: string) => {
         if (!val || !customVal) return true
 
-        const currLen = val.length
+        const currLen = val.trim().length
 
         switch (selectedValidation) {
           case TextSelectedValidation.Exact:


### PR DESCRIPTION
## Problem
Some field validation are inconsistent between angular and react. 

Closes #5372 

## Solution
In angular, we always trim text fields before validation and submission, so this PR implements this for react.

Additionally, I snuck in a quick change to the `Input` component which had a small bug before. Sorry!

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Create a short/long text field with some custom length validation. Then, fill the form field with some leading/trailing spaces. The character count should not count the leading/trailing spaces.
- [x] Submit the form with the text field containing leading/trailing spaces, and look at the sent payload from the Network panel. The sent answer should be trimmed, and contain the correct number of characters that the custom validation requested for.