### PR TITLE
fix: remove background for desktop mode workspace filter button when filter is active

### DIFF
--- a/frontend/src/features/workspace/WorkspaceContext.tsx
+++ b/frontend/src/features/workspace/WorkspaceContext.tsx
@@ -13,6 +13,7 @@ export interface WorkspaceContextProps {
   setActiveSearch: (searchTerm: string) => void
   activeFilter: FilterOption
   setActiveFilter: (filterOption: FilterOption) => void
+  hasActiveSearchOrFilter: boolean
 }
 
 export const WorkspaceContext = createContext<

--- a/frontend/src/features/workspace/WorkspaceProvider.tsx
+++ b/frontend/src/features/workspace/WorkspaceProvider.tsx
@@ -63,6 +63,11 @@ export const WorkspaceProvider = ({
     [displayedForms.length],
   )
 
+  const hasActiveSearchOrFilter = useMemo(
+    () => !!activeSearch || activeFilter !== FilterOption.AllForms,
+    [activeFilter, activeSearch],
+  )
+
   return (
     <WorkspaceContext.Provider
       value={{
@@ -74,6 +79,7 @@ export const WorkspaceProvider = ({
         setActiveFilter,
         activeSearch,
         setActiveSearch,
+        hasActiveSearchOrFilter,
       }}
     >
       {children}

--- a/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceHeader/WorkspaceHeader.tsx
@@ -13,7 +13,6 @@ import simplur from 'simplur'
 import { useIsDesktop, useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 
-import { FilterOption } from '~features/workspace/types'
 import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import { MobileWorkspaceSearchbar } from '../WorkspaceSearchbar/MobileWorkspaceSearchbar'
@@ -40,6 +39,7 @@ export const WorkspaceHeader = ({
     setActiveSearch,
     activeFilter,
     setActiveFilter,
+    hasActiveSearchOrFilter,
   } = useWorkspaceContext()
 
   const { isOpen: isSearchExpanded, onToggle: onToggleSearchExpansion } =
@@ -47,10 +47,10 @@ export const WorkspaceHeader = ({
 
   const headerText = useMemo(
     () =>
-      activeSearch || activeFilter !== FilterOption.AllForms
+      hasActiveSearchOrFilter
         ? simplur`Showing ${displayedFormsCount} of ${totalFormsCount} form[|s]`
         : `All forms (${totalFormsCount})`,
-    [activeFilter, activeSearch, displayedFormsCount, totalFormsCount],
+    [displayedFormsCount, hasActiveSearchOrFilter, totalFormsCount],
   )
 
   return (
@@ -81,11 +81,7 @@ export const WorkspaceHeader = ({
       >
         <Skeleton isLoaded={!isLoading}>
           <Text
-            textStyle={
-              isMobile && (activeFilter !== null || activeSearch !== '')
-                ? 'subhead-1'
-                : 'h2'
-            }
+            textStyle={isMobile && hasActiveSearchOrFilter ? 'subhead-1' : 'h2'}
           >
             {headerText}
           </Text>
@@ -96,9 +92,9 @@ export const WorkspaceHeader = ({
         // Combination box used in desktop mode.
         <Box gridArea="searchFilter">
           <WorkspaceSearchbar
+            placeholder="Search by title"
             value={activeSearch}
             onChange={setActiveSearch}
-            placeholder="Search by title"
             filterValue={activeFilter}
             onFilter={setActiveFilter}
           />
@@ -107,9 +103,9 @@ export const WorkspaceHeader = ({
         <MobileWorkspaceSearchbar
           isExpanded={isSearchExpanded}
           onToggleExpansion={onToggleSearchExpansion}
-          onChange={setActiveSearch}
-          value={activeSearch}
           placeholder="Search by title"
+          value={activeSearch}
+          onChange={setActiveSearch}
           filterValue={activeFilter}
           onFilter={setActiveFilter}
         />

--- a/frontend/src/features/workspace/components/WorkspaceSearchbar/WorkspaceSearchbar.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceSearchbar/WorkspaceSearchbar.tsx
@@ -95,7 +95,6 @@ export const WorkspaceSearchbar = forwardRef<WorkspaceSearchbarProps, 'input'>(
       internalValue,
       setInternalFilter,
       setInternalValue,
-      hasFilter,
     } = useWorkspaceSearchbar({
       defaultValue,
       value,
@@ -144,7 +143,6 @@ export const WorkspaceSearchbar = forwardRef<WorkspaceSearchbarProps, 'input'>(
               size="sm"
               variant="clear"
               colorScheme="secondary"
-              backgroundColor={hasFilter ? 'neutral.200' : undefined}
               aria-label="Filter forms"
               leftIcon={<BiFilter fontSize="1.25rem" />}
               px="0.5rem"


### PR DESCRIPTION
## Problem
Fixes a design error made in the workspace search and filter component for desktop mode. We do not want a grey background when the filter is active.

## Solution
Remove the check the updates the background color if there is an active filter. 

**Breaking Changes** 
- No - this PR is backwards compatible  
