### PR TITLE
fix: strip whitespace for logic conditions on frontend

### DIFF
--- a/frontend/src/features/logic/utils/isConditionFulfilled.ts
+++ b/frontend/src/features/logic/utils/isConditionFulfilled.ts
@@ -10,7 +10,11 @@ import {
 import { FormFieldValue } from '~templates/Field'
 import { RADIO_OTHERS_INPUT_VALUE } from '~templates/Field/Radio/RadioField'
 
-import { isLogicableField, isRadioFormFieldValue } from './typeguards'
+import {
+  isLogicableField,
+  isRadioFormFieldValue,
+  isValueStringArray,
+} from './typeguards'
 
 const getCurrentFieldValue = (
   input: DeepPartial<FormFieldValue<LogicableField>>,
@@ -34,15 +38,16 @@ const getCurrentFieldValue = (
  * TODO #4279: Revisit decision to trim after React rollout is complete
  */
 const trimConditionValue = (condition: FormCondition) => {
-  if (Array.isArray(condition.value)) {
+  if (isValueStringArray(condition.value)) {
     return {
       ...condition,
-      value: condition.value.map((value) =>
-        typeof value === 'string' ? value.trim() : value,
-      ),
+      value: condition.value.map((value) => value.trim()),
     }
   } else if (typeof condition.value === 'string') {
-    return { ...condition, value: condition.value.trim() }
+    return {
+      ...condition,
+      value: condition.value.trim(),
+    }
   } else {
     return condition
   }

--- a/frontend/src/features/logic/utils/typeguards.ts
+++ b/frontend/src/features/logic/utils/typeguards.ts
@@ -2,6 +2,7 @@ import { DeepPartial } from 'react-hook-form'
 
 import { BasicField } from '~shared/types/field'
 import {
+  FormCondition,
   LogicableField,
   LogicDto,
   LogicType,
@@ -39,4 +40,11 @@ export const isLogicableField = (args: {
   input: FormFieldValue<LogicableField>
 } => {
   return ALLOWED_LOGIC_FIELDS.has(args.fieldType)
+}
+
+export const isValueStringArray = (
+  value: FormCondition['value'],
+): value is string[] => {
+  // use .some because of limitation of typecript in calling .every() on union of array types: https://github.com/microsoft/TypeScript/issues/44373
+  return Array.isArray(value) && !value.some((v) => typeof v === 'number')
 }


### PR DESCRIPTION
## Problem

- Follow up to #5433, which trimmed whitespace for logic checks on the backend. 
- In some cases, existing logic contains trailing whitespace. This PR ensures that existing logic with whitespace is also trimmed on the frontend so that form logic works properly.

## Tests
- [ ] Create form with dropdown option as logic condition for prevent submission. In the DB, add trailing whitespace to the logic condition for that dropdown option. Check that submission is prevented when the option is chosen.
- [ ] Repeat for show field logic.