### PR TITLE
fix: meta tags for public form pages

### DIFF
--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -217,10 +217,10 @@ export const servePublicForm: ControllerHandler<
   })
 
   if (showReact) {
-    const isPublicForm = Boolean(
-      !formResult.isErr() && formResult.value.status === FormStatus.Public,
-    )
-    return serveFormReact(/* isPublic= */ isPublicForm)(req, res, next)
+    const isPublicForm =
+      !formResult.isErr() && formResult.value.status === FormStatus.Public
+
+    return serveFormReact(isPublicForm)(req, res, next)
   } else {
     return serveFormAngular(req, res, next)
   }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -220,23 +220,7 @@ export const servePublicForm: ControllerHandler<
     const isPublicForm = Boolean(
       !formResult.isErr() && formResult.value.status === FormStatus.Public,
     )
-    const formStatus = !formResult.isErr()
-      ? `${formResult.value.status}`
-      : 'formresulterr'
-    logger.info({
-      message: 'metatags test',
-      meta: {
-        action: 'metatags test',
-        formResult: formResult,
-        isFormResultErr: formResult.isErr(),
-        formStatus: formStatus,
-        formStatusRaw: formResult.isErr() ? null : formResult.value.status,
-        isPublicForm: isPublicForm,
-      },
-    })
     return serveFormReact(/* isPublic= */ isPublicForm)(req, res, next)
-    // return serveFormReact(/* isPublic= */ true)(req, res, next)
-    // return serveFormReact(!formResult.isErr() && formResult.value.status === FormStatus.Public,)(req, res, next)
   } else {
     return serveFormAngular(req, res, next)
   }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -6,7 +6,7 @@ import path from 'path'
 
 import {
   FormResponseMode,
-  // FormStatus,
+  FormStatus,
   UiCookieValues,
 } from '../../../../shared/types'
 import config from '../../config/config'
@@ -216,7 +216,11 @@ export const servePublicForm: ControllerHandler<
   })
 
   if (showReact) {
-    return serveFormReact(/* isPublic= */ true)(req, res, next)
+    const isPublicForm = Boolean(
+      !formResult.isErr() && formResult.value.status === FormStatus.Public,
+    )
+    return serveFormReact(/* isPublic= */ isPublicForm)(req, res, next)
+    // return serveFormReact(/* isPublic= */ true)(req, res, next)
     // return serveFormReact(!formResult.isErr() && formResult.value.status === FormStatus.Public,)(req, res, next)
   } else {
     return serveFormAngular(req, res, next)

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -6,7 +6,7 @@ import path from 'path'
 
 import {
   FormResponseMode,
-  FormStatus,
+  // FormStatus,
   UiCookieValues,
 } from '../../../../shared/types'
 import config from '../../config/config'
@@ -216,9 +216,8 @@ export const servePublicForm: ControllerHandler<
   })
 
   if (showReact) {
-    return serveFormReact(
-      !formResult.isErr() && formResult.value.status === FormStatus.Public,
-    )(req, res, next)
+    return serveFormReact(/* isPublic= */ true)(req, res, next)
+    // return serveFormReact(!formResult.isErr() && formResult.value.status === FormStatus.Public,)(req, res, next)
   } else {
     return serveFormAngular(req, res, next)
   }

--- a/src/app/modules/react-migration/react-migration.controller.ts
+++ b/src/app/modules/react-migration/react-migration.controller.ts
@@ -147,6 +147,7 @@ export const servePublicForm: ControllerHandler<
 > = async (req, res, next) => {
   const formResult = await FormService.retrieveFormKeysById(req.params.formId, [
     'responseMode',
+    'status',
   ])
   let showReact: boolean | undefined = undefined
   let isEmail = false
@@ -219,6 +220,20 @@ export const servePublicForm: ControllerHandler<
     const isPublicForm = Boolean(
       !formResult.isErr() && formResult.value.status === FormStatus.Public,
     )
+    const formStatus = !formResult.isErr()
+      ? `${formResult.value.status}`
+      : 'formresulterr'
+    logger.info({
+      message: 'metatags test',
+      meta: {
+        action: 'metatags test',
+        formResult: formResult,
+        isFormResultErr: formResult.isErr(),
+        formStatus: formStatus,
+        formStatusRaw: formResult.isErr() ? null : formResult.value.status,
+        isPublicForm: isPublicForm,
+      },
+    })
     return serveFormReact(/* isPublic= */ isPublicForm)(req, res, next)
     // return serveFormReact(/* isPublic= */ true)(req, res, next)
     // return serveFormReact(!formResult.isErr() && formResult.value.status === FormStatus.Public,)(req, res, next)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Social media previews were not being generated correctly for public forms.

`formResult.value.status` was `undefined` as `status` was not retrieved in the form result. Hence the check for public forms was always returning `false`, and the default meta tags would be used for public forms, instead of the public form-specific meta tags.

Closes #5589

## Solution
<!-- How did you solve the problem? -->
To fix this, I specified `status` when retrieving the form using `FormService.retrieveFormKeysById`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
Public form
<img width="426" alt="image" src="https://user-images.githubusercontent.com/56983748/220242222-0914dd1b-9237-4f5c-8e4b-411acc689b9d.png">

Private form
<img width="418" alt="image" src="https://user-images.githubusercontent.com/56983748/220242336-b71d3bc1-dafe-482b-b580-89f2e919dbaa.png">

## Tests
<!-- What tests should be run to confirm functionality? -->
[Preview and generate](https://www.opengraph.xyz/) Open Graph meta tags, check that `title`, `description` and `image` are populated for
- [x] public form
- [x] private form