### PR TITLE
feat: add console.error to instances of arrayBuffer in the frontend

### DIFF
--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -180,7 +180,11 @@ const encryptAttachment = async (
     }
     return { id, encryptedFile: encodedEncryptedAttachment }
   } catch (error) {
+    // TODO: remove error logging when error about arrayBuffer not being a function is resolved
     console.error(error)
+    console.error(`Information about attachment ${id}`)
+    console.error(typeof attachment)
+    console.error(attachment)
     return { id, encryptedFile: undefined }
   }
 }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -166,17 +166,21 @@ const encryptAttachment = async (
   attachment: File,
   { id, publicKey }: { id: string; publicKey: string },
 ): Promise<StorageModeAttachment & { id: string }> => {
-  const fileArrayBuffer = await attachment.arrayBuffer()
-  const fileContentsView = new Uint8Array(fileArrayBuffer)
+  try {
+    const fileArrayBuffer = await attachment.arrayBuffer()
+    const fileContentsView = new Uint8Array(fileArrayBuffer)
 
-  const encryptedAttachment = await formsgSdk.crypto.encryptFile(
-    fileContentsView,
-    publicKey,
-  )
-  const encodedEncryptedAttachment = {
-    ...encryptedAttachment,
-    binary: encodeBase64(encryptedAttachment.binary),
+    const encryptedAttachment = await formsgSdk.crypto.encryptFile(
+      fileContentsView,
+      publicKey,
+    )
+    const encodedEncryptedAttachment = {
+      ...encryptedAttachment,
+      binary: encodeBase64(encryptedAttachment.binary),
+    }
+    return { id, encryptedFile: encodedEncryptedAttachment }
+  } catch (error) {
+    console.error(error)
+    return { id, encryptedFile: undefined }
   }
-
-  return { id, encryptedFile: encodedEncryptedAttachment }
 }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -185,6 +185,8 @@ const encryptAttachment = async (
     console.error(`Information about attachment ${id}`)
     console.error(typeof attachment)
     console.error(attachment)
-    return { id, encryptedFile: undefined }
+
+    // Rethrow to maintain behaviour
+    throw error
   }
 }

--- a/frontend/src/services/FileHandlerService.ts
+++ b/frontend/src/services/FileHandlerService.ts
@@ -48,6 +48,7 @@ const computeChecksumMd5 = (file: File): Promise<string> => {
     fileReader.onload = (e) => {
       const arrayBuffer = e.target?.result
       if (!(arrayBuffer instanceof ArrayBuffer)) {
+        console.error('Empty array buffer - error reading the file')
         return reject('Empty array buffer - error reading the file')
       }
       spark.append(arrayBuffer) // Accumulate chunk to md5 computation

--- a/frontend/src/services/FileHandlerService.ts
+++ b/frontend/src/services/FileHandlerService.ts
@@ -48,7 +48,6 @@ const computeChecksumMd5 = (file: File): Promise<string> => {
     fileReader.onload = (e) => {
       const arrayBuffer = e.target?.result
       if (!(arrayBuffer instanceof ArrayBuffer)) {
-        console.error('Empty array buffer - error reading the file')
         return reject('Empty array buffer - error reading the file')
       }
       spark.append(arrayBuffer) // Accumulate chunk to md5 computation


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to investigate the arrayBuffer issue by documenting where the error occurs

Closes #5656

## Solution
<!-- How did you solve the problem? -->
Add `console.error` to the 2 instances where arrayBuffer appears in the frontend React code