### PR TITLE
fix: trim dropdown option answer in backend and in angularjs frontend

### DIFF
--- a/src/app/utils/field-validation/validators/dropdownValidator.ts
+++ b/src/app/utils/field-validation/validators/dropdownValidator.ts
@@ -31,7 +31,8 @@ const makeDropdownValidator: DropdownValidatorConstructor =
       : // TODO #4279: Revisit decision to trim in backend after React rollout is complete
         fieldOptions.map((opt) => opt.trim())
     const { answer } = response
-    return isOneOfOptions(validOptions, answer)
+    const trimmedAnswer = answer.trim()
+    return isOneOfOptions(validOptions, trimmedAnswer)
       ? right(response)
       : left(`DropdownValidator:\t answer is not a valid dropdown option`)
   }

--- a/src/public/modules/forms/base/components/field-dropdown.client.component.js
+++ b/src/public/modules/forms/base/components/field-dropdown.client.component.js
@@ -34,7 +34,9 @@ function dropdownFieldComponentController() {
   vm.dropdownFilter = function (searchString) {
     let dropdownOptions = getFieldOptions()
     vm.filteredDropdownOptions = dropdownOptions.filter((option) => {
-      return option.toLowerCase().indexOf(searchString.toLowerCase()) > -1
+      return (
+        option.trim().toLowerCase().indexOf(searchString.toLowerCase()) > -1
+      )
     })
   }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In a previous fix, we trimmed whitespaces from dropdown options in the backend (#5433). 

However, we did not add this trimming to the frontend for AngularJS.

When a respondent attempted to select a dropdown option that contains a whitespace in AngularJS, this would lead to a Validation Field error as their answer still contains the leading/trailing whitespace, which did not match the (trimmed) field options in the backend. This invalidated the submission; respondents were unable to submit their form.

NOTE: the raw options in the DB still contain the leading/trailing whitespace as we'd have to modify the form admin's form fields directly to remove these

## Solution
<!-- How did you solve the problem? -->
- Trim the validation options in the frontend in AngularJS
- Trim the selected answer in the backend

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Create a dropdown field with at least 1 option that contains a leading/trailing whitespace in the db directly. As a respondent, select the dropdown field with the whitespace in Angular. You should be able to submit the form successfully.
