### PR TITLE
fix: update field validators with more specific type guarantees

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -4,6 +4,7 @@
  */
 import { RegisterOptions } from 'react-hook-form'
 import { isValid, parse } from 'date-fns'
+import { identity } from 'lodash'
 import simplur from 'simplur'
 import validator from 'validator'
 
@@ -43,7 +44,11 @@ import {
   REQUIRED_ERROR,
 } from '~constants/validation'
 import { DATE_PARSE_FORMAT } from '~templates/Field/Date/DateField'
-import { VerifiableFieldValues } from '~templates/Field/types'
+import {
+  CheckboxFieldValues,
+  SingleAnswerValue,
+  VerifiableFieldValues,
+} from '~templates/Field/types'
 
 import { VerifiableFieldBase } from '~features/verifiable-fields/types'
 
@@ -75,21 +80,11 @@ type ValidationRuleFnEmailAndMobile<T extends FieldBase = FieldBase> = (
   schema: MinimumFieldValidationPropsEmailAndMobile<T>,
 ) => RegisterOptions
 
-const requiredValidationFn =
-  (schema: Pick<FieldBase, 'required'>) => (value: unknown) => {
+const requiredSingleAnswerValidationFn =
+  (schema: Pick<FieldBase, 'required'>) => (value?: SingleAnswerValue) => {
     if (!schema.required) return true
-    // Trim strings before checking for emptiness
-    const trimmedValue = typeof value === 'string' ? value.trim() : value
-    return !!trimmedValue || REQUIRED_ERROR
+    return !!value?.trim() || REQUIRED_ERROR
   }
-
-const createRequiredInValidationRules = (
-  schema: Pick<FieldBase, 'required'>,
-): RegisterOptions['validate'] => {
-  return {
-    required: requiredValidationFn(schema),
-  }
-}
 
 /**
  * Validation rules for verifiable fields.
@@ -102,7 +97,7 @@ const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   return {
     validate: {
       required: (value?: VerifiableFieldValues) => {
-        return requiredValidationFn(schema)(value?.value)
+        return requiredSingleAnswerValidationFn(schema)(value?.value)
       },
       hasSignature: (val?: VerifiableFieldValues) => {
         if (!schema.isVerifiable) return true
@@ -125,7 +120,7 @@ export const createBaseValidationRules = (
   schema: Pick<FieldBase, 'required'>,
 ): RegisterOptions => {
   return {
-    validate: createRequiredInValidationRules(schema),
+    validate: requiredSingleAnswerValidationFn(schema),
   }
 }
 
@@ -135,7 +130,7 @@ export const createDropdownValidationRules: ValidationRuleFn<
   // TODO(#3360): Handle MyInfo dropdown validation
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validOptions: (value: string) => {
         if (!value) return
         return (
@@ -155,7 +150,12 @@ export const createRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
 export const createAttachmentValidationRules: ValidationRuleFn<
   AttachmentFieldBase
 > = (schema): RegisterOptions => {
-  return createBaseValidationRules(schema)
+  return {
+    validate: (value?: File) => {
+      if (!schema.required) return true
+      return !!value || REQUIRED_ERROR
+    },
+  }
 }
 
 export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
@@ -163,7 +163,7 @@ export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validHomeNo: (val?: string) => {
         if (!val) return true
         return isHomePhoneNumber(val) || 'Please enter a valid landline number'
@@ -192,7 +192,7 @@ export const createNumberValidationRules: ValidationRuleFn<NumberFieldBase> = (
 
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validNumber: (val?: string) => {
         if (!val || !customVal) return true
 
@@ -225,7 +225,7 @@ export const createDecimalValidationRules: ValidationRuleFn<
 > = (schema): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validDecimal: (val: string) => {
         const {
           ValidationOptions: { customMax, customMin },
@@ -277,7 +277,7 @@ export const createTextValidationRules: ValidationRuleFn<
   const { selectedValidation, customVal } = schema.ValidationOptions
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validText: (val?: string) => {
         if (!val || !customVal) return true
 
@@ -310,7 +310,7 @@ export const createUenValidationRules: ValidationRuleFn<UenFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validUen: (val?: string) => {
         if (!val) return true
         return isUenValid(val) || 'Please enter a valid UEN'
@@ -324,7 +324,7 @@ export const createNricValidationRules: ValidationRuleFn<NricFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validNric: (val?: string) => {
         if (!val) return true
         return (
@@ -342,8 +342,12 @@ export const createCheckboxValidationRules: ValidationRuleFn<
 > = (schema): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
-      validOptions: (val?: string[]) => {
+      required: (val?: CheckboxFieldValues['value']) => {
+        if (!val) return REQUIRED_ERROR
+        // Trim strings before checking for emptiness
+        return val.map((v) => v.trim()).some(identity) || REQUIRED_ERROR
+      },
+      validOptions: (val?: CheckboxFieldValues['value']) => {
         const {
           ValidationOptions: { customMin, customMax },
           validateByValue,
@@ -382,7 +386,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...createRequiredInValidationRules(schema),
+      ...requiredSingleAnswerValidationFn(schema),
       validDate: (val) => {
         if (!val) return true
         if (val === DATE_PARSE_FORMAT.toLowerCase()) {

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -130,7 +130,7 @@ export const createDropdownValidationRules: ValidationRuleFn<
   // TODO(#3360): Handle MyInfo dropdown validation
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validOptions: (value: string) => {
         if (!value) return
         return (
@@ -163,7 +163,7 @@ export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validHomeNo: (val?: string) => {
         if (!val) return true
         return isHomePhoneNumber(val) || 'Please enter a valid landline number'
@@ -192,7 +192,7 @@ export const createNumberValidationRules: ValidationRuleFn<NumberFieldBase> = (
 
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validNumber: (val?: string) => {
         if (!val || !customVal) return true
 
@@ -225,7 +225,7 @@ export const createDecimalValidationRules: ValidationRuleFn<
 > = (schema): RegisterOptions => {
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validDecimal: (val: string) => {
         const {
           ValidationOptions: { customMax, customMin },
@@ -277,7 +277,7 @@ export const createTextValidationRules: ValidationRuleFn<
   const { selectedValidation, customVal } = schema.ValidationOptions
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validText: (val?: string) => {
         if (!val || !customVal) return true
 
@@ -310,7 +310,7 @@ export const createUenValidationRules: ValidationRuleFn<UenFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validUen: (val?: string) => {
         if (!val) return true
         return isUenValid(val) || 'Please enter a valid UEN'
@@ -324,7 +324,7 @@ export const createNricValidationRules: ValidationRuleFn<NricFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validNric: (val?: string) => {
         if (!val) return true
         return (
@@ -386,7 +386,7 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
 ): RegisterOptions => {
   return {
     validate: {
-      ...requiredSingleAnswerValidationFn(schema),
+      required: requiredSingleAnswerValidationFn(schema),
       validDate: (val) => {
         if (!val) return true
         if (val === DATE_PARSE_FORMAT.toLowerCase()) {

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -343,6 +343,7 @@ export const createCheckboxValidationRules: ValidationRuleFn<
   return {
     validate: {
       required: (val?: CheckboxFieldValues['value']) => {
+        if (!schema.required) return true
         if (!val) return REQUIRED_ERROR
         // Trim strings before checking for emptiness
         return val.map((v) => v.trim()).some(identity) || REQUIRED_ERROR


### PR DESCRIPTION
## Problem
There is an issue with required checkboxes being able to be submitted even with invalid responses. This PR fixes that

https://user-images.githubusercontent.com/25571626/204191918-61ca4b66-01da-4503-92b1-0aec6dc80e33.mov

https://user-images.githubusercontent.com/25571626/204191948-b4b3b70a-d143-45fe-927e-9059d5c0301d.mov


## Solution
Refactor validators to use `FormFieldValues` as a minimal type guarantee.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/204191996-6f1737af-fb69-4e0e-a234-add7d36bdd97.mov

