### PR TITLE
chore: update chromatic GA to only run in PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,9 +9,8 @@ defaults:
 
 # Event for the workflow
 on:
-  push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 # List of jobs
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,9 @@ defaults:
 
 # Event for the workflow
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Running Chromatic on every commit push is burning up the snapshot quota. This PR restricts chromatic to only run on PRs.
