### PR TITLE
feat: improved FE logging for unexpected errors

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormPageService.ts
+++ b/frontend/src/features/admin-form/common/AdminFormPageService.ts
@@ -2,7 +2,7 @@ import { EndPageUpdateDto, StartPageUpdateDto } from '~shared/types'
 
 import { ApiService } from '~services/ApiService'
 
-const ADMIN_FORM_ENDPOINT = 'admin/forms'
+const ADMIN_FORM_ENDPOINT = '/admin/forms'
 
 /**
  * Updates the start page for the given form referenced by its id

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -231,9 +231,14 @@ export const PublicFormProvider = ({
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
-                  action: 'handleSubmitForm',
-                  responseMode: 'email',
-                  error,
+                  meta: {
+                    action: 'handleSubmitForm',
+                    responseMode: 'email',
+                    error: {
+                      message: error.message,
+                      stack: error.stack,
+                    },
+                  },
                 })
                 showErrorToast(error, form)
               })
@@ -264,9 +269,14 @@ export const PublicFormProvider = ({
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
-                  action: 'handleSubmitForm',
-                  responseMode: 'storage',
-                  error,
+                  meta: {
+                    action: 'handleSubmitForm',
+                    responseMode: 'storage',
+                    error: {
+                      message: error.message,
+                      stack: error.stack,
+                    },
+                  },
                 })
                 showErrorToast(error, form)
               })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -230,13 +230,10 @@ export const PublicFormProvider = ({
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
-                datadogLogs.logger.warn('handleSubmitForm', {
-                  meta: {
-                    action: 'handleSubmitForm',
-                    responseMode: 'email',
-                    error: error,
-                    message: error.message,
-                  },
+                datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
+                  action: 'handleSubmitForm',
+                  responseMode: 'email',
+                  error,
                 })
                 showErrorToast(error, form)
               })
@@ -266,13 +263,10 @@ export const PublicFormProvider = ({
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
               .catch((error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
-                datadogLogs.logger.warn('handleSubmitForm', {
-                  meta: {
-                    action: 'handleSubmitForm',
-                    responseMode: 'storage',
-                    error: error,
-                    message: error.message,
-                  },
+                datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
+                  action: 'handleSubmitForm',
+                  responseMode: 'storage',
+                  error,
                 })
                 showErrorToast(error, form)
               })

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -188,15 +188,20 @@ const encryptAttachment = async (
   } catch (error) {
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved
     datadogLogs.logger.error(`encryptAttachment: ${label}: ${error?.message}`, {
-      error,
-      attachment: {
-        id,
-        type: typeof attachment,
-        extension: attachment.name?.split('.').pop(),
-        size: attachment.size,
-        isBlob: attachment instanceof Blob,
-        isFile: attachment instanceof File,
-        arrayBuffer: typeof attachment.arrayBuffer,
+      meta: {
+        error: {
+          message: error?.message,
+          stack: error?.stack,
+        },
+        attachment: {
+          id,
+          type: typeof attachment,
+          extension: attachment.name?.split('.').pop(),
+          size: attachment.size,
+          isBlob: attachment instanceof Blob,
+          isFile: attachment instanceof File,
+          arrayBuffer: typeof attachment.arrayBuffer,
+        },
       },
     })
     // Rethrow to maintain behaviour

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -101,19 +101,17 @@ const getEncryptedAttachmentsMap = async (
 ): Promise<StorageModeAttachmentsMap> => {
   const attachmentsMap = getAttachmentsMap(formFields, formInputs)
 
-  const attachmentPromises = Object.keys(attachmentsMap).map((id) =>
-    encryptAttachment(attachmentsMap[id], { id, publicKey }),
+  const attachmentPromises = Object.entries(attachmentsMap).map(
+    ([id, attachment]) => encryptAttachment(attachment, { id, publicKey }),
   )
 
-  return Promise.all(attachmentPromises).then((encryptedAttachmentsMeta) => {
-    return (
-      chain(encryptedAttachmentsMeta)
-        .keyBy('id')
-        // Remove id from object.
-        .mapValues((v) => omit(v, 'id'))
-        .value()
-    )
-  })
+  return Promise.all(attachmentPromises).then((encryptedAttachmentsMeta) =>
+    chain(encryptedAttachmentsMeta)
+      .keyBy('id')
+      // Remove id from object.
+      .mapValues((v) => omit(v, 'id'))
+      .value(),
+  )
 }
 
 const getAttachmentsMap = (

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -188,18 +188,15 @@ const encryptAttachment = async (
   } catch (error) {
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved
     datadogLogs.logger.error(`encryptAttachment: ${label}: ${error?.message}`, {
-      meta: {
-        action: 'encryptAttachment',
-        error,
-        attachment: {
-          id,
-          type: typeof attachment,
-          extension: attachment.name?.split('.').pop(),
-          size: attachment.size,
-          isBlob: attachment instanceof Blob,
-          isFile: attachment instanceof File,
-          arrayBuffer: typeof attachment.arrayBuffer,
-        },
+      error,
+      attachment: {
+        id,
+        type: typeof attachment,
+        extension: attachment.name?.split('.').pop(),
+        size: attachment.size,
+        isBlob: attachment instanceof Blob,
+        isFile: attachment instanceof File,
+        arrayBuffer: typeof attachment.arrayBuffer,
       },
     })
     // Rethrow to maintain behaviour

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -192,21 +192,24 @@ const encryptAttachment = async (
     return { id, encryptedFile: encodedEncryptedAttachment }
   } catch (error) {
     // TODO: remove error logging when error about arrayBuffer not being a function is resolved
-    datadogLogs.logger.error('encryptAttachment', {
-      meta: {
-        action: 'encryptAttachment',
-        error,
-        message: error?.message,
-        marker,
-        attachment: {
-          id,
-          type: typeof attachment,
-          extension: attachment.name?.split('.').pop(),
-          size: attachment.size,
-          arrayBuffer: typeof attachment.arrayBuffer,
+    datadogLogs.logger.error(
+      `encryptAttachment error [${marker}]: ${error?.message}`,
+      {
+        meta: {
+          action: 'encryptAttachment',
+          error,
+          attachment: {
+            id,
+            type: typeof attachment,
+            extension: attachment.name?.split('.').pop(),
+            size: attachment.size,
+            isBlob: attachment instanceof Blob,
+            isFile: attachment instanceof File,
+            arrayBuffer: typeof attachment.arrayBuffer,
+          },
         },
       },
-    })
+    )
     // Rethrow to maintain behaviour
     throw error
   }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -46,8 +46,13 @@ export const transformAxiosError = (error: Error): ApiError => {
     } else if (error.request) {
       // TODO: Remove this logging once Network Error sources have been identified.
       datadogLogs.logger.warn(`Unknown error: ${error.message}`, {
-        action: 'transformAxiosError',
-        error,
+        meta: {
+          action: 'transformAxiosError',
+          error: {
+            message: error?.message,
+            stack: error?.stack,
+          },
+        },
       })
       return new Error(
         `There was a problem with your internet connection. Please check your network and try again. Error [006]: ${error.message}`,

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -20,44 +20,41 @@ export class HttpError extends Error {
  *
  * @returns HttpError if AxiosError, else original error
  */
-export const transformAxiosError = (e: Error): ApiError => {
-  if (axios.isAxiosError(e)) {
-    if (e.response) {
-      const statusCode = e.response.status
+export const transformAxiosError = (error: Error): ApiError => {
+  if (axios.isAxiosError(error)) {
+    if (error.response) {
+      const statusCode = error.response.status
       if (statusCode === StatusCodes.TOO_MANY_REQUESTS) {
         return new HttpError('Error [001]: Please try again later.', statusCode)
       }
-      if (typeof e.response.data === 'string') {
-        return new HttpError(`Error [002]: ${e.response.data}`, statusCode)
+      if (typeof error.response.data === 'string') {
+        return new HttpError(`Error [002]: ${error.response.data}`, statusCode)
       }
-      if (e.response.data?.message) {
+      if (error.response.data?.message) {
         return new HttpError(
-          `Error [003]: ${e.response.data.message}`,
+          `Error [003]: ${error.response.data.message}`,
           statusCode,
         )
       }
-      if (e.response.statusText) {
+      if (error.response.statusText) {
         return new HttpError(
-          `Error [004]: ${e.response.statusText}`,
+          `Error [004]: ${error.response.statusText}`,
           statusCode,
         )
       }
       return new HttpError(`Error [005]: ${statusCode} error`, statusCode)
-    } else if (e.request) {
+    } else if (error.request) {
       // TODO: Remove this logging once Network Error sources have been identified.
-      datadogLogs.logger.warn(`Unknown error: ${e.message}`, {
-        meta: {
-          action: 'transformAxiosError',
-          errorRaw: e,
-          error: JSON.stringify(e),
-        },
+      datadogLogs.logger.warn(`Unknown error: ${error.message}`, {
+        action: 'transformAxiosError',
+        error,
       })
       return new Error(
-        `There was a problem with your internet connection. Please check your network and try again. Error [006]: ${e.message}`,
+        `There was a problem with your internet connection. Please check your network and try again. Error [006]: ${error.message}`,
       )
     }
   }
-  return e
+  return error
 }
 
 // Create own axios instance with defaults.

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -45,7 +45,7 @@ export const transformAxiosError = (e: Error): ApiError => {
       return new HttpError(`Error [005]: ${statusCode} error`, statusCode)
     } else if (e.request) {
       // TODO: Remove this logging once Network Error sources have been identified.
-      datadogLogs.logger.warn('Unknown error', {
+      datadogLogs.logger.warn(`Unknown error: ${e.message}`, {
         meta: {
           action: 'transformAxiosError',
           errorRaw: e,


### PR DESCRIPTION
## Context

We are receiving frontend errors that we haven't managed to reproduce. These errors are not tracked automatically by RUM because they are caught and displayed in a user toast. 

That is enough information to lead us in the right direction but not enough to toubleshoot definitely.

We have previously added DD browser logs but they are still not sufficient.


## Approach

Several incremental improvements are done to make the log more useful to us:
* Add more context fields into error logs
* Split code known to give error into recognizable steps in logs

Additional bonus refactoring
* in APIService's `transformAxiosError()` method, get rid of single letter variable
* minor code reduction in `createSubmission.ts`

