### PR TITLE
fix(a11y): move aria required and invalid from individual rating options to rating group

### DIFF
--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -54,6 +54,16 @@ export interface RatingProps {
    * Whether the rating field is disabled.
    */
   isDisabled?: boolean
+
+  /**
+   * Whether the rating field is required.
+   */
+  isRequired: boolean
+
+  /**
+   * Title of the rating field to label the rating group
+   */
+  fieldTitle: string
 }
 
 export const Rating = forwardRef<RatingProps, 'input'>(
@@ -68,6 +78,8 @@ export const Rating = forwardRef<RatingProps, 'input'>(
       wrapComponentsPerRow = 5,
       helperText,
       isDisabled,
+      isRequired,
+      fieldTitle,
     },
     ref,
   ) => {
@@ -140,6 +152,9 @@ export const Rating = forwardRef<RatingProps, 'input'>(
       >
         <Stack
           gridArea="rating"
+          aria-label={fieldTitle}
+          aria-required={isRequired}
+          role="radiogroup"
           as="fieldset"
           direction={{ base: 'column', md: 'row' }}
           spacing={{ base: '0.5rem', md: '1rem' }}

--- a/frontend/src/components/Field/Rating/Rating.tsx
+++ b/frontend/src/components/Field/Rating/Rating.tsx
@@ -61,6 +61,11 @@ export interface RatingProps {
   isRequired: boolean
 
   /**
+   * Whether the current response is invalid.
+   */
+  isInvalid?: boolean
+
+  /**
    * Title of the rating field to label the rating group
    */
   fieldTitle: string
@@ -79,6 +84,7 @@ export const Rating = forwardRef<RatingProps, 'input'>(
       helperText,
       isDisabled,
       isRequired,
+      isInvalid,
       fieldTitle,
     },
     ref,
@@ -154,6 +160,7 @@ export const Rating = forwardRef<RatingProps, 'input'>(
           gridArea="rating"
           aria-label={fieldTitle}
           aria-required={isRequired}
+          aria-invalid={isInvalid}
           role="radiogroup"
           as="fieldset"
           direction={{ base: 'column', md: 'row' }}

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -1,6 +1,7 @@
 import { HTMLProps, KeyboardEvent, useCallback, useMemo } from 'react'
 import {
   Box,
+  chakra,
   forwardRef,
   Icon,
   useMultiStyleConfig,
@@ -204,20 +205,26 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
     }, [radioProps, colorScheme, inputProps.id, selectedValue, value, variant])
 
     return (
-      <Box _active={{ zIndex: 1 }} _focusWithin={{ zIndex: 1 }}>
-        <input
-          type="radio"
-          aria-checked={isChecked}
-          aria-label={simplur`${value} ${variant}${[value]}[|s]`}
-          {...(isChecked ? { 'data-checked': '' } : {})}
-          {...inputProps}
-          data-testid={inputProps.id}
-          onChange={handleSelect}
-          onKeyDown={handleSpacebar}
-          ref={ref}
-        />
-        {componentToRender}
-      </Box>
+      <chakra.label
+        className="chakra-radio"
+        // This is the adapted line of code which applies the internal label styles
+        // to the whole container
+        {...(isChecked ? { 'data-checked': '' } : {})}
+      >
+        <Box _active={{ zIndex: 1 }} _focusWithin={{ zIndex: 1 }}>
+          <input
+            type="radio"
+            aria-checked={isChecked}
+            aria-label={simplur`${value} ${variant}${[value]}[|s]`}
+            {...inputProps}
+            data-testid={inputProps.id}
+            onChange={handleSelect}
+            onKeyDown={handleSpacebar}
+            ref={ref}
+          />
+          {componentToRender}
+        </Box>
+      </chakra.label>
     )
   },
 )

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -172,6 +172,8 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
       onChange: handleSelect,
       value,
       isDisabled,
+      // Required should apply to rating field rather than individual rating.
+      isRequired: false,
     })
 
     const inputProps = getInputProps()

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -172,8 +172,9 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
       onChange: handleSelect,
       value,
       isDisabled,
-      // Required should apply to rating field rather than individual rating.
+      // Required & invalid should apply to rating field rather than individual rating.
       isRequired: false,
+      isInvalid: false,
     })
 
     const inputProps = getInputProps()

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -181,6 +181,8 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
     const inputProps = getInputProps()
     const radioProps = getCheckboxProps()
 
+    const isChecked = value === selectedValue
+
     const componentToRender = useMemo(() => {
       const props = {
         radioProps,
@@ -205,8 +207,9 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
       <Box _active={{ zIndex: 1 }} _focusWithin={{ zIndex: 1 }}>
         <input
           type="radio"
-          aria-checked={selectedValue === value}
+          aria-checked={isChecked}
           aria-label={simplur`${value} ${variant}${[value]}[|s]`}
+          {...(isChecked ? { 'data-checked': '' } : {})}
           {...inputProps}
           data-testid={inputProps.id}
           onChange={handleSelect}

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -1,7 +1,6 @@
 import { HTMLProps, KeyboardEvent, useCallback, useMemo } from 'react'
 import {
   Box,
-  chakra,
   forwardRef,
   Icon,
   useMultiStyleConfig,
@@ -205,26 +204,20 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
     }, [radioProps, colorScheme, inputProps.id, selectedValue, value, variant])
 
     return (
-      <chakra.label
-        className="chakra-radio"
-        // This is the adapted line of code which applies the internal label styles
-        // to the whole container
-        {...(isChecked ? { 'data-checked': '' } : {})}
-      >
-        <Box _active={{ zIndex: 1 }} _focusWithin={{ zIndex: 1 }}>
-          <input
-            type="radio"
-            aria-checked={isChecked}
-            aria-label={simplur`${value} ${variant}${[value]}[|s]`}
-            {...inputProps}
-            data-testid={inputProps.id}
-            onChange={handleSelect}
-            onKeyDown={handleSpacebar}
-            ref={ref}
-          />
-          {componentToRender}
-        </Box>
-      </chakra.label>
+      <Box _active={{ zIndex: 1 }} _focusWithin={{ zIndex: 1 }}>
+        <input
+          type="radio"
+          aria-checked={isChecked}
+          aria-label={simplur`${value} ${variant}${[value]}[|s]`}
+          {...(isChecked ? { 'data-checked': '' } : {})}
+          {...inputProps}
+          data-testid={inputProps.id}
+          onChange={handleSelect}
+          onKeyDown={handleSpacebar}
+          ref={ref}
+        />
+        {componentToRender}
+      </Box>
     )
   },
 )

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -6,6 +6,7 @@ import {
   useMultiStyleConfig,
   useRadio,
 } from '@chakra-ui/react'
+import simplur from 'simplur'
 
 import { BxHeart, BxsHeart, BxsStar, BxStar } from '~assets/icons'
 import { RATING_THEME_KEY } from '~theme/components/Field/Rating'
@@ -205,7 +206,7 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
         <input
           type="radio"
           aria-checked={selectedValue === value}
-          aria-label={`${value} ${variant}${value === 1 ? '' : 's'}`}
+          aria-label={simplur`${value} ${variant}${[value]}[|s]`}
           {...inputProps}
           data-testid={inputProps.id}
           onChange={handleSelect}

--- a/frontend/src/components/Field/Rating/RatingOption.tsx
+++ b/frontend/src/components/Field/Rating/RatingOption.tsx
@@ -204,6 +204,7 @@ export const RatingOption = forwardRef<RatingOptionProps, 'input'>(
         <input
           type="radio"
           aria-checked={selectedValue === value}
+          aria-label={`${value} ${variant}${value === 1 ? '' : 's'}`}
           {...inputProps}
           data-testid={inputProps.id}
           onChange={handleSelect}

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -2,7 +2,8 @@
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
 import { useMemo } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useFormState } from 'react-hook-form'
+import { get } from 'lodash'
 
 import { FormColorTheme } from '~shared/types'
 import { RatingShape } from '~shared/types/field'
@@ -45,6 +46,7 @@ export const RatingField = ({
   }, [schema.ratingOptions.shape])
 
   const { control } = useFormContext<SingleAnswerFieldInput>()
+  const { errors } = useFormState<SingleAnswerFieldInput>()
 
   return (
     <FieldContainer schema={schema}>
@@ -59,6 +61,7 @@ export const RatingField = ({
             variant={ratingVariant}
             value={transform.toNumber(value)}
             isRequired={schema.required}
+            isInvalid={!!get(errors, schema._id)}
             fieldTitle={schema.title}
             onChange={(val) => onChange(transform.toString(val))}
             {...rest}

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -58,6 +58,8 @@ export const RatingField = ({
             numberOfRatings={schema.ratingOptions.steps}
             variant={ratingVariant}
             value={transform.toNumber(value)}
+            isRequired={schema.required}
+            fieldTitle={schema.title}
             onChange={(val) => onChange(transform.toString(val))}
             {...rest}
           />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently every individual rating option are tagged as aria-required and aria-invalid, which results in Mac Voiceover reading it as 'required selected invalid data'. 

Additionally, the labels of the rating option are not informative and aria labels should be implemented to describe how the rating options are visually represented.

Closes [#5503]

## Solution
<!-- How did you solve the problem? -->
Added aria labels to describe the rating options
Remove aria-required and aria-invalid labels by setting them as false (similar to our approach for radio buttons)
Updated Rating field container and Rating group to adopt aria-required and aria-invalid labels

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![Recording 2023-02-14 at 15 53 57](https://user-images.githubusercontent.com/59867455/218674015-9f03c8ee-220c-4370-bd21-88404b9e2061.gif)


**AFTER**:
<!-- [insert screenshot here] -->
![Recording 2023-02-14 at 15 57 52](https://user-images.githubusercontent.com/59867455/218674267-81c2f103-c4f7-46b7-89e1-741a1dae4e12.gif)


## Tests
<!-- What tests should be run to confirm functionality? -->
On Mac, ensure voiceover is turned on:
- [ ] Go to a form with ratings set as required. Go through the ratings field and ensure that the required label is in the rating group (not each option).
- [ ] Try and submit form without indicating a rating (submission will fail). Voiceover will redirect to top of form. Go to ratings field and make sure 'invalid' label is together with the required label in the rating group (not each option). Select an option, submit the form.
- [ ] Go to a form with ratings, but not set as required. Go through the ratings field. Ensure that no required label is tagged on to the rating field (group or individual options). Submit the form.

On iOS, ensure voiceover is turned on:
- [ ] Go to a form with ratings set as required. Go through the ratings field and ensure that the required label is in the rating group. Ensure that each individual option do not read 'required' and do not read 'unticked' when it is selected.