### PR TITLE
fix: update max dimension for image uploads

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -151,7 +151,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
         ) {
           return imageCompression(acceptedFile, {
             maxSizeMB: maxSize ? maxSize / MB : undefined,
-            maxWidthOrHeight: 1024,
+            maxWidthOrHeight: 1440,
             initialQuality: 0.8,
             useWebWorker: false,
           }).then((blob) =>


### PR DESCRIPTION
## Problem
We want to update the max dim for images to be 1440px.

## Solution

**Breaking Changes** 
- No - this PR is backwards compatible  