### PR TITLE
fix: squished logic block equals to/either option

### DIFF
--- a/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -25,7 +25,8 @@ const MultiItemsContainer: FC = ({ children }) => {
       // Margin difference for selected items.
       my="-3px"
       // Padding for dropdown toggle.
-      maxW="calc(100% - 2.5rem)"
+      flexBasis="calc(100% - 2.5rem)"
+      minW="0px"
     >
       {children}
     </Box>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -180,6 +180,16 @@ export const EditConditionBlock = ({
     }
   }, [currentSelectedField])
 
+  const logicValueWrapperWidth = useMemo(() => {
+    if (!ifValueTypeValue) return 'auto'
+    switch (ifValueTypeValue) {
+      case LogicIfValue.MultiSelect:
+        return '0px'
+      default:
+        return 'auto'
+    }
+  }, [ifValueTypeValue])
+
   const validateValueInputComponent = useCallback(
     (val) => {
       switch (ifValueTypeValue) {
@@ -367,6 +377,7 @@ export const EditConditionBlock = ({
                 isRequired
                 isReadOnly={isLoading}
                 isInvalid={!!get(errors, `${name}.value`)}
+                minW={{ md: logicValueWrapperWidth }}
               >
                 <VisuallyHidden
                   as="label"


### PR DESCRIPTION
Add minimum width 0 for flex child items that do not respect flex basis settings


## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes or Fixes #5508 

## Solution
<!-- How did you solve the problem? -->
Flex basis which should be used to size the width of the rendered multi select input is not respected because there is a max width set on the multi select combo box input beside it. This results in the squished component.

The solution is to:
- convert max width into flex basis on the multi select combo box container
- rely on current set flex grow and flex shrink settings on the multi select combo box container to size that input
- not let the dropdown icon overflow to the next line due to insufficient width available
- and also apply min width 0 on both inputs for desktop screen sizes to let the implicit flex basis auto of the multi select input on the left size the input correctly
- also add a useEffect hook to set min width for the multi select input in case of other types of inputs needing this. It can be simplified from a switch to a simple if else since there is only one condition now

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
From issue #5508:
<img width="635" alt="issue" src="https://user-images.githubusercontent.com/56983748/204996203-30e00c8d-cc83-4e51-ac52-f250d3d23dba.png">

**AFTER**:
<!-- [insert screenshot here] -->
See issue fixed:
<img width="635" alt="Screenshot 2023-02-23 at 12 54 41 AM" src="https://user-images.githubusercontent.com/1590864/220700413-8e6ed7ba-814b-4596-b9a8-ad2030aa4636.png">

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
