### PR TITLE
fix: correctly perform logic validation on MyInfo prefilled fields

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -21,6 +21,7 @@ import {
   createEmailSubmissionFormData,
   createEncryptedSubmissionData,
 } from '~features/public-form/utils'
+import { filterHiddenInputs } from '~features/public-form/utils/filterHiddenInputs'
 
 import { PREVIEW_MOCK_UINFIN } from '../preview/constants'
 
@@ -122,10 +123,16 @@ export const removeSelfFromFormCollaborators = async (
  */
 export const submitEmailModeFormPreview = async ({
   formFields,
+  formLogics,
   formInputs,
   formId,
 }: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
-  const formData = createEmailSubmissionFormData(formFields, formInputs)
+  const filteredInputs = filterHiddenInputs({
+    formFields,
+    formInputs,
+    formLogics,
+  })
+  const formData = createEmailSubmissionFormData(formFields, filteredInputs)
 
   return ApiService.post<SubmissionResponseDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/email`,
@@ -138,13 +145,19 @@ export const submitEmailModeFormPreview = async ({
  */
 export const submitStorageModeFormPreview = async ({
   formFields,
+  formLogics,
   formInputs,
   formId,
   publicKey,
 }: SubmitStorageFormArgs) => {
-  const submissionContent = await createEncryptedSubmissionData(
+  const filteredInputs = filterHiddenInputs({
     formFields,
     formInputs,
+    formLogics,
+  })
+  const submissionContent = await createEncryptedSubmissionData(
+    formFields,
+    filteredInputs,
     publicKey,
   )
 

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -20,8 +20,8 @@ import {
 import {
   createEmailSubmissionFormData,
   createEncryptedSubmissionData,
+  filterHiddenInputs,
 } from '~features/public-form/utils'
-import { filterHiddenInputs } from '~features/public-form/utils/filterHiddenInputs'
 
 import { PREVIEW_MOCK_UINFIN } from '../preview/constants'
 

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -114,7 +114,11 @@ export const PreviewFormProvider = ({
           return (
             submitEmailModeFormMutation
               .mutateAsync(
-                { formFields: form.form_fields, formInputs },
+                {
+                  formFields: form.form_fields,
+                  formLogics: form.form_logics,
+                  formInputs,
+                },
                 {
                   onSuccess: ({ submissionId }) =>
                     setSubmissionData({
@@ -134,6 +138,7 @@ export const PreviewFormProvider = ({
               .mutateAsync(
                 {
                   formFields: form.form_fields,
+                  formLogics: form.form_logics,
                   formInputs,
                   publicKey: form.publicKey,
                 },

--- a/frontend/src/features/logic/utils/getLogicUnitPreventingSubmit.tsx
+++ b/frontend/src/features/logic/utils/getLogicUnitPreventingSubmit.tsx
@@ -4,6 +4,8 @@ import { FormCondition, FormDto, PreventSubmitLogicDto } from '~shared/types'
 
 import { FormFieldValues } from '~templates/Field'
 
+import { filterHiddenInputs } from '~features/public-form/utils/filterHiddenInputs'
+
 import { FieldIdToType } from '../types'
 
 import { allConditionsExist } from './allConditionsExist'
@@ -66,8 +68,14 @@ export const getLogicUnitPreventingSubmit = ({
 }: {
   formFields: FormDto['form_fields']
   formLogics: FormDto['form_logics']
-  formInputs: UnpackNestedValue<DeepPartialSkipArrayKey<FormFieldValues>>
+  formInputs: FormFieldValues
 }) => {
+  const filteredFormInputs = filterHiddenInputs({
+    formFields,
+    formInputs,
+    formLogics,
+  })
+
   const fieldIdToType = formFields.reduce<FieldIdToType>((acc, ff) => {
     acc[ff._id] = ff.fieldType
     return acc
@@ -78,6 +86,10 @@ export const getLogicUnitPreventingSubmit = ({
     fieldIdToType,
   )
   return preventSubmitConditions.find((logicUnit) =>
-    isLogicUnitSatisfied(formInputs, logicUnit.conditions, fieldIdToType),
+    isLogicUnitSatisfied(
+      filteredFormInputs,
+      logicUnit.conditions,
+      fieldIdToType,
+    ),
   )
 }

--- a/frontend/src/features/logic/utils/getLogicUnitPreventingSubmit.tsx
+++ b/frontend/src/features/logic/utils/getLogicUnitPreventingSubmit.tsx
@@ -4,7 +4,7 @@ import { FormCondition, FormDto, PreventSubmitLogicDto } from '~shared/types'
 
 import { FormFieldValues } from '~templates/Field'
 
-import { filterHiddenInputs } from '~features/public-form/utils/filterHiddenInputs'
+import { filterHiddenInputs } from '~features/public-form/utils'
 
 import { FieldIdToType } from '../types'
 

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -210,7 +210,12 @@ export const PublicFormProvider = ({
           return (
             submitEmailModeFormMutation
               .mutateAsync(
-                { formFields: form.form_fields, formInputs, captchaResponse },
+                {
+                  formFields: form.form_fields,
+                  formLogics: form.form_logics,
+                  formInputs,
+                  captchaResponse,
+                },
                 {
                   onSuccess: ({ submissionId }) => {
                     setSubmissionData({
@@ -232,6 +237,7 @@ export const PublicFormProvider = ({
               .mutateAsync(
                 {
                   formFields: form.form_fields,
+                  formLogics: form.form_logics,
                   formInputs,
                   publicKey: form.publicKey,
                   captchaResponse,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -86,7 +86,6 @@ export const FormFields = ({
   const formMethods = useForm<FormFieldValues>({
     defaultValues: defaultFormValues,
     mode: 'onTouched',
-    shouldUnregister: true,
   })
 
   const {

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -31,7 +31,7 @@ export const PublicFormSubmitButton = ({
 }: PublicFormSubmitButtonProps): JSX.Element => {
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
-  const formInputs = useWatch<FormFieldValues>({})
+  const formInputs = useWatch<FormFieldValues>({}) as FormFieldValues
 
   const preventSubmissionLogic = useMemo(() => {
     return getLogicUnitPreventingSubmit({

--- a/frontend/src/features/public-form/utils/filterHiddenInputs.ts
+++ b/frontend/src/features/public-form/utils/filterHiddenInputs.ts
@@ -1,0 +1,26 @@
+import { pick } from 'lodash'
+
+import type { FormDto, FormFieldDto } from '~shared/types'
+
+import type { FormFieldValues } from '~templates/Field/types'
+
+import { getVisibleFieldIds } from '~features/logic/utils'
+
+export const filterHiddenInputs = ({
+  formFields,
+  formInputs,
+  formLogics,
+}: {
+  formFields: FormFieldDto[]
+  formLogics: FormDto['form_logics']
+  formInputs: FormFieldValues
+}) => {
+  // Remove form inputs (could be prefilled/MyInfo) from fields hidden due to logic.
+  const visibleFieldIds = getVisibleFieldIds(formInputs, {
+    formFields,
+    formLogics,
+  })
+  const filteredFormInputs = pick(formInputs, Array.from(visibleFieldIds))
+
+  return filteredFormInputs
+}

--- a/frontend/src/features/public-form/utils/filterHiddenInputs.ts
+++ b/frontend/src/features/public-form/utils/filterHiddenInputs.ts
@@ -8,7 +8,7 @@ import { getVisibleFieldIds } from '~features/logic/utils'
 
 export const filterHiddenInputs = ({
   formFields,
-  formInputs,
+  formInputs = {},
   formLogics,
 }: {
   formFields: FormFieldDto[]

--- a/frontend/src/features/public-form/utils/index.ts
+++ b/frontend/src/features/public-form/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './createSubmission'
+export * from './filterHiddenInputs'
 export * from './inputTransformation'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
If you have nested logic on FormSG's React client (field 1 -> field 2 -> field 3) and field 2 is a prefilled MyInfo field, then field 3 does not render until you trigger an additional logic calculation.

Investigation shows that this was due to `react-hook-form`'s [`useForm#shouldUnregister` prop](https://react-hook-form.com/api/useform/#:~:text=CODESANDBOX-,shouldUnregister,-%3A%20boolean%20%3D%20false). When inputs are unregistered, the `defaultValues` set on the MyInfo (and others) fields will be removed on unmount, which would be the case when the field is hidden via logic. When the field is then unhidden, it will not trigger a new subscription event to `watch` subscribers since the field value has not changed. Could be a bug in rhf, but fixing it here first.

This PR fixes the bug by not unregistering inputs on the form level and filtering the form inputs based on logic visibility. 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible, purely client-side changes.

**Bug Fixes**:
- fix: stop unregistering inputs on form field unmount
- feat: filter hidden inputs from submission before sending to server
- feat: filter field inputs when evaluating prevent submission logic


## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Add nested logic with MyInfo field. Logic should correctly evaluate when MyInfo field is unhidden.
- [x] Add nested logic with normal field to disable submission. 
  - [x] When criteria is true and preventSubmit field is unhidden, submission is prevented
  - [x]  When criteria is true and preventSubmit field is hidden, submission is **NOT** prevented.
