### PR TITLE
fix: avoid using merge to set query after reordering fields

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useReorderFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useReorderFormField.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
-import { merge } from 'lodash'
 
 import { FormFieldDto } from '~shared/types/field'
 import { AdminFormDto } from '~shared/types/form'
@@ -61,7 +60,7 @@ export const useReorderFormField = () => {
             queryClient.setQueryData<AdminFormDto>(adminFormKey, (old) => {
               if (!old) throw new Error('Query should have been set')
               const reorderedFields = reorder(old.form_fields, from, to)
-              return merge({}, old, { form_fields: reorderedFields })
+              return { ...old, form_fields: reorderedFields }
             })
           }
           // Return a context object with the snapshotted value


### PR DESCRIPTION
## Problem
Reordering fields with options with different lengths causes the excess options in the field with longer options to be replicated in the field with shorter options.

https://user-images.githubusercontent.com/25571626/208871283-c46de3ca-a5d3-45cb-81a4-af13271d8588.mov

Closes #5603 

## Solution
The reason for this is that we use lodash's `merge` when we set the query. This modifies the old array values in-place, and does not replace the array. Therefore, avoid using `merge`.  

**Breaking Changes** 
- No - this PR is backwards compatible  

https://user-images.githubusercontent.com/25571626/208871811-932bd2cf-479c-490a-bd9b-fd47ba1ce691.mov


