### PR TITLE
fix: use readAsArrayBuffer polyfill when browser does not recognise arrayBuffer

### DIFF
--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -167,9 +167,31 @@ const encryptAttachment = async (
 ): Promise<StorageModeAttachment & { id: string }> => {
   let label
 
+  function promisifyFile(obj: FileReader): Promise<ArrayBuffer> {
+    return new Promise(function (resolve, reject) {
+      obj.onload = obj.onerror = function (evt) {
+        obj.onload = obj.onerror = null
+        console.log(obj.result)
+        evt.type === 'load' && obj.result
+          ? resolve(obj.result as ArrayBuffer)
+          : reject(new Error('Failed to read the blob/file'))
+      }
+    })
+  }
+
   try {
     label = 'Read file content'
-    const fileArrayBuffer = await attachment.arrayBuffer()
+    let fileArrayBuffer
+
+    // arrayBuffer is only compatible with Safari 14 onwards
+    // for older browsers, use readAsArrayBuffer
+    if (!attachment.arrayBuffer) {
+      const fr = new FileReader()
+      fr.readAsArrayBuffer(attachment)
+      fileArrayBuffer = await promisifyFile(fr)
+    } else {
+      fileArrayBuffer = await attachment.arrayBuffer()
+    }
     const fileContentsView = new Uint8Array(fileArrayBuffer)
 
     label = 'Encrypt content'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Users were getting a `t.arrayBuffer is not a function. (In 't.arrayBuffer()', 't.arrayBuffer' is undefined)` error message when using storage mode forms with attachments in React. Further investigation revealed that this is due to browser incompatibility; [arrayBuffer()](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer) is a newer promise-based API only compatible with Safari version 14 onwards, which was released in Sep 2020 (refer to the link for more browser compatibility information).

Closes #5552

## Solution
<!-- How did you solve the problem? -->
When encrypting attachments in `createSubmission`, use [`readAsArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer) in place of `.arrayBuffer()` when `.arrayBuffer()` is undefined.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Details**:

I explored using [polyfill.io](https://polyfill.io/v3/url-builder/) and the [blob-polyfill](https://github.com/bjornstar/blob-polyfill) package directly as polyfills for the Blob interface. 

Given that the polyfill is only necessary for the `arrayBuffer()` function, I adapted [that portion of the code](https://github.com/bjornstar/blob-polyfill/blob/master/Blob.js#L681) from `blob-polyfill`.

## Before & After Screenshots

**BEFORE**:
**Safari 11.1**
![before](https://user-images.githubusercontent.com/56983748/219280988-a60586a3-b86e-40b5-bd50-aad6e7b4e128.gif)

**AFTER**:
**Safari 11.1**
![after (1)](https://user-images.githubusercontent.com/56983748/219284717-dc81628e-79f4-4508-8a4a-99e86e4146fa.gif)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Upload a single attachment to a form using Safari >13. You should be able to download this attachment successfully in the form's responses.
- [x] Same as above, but with Safari <14 (we now have access to [browserstack](https://www.browserstack.com/)!)
- [x] Upload multiple attachments to a form using Safari >13. You should be able to download this attachment successfully in the form's responses.
- [x] Same as above, but with Safari <14
