### PR TITLE
fix: filter out unusable React feedback

### DIFF
--- a/frontend/src/features/env/AdminFeedbackModal.tsx
+++ b/frontend/src/features/env/AdminFeedbackModal.tsx
@@ -34,6 +34,7 @@ import { useUser } from '~features/user/queries'
 
 import { useFeedbackMutation } from './mutations'
 import { useAdminFeedbackFormView } from './queries'
+import { isUsableFeedback } from './utils'
 
 export const AdminFeedbackModal = ({
   isOpen,
@@ -68,10 +69,12 @@ export const AdminFeedbackModal = ({
 
   const handleSubmitForm = handleSubmit((formInputs: AdminFeedbackFormDto) => {
     if (!feedbackForm) return
-    feedbackMutation.mutateAsync({
-      formInputs,
-      feedbackForm,
-    })
+    if (isUsableFeedback(formInputs.feedback)) {
+      feedbackMutation.mutateAsync({
+        formInputs,
+        feedbackForm,
+      })
+    }
     toast({ description: 'Your feedback has been submitted.' })
     onClose()
   })

--- a/frontend/src/features/env/AdminFeedbackModal.tsx
+++ b/frontend/src/features/env/AdminFeedbackModal.tsx
@@ -70,7 +70,7 @@ export const AdminFeedbackModal = ({
   const handleSubmitForm = handleSubmit((formInputs: AdminFeedbackFormDto) => {
     if (!feedbackForm) return
     if (isUsableFeedback(formInputs.feedback)) {
-      feedbackMutation.mutateAsync({
+      feedbackMutation.mutate({
         formInputs,
         feedbackForm,
       })

--- a/frontend/src/features/env/PublicFeedbackModal.tsx
+++ b/frontend/src/features/env/PublicFeedbackModal.tsx
@@ -68,7 +68,7 @@ export const PublicFeedbackModal = ({
   const handleSubmitForm = handleSubmit((formInputs: PublicFeedbackFormDto) => {
     if (!feedbackForm) return
     if (isUsableFeedback(formInputs.feedback)) {
-      feedbackMutation.mutateAsync({ formInputs, feedbackForm })
+      feedbackMutation.mutate({ formInputs, feedbackForm })
     }
     setShowThanksPage(true)
   })

--- a/frontend/src/features/env/PublicFeedbackModal.tsx
+++ b/frontend/src/features/env/PublicFeedbackModal.tsx
@@ -32,6 +32,7 @@ import { useEnvMutations, useFeedbackMutation } from '~features/env/mutations'
 import { useUser } from '~features/user/queries'
 
 import { usePublicFeedbackFormView } from './queries'
+import { isUsableFeedback } from './utils'
 
 export const PublicFeedbackModal = ({
   isOpen,
@@ -66,7 +67,9 @@ export const PublicFeedbackModal = ({
 
   const handleSubmitForm = handleSubmit((formInputs: PublicFeedbackFormDto) => {
     if (!feedbackForm) return
-    feedbackMutation.mutateAsync({ formInputs, feedbackForm })
+    if (isUsableFeedback(formInputs.feedback)) {
+      feedbackMutation.mutateAsync({ formInputs, feedbackForm })
+    }
     setShowThanksPage(true)
   })
 

--- a/frontend/src/features/env/utils.ts
+++ b/frontend/src/features/env/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * TODO(#4279): Remove this function
+ * Filter to prevent empty or non-actionable feedback
+ * from being sent.
+ */
+export const isUsableFeedback = (feedback: string): boolean => {
+  const trimmed = feedback.trim()
+  return (
+    trimmed.length > 5 &&
+    !['na', 'nil', 'nothing', 'none'].includes(trimmed.toLowerCase())
+  )
+}


### PR DESCRIPTION
## Problem

Since feedback is compulsory when switching away from React, users often submit whitespace, a few nonsense characters or NIL/NA/Nothing/None for feedback. Filtering through these responses is unnecessary ops work.

## Solution

Filter out responses with fewer than 5 characters or NIL/NA/Nothing/None. In addition, use `mutate` instead of `mutateAsync` so that failed feedback submissions do not cause a frontend error, since this is a non-critical operation.