### PR TITLE
fix: extend tags in then show logic blocks to be full width 

### DIFF
--- a/__tests__/e2e/constants/field.ts
+++ b/__tests__/e2e/constants/field.ts
@@ -89,7 +89,7 @@ export type E2eFieldMetadata =
   | (E2ePickFieldMetadata<HomenoFieldBase, 'fieldType'> &
       E2eFieldSingleValue &
       E2eFieldHidden)
-  | (E2ePickFieldMetadata<ImageFieldBase, never> &
+  | (E2ePickFieldMetadata<ImageFieldBase, 'name'> &
       E2eFieldFilepath &
       E2eFieldHidden)
   | (E2ePickFieldMetadata<LongTextFieldBase, 'ValidationOptions'> &
@@ -203,6 +203,7 @@ export const ALL_FIELDS: E2eFieldMetadata[] = [
   //   fieldType: BasicField.Image,
   //   path: '__tests__/e2e/files/logo.jpg',
   //   description: 'Logo for an organization.',
+  //   name: 'logo.jpg',
   // },
   {
     title: 'Your Life Story',
@@ -266,8 +267,7 @@ export const ALL_FIELDS: E2eFieldMetadata[] = [
   {
     title: 'Statement',
     fieldType: BasicField.Statement,
-    description:
-      'This is a paragraph with **markdown** and a url to https://open.gov.sg/.\n\n* Please type your answers here.\n* Please press submit once you are done.\n\nThank you!',
+    description: 'This is a statement. Read me!',
   },
   {
     title: 'Family Members',

--- a/__tests__/e2e/utils/field.ts
+++ b/__tests__/e2e/utils/field.ts
@@ -103,10 +103,12 @@ export const getTitleWithQuestionNumber = (
   const field = formFields[i]
   switch (field.fieldType) {
     case BasicField.Section:
-    case BasicField.Image:
-    case BasicField.Statement: {
       return field.title
-    }
+    case BasicField.Image:
+      return field.name
+    case BasicField.Statement:
+      // Replacement strategy for viewing in single line.
+      return field.description?.replace(/\s+/, ' ') ?? ''
     default: {
       const countNonInput = formFields
         .slice(0, i)

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -44,6 +44,10 @@ export interface MultiSelectProviderProps<
    * Defaults to `4`. Set to `null` to render all items.
    */
   maxItems?: number | null
+  /**
+   * If enabled, extends the length of each selected item to be full width in the input box.
+   */
+  isValueFullWidth?: boolean
   /** aria-describedby to be attached to the combobox input, if any. */
   inputAria?: {
     id: string
@@ -59,6 +63,7 @@ export interface MultiSelectProviderProps<
    */
   downshiftMultiSelectProps?: Partial<UseMultipleSelectionProps<Item>>
 }
+
 export const MultiSelectProvider = ({
   items: rawItems,
   values,
@@ -75,6 +80,7 @@ export const MultiSelectProvider = ({
   isDisabled: isDisabledProp,
   isRequired: isRequiredProp,
   maxItems = 4,
+  isValueFullWidth,
   downshiftComboboxProps = {},
   downshiftMultiSelectProps = {},
   inputAria: inputAriaProp,
@@ -333,6 +339,7 @@ export const MultiSelectProvider = ({
           removeSelectedItem,
           reset,
           maxItems,
+          isValueFullWidth,
           activeIndex,
           setActiveIndex,
         }}

--- a/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -47,7 +47,7 @@ export interface MultiSelectProviderProps<
   /**
    * If enabled, extends the length of each selected item to be full width in the input box.
    */
-  isValueFullWidth?: boolean
+  isSelectedItemFullWidth?: boolean
   /** aria-describedby to be attached to the combobox input, if any. */
   inputAria?: {
     id: string
@@ -80,7 +80,7 @@ export const MultiSelectProvider = ({
   isDisabled: isDisabledProp,
   isRequired: isRequiredProp,
   maxItems = 4,
-  isValueFullWidth,
+  isSelectedItemFullWidth,
   downshiftComboboxProps = {},
   downshiftMultiSelectProps = {},
   inputAria: inputAriaProp,
@@ -339,7 +339,7 @@ export const MultiSelectProvider = ({
           removeSelectedItem,
           reset,
           maxItems,
-          isValueFullWidth,
+          isSelectedItemFullWidth,
           activeIndex,
           setActiveIndex,
         }}

--- a/frontend/src/components/Dropdown/MultiSelectContext.tsx
+++ b/frontend/src/components/Dropdown/MultiSelectContext.tsx
@@ -16,7 +16,7 @@ interface MultiSelectContextReturn<Item extends ComboboxItem = ComboboxItem>
       'reset' | 'addSelectedItem' | 'removeSelectedItem' | 'setActiveIndex'
     > {
   maxItems: number | null
-  isValueFullWidth?: boolean
+  isSelectedItemFullWidth?: boolean
 }
 
 export const MultiSelectContext = createContext<

--- a/frontend/src/components/Dropdown/MultiSelectContext.tsx
+++ b/frontend/src/components/Dropdown/MultiSelectContext.tsx
@@ -16,6 +16,7 @@ interface MultiSelectContextReturn<Item extends ComboboxItem = ComboboxItem>
       'reset' | 'addSelectedItem' | 'removeSelectedItem' | 'setActiveIndex'
     > {
   maxItems: number | null
+  isValueFullWidth?: boolean
 }
 
 export const MultiSelectContext = createContext<

--- a/frontend/src/components/Dropdown/components/MultiSelectCombobox/SelectedItems.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectCombobox/SelectedItems.tsx
@@ -28,7 +28,7 @@ const ShowMoreItemBlock = ({ amountToShow }: { amountToShow: number }) => {
 }
 
 export const SelectedItems = (): JSX.Element => {
-  const { selectedItems, maxItems } = useMultiSelectContext()
+  const { selectedItems, maxItems, isValueFullWidth } = useMultiSelectContext()
   const { isFocused } = useSelectContext()
 
   const items = useMemo(() => {
@@ -38,7 +38,14 @@ export const SelectedItems = (): JSX.Element => {
         const item = selectedItems[i]
         // Key has to be index so focus is maintained correctly when items are removed.
         // Some downshift quirk it seems.
-        itemsToRender.push(<MultiSelectItem item={item} index={i} key={i} />)
+        itemsToRender.push(
+          <MultiSelectItem
+            item={item}
+            index={i}
+            key={i}
+            w={isValueFullWidth ? '100%' : undefined}
+          />,
+        )
       } else {
         itemsToRender.push(
           <ShowMoreItemBlock
@@ -50,7 +57,7 @@ export const SelectedItems = (): JSX.Element => {
       }
     }
     return itemsToRender
-  }, [isFocused, maxItems, selectedItems])
+  }, [isFocused, isValueFullWidth, maxItems, selectedItems])
 
   return <>{items}</>
 }

--- a/frontend/src/components/Dropdown/components/MultiSelectCombobox/SelectedItems.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectCombobox/SelectedItems.tsx
@@ -28,7 +28,8 @@ const ShowMoreItemBlock = ({ amountToShow }: { amountToShow: number }) => {
 }
 
 export const SelectedItems = (): JSX.Element => {
-  const { selectedItems, maxItems, isValueFullWidth } = useMultiSelectContext()
+  const { selectedItems, maxItems, isSelectedItemFullWidth } =
+    useMultiSelectContext()
   const { isFocused } = useSelectContext()
 
   const items = useMemo(() => {
@@ -43,7 +44,7 @@ export const SelectedItems = (): JSX.Element => {
             item={item}
             index={i}
             key={i}
-            w={isValueFullWidth ? '100%' : undefined}
+            w={isSelectedItemFullWidth ? '100%' : undefined}
           />,
         )
       } else {
@@ -57,7 +58,7 @@ export const SelectedItems = (): JSX.Element => {
       }
     }
     return itemsToRender
-  }, [isFocused, isValueFullWidth, maxItems, selectedItems])
+  }, [isFocused, isSelectedItemFullWidth, maxItems, selectedItems])
 
   return <>{items}</>
 }

--- a/frontend/src/components/Dropdown/components/MultiSelectItem/MultiSelectItem.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectItem/MultiSelectItem.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useCallback, useMemo } from 'react'
-import { Icon, TagLabel } from '@chakra-ui/react'
+import { Flex, Icon, Stack, TagLabel } from '@chakra-ui/react'
 
 import { useMultiSelectContext } from '~components/Dropdown/MultiSelectContext'
 import { useSelectContext } from '~components/Dropdown/SelectContext'
@@ -8,11 +8,10 @@ import {
   itemToIcon,
   itemToLabelString,
 } from '~components/Dropdown/utils/itemUtils'
-import { Tag, TagCloseButton } from '~components/Tag'
+import { Tag, TagCloseButton, TagProps } from '~components/Tag'
 
-export interface MultiSelectItemProps<
-  Item extends ComboboxItem = ComboboxItem,
-> {
+export interface MultiSelectItemProps<Item extends ComboboxItem = ComboboxItem>
+  extends TagProps {
   item: Item
   index: number
 }
@@ -20,6 +19,7 @@ export interface MultiSelectItemProps<
 export const MultiSelectItem = ({
   item,
   index,
+  ...props
 }: MultiSelectItemProps): JSX.Element => {
   const { isDisabled, isReadOnly, setIsFocused, closeMenu, isOpen, styles } =
     useSelectContext()
@@ -81,24 +81,33 @@ export const MultiSelectItem = ({
         },
         onClick: handleTagClick,
       })}
+      {...props}
     >
-      {itemMeta.icon ? (
-        <Icon
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        w="100%"
+      >
+        <Flex alignItems="center" overflow="hidden">
+          {itemMeta.icon ? (
+            <Icon
+              aria-hidden
+              sx={styles.icon}
+              mr="0.25rem"
+              as={itemMeta.icon}
+              aria-disabled={isDisabled}
+            />
+          ) : null}
+          <TagLabel>{itemMeta.label}</TagLabel>
+        </Flex>
+        <TagCloseButton
+          tabIndex={-1}
           aria-hidden
-          sx={styles.icon}
-          ml="-0.25rem"
-          mr="0.25rem"
-          as={itemMeta.icon}
-          aria-disabled={isDisabled}
+          isDisabled={isDisabled}
+          onClick={handleRemoveItem}
         />
-      ) : null}
-      <TagLabel>{itemMeta.label}</TagLabel>
-      <TagCloseButton
-        tabIndex={-1}
-        aria-hidden
-        isDisabled={isDisabled}
-        onClick={handleRemoveItem}
-      />
+      </Stack>
     </Tag>
   )
 }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -276,7 +276,7 @@ const ThenLogicInput = ({
             placeholder={null}
             items={thenValueItems}
             values={value ?? []}
-            isValueFullWidth
+            isSelectedItemFullWidth
             {...rest}
           />
         )}

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/ThenShowBlock.tsx
@@ -18,6 +18,8 @@ import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants
 import { EditLogicInputs } from '~features/admin-form/create/logic/types'
 import { FormFieldWithQuestionNo } from '~features/form/types'
 
+import { getLogicFieldLabel } from '../../utils/getLogicFieldLabel'
+
 import { BlockLabelText } from './BlockLabelText'
 
 interface ThenShowBlockProps {
@@ -209,24 +211,17 @@ const ThenLogicInput = ({
   const thenValueItems = useMemo(() => {
     // Return every field except fields that are already used in the logic.
     if (logicTypeValue === LogicType.ShowFields) {
+      if (!formFields || !mapIdToField) return []
       const usedFieldIds = new Set(
         logicConditionsWatch.value.map((condition) => condition.field),
       )
-      if (!formFields || !mapIdToField) return []
       return formFields
         .filter((f) => !usedFieldIds.has(f._id))
-        .map((f) => {
-          const mappedField = mapIdToField[f._id]
-          return {
-            value: f._id,
-            label: `${
-              mappedField.questionNumber
-                ? `${mappedField.questionNumber}. `
-                : ''
-            }${mappedField.title}`,
-            icon: BASICFIELD_TO_DRAWER_META[f.fieldType].icon,
-          }
-        })
+        .map((f) => ({
+          value: f._id,
+          label: getLogicFieldLabel(mapIdToField[f._id]),
+          icon: BASICFIELD_TO_DRAWER_META[f.fieldType].icon,
+        }))
     }
     return []
     // Watch entire <***>Watch variables since <***>Watch.value is a Proxy object
@@ -281,6 +276,7 @@ const ThenLogicInput = ({
             placeholder={null}
             items={thenValueItems}
             values={value ?? []}
+            isValueFullWidth
             {...rest}
           />
         )}

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -65,9 +65,7 @@ export const FieldLogicBadge = ({
           </Box>
         </Tooltip>
         {field ? (
-          <>
-            <Text noOfLines={1}>{getLogicFieldLabel(field)}</Text>
-          </>
+          <Text noOfLines={1}>{getLogicFieldLabel(field)}</Text>
         ) : (
           <Text textColor={textColor} noOfLines={1}>
             {defaults.message}

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -7,6 +7,8 @@ import Tooltip from '~components/Tooltip'
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { FormFieldWithQuestionNo } from '~features/form/types'
 
+import { getLogicFieldLabel } from '../utils/getLogicFieldLabel'
+
 import { LogicBadge } from './LogicBadge'
 
 interface FieldLogicBadgeProps {
@@ -64,8 +66,7 @@ export const FieldLogicBadge = ({
         </Tooltip>
         {field ? (
           <>
-            {field.questionNumber ? <Text>{field.questionNumber}.</Text> : null}
-            <Text noOfLines={1}>{field.title}</Text>
+            <Text noOfLines={1}>{getLogicFieldLabel(field)}</Text>
           </>
         ) : (
           <Text textColor={textColor} noOfLines={1}>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
@@ -1,0 +1,19 @@
+import { BasicField } from '~shared/types'
+
+import { FormFieldWithQuestionNo } from '~features/form/types'
+
+export const getLogicFieldLabel = (field: FormFieldWithQuestionNo) => {
+  const questionNumber = field.questionNumber ? `${field.questionNumber}. ` : ''
+  let title = field.title
+  switch (field.fieldType) {
+    case BasicField.Statement:
+      title = field.description
+      break
+    case BasicField.Image:
+      title = field.name
+      break
+    default:
+      break
+  }
+  return questionNumber + title
+}

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
@@ -7,7 +7,8 @@ export const getLogicFieldLabel = (field: FormFieldWithQuestionNo) => {
   let title = field.title
   switch (field.fieldType) {
     case BasicField.Statement:
-      title = field.description
+      // Replaces all continuous whitespace with a single space for display on a single line.
+      title = field.description.replace(/\s+/, ' ')
       break
     case BasicField.Image:
       title = field.name


### PR DESCRIPTION
## Problem
We want to extend then-show block tags to be full width

Closes #5495 

Also temporarily remedies #5431, while we wait for design input.

## Solution
Add `isSelectedItemFullWidth` flag to multiselect provider, which will extend the tag to be full width if set. 

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

Above: multiselect without `isSelectedItemFullWidth`
Below: multiselect with `isSelectedItemFullWidth`

<img width="928" alt="image" src="https://user-images.githubusercontent.com/25571626/204944826-56af2d79-ccc5-4b59-a9da-8d4cef2e0354.png">
