### PR TITLE
feat: use find instead of aggregation for better performance

### DIFF
--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -291,31 +291,17 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
   const numToSkip = (page - 1) * pageSize
 
   // return documents within the page
-  const pageResults = this.aggregate<MetadataAggregateResult>([
+  const pageResults: Promise<MetadataAggregateResult[]> = this.find(
     {
-      $match: {
-        form: mongoose.Types.ObjectId(formId),
-        submissionType: SubmissionType.Encrypt,
-      },
+      form: mongoose.Types.ObjectId(formId),
+      submissionType: SubmissionType.Encrypt,
     },
-    {
-      $sort: {
-        created: -1,
-      },
-    },
-    {
-      $skip: numToSkip,
-    },
-    {
-      $limit: pageSize,
-    },
-    {
-      $project: {
-        _id: 1,
-        created: 1,
-      },
-    },
-  ])
+    { _id: 1, created: 1 },
+  )
+    .sort({ created: -1 })
+    .skip(numToSkip)
+    .limit(pageSize)
+    .exec()
 
   const count =
     this.countDocuments({


### PR DESCRIPTION
## Problem
- Further optimises #5763 by using `find` instead of aggregation pipeline
- When paginating across a large number of responses (e.g. 200k), this reduces the time taken for the query from >60s to 600ms
- Note the still O(n) increase in query time across page number but now much more manageable
- Closes [#138](https://github.com/opengovsg/formsg-private/issues/138)