### PR TITLE
feat: add prefix to OTPs

### DIFF
--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   Input as ChakraInput,
   InputGroup,
+  InputLeftAddon,
   InputProps as ChakraInputProps,
   InputRightElement,
   useMultiStyleConfig,
@@ -55,14 +56,28 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
 
   // Return normal input component if not success state.
   if (!props.isSuccess) {
-    return (
-      <ChakraInput
-        ref={ref}
-        {...preventDefault}
-        {...inputProps}
-        sx={props.sx ?? inputStyles.field}
-      />
-    )
+    if (props.prefix) {
+      return (
+        <InputGroup>
+          <InputLeftAddon pointerEvents="none" children={props.prefix} />
+          <ChakraInput
+            ref={ref}
+            {...preventDefault}
+            {...inputProps}
+            sx={props.sx ?? inputStyles.field}
+          />
+        </InputGroup>
+      )
+    } else {
+      return (
+        <ChakraInput
+          ref={ref}
+          {...preventDefault}
+          {...inputProps}
+          sx={props.sx ?? inputStyles.field}
+        />
+      )
+    }
   }
 
   return (

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -99,6 +99,7 @@ export const LoginPage = (): JSX.Element => {
   const { data: { siteBannerContentReact, isLoginBannerReact } = {} } = useEnv()
   const [, setIsAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
   const [email, setEmail] = useState<string>()
+  const [otpPrefix, setOtpPrefix] = useState<string>('')
   const { t } = useTranslation()
 
   // TODO (#4279): Revert back to non-react banners post-migration.
@@ -115,8 +116,10 @@ export const LoginPage = (): JSX.Element => {
 
   const handleSendOtp = async ({ email }: LoginFormInputs) => {
     const trimmedEmail = email.trim()
-    await sendLoginOtp(trimmedEmail)
-    return setEmail(trimmedEmail)
+    await sendLoginOtp(trimmedEmail).then(({ otpPrefix }) => {
+      setOtpPrefix(otpPrefix)
+      setEmail(trimmedEmail)
+    })
   }
 
   const handleVerifyOtp = async ({ otp }: OtpFormInputs) => {
@@ -143,7 +146,7 @@ export const LoginPage = (): JSX.Element => {
     if (!email) {
       throw new Error('Something went wrong')
     }
-    await sendLoginOtp(email)
+    await sendLoginOtp(email).then(({ otpPrefix }) => setOtpPrefix(otpPrefix))
   }
 
   return (
@@ -186,6 +189,7 @@ export const LoginPage = (): JSX.Element => {
             ) : (
               <OtpForm
                 email={email}
+                otpPrefix={otpPrefix}
                 onSubmit={handleVerifyOtp}
                 onResendOtp={handleResendOtp}
               />

--- a/frontend/src/features/login/components/OtpForm.tsx
+++ b/frontend/src/features/login/components/OtpForm.tsx
@@ -61,7 +61,7 @@ export const OtpForm = ({
             },
             validate: validateOtp,
           })}
-          prefix={`${otpPrefix} -`}
+          prefix={otpPrefix === undefined ? undefined : `${otpPrefix} -`}
         />
         {formState.errors.otp && (
           <FormErrorMessage>{formState.errors.otp.message}</FormErrorMessage>

--- a/frontend/src/features/login/components/OtpForm.tsx
+++ b/frontend/src/features/login/components/OtpForm.tsx
@@ -14,12 +14,14 @@ export type OtpFormInputs = {
 
 interface OtpFormProps {
   email: string
+  otpPrefix: string
   onSubmit: (inputs: OtpFormInputs) => Promise<void>
   onResendOtp: () => Promise<void>
 }
 
 export const OtpForm = ({
   email,
+  otpPrefix,
   onSubmit,
   onResendOtp,
 }: OtpFormProps): JSX.Element => {
@@ -59,6 +61,7 @@ export const OtpForm = ({
             },
             validate: validateOtp,
           })}
+          prefix={`${otpPrefix} -`}
         />
         {formState.errors.otp && (
           <FormErrorMessage>{formState.errors.otp.message}</FormErrorMessage>

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -1,4 +1,4 @@
-import { UserDto } from '~shared/types/user'
+import { SendOtpResponseDto, UserDto } from '~shared/types/user'
 
 import { LOCAL_STORAGE_EVENT, LOGGED_IN_KEY } from '~constants/localStorage'
 
@@ -11,8 +11,10 @@ const AUTH_ENDPOINT = '/auth'
  * @param email email to send login OTP to
  * @returns success string if login OTP is sent successfully
  */
-export const sendLoginOtp = async (email: string): Promise<string> => {
-  return ApiService.post<string>(`${AUTH_ENDPOINT}/otp/generate`, {
+export const sendLoginOtp = async (
+  email: string,
+): Promise<SendOtpResponseDto> => {
+  return ApiService.post<SendOtpResponseDto>(`${AUTH_ENDPOINT}/otp/generate`, {
     email: email.toLowerCase(),
   }).then(({ data }) => data)
 }

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -49,3 +49,8 @@ export type VerifyUserContactOtpDto = {
   otp: string
   contact: string
 }
+
+export type SendOtpResponseDto = {
+  message: string
+  otpPrefix: string
+}

--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -133,7 +133,7 @@ describe('auth.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message:
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
       })
       // Sending login OTP should not have been called.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)

--- a/src/app/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.controller.spec.ts
@@ -66,6 +66,7 @@ describe('auth.controller', () => {
 
   describe('handleLoginSendOtp', () => {
     const MOCK_OTP = '123456'
+    const MOCK_OTP_PREFIX = 'ABC'
     const MOCK_REQ = expressHandler.mockRequest({
       body: { email: VALID_EMAIL },
     })
@@ -77,7 +78,9 @@ describe('auth.controller', () => {
       MockAuthService.validateEmailDomain.mockReturnValueOnce(
         okAsync(<AgencyDocument>{}),
       )
-      MockAuthService.createLoginOtp.mockReturnValueOnce(okAsync(MOCK_OTP))
+      MockAuthService.createLoginOtp.mockReturnValueOnce(
+        okAsync({ otp: MOCK_OTP, otpPrefix: MOCK_OTP_PREFIX }),
+      )
       MockMailService.sendLoginOtp.mockReturnValueOnce(okAsync(true))
 
       // Act
@@ -85,7 +88,10 @@ describe('auth.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(200)
-      expect(mockRes.json).toHaveBeenCalledWith(`OTP sent to ${VALID_EMAIL}`)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: `OTP sent to ${VALID_EMAIL}`,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
       // Services should have been invoked.
       expect(MockAuthService.createLoginOtp).toHaveBeenCalledTimes(1)
       expect(MockMailService.sendLoginOtp).toHaveBeenCalledTimes(1)
@@ -141,7 +147,9 @@ describe('auth.controller', () => {
         okAsync(<AgencyDocument>{}),
       )
       // Mock createLoginOtp success but sendLoginOtp failure.
-      MockAuthService.createLoginOtp.mockReturnValueOnce(okAsync(MOCK_OTP))
+      MockAuthService.createLoginOtp.mockReturnValueOnce(
+        okAsync({ otp: MOCK_OTP, otpPrefix: MOCK_OTP_PREFIX }),
+      )
       MockMailService.sendLoginOtp.mockReturnValueOnce(
         errAsync(new MailSendError('send error')),
       )

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -209,7 +209,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(500)
       expect(response.body).toEqual({
         message:
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
       })
     })
 
@@ -249,7 +249,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(500)
       expect(response.body).toEqual({
         message:
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
       })
     })
 

--- a/src/app/modules/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.routes.spec.ts
@@ -142,6 +142,7 @@ describe('auth.routes', () => {
     const VALID_DOMAIN = 'example.com'
     const VALID_EMAIL = `test@${VALID_DOMAIN}`
     const INVALID_DOMAIN = 'example.org'
+    const MOCK_OTP_PREFIX = 'ABC'
 
     beforeEach(async () => dbHandler.insertAgency({ mailDomain: VALID_DOMAIN }))
 
@@ -257,6 +258,7 @@ describe('auth.routes', () => {
       const sendLoginOtpSpy = jest
         .spyOn(MailService, 'sendLoginOtp')
         .mockReturnValueOnce(okAsync(true))
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
       // Act
       const response = await request
@@ -266,7 +268,10 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+      expect(response.body).toEqual({
+        message: `OTP sent to ${VALID_EMAIL}`,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
     })
 
     it('should return 200 when otp is sent successfully and email is non-lowercase', async () => {
@@ -274,6 +279,7 @@ describe('auth.routes', () => {
       const sendLoginOtpSpy = jest
         .spyOn(MailService, 'sendLoginOtp')
         .mockReturnValueOnce(okAsync(true))
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
       // Act
       const response = await request
@@ -283,12 +289,16 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+      expect(response.body).toEqual({
+        message: `OTP sent to ${VALID_EMAIL}`,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
     })
   })
 
   describe('POST /auth/verifyotp', () => {
     const MOCK_VALID_OTP = '123456'
+    const MOCK_OTP_PREFIX = 'ABC'
     const VALID_DOMAIN = 'example.com'
     const VALID_EMAIL = `test@${VALID_DOMAIN}`
     const INVALID_DOMAIN = 'example.org'
@@ -300,6 +310,7 @@ describe('auth.routes', () => {
         mailDomain: VALID_DOMAIN,
       })
       jest.spyOn(OtpUtils, 'generateOtp').mockReturnValue(MOCK_VALID_OTP)
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
     })
 
     it('should return 400 when body.email is not provided as a param', async () => {
@@ -564,6 +575,7 @@ describe('auth.routes', () => {
 
   describe('GET /auth/signout', () => {
     const MOCK_VALID_OTP = '123456'
+    const MOCK_OTP_PREFIX = 'ABC'
     const VALID_DOMAIN = 'example.com'
     const VALID_EMAIL = `test@${VALID_DOMAIN}`
 
@@ -572,6 +584,7 @@ describe('auth.routes', () => {
         mailDomain: VALID_DOMAIN,
       })
       jest.spyOn(OtpUtils, 'generateOtp').mockReturnValue(MOCK_VALID_OTP)
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
     })
 
     it('should return 200 and clear cookies when signout is successful', async () => {
@@ -604,11 +617,16 @@ describe('auth.routes', () => {
 
   // Helper functions
   const requestForOtp = async (email: string) => {
+    const MOCK_OTP_PREFIX = 'ABC'
     // Set that so no real mail is sent.
     jest.spyOn(MailService, 'sendLoginOtp').mockReturnValue(okAsync(true))
+    jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
     const response = await request.post('/auth/sendotp').send({ email })
-    expect(response.body).toEqual(`OTP sent to ${email}`)
+    expect(response.body).toEqual({
+      message: `OTP sent to ${email}`,
+      otpPrefix: MOCK_OTP_PREFIX,
+    })
   }
 
   const signInUser = async (email: string, otp: string) => {

--- a/src/app/modules/auth/__tests__/auth.service.spec.ts
+++ b/src/app/modules/auth/__tests__/auth.service.spec.ts
@@ -31,6 +31,7 @@ const TokenModel = getTokenModel(mongoose)
 const VALID_EMAIL_DOMAIN = 'test.gov.sg'
 const VALID_EMAIL = `valid@${VALID_EMAIL_DOMAIN}`
 const MOCK_OTP = '123456'
+const MOCK_OTP_PREFIX = 'ABC'
 
 describe('auth.service', () => {
   let defaultAgency: AgencyDocument
@@ -93,13 +94,19 @@ describe('auth.service', () => {
       // Should have no documents prior to this.
       await expect(TokenModel.countDocuments()).resolves.toEqual(0)
       jest.spyOn(OtpUtils, 'generateOtp').mockReturnValueOnce(MOCK_OTP)
+      jest
+        .spyOn(OtpUtils, 'generateOtpPrefix')
+        .mockReturnValueOnce(MOCK_OTP_PREFIX)
 
       // Act
       const actualResult = await AuthService.createLoginOtp(VALID_EMAIL)
 
       // Assert
       expect(actualResult.isOk()).toBe(true)
-      expect(actualResult._unsafeUnwrap()).toEqual(MOCK_OTP)
+      expect(actualResult._unsafeUnwrap()).toEqual({
+        otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
       // Should have new token document inserted.
       await expect(TokenModel.countDocuments()).resolves.toEqual(1)
     })

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -111,7 +111,7 @@ export const _handleLoginSendOtp: ControllerHandler<
         })
     )
   } else {
-    // Step 4b: Error occurred whilst creating otp.
+    // Step 3b: Error occurred whilst creating otp.
     const error = loginOtpResult.error
     logger.error({
       message: 'Error creating login OTP',

--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import { isEmpty } from 'lodash'
+import { SendOtpResponseDto } from 'shared/types/user'
 
 import { SUPPORT_FORM_LINK } from '../../../../shared/constants/links'
 import { createLoggerWithLabel } from '../../config/logger'
@@ -57,7 +58,7 @@ export const handleCheckUser = [
 
 export const _handleLoginSendOtp: ControllerHandler<
   unknown,
-  { message: string } | string,
+  { message: string } | SendOtpResponseDto,
   { email: string }
 > = async (req, res) => {
   // Joi validation ensures existence.
@@ -69,42 +70,60 @@ export const _handleLoginSendOtp: ControllerHandler<
     ...createReqMeta(req),
   }
 
-  return (
-    // Step 1: Validate email domain.
-    AuthService.validateEmailDomain(email)
-      // Step 2: Create login OTP.
-      .andThen(() => AuthService.createLoginOtp(email))
-      // Step 3: Send login OTP to email address.
-      .andThen((otp) =>
-        MailService.sendLoginOtp({
-          recipient: email,
-          otp,
-          ipAddress: requestIp,
-        }),
-      )
-      // Step 4a: Successfully sent login otp.
-      .map(() => {
-        logger.info({
-          message: 'Login OTP sent successfully',
-          meta: logMeta,
-        })
-
-        return res.status(StatusCodes.OK).json(`OTP sent to ${email}`)
-      })
-      // Step 4b: Error occurred whilst sending otp.
-      .mapErr((error) => {
-        logger.error({
-          message: 'Error sending login OTP',
-          meta: logMeta,
-          error,
-        })
-        const { errorMessage, statusCode } = mapRouteError(
-          error,
-          /* coreErrorMessage=*/ 'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
-        )
-        return res.status(statusCode).json({ message: errorMessage })
-      })
+  // Step 1: Validate email domain.
+  const loginOtpResult = await AuthService.validateEmailDomain(email).andThen(
+    // Step 2: Create login OTP.
+    () => AuthService.createLoginOtp(email),
   )
+  // Step 3a: Successfully created login otp.
+  if (loginOtpResult.isOk()) {
+    const { otp, otpPrefix } = loginOtpResult.value
+    return (
+      // Step 4: Send login OTP to email address.
+      MailService.sendLoginOtp({
+        recipient: email,
+        otpPrefix,
+        otp,
+        ipAddress: requestIp,
+      })
+        // Step 5a: Successfully sent login otp.
+        .map(() => {
+          logger.info({
+            message: 'Login OTP sent successfully',
+            meta: logMeta,
+          })
+          return res
+            .status(StatusCodes.OK)
+            .json({ message: `OTP sent to ${email}`, otpPrefix })
+        })
+        // Step 5b: Error occurred whilst sending otp.
+        .mapErr((error) => {
+          logger.error({
+            message: 'Error sending login OTP',
+            meta: logMeta,
+            error,
+          })
+          const { errorMessage, statusCode } = mapRouteError(
+            error,
+            /* coreErrorMessage=*/ 'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          )
+          return res.status(statusCode).json({ message: errorMessage })
+        })
+    )
+  } else {
+    // Step 4b: Error occurred whilst creating otp.
+    const error = loginOtpResult.error
+    logger.error({
+      message: 'Error creating login OTP',
+      meta: logMeta,
+      error,
+    })
+    const { errorMessage, statusCode } = mapRouteError(
+      error,
+      /* coreErrorMessage=*/ 'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
+    )
+    return res.status(statusCode).json({ message: errorMessage })
+  }
 }
 
 /**

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -97,7 +97,10 @@ export const validateEmailDomain = (
  */
 export const createLoginOtp = (
   email: string,
-): ResultAsync<string, HashingError | DatabaseError | InvalidDomainError> => {
+): ResultAsync<
+  { otp: string; otpPrefix: string },
+  HashingError | DatabaseError | InvalidDomainError
+> => {
   if (!validator.isEmail(email)) {
     return errAsync(new InvalidDomainError())
   }
@@ -106,10 +109,12 @@ export const createLoginOtp = (
     // Step 1: Generate and hash OTP.
     generateOtpWithHash({ email })
       // Step 2: Upsert otp hash into database.
-      .andThen(({ otp, hashedOtp }) =>
+      .andThen(({ otp, hashedOtp, otpPrefix }) =>
         upsertOtp(email, hashedOtp)
           // Step 3: Return generated OTP.
-          .map(() => otp),
+          .map(() => {
+            return { otp, otpPrefix }
+          }),
       )
   )
 }

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -208,7 +208,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(500)
       expect(response.body).toEqual({
         message:
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
       })
     })
 
@@ -248,7 +248,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(500)
       expect(response.body).toEqual({
         message:
-          'Failed to send login OTP. Please try again later and if the problem persists, contact us.',
+          'Failed to create login OTP. Please try again later and if the problem persists, contact us.',
       })
     })
 

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -141,6 +141,7 @@ describe('auth.routes', () => {
     const VALID_DOMAIN = 'example.com'
     const VALID_EMAIL = `test@${VALID_DOMAIN}`
     const INVALID_DOMAIN = 'example.org'
+    const MOCK_OTP_PREFIX = 'ABC'
 
     beforeEach(async () => dbHandler.insertAgency({ mailDomain: VALID_DOMAIN }))
 
@@ -256,6 +257,7 @@ describe('auth.routes', () => {
       const sendLoginOtpSpy = jest
         .spyOn(MailService, 'sendLoginOtp')
         .mockReturnValueOnce(okAsync(true))
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
       // Act
       const response = await request
@@ -265,7 +267,10 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+      expect(response.body).toEqual({
+        message: `OTP sent to ${VALID_EMAIL}`,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
     })
 
     it('should return 200 when otp is sent successfully and email is non-lowercase', async () => {
@@ -273,6 +278,7 @@ describe('auth.routes', () => {
       const sendLoginOtpSpy = jest
         .spyOn(MailService, 'sendLoginOtp')
         .mockReturnValueOnce(okAsync(true))
+      jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
       // Act
       const response = await request
@@ -282,7 +288,10 @@ describe('auth.routes', () => {
       // Assert
       expect(sendLoginOtpSpy).toHaveBeenCalled()
       expect(response.status).toEqual(200)
-      expect(response.body).toEqual(`OTP sent to ${VALID_EMAIL}`)
+      expect(response.body).toEqual({
+        message: `OTP sent to ${VALID_EMAIL}`,
+        otpPrefix: MOCK_OTP_PREFIX,
+      })
     })
   })
 
@@ -603,11 +612,16 @@ describe('auth.routes', () => {
 
   // Helper functions
   const requestForOtp = async (email: string) => {
+    const MOCK_OTP_PREFIX = 'ABC'
     // Set that so no real mail is sent.
     jest.spyOn(MailService, 'sendLoginOtp').mockReturnValue(okAsync(true))
+    jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
     const response = await request.post('/auth/otp/generate').send({ email })
-    expect(response.body).toEqual(`OTP sent to ${email}`)
+    expect(response.body).toEqual({
+      message: `OTP sent to ${email}`,
+      otpPrefix: MOCK_OTP_PREFIX,
+    })
   }
 
   const signInUser = async (email: string, otp: string) => {

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -227,6 +227,7 @@ describe('mail.service', () => {
   describe('sendLoginOtp', () => {
     const MOCK_OTP = '123456'
     const MOCK_IP = 'mock:5000'
+    const MOCK_OTP_PREFIX = 'ABC'
 
     const generateExpectedArg = async () => {
       return {
@@ -239,6 +240,7 @@ describe('mail.service', () => {
             appName: MOCK_APP_NAME,
             appUrl: MOCK_APP_URL,
             ipAddress: MOCK_IP,
+            otpPrefix: MOCK_OTP_PREFIX,
           })
         )._unsafeUnwrap(),
         headers: {
@@ -259,6 +261,7 @@ describe('mail.service', () => {
       const actualResult = await mailService.sendLoginOtp({
         recipient: MOCK_VALID_EMAIL,
         otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
         ipAddress: MOCK_IP,
       })
 
@@ -278,6 +281,7 @@ describe('mail.service', () => {
       const actualResult = await mailService.sendLoginOtp({
         recipient: invalidEmail,
         otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
         ipAddress: MOCK_IP,
       })
       // Assert
@@ -303,6 +307,7 @@ describe('mail.service', () => {
       const actualResult = await mailService.sendLoginOtp({
         recipient: MOCK_VALID_EMAIL,
         otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
         ipAddress: MOCK_IP,
       })
 
@@ -330,6 +335,7 @@ describe('mail.service', () => {
       const actualResult = await mailService.sendLoginOtp({
         recipient: MOCK_VALID_EMAIL,
         otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
         ipAddress: MOCK_IP,
       })
 
@@ -360,6 +366,7 @@ describe('mail.service', () => {
       const actualResult = await mailService.sendLoginOtp({
         recipient: MOCK_VALID_EMAIL,
         otp: MOCK_OTP,
+        otpPrefix: MOCK_OTP_PREFIX,
         ipAddress: MOCK_IP,
       })
 

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -346,10 +346,12 @@ export class MailService {
   sendLoginOtp = ({
     recipient,
     otp,
+    otpPrefix,
     ipAddress,
   }: {
     recipient: string
     otp: string
+    otpPrefix: string
     ipAddress: string
   }): ResultAsync<true, MailSendError> => {
     return generateLoginOtpHtml({
@@ -357,6 +359,7 @@ export class MailService {
       appUrl: this.#appUrl,
       ipAddress: ipAddress,
       otp,
+      otpPrefix,
     }).andThen((loginHtml) => {
       const mail: MailOptions = {
         to: recipient,

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -71,6 +71,7 @@ const generateAutoreplyPdfPromise = async (
 }
 
 export const generateLoginOtpHtml = (htmlData: {
+  otpPrefix: string
   otp: string
   appName: string
   appUrl: string

--- a/src/app/utils/otp.ts
+++ b/src/app/utils/otp.ts
@@ -18,6 +18,18 @@ export const generateOtp = (): string => {
 }
 
 /**
+ * Randomly generates and returns a 3 letter OTP prefix.
+ * @returns 3 letter OTP prefix string
+ */
+export const generateOtpPrefix = (): string => {
+  // Generates cryptographically strong pseudo-random data. 65 is the starting ASCII character code for upper case letters.
+  return Array(3)
+    .fill(0)
+    .map(() => String.fromCharCode(65 + crypto.randomInt(0, 26)))
+    .join('')
+}
+
+/**
  * Generates a 6-digit OTP together with its hash.
  * @param logMeta Metadata to be included in logs. Defaults to empty object.
  * @param saltRounds Number of salt rounds to use when hashing. Defaults to 10.
@@ -31,12 +43,15 @@ export const generateOtpWithHash = (
   {
     otp: string
     hashedOtp: string
+    otpPrefix: string
   },
   HashingError
 > => {
   const otp = generateOtp()
+  const otpPrefix = generateOtpPrefix()
   return hashData(otp, logMeta, saltRounds).map((hashedOtp) => ({
     otp,
     hashedOtp,
+    otpPrefix,
   }))
 }

--- a/src/app/views/templates/otp-email.server.view.html
+++ b/src/app/views/templates/otp-email.server.view.html
@@ -3,8 +3,8 @@
   <head> </head>
   <body>
     <p>
-      Your OTP is <strong><%= otp %></strong>. Please use this to log in to your
-      <%= appName %> account.
+      Your OTP is <%= otpPrefix %>-<strong><%= otp %></strong>. Please use this
+      to log in to your <%= appName %> account.
     </p>
     <p>
       If your OTP does not work, please request for a new OTP at <%= appUrl %>

--- a/tests/integration/helpers/express-auth.ts
+++ b/tests/integration/helpers/express-auth.ts
@@ -5,6 +5,7 @@ import MailService from 'src/app/services/mail/mail.service'
 import * as OtpUtils from 'src/app/utils/otp'
 
 const MOCK_VALID_OTP = '123456'
+const MOCK_OTP_PREFIX = 'ABC'
 
 /**
  * Integration test helper to create an authenticated session where the user
@@ -32,10 +33,14 @@ export const createAuthedSession = async (
   const otpSpy = jest
     .spyOn(OtpUtils, 'generateOtp')
     .mockReturnValueOnce(MOCK_VALID_OTP)
+  jest.spyOn(OtpUtils, 'generateOtpPrefix').mockReturnValue(MOCK_OTP_PREFIX)
 
   const sendOtpResponse = await request.post('/auth/sendotp').send({ email })
   expect(sendOtpResponse.status).toEqual(200)
-  expect(sendOtpResponse.body).toEqual(`OTP sent to ${email.toLowerCase()}`)
+  expect(sendOtpResponse.body).toEqual({
+    message: `OTP sent to ${email.toLowerCase()}`,
+    otpPrefix: MOCK_OTP_PREFIX,
+  })
 
   // Act
   await request.post('/auth/verifyotp').send({ email, otp: MOCK_VALID_OTP })


### PR DESCRIPTION
## Problem

When multiple OTP requests are triggered, but messages come in after a long time, admin users have no way of checking which is the right OTP to key in other than trying out all of them. Refer to #5710 for more context.

Closes #5710

## Solution

Add a 3 letter prefix to OTPs to the OTP emails and the OTP input field.

**Breaking Changes** 
- [x] Yes - this PR contains breaking changes
    - When the old UIs hit the new servers, since the response was never used, there would be no issue.
    - When the new UIs hit the old servers, `const { otpPrefix } = response` (in `frontend/src/features/login/LoginPage.tsx` line 119 to 122) will yield `undefined`. In this case, anything related to the OTP prefix should not be shown to users.

**Features**:

- Randomly generate 3 letters to be OTP prefix
- Add OTP prefix to OTP in email
- Add OTP prefix on the left of OTP input field
- Fix tests affected by adding of OTP prefix

## Before & After Screenshots

**BEFORE**:

OTP input form:
<img width="661" alt="Screenshot 2023-02-22 at 3 06 59 PM" src="https://user-images.githubusercontent.com/37061143/220548096-676aca8c-5509-4b9e-aadd-193d1b3c9be0.png">

Email:
<img width="972" alt="Screenshot 2023-02-22 at 3 09 52 PM" src="https://user-images.githubusercontent.com/37061143/220548340-5738878a-853a-4036-8d62-0c71f493c8ae.png">


**AFTER**:

OTP input form:
<img width="661" alt="Screenshot 2023-02-22 at 3 08 12 PM" src="https://user-images.githubusercontent.com/37061143/220548112-ea422fe4-4d5a-4749-80d9-940ac3c84495.png">

OTP prefix on input form is updated when OTP is resent:

https://user-images.githubusercontent.com/37061143/220548740-52cacc08-570e-4713-8b3a-c8bdaa0741f7.mov

Email:
<img width="952" alt="Screenshot 2023-02-22 at 3 10 51 PM" src="https://user-images.githubusercontent.com/37061143/220548511-badd2b78-f8a4-4baf-820e-69b4848a7928.png">

## Tests

At the login page, enter your .gov.sg email. You should be at the OTP input form.
- [ ] The OTP input should be prefixed by 3 letters followed by a dash (e.g. `ABC-`).
- [ ] The OTP email should have the OTP prefix before the OTP (e.g. `ABC-12345`).
- [ ] Wait for a OTP resend to be allowed, then resend the OTP. 
  - [ ] The OTP prefix on the email should change when the OTP sent is different.
  - [ ] The OTP prefix on the OTP input field should be updated to the right OTP prefix.
  - [ ] Entering the old OTP (with the old prefix) should not allow the user to login.
- [ ] Entering the OTP with the same OTP prefix as the input form should allow admin user to login.
