### PR TITLE
fix: return 404 for unmatched static assets

### DIFF
--- a/src/app/loaders/express/__tests__/error-handler.spec.ts
+++ b/src/app/loaders/express/__tests__/error-handler.spec.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import supertest, { Session } from 'supertest-session'
 
-import errorHandlerMiddlewares from '../error-handler'
+import { errorHandlerMiddlewares } from '../error-handler'
 import parserMiddlewares from '../parser'
 
 describe('error-handler.loader', () => {

--- a/src/app/loaders/express/error-handler.ts
+++ b/src/app/loaders/express/error-handler.ts
@@ -22,6 +22,14 @@ const isHTTPLikeError = (
   return types.isNativeError(err) && 'statusCode' in err
 }
 
+// 404 since no middleware responded
+export const catchNonExistentRoutesMiddleware: RequestHandler = function (
+  _req,
+  res,
+) {
+  res.sendStatus(StatusCodes.NOT_FOUND)
+}
+
 const errorHandlerMiddlewares = (): (
   | ErrorRequestHandler
   | RequestHandler
@@ -113,14 +121,6 @@ const errorHandlerMiddlewares = (): (
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
         .json({ message: genericErrorMessage })
     }
-  }
-
-  // Assume 404 since no middleware responded
-  const catchNonExistentRoutesMiddleware: RequestHandler = function (
-    _req,
-    res,
-  ) {
-    res.sendStatus(StatusCodes.NOT_FOUND)
   }
 
   return [genericErrorHandlerMiddleware, catchNonExistentRoutesMiddleware]

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -140,6 +140,9 @@ const loadExpressApp = async (connection: Connection) => {
   // Requests for known static asset patterns which were not served by
   // the static handlers above should return 404s
   app.get(/^\/(public|static)\//, catchNonExistentRoutesMiddleware)
+
+  // Requests for root files (e.g. /robots.txt or /favicon.ico) that were
+  // not served statically above will also return 404
   app.get(/^\/[^/]+\.[a-z]{2,}$/, catchNonExistentRoutesMiddleware)
 
   app.get('/old/', HomeController.home)

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -23,8 +23,9 @@ import { ApiRouter } from '../../routes/api'
 import { SpOidcJwksRouter } from '../../routes/singpass'
 import * as IntranetMiddleware from '../../services/intranet/intranet.middleware'
 
-import errorHandlerMiddlewares, {
+import {
   catchNonExistentRoutesMiddleware,
+  errorHandlerMiddlewares,
 } from './error-handler'
 import helmetMiddlewares from './helmet'
 import appLocals from './locals'

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -145,7 +145,7 @@ const loadExpressApp = async (connection: Connection) => {
 
   // Requests for root files (e.g. /robots.txt or /favicon.ico) that were
   // not served statically above will also return 404
-  app.get(/^\/[^/]+\.[a-z]{2,}$/, catchNonExistentRoutesMiddleware)
+  app.get(/^\/[^/]+\.[a-z]+$/, catchNonExistentRoutesMiddleware)
 
   app.get('/old/', HomeController.home)
   app.use('/', ReactMigrationRouter)

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -133,7 +133,8 @@ const loadExpressApp = async (connection: Connection) => {
   // New routes in preparation for API refactor.
   app.use('/api', ApiRouter)
 
-  // serve static assets
+  // serve static assets. `dist/frontend` contains the root files as well as a `/static` folder
+  // express.static calls next() if the file is not found
   app.use(express.static(path.resolve('dist/frontend'), { index: false }))
   app.use('/public', express.static(path.resolve('dist/angularjs')))
 

--- a/src/app/routes/api/api.routes.ts
+++ b/src/app/routes/api/api.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 
-import errorHandlerMiddlewares from '../../loaders/express/error-handler'
+import { errorHandlerMiddlewares } from '../../loaders/express/error-handler'
 
 import { V3Router } from './v3'
 

--- a/tests/integration/helpers/express-setup.ts
+++ b/tests/integration/helpers/express-setup.ts
@@ -4,7 +4,7 @@ import express, { Express, Router } from 'express'
 import session from 'express-session'
 import nocache from 'nocache'
 
-import errorHandlerMiddlewares from 'src/app/loaders/express/error-handler'
+import { errorHandlerMiddlewares } from 'src/app/loaders/express/error-handler'
 import helmetMiddlewares from 'src/app/loaders/express/helmet'
 import loggingMiddleware from 'src/app/loaders/express/logging'
 import parserMiddlewares from 'src/app/loaders/express/parser'


### PR DESCRIPTION
## Problem
The catch-all handler we have for react (which is mostly used to catch all the admin routes) is hiding 404 responses because it always returns 200 with html content.

We know some users sometimes see blank pages and it's likely during release when there's a mismatch between static assets (old assets requested on new server, or new assets requested on old server).

fixes #5577 

Additional info: the reason we have a catch-all in react is to capture all the admins routes without having to list them explicitly in express. Listing all app routes (admins and respondent) rather than `*` would be an alternative solution, since then the final catcher would be the error handler, which would return 404 for all non-matched routes.

## Solution
This PR doesn't fix the problem (this will come in a separate process), but it restored our visibility into 404s for static assets.

Tested locally:
```bash
➜ curl -v http://localhost:5001/617acb2cf1180300148af690 2>&1 | grep '< HTTP'
< HTTP/1.1 200 OK

➜ curl -v http://localhost:5001/static/ 2>&1 | grep '< HTTP'
< HTTP/1.1 404 Not Found

➜ curl -v http://localhost:5001/static/foo 2>&1 | grep '< HTTP'
< HTTP/1.1 404 Not Found

➜ curl -v http://localhost:5001/foo.bar 2>&1 | grep '< HTTP'
< HTTP/1.1 404 Not Found

➜ curl -v http://localhost:5001/robots.txt 2>&1 | grep '< HTTP'
< HTTP/1.1 200 OK

➜ curl -v http://localhost:5001/static/js/1.e7cd9c85.chunk.js 2>&1 | grep '< HTTP'
< HTTP/1.1 200 OK

➜ curl -v http://localhost:5001/static/js/1.aaaaaaaa.chunk.js 2>&1 | grep '< HTTP'
< HTTP/1.1 404 Not Found
```