### PR TITLE
refactor: clean up old MyInfo cookie handling

### DIFF
--- a/src/app/modules/myinfo/myinfo.errors.ts
+++ b/src/app/modules/myinfo/myinfo.errors.ts
@@ -57,16 +57,6 @@ export class MyInfoParseRelayStateError extends ApplicationError {
 }
 
 /**
- * TODO(#5452): Delete this error
- * Submission on MyInfo form missing access token.
- */
-export class MyInfoMissingAccessTokenError extends ApplicationError {
-  constructor(message = 'Access token not present on MyInfo submission') {
-    super(message)
-  }
-}
-
-/**
  * Submission on MyInfo form missing access token.
  */
 export class MyInfoMissingLoginCookieError extends ApplicationError {

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -32,24 +32,6 @@ export type MyInfoLoginCookiePayload = {
   uinFin: string
 }
 
-// TODO(#5452): Delete this enum
-export enum MyInfoOldCookieState {
-  Success = 'success',
-  Error = 'error',
-}
-
-// TODO(#5452): Delete this type
-export type MyInfoSuccessfulOldCookiePayload = {
-  accessToken: string
-  usedCount: number
-  state: MyInfoOldCookieState.Success
-}
-
-// TODO(#5452): Delete this type
-export type MyInfoOldCookiePayload =
-  | MyInfoSuccessfulOldCookiePayload
-  | { state: Exclude<MyInfoOldCookieState, MyInfoOldCookieState.Success> }
-
 export enum MyInfoAuthCodeCookieState {
   Success = 'success',
   Error = 'error',

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -21,6 +21,7 @@ import {
   MYINFO_LOGIN_COOKIE_OPTIONS,
 } from '../../myinfo/myinfo.constants'
 import { MyInfoService } from '../../myinfo/myinfo.service'
+import { extractMyInfoLoginJwt } from '../../myinfo/myinfo.util'
 import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import * as EmailSubmissionMiddleware from '../email-submission/email-submission.middleware'
@@ -202,8 +203,9 @@ const submitEmailModeForm: ControllerHandler<
               })
           }
           case FormAuthType.MyInfo:
-            return MyInfoService.extractUinFromOldAndNewLoginCookie(req.cookies)
-              .asyncAndThen((uinFin) =>
+            return extractMyInfoLoginJwt(req.cookies)
+              .andThen(MyInfoService.verifyLoginJwt)
+              .asyncAndThen(({ uinFin }) =>
                 MyInfoService.fetchMyInfoHashes(uinFin, formId)
                   .andThen((hashes) =>
                     MyInfoService.checkMyInfoHashes(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Old format of MyInfo cookie should no longer be accepted by the server, as all old cookies should have expired 30 minutes after release 6.18.5

Closes #5452 

## Solution
<!-- How did you solve the problem? -->

Clean up code which handles old cookie format.