### PR TITLE
fix: inefficient form metadata query leading to excessive memory usage

### DIFF
--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -1,6 +1,5 @@
 import moment from 'moment-timezone'
 import mongoose, { Mongoose, QueryCursor, Schema } from 'mongoose'
-import type { FixedLengthArray } from 'type-fest'
 
 import {
   FormAuthType,
@@ -274,10 +273,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
  * Unexported as the type is only used in {@see findAllMetadataByFormId} for
  * now.
  */
-type MetadataAggregateResult = {
-  pageResults: Pick<ISubmissionSchema, '_id' | 'created'>[]
-  allResults: FixedLengthArray<{ count: number }, 1> | []
-}
+type MetadataAggregateResult = Pick<ISubmissionSchema, '_id' | 'created'>
 
 EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
   formId: string,
@@ -294,54 +290,60 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
 }> {
   const numToSkip = (page - 1) * pageSize
 
-  return (
-    this.aggregate()
-      .match({
-        // Casting to ObjectId as Mongoose does not cast pipeline stages.
-        // See https://mongoosejs.com/docs/api.html#aggregate_Aggregate.
+  // return documents within the page
+  const pageResults = this.aggregate<MetadataAggregateResult>([
+    {
+      $match: {
         form: mongoose.Types.ObjectId(formId),
         submissionType: SubmissionType.Encrypt,
-      })
-      .sort({ created: -1 })
-      .facet({
-        pageResults: [
-          { $skip: numToSkip },
-          { $limit: pageSize },
-          { $project: { _id: 1, created: 1 } },
-        ],
-        allResults: [
-          { $group: { _id: null, count: { $sum: 1 } } },
-          { $project: { _id: 0 } },
-        ],
-      })
-      // prevents out-of-memory for large search results (max 100MB).
-      .allowDiskUse(true)
-      .then((result: MetadataAggregateResult[]) => {
-        const [{ pageResults, allResults }] = result
-        const [numResults] = allResults
-        const count = numResults?.count ?? 0
+      },
+    },
+    {
+      $sort: {
+        created: -1,
+      },
+    },
+    {
+      $skip: numToSkip,
+    },
+    {
+      $limit: pageSize,
+    },
+    {
+      $project: {
+        _id: 1,
+        created: 1,
+      },
+    },
+  ])
 
-        let currentNumber = count - numToSkip
+  const count =
+    this.countDocuments({
+      form: mongoose.Types.ObjectId(formId),
+      submissionType: SubmissionType.Encrypt,
+    }).exec() ?? 0
 
-        const metadata = pageResults.map((data) => {
-          const metadataEntry: StorageModeSubmissionMetadata = {
-            number: currentNumber,
-            refNo: data._id,
-            submissionTime: moment(data.created)
-              .tz('Asia/Singapore')
-              .format('Do MMM YYYY, h:mm:ss a'),
-          }
+  return Promise.all([pageResults, count]).then(([result, count]) => {
+    let currentNumber = count - numToSkip
 
-          currentNumber--
-          return metadataEntry
-        })
+    const metadata = result.map((data) => {
+      const metadataEntry: StorageModeSubmissionMetadata = {
+        number: currentNumber,
+        refNo: data._id,
+        submissionTime: moment(data.created)
+          .tz('Asia/Singapore')
+          .format('Do MMM YYYY, h:mm:ss a'),
+      }
 
-        return {
-          metadata,
-          count,
-        }
-      })
-  )
+      currentNumber--
+      return metadataEntry
+    })
+
+    return {
+      metadata,
+      count,
+    }
+  })
 }
 
 EncryptSubmissionSchema.statics.getSubmissionCursorByFormId = function (


### PR DESCRIPTION
## Problem

- We have been seeing very slow `formsg.submissions` operations which have very high db disk util
- Initial suspicion was that this was due to download of large forms

- Closes #3394

## Solution
- For load test example, see forms `63e9b7e27e26fb0012795ca8` (200k small responses) and `63e9d46e6d6d6f0012d14402` (20k large responses of >700KB each) on staging (log in using form team email, key in 1pw).
- It turns out that response download is already efficient. The current implementation returns a cursor which iterates over the matching documents. It appears that mongoDB has implemented this in a non-blocking fashion (from testing, multiple concurrent downloads of large forms can proceed concurrently without spike in disk util).
- Instead, the reason for the high disk utilisation was inefficient query implementation in the `/metadata` endpoint, which returns response metadata for storage mode submissions. This is triggered once the admin navigates to response tab.
  - In `submission.server.model.ts`, the following code retrieves all submission documents corresponding to the form, stores it all in memory (or disk, because `allowDiskUse(true)`), in order to count the number of responses. This led to excessive disk utilisation and slow query (see `NOTE` below).
  - To solve this, this has been replaced with a simpler `countDocuments` query.

**Existing code**
```
.facet({
  pageResults: [
    { $skip: numToSkip },
    { $limit: pageSize },
    { $project: { _id: 1, created: 1 } },
  ],
  allResults: [
    { $group: { _id: null, count: { $sum: 1 } } },
    { $project: { _id: 0 } }, // NOTE: Means project ALL fields except _id
  ],
})
// prevents out-of-memory for large search results (max 100MB).
.allowDiskUse(true) 
// NOTE: As the above query required excessive memory, 
// it was written to disk instead and this led to high disk utilisation 
.then((result: MetadataAggregateResult[]) => {
  const [{ pageResults, allResults }] = result
  const [numResults] = allResults
  const count = numResults?.count ?? 0
```

**Improvements**:

## Before & After Screenshots

**BEFORE**:
- Timeout (504) for metadata endpoint for forms with many submissions
<img width="843" alt="timeout" src="https://user-images.githubusercontent.com/63710093/218619800-9faf3aea-9b9b-43e5-84e7-e52977cebe44.png">

- 100% disk utilisation on DB
<img width="480" alt="diskutil" src="https://user-images.githubusercontent.com/63710093/218619827-170974bf-c023-4920-96ca-72c4882f2b07.png">

**AFTER**:

- metadata endpoint resolves in 200+ms
<img width="913" alt="fasteresolve" src="https://user-images.githubusercontent.com/63710093/218621208-ac1c5ce8-36ed-46f0-9ddf-9bdc1b2b6c92.png">

- No impact to db disk util
<img width="460" alt="lowdiskutil" src="https://user-images.githubusercontent.com/63710093/218621043-0b515216-15b6-4888-80c3-5df90b02f02e.png">

## Tests
- [ ] Create storage mode form. Submit 20 responses. Check that metadata and pagination shows correctly on results tab.