### PR TITLE
fix: local dev

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -53,6 +53,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
 
 COPY package*.json ./
+COPY shared/package*.json ./shared/
 # --legacy-peer-deps flag
 # A breaking change in the peer dependency resolution strategy was introduced in
 # npm 7. This resulted in npm throwing an error when installing packages:

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -26,6 +26,7 @@ RUN npm config set unsafe-perm true
 # * https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh
 # NOTE: This flag is used again later in the build process when calling npm prune.
 RUN npm ci --legacy-peer-deps
+RUN npm run postinstall:frontend
 
 COPY . ./
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Notable features include:
 - (Singapore government agencies only) Citizen authentication with [SingPass](https://www.singpass.gov.sg/singpass/common/aboutus)
 - (Singapore government agencies only) Corporate authentication with [CorpPass](https://www.corppass.gov.sg/corppass/common/aboutus)
 - (Singapore government agencies only) Automatic prefill of verified data with [MyInfo](https://www.singpass.gov.sg/myinfo/common/aboutus)
-- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK](<https://github.com/opengovsg/formsg-ruby-sdk>)
+- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK](https://github.com/opengovsg/formsg-ruby-sdk)
 
 The current product roadmap includes:
 
@@ -57,11 +57,7 @@ Install [docker and docker-compose](https://docs.docker.com/get-docker/).
 
 ### First Setup
 
-Run the following shell command to install relevant npm packages.
-
-```bash
-npm install
-```
+Run `npm install` in both root and frontend directory to install relevant npm packages.
 
 If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of 4GB) by clicking on the Docker icon on the toolbar, clicking on the "Preferences" menu item, then clicking on the "Resources" link on the left.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,7 +93,7 @@
     "gen:theme-typings": "chakra-cli tokens src/theme/index.ts || true",
     "clean:emotion-types": "rimraf node_modules/@emotion/core/types",
     "postinstall": "patch-package && npm run gen:theme-typings && npm run clean:emotion-types && npm --prefix ../shared install",
-    "start": "env-cmd -f .buildtime-env craco start",
+    "start": "env-cmd -f .buildtime-env craco --openssl-legacy-provider start",
     "build": "cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test --silent",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "scripts": {
-    "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
+    "postinstall": "npm run postinstall:shared",
     "test:backend": "env-cmd -f tests/.test-env jest --coverage --maxWorkers=4",
     "test:backend:watch": "env-cmd -f tests/.test-env jest --watch",
     "test:frontend": "npm --prefix frontend test",


### PR DESCRIPTION
Changes:

- copy 'shared' project package.json files to container so it doesn't break install
- update frontend start command with  --openssl-legacy-provider flag
- don't install frontend dependencies by default in postinstall as it is not required in local dev. Install frontend dependencies production dockerfile