### PR TITLE
feat: remove check for user in public form switchback modal

### DIFF
--- a/frontend/src/features/env/PublicFeedbackModal.tsx
+++ b/frontend/src/features/env/PublicFeedbackModal.tsx
@@ -29,7 +29,6 @@ import { ModalCloseButton } from '~components/Modal'
 import Textarea from '~components/Textarea'
 
 import { useEnvMutations, useFeedbackMutation } from '~features/env/mutations'
-import { useUser } from '~features/user/queries'
 
 import { usePublicFeedbackFormView } from './queries'
 import { isUsableFeedback } from './utils'
@@ -56,7 +55,6 @@ export const PublicFeedbackModal = ({
 
   const initialRef = useRef(null)
 
-  const { user } = useUser()
   const url = window.location.href
   const rumSessionId = datadogRum.getInternalContext()?.session_id
   const [showThanksPage, setShowThanksPage] = useState<boolean>(false)
@@ -143,36 +141,27 @@ export const PublicFeedbackModal = ({
                       {errors['feedback']?.message}
                     </FormErrorMessage>
                   </FormControl>
-
-                  {user ? (
+                  <FormControl isInvalid={!!errors['email']}>
+                    <FormLabel>
+                      Email, if we need to contact you for details
+                    </FormLabel>
                     <Input
-                      type="hidden"
-                      {...register('email')}
-                      value={user.email}
+                      {...register('email', {
+                        validate: (value) => {
+                          if (!value) {
+                            return true
+                          }
+                          // Valid email check
+                          if (!validator.isEmail(value)) {
+                            return INVALID_EMAIL_ERROR
+                          }
+                        },
+                      })}
                     />
-                  ) : (
-                    <FormControl isInvalid={!!errors['email']}>
-                      <FormLabel>
-                        Email, if we need to contact you for details
-                      </FormLabel>
-                      <Input
-                        {...register('email', {
-                          validate: (value) => {
-                            if (!value) {
-                              return true
-                            }
-                            // Valid email check
-                            if (!validator.isEmail(value)) {
-                              return INVALID_EMAIL_ERROR
-                            }
-                          },
-                        })}
-                      />
-                      <FormErrorMessage>
-                        {errors['email']?.message}
-                      </FormErrorMessage>
-                    </FormControl>
-                  )}
+                    <FormErrorMessage>
+                      {errors['email']?.message}
+                    </FormErrorMessage>
+                  </FormControl>
 
                   {rumSessionId ? (
                     <Input

--- a/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
+++ b/frontend/src/features/public-form/components/PublicSwitchEnvMessage.tsx
@@ -92,6 +92,7 @@ export const PublicSwitchEnvMessage = ({
               onClick={onOpen}
               onKeyDown={handleKeydown}
               aria-labelledby="switch-env-msg"
+              cursor="pointer"
             >
               <VisuallyHidden>
                 Click to switch to the original FormSG


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #5569

## Solution
<!-- How did you solve the problem? -->
Remove the `useUser` query, so we no longer check if an admin is logged in when filling up a public form. The email field now shows up for all users that open the feedback modal.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:
- Change the cursor to a pointer when clicking the switchback link

## Before & After Screenshots

**BEFORE**:
For a logged in admin
![image](https://user-images.githubusercontent.com/56983748/207757468-7556e90f-4ac7-4e98-896d-7cf48e19d651.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/56983748/207760372-6cc61a17-1d3d-40ce-9ea0-a38f7ba29bc4.png)
