### PR TITLE
fix(a11y): change heading label from instruction and section field container to h2 element

### DIFF
--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructions.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types'
 
@@ -27,9 +27,9 @@ export const FormInstructions = ({
 
   return (
     <>
-      <Text textStyle="h2" color={sectionColor}>
+      <Box as="h2" textStyle="h2" color={sectionColor}>
         Instructions
-      </Text>
+      </Box>
       <Box mt="1rem">
         <MarkdownText multilineBreaks components={mdComponents}>
           {content}

--- a/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormInstructions/FormInstructionsContainer.tsx
@@ -34,7 +34,6 @@ export const FormInstructionsContainer = (): JSX.Element | null => {
         <Box
           id={PUBLICFORM_INSTRUCTIONS_SECTIONID}
           ref={sectionRefs[PUBLICFORM_INSTRUCTIONS_SECTIONID]}
-          role="heading"
           // Allow focus on instructions when sidebar link is clicked.
           tabIndex={-1}
         >

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -54,7 +54,6 @@ export const BaseSectionField = forwardRef<
     // id given so app can scrolled to this section.
     <Box
       id={schema._id}
-      role="heading"
       ref={ref}
       _focus={{
         boxShadow: `0 0 0 2px var(--chakra-colors-theme-${colorTheme}-500)`,

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, forwardRef, Text } from '@chakra-ui/react'
+import { Box, forwardRef } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types'
 

--- a/frontend/src/templates/Field/Section/SectionField.tsx
+++ b/frontend/src/templates/Field/Section/SectionField.tsx
@@ -60,9 +60,9 @@ export const BaseSectionField = forwardRef<
       }}
       {...rest}
     >
-      <Text textStyle="h2" color={sectionColor}>
+      <Box as="h2" textStyle="h2" color={sectionColor}>
         {schema.title}
-      </Text>
+      </Box>
       {schema.description && (
         <Box mt="1rem">
           <MarkdownText multilineBreaks components={mdComponents}>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, we include the heading role in the parent element of both the instruction/heading of the section and the descriptions.

This causes the description/paragraph to also be labelled as "heading level 2" and will be read out as such on iOS Voiceover and window's NVDA screen reader. 

Closes #5501

## Solution
<!-- How did you solve the problem? -->

Removed `role=heading` in the parent element of section and instruction fields. Using `role=heading` is actually [dissuaded](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role), and we should use `<h2>` element instead. 

Change the element of instruction and heading from `<Text>` to `<Box as="h2">` using the advice from this [issue](https://github.com/chakra-ui/chakra-ui/issues/3658) to retain our text styles.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

Heading level 2 after both the headers and the paragraphs
![2023-02-16 (1)](https://user-images.githubusercontent.com/59867455/219331501-20e8377c-3fea-482c-b6fc-81ea2f546d6c.png)

**AFTER**:
<!-- [insert screenshot here] -->

Heading level 2 after the header and before the paragraph 
![2023-02-16](https://user-images.githubusercontent.com/59867455/219331608-1176a197-a266-48dd-a9f0-7381cae2e0b5.png)

## Tests
<!-- What tests should be run to confirm functionality? -->

On Windows:
- [x] Open a form with instructions. Use NVDA screen reader, navigate to the instruction section using the navbar. The screen reader should read 'Instructions Heading Level 2 (your instruction here)'.
- [x] Open a form with a heading field, including description of the heading. Use NVDA screen reader, navigate to the section using the navbar. The screen reader should read '(your heading here) Heading Level 2 (your description here)'.

On iOS:
- [x] Open a form with instructions. Use iOS voiceover, navigate to the instruction section. The screen reader should read 'Instructions Heading Level 2'. And upon next swipe it should read your instruction without any 'Heading Level 2' attached behind it.
- [x] Open a form with a heading field, including description of the heading. Use iOS voiceover, navigate to your section. The screen reader should read '(your heading here) Heading Level 2'. And upon next swipe it should read your description without any 'Heading Level 2' attached behind it.


