### PR TITLE
fix(a11y/windows): read out question text when using Tab to navigate

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -80,6 +80,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
       value,
       name,
       colorScheme,
+      title,
       ...props
     },
     ref,
@@ -250,6 +251,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
                 isDragActive={isDragActive}
                 inputProps={processedInputProps}
                 readableMaxSize={readableMaxSize}
+                question={title}
               />
             )}
           </Box>

--- a/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
@@ -8,19 +8,21 @@ interface AttachmentDropzoneProps {
   inputProps: DropzoneInputProps
   isDragActive: DropzoneState['isDragActive']
   readableMaxSize?: string
+  question?: string
 }
 
 export const AttachmentDropzone = ({
   inputProps,
   isDragActive,
   readableMaxSize,
+  question,
 }: AttachmentDropzoneProps): JSX.Element => {
   const styles = useStyles()
 
   return (
     <>
       <VisuallyHidden>
-        Click to upload file, maximum file size of {readableMaxSize}
+        {question} Click to upload file, maximum file size of {readableMaxSize}
       </VisuallyHidden>
       <chakra.input {...inputProps} data-testid={inputProps.name} />
       <Icon aria-hidden as={BxsCloudUpload} __css={styles.icon} />

--- a/frontend/src/components/Field/YesNo/YesNo.tsx
+++ b/frontend/src/components/Field/YesNo/YesNo.tsx
@@ -89,6 +89,7 @@ export const YesNo = forwardRef<YesNoProps, 'input'>(
           // Ref is set here for tracking current value, and also so any errors
           // can focus this input.
           ref={ref}
+          title={props.title}
         />
         <YesNoOption
           side="right"
@@ -96,6 +97,7 @@ export const YesNo = forwardRef<YesNoProps, 'input'>(
           {...yesProps}
           leftIcon={BiCheck}
           label="Yes"
+          title={props.title}
         />
       </HStack>
     )

--- a/frontend/src/components/Field/YesNo/YesNoOption.tsx
+++ b/frontend/src/components/Field/YesNo/YesNoOption.tsx
@@ -87,7 +87,7 @@ export const YesNoOption = forwardRef<YesNoOptionProps, 'input'>(
         data-testid={`${props.name}-${props.side}`}
         role="button"
         ref={ref}
-        aria-label={`${label} option, ${
+        aria-label={`${props.title} ${label} option, ${
           props.isChecked ? 'selected' : 'unselected'
         }`}
       >

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -58,6 +58,7 @@ export const AttachmentField = ({
               onChange(file)
             }}
             onError={setErrorMessage}
+            title={schema.title}
           />
         )}
         name={fieldName}

--- a/frontend/src/templates/Field/YesNo/YesNoField.tsx
+++ b/frontend/src/templates/Field/YesNo/YesNoField.tsx
@@ -35,7 +35,11 @@ export const YesNoField = ({
         rules={validationRules}
         name={schema._id}
         render={({ field }) => (
-          <YesNo colorScheme={`theme-${colorTheme}`} {...field} />
+          <YesNo
+            colorScheme={`theme-${colorTheme}`}
+            title={schema.title}
+            {...field}
+          />
         )}
       />
     </FieldContainer>


### PR DESCRIPTION
## Problem

On Windows devices, when the Tab key is used for navigation, the question texts for the following question types are not read out:

- Yes/no
- Attachment
- Rating (addressed in PR #5767)

Refer to issue #5588 for more details.

Closes #5588

## Solution

As Tab key reads out information for options directly, pass the question text into the options to be read out as aria-labels.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Questions will now be read out for Yes/no and Attachment fields

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/37061143/218991896-f1b8c510-7191-4de3-90f1-ad39a631ab5c.mp4

**AFTER**:

https://user-images.githubusercontent.com/37061143/218986659-6f9dbc3e-8bcf-4ee9-aa3e-c229e2d3501b.mp4

## Tests

- [ ] Using Windows' NVDA software, use Tab navigation to get around in a form with Yes/no and Attachment fields. 
- [ ] You should be able to hear the question text for Yes/no fields now.
- [ ] You should be able to hear the question text for Attachment fields now.