### PR TITLE
test: fix race condition in field schema test

### DIFF
--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -42,19 +42,21 @@ describe('Form Field Schema', () => {
         // Arrange
         // Get all field types
         const fieldTypes = Object.values(BasicField)
+        const makeFieldTitle = (type: BasicField) => `test ${type} field title`
+        const formFieldPromises = fieldTypes
+          .filter((type) => type !== BasicField.Table)
+          .map((type) =>
+            createAndReturnFormField({
+              fieldType: type,
+              title: makeFieldTitle(type),
+            }),
+          )
+        const formFields = await Promise.all(formFieldPromises)
 
         // Asserts
-        fieldTypes.forEach(async (type) => {
-          // Skip table field.
-          if (type === BasicField.Table) return
-          const fieldTitle = `test ${type} field title`
-          const field = await createAndReturnFormField({
-            fieldType: type,
-            title: fieldTitle,
-          })
-
-          // Assert
-          expect(field.getQuestion()).toEqual(fieldTitle)
+        formFields.forEach((field) => {
+          const expectedTitle = makeFieldTitle(field.fieldType)
+          expect(field.getQuestion()).toEqual(expectedTitle)
         })
       })
 

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -48,7 +48,7 @@ describe('Form Field Schema', () => {
           // Act
           const fieldTitle = `test ${fieldType} field title`
           const field = await createAndReturnFormField({
-            fieldType: fieldType,
+            fieldType,
             title: fieldTitle,
           })
 

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -42,22 +42,19 @@ describe('Form Field Schema', () => {
         // Arrange
         // Get all field types
         const fieldTypes = Object.values(BasicField)
-        const makeFieldTitle = (type: BasicField) => `test ${type} field title`
-        const formFieldPromises = fieldTypes
-          .filter((type) => type !== BasicField.Table)
-          .map((type) =>
-            createAndReturnFormField({
-              fieldType: type,
-              title: makeFieldTitle(type),
-            }),
-          )
-        const formFields = await Promise.all(formFieldPromises)
+        for (const fieldType of fieldTypes) {
+          if (fieldType === BasicField.Table) return
 
-        // Asserts
-        formFields.forEach((field) => {
-          const expectedTitle = makeFieldTitle(field.fieldType)
-          expect(field.getQuestion()).toEqual(expectedTitle)
-        })
+          // Act
+          const fieldTitle = `test ${fieldType} field title`
+          const field = await createAndReturnFormField({
+            fieldType: fieldType,
+            title: fieldTitle,
+          })
+
+          // Assert
+          expect(field.getQuestion()).toEqual(fieldTitle)
+        }
       })
 
       it('should return table title concatenated with all column titles when field type is a table field', async () => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Tests occasionally fail with this error:
<img width="876" alt="Screenshot 2022-12-15 at 11 33 56 AM" src="https://user-images.githubusercontent.com/29480346/208855837-218e0132-8e8f-4c13-aebb-5b072743fd1c.png">


## Solution
<!-- How did you solve the problem? -->

[`forEach`](https://gist.github.com/joeytwiddle/37d2085425c049629b80956d3c618971) [with](https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop) [`await`](https://stackoverflow.com/questions/51738684/await-with-array-foreach-containing-async-await) [famously](https://plainenglish.io/blog/async-await-foreach) [does](https://www.becomebetterprogrammer.com/javascript-foreach-async-await/) [not](https://maximorlov.com/async-await-inside-foreach/) [work](https://masteringjs.io/tutorials/fundamentals/async-foreach). The test function returns while the async asserts are still executing, so the test database gets cleared in the `afterEach` hook before some of the asserts can finish.

Use `for`...`of` instead.