### PR TITLE
fix: save secret key per form with useQuery to prevent need for entering secret key

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useSecretKey.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useSecretKey.ts
@@ -1,7 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { useQuery, useQueryClient } from 'react-query'
 import { BroadcastChannel } from 'broadcast-channel'
 
 import { useHasChanged } from '~hooks/useHasChanged'
+
+import { adminFormResponsesKeys } from '../../queries'
 
 const SECRETKEY_BROADCAST_KEY = 'formsg_private_key_sharing'
 
@@ -17,7 +20,21 @@ type SecretKeyBroadcastMessage =
     }
 
 export const useSecretKey = (formId: string) => {
-  const [secretKey, setSecretKey] = useState<string>()
+  const { data: secretKey } = useQuery({
+    queryKey: adminFormResponsesKeys.secretKey(formId),
+    initialData: '',
+  })
+
+  const queryClient = useQueryClient()
+  const setSecretKey = useCallback(
+    (secretKey: string) =>
+      queryClient.setQueryData(
+        adminFormResponsesKeys.secretKey(formId),
+        secretKey,
+      ),
+    [formId, queryClient],
+  )
+
   const hasSecretKeyChanged = useHasChanged(secretKey)
 
   // BroadcastChannel will only broadcast the message to scripts from the same origin
@@ -80,7 +97,7 @@ export const useSecretKey = (formId: string) => {
         }
       }
     }
-  }, [secretKey, formId])
+  }, [secretKey, formId, setSecretKey])
 
   return [secretKey, setSecretKey] as const
 }

--- a/frontend/src/features/admin-form/responses/queries.ts
+++ b/frontend/src/features/admin-form/responses/queries.ts
@@ -35,6 +35,7 @@ export const adminFormResponsesKeys = {
   },
   individual: (id: string, submissionId: string) =>
     [...adminFormResponsesKeys.id(id), 'individual', submissionId] as const,
+  secretKey: (id: string) => [...adminFormResponsesKeys.id(id), 'secretKey'],
 }
 
 export const adminFormFeedbackKeys = {


### PR DESCRIPTION
## Problem
Users need to key in secret key each time they exit the form. PR also serves to achieve feature parity with angular

Closes #5514

## Solution
use useQuery to store secretKey per form. Maintained signature of secretKey and setSecretKey in `useSecretKeys.ts` for minimal code change. queryFn resolves to string for type inference. Set stale time to infinity so that queryFn is never called again, resetting secretKey. 

cc @amitogp @kennethchangOPENGOV

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  