### PR TITLE
chore: swap cookie names for admin ui from `v2-admin-ui` to `v2-admin-ui-Jan-2023`

### DIFF
--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -361,10 +361,16 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       env: 'REACT_MIGRATION_RESP_COOKIE_NAME',
     },
     adminCookieName: {
-      doc: "Name of the cookie that will store admins' choice of environment.",
+      doc: "Name of the cookie that will store admins' choice of environment. (Deprecated)",
       format: String,
       default: 'v2-admin-ui',
       env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME',
+    },
+    adminCookieNameJan2023: {
+      doc: "Name of the cookie that will store admins' choice of environment.",
+      format: String,
+      default: 'v2-admin-ui-Jan-2023',
+      env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME_JAN_2023',
     },
     qaCookieName: {
       doc: 'Priority cookie to select react/angular during QA.',

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -360,17 +360,17 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 'v2-respondent-ui',
       env: 'REACT_MIGRATION_RESP_COOKIE_NAME',
     },
-    adminCookieName: {
-      doc: "Name of the cookie that will store admins' choice of environment. (Deprecated)",
+    adminCookieNameOld: {
+      doc: "Name of the old cookie that will store admins' choice of environment.",
       format: String,
       default: 'v2-admin-ui',
-      env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME',
+      env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME_OLD',
     },
-    adminCookieNameJan2023: {
+    adminCookieName: {
       doc: "Name of the cookie that will store admins' choice of environment.",
       format: String,
       default: 'v2-admin-ui-Jan-2023',
-      env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME_JAN_2023',
+      env: 'REACT_MIGRATION_ADMIN_COOKIE_NAME',
     },
     qaCookieName: {
       doc: 'Priority cookie to select react/angular during QA.',

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -25,9 +25,8 @@ const frontendVars = {
   // react migration variables
   reactMigrationRespondentCookieName:
     config.reactMigration.respondentCookieName,
+  reactMigrationAdminCookieNameOld: config.reactMigration.adminCookieNameOld,
   reactMigrationAdminCookieName: config.reactMigration.adminCookieName,
-  reactMigrationAdminCookieNameJan2023:
-    config.reactMigration.adminCookieNameJan2023,
   reactMigrationRespondentRolloutEmail:
     config.reactMigration.respondentRolloutEmail,
   reactMigrationRespondentRolloutStorage:

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -59,8 +59,8 @@ const environment = ejs.render(
     var spcpCookieDomain = "<%= spcpCookieDomain%>"
     // React Migration
     var reactMigrationRespondentCookieName = "<%= reactMigrationRespondentCookieName%>"
+    var reactMigrationAdminCookieNameOld = "<%= reactMigrationAdminCookieNameOld%>"
     var reactMigrationAdminCookieName = "<%= reactMigrationAdminCookieName%>"
-    var reactMigrationAdminCookieNameJan2023 = "<%= reactMigrationAdminCookieNameJan2023%>"
     var reactMigrationRespondentRolloutEmail = "<%= reactMigrationRespondentRolloutEmail%>"
     var reactMigrationRespondentRolloutStorage = "<%= reactMigrationRespondentRolloutStorage%>"
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -26,6 +26,8 @@ const frontendVars = {
   reactMigrationRespondentCookieName:
     config.reactMigration.respondentCookieName,
   reactMigrationAdminCookieName: config.reactMigration.adminCookieName,
+  reactMigrationAdminCookieNameJan2023:
+    config.reactMigration.adminCookieNameJan2023,
   reactMigrationRespondentRolloutEmail:
     config.reactMigration.respondentRolloutEmail,
   reactMigrationRespondentRolloutStorage:
@@ -58,6 +60,7 @@ const environment = ejs.render(
     // React Migration
     var reactMigrationRespondentCookieName = "<%= reactMigrationRespondentCookieName%>"
     var reactMigrationAdminCookieName = "<%= reactMigrationAdminCookieName%>"
+    var reactMigrationAdminCookieNameJan2023 = "<%= reactMigrationAdminCookieNameJan2023%>"
     var reactMigrationRespondentRolloutEmail = "<%= reactMigrationRespondentRolloutEmail%>"
     var reactMigrationRespondentRolloutStorage = "<%= reactMigrationRespondentRolloutStorage%>"
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"

--- a/src/app/loaders/express/logging.ts
+++ b/src/app/loaders/express/logging.ts
@@ -20,6 +20,7 @@ type LogMeta = {
     adminRollout: number
     qaCookie: string | undefined
     adminCookie: string | undefined
+    adminCookieOverride: string | undefined
     respCookie: string | undefined
   }
 }
@@ -73,6 +74,7 @@ const loggingMiddleware = () => {
       // Temporary: cookies are blacklisted, but we to track the state of the rollout for this particular request
       if (
         req.cookies?.[config.reactMigration.adminCookieName] ||
+        req.cookies?.[config.reactMigration.adminCookieNameJan2023] ||
         req.cookies?.[config.reactMigration.respondentCookieName] ||
         req.cookies?.[config.reactMigration.qaCookieName]
       ) {
@@ -82,6 +84,8 @@ const loggingMiddleware = () => {
           adminRollout: config.reactMigration.adminRollout,
           qaCookie: req.cookies?.[config.reactMigration.qaCookieName],
           adminCookie: req.cookies?.[config.reactMigration.adminCookieName],
+          adminCookieOverride:
+            req.cookies?.[config.reactMigration.adminCookieNameJan2023],
           respCookie: req.cookies?.[config.reactMigration.respondentCookieName],
         }
       }

--- a/src/app/loaders/express/logging.ts
+++ b/src/app/loaders/express/logging.ts
@@ -19,8 +19,8 @@ type LogMeta = {
     respRolloutStorage: number
     adminRollout: number
     qaCookie: string | undefined
+    adminCookieOld: string | undefined
     adminCookie: string | undefined
-    adminCookieOverride: string | undefined
     respCookie: string | undefined
   }
 }
@@ -73,8 +73,8 @@ const loggingMiddleware = () => {
 
       // Temporary: cookies are blacklisted, but we to track the state of the rollout for this particular request
       if (
+        req.cookies?.[config.reactMigration.adminCookieNameOld] ||
         req.cookies?.[config.reactMigration.adminCookieName] ||
-        req.cookies?.[config.reactMigration.adminCookieNameJan2023] ||
         req.cookies?.[config.reactMigration.respondentCookieName] ||
         req.cookies?.[config.reactMigration.qaCookieName]
       ) {
@@ -83,9 +83,9 @@ const loggingMiddleware = () => {
           respRolloutStorage: config.reactMigration.respondentRolloutStorage,
           adminRollout: config.reactMigration.adminRollout,
           qaCookie: req.cookies?.[config.reactMigration.qaCookieName],
+          adminCookieOld:
+            req.cookies?.[config.reactMigration.adminCookieNameOld],
           adminCookie: req.cookies?.[config.reactMigration.adminCookieName],
-          adminCookieOverride:
-            req.cookies?.[config.reactMigration.adminCookieNameJan2023],
           respCookie: req.cookies?.[config.reactMigration.respondentCookieName],
         }
       }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -226,8 +226,8 @@ export const servePublicForm: ControllerHandler<
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
   // Delete the deprecated cookie.
-  if (req.cookies) {
-    res.clearCookie(config.reactMigration.adminCookieName)
+  if (req.cookies[config.reactMigration.adminCookieNameOld]) {
+    res.clearCookie(config.reactMigration.adminCookieNameOld)
   }
 
   // Admins assigned react, or who choose react will stay on react until they opt out
@@ -245,13 +245,13 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     showReact = false
     // Delete existing cookie to prevent infinite redirection
     if (req.cookies) {
-      res.clearCookie(config.reactMigration.adminCookieNameJan2023)
+      res.clearCookie(config.reactMigration.adminCookieName)
     }
   } else if (req.cookies) {
-    if (config.reactMigration.adminCookieNameJan2023 in req.cookies) {
+    if (config.reactMigration.adminCookieName in req.cookies) {
       // Check if admin had already chosen react previously
       showReact =
-        req.cookies[config.reactMigration.adminCookieNameJan2023] ===
+        req.cookies[config.reactMigration.adminCookieName] ===
         UiCookieValues.React
     }
   }
@@ -271,7 +271,7 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     })
 
     res.cookie(
-      config.reactMigration.adminCookieNameJan2023,
+      config.reactMigration.adminCookieName,
       showReact ? UiCookieValues.React : UiCookieValues.Angular,
       // If assigned react, admins will stay on it unless they opt out.
       // If assigned angular, the admin cookie is for a single session
@@ -310,7 +310,7 @@ export const adminChooseEnvironment: ControllerHandler<
       ? UiCookieValues.React
       : UiCookieValues.Angular
   res.cookie(
-    config.reactMigration.adminCookieNameJan2023,
+    config.reactMigration.adminCookieName,
     ui,
     // When admin chooses to switch environments, we want them to stay on their
     // chosen environment until the alternative is stable.
@@ -353,7 +353,7 @@ export const redirectAdminEnvironment: ControllerHandler<
       ? UiCookieValues.React
       : UiCookieValues.Angular
   res.cookie(
-    config.reactMigration.adminCookieNameJan2023,
+    config.reactMigration.adminCookieName,
     ui,
     // When admin chooses to switch environments, we want them to stay on their
     // chosen environment until the alternative is stable.

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -225,6 +225,11 @@ export const servePublicForm: ControllerHandler<
 }
 
 export const serveDefault: ControllerHandler = (req, res, next) => {
+  // Delete the deprecated cookie.
+  if (req.cookies) {
+    res.clearCookie(config.reactMigration.adminCookieName)
+  }
+
   // Admins assigned react, or who choose react will stay on react until they opt out
   // Admins assigned angular will stay on it for that session
   let showReact: boolean | undefined = undefined
@@ -240,13 +245,13 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     showReact = false
     // Delete existing cookie to prevent infinite redirection
     if (req.cookies) {
-      res.clearCookie(config.reactMigration.adminCookieName)
+      res.clearCookie(config.reactMigration.adminCookieNameJan2023)
     }
   } else if (req.cookies) {
-    if (config.reactMigration.adminCookieName in req.cookies) {
+    if (config.reactMigration.adminCookieNameJan2023 in req.cookies) {
       // Check if admin had already chosen react previously
       showReact =
-        req.cookies[config.reactMigration.adminCookieName] ===
+        req.cookies[config.reactMigration.adminCookieNameJan2023] ===
         UiCookieValues.React
     }
   }
@@ -266,7 +271,7 @@ export const serveDefault: ControllerHandler = (req, res, next) => {
     })
 
     res.cookie(
-      config.reactMigration.adminCookieName,
+      config.reactMigration.adminCookieNameJan2023,
       showReact ? UiCookieValues.React : UiCookieValues.Angular,
       // If assigned react, admins will stay on it unless they opt out.
       // If assigned angular, the admin cookie is for a single session
@@ -305,7 +310,7 @@ export const adminChooseEnvironment: ControllerHandler<
       ? UiCookieValues.React
       : UiCookieValues.Angular
   res.cookie(
-    config.reactMigration.adminCookieName,
+    config.reactMigration.adminCookieNameJan2023,
     ui,
     // When admin chooses to switch environments, we want them to stay on their
     // chosen environment until the alternative is stable.
@@ -348,7 +353,7 @@ export const redirectAdminEnvironment: ControllerHandler<
       ? UiCookieValues.React
       : UiCookieValues.Angular
   res.cookie(
-    config.reactMigration.adminCookieName,
+    config.reactMigration.adminCookieNameJan2023,
     ui,
     // When admin chooses to switch environments, we want them to stay on their
     // chosen environment until the alternative is stable.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -59,6 +59,7 @@ export type ReactMigrationConfig = {
   adminRollout: number
   respondentCookieName: string
   adminCookieName: string
+  adminCookieNameJan2023: string
   qaCookieName: string
   adminSwitchEnvFeedbackFormId: string
   respondentSwitchEnvFeedbackFormId: string
@@ -195,6 +196,7 @@ export interface IOptionalVarsSchema {
     adminRollout: number
     respondentCookieName: string
     adminCookieName: string
+    adminCookieNameJan2023: string
     qaCookieName: string
     angularPhaseOutDate: string
     removeAdminInfoboxThreshold: number

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -58,8 +58,8 @@ export type ReactMigrationConfig = {
   respondentRolloutStorage: number
   adminRollout: number
   respondentCookieName: string
+  adminCookieNameOld: string
   adminCookieName: string
-  adminCookieNameJan2023: string
   qaCookieName: string
   adminSwitchEnvFeedbackFormId: string
   respondentSwitchEnvFeedbackFormId: string
@@ -195,8 +195,8 @@ export interface IOptionalVarsSchema {
     respondentRolloutStorage: number
     adminRollout: number
     respondentCookieName: string
+    adminCookieNameOld: string
     adminCookieName: string
-    adminCookieNameJan2023: string
     qaCookieName: string
     angularPhaseOutDate: string
     removeAdminInfoboxThreshold: number


### PR DESCRIPTION
## Problem
We want to force admins who were on angular onto react now.

Closes #5662 

## Solution

Add a new cookie, `v2-admin-ui-Jan-2023` that is the new cookie that will be used. The deprecated cookie is cleared.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Deploy Notes

**New environment variables**:

- `REACT_MIGRATION_ADMIN_COOKIE_NAME_OLD` : The name of the old admin cookie to be deleted. Defaults to `v2-admin-ui`.

## Tests

Assuming admin rollout is at 100%,
- [x] As an admin who has no cookies, log in. Should be served react, with `v2-admin-ui-Jan-2023` = `react`.
- [x] As an admin who has `v2-admin-ui` = `react`, log in. Should be served react, with `v2-admin-ui` cleared and `v2-admin-ui-Jan-2023` = `react`.
- [x] As an admin who has `v2-admin-ui` = `angular`, log in. Should be served react, with `v2-admin-ui` cleared and `v2-admin-ui-Jan-2023` = `react`.
- [x] As an admin who has no cookies, go to `/environment/angular`. Then, log in. Should be served angular, with `v2-admin-ui-Jan-2023` = `angular`.
- [x] As an admin who has `v2-admin-ui` = `react`, go to `/environment/angular`. Then, log in. Should be served angular, with `v2-admin-ui` cleared and `v2-admin-ui-Jan-2023` = `angular`.
- [x] As an admin who has `v2-admin-ui` = `angular`, go to `/environment/react`. Then, log in. Should be served react, with `v2-admin-ui` cleared and `v2-admin-ui-Jan-2023` = `react`.