### PR TITLE
chore: remove instrumentation for email performance monitoring and SES migration

### DIFF
--- a/__tests__/e2e/setup/.test-env
+++ b/__tests__/e2e/setup/.test-env
@@ -60,12 +60,6 @@ SESSION_SECRET=sandcrawler-138577
 SES_PORT=1025 
 SES_HOST=0.0.0.0
 
-# TODO #130 Remove these when SES migration is over (opengovsg/formsg-private#130)
-SES_PORT_US=1025
-SES_HOST_US=0.0.0.0
-SES_PORT_SG=1025
-SES_HOST_SG=0.0.0.0
-
 SERVICES=s3
 
 IMAGE_S3_BUCKET=local-image-bucket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,11 +33,8 @@ services:
       - SECRET_ENV=development
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60
-      # TODO(opengovsg/formsg-private#130) Retain only SG env vars when SES migration is over
-      - SES_PORT_US=1025
-      - SES_HOST_US=maildev
-      - SES_PORT_SG=1025
-      - SES_HOST_SG=maildev
+      - SES_PORT=1025
+      - SES_HOST=maildev
       - WEBHOOK_SQS_URL=http://localhost:4566/000000000000/local-webhooks-sqs-main
       - INTRANET_IP_LIST_PATH
       - SENTRY_CONFIG_URL=https://random@sentry.io/123456

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -123,8 +123,7 @@ const dbConfig: DbConfig = {
   },
 }
 
-// TODO #130 Delete this mail config once SES migration is over (opengovsg/formsg-private#130)
-const mailConfig_us: MailConfig = (function () {
+const mailConfig: MailConfig = (function () {
   const mailFrom = basicVars.mail.from
   const official = basicVars.mail.official
   const mailer = {
@@ -135,12 +134,12 @@ const mailConfig_us: MailConfig = (function () {
   let transporter: Mail
   if (!isDev) {
     const options: SMTPPool.Options = {
-      host: prodOnlyVars.host_us,
+      host: prodOnlyVars.host,
       auth: {
-        user: prodOnlyVars.user_us,
-        pass: prodOnlyVars.pass_us,
+        user: prodOnlyVars.user,
+        pass: prodOnlyVars.pass,
       },
-      port: prodOnlyVars.port_us,
+      port: prodOnlyVars.port,
       // Options as advised from https://nodemailer.com/usage/bulk-mail/
       // pool connections instead of creating fresh one for each email
       pool: true,
@@ -157,56 +156,8 @@ const mailConfig_us: MailConfig = (function () {
     transporter = nodemailer.createTransport(options)
   } else {
     transporter = nodemailer.createTransport({
-      port: prodOnlyVars.port_us,
-      host: prodOnlyVars.host_us,
-      ignoreTLS: true,
-    })
-  }
-
-  return {
-    mailFrom,
-    official,
-    mailer,
-    transporter,
-  }
-})()
-
-// TODO #130 Use this mail config when SES migration is over, after renaming env vars back to without _sg suffix (opengovsg/formsg-private#130)
-const mailConfig_sg: MailConfig = (function () {
-  const mailFrom = basicVars.mail.from
-  const official = basicVars.mail.official
-  const mailer = {
-    from: `${basicVars.appConfig.title} <${mailFrom}>`,
-  }
-
-  // Creating mail transport
-  let transporter: Mail
-  if (!isDev) {
-    const options: SMTPPool.Options = {
-      host: prodOnlyVars.host_sg,
-      auth: {
-        user: prodOnlyVars.user_sg,
-        pass: prodOnlyVars.pass_sg,
-      },
-      port: prodOnlyVars.port_sg,
-      // Options as advised from https://nodemailer.com/usage/bulk-mail/
-      // pool connections instead of creating fresh one for each email
-      pool: true,
-      maxMessages: basicVars.mail.maxMessages,
-      maxConnections: basicVars.mail.maxConnections,
-      socketTimeout: basicVars.mail.socketTimeout,
-      // If set to true then logs to console. If value is not set or is false
-      // then nothing is logged.
-      logger: basicVars.mail.logger,
-      // If set to true, then logs SMTP traffic, otherwise logs only transaction
-      // events.
-      debug: basicVars.mail.debug,
-    }
-    transporter = nodemailer.createTransport(options)
-  } else {
-    transporter = nodemailer.createTransport({
-      port: prodOnlyVars.port_sg,
-      host: prodOnlyVars.host_sg,
+      port: prodOnlyVars.port,
+      host: prodOnlyVars.host,
       ignoreTLS: true,
     })
   }
@@ -257,9 +208,7 @@ const config: Config = {
   app: basicVars.appConfig,
   db: dbConfig,
   aws: awsConfig,
-  mail_us: mailConfig_us,
-  mail_sg: mailConfig_sg,
-  nodemailer_sg_warmup_start_date: prodOnlyVars.nodemailer_sg_warmup_start_date,
+  mail: mailConfig,
   cookieSettings,
   isDev,
   nodeEnv,

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -400,30 +400,29 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
 }
 
 export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {
-  // TODO #130 Delete these env vars when SES migration is over (opengovsg/formsg-private#130)
-  port_us: {
+  port: {
     doc: 'SMTP port number',
     format: 'port',
     default: null,
-    env: 'SES_PORT_US',
+    env: 'SES_PORT',
   },
-  host_us: {
+  host: {
     doc: 'SMTP hostname',
     format: String,
     default: null,
-    env: 'SES_HOST_US',
+    env: 'SES_HOST',
   },
-  user_us: {
+  user: {
     doc: 'SMTP username',
     format: String,
     default: null,
-    env: 'SES_USER_US',
+    env: 'SES_USER',
   },
-  pass_us: {
+  pass: {
     doc: 'SMTP password',
     format: String,
     default: null,
-    env: 'SES_PASS_US',
+    env: 'SES_PASS',
     sensitive: true,
   },
   dbHost: {
@@ -454,39 +453,6 @@ export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {
     default: null,
     env: 'DB_HOST',
     sensitive: true,
-  },
-  // TODO #130 Rename these env vars to without the _sg suffix when SES migration is over (opengovsg/formsg-private#130)
-  port_sg: {
-    doc: 'SMTP port number',
-    format: 'port',
-    default: null,
-    env: 'SES_PORT_SG',
-  },
-  host_sg: {
-    doc: 'SMTP hostname',
-    format: String,
-    default: null,
-    env: 'SES_HOST_SG',
-  },
-  user_sg: {
-    doc: 'SMTP username',
-    format: String,
-    default: null,
-    env: 'SES_USER_SG',
-  },
-  pass_sg: {
-    doc: 'SMTP password',
-    format: String,
-    default: null,
-    env: 'SES_PASS_SG',
-    sensitive: true,
-  },
-  // TODO #130 Remove this when SES migration is over (opengovsg/formsg-private#130)
-  nodemailer_sg_warmup_start_date: {
-    doc: 'Date where SG nodemailer client will start sending emails',
-    format: String,
-    default: '2099-01-01T23:59:59+08:00',
-    env: 'NODEMAILER_SG_WARMUP_START_DATE',
   },
 }
 

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -54,9 +54,7 @@ describe('mail.service', () => {
   beforeEach(() => sendMailSpy.mockReset())
 
   const mailService = new MailService({
-    // Remove references to US when SES migration is over (opengovsg/formsg-private#130)
-    transporter_us: mockTransporter,
-    transporter_sg: mockTransporter,
+    transporter: mockTransporter,
     senderMail: MOCK_SENDER_EMAIL,
     officialMail: MOCK_SENDER_EMAIL,
     appName: MOCK_APP_NAME,
@@ -69,9 +67,7 @@ describe('mail.service', () => {
     it('should throw error when invalid senderMail param is passed', () => {
       // Arrange
       const invalidParams = {
-        // TODO #130 Remove references to US when SES migration is over (opengovsg/formsg-private#130)
-        transporter_us: mockTransporter,
-        transporter_sg: mockTransporter,
+        transporter: mockTransporter,
         senderMail: 'notAnEmail',
       }
       // Act + Assert

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1,4 +1,3 @@
-import { tracer } from 'dd-trace'
 import { get, inRange, isEmpty } from 'lodash'
 import moment from 'moment-timezone'
 import { err, errAsync, okAsync, Result, ResultAsync } from 'neverthrow'
@@ -64,21 +63,6 @@ const DEFAULT_RETRY_PARAMS: MailServiceParams['retryParams'] = {
   minTimeout: 5000,
 }
 
-// TODO #130 Delete references to US SES when SES migration is over (opengovsg/formsg-private#130)
-const START_TS = new Date(config.nodemailer_sg_warmup_start_date).getTime()
-const WARM_UP_DURATION = 6 * 7 * 24 * 60 * 60 * 1000 // 6 weeks
-
-const getWarmUpThreshold = () => {
-  // if START_TS is an empty string or unparseable input, set threshold to 0
-  if (isNaN(START_TS)) {
-    return 0
-  }
-  const now = Date.now()
-  const elapsed = Math.max(0, Math.min(now - START_TS, WARM_UP_DURATION))
-  const linear = elapsed / WARM_UP_DURATION
-  return linear * linear
-}
-
 export class MailService {
   /**
    * The application name to be shown in some sent emails' fields such as mail
@@ -91,13 +75,9 @@ export class MailService {
    */
   #appUrl: Required<MailServiceParams>['appUrl']
   /**
-   * The transporter to be used to send mail (SES in US).
-   */
-  #transporter_us: Required<MailServiceParams>['transporter_us']
-  /**
    * The transporter to be used to send mail (SES in SG).
    */
-  #transporter_sg: Required<MailServiceParams>['transporter_sg']
+  #transporter: Required<MailServiceParams>['transporter']
   /**
    * The email string to denote the "from" field of the email.
    */
@@ -123,10 +103,9 @@ export class MailService {
   constructor({
     appName = config.app.title,
     appUrl = config.app.appUrl,
-    transporter_us = config.mail_us.transporter,
-    transporter_sg = config.mail_sg.transporter,
-    senderMail = config.mail_us.mailFrom,
-    officialMail = config.mail_us.official,
+    transporter = config.mail.transporter,
+    senderMail = config.mail.mailFrom,
+    officialMail = config.mail.official,
     retryParams = DEFAULT_RETRY_PARAMS,
   }: MailServiceParams = {}) {
     // Email validation
@@ -147,8 +126,7 @@ export class MailService {
     this.#appUrl = appUrl
     this.#senderMail = senderMail
     this.#senderFromString = `${appName} <${senderMail}>`
-    this.#transporter_us = transporter_us
-    this.#transporter_sg = transporter_sg
+    this.#transporter = transporter
     this.#officialMail = officialMail
     this.#retryParams = retryParams
   }
@@ -178,27 +156,10 @@ export class MailService {
       })
 
       try {
-        const rand = Math.random()
-        const threshold = getWarmUpThreshold()
-        const sendMailFromSG = rand < threshold
-        const info = await tracer.trace('nodemailer/sendMail', () => {
-          const span = tracer.scope().active()
-          if (span) span.setTag('ses.region', sendMailFromSG ? 'sg' : 'us')
-          return sendMailFromSG
-            ? this.#transporter_sg.sendMail(mail)
-            : this.#transporter_us.sendMail(mail)
-        })
-
-        const logNodemailerMeta = {
-          action: 'Nodemailer evaluation done',
-          sendMailFromSG: sendMailFromSG,
-          mathRandom: rand,
-          threshold: threshold,
-          sendFromSGStartDate: START_TS,
-        }
+        const info = this.#transporter.sendMail(mail)
         logger.info({
           message: `Mail successfully sent on attempt ${attemptNum}`,
-          meta: { ...logMeta, info, ...logNodemailerMeta },
+          meta: { ...logMeta, info },
         })
 
         return true

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1,3 +1,4 @@
+import tracer from 'dd-trace'
 import { get, inRange, isEmpty } from 'lodash'
 import moment from 'moment-timezone'
 import { err, errAsync, okAsync, Result, ResultAsync } from 'neverthrow'
@@ -156,7 +157,10 @@ export class MailService {
       })
 
       try {
-        const info = await this.#transporter.sendMail(mail)
+        const info = await tracer.trace('nodemailer/sendMail', () =>
+          this.#transporter.sendMail(mail),
+        )
+
         logger.info({
           message: `Mail successfully sent on attempt ${attemptNum}`,
           meta: { ...logMeta, info },

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -156,7 +156,7 @@ export class MailService {
       })
 
       try {
-        const info = this.#transporter.sendMail(mail)
+        const info = await this.#transporter.sendMail(mail)
         logger.info({
           message: `Mail successfully sent on attempt ${attemptNum}`,
           meta: { ...logMeta, info },

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -37,8 +37,7 @@ export type SendAutoReplyEmailsArgs = {
 export type MailServiceParams = {
   appName?: string
   appUrl?: string
-  transporter_us?: Mail
-  transporter_sg?: Mail
+  transporter?: Mail
   senderMail?: string
   officialMail?: string
   retryParams?: Partial<OperationOptions>

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -1,3 +1,4 @@
+import tracer from 'dd-trace'
 import dedent from 'dedent-js'
 import ejs, { Data } from 'ejs'
 import { flattenDeep } from 'lodash'
@@ -170,24 +171,26 @@ export const generateAutoreplyPdf = (
     },
   })
 
-  return safeRenderFile(pathToTemplate, renderData).andThen((summaryHtml) => {
-    return ResultAsync.fromPromise(
-      generateAutoreplyPdfPromise(summaryHtml),
-      (error) => {
-        logger.error({
-          meta: {
-            action: 'generateAutoreplyPdf',
-          },
-          message: 'Error occurred whilst generating autoreply PDF',
-          error,
-        })
+  return tracer.trace('generateAutoreplyPdf', () =>
+    safeRenderFile(pathToTemplate, renderData).andThen((summaryHtml) => {
+      return ResultAsync.fromPromise(
+        generateAutoreplyPdfPromise(summaryHtml),
+        (error) => {
+          logger.error({
+            meta: {
+              action: 'generateAutoreplyPdf',
+            },
+            message: 'Error occurred whilst generating autoreply PDF',
+            error,
+          })
 
-        return new MailGenerationError(
-          'Error occurred whilst generating autoreply PDF',
-        )
-      },
-    )
-  })
+          return new MailGenerationError(
+            'Error occurred whilst generating autoreply PDF',
+          )
+        },
+      )
+    }),
+  )
 }
 
 export const generateAutoreplyHtml = (

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -1,4 +1,3 @@
-import tracer from 'dd-trace'
 import dedent from 'dedent-js'
 import ejs, { Data } from 'ejs'
 import { flattenDeep } from 'lodash'
@@ -171,27 +170,24 @@ export const generateAutoreplyPdf = (
     },
   })
 
-  // TODO: Remove tracer once issue is resolved.
-  return tracer.trace('generateAutoreplyPdf', () =>
-    safeRenderFile(pathToTemplate, renderData).andThen((summaryHtml) => {
-      return ResultAsync.fromPromise(
-        generateAutoreplyPdfPromise(summaryHtml),
-        (error) => {
-          logger.error({
-            meta: {
-              action: 'generateAutoreplyPdf',
-            },
-            message: 'Error occurred whilst generating autoreply PDF',
-            error,
-          })
+  return safeRenderFile(pathToTemplate, renderData).andThen((summaryHtml) => {
+    return ResultAsync.fromPromise(
+      generateAutoreplyPdfPromise(summaryHtml),
+      (error) => {
+        logger.error({
+          meta: {
+            action: 'generateAutoreplyPdf',
+          },
+          message: 'Error occurred whilst generating autoreply PDF',
+          error,
+        })
 
-          return new MailGenerationError(
-            'Error occurred whilst generating autoreply PDF',
-          )
-        },
-      )
-    }),
-  )
+        return new MailGenerationError(
+          'Error occurred whilst generating autoreply PDF',
+        )
+      },
+    )
+  })
 }
 
 export const generateAutoreplyHtml = (

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -72,10 +72,7 @@ export type Config = {
   app: AppConfig
   db: DbConfig
   aws: AwsConfig
-  // TODO #130 Remove references to US SES when SES migration is over (opengovsg/formsg-private#130)
-  mail_us: MailConfig
-  mail_sg: MailConfig
-  nodemailer_sg_warmup_start_date: string
+  mail: MailConfig
 
   cookieSettings: SessionOptions['cookie']
   // Consts
@@ -110,17 +107,11 @@ export type Config = {
 
 // Interface
 export interface IProdOnlyVarsSchema {
-  // TODO #130 Remove references to US SES when SES migration is over (opengovsg/formsg-private#130)
-  port_us: number
-  host_us: string
-  user_us: string
-  pass_us: string
+  port: number
+  host: string
+  user: string
+  pass: string
   dbHost: string
-  port_sg: number
-  host_sg: string
-  user_sg: string
-  pass_sg: string
-  nodemailer_sg_warmup_start_date: string
 }
 
 export interface ICompulsoryVarsSchema {

--- a/tests/.test-env
+++ b/tests/.test-env
@@ -48,12 +48,6 @@ SESSION_SECRET=sandcrawler-138577
 SES_PORT=1025 
 SES_HOST=0.0.0.0
 
-# TODO #130 Remove these when SES migration is over (opengovsg/formsg-private#130)
-SES_PORT_US=1025
-SES_HOST_US=0.0.0.0
-SES_PORT_SG=1025
-SES_HOST_SG=0.0.0.0
-
 SERVICES=s3
 
 IMAGE_S3_BUCKET=local-image-bucket


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We created additional instrumentation over our mailing system in #5019 and #5369 and #5442. This PR tears them down, since they are not needed anymore.

Closes https://github.com/opengovsg/formsg-private/issues/130 and closes https://github.com/opengovsg/formsg-private/issues/132.

Cleaning up old SES config will also close https://github.com/opengovsg/formsg-private/issues/91.

## Solution

Delete code that references datadog traces and SES in the US.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [x] OTP emails can be sent to admins to log in.
- [x] Email responses can be sent to admins after submitting an email mode form.
- [x] OTP emails can be sent to respondents when verifying an email in a public form.
- [x] Confirmation emails can be sent to respondents when submitting and email mode form.

## Deploy Notes

**New environment variables**:

for `x` = `HOST`, `PORT`, `USER`, `PASS`:

- `SES_{x}` : Should be the value of the old variable `SES_{x}_SG`
- `SES_{x}_US` and `SES_{x}_SG`: Should be deleted