### PR TITLE
chore: update README.md to fix bug on first setup instructions (export NODE_OPTIONS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm install --legacy-peer-deps
 To prevent breaking changes to webpack4 introduced in node 17 and above, enable the `--openssl-legacy-provider` flag:
 
 ```bash
-export NODE_OPTIONS= --openssl-legacy-provider
+export NODE_OPTIONS=--openssl-legacy-provider
 ```
 
 If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of 4GB) by clicking on the Docker icon on the toolbar, clicking on the "Preferences" menu item, then clicking on the "Resources" link on the left.


### PR DESCRIPTION
No spaces around = in bash

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Space after ```=``` before ```--openssl-legacy-provider``` causing issues during initial setup. This is on README.md,

```
$ export NODE_OPTIONS= --openssl-legacy-provider
bash: export: `--openssl-legacy-provider': not a valid identifier
```

Closes #5744

## Solution
<!-- How did you solve the problem? -->

Remove the space.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

Fixes README.md setup documentation. Removed space on:

```
export NODE_OPTIONS= --openssl-legacy-provider
```

After:

```
export NODE_OPTIONS=--openssl-legacy-provider
```

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
