### PR TITLE
feat: add datadog logging for frontend errors

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -51,6 +51,8 @@ jobs:
           echo REACT_APP_VERSION=${{env.APP_VERSION}} > frontend/.env
           echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
           echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
+          echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env
+          echo REACT_APP_DD_RUM_ENV=$REACT_APP_DD_RUM_ENV >> frontend/.env
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0

--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -3,6 +3,7 @@
  * This ensures that datadog is initialised before the react app
  */
 
+import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum, RumInitConfiguration } from '@datadog/browser-rum'
 
 // Discard benign RUM errors.
@@ -49,3 +50,15 @@ datadogRum.init({
 })
 
 datadogRum.startSessionReplayRecording()
+
+// Init Datadog browser logs
+datadogLogs.init({
+  clientToken: '@REACT_APP_DD_RUM_CLIENT_TOKEN',
+  env: '@REACT_APP_DD_RUM_ENV',
+  site: 'datadoghq.com',
+  service: 'formsg-react',
+  // Specify a version number to identify the deployed version of your application in Datadog
+  version: '@REACT_APP_VERSION',
+  forwardErrorsToLogs: true,
+  sampleRate: 100,
+})

--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -3,7 +3,6 @@
  * This ensures that datadog is initialised before the react app
  */
 
-import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum, RumInitConfiguration } from '@datadog/browser-rum'
 
 // Discard benign RUM errors.
@@ -50,15 +49,3 @@ datadogRum.init({
 })
 
 datadogRum.startSessionReplayRecording()
-
-// Init Datadog browser logs
-datadogLogs.init({
-  clientToken: '@REACT_APP_DD_RUM_CLIENT_TOKEN',
-  env: '@REACT_APP_DD_RUM_ENV',
-  site: 'datadoghq.com',
-  service: 'formsg-react',
-  // Specify a version number to identify the deployed version of your application in Datadog
-  version: '@REACT_APP_VERSION',
-  forwardErrorsToLogs: true,
-  sampleRate: 100,
-})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@chakra-ui/react": "^1.8.6",
+        "@datadog/browser-logs": "^4.28.1",
         "@datadog/browser-rum": "^4.14.0",
         "@emotion/react": "^11.7.0",
         "@emotion/styled": "^11.6.0",
@@ -3224,6 +3225,27 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
       "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+    },
+    "node_modules/@datadog/browser-logs": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.28.1.tgz",
+      "integrity": "sha512-3TUybhC1apfGnyAREBuqOI6LA96tlrdgilKoPGR/8wf9wvpRJ/zXx0gm4WgzRPilEDFfJxWfvB/IUYg0MYh/GA==",
+      "dependencies": {
+        "@datadog/browser-core": "4.28.1"
+      },
+      "peerDependencies": {
+        "@datadog/browser-rum": "4.28.1"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-rum": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-logs/node_modules/@datadog/browser-core": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.28.1.tgz",
+      "integrity": "sha512-BmMJA3SpZtI5VVukuxMKYc7ALBLcydnG+tRh5pXP/Tjjejh9sx611TdspeAd00rfpYQ4c51CcHkhem3oU/WJCQ=="
     },
     "node_modules/@datadog/browser-rum": {
       "version": "4.14.0",
@@ -53305,6 +53327,21 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
       "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+    },
+    "@datadog/browser-logs": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.28.1.tgz",
+      "integrity": "sha512-3TUybhC1apfGnyAREBuqOI6LA96tlrdgilKoPGR/8wf9wvpRJ/zXx0gm4WgzRPilEDFfJxWfvB/IUYg0MYh/GA==",
+      "requires": {
+        "@datadog/browser-core": "4.28.1"
+      },
+      "dependencies": {
+        "@datadog/browser-core": {
+          "version": "4.28.1",
+          "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.28.1.tgz",
+          "integrity": "sha512-BmMJA3SpZtI5VVukuxMKYc7ALBLcydnG+tRh5pXP/Tjjejh9sx611TdspeAd00rfpYQ4c51CcHkhem3oU/WJCQ=="
+        }
+      }
     },
     "@datadog/browser-rum": {
       "version": "4.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@chakra-ui/react": "^1.8.6",
+    "@datadog/browser-logs": "^4.28.1",
     "@datadog/browser-rum": "^4.14.0",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -38,26 +38,6 @@ datadogLogs.init({
   version: process.env.REACT_APP_VERSION,
   forwardErrorsToLogs: true,
   sampleRate: 100,
-  // Scrub phone numbers and email addresses from browser logs.
-  // Phone numbers will always start with +
-  beforeSend: (log) => {
-    log.message = log.message
-      .replace(/"\+\d+"/, '"number=REDACTED"')
-      .replace(
-        /"([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)"/,
-        'email=REDACTED',
-      )
-      .replace(/^\+\d+/, '"number=REDACTED"')
-      .replace(
-        /(^[a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/,
-        'email=REDACTED',
-      )
-      .replace(/\+\d+/, '"number=REDACTED"')
-      .replace(
-        /([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/,
-        'email=REDACTED',
-      )
-  },
 })
 
 export const App = (): JSX.Element => (

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
 import { BrowserRouter } from 'react-router-dom'
 import { ChakraProvider } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 
 import { theme } from '~theme/index'
 import { AuthProvider } from '~contexts/AuthContext'
@@ -25,6 +26,18 @@ const queryClient = new QueryClient({
       },
     },
   },
+})
+
+// Init Datadog browser logs
+datadogLogs.init({
+  clientToken: 'pub30d7ad4705b1bbb6d6bb60b4ac23f789',
+  env: 'staging',
+  site: 'datadoghq.com',
+  service: 'formsg-react',
+  // Specify a version number to identify the deployed version of your application in Datadog
+  version: '1',
+  forwardErrorsToLogs: true,
+  sampleRate: 100,
 })
 
 export const App = (): JSX.Element => (

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -30,12 +30,12 @@ const queryClient = new QueryClient({
 
 // Init Datadog browser logs
 datadogLogs.init({
-  clientToken: 'pub30d7ad4705b1bbb6d6bb60b4ac23f789',
-  env: 'staging',
+  clientToken: process.env.REACT_APP_DD_RUM_CLIENT_TOKEN || '',
+  env: process.env.REACT_APP_DD_RUM_ENV,
   site: 'datadoghq.com',
   service: 'formsg-react',
   // Specify a version number to identify the deployed version of your application in Datadog
-  version: '1',
+  version: process.env.REACT_APP_VERSION,
   forwardErrorsToLogs: true,
   sampleRate: 100,
 })

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -47,6 +47,16 @@ datadogLogs.init({
         /"([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)"/,
         'email=REDACTED',
       )
+      .replace(/^\+\d+/, '"number=REDACTED"')
+      .replace(
+        /(^[a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/,
+        'email=REDACTED',
+      )
+      .replace(/\+\d+/, '"number=REDACTED"')
+      .replace(
+        /([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/,
+        'email=REDACTED',
+      )
   },
 })
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -33,7 +33,7 @@ datadogLogs.init({
   clientToken: process.env.REACT_APP_DD_RUM_CLIENT_TOKEN || '',
   env: process.env.REACT_APP_DD_RUM_ENV,
   site: 'datadoghq.com',
-  service: 'formsg-react',
+  service: 'formsg',
   // Specify a version number to identify the deployed version of your application in Datadog
   version: process.env.REACT_APP_VERSION,
   forwardErrorsToLogs: true,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -38,6 +38,16 @@ datadogLogs.init({
   version: process.env.REACT_APP_VERSION,
   forwardErrorsToLogs: true,
   sampleRate: 100,
+  // Scrub phone numbers and email addresses from browser logs.
+  // Phone numbers will always start with +
+  beforeSend: (log) => {
+    log.message = log.message
+      .replace(/"\+\d+"/, '"number=REDACTED"')
+      .replace(
+        /"([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)"/,
+        'email=REDACTED',
+      )
+  },
 })
 
 export const App = (): JSX.Element => (

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -233,6 +233,7 @@ export const PublicFormProvider = ({
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
+                    action: 'handleSubmitForm',
                     formInputs: formInputs,
                     responseMode: 'email',
                   },
@@ -268,6 +269,7 @@ export const PublicFormProvider = ({
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
+                    action: 'handleSubmitForm',
                     formInputs: formInputs,
                     responseMode: 'storage',
                   },

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -218,17 +218,6 @@ export const PublicFormProvider = ({
 
       switch (form.responseMode) {
         case FormResponseMode.Email:
-          console.log(
-            'removePIIdata_email:',
-            JSON.stringify(formInputs, removePIIData),
-          )
-          datadogLogs.logger.warn('handleSubmitFormTest', {
-            meta: {
-              action: 'handleSubmitForm',
-              formInputs: JSON.stringify(formInputs, removePIIData),
-              responseMode: 'email',
-            },
-          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitEmailModeFormMutation
@@ -264,17 +253,6 @@ export const PublicFormProvider = ({
               })
           )
         case FormResponseMode.Encrypt:
-          console.log(
-            'removePIIdata_storage:',
-            JSON.stringify(formInputs, removePIIData),
-          )
-          datadogLogs.logger.warn('handleSubmitFormTest', {
-            meta: {
-              action: 'handleSubmitForm',
-              formInputs: JSON.stringify(formInputs, removePIIData),
-              responseMode: 'storage',
-            },
-          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitStorageModeFormMutation

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -207,6 +207,13 @@ export const PublicFormProvider = ({
 
       switch (form.responseMode) {
         case FormResponseMode.Email:
+          datadogLogs.logger.warn('handleSubmitFormTest', {
+            meta: {
+              action: 'handleSubmitForm',
+              formInputs: formInputs,
+              responseMode: 'email',
+            },
+          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitEmailModeFormMutation
@@ -242,6 +249,13 @@ export const PublicFormProvider = ({
               })
           )
         case FormResponseMode.Encrypt:
+          datadogLogs.logger.warn('handleSubmitFormTest', {
+            meta: {
+              action: 'handleSubmitForm',
+              formInputs: formInputs,
+              responseMode: 'storage',
+            },
+          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitStorageModeFormMutation

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -207,13 +207,6 @@ export const PublicFormProvider = ({
 
       switch (form.responseMode) {
         case FormResponseMode.Email:
-          datadogLogs.logger.warn('handleSubmitFormTest', {
-            meta: {
-              formFields: form.form_fields,
-              formInputs: JSON.stringify(formInputs),
-              responseMode: 'email',
-            },
-          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitEmailModeFormMutation
@@ -238,7 +231,6 @@ export const PublicFormProvider = ({
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
-                console.warn(formInputs)
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     formInputs: formInputs,
@@ -249,13 +241,6 @@ export const PublicFormProvider = ({
               })
           )
         case FormResponseMode.Encrypt:
-          datadogLogs.logger.warn('handleSubmitFormTest', {
-            meta: {
-              formInputsRaw: formInputs,
-              formInputs: JSON.stringify(formInputs),
-              responseMode: 'storage',
-            },
-          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitStorageModeFormMutation
@@ -281,7 +266,6 @@ export const PublicFormProvider = ({
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
-                console.warn(formInputs)
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     formInputs: formInputs,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -211,6 +211,7 @@ export const PublicFormProvider = ({
             meta: {
               action: 'handleSubmitForm',
               formInputs: formInputs,
+              formInputsString: JSON.stringify(formInputs),
               responseMode: 'email',
             },
           })
@@ -253,6 +254,7 @@ export const PublicFormProvider = ({
             meta: {
               action: 'handleSubmitForm',
               formInputs: formInputs,
+              formInputsString: JSON.stringify(formInputs),
               responseMode: 'storage',
             },
           })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -101,6 +101,17 @@ export const PublicFormProvider = ({
   formId,
   children,
 }: PublicFormProviderProps): JSX.Element => {
+  // Scrub phone numbers and email addresses from browser logs.
+  // Phone numbers will always start with +
+  const removePIIData = (_key: string, value: string) => {
+    return JSON.stringify(value)
+      .replace(
+        /([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/g,
+        'email=REDACTED',
+      )
+      .replace(/\+\d+/g, 'number=REDACTED')
+  }
+
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
 
@@ -207,11 +218,14 @@ export const PublicFormProvider = ({
 
       switch (form.responseMode) {
         case FormResponseMode.Email:
+          console.log(
+            'removePIIdata_email:',
+            JSON.stringify(formInputs, removePIIData),
+          )
           datadogLogs.logger.warn('handleSubmitFormTest', {
             meta: {
               action: 'handleSubmitForm',
-              formInputs: formInputs,
-              formInputsString: JSON.stringify(formInputs),
+              formInputs: JSON.stringify(formInputs, removePIIData),
               responseMode: 'email',
             },
           })
@@ -242,7 +256,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     action: 'handleSubmitForm',
-                    formInputs: formInputs,
+                    formInputs: JSON.stringify(formInputs, removePIIData),
                     responseMode: 'email',
                   },
                 })
@@ -250,11 +264,14 @@ export const PublicFormProvider = ({
               })
           )
         case FormResponseMode.Encrypt:
+          console.log(
+            'removePIIdata_storage:',
+            JSON.stringify(formInputs, removePIIData),
+          )
           datadogLogs.logger.warn('handleSubmitFormTest', {
             meta: {
               action: 'handleSubmitForm',
-              formInputs: formInputs,
-              formInputsString: JSON.stringify(formInputs),
+              formInputs: JSON.stringify(formInputs, removePIIData),
               responseMode: 'storage',
             },
           })
@@ -286,7 +303,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     action: 'handleSubmitForm',
-                    formInputs: formInputs,
+                    formInputs: JSON.stringify(formInputs, removePIIData),
                     responseMode: 'storage',
                   },
                 })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -209,7 +209,8 @@ export const PublicFormProvider = ({
         case FormResponseMode.Email:
           datadogLogs.logger.warn('handleSubmitFormTest', {
             meta: {
-              formInputs: formInputs,
+              formFields: form.form_fields,
+              formInputs: JSON.stringify(formInputs),
               responseMode: 'email',
             },
           })
@@ -250,7 +251,8 @@ export const PublicFormProvider = ({
         case FormResponseMode.Encrypt:
           datadogLogs.logger.warn('handleSubmitFormTest', {
             meta: {
-              formInputs: formInputs,
+              formInputsRaw: formInputs,
+              formInputs: JSON.stringify(formInputs),
               responseMode: 'storage',
             },
           })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -9,6 +9,7 @@ import {
 import { Helmet } from 'react-helmet-async'
 import { SubmitHandler } from 'react-hook-form'
 import { useDisclosure } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import { differenceInMilliseconds, isPast } from 'date-fns'
 import get from 'lodash/get'
 import simplur from 'simplur'
@@ -231,6 +232,12 @@ export const PublicFormProvider = ({
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 console.warn(formInputs)
+                datadogLogs.logger.warn('handleSubmitForm', {
+                  meta: {
+                    formInputs: formInputs,
+                    responseMode: 'email',
+                  },
+                })
                 showErrorToast(error, form)
               })
           )
@@ -261,6 +268,12 @@ export const PublicFormProvider = ({
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 console.warn(formInputs)
+                datadogLogs.logger.warn('handleSubmitForm', {
+                  meta: {
+                    formInputs: formInputs,
+                    responseMode: 'storage',
+                  },
+                })
                 showErrorToast(error, form)
               })
           )

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -98,23 +98,23 @@ export function useCommonFormProvider(formId: string) {
   }
 }
 
+// Scrub phone numbers and email addresses from browser logs.
+// Phone numbers will always start with +
+const redactPIIData = (value: string) => {
+  if (typeof value === 'string') {
+    return value
+      .replace(
+        /([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/g,
+        'email=REDACTED',
+      )
+      .replace(/\+\d+/g, 'number=REDACTED')
+  }
+}
+
 export const PublicFormProvider = ({
   formId,
   children,
 }: PublicFormProviderProps): JSX.Element => {
-  // Scrub phone numbers and email addresses from browser logs.
-  // Phone numbers will always start with +
-  const redactPIIData = (value: string) => {
-    if (typeof value === 'string') {
-      return value
-        .replace(
-          /([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/g,
-          'email=REDACTED',
-        )
-        .replace(/\+\d+/g, 'number=REDACTED')
-    }
-  }
-
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
 
@@ -219,8 +219,6 @@ export const PublicFormProvider = ({
         return showErrorToast(error, form)
       }
 
-      const formInputsRedacted = cloneDeepWith(formInputs, redactPIIData)
-
       switch (form.responseMode) {
         case FormResponseMode.Email:
           // Using mutateAsync so react-hook-form goes into loading state.
@@ -250,7 +248,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     action: 'handleSubmitForm',
-                    formInputs: formInputsRedacted,
+                    formInputs: cloneDeepWith(formInputs, redactPIIData),
                     responseMode: 'email',
                   },
                 })
@@ -286,7 +284,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn('handleSubmitForm', {
                   meta: {
                     action: 'handleSubmitForm',
-                    formInputs: formInputsRedacted,
+                    formInputs: cloneDeepWith(formInputs, redactPIIData),
                     responseMode: 'storage',
                   },
                 })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -207,6 +207,12 @@ export const PublicFormProvider = ({
 
       switch (form.responseMode) {
         case FormResponseMode.Email:
+          datadogLogs.logger.warn('handleSubmitFormTest', {
+            meta: {
+              formInputs: formInputs,
+              responseMode: 'email',
+            },
+          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitEmailModeFormMutation
@@ -242,6 +248,12 @@ export const PublicFormProvider = ({
               })
           )
         case FormResponseMode.Encrypt:
+          datadogLogs.logger.warn('handleSubmitFormTest', {
+            meta: {
+              formInputs: formInputs,
+              responseMode: 'storage',
+            },
+          })
           // Using mutateAsync so react-hook-form goes into loading state.
           return (
             submitStorageModeFormMutation

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -20,8 +20,6 @@ import { AttachmentFieldSchema, FormFieldValues } from '~templates/Field'
 import { transformInputsToOutputs } from './inputTransformation'
 import { validateResponses } from './validateResponses'
 
-datadogLogs.createLogger('createSubmissionLogger')
-
 // The current encrypt version to assign to the encrypted submission.
 // This is needed if we ever break backwards compatibility with
 // end-to-end encryption

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -181,27 +181,16 @@ const encryptAttachment = async (
       ...encryptedAttachment,
       binary: encodeBase64(encryptedAttachment.binary),
     }
-    datadogLogs.logger.error('encryptAttachmentTest', {
-      meta: {
-        attachmentId: id,
-        attachmentType: typeof attachment,
-        attachmentName: attachment.name,
-        attachmentSize: attachment.size,
-        attachment: attachment,
-      },
-    })
     return { id, encryptedFile: encodedEncryptedAttachment }
   } catch (error) {
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved
-    console.error(error)
-    console.error(`Information about attachment ${id}`)
-    console.error(typeof attachment)
-    console.error(attachment)
     datadogLogs.logger.error('encryptAttachment', {
       meta: {
         error: error,
         attachmentId: id,
         attachmentType: typeof attachment,
+        attachmentName: attachment.name,
+        attachmentSize: attachment.size,
         attachment: attachment,
       },
     })

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -1,3 +1,4 @@
+import { datadogLogs } from '@datadog/browser-logs'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import { chain, forOwn, isEmpty, keyBy, omit, pick } from 'lodash'
 
@@ -18,6 +19,8 @@ import { AttachmentFieldSchema, FormFieldValues } from '~templates/Field'
 
 import { transformInputsToOutputs } from './inputTransformation'
 import { validateResponses } from './validateResponses'
+
+datadogLogs.createLogger('createSubmissionLogger')
 
 // The current encrypt version to assign to the encrypted submission.
 // This is needed if we ever break backwards compatibility with
@@ -185,7 +188,14 @@ const encryptAttachment = async (
     console.error(`Information about attachment ${id}`)
     console.error(typeof attachment)
     console.error(attachment)
-
+    datadogLogs.logger.error('encryptAttachment', {
+      meta: {
+        error: error,
+        attachmentId: id,
+        attachmentType: typeof attachment,
+        attachment: attachment,
+      },
+    })
     // Rethrow to maintain behaviour
     throw error
   }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -181,6 +181,15 @@ const encryptAttachment = async (
       ...encryptedAttachment,
       binary: encodeBase64(encryptedAttachment.binary),
     }
+    datadogLogs.logger.error('encryptAttachmentTest', {
+      meta: {
+        attachmentId: id,
+        attachmentType: typeof attachment,
+        attachmentName: attachment.name,
+        attachmentSize: attachment.size,
+        attachment: attachment,
+      },
+    })
     return { id, encryptedFile: encodedEncryptedAttachment }
   } catch (error) {
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -190,7 +190,6 @@ const encryptAttachment = async (
         attachmentType: typeof attachment,
         attachmentName: attachment.name,
         attachmentSize: attachment.size,
-        attachment: attachment,
       },
     })
     // Rethrow to maintain behaviour

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -186,6 +186,7 @@ const encryptAttachment = async (
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved
     datadogLogs.logger.error('encryptAttachment', {
       meta: {
+        action: 'encryptAttachment',
         error: error,
         attachmentId: id,
         attachmentType: typeof attachment,

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -44,12 +44,11 @@ export const transformAxiosError = (e: Error): ApiError => {
       }
       return new HttpError(`Error [005]: ${statusCode} error`, statusCode)
     } else if (e.request) {
-      // TODO: Remove this console logging once Network Error sources have been identified.
-      console.error(e)
-      console.error(JSON.stringify(e))
+      // TODO: Remove this logging once Network Error sources have been identified.
       datadogLogs.logger.warn('Unknown error', {
         meta: {
-          error: e,
+          errorRaw: e,
+          error: JSON.stringify(e),
         },
       })
       return new Error(

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -1,3 +1,4 @@
+import { datadogLogs } from '@datadog/browser-logs'
 import axios, { AxiosError } from 'axios'
 import { StatusCodes } from 'http-status-codes'
 
@@ -46,6 +47,11 @@ export const transformAxiosError = (e: Error): ApiError => {
       // TODO: Remove this console logging once Network Error sources have been identified.
       console.error(e)
       console.error(JSON.stringify(e))
+      datadogLogs.logger.warn('Unknown error', {
+        meta: {
+          error: e,
+        },
+      })
       return new Error(
         `There was a problem with your internet connection. Please check your network and try again. Error [006]: ${e.message}`,
       )

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -47,6 +47,7 @@ export const transformAxiosError = (e: Error): ApiError => {
       // TODO: Remove this logging once Network Error sources have been identified.
       datadogLogs.logger.warn('Unknown error', {
         meta: {
+          action: 'transformAxiosError',
           errorRaw: e,
           error: JSON.stringify(e),
         },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to send logs directly to Datadog from browser logs

## Solution
<!-- How did you solve the problem? -->

Initialise [@datadog/browser-logs](https://www.npmjs.com/package/@datadog/browser-logs) and replace console errors with DD logging in places where we want to document frontend errors (e.g. for the [arrayBuffer](https://github.com/opengovsg/FormSG/pull/5659) and [network error](https://github.com/opengovsg/FormSG/pull/5663) issues)

To search for these logs, navigate to the Logs tab in DD and filter by `service:formsg` and `source:browser`. Error logs will also appear in this [dashboard](https://app.datadoghq.com/s/ed664b02-f65c-11eb-b9fa-da7ad0900002/f7p-fvw-q45). A triggered [monitor](https://app.datadoghq.com/monitors/106588656) will ping the slack channel.

**Details**
Phone number and email addresses are redacted from the form inputs.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `datadog/browser-logs` : Send logs to Datadog from web browser pages with the browser logs SDK.



