### PR TITLE
fix: update readme testing section with correct node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Make you sure have the following node version & package manager on your machine:
 Run
 
 ```bash
-nvm install 14
+nvm install 18
 npm install
 pip install "localstack[full]"
 ```
@@ -196,6 +196,7 @@ npm run test-e2e-ci
 ```
 
 #### Cross-browser testing
+
 This project is tested with [BrowserStack](https://www.browserstack.com/open-source).
 
 ## Architecture


### PR DESCRIPTION
## Problem
Wrong version of nvm suggested to install in README testing section

## Solution
Update version from 14 to 18

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  
