### PR TITLE
feat: improve admin storage mode response printability

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -34,6 +34,7 @@ import {
   ADMINFORM_SETTINGS_SUBROUTE,
 } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
+import { noPrintCss } from '~utils/noPrintCss'
 import Button, { ButtonProps } from '~components/Button'
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
@@ -115,6 +116,7 @@ export const AdminFormNavbar = ({
 
   return (
     <Grid
+      sx={noPrintCss}
       w="100vw"
       position="sticky"
       top={0}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -16,6 +16,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 
+import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
@@ -100,6 +101,7 @@ export const IndividualResponseNavbar = (): JSX.Element => {
 
   return (
     <Grid
+      sx={noPrintCss}
       position="sticky"
       top={0}
       bg="white"

--- a/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
@@ -8,6 +8,7 @@ import {
   RESULTS_RESPONSES_SUBROUTE,
 } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
+import { noPrintCss } from '~utils/noPrintCss'
 import { NavigationTab, NavigationTabList } from '~templates/NavigationTabs'
 
 export const FormResultsNavbar = (): JSX.Element => {
@@ -25,6 +26,7 @@ export const FormResultsNavbar = (): JSX.Element => {
 
   return (
     <Flex
+      sx={noPrintCss}
       w="100vw"
       position="sticky"
       top={0}

--- a/frontend/src/features/env/SwitchEnvIcon.tsx
+++ b/frontend/src/features/env/SwitchEnvIcon.tsx
@@ -5,6 +5,7 @@ import { Flex, Portal, useDisclosure } from '@chakra-ui/react'
 
 import { SwitchEnvFeedbackFormBodyDto } from '~shared/types'
 
+import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 
@@ -42,7 +43,13 @@ export const SwitchEnvIcon = (): JSX.Element | null => {
 
   return (
     <Portal>
-      <Flex position="fixed" bottom="2.75rem" right="2.75rem" cursor="pointer">
+      <Flex
+        position="fixed"
+        bottom="2.75rem"
+        right="2.75rem"
+        cursor="pointer"
+        sx={noPrintCss}
+      >
         <Tooltip placement="left" label="Have feedback?">
           <IconButton
             variant="outline"

--- a/frontend/src/utils/noPrintCss.ts
+++ b/frontend/src/utils/noPrintCss.ts
@@ -1,0 +1,5 @@
+export const noPrintCss = {
+  '@media print': {
+    display: 'none !important',
+  },
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some text are still being cut off in individual storage mode responses. This PR attempts to fix that by removing all non-essential elements so the DOM to be printed can hopefully be parsed better by the browser. Not guaranteed fix, but seems to work with my limited testing.

Related to and closes #5278 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- feat: add `noPrintCss` util to hide elements that should not be printed
- feat: hide some elements when printing storage mode responses
