### PR TITLE
fix(docker-compose): include US and SG SES env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,11 @@ services:
       - SECRET_ENV=development
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60
-      - SES_PORT=1025
-      - SES_HOST=maildev
+      # TODO(opengovsg/formsg-private#130) Retain only SG env vars when SES migration is over
+      - SES_PORT_US=1025
+      - SES_HOST_US=maildev
+      - SES_PORT_SG=1025
+      - SES_HOST_SG=maildev
       - WEBHOOK_SQS_URL=http://localhost:4566/000000000000/local-webhooks-sqs-main
       - INTRANET_IP_LIST_PATH
       - SENTRY_CONFIG_URL=https://random@sentry.io/123456


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Dev environment doesn't work out of the box because `SES_PORT` and `SES_HOST` env vars for both US and SG are not included by default.

## Solution
<!-- How did you solve the problem? -->

Add them to `docker-compose.yml` so each dev doesn't have to add them to an env file individually.