### PR TITLE
fix(a11y/windows): read qn number for all fields

### DIFF
--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -58,7 +58,7 @@ export const AttachmentField = ({
               onChange(file)
             }}
             onError={setErrorMessage}
-            title={schema.title}
+            title={`${schema.questionNumber}. ${schema.title}`}
           />
         )}
         name={fieldName}

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -79,7 +79,7 @@ export const CheckboxField = ({
 
   return (
     <FieldContainer schema={schema} errorKey={checkboxInputName}>
-      <Box aria-label={schema.title} role="list">
+      <Box aria-label={`${schema.questionNumber}. ${schema.title}`} role="list">
         {schema.fieldOptions.map((o, idx) => (
           <Checkbox
             colorScheme={fieldColorScheme}

--- a/frontend/src/templates/Field/Decimal/DecimalField.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.tsx
@@ -32,7 +32,7 @@ export const DecimalField = ({ schema }: DecimalFieldProps): JSX.Element => {
         render={({ field }) => (
           <NumberInput
             inputMode="decimal"
-            aria-label={schema.title}
+            aria-label={`${schema.questionNumber}. ${schema.title}`}
             allowMouseWheel
             preventDefaultOnEnter
             {...field}

--- a/frontend/src/templates/Field/LongText/LongTextField.stories.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.stories.tsx
@@ -41,6 +41,7 @@ const baseSchema: LongTextFieldSchema = {
   disabled: false,
   fieldType: BasicField.LongText,
   _id: '611b94dfbb9e300012f702a7',
+  questionNumber: 1,
 }
 
 interface StoryLongTextFieldProps extends LongTextFieldProps {

--- a/frontend/src/templates/Field/LongText/LongTextField.test.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.test.tsx
@@ -30,7 +30,9 @@ describe('validation required', () => {
     const user = userEvent.setup()
     const schema = ValidationRequired.args?.schema
     render(<ValidationRequired />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -69,7 +71,9 @@ describe('validation optional', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -101,7 +105,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -127,7 +133,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -156,7 +164,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -182,7 +192,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -212,7 +224,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -238,7 +252,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')

--- a/frontend/src/templates/Field/LongText/LongTextField.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.tsx
@@ -25,7 +25,7 @@ export const LongTextField = ({ schema }: LongTextFieldProps): JSX.Element => {
   return (
     <FieldContainer schema={schema}>
       <Textarea
-        aria-label={schema.title}
+        aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         {...register(schema._id, validationRules)}
       />

--- a/frontend/src/templates/Field/Nric/NricField.stories.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.stories.tsx
@@ -34,6 +34,7 @@ const baseSchema: NricFieldSchema = {
   disabled: false,
   fieldType: BasicField.Nric,
   _id: '611b94dfbb9e300012f702a7',
+  questionNumber: 1,
 }
 
 interface StoryNricFieldProps extends NricFieldProps {

--- a/frontend/src/templates/Field/Nric/NricField.test.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.test.tsx
@@ -29,7 +29,9 @@ describe('validation required', () => {
     const user = userEvent.setup()
     const schema = ValidationRequired.args?.schema
     render(<ValidationRequired />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -69,7 +71,9 @@ describe('validation optional', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -93,7 +97,9 @@ describe('NRIC validation', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -25,7 +25,7 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
   return (
     <FieldContainer schema={schema}>
       <Input
-        aria-label={schema.title}
+        aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/Number/NumberField.stories.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.stories.tsx
@@ -41,6 +41,7 @@ const baseSchema: NumberFieldSchema = {
     selectedValidation: null,
   },
   _id: '611b94dfbb9e300012f702a7',
+  questionNumber: 1,
 }
 
 interface StoryNumberFieldProps extends NumberFieldProps {

--- a/frontend/src/templates/Field/Number/NumberField.test.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.test.tsx
@@ -30,7 +30,9 @@ describe('validation required', () => {
     const user = userEvent.setup()
     const schema = ValidationRequired.args?.schema
     render(<ValidationRequired />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -69,7 +71,9 @@ describe('validation optional', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -101,7 +105,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -127,7 +133,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -156,7 +164,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -182,7 +192,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -211,7 +223,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -237,7 +251,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -36,7 +36,7 @@ export const NumberField = ({
             min={0}
             inputMode="numeric"
             colorScheme={`theme-${colorTheme}`}
-            aria-label={schema.title}
+            aria-label={`${schema.questionNumber}. ${schema.title}`}
             allowMouseWheel
             precision={0}
             value={value}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -86,7 +86,7 @@ export const RadioField = ({
               // Trigger validation of others input if Other radio is selected.
               if (value === RADIO_OTHERS_INPUT_VALUE) trigger(othersInputName)
             }}
-            aria-label={schema.title}
+            aria-label={`${schema.questionNumber}. ${schema.title}`}
             aria-invalid={
               !!get(errors, radioInputName) || !!get(errors, othersInputName)
             }

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -62,7 +62,7 @@ export const RatingField = ({
             value={transform.toNumber(value)}
             isRequired={schema.required}
             isInvalid={!!get(errors, schema._id)}
-            fieldTitle={schema.title}
+            fieldTitle={`${schema.questionNumber}. ${schema.title}`}
             onChange={(val) => onChange(transform.toString(val))}
             {...rest}
           />

--- a/frontend/src/templates/Field/ShortText/ShortTextField.stories.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.stories.tsx
@@ -41,6 +41,7 @@ const baseSchema: ShortTextFieldSchema = {
   disabled: false,
   fieldType: BasicField.ShortText,
   _id: '611b94dfbb9e300012f702a7',
+  questionNumber: 1,
 }
 
 interface StoryShortTextFieldProps extends ShortTextFieldProps {

--- a/frontend/src/templates/Field/ShortText/ShortTextField.test.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.test.tsx
@@ -30,7 +30,9 @@ describe('validation required', () => {
     const user = userEvent.setup()
     const schema = ValidationRequired.args?.schema
     render(<ValidationRequired />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -69,7 +71,9 @@ describe('validation optional', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -102,7 +106,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -128,7 +134,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -157,7 +165,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -183,7 +193,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -212,7 +224,9 @@ describe('text validation', () => {
       })
       // Using ValidationRequired base story to render the field without any value.
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')
@@ -238,7 +252,9 @@ describe('text validation', () => {
         },
       })
       render(<ValidationRequired schema={schema} />)
-      const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+      const input = screen.getByLabelText(
+        `${schema!.questionNumber}. ${schema!.title}`,
+      ) as HTMLInputElement
       const submitButton = screen.getByText('Submit')
 
       expect(input.value).toBe('')

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -30,7 +30,7 @@ export const ShortTextField = ({
     <FieldContainer schema={schema} {...fieldContainerProps}>
       <Input
         isPrefilled={isPrefilled}
-        aria-label={schema.title}
+        aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/Uen/UenField.stories.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.stories.tsx
@@ -34,6 +34,7 @@ const baseSchema: UenFieldSchema = {
   disabled: false,
   fieldType: BasicField.Uen,
   _id: '611b94dfbb9e300012f702a7',
+  questionNumber: 1,
 }
 
 interface StoryUenFieldProps extends UenFieldProps {

--- a/frontend/src/templates/Field/Uen/UenField.test.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.test.tsx
@@ -29,7 +29,9 @@ describe('validation required', () => {
     const user = userEvent.setup()
     const schema = ValidationRequired.args?.schema
     render(<ValidationRequired />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -69,7 +71,9 @@ describe('validation optional', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')
@@ -93,7 +97,9 @@ describe('uen validation', () => {
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
-    const input = screen.getByLabelText(schema!.title) as HTMLInputElement
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
     const submitButton = screen.getByText('Submit')
 
     expect(input.value).toBe('')

--- a/frontend/src/templates/Field/Uen/UenField.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.tsx
@@ -25,7 +25,7 @@ export const UenField = ({ schema }: UenFieldProps): JSX.Element => {
   return (
     <FieldContainer schema={schema}>
       <Input
-        aria-label={schema.title}
+        aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
         {...register(schema._id, validationRules)}

--- a/frontend/src/templates/Field/YesNo/YesNoField.tsx
+++ b/frontend/src/templates/Field/YesNo/YesNoField.tsx
@@ -37,7 +37,7 @@ export const YesNoField = ({
         render={({ field }) => (
           <YesNo
             colorScheme={`theme-${colorTheme}`}
-            title={schema.title}
+            title={`${schema.questionNumber}. ${schema.title}`}
             {...field}
           />
         )}


### PR DESCRIPTION
## Problem

When using NVDA's Tab navigation on a Windows device, question numbers are not read out for the following fields:

- Short answer
- Long answer
- Radio
- Checkbox
- Yes/no
- Rating
- Attachment
- Number
- Decimal
- NRIC
- UEN

Closes #5587

## Solution

Pass question numbers as part of title to be read out when fields are tabbed into. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Question numbers read out by NVDA on Windows when Tab navigation is used.

**Improvements**:

- Tests updated to include question numbers.

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/37061143/219382364-41f5d1a2-1cf3-4757-9d0b-d7e23cd8463e.mp4

**AFTER**:

https://user-images.githubusercontent.com/37061143/219382330-4a7a8bfb-944b-49b2-b5d5-ff0d1e4463e0.mp4

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a form with all these fields (e.g. [https://staging.form.gov.sg/63edba8300b178001290fff6](https://staging.form.gov.sg/63edba8300b178001290fff6) if using `staging-al2`)
  - [ ] Short answer
  - [ ] Long answer
  - [ ] Radio
  - [ ] Checkbox
  - [ ] Yes/no
  - [ ] Rating
  - [ ] Attachment
  - [ ] Number
  - [ ] Decimal
  - [ ] NRIC
  - [ ] UEN
- [ ] Check that when Tab-navigated into the following fields, the question numbers are read out.
  - [ ] Short answer
  - [ ] Long answer
  - [ ] Radio
  - [ ] Checkbox
  - [ ] Yes/no
  - [ ] Rating
  - [ ] Attachment
  - [ ] Number
  - [ ] Decimal
  - [ ] NRIC
  - [ ] UEN