### PR TITLE
build: remove lint steps from production Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - run: npm ci
       - run: npm run lint-ci
+      - run: npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
 
   src_e2e:
     needs: [changes, build]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -41,7 +41,6 @@ COPY . ./
 ENV NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"
 
 RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
-RUN npm run lint-ci
 RUN npm run build
 
 ARG APP_VERSION

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -40,7 +40,6 @@ COPY . ./
 # These options are only used in the build stage, not the start stage.
 ENV NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"
 
-RUN npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm
 RUN npm run build
 
 ARG APP_VERSION


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We run `npm run lint-ci` when building the production Docker image, but there's really no need to. Linting doesn't affect the build, and we already have a separate lint step outside Docker in the CICD pipeline.

We also run `lockfile-lint` in the Docker image build, which seems like the wrong place to do it. It should be part of the lint step.

## Solution
<!-- How did you solve the problem? -->

Remove the linting step in the Docker image build process. This cuts down deployment time by more than 10%, e.g. in [this deploy](https://github.com/opengovsg/FormSG/actions/runs/3763084026/jobs/6396326381), building the image took 918 seconds, out of which 101 seconds were spent on linting.