### PR TITLE
fix: date picker calendar select correct date in negative UTC offset timezones

### DIFF
--- a/frontend/src/components/DatePicker/DatePickerContext.tsx
+++ b/frontend/src/components/DatePicker/DatePickerContext.tsx
@@ -84,7 +84,7 @@ const useProvideDatePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
   locale,
   isDateUnavailable,
   allowManualInput = true,


### PR DESCRIPTION
This PR fixes an issue brought up in #5510. It seems to be caused modifications to date in `handleDateChange`. 
demo:
https://user-images.githubusercontent.com/39296145/216810183-b8ca0036-416b-45c1-be25-530eb6c90729.mov


1. Date picker selection returns date at 00:00:00 in local timezone
2. Default 'UTC' string is passed to `zonedTimeToUtc`
3. `zonedTimeToUtc` returns equivalent datetime in UTC after comparing local timezone to 'UTC' time
4. Any local timezone that is negative offset from UTC will result in the date being change to the day before.

For better visualisation:
*BEFORE*
<img width="988" alt="Screen Shot 2023-02-05 at 2 08 35 AM" src="https://user-images.githubusercontent.com/39296145/216809604-ad1704eb-9d8d-4ec8-ac7d-8d3315a5cdca.png">

*AFTER*
<img width="988" alt="Screen Shot 2023-02-05 at 2 07 19 AM" src="https://user-images.githubusercontent.com/39296145/216809610-942b5333-de0e-4c84-a0c6-c47699c8df7e.png">

## Solution
Instead of specifying 'UTC' to `zoneTimeToUtc`, provide the local timezone instead. This fixes the issue but I'm not actually sure whether its correct as it feels like its just reversing the use of `zoneTimeToUtc`. More info at [marnusw/date-fns-tz.js#174](https://github.com/marnusw/date-fns-tz/issues/174)

I believe this can be discussed further @karrui

**Breaking Changes** 
No - this PR is backwards compatible  

