### PR TITLE
fix: move respondent switch env to the end of the form

### DIFF
--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -32,9 +32,9 @@ export const PreviewFormPage = (): JSX.Element => {
         <FormSectionsProvider>
           <PublicFormLogo />
           <FormStartPage />
-          <PublicFormWrapper isPreview>
+          <PublicFormWrapper>
             <FormInstructions />
-            <FormFields />
+            <FormFields isPreview />
             <FormEndPage isPreview />
             <FormFooter />
           </PublicFormWrapper>

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -32,9 +32,9 @@ export const TemplateFormPage = (): JSX.Element => {
         <FormSectionsProvider>
           <PublicFormLogo />
           <FormStartPage isTemplate />
-          <PublicFormWrapper isPreview>
+          <PublicFormWrapper>
             <FormInstructions />
-            <FormFields />
+            <FormFields isPreview />
             <FormEndPage isPreview />
             <FormFooter />
           </PublicFormWrapper>

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react'
 import { Box } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types'
 import { FormAuthType } from '~shared/types/form/form'
 
-import { useEnv } from '~features/env/queries'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FormAuth } from '../FormAuth'
@@ -50,41 +48,18 @@ export const FormFieldsContainer = ({
     )
   }, [form, handleSubmitForm, isAuthRequired, isLoading])
 
-  // TODO #4279: Computes whether to show the switch env message, remove after React rollout is complete
-  const {
-    data: {
-      respondentRolloutEmail,
-      respondentRolloutStorage,
-      removeRespondentsInfoboxThreshold,
-    } = {},
-  } = useEnv()
-
-  const switchEnvRolloutPercentage = useMemo(
-    () =>
-      form?.responseMode === FormResponseMode.Email
-        ? respondentRolloutEmail
-        : respondentRolloutStorage,
-    [form?.responseMode, respondentRolloutEmail, respondentRolloutStorage],
-  )
-
-  // Remove the switch env message if the React rollout for public form respondents is => threshold
-  const showSwitchEnvMessage = useMemo(
-    () =>
-      !!(
-        switchEnvRolloutPercentage &&
-        removeRespondentsInfoboxThreshold &&
-        switchEnvRolloutPercentage < removeRespondentsInfoboxThreshold
-      ),
-    [switchEnvRolloutPercentage, removeRespondentsInfoboxThreshold],
-  )
-
   if (submissionData) return null
 
   return (
     <Box w="100%" minW={0} h="fit-content" maxW="57rem">
       {renderFields}
       {/* TODO(#4279): Remove switch env message on full rollout */}
-      {!isPreview && showSwitchEnvMessage && <PublicSwitchEnvMessage />}
+      {!isPreview && (
+        <PublicSwitchEnvMessage
+          responseMode={form?.responseMode}
+          isAuthRequired={isAuthRequired}
+        />
+      )}
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,16 +1,26 @@
 import { useMemo } from 'react'
 import { Box } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types'
 import { FormAuthType } from '~shared/types/form/form'
 
+import { useEnv } from '~features/env/queries'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FormAuth } from '../FormAuth'
+// TODO #4279: Remove after React rollout is complete
+import { PublicSwitchEnvMessage } from '../PublicSwitchEnvMessage'
 
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
 
-export const FormFieldsContainer = (): JSX.Element | null => {
+interface FormFieldsContainerProps {
+  isPreview?: boolean
+}
+
+export const FormFieldsContainer = ({
+  isPreview,
+}: FormFieldsContainerProps): JSX.Element | null => {
   const { form, isAuthRequired, isLoading, handleSubmitForm, submissionData } =
     usePublicFormContext()
 
@@ -40,11 +50,41 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     )
   }, [form, handleSubmitForm, isAuthRequired, isLoading])
 
+  // TODO #4279: Computes whether to show the switch env message, remove after React rollout is complete
+  const {
+    data: {
+      respondentRolloutEmail,
+      respondentRolloutStorage,
+      removeRespondentsInfoboxThreshold,
+    } = {},
+  } = useEnv()
+
+  const switchEnvRolloutPercentage = useMemo(
+    () =>
+      form?.responseMode === FormResponseMode.Email
+        ? respondentRolloutEmail
+        : respondentRolloutStorage,
+    [form?.responseMode, respondentRolloutEmail, respondentRolloutStorage],
+  )
+
+  // Remove the switch env message if the React rollout for public form respondents is => threshold
+  const showSwitchEnvMessage = useMemo(
+    () =>
+      !!(
+        switchEnvRolloutPercentage &&
+        removeRespondentsInfoboxThreshold &&
+        switchEnvRolloutPercentage < removeRespondentsInfoboxThreshold
+      ),
+    [switchEnvRolloutPercentage, removeRespondentsInfoboxThreshold],
+  )
+
   if (submissionData) return null
 
   return (
     <Box w="100%" minW={0} h="fit-content" maxW="57rem">
       {renderFields}
+      {/* TODO(#4279): Remove switch env message on full rollout */}
+      {!isPreview && showSwitchEnvMessage && <PublicSwitchEnvMessage />}
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -42,7 +42,7 @@ export const PublicFormSubmitButton = ({
   }, [formInputs, formFields, formLogics])
 
   return (
-    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="1.5rem">
+    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
       <Button
         isFullWidth={isMobile}
         w="100%"

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -42,7 +42,7 @@ export const PublicFormSubmitButton = ({
   }, [formInputs, formFields, formLogics])
 
   return (
-    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
+    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="1.5rem">
       <Button
         isFullWidth={isMobile}
         w="100%"

--- a/frontend/src/features/public-form/components/PublicFormWrapper.tsx
+++ b/frontend/src/features/public-form/components/PublicFormWrapper.tsx
@@ -1,14 +1,10 @@
 import { useMemo } from 'react'
 import { Flex, Spacer } from '@chakra-ui/react'
 
-import { FormColorTheme, FormResponseMode } from '~shared/types'
-
-import { useEnv } from '~features/env/queries'
+import { FormColorTheme } from '~shared/types'
 
 import { usePublicFormContext } from '../PublicFormContext'
 
-// TODO #4279: Remove after React rollout is complete
-import { PublicSwitchEnvMessage } from './PublicSwitchEnvMessage'
 import SectionSidebar from './SectionSidebar'
 
 export interface BgColorProps {
@@ -26,7 +22,6 @@ export const useBgColor = ({ colorTheme, isFooter }: BgColorProps) =>
   }, [colorTheme, isFooter])
 
 export interface PublicFormWrapperProps {
-  isPreview?: boolean
   children: React.ReactNode
 }
 
@@ -35,42 +30,18 @@ export interface PublicFormWrapperProps {
  * @precondition Must be nested inside a `PublicFormProvider`
  */
 export const PublicFormWrapper = ({
-  isPreview,
   children,
 }: PublicFormWrapperProps): JSX.Element => {
   const { form, isAuthRequired } = usePublicFormContext()
-  const {
-    data: {
-      respondentRolloutEmail,
-      respondentRolloutStorage,
-      removeRespondentsInfoboxThreshold,
-    } = {},
-  } = useEnv()
 
   const bgColour = useBgColor({
     colorTheme: form?.startPage.colorTheme,
   })
-  const isEmailForm = form?.responseMode === FormResponseMode.Email
-  const switchEnvRolloutPercentage = isEmailForm
-    ? respondentRolloutEmail
-    : respondentRolloutStorage
 
-  // Remove the switch env message if the React rollout for public form respondents is => threshold
-  const showSwitchEnvMessage = useMemo(
-    () =>
-      !!(
-        switchEnvRolloutPercentage &&
-        removeRespondentsInfoboxThreshold &&
-        switchEnvRolloutPercentage < removeRespondentsInfoboxThreshold
-      ),
-    [switchEnvRolloutPercentage, removeRespondentsInfoboxThreshold],
-  )
   return (
     <Flex bg={bgColour} p={{ base: 0, md: '1.5rem' }} flex={1} justify="center">
       {isAuthRequired ? null : <SectionSidebar />}
       <Flex flexDir="column" maxW="57rem" w="100%">
-        {/* TODO(#4279): Remove switch env message on full rollout */}
-        {!isPreview && showSwitchEnvMessage && <PublicSwitchEnvMessage />}
         {children}
       </Flex>
       {isAuthRequired ? null : <Spacer />}

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -1,5 +1,5 @@
 // TODO #4279: Remove after React rollout is complete
-import { KeyboardEventHandler, useCallback } from 'react'
+import { KeyboardEventHandler, useCallback, useMemo } from 'react'
 import {
   Box,
   Flex,
@@ -8,14 +8,52 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types'
+
 import { noPrintCss } from '~utils/noPrintCss'
 import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 
 import { PublicFeedbackModal } from '~features/env/PublicFeedbackModal'
+import { useEnv } from '~features/env/queries'
 
-export const PublicSwitchEnvMessage = (): JSX.Element => {
+type PublicSwitchEnvMessageProps = {
+  responseMode?: FormResponseMode
+  isAuthRequired: boolean
+}
+
+export const PublicSwitchEnvMessage = ({
+  responseMode,
+  isAuthRequired,
+}: PublicSwitchEnvMessageProps): JSX.Element | null => {
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const {
+    data: {
+      respondentRolloutEmail,
+      respondentRolloutStorage,
+      removeRespondentsInfoboxThreshold,
+    } = {},
+  } = useEnv()
+
+  const switchEnvRolloutPercentage = useMemo(
+    () =>
+      responseMode === FormResponseMode.Email
+        ? respondentRolloutEmail
+        : respondentRolloutStorage,
+    [responseMode, respondentRolloutEmail, respondentRolloutStorage],
+  )
+
+  // Remove the switch env message if the React rollout for public form respondents is => threshold
+  const showSwitchEnvMessage = useMemo(
+    () =>
+      !!(
+        switchEnvRolloutPercentage &&
+        removeRespondentsInfoboxThreshold &&
+        switchEnvRolloutPercentage < removeRespondentsInfoboxThreshold
+      ),
+    [switchEnvRolloutPercentage, removeRespondentsInfoboxThreshold],
+  )
 
   const handleKeydown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
     (event) => {
@@ -27,8 +65,14 @@ export const PublicSwitchEnvMessage = (): JSX.Element => {
     [onOpen],
   )
 
+  if (!showSwitchEnvMessage) return null
+
   return (
-    <Flex justify="center" sx={noPrintCss}>
+    <Flex
+      mt={isAuthRequired ? undefined : '-2.5rem'}
+      justify="center"
+      sx={noPrintCss}
+    >
       <Box w="100%" minW={0} h="fit-content" maxW="57rem">
         <InlineMessage
           variant="warning"


### PR DESCRIPTION
## Problem
We want to move the switch env message to the end of the form.

## Solution
Move the switch env message into the form fields component (it could not simply be be moved down within the form wrapper, since children includes the form footer).

## Screenshots
Public without auth
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/25571626/207382664-00bd9d16-5ee4-49cb-87a9-f4d15cb05c08.png">

Public with auth
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/25571626/207382797-61f2e2d9-49c8-43ca-8b70-4e7bc66c3ac4.png">

Preview mode (same as before - should not show the switch env message)
<img width="863" alt="image" src="https://user-images.githubusercontent.com/25571626/207382992-2f7b3807-e5ce-4b41-8dc3-0df48de97e48.png">

