### PR TITLE
fix: remove deprecated GA command set-output

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -53,7 +53,7 @@ jobs:
           echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
           role-to-assume: ${{ secrets.AWS_CI_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: set-environment
-        run: echo "::set-output name=current_env::${{github.ref_name}}"
+        run: echo "current_env=${{github.ref_name}}" >> $GITHUB_OUTPUT
 
   build_deploy_application:
     needs: set_environment


### PR DESCRIPTION
## Problem
Our actions and some of the actions we import use the deprecated command `set-output`. Github is warning us it will be removed soon and we should use the new setup, per the instructions [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

![image](https://user-images.githubusercontent.com/935223/209313046-7cc7c19e-2f94-41ae-8670-68cb0a89171a.png)

![image](https://user-images.githubusercontent.com/935223/209312756-6106a414-4cf7-4f6b-8d96-83e73a7d0bb2.png)


## Solution
* Upgrade `set-output` commands
* Upgrade imported actions that use `set-output`