### PR TITLE
feat: use-template for forms

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -13,6 +13,7 @@ import {
   LOGIN_ROUTE,
   PRIVACY_POLICY_ROUTE,
   PUBLICFORM_ROUTE,
+  PUBLICFORM_USETEMPLATE_ROUTE,
   RESULTS_FEEDBACK_SUBROUTE,
   TOU_ROUTE,
 } from '~constants/routes'
@@ -48,6 +49,9 @@ const PrivacyPolicyPage = lazy(() =>
 const TermsOfUsePage = lazy(() => lazyRetry(() => import('~pages/TermsOfUse')))
 const PreviewFormPage = lazy(() =>
   lazyRetry(() => import('~features/admin-form/preview')),
+)
+const TemplateFormPage = lazy(() =>
+  lazyRetry(() => import('~features/admin-form/template')),
 )
 
 const WithSuspense = ({ children }: { children: React.ReactNode }) => (
@@ -87,6 +91,10 @@ export const AppRouter = (): JSX.Element => {
         <Route
           path={PUBLICFORM_ROUTE}
           element={<PublicElement element={<PublicFormPage />} />}
+        />
+        <Route
+          path={`${PUBLICFORM_ROUTE}/${PUBLICFORM_USETEMPLATE_ROUTE}`}
+          element={<PrivateElement element={<TemplateFormPage />} />}
         />
         <Route
           path={`${ADMINFORM_ROUTE}/:formId`}

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -7,13 +7,13 @@ import {
   ADMINFORM_RESULTS_SUBROUTE,
   ADMINFORM_ROUTE,
   ADMINFORM_SETTINGS_SUBROUTE,
+  ADMINFORM_USETEMPLATE_ROUTE,
   BILLING_ROUTE,
   DASHBOARD_ROUTE,
   LANDING_ROUTE,
   LOGIN_ROUTE,
   PRIVACY_POLICY_ROUTE,
   PUBLICFORM_ROUTE,
-  PUBLICFORM_USETEMPLATE_ROUTE,
   RESULTS_FEEDBACK_SUBROUTE,
   TOU_ROUTE,
 } from '~constants/routes'
@@ -93,10 +93,6 @@ export const AppRouter = (): JSX.Element => {
           element={<PublicElement element={<PublicFormPage />} />}
         />
         <Route
-          path={`${PUBLICFORM_ROUTE}/${PUBLICFORM_USETEMPLATE_ROUTE}`}
-          element={<PrivateElement element={<TemplateFormPage />} />}
-        />
-        <Route
           path={`${ADMINFORM_ROUTE}/:formId`}
           element={<PrivateElement element={<AdminFormLayout />} />}
         >
@@ -125,6 +121,10 @@ export const AppRouter = (): JSX.Element => {
         <Route
           path={`${ADMINFORM_ROUTE}/:formId/${ADMINFORM_PREVIEW_ROUTE}`}
           element={<PrivateElement element={<PreviewFormPage />} />}
+        />
+        <Route
+          path={`${ADMINFORM_ROUTE}/:formId/${ADMINFORM_USETEMPLATE_ROUTE}`}
+          element={<PrivateElement element={<TemplateFormPage />} />}
         />
         <Route path="*" element={<NotFoundErrorPage />} />
       </Routes>

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,10 +1,7 @@
 import { useLayoutEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import {
-  DASHBOARD_ROUTE,
-  PUBLICFORM_USETEMPLATE_ROUTE,
-} from '~constants/routes'
+import { ADMINFORM_USETEMPLATE_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 
 import { PublicElement } from './PublicElement'
 
@@ -45,7 +42,7 @@ const pathMapper = [
   {
     regex: /^\/(?<formid>[0-9a-fA-F]{24})\/use-template$/,
     getTarget: (m: FormRegExpMatchArray) =>
-      `/${m.groups.formid}/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+      `/admin/form/${m.groups.formid}/${ADMINFORM_USETEMPLATE_ROUTE}`,
   },
   {
     regex: /^\/forms$/,

--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -1,7 +1,10 @@
 import { useLayoutEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { DASHBOARD_ROUTE } from '~constants/routes'
+import {
+  DASHBOARD_ROUTE,
+  PUBLICFORM_USETEMPLATE_ROUTE,
+} from '~constants/routes'
 
 import { PublicElement } from './PublicElement'
 
@@ -38,6 +41,11 @@ const pathMapper = [
     regex: /^\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
     getTarget: (m: FormRegExpMatchArray) =>
       `/admin/form/${m.groups.formid}/preview`,
+  },
+  {
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/use-template$/,
+    getTarget: (m: FormRegExpMatchArray) =>
+      `/${m.groups.formid}/${PUBLICFORM_USETEMPLATE_ROUTE}`,
   },
   {
     regex: /^\/forms$/,

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -18,7 +18,7 @@ export const ADMINFORM_BUILD_SUBROUTE = ''
 export const ADMINFORM_SETTINGS_SUBROUTE = 'settings'
 export const ADMINFORM_RESULTS_SUBROUTE = 'results'
 export const ADMINFORM_PREVIEW_ROUTE = 'preview'
-export const PUBLICFORM_USETEMPLATE_ROUTE = 'use-template'
+export const ADMINFORM_USETEMPLATE_ROUTE = 'use-template'
 
 /**
  * Regex for active path matching on adminform builder routes/subroutes.

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -18,6 +18,7 @@ export const ADMINFORM_BUILD_SUBROUTE = ''
 export const ADMINFORM_SETTINGS_SUBROUTE = 'settings'
 export const ADMINFORM_RESULTS_SUBROUTE = 'results'
 export const ADMINFORM_PREVIEW_ROUTE = 'preview'
+export const PUBLICFORM_USETEMPLATE_ROUTE = 'use-template'
 
 /**
  * Regex for active path matching on adminform builder routes/subroutes.

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -9,7 +9,7 @@ import {
   SmsCountsDto,
 } from '~shared/types/form/form'
 
-import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
+import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
@@ -80,7 +80,7 @@ export const viewFormTemplate = async (
   formId: string,
 ): Promise<PreviewFormViewDto> => {
   return ApiService.get<PreviewFormViewDto>(
-    `${ADMIN_FORM_ENDPOINT}/${formId}/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+    `${ADMIN_FORM_ENDPOINT}/${formId}/${ADMINFORM_USETEMPLATE_ROUTE}`,
   )
     .then(({ data }) => {
       // Add default mock authenticated state if previewing an authenticatable form

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -78,7 +78,9 @@ export const previewForm = async (
 export const viewFormTemplate = async (
   formId: string,
 ): Promise<PreviewFormViewDto> => {
-  return ApiService.get<PreviewFormViewDto>(`${formId}/use-template`)
+  return ApiService.get<PreviewFormViewDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/use-template`,
+  )
     .then(({ data }) => {
       // Add default mock authenticated state if previewing an authenticatable form
       // and if server has not already sent back a mock authenticated state.

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -69,6 +69,33 @@ export const previewForm = async (
     .then(transformAllIsoStringsToDate)
 }
 
+/**
+ * Gets the public view of a form. Used for viewing the form from the form template page.
+ * Must be an admin.
+ * @param formId formId of form in question
+ * @returns Public view of a form
+ */
+export const viewFormTemplate = async (
+  formId: string,
+): Promise<PreviewFormViewDto> => {
+  return ApiService.get<PreviewFormViewDto>(`${formId}/use-template`)
+    .then(({ data }) => {
+      // Add default mock authenticated state if previewing an authenticatable form
+      // and if server has not already sent back a mock authenticated state.
+      if (data.form.authType !== FormAuthType.NIL && !data.spcpSession) {
+        data.spcpSession = { userName: PREVIEW_MOCK_UINFIN }
+      }
+
+      // Inject MyInfo preview values into form fields (if they are MyInfo fields).
+      data.form.form_fields = data.form.form_fields.map(
+        augmentWithMyInfoDisplayValue,
+      )
+
+      return data
+    })
+    .then(transformAllIsoStringsToDate)
+}
+
 export const getFreeSmsQuota = async (formId: string) => {
   return ApiService.get<SmsCountsDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/verified-sms/count/free`,

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -9,6 +9,7 @@ import {
   SmsCountsDto,
 } from '~shared/types/form/form'
 
+import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService } from '~services/ApiService'
 
@@ -79,7 +80,7 @@ export const viewFormTemplate = async (
   formId: string,
 ): Promise<PreviewFormViewDto> => {
   return ApiService.get<PreviewFormViewDto>(
-    `${ADMIN_FORM_ENDPOINT}/${formId}/use-template`,
+    `${ADMIN_FORM_ENDPOINT}/${formId}/${PUBLICFORM_USETEMPLATE_ROUTE}`,
   )
     .then(({ data }) => {
       // Add default mock authenticated state if previewing an authenticatable form

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -1,29 +1,59 @@
 import { BiShow } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
-import { Flex, Icon, Text } from '@chakra-ui/react'
+import { Flex, Icon, Stack, Text } from '@chakra-ui/react'
 
-import { ADMINFORM_ROUTE } from '~constants/routes'
+import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button from '~components/Button'
+import Link from '~components/Link'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-export const PreviewFormBanner = (): JSX.Element => {
+interface PreviewFormBannerProps {
+  isTemplate?: boolean
+}
+
+export const PreviewFormBanner = ({
+  isTemplate,
+}: PreviewFormBannerProps): JSX.Element => {
   const { formId } = usePublicFormContext()
 
   return (
-    <Flex bg="primary.100" py="1rem" px="2rem" display="flex" width="100%">
+    <Flex
+      bg="primary.100"
+      py="1rem"
+      px="2rem"
+      display="flex"
+      width="100%"
+      // position="fixed"
+    >
       <Flex align="center" flex={1} justify="space-between" flexDir="row">
         <Flex align="center">
           <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
           <Text textStyle="subhead-3">Form Preview</Text>
         </Flex>
-        <Button
-          aria-label="Click to edit the form"
-          as={ReactLink}
-          to={`${ADMINFORM_ROUTE}/${formId}`}
-        >
-          Edit form
-        </Button>
+        {isTemplate ? (
+          <Stack spacing="1rem" direction="row">
+            <Link
+              variant="standalone"
+              aria-label="Click to return to the admin dashboard"
+              as={ReactLink}
+              to={DASHBOARD_ROUTE}
+            >
+              Back to FormSG
+            </Link>
+            <Button aria-label="Click to use this template">
+              Use this template
+            </Button>
+          </Stack>
+        ) : (
+          <Button
+            aria-label="Click to edit the form"
+            as={ReactLink}
+            to={`${ADMINFORM_ROUTE}/${formId}`}
+          >
+            Edit form
+          </Button>
+        )}
       </Flex>
     </Flex>
   )

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -1,6 +1,16 @@
+import { useCallback } from 'react'
 import { BiShow } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
-import { Flex, Icon, Stack, Text, useDisclosure } from '@chakra-ui/react'
+import { Waypoint } from 'react-waypoint'
+import {
+  Flex,
+  Icon,
+  Portal,
+  Slide,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
 
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button from '~components/Button'
@@ -9,6 +19,17 @@ import Link from '~components/Link'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 import { DuplicateFormModal } from '~features/workspace/components/DuplicateFormModal'
 
+export const StickyPreviewHeader = ({
+  isOpen,
+}: {
+  isOpen: boolean
+}): JSX.Element => (
+  <Portal>
+    <Slide aria-hidden direction="top" in={isOpen}>
+      <PreviewFormBanner isTemplate />
+    </Slide>
+  </Portal>
+)
 interface PreviewFormBannerProps {
   isTemplate?: boolean
 }
@@ -19,49 +40,74 @@ export const PreviewFormBanner = ({
   const { formId } = usePublicFormContext()
   const { isOpen, onOpen, onClose } = useDisclosure()
   return (
-    <Flex
-      bg="primary.100"
-      py="1rem"
-      px="2rem"
-      display="flex"
-      width="100%"
-      // position="fixed"
-    >
-      <Flex align="center" flex={1} justify="space-between" flexDir="row">
-        <Flex align="center">
-          <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
-          <Text textStyle="subhead-3">Form Preview</Text>
-        </Flex>
-        {isTemplate ? (
-          <Stack spacing="1rem" direction="row">
-            <Link
-              variant="standalone"
-              aria-label="Click to return to the admin dashboard"
+    <>
+      <Flex bg="primary.100" py="1rem" px="2rem" display="flex" width="100%">
+        <Flex align="center" flex={1} justify="space-between" flexDir="row">
+          <Flex align="center">
+            <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
+            <Text textStyle="subhead-3">Form Preview</Text>
+          </Flex>
+          {isTemplate ? (
+            <Stack spacing="1rem" direction="row">
+              <Link
+                variant="standalone"
+                aria-label="Click to return to the admin dashboard"
+                as={ReactLink}
+                to={DASHBOARD_ROUTE}
+              >
+                Back to FormSG
+              </Link>
+              <Button aria-label="Click to use this template" onClick={onOpen}>
+                Use this template
+              </Button>
+            </Stack>
+          ) : (
+            <Button
+              aria-label="Click to edit the form"
               as={ReactLink}
-              to={DASHBOARD_ROUTE}
+              to={`${ADMINFORM_ROUTE}/${formId}`}
             >
-              Back to FormSG
-            </Link>
-            <Button aria-label="Click to use this template" onClick={onOpen}>
-              Use this template
+              Edit form
             </Button>
-          </Stack>
-        ) : (
-          <Button
-            aria-label="Click to edit the form"
-            as={ReactLink}
-            to={`${ADMINFORM_ROUTE}/${formId}`}
-          >
-            Edit form
-          </Button>
-        )}
+          )}
+        </Flex>
+        <DuplicateFormModal
+          formId={formId}
+          isTemplate
+          isOpen={isOpen}
+          onClose={onClose}
+        />
       </Flex>
-      <DuplicateFormModal
-        formId={formId}
-        isTemplate
-        isOpen={isOpen}
-        onClose={onClose}
-      />
-    </Flex>
+    </>
+  )
+}
+
+export const PreviewFormBannerContainer = ({
+  isTemplate,
+}: PreviewFormBannerProps): JSX.Element => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const handlePositionChange = useCallback(
+    (pos: Waypoint.CallbackArgs) => {
+      // Required so a page that loads in the middle of the page can still
+      // trigger the mini header.
+      if (pos.currentPosition === 'above') {
+        onOpen()
+      } else {
+        onClose()
+      }
+    },
+    [onClose, onOpen],
+  )
+
+  return (
+    <>
+      {isTemplate ? <StickyPreviewHeader isOpen={isOpen} /> : null}
+      <PreviewFormBanner isTemplate={isTemplate} />
+      {
+        /* Sentinel to know when sticky navbar is starting */
+
+        <Waypoint topOffset="64px" onPositionChange={handlePositionChange} />
+      }
+    </>
   )
 }

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -45,7 +45,7 @@ export const PreviewFormBanner = ({
         <Flex align="center" flex={1} justify="space-between" flexDir="row">
           <Flex align="center">
             <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
-            <Text textStyle="subhead-3">Form Preview</Text>
+            <Text textStyle="subhead-3">Template Preview</Text>
           </Flex>
           {isTemplate ? (
             <Stack spacing="1rem" direction="row">

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -67,10 +67,21 @@ export const PreviewFormBanner = ({
   )
   return (
     <>
-      <Flex bg="primary.100" py="1rem" px="2rem" display="flex" width="100%">
+      <Flex
+        bg="primary.100"
+        py="1rem"
+        px={{ base: '1.5rem', md: '2rem' }}
+        display="flex"
+        width="100%"
+      >
         <Flex align="center" flex={1} justify="space-between" flexDir="row">
           <Flex align="center">
-            <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
+            <Icon
+              aria-hidden
+              as={BiShow}
+              fontSize="1.5rem"
+              mr={{ base: '0.5rem', md: '1rem' }}
+            />
             <Text textStyle="subhead-3">
               {isTemplate ? 'Template Preview' : 'Form Preview'}
             </Text>
@@ -150,6 +161,7 @@ export const PreviewFormBanner = ({
           </DrawerContent>
         </Drawer>
       </Flex>
+      <Divider />
     </>
   )
 }

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -1,12 +1,13 @@
 import { BiShow } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
-import { Flex, Icon, Stack, Text } from '@chakra-ui/react'
+import { Flex, Icon, Stack, Text, useDisclosure } from '@chakra-ui/react'
 
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button from '~components/Button'
 import Link from '~components/Link'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+import { DuplicateFormModal } from '~features/workspace/components/DuplicateFormModal'
 
 interface PreviewFormBannerProps {
   isTemplate?: boolean
@@ -16,7 +17,7 @@ export const PreviewFormBanner = ({
   isTemplate,
 }: PreviewFormBannerProps): JSX.Element => {
   const { formId } = usePublicFormContext()
-
+  const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <Flex
       bg="primary.100"
@@ -41,7 +42,7 @@ export const PreviewFormBanner = ({
             >
               Back to FormSG
             </Link>
-            <Button aria-label="Click to use this template">
+            <Button aria-label="Click to use this template" onClick={onOpen}>
               Use this template
             </Button>
           </Stack>
@@ -55,6 +56,12 @@ export const PreviewFormBanner = ({
           </Button>
         )}
       </Flex>
+      <DuplicateFormModal
+        formId={formId}
+        isTemplate
+        isOpen={isOpen}
+        onClose={onClose}
+      />
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -1,10 +1,16 @@
-import { useCallback } from 'react'
-import { BiShow } from 'react-icons/bi'
+import { useCallback, useMemo } from 'react'
+import { BiArrowBack, BiDotsHorizontalRounded, BiShow } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
 import { Waypoint } from 'react-waypoint'
 import {
+  Divider,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerOverlay,
   Flex,
   Icon,
+  IconButton,
   Portal,
   Slide,
   Stack,
@@ -13,7 +19,7 @@ import {
 } from '@chakra-ui/react'
 
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
-import Button from '~components/Button'
+import Button, { ButtonProps } from '~components/Button'
 import Link from '~components/Link'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
@@ -38,7 +44,27 @@ export const PreviewFormBanner = ({
   isTemplate,
 }: PreviewFormBannerProps): JSX.Element => {
   const { formId } = usePublicFormContext()
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isModalOpen,
+    onOpen: onModalOpen,
+    onClose: onModalClose,
+  } = useDisclosure()
+  const {
+    isOpen: isDrawerOpen,
+    onOpen: onDrawerOpen,
+    onClose: onDrawerClose,
+  } = useDisclosure()
+  const mobileDrawerButtonProps: Partial<ButtonProps> = useMemo(
+    () => ({
+      isFullWidth: true,
+      iconSpacing: '1rem',
+      justifyContent: 'flex-start',
+      variant: 'clear',
+      colorScheme: 'secondary',
+      textStyle: 'body-1',
+    }),
+    [],
+  )
   return (
     <>
       <Flex bg="primary.100" py="1rem" px="2rem" display="flex" width="100%">
@@ -48,19 +74,36 @@ export const PreviewFormBanner = ({
             <Text textStyle="subhead-3">Template Preview</Text>
           </Flex>
           {isTemplate ? (
-            <Stack spacing="1rem" direction="row">
-              <Link
-                variant="standalone"
-                aria-label="Click to return to the admin dashboard"
-                as={ReactLink}
-                to={DASHBOARD_ROUTE}
+            <>
+              <Stack
+                spacing="1rem"
+                direction="row"
+                d={{ base: 'none', md: 'flex' }}
               >
-                Back to FormSG
-              </Link>
-              <Button aria-label="Click to use this template" onClick={onOpen}>
-                Use this template
-              </Button>
-            </Stack>
+                <Link
+                  variant="standalone"
+                  aria-label="Click to return to the admin dashboard"
+                  as={ReactLink}
+                  to={DASHBOARD_ROUTE}
+                >
+                  Back to FormSG
+                </Link>
+                <Button
+                  aria-label="Click to use this template"
+                  onClick={onModalOpen}
+                >
+                  Use this template
+                </Button>
+              </Stack>
+              <IconButton
+                color="primary.500"
+                variant="clear"
+                display={{ base: 'flex', md: 'none' }}
+                aria-label="Template preview actions"
+                onClick={onDrawerOpen}
+                icon={<BiDotsHorizontalRounded />}
+              />
+            </>
           ) : (
             <Button
               aria-label="Click to edit the form"
@@ -74,9 +117,36 @@ export const PreviewFormBanner = ({
         <DuplicateFormModal
           formId={formId}
           isTemplate
-          isOpen={isOpen}
-          onClose={onClose}
+          isOpen={isModalOpen}
+          onClose={onModalClose}
         />
+        <Drawer
+          placement="bottom"
+          onClose={onDrawerClose}
+          isOpen={isDrawerOpen}
+        >
+          <DrawerOverlay />
+          <DrawerContent borderTopRadius="0.25rem">
+            <DrawerBody px={0} py="0.5rem">
+              <Button
+                onClick={onModalOpen}
+                isFullWidth={true}
+                {...mobileDrawerButtonProps}
+              >
+                Use this template
+              </Button>
+              <Divider />
+              <Button
+                as={ReactLink}
+                to={DASHBOARD_ROUTE}
+                leftIcon={<BiArrowBack fontSize="1.25rem" />}
+                {...mobileDrawerButtonProps}
+              >
+                Back to FormSG
+              </Button>
+            </DrawerBody>
+          </DrawerContent>
+        </Drawer>
       </Flex>
     </>
   )

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -1,38 +1,29 @@
+import { BiShow } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
 import { Flex, Icon, Text } from '@chakra-ui/react'
 
-import { FormAuthType } from '~shared/types'
-
-import { BxsEditAlt } from '~assets/icons/BxsEditAlt'
 import { ADMINFORM_ROUTE } from '~constants/routes'
-import Link from '~components/Link'
+import Button from '~components/Button'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 export const PreviewFormBanner = (): JSX.Element => {
-  const { form, formId } = usePublicFormContext()
+  const { formId } = usePublicFormContext()
 
   return (
-    <Flex bg="success.600" px="2rem" display="flex" width="100%">
+    <Flex bg="primary.100" py="1rem" px="2rem" display="flex" width="100%">
       <Flex align="center" flex={1} justify="space-between" flexDir="row">
-        <Text textStyle="caption-1">
-          Preview{' '}
-          {form?.authType && form.authType !== FormAuthType.NIL
-            ? 'with test data'
-            : 'mode'}
-        </Text>
-        <Link
-          variant="standalone"
-          color="secondary.700"
+        <Flex align="center">
+          <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
+          <Text textStyle="subhead-3">Form Preview</Text>
+        </Flex>
+        <Button
           aria-label="Click to edit the form"
           as={ReactLink}
           to={`${ADMINFORM_ROUTE}/${formId}`}
         >
-          <Flex align="center">
-            <Icon aria-hidden as={BxsEditAlt} fontSize="1rem" mr="0.75rem" />
-            <Text textStyle="subhead-2">Edit form</Text>
-          </Flex>
-        </Link>
+          Edit form
+        </Button>
       </Flex>
     </Flex>
   )

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -71,7 +71,9 @@ export const PreviewFormBanner = ({
         <Flex align="center" flex={1} justify="space-between" flexDir="row">
           <Flex align="center">
             <Icon aria-hidden as={BiShow} fontSize="1rem" mr="0.75rem" />
-            <Text textStyle="subhead-3">Template Preview</Text>
+            <Text textStyle="subhead-3">
+              {isTemplate ? 'Template Preview' : 'Form Preview'}
+            </Text>
           </Flex>
           {isTemplate ? (
             <>

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/index.ts
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/index.ts
@@ -1,1 +1,1 @@
-export { PreviewFormBanner } from './PreviewFormBanner'
+export { PreviewFormBannerContainer } from './PreviewFormBanner'

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -15,6 +15,7 @@ import {
   getFormCollaborators,
   getFreeSmsQuota,
   previewForm,
+  viewFormTemplate,
 } from './AdminViewFormService'
 
 export const adminFormKeys = {
@@ -26,6 +27,8 @@ export const adminFormKeys = {
     [...adminFormKeys.id(id), 'collaborators'] as const,
   previewForm: (id: string) =>
     [...adminFormKeys.id(id), 'previewForm'] as const,
+  viewFormTemplate: (id: string) =>
+    [...adminFormKeys.id(id), 'viewFormTemplate'] as const,
 }
 
 /**
@@ -128,6 +131,22 @@ export const usePreviewForm = (
   return useQuery(
     adminFormKeys.previewForm(formId),
     () => previewForm(formId),
+    {
+      // Treat preview form as static on load.
+      staleTime: Infinity,
+      enabled: FORMID_REGEX.test(formId) && enabled,
+    },
+  )
+}
+
+export const useFormTemplate = (
+  formId: string,
+  /** Extra override to determine whether query is enabled */
+  enabled = true,
+): UseQueryResult<PreviewFormViewDto, ApiError> => {
+  return useQuery(
+    adminFormKeys.viewFormTemplate(formId),
+    () => viewFormTemplate(formId),
     {
       // Treat preview form as static on load.
       staleTime: Infinity,

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -15,7 +15,7 @@ import { PublicFormLogo } from '~features/public-form/components/FormLogo'
 import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 
-import { PreviewFormBanner } from '../common/components/PreviewFormBanner'
+import { PreviewFormBannerContainer } from '../common/components/PreviewFormBanner'
 
 import { PreviewFormProvider } from './PreviewFormProvider'
 
@@ -27,7 +27,7 @@ export const PreviewFormPage = (): JSX.Element => {
     <Flex flexDir="column" css={fillHeightCss} pos="relative">
       <PreviewFormProvider formId={formId}>
         <GovtMasthead />
-        <PreviewFormBanner />
+        <PreviewFormBannerContainer />
         <SwitchEnvIcon />
         <FormSectionsProvider>
           <PublicFormLogo />

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -20,7 +20,7 @@ import dedent from 'dedent'
 import {
   ADMINFORM_ROUTE,
   ADMINFORM_SETTINGS_SUBROUTE,
-  PUBLICFORM_USETEMPLATE_ROUTE,
+  ADMINFORM_USETEMPLATE_ROUTE,
 } from '~constants/routes'
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -57,6 +57,12 @@ export const ShareFormModal = ({
 
   const shareLink = useMemo(
     () => `${window.location.origin}/${formId}`,
+    [formId],
+  )
+
+  const templateLink = useMemo(
+    () =>
+      `${window.location.origin}${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_USETEMPLATE_ROUTE}`,
     [formId],
   )
 
@@ -174,13 +180,13 @@ export const ShareFormModal = ({
                     data-chromatic="ignore"
                     isReadOnly
                     isDisabled={isFormPrivate}
-                    value={`${shareLink}/use-template`}
+                    value={`${templateLink}`}
                   />
                   {formId ? (
                     <InputRightElement>
                       <CopyButton
                         colorScheme="secondary"
-                        stringToCopy={`${shareLink}/${PUBLICFORM_USETEMPLATE_ROUTE}`}
+                        stringToCopy={`${templateLink}`}
                         aria-label="Copy link to use this form as a template"
                         isDisabled={isFormPrivate}
                       />

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -122,7 +122,7 @@ export const ShareFormModal = ({
                   >
                     Settings
                   </Button>{' '}
-                  to allow new responses.
+                  to allow new responses or to share it as a template.
                 </Box>
               </InlineMessage>
             ) : null}

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -17,7 +17,11 @@ import {
 } from '@chakra-ui/react'
 import dedent from 'dedent'
 
-import { ADMINFORM_ROUTE, ADMINFORM_SETTINGS_SUBROUTE } from '~constants/routes'
+import {
+  ADMINFORM_ROUTE,
+  ADMINFORM_SETTINGS_SUBROUTE,
+  PUBLICFORM_USETEMPLATE_ROUTE,
+} from '~constants/routes'
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
 import IconButton from '~components/IconButton'
@@ -162,9 +166,7 @@ export const ShareFormModal = ({
               </Skeleton>
             </FormControl>
             <FormControl isReadOnly>
-              <FormLabel isRequired useMarkdownForDescription>
-                Share template
-              </FormLabel>
+              <FormLabel isRequired>Share template</FormLabel>
               <Skeleton isLoaded={!!formId}>
                 <InputGroup>
                   <Input
@@ -178,8 +180,8 @@ export const ShareFormModal = ({
                     <InputRightElement>
                       <CopyButton
                         colorScheme="secondary"
-                        stringToCopy={`${shareLink}/use-template`}
-                        aria-label="Copy use-template form link"
+                        stringToCopy={`${shareLink}/${PUBLICFORM_USETEMPLATE_ROUTE}`}
+                        aria-label="Copy link to use this form as a template"
                         isDisabled={isFormPrivate}
                       />
                     </InputRightElement>

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -162,6 +162,32 @@ export const ShareFormModal = ({
               </Skeleton>
             </FormControl>
             <FormControl isReadOnly>
+              <FormLabel isRequired useMarkdownForDescription>
+                Share template
+              </FormLabel>
+              <Skeleton isLoaded={!!formId}>
+                <InputGroup>
+                  <Input
+                    // The link will always change in Chromatic so this should be ignored.
+                    data-chromatic="ignore"
+                    isReadOnly
+                    isDisabled={isFormPrivate}
+                    value={`${shareLink}/use-template`}
+                  />
+                  {formId ? (
+                    <InputRightElement>
+                      <CopyButton
+                        colorScheme="secondary"
+                        stringToCopy={`${shareLink}/use-template`}
+                        aria-label="Copy use-template form link"
+                        isDisabled={isFormPrivate}
+                      />
+                    </InputRightElement>
+                  ) : null}
+                </InputGroup>
+              </Skeleton>
+            </FormControl>
+            <FormControl isReadOnly>
               <FormLabel isRequired>Embed HTML</FormLabel>
               <Skeleton isLoaded={!!formId}>
                 <InputGroup>

--- a/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
@@ -1,0 +1,59 @@
+import { Meta, Story } from '@storybook/react'
+
+import {
+  getPreviewFormErrorResponse,
+  getPreviewFormResponse,
+} from '~/mocks/msw/handlers/admin-form/preview-form'
+import { envHandlers } from '~/mocks/msw/handlers/env'
+import {
+  postGenerateVfnOtpResponse,
+  postVerifyVfnOtpResponse,
+  postVfnTransactionResponse,
+} from '~/mocks/msw/handlers/public-form'
+
+import { ADMINFORM_PREVIEW_ROUTE } from '~constants/routes'
+import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
+
+import TemplateFormPage from './TemplateFormPage'
+
+const DEFAULT_MSW_HANDLERS = [
+  ...envHandlers,
+  getPreviewFormResponse(),
+  postVfnTransactionResponse(),
+  postGenerateVfnOtpResponse(),
+  postVerifyVfnOtpResponse(),
+]
+
+export default {
+  title: 'Pages/TemplateFormPage',
+  component: TemplateFormPage,
+  decorators: [
+    StoryRouter({
+      initialEntries: ['/61540ece3d4a6e50ac0cc6ff/preview'],
+      path: `/:formId/${ADMINFORM_PREVIEW_ROUTE}`,
+    }),
+  ],
+  parameters: {
+    // Required so skeleton "animation" does not hide content.
+    chromatic: { pauseAnimationAtEnd: true },
+    layout: 'fullscreen',
+    msw: DEFAULT_MSW_HANDLERS,
+  },
+} as Meta
+
+const Template: Story = () => <TemplateFormPage />
+export const Default = Template.bind({})
+
+export const Mobile = Template.bind({})
+Mobile.parameters = getMobileViewParameters()
+
+export const FormNotFound = Template.bind({})
+FormNotFound.parameters = {
+  msw: [getPreviewFormErrorResponse()],
+}
+
+export const FormNotFoundMobile = Template.bind({})
+FormNotFoundMobile.parameters = {
+  ...FormNotFound.parameters,
+  ...getMobileViewParameters(),
+}

--- a/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, Story } from '@storybook/react'
 
 import {
-  getPreviewFormErrorResponse,
-  getPreviewFormResponse,
-} from '~/mocks/msw/handlers/admin-form/preview-form'
+  getTemplateFormErrorResponse,
+  getTemplateFormResponse,
+} from '~/mocks/msw/handlers/admin-form/template-form'
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   postGenerateVfnOtpResponse,
@@ -11,14 +11,14 @@ import {
   postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
 
-import { ADMINFORM_PREVIEW_ROUTE } from '~constants/routes'
+import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import TemplateFormPage from './TemplateFormPage'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
-  getPreviewFormResponse(),
+  getTemplateFormResponse(),
   postVfnTransactionResponse(),
   postGenerateVfnOtpResponse(),
   postVerifyVfnOtpResponse(),
@@ -29,8 +29,8 @@ export default {
   component: TemplateFormPage,
   decorators: [
     StoryRouter({
-      initialEntries: ['/61540ece3d4a6e50ac0cc6ff/preview'],
-      path: `/:formId/${ADMINFORM_PREVIEW_ROUTE}`,
+      initialEntries: ['/61540ece3d4a6e50ac0cc6ff/use-template'],
+      path: `/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
     }),
   ],
   parameters: {
@@ -49,7 +49,7 @@ Mobile.parameters = getMobileViewParameters()
 
 export const FormNotFound = Template.bind({})
 FormNotFound.parameters = {
-  msw: [getPreviewFormErrorResponse()],
+  msw: [getTemplateFormErrorResponse()],
 }
 
 export const FormNotFoundMobile = Template.bind({})

--- a/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
@@ -11,7 +11,7 @@ import {
   postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
 
-import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
+import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import TemplateFormPage from './TemplateFormPage'
@@ -30,7 +30,7 @@ export default {
   decorators: [
     StoryRouter({
       initialEntries: ['/61540ece3d4a6e50ac0cc6ff/use-template'],
-      path: `/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+      path: `/:formId/${ADMINFORM_USETEMPLATE_ROUTE}`,
     }),
   ],
   parameters: {

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -1,0 +1,46 @@
+import { useParams } from 'react-router-dom'
+import { Flex } from '@chakra-ui/react'
+
+import { fillHeightCss } from '~utils/fillHeightCss'
+import GovtMasthead from '~components/GovtMasthead'
+
+// TODO #4279: Remove after React rollout is complete
+import { SwitchEnvIcon } from '~features/env/SwitchEnvIcon'
+import FormEndPage from '~features/public-form/components/FormEndPage'
+import FormFields from '~features/public-form/components/FormFields'
+import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
+import { FormFooter } from '~features/public-form/components/FormFooter'
+import FormInstructions from '~features/public-form/components/FormInstructions'
+import { PublicFormLogo } from '~features/public-form/components/FormLogo'
+import FormStartPage from '~features/public-form/components/FormStartPage'
+import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
+
+import { PreviewFormBanner } from '../common/components/PreviewFormBanner'
+import { PreviewFormProvider } from '../preview/PreviewFormProvider'
+
+export const TemplateFormPage = (): JSX.Element => {
+  const { formId } = useParams()
+  if (!formId) throw new Error('No formId provided')
+
+  return (
+    <Flex flexDir="column" css={fillHeightCss} pos="relative">
+      <PreviewFormProvider formId={formId}>
+        <GovtMasthead />
+        <PreviewFormBanner isTemplate />
+        <SwitchEnvIcon />
+        <FormSectionsProvider>
+          <PublicFormLogo />
+          <FormStartPage />
+          <PublicFormWrapper isPreview>
+            <FormInstructions />
+            <FormFields />
+            <FormEndPage isPreview />
+            <FormFooter />
+          </PublicFormWrapper>
+        </FormSectionsProvider>
+      </PreviewFormProvider>
+    </Flex>
+  )
+}
+
+export default TemplateFormPage

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -30,7 +30,7 @@ export const TemplateFormPage = (): JSX.Element => {
         <SwitchEnvIcon />
         <FormSectionsProvider>
           <PublicFormLogo />
-          <FormStartPage />
+          <FormStartPage isTemplate />
           <PublicFormWrapper isPreview>
             <FormInstructions />
             <FormFields />

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -15,7 +15,7 @@ import { PublicFormLogo } from '~features/public-form/components/FormLogo'
 import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 
-import { PreviewFormBanner } from '../common/components/PreviewFormBanner'
+import { PreviewFormBannerContainer } from '../common/components/PreviewFormBanner'
 import { PreviewFormProvider } from '../preview/PreviewFormProvider'
 
 export const TemplateFormPage = (): JSX.Element => {
@@ -26,7 +26,7 @@ export const TemplateFormPage = (): JSX.Element => {
     <Flex flexDir="column" css={fillHeightCss} pos="relative">
       <PreviewFormProvider formId={formId}>
         <GovtMasthead />
-        <PreviewFormBanner isTemplate />
+        <PreviewFormBannerContainer isTemplate />
         <SwitchEnvIcon />
         <FormSectionsProvider>
           <PublicFormLogo />

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -16,7 +16,8 @@ import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 
 import { PreviewFormBannerContainer } from '../common/components/PreviewFormBanner'
-import { PreviewFormProvider } from '../preview/PreviewFormProvider'
+
+import { TemplateFormProvider } from './TemplateFormProvider'
 
 export const TemplateFormPage = (): JSX.Element => {
   const { formId } = useParams()
@@ -24,7 +25,7 @@ export const TemplateFormPage = (): JSX.Element => {
 
   return (
     <Flex flexDir="column" css={fillHeightCss} pos="relative">
-      <PreviewFormProvider formId={formId}>
+      <TemplateFormProvider formId={formId}>
         <GovtMasthead />
         <PreviewFormBannerContainer isTemplate />
         <SwitchEnvIcon />
@@ -38,7 +39,7 @@ export const TemplateFormPage = (): JSX.Element => {
             <FormFooter />
           </PublicFormWrapper>
         </FormSectionsProvider>
-      </PreviewFormProvider>
+      </TemplateFormProvider>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -18,6 +18,7 @@ import { useTimeout } from '~hooks/useTimeout'
 import { HttpError } from '~services/ApiService'
 import { FormFieldValues } from '~templates/Field'
 
+import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
 
 import { usePreviewFormMutations } from '../common/mutations'
@@ -161,6 +162,10 @@ export const TemplateFormProvider = ({
 
   if (isNotFormId) {
     return <NotFoundErrorPage />
+  }
+
+  if (get(error, 'code') === 403) {
+    return <AdminForbiddenErrorPage message={error?.message} />
   }
 
   return (

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -65,7 +65,8 @@ export const TemplateFormProvider = ({
 
   const isFormNotFound = useMemo(() => {
     return (
-      error instanceof HttpError && (error.code === 404 || error.code === 410)
+      error instanceof HttpError &&
+      (error.code === 404 || error.code === 410 || error.code === 403)
     )
   }, [error])
 
@@ -162,10 +163,6 @@ export const TemplateFormProvider = ({
 
   if (isNotFormId) {
     return <NotFoundErrorPage />
-  }
-
-  if (get(error, 'code') === 403) {
-    return <AdminForbiddenErrorPage message={error?.message} />
   }
 
   return (

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { SubmitHandler } from 'react-hook-form'
+import get from 'lodash/get'
+import simplur from 'simplur'
+
+import { FormAuthType, FormResponseMode } from '~shared/types/form'
+
+import { useFormTemplate } from '~/features/admin-form/common/queries'
+import { FormNotFound } from '~/features/public-form/components/FormNotFound'
+import {
+  PublicFormContext,
+  SubmissionData,
+} from '~/features/public-form/PublicFormContext'
+import { useCommonFormProvider } from '~/features/public-form/PublicFormProvider'
+
+import { useTimeout } from '~hooks/useTimeout'
+import { HttpError } from '~services/ApiService'
+import { FormFieldValues } from '~templates/Field'
+
+import NotFoundErrorPage from '~pages/NotFoundError'
+
+import { usePreviewFormMutations } from '../common/mutations'
+
+interface PreviewFormProviderProps {
+  formId: string
+  children: React.ReactNode
+}
+
+export const TemplateFormProvider = ({
+  formId,
+  children,
+}: PreviewFormProviderProps): JSX.Element => {
+  // Once form has been submitted, submission data will be set here.
+  const [submissionData, setSubmissionData] = useState<SubmissionData>()
+
+  const { data, isLoading, error, ...rest } = useFormTemplate(
+    formId,
+    // Stop querying once submissionData is present.
+    /* enabled= */ !submissionData,
+  )
+
+  const { isNotFormId, toast, vfnToastIdRef, expiryInMs, ...commonFormValues } =
+    useCommonFormProvider(formId)
+
+  const showErrorToast = useCallback(
+    (error) => {
+      toast({
+        status: 'danger',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'An error occurred whilst processing your submission. Please refresh and try again.',
+      })
+    },
+    [toast],
+  )
+
+  useEffect(() => {
+    return () => {
+      document.title = 'FormSG'
+    }
+  }, [])
+
+  const isFormNotFound = useMemo(() => {
+    return (
+      error instanceof HttpError && (error.code === 404 || error.code === 410)
+    )
+  }, [error])
+
+  const generateVfnExpiryToast = useCallback(() => {
+    if (vfnToastIdRef.current) {
+      toast.close(vfnToastIdRef.current)
+    }
+    const numVerifiable = data?.form.form_fields.filter((ff) =>
+      get(ff, 'isVerifiable'),
+    ).length
+
+    if (numVerifiable) {
+      vfnToastIdRef.current = toast({
+        duration: null,
+        status: 'warning',
+        isClosable: true,
+        description: simplur`Your verified field[|s] ${[
+          numVerifiable,
+        ]} [has|have] expired. Please verify [the|those] ${[
+          numVerifiable,
+        ]} field[|s] again.`,
+      })
+    }
+  }, [data?.form.form_fields, toast, vfnToastIdRef])
+
+  useTimeout(generateVfnExpiryToast, expiryInMs)
+
+  const isAuthRequired = useMemo(
+    () =>
+      !!data?.form &&
+      data.form.authType !== FormAuthType.NIL &&
+      !data.spcpSession,
+    [data?.form, data?.spcpSession],
+  )
+
+  const { submitEmailModeFormMutation, submitStorageModeFormMutation } =
+    usePreviewFormMutations(formId)
+
+  const handleSubmitForm: SubmitHandler<FormFieldValues> = useCallback(
+    async (formInputs) => {
+      const { form } = data ?? {}
+      if (!form) return
+
+      switch (form.responseMode) {
+        case FormResponseMode.Email:
+          // Using mutateAsync so react-hook-form goes into loading state.
+          return (
+            submitEmailModeFormMutation
+              .mutateAsync(
+                { formFields: form.form_fields, formInputs },
+                {
+                  onSuccess: ({ submissionId }) =>
+                    setSubmissionData({
+                      id: submissionId,
+                      // TODO: Server should return server time so browser time is not used.
+                      timeInEpochMs: Date.now(),
+                    }),
+                },
+              )
+              // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
+              .catch(showErrorToast)
+          )
+        case FormResponseMode.Encrypt:
+          // Using mutateAsync so react-hook-form goes into loading state.
+          return (
+            submitStorageModeFormMutation
+              .mutateAsync(
+                {
+                  formFields: form.form_fields,
+                  formInputs,
+                  publicKey: form.publicKey,
+                },
+                {
+                  onSuccess: ({ submissionId }) =>
+                    setSubmissionData({
+                      id: submissionId,
+                      // TODO: Server should return server time so browser time is not used.
+                      timeInEpochMs: Date.now(),
+                    }),
+                },
+              )
+              // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
+              .catch(showErrorToast)
+          )
+      }
+    },
+    [
+      data,
+      showErrorToast,
+      submitEmailModeFormMutation,
+      submitStorageModeFormMutation,
+    ],
+  )
+
+  if (isNotFormId) {
+    return <NotFoundErrorPage />
+  }
+
+  return (
+    <PublicFormContext.Provider
+      value={{
+        handleSubmitForm,
+        formId,
+        error,
+        submissionData,
+        isAuthRequired,
+        expiryInMs,
+        isLoading,
+        handleLogout: undefined,
+        ...commonFormValues,
+        ...data,
+        ...rest,
+      }}
+    >
+      <Helmet title={isFormNotFound ? 'Form not found' : data?.form.title} />
+      {isFormNotFound ? <FormNotFound message={error?.message} /> : children}
+    </PublicFormContext.Provider>
+  )
+}

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -18,7 +18,6 @@ import { useTimeout } from '~hooks/useTimeout'
 import { HttpError } from '~services/ApiService'
 import { FormFieldValues } from '~templates/Field'
 
-import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
 
 import { usePreviewFormMutations } from '../common/mutations'

--- a/frontend/src/features/admin-form/template/index.ts
+++ b/frontend/src/features/admin-form/template/index.ts
@@ -1,0 +1,2 @@
+// Default required for lazy loading.
+export { TemplateFormPage as default } from './TemplateFormPage'

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Flex,
   Icon,
-  Portal,
   Skeleton,
   Slide,
   Text,
@@ -40,7 +39,6 @@ export const MiniHeader = ({
   isOpen,
   isTemplate,
 }: MiniHeaderProps): JSX.Element => (
-  // <Portal>
   <Slide
     // Screen readers do not need to know of the existence of this component.
     aria-hidden
@@ -94,7 +92,6 @@ export const MiniHeader = ({
       </Skeleton>
     </Box>
   </Slide>
-  // </Portal>
 )
 
 interface FormHeaderProps {

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -40,60 +40,61 @@ export const MiniHeader = ({
   isOpen,
   isTemplate,
 }: MiniHeaderProps): JSX.Element => (
-  <Portal>
-    <Slide
-      // Screen readers do not need to know of the existence of this component.
-      aria-hidden
-      ref={miniHeaderRef}
-      direction="top"
-      in={isOpen}
+  // <Portal>
+  <Slide
+    // Screen readers do not need to know of the existence of this component.
+    aria-hidden
+    ref={miniHeaderRef}
+    direction="top"
+    in={isOpen}
+    style={{ zIndex: 1000 }}
+  >
+    <Box
+      bg={titleBg}
+      mt={isTemplate ? '4.75rem' : '0'}
+      px={{ base: '1.5rem', md: '2rem' }}
+      py={{ base: '0.5rem', md: '1rem' }}
     >
-      <Box
-        bg={titleBg}
-        mt={isTemplate ? '4.75rem' : '0'}
-        px={{ base: '1.5rem', md: '2rem' }}
-        py={{ base: '0.5rem', md: '1rem' }}
-      >
-        <Skeleton isLoaded={!!title}>
+      <Skeleton isLoaded={!!title}>
+        <Flex
+          align="center"
+          flex={1}
+          gap="0.5rem"
+          justify="space-between"
+          flexDir="row"
+        >
           <Flex
-            align="center"
-            flex={1}
-            gap="0.5rem"
-            justify="space-between"
-            flexDir="row"
+            alignItems="center"
+            minH={{ base: '4rem', md: '0' }}
+            flex="1 1 0"
+            w="100%"
+            overflow="hidden"
           >
-            <Flex
-              alignItems="center"
-              minH={{ base: '4rem', md: '0' }}
-              flex="1 1 0"
-              w="100%"
-              overflow="hidden"
+            <Text
+              textStyle={{ base: 'h4', md: 'h2' }}
+              textAlign="start"
+              color={titleColor}
+              noOfLines={2}
             >
-              <Text
-                textStyle={{ base: 'h4', md: 'h2' }}
-                textAlign="start"
-                color={titleColor}
-                noOfLines={2}
-              >
-                {title ?? 'Loading title'}
-              </Text>
-            </Flex>
-            {activeSectionId ? (
-              // Section sidebar icon should only show up if sections exist
-              <IconButton
-                colorScheme={colorScheme}
-                aria-label="Mobile section sidebar"
-                fontSize="1.5rem"
-                icon={<BxMenuAltLeft />}
-                d={{ base: 'flex', md: 'none' }}
-                onClick={onMobileDrawerOpen}
-              />
-            ) : null}
+              {title ?? 'Loading title'}
+            </Text>
           </Flex>
-        </Skeleton>
-      </Box>
-    </Slide>
-  </Portal>
+          {activeSectionId ? (
+            // Section sidebar icon should only show up if sections exist
+            <IconButton
+              colorScheme={colorScheme}
+              aria-label="Mobile section sidebar"
+              fontSize="1.5rem"
+              icon={<BxMenuAltLeft />}
+              d={{ base: 'flex', md: 'none' }}
+              onClick={onMobileDrawerOpen}
+            />
+          ) : null}
+        </Flex>
+      </Skeleton>
+    </Box>
+  </Slide>
+  // </Portal>
 )
 
 interface FormHeaderProps {

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -27,7 +27,7 @@ export type MiniHeaderProps = Pick<
   | 'miniHeaderRef'
   | 'onMobileDrawerOpen'
   | 'colorScheme'
-> & { isOpen: boolean }
+> & { isOpen: boolean; isTemplate?: boolean }
 
 export const MiniHeader = ({
   title,
@@ -38,6 +38,7 @@ export const MiniHeader = ({
   onMobileDrawerOpen,
   colorScheme,
   isOpen,
+  isTemplate,
 }: MiniHeaderProps): JSX.Element => (
   <Portal>
     <Slide
@@ -49,6 +50,7 @@ export const MiniHeader = ({
     >
       <Box
         bg={titleBg}
+        mt={isTemplate ? '4.75rem' : '0'}
         px={{ base: '1.5rem', md: '2rem' }}
         py={{ base: '0.5rem', md: '1rem' }}
       >
@@ -104,6 +106,7 @@ interface FormHeaderProps {
   loggedInId?: string
   showMiniHeader?: boolean
   activeSectionId?: string
+  isTemplate?: boolean
   miniHeaderRef?: RefObject<HTMLDivElement>
   onMobileDrawerOpen?: () => void
   handleLogout?: () => void
@@ -120,6 +123,7 @@ export const FormHeader = ({
   showMiniHeader,
   activeSectionId,
   miniHeaderRef,
+  isTemplate,
   onMobileDrawerOpen,
   handleLogout,
 }: FormHeaderProps): JSX.Element | null => {
@@ -152,6 +156,7 @@ export const FormHeader = ({
           miniHeaderRef={miniHeaderRef}
           onMobileDrawerOpen={onMobileDrawerOpen}
           isOpen={isOpen}
+          isTemplate={isTemplate}
         />
       ) : null}
       <Flex

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
@@ -7,7 +7,12 @@ import { useFormSections } from '../FormFields/FormSectionsContext'
 import { FormHeader } from './FormHeader'
 import { useFormHeader } from './useFormHeader'
 
-export const FormStartPage = (): JSX.Element => {
+interface FormStartPageProps {
+  isTemplate?: boolean
+}
+export const FormStartPage = ({
+  isTemplate,
+}: FormStartPageProps): JSX.Element => {
   const {
     form,
     spcpSession,
@@ -35,6 +40,7 @@ export const FormStartPage = (): JSX.Element => {
       miniHeaderRef={miniHeaderRef}
       onMobileDrawerOpen={onMobileDrawerOpen}
       handleLogout={handleLogout}
+      isTemplate={isTemplate}
       {...formHeaderProps}
     />
   )

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -63,7 +63,7 @@ export const useDupeFormWizardContext = (
         ? FormResponseMode.Email
         : FormResponseMode.Encrypt,
       title: makeDuplicateFormTitle(
-        isTemplate ? `Template_${data?.form.title}` : data?.form.title,
+        isTemplate ? `[Template] ${data?.form.title}` : data?.form.title,
         dashboardForms,
       ),
     })

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -63,7 +63,7 @@ export const useDupeFormWizardContext = (
         ? FormResponseMode.Email
         : FormResponseMode.Encrypt,
       title: makeDuplicateFormTitle(
-        isTemplate ? `[Template] ${data?.form.title}` : data?.form.title,
+        isTemplate ? `Template_${data?.form.title}` : data?.form.title,
         dashboardForms,
       ),
     })

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -23,7 +23,7 @@ export const useDupeFormWizardContext = (
 
   const { data: previewFormData, isLoading: isPreviewFormLoading } =
     usePreviewForm(
-      formId ?? '',
+      formId,
       // Stop querying once submissionData is present.
       /* enabled= */ !!formId,
     )

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -14,9 +14,11 @@ import { DupeFormWizardProvider } from './DupeFormWizardProvider'
 export type DuplicateFormModalProps = Pick<
   UseDisclosureReturn,
   'onClose' | 'isOpen'
->
+> & { formId: string; isTemplate?: boolean }
 
 export const DuplicateFormModal = ({
+  formId,
+  isTemplate,
   isOpen,
   onClose,
 }: DuplicateFormModalProps): JSX.Element => {
@@ -25,12 +27,12 @@ export const DuplicateFormModal = ({
     xs: 'mobile',
     md: 'full',
   })
-
+  console.log(isTemplate)
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
         <ModalCloseButton />
-        <DupeFormWizardProvider>
+        <DupeFormWizardProvider formId={formId} isTemplate={isTemplate}>
           <CreateFormModalContent />
         </DupeFormWizardProvider>
       </ModalContent>

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -27,7 +27,6 @@ export const DuplicateFormModal = ({
     xs: 'mobile',
     md: 'full',
   })
-  console.log(isTemplate)
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -76,6 +76,7 @@ export const WorkspaceRowsProvider = ({
       }}
     >
       <DuplicateFormModal
+        formId={activeFormMeta?._id ?? ''}
         isOpen={dupeFormModalDisclosure.isOpen}
         onClose={dupeFormModalDisclosure.onClose}
       />

--- a/frontend/src/mocks/msw/handlers/admin-form/template-form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/template-form.ts
@@ -1,0 +1,60 @@
+import { mergeWith } from 'lodash'
+import { rest } from 'msw'
+import { PartialDeep } from 'type-fest'
+
+import { FormId, PreviewFormViewDto } from '~shared/types/form/form'
+
+import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
+
+import { BASE_FORM } from '../public-form'
+
+export const getTemplateFormResponse = ({
+  delay = 0,
+  overrides,
+}: {
+  delay?: number | 'infinite'
+  overrides?: PartialDeep<PreviewFormViewDto>
+} = {}) => {
+  return rest.get<PreviewFormViewDto>(
+    `/api/v3/admin/forms/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+    (req, res, ctx) => {
+      const formId = req.params.formId ?? '61540ece3d4a6e50ac0cc6ff'
+
+      const response = mergeWith(
+        {},
+        {
+          form: {
+            _id: formId as FormId,
+            ...BASE_FORM,
+          },
+        },
+        overrides,
+        (objValue, srcValue) => {
+          if (Array.isArray(objValue)) {
+            return [...srcValue, ...objValue]
+          }
+        },
+      ) as PreviewFormViewDto
+      return res(ctx.delay(delay), ctx.json(response))
+    },
+  )
+}
+
+export const getTemplateFormErrorResponse = ({
+  delay = 0,
+  status = 403,
+  message = 'If you think this is a mistake, please contact the agency that gave you the form link.',
+}: {
+  delay?: number | 'infinite'
+  status?: number
+  message?: string
+} = {}) => {
+  return rest.get<PreviewFormViewDto>(
+    `/api/v3/admin/forms/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+    (req, res, ctx) => {
+      return res(ctx.delay(delay), ctx.status(status), ctx.json({ message }))
+    },
+  )
+}
+
+export const publicFormHandlers = [getTemplateFormResponse()]

--- a/frontend/src/mocks/msw/handlers/admin-form/template-form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/template-form.ts
@@ -4,7 +4,7 @@ import { PartialDeep } from 'type-fest'
 
 import { FormId, PreviewFormViewDto } from '~shared/types/form/form'
 
-import { PUBLICFORM_USETEMPLATE_ROUTE } from '~constants/routes'
+import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 
 import { BASE_FORM } from '../public-form'
 
@@ -16,7 +16,7 @@ export const getTemplateFormResponse = ({
   overrides?: PartialDeep<PreviewFormViewDto>
 } = {}) => {
   return rest.get<PreviewFormViewDto>(
-    `/api/v3/admin/forms/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+    `/api/v3/admin/forms/:formId/${ADMINFORM_USETEMPLATE_ROUTE}`,
     (req, res, ctx) => {
       const formId = req.params.formId ?? '61540ece3d4a6e50ac0cc6ff'
 
@@ -50,7 +50,7 @@ export const getTemplateFormErrorResponse = ({
   message?: string
 } = {}) => {
   return rest.get<PreviewFormViewDto>(
-    `/api/v3/admin/forms/:formId/${PUBLICFORM_USETEMPLATE_ROUTE}`,
+    `/api/v3/admin/forms/:formId/${ADMINFORM_USETEMPLATE_ROUTE}`,
     (req, res, ctx) => {
       return res(ctx.delay(delay), ctx.status(status), ctx.json({ message }))
     },

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -16,10 +16,6 @@ export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
     value: MAX_TITLE_LENGTH,
     message: `Form name must be at most ${MAX_TITLE_LENGTH} characters`,
   },
-  pattern: {
-    value: /^[a-zA-Z0-9_\-./() &`;'"]*$/,
-    message: 'Form name cannot contain special characters',
-  },
   validate: {
     trimMinLength: (value: string) => {
       return (

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -16,6 +16,10 @@ export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
     value: MAX_TITLE_LENGTH,
     message: `Form name must be at most ${MAX_TITLE_LENGTH} characters`,
   },
+  pattern: {
+    value: /^[a-zA-Z0-9_\-./() &`;'"]*$/,
+    message: 'Form name cannot contain special characters',
+  },
   validate: {
     trimMinLength: (value: string) => {
       return (

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -17,7 +17,7 @@ export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
     message: `Form name must be at most ${MAX_TITLE_LENGTH} characters`,
   },
   pattern: {
-    value: /^[a-zA-Z0-9_\-./() &`;'"]*$/,
+    value: /^[a-zA-Z0-9_\-./()[\] &`;'"]*$/,
     message: 'Form name cannot contain special characters',
   },
   validate: {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -58,7 +58,11 @@ import {
 } from '../../types'
 import { IPopulatedUser, IUserSchema } from '../../types/user'
 import { OverrideProps } from '../modules/form/admin-form/admin-form.types'
-import { getFormFieldById, transformEmails } from '../modules/form/form.utils'
+import {
+  getFormFieldById,
+  transformEmails,
+  UNICODE_ESCAPED_REGEX,
+} from '../modules/form/form.utils'
 import { validateWebhookUrl } from '../modules/webhook/webhook.validation'
 
 import getAgencyModel from './agency.server.model'
@@ -163,10 +167,13 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     {
       title: {
         type: String,
-        validate: [
-          /^[a-zA-Z0-9_\-./() &`;'"]*$/,
-          'Form name cannot contain special characters',
-        ],
+        validate: {
+          // validation fails if regex pattern exists in the title
+          validator: function (v: string) {
+            return !UNICODE_ESCAPED_REGEX.test(v)
+          },
+          message: 'Form name cannot contain improperly encoded characters',
+        },
         required: 'Form name cannot be blank',
         minlength: [4, 'Form name must be at least 4 characters'],
         maxlength: [200, 'Form name can have a maximum of 200 characters'],

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -58,11 +58,7 @@ import {
 } from '../../types'
 import { IPopulatedUser, IUserSchema } from '../../types/user'
 import { OverrideProps } from '../modules/form/admin-form/admin-form.types'
-import {
-  getFormFieldById,
-  transformEmails,
-  UNICODE_ESCAPED_REGEX,
-} from '../modules/form/form.utils'
+import { getFormFieldById, transformEmails } from '../modules/form/form.utils'
 import { validateWebhookUrl } from '../modules/webhook/webhook.validation'
 
 import getAgencyModel from './agency.server.model'
@@ -167,13 +163,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     {
       title: {
         type: String,
-        validate: {
-          // validation fails if regex pattern exists in the title
-          validator: function (v: string) {
-            return !UNICODE_ESCAPED_REGEX.test(v)
-          },
-          message: 'Form name cannot contain improperly encoded characters',
-        },
+        validate: [
+          /^[a-zA-Z0-9_\-./() &`;'"]*$/,
+          'Form name cannot contain special characters',
+        ],
         required: 'Form name cannot be blank',
         minlength: [4, 'Form name must be at least 4 characters'],
         maxlength: [200, 'Form name can have a maximum of 200 characters'],

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -136,24 +136,7 @@ const createFormValidator = celebrate({
       })
       .required()
       // Allow other form schema keys to be passed for form creation.
-      .unknown(true)
-      .custom((value, helpers) => {
-        // If there are unicode-escaped characters are not valid utf-8 encoded,
-        // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
-        // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode sequence
-        // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
-        // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
-
-        const valueStr = JSON.stringify(value)
-
-        if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
-          return helpers.message({
-            custom:
-              'Please check that there are no improperly encoded characters in your input',
-          })
-        }
-        return value
-      }),
+      .unknown(true),
   },
 })
 

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -898,6 +898,7 @@ export const handleDuplicateAdminForm = [
 
 /**
  * Handler for GET /:formId/adminform/template
+ * Handler for GET /api/v3/admin/forms/:formId/use-template
  * @security session
  *
  * @returns 200 with target form's public view

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -901,7 +901,7 @@ export const handleDuplicateAdminForm = [
  * Handler for GET /api/v3/admin/forms/:formId/use-template
  * @security session
  *
- * @returns 200 with target form's public view
+ * @returns 200 with target form's template view
  * @returns 403 when the target form is private
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -136,7 +136,24 @@ const createFormValidator = celebrate({
       })
       .required()
       // Allow other form schema keys to be passed for form creation.
-      .unknown(true),
+      .unknown(true)
+      .custom((value, helpers) => {
+        // If there are unicode-escaped characters are not valid utf-8 encoded,
+        // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
+        // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode sequence
+        // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
+        // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
+
+        const valueStr = JSON.stringify(value)
+
+        if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
+          return helpers.message({
+            custom:
+              'Please check that there are no improperly encoded characters in your input',
+          })
+        }
+        return value
+      }),
   },
 })
 

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -5,6 +5,7 @@ import {
   FormStatus,
   SettingsUpdateDto,
 } from '../../../../../shared/types'
+import { UNICODE_ESCAPED_REGEX } from '../form.utils'
 
 /**
  * Joi validator for PATCH /forms/:formId/settings route.
@@ -26,5 +27,23 @@ export const updateSettingsValidator = celebrate({
       url: Joi.string().uri().allow(''),
       isRetryEnabled: Joi.boolean(),
     }).min(1),
-  }).min(1),
+  })
+    .min(1)
+    .custom((value, helpers) => {
+      // If there are unicode-escaped characters are not valid utf-8 encoded,
+      // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
+      // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode sequence
+      // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
+      // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
+
+      const valueStr = JSON.stringify(value)
+
+      if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
+        return helpers.message({
+          custom:
+            'Please check that there are no improperly encoded characters in your input',
+        })
+      }
+      return value
+    }),
 })

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -5,7 +5,6 @@ import {
   FormStatus,
   SettingsUpdateDto,
 } from '../../../../../shared/types'
-import { UNICODE_ESCAPED_REGEX } from '../form.utils'
 
 /**
  * Joi validator for PATCH /forms/:formId/settings route.
@@ -27,23 +26,5 @@ export const updateSettingsValidator = celebrate({
       url: Joi.string().uri().allow(''),
       isRetryEnabled: Joi.boolean(),
     }).min(1),
-  })
-    .min(1)
-    .custom((value, helpers) => {
-      // If there are unicode-escaped characters are not valid utf-8 encoded,
-      // node 14 treats the sequence of characters as a string e.g. \udbbb is treated as a 6-character string instead of an escaped unicode sequence
-      // If this is saved into the db, an error is thrown when the driver attempts to read the db document as the driver interprets this as an escaped unicode sequence
-      // Since valid unicode-escaped characters will be processed correctly (e.g. \u00ae is processed as ®), they will not trigger an error
-      // Also note that if the user intends to input a 6-character string of the same form e.g. \udbbb, the backslash will be escaped (i.e. double backslash) and hence this will also not trigger an error
-
-      const valueStr = JSON.stringify(value)
-
-      if (UNICODE_ESCAPED_REGEX.test(valueStr)) {
-        return helpers.message({
-          custom:
-            'Please check that there are no improperly encoded characters in your input',
-        })
-      }
-      return value
-    }),
+  }).min(1),
 })

--- a/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
@@ -57,3 +57,21 @@ AdminFormsPreviewRouter.post(
   '/:formId([a-fA-F0-9]{24})/preview/submissions/encrypt',
   AdminFormController.handleEncryptPreviewSubmission,
 )
+
+/**
+ * Return the template preview of a form to the user.
+ * Allows for public forms, only for users who are signed in.
+ * @route GET api/v3/admin/forms/:formId/use-template
+ * @security session
+ *
+ * @returns 200 with target form's public view
+ * @returns 403 when user does not have permissions to access form
+ * @returns 404 when form cannot be found
+ * @returns 410 when form is archived
+ * @returns 422 when user in session cannot be retrieved from the database
+ * @returns 500 when database error occurs
+ */
+AdminFormsPreviewRouter.get(
+  '/:formId([a-fA-F0-9]{24})/use-template',
+  AdminFormController.handleGetTemplateForm,
+)

--- a/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
@@ -64,7 +64,7 @@ AdminFormsPreviewRouter.post(
  * @route GET api/v3/admin/forms/:formId/use-template
  * @security session
  *
- * @returns 200 with target form's public view
+ * @returns 200 with target form's template view
  * @returns 403 when user does not have permissions to access form
  * @returns 404 when form cannot be found
  * @returns 410 when form is archived


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #5161
## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:
- Public forms can be used as a template

**Details**:
- Added the use-template link to `ShareFormModal`. This input field is disabled if the form is closed.
- Added a new component `TemplateFormPage`, which is similar in structure to `PreviewFormPage`. This also uses a new `TemplateFormProvider`, which only differs from `PreviewFormProvider` in the query used (`useFormTemplate`)
- Use `DuplicateFormModal` to duplicate the template form. The `formId` is now injected into `DupeFormWizardProvider` at a higher level, so that `DuplicateFormModal` can be used across workspace rows and the template form page.
- Use `z-index` in form page's `MiniHeader` instead of `Portal` to enable stacking of the sticky headers

**Improvements**:

- Updated the design of `PreviewFormPage`

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->

https://user-images.githubusercontent.com/56983748/202135080-868110c0-1804-45b3-847c-894eafc6803c.mov


## Tests
<!-- What tests should be run to confirm functionality? -->
New stories have been added.

Use-template:
- [x] As a logged in admin, visit the use-template endpoint of a public form `admin/form/:formId/use-template`. Click on the button 'Use this template'. The form title should be prefixed with '[Template]' and you should be able to duplicate the form successfully.
- [x] As a logged in admin, visit the use-template endpoint of a **public** form that you're not the owner of. You should be able to create a duplicate of the form template successfully.
- [x] As a logged in admin, visit the use-template endpoint of a **private** form that you're not the owner of. You should see the admin forbidden error page.
- [x] As a public user, visit the use-template endpoint of a public form. You should be redirected to the login page.