### PR TITLE
fix: make email validation insensitive to domains case and trailing whitespace

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -479,7 +479,7 @@ export const baseEmailValidationFn =
       ? new Set(schema.allowedEmailDomains)
       : new Set()
     if (allowedDomains.size !== 0) {
-      const domainInValue = inputValue.split('@')[1]
+      const domainInValue = inputValue.split('@')[1].toLowerCase()
       if (domainInValue && !allowedDomains.has(`@${domainInValue}`)) {
         return INVALID_EMAIL_DOMAIN_ERROR
       }

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -471,15 +471,17 @@ export const baseEmailValidationFn =
   (inputValue?: string) => {
     if (!inputValue) return true
 
+    const trimmedInputValue = inputValue.trim()
+
     // Valid email check
-    if (!validator.isEmail(inputValue)) return INVALID_EMAIL_ERROR
+    if (!validator.isEmail(trimmedInputValue)) return INVALID_EMAIL_ERROR
 
     // Valid domain check
     const allowedDomains = schema.isVerifiable
       ? new Set(schema.allowedEmailDomains)
       : new Set()
     if (allowedDomains.size !== 0) {
-      const domainInValue = inputValue.split('@')[1].toLowerCase()
+      const domainInValue = trimmedInputValue.split('@')[1].toLowerCase()
       if (domainInValue && !allowedDomains.has(`@${domainInValue}`)) {
         return INVALID_EMAIL_DOMAIN_ERROR
       }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes [#5557]

## Solution
<!-- How did you solve the problem? -->
Trim whitespace and lower case domain value before comparison with allowedDomains.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![image](https://user-images.githubusercontent.com/59867455/207267933-c5ef48c9-9488-4fd2-8ac4-cc02959f846f.png)

**AFTER**:
<!-- [insert screenshot here] -->
<img width="917" alt="image" src="https://user-images.githubusercontent.com/59867455/207511018-e2fb7d75-6136-44f1-8f61-b4b8fdc45595.png">


## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a form with an email field. Enable 'Restrict Email Domains'. Arbitrarily fill in 'Domains allowed' (e.g. @data.gov.sg). Open/Activate form. Access the form and input an email account (with allowed domain) with **capitalisation in the domain name** (e.g. bob@DATA.gov.sg), email should be verifiable.
- [ ] Create a form with an email field. Enable 'Restrict Email Domains'. Arbitrarily fill in 'Domains allowed' (e.g. @data.gov.sg). Open/Activate form. Access the form and input an email account (with allowed domain) with **preceding or trailing whitespaces**, email should be verifiable.