### PR TITLE
feat: add public form `/use-template` redirection to admin form template page

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react'
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
 import {
@@ -16,6 +16,7 @@ import {
   PUBLICFORM_ROUTE,
   RESULTS_FEEDBACK_SUBROUTE,
   TOU_ROUTE,
+  USE_TEMPLATE_REDIRECT_SUBROUTE,
 } from '~constants/routes'
 import { fillHeightCss } from '~utils/fillHeightCss'
 import { lazyRetry } from '~utils/lazyRetry'
@@ -37,6 +38,7 @@ import { HashRouterElement } from './HashRouterElement'
 import { PrivateElement } from './PrivateElement'
 import { PublicElement } from './PublicElement'
 
+const UseTemplateRedirectPage = lazy(() => import('~pages/UseTemplateRedirect'))
 const PublicFormPage = lazy(() =>
   lazyRetry(() => import('~features/public-form/PublicFormPage')),
 )
@@ -88,10 +90,16 @@ export const AppRouter = (): JSX.Element => {
           path={BILLING_ROUTE}
           element={<PrivateElement element={<BillingPage />} />}
         />
-        <Route
-          path={PUBLICFORM_ROUTE}
-          element={<PublicElement element={<PublicFormPage />} />}
-        />
+        <Route path={PUBLICFORM_ROUTE}>
+          <Route
+            index
+            element={<PublicElement element={<PublicFormPage />} />}
+          />
+          <Route
+            path={USE_TEMPLATE_REDIRECT_SUBROUTE}
+            element={<PublicElement element={<UseTemplateRedirectPage />} />}
+          />
+        </Route>
         <Route
           path={`${ADMINFORM_ROUTE}/:formId`}
           element={<PrivateElement element={<AdminFormLayout />} />}

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -10,6 +10,7 @@ export const BILLING_ROUTE = '/billing'
 // Cannot use regex match in react-router@6, which means we need to validate
 // the regex in PublicFormPage.
 export const PUBLICFORM_ROUTE = '/:formId'
+export const USE_TEMPLATE_REDIRECT_SUBROUTE = 'use-template'
 export const FORMID_REGEX = /^([a-fA-F0-9]{24})$/
 
 export const ADMINFORM_ROUTE = '/admin/form'

--- a/frontend/src/features/public-form/utils/filterHiddenInputs.ts
+++ b/frontend/src/features/public-form/utils/filterHiddenInputs.ts
@@ -4,7 +4,8 @@ import type { FormDto, FormFieldDto } from '~shared/types'
 
 import type { FormFieldValues } from '~templates/Field/types'
 
-import { getVisibleFieldIds } from '~features/logic/utils'
+// Cannot import from directory index because of circular imports.
+import { getVisibleFieldIds } from '~features/logic/utils/getVisibleFieldIds'
 
 export const filterHiddenInputs = ({
   formFields,

--- a/frontend/src/pages/UseTemplateRedirect/UseTemplateRedirectPage.tsx
+++ b/frontend/src/pages/UseTemplateRedirect/UseTemplateRedirectPage.tsx
@@ -1,0 +1,17 @@
+import { Navigate, useParams } from 'react-router-dom'
+
+import { ADMINFORM_ROUTE, ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
+
+export const UseTemplateRedirectPage = (): JSX.Element => {
+  const { formId } = useParams()
+  if (!formId) {
+    throw new Error('Form ID not found')
+  }
+
+  return (
+    <Navigate
+      to={`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_USETEMPLATE_ROUTE}`}
+      replace
+    />
+  )
+}

--- a/frontend/src/pages/UseTemplateRedirect/index.ts
+++ b/frontend/src/pages/UseTemplateRedirect/index.ts
@@ -1,0 +1,1 @@
+export { UseTemplateRedirectPage as default } from './UseTemplateRedirectPage'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds backwards compatibility with the URL form admins are used to. 
Redirects `/:formId/use-template` to `/admin/form/:formId/use-template`.

Also fixes bad UX when users call `/use-template` and gets redirected to broken AngularJS + ReactJS iframe page.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:
- feat: add public form use-template redirection


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Append `/use-template` in a public form URL **when logged out**. Should be redirected to login page, and then to the correct template page once logged in.
- [ ] Append `/use-template` when logged in. Should redirect to the template page. And creating template should work.
