### PR TITLE
fix: render saved title and esrvcId

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -60,7 +60,10 @@ export const EsrvcIdBox = ({
     if (esrvcId.trim() === initialEsrvcId) return
     return mutateFormEsrvcId.mutate(esrvcId.trim(), {
       onError: () => reset(),
-      onSuccess: ({ esrvcId }) => setValue('esrvcId', esrvcId ?? ''),
+      onSuccess: ({ esrvcId }) => {
+        setValue('esrvcId', esrvcId ?? '')
+        reset({ esrvcId })
+      },
     })
   })
 

--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -54,7 +54,10 @@ const FormTitleInput = ({ initialTitle }: FormTitleInputProps): JSX.Element => {
       ({ title }) => {
         if (title === initialTitle) return
 
-        return mutateFormTitle.mutate(title, { onError: () => reset() })
+        return mutateFormTitle.mutate(title, {
+          onError: () => reset(),
+          onSuccess: () => reset({ title }),
+        })
       },
       () => reset(),
     )()


### PR DESCRIPTION
## Problem
Form title field and Singpass esrvcId field in settings will reset to original value instead of latest updated value. 

Closes #5487 

## Solution
Upon mutate success, update useForm defaultvalues of title/esrvcId by using [reset](https://react-hook-form.com/api/useform/reset).

**Breaking Changes**
- No - this PR is backwards compatible

## Screenshots
**AFTER**
![Recording 2022-11-30 at 16 33 54](https://user-images.githubusercontent.com/59867455/204746853-4a9d079d-6064-4c4b-9bc2-bbccdd075c2e.gif)


## Tests
<!-- What tests should be run to confirm functionality? -->

- [x] Rename an existing title of a form successfully. Input an erroneous title (e.g. <4 words) and click out of the input box, title in the input box should revert to the updated title that you have renamed to.

- [x] In the Singpass panel in the settings of a form, select a toggle other than 'None', successfully change the esrvcId field. Input an erroneous esrvcId (e.g. whitespace between words) and click out of the input box, esrvcId in the input box should revert to the updated value that you have changed to.
