### PR TITLE
chore: drop unsafe-perm from dockerfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm=true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -16,7 +16,7 @@ COPY frontend/package.json frontend/package-lock.json ./frontend/
 COPY frontend/patches ./frontend/patches
 
 # Allow running of postinstall scripts
-RUN npm config set unsafe-perm true
+# RUN npm config set unsafe-perm true
 # --legacy-peer-deps flag
 # A breaking change in the peer dependency resolution strategy was introduced in
 # npm 7. This resulted in npm throwing an error when installing packages:


### PR DESCRIPTION
## Problem

Build process for deployment is broken `set unsafe-perm true` no longer works (for some reason)

## Solution
Drop setting `unsafe-perm` via a config set command
