### PR TITLE
fix: correctly handle captcha cancellation

### DIFF
--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -121,11 +121,15 @@ export const useRecaptcha = ({
       executionPromise.current.reject()
       executionPromise.current = {}
     }
+    setIsVfnInProgress(false)
+    setHasDisplayed(false)
   }, [])
 
   const handleExpiry = useCallback(() => {
     grecaptcha?.reset(widgetId)
     handleChange(null)
+    setIsVfnInProgress(false)
+    setHasDisplayed(false)
   }, [grecaptcha, handleChange, widgetId])
 
   // Poll to check if recaptcha window has closed and display error accordingly.

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -113,6 +113,7 @@ export const useRecaptcha = ({
       executionPromise.current.resolve(response)
       executionPromise.current = {}
     }
+    setIsVfnInProgress(false)
   }, [])
 
   const handleError = useCallback(() => {
@@ -145,10 +146,9 @@ export const useRecaptcha = ({
       }
       if (isVfnInProgress && recaptchaVisibility === 'hidden' && hasDisplayed) {
         executionPromise.current.reject?.(new RecaptchaClosedError())
+        setIsVfnInProgress(false)
+        setHasDisplayed(false)
       }
-
-      setIsVfnInProgress(false)
-      setHasDisplayed(false)
     },
     /* intervalDurationMs= */ 100,
     /* when= */ isVfnInProgress,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Incorrect captcha close handling logic caused submission to be stuck in pending submission state without any recourse.

This PR fixes that bug.

Closes #5497

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- fix: update recaptcha cancellation check

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
![Recording 2022-12-05 at 14 17 32](https://user-images.githubusercontent.com/22133008/205563045-de1d4e2e-7f2a-4c2c-8f97-1968e2503fba.gif)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Trigger captcha (use VPN and incognito, will most likely trigger it all the time). Click outside of captcha (cancel). Should return to normal form state without any stuck loading buttons.
