### PR TITLE
ci: add node options to src_e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
   src_e2e:
     needs: [changes, build]
-    # if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.angularjs == 'true' }}
+    if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.angularjs == 'true' }}
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
     needs: [changes, build]
     if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.angularjs == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
   src_e2e:
     needs: [changes, build]
-    if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.angularjs == 'true' }}
+    # if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.angularjs == 'true' }}
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

CI src_e2e tests are failing with a `Javascript out of memory` error
[One example](https://github.com/opengovsg/FormSG/actions/runs/3763084027/jobs/6397582495)

## Solution
<!-- How did you solve the problem? -->
- Specify NODE_OPTIONS setting in src_e2e