### PR TITLE
fix: remove form title special characters validation

### DIFF
--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -16,10 +16,6 @@ export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
     value: MAX_TITLE_LENGTH,
     message: `Form name must be at most ${MAX_TITLE_LENGTH} characters`,
   },
-  pattern: {
-    value: /^[a-zA-Z0-9_\-./()[\] &`;'"]*$/,
-    message: 'Form name cannot contain special characters',
-  },
   validate: {
     trimMinLength: (value: string) => {
       return (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Form titles still disallow special characters in the frontend when a form is being created. Bug from previous PR #5436

## Solution
<!-- How did you solve the problem? -->
Remove special chars validation from `FORM_TITLE_VALIDATION_RULES` 
