### PR TITLE
feat: implement payment beta

### DIFF
--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
@@ -14,6 +14,7 @@ import {
   DrawerTabs,
   useCreatePageSidebar,
 } from '~features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext'
+import { useUser } from '~features/user/queries'
 
 import {
   isDirtySelector,
@@ -31,6 +32,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
   const isMobile = useIsMobile()
   const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
   const isDirty = useDirtyFieldStore(isDirtySelector)
+  const { user } = useUser()
   const {
     activeTab,
     handleBuilderClick,
@@ -102,12 +104,15 @@ export const CreatePageSidebar = (): JSX.Element | null => {
           isActive={activeTab === DrawerTabs.Logic}
           id={FEATURE_TOUR[2].id}
         />
-        <DrawerTabIcon
-          label="Add payment"
-          icon={<BiCreditCard fontSize="1.5rem" />}
-          onClick={handleDrawerPaymentClick}
-          isActive={activeTab === DrawerTabs.Payment}
-        />
+        {user?.betaFlags?.payment && (
+          <DrawerTabIcon
+            label="Add payment"
+            icon={<BiCreditCard fontSize="1.5rem" />}
+            onClick={handleDrawerPaymentClick}
+            isActive={activeTab === DrawerTabs.Payment}
+          />
+        )}
+
         <DrawerTabIcon
           label="Edit Thank you page"
           icon={<PhHandsClapping fontSize="1.5rem" />}

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -14,6 +14,8 @@ import {
 import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
 
+import { useUser } from '~features/user/queries'
+
 import { useAdminFormCollaborators } from '../common/queries'
 
 import { SettingsTab } from './components/SettingsTab'
@@ -25,6 +27,8 @@ import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
 export const SettingsPage = (): JSX.Element => {
   const { formId } = useParams()
+  const { user } = useUser()
+
   if (!formId) throw new Error('No formId provided')
 
   const { hasEditAccess, isLoading: isCollabLoading } =
@@ -80,7 +84,9 @@ export const SettingsPage = (): JSX.Element => {
             <SettingsTab label="Singpass" icon={BiKey} />
             <SettingsTab label="Twilio credentials" icon={BiMessage} />
             <SettingsTab label="Webhooks" icon={BiCodeBlock} />
-            <SettingsTab label="Payments" icon={BiDollar} />
+            {user?.betaFlags?.payment && (
+              <SettingsTab label="Payments" icon={BiDollar} />
+            )}
           </TabList>
         </Flex>
         <TabPanels
@@ -100,9 +106,11 @@ export const SettingsPage = (): JSX.Element => {
           <TabPanel>
             <SettingsWebhooksPage />
           </TabPanel>
-          <TabPanel>
-            <SettingsPaymentsPage />
-          </TabPanel>
+          {user?.betaFlags?.payment && (
+            <TabPanel>
+              <SettingsPaymentsPage />
+            </TabPanel>
+          )}
         </TabPanels>
         <Spacer />
       </Tabs>

--- a/scripts/20232202_add-payments-flag/add-payment-flag.js
+++ b/scripts/20232202_add-payments-flag/add-payment-flag.js
@@ -1,0 +1,58 @@
+/* eslint-disable */
+
+/*
+Adding payment beta flag to specfic user
+*/
+
+/*
+List of user emails to add payment flag to
+*/
+const emails = [
+    // user emails to update
+]
+
+/* 
+Count of users who should have payment flag added to
+*/
+emails.length
+
+/*
+Get count of users who are to 
+*/
+
+db.getCollection('users')
+  .find({email: {$in: emails}})
+  .count();
+
+// check length of emails to count of users 
+
+/*
+Get count of current users who have payment set to true
+*/
+db.getCollection('users').find({ betaFlags: {
+    payment: true
+} }).count()
+
+/*
+Update selected user's payment betaflag to true
+*/
+db.getCollection('users').update({
+    email: {$in: emails}
+}, {
+    $set: {
+        betaFlags: {
+            payment: true
+        }
+    }
+}, {
+    multi: true
+})
+
+/*
+Get count of updated number of users who have payment set to true
+*/
+db.getCollection('users').find({ betaFlags: {
+    payment: true
+} }).count()
+
+// check that beforeCount === afterCount + noOfUsersToAdd

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -11,7 +11,11 @@ export type UserId = Opaque<string, 'UserId'>
 export const UserBase = z.object({
   email: z.string().email(),
   agency: AgencyBase.shape._id,
-  betaFlags: z.object({}).optional(),
+  betaFlags: z
+    .object({
+      payment: z.boolean().optional(),
+    })
+    .optional(),
   flags: z
     .object({ lastSeenFeatureUpdateVersion: z.number().optional() })
     .optional(),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -70,7 +70,9 @@ const compileUserModel = (db: Mongoose) => {
         type: Date,
         default: () => Date.now(),
       },
-      betaFlags: {},
+      betaFlags: {
+        payments: Boolean,
+      },
       flags: {
         lastSeenFeatureUpdateVersion: Number,
       },

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -71,7 +71,7 @@ const compileUserModel = (db: Mongoose) => {
         default: () => Date.now(),
       },
       betaFlags: {
-        payments: Boolean,
+        payment: Boolean,
       },
       flags: {
         lastSeenFeatureUpdateVersion: Number,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -93,7 +93,11 @@ import { EditFieldError } from './admin-form.errors'
 import { updateSettingsValidator } from './admin-form.middlewares'
 import * as AdminFormService from './admin-form.service'
 import { PermissionLevel } from './admin-form.types'
-import { mapRouteError, verifyValidUnicodeString } from './admin-form.utils'
+import {
+  mapRouteError,
+  verifyUserBetaflag,
+  verifyValidUnicodeString,
+} from './admin-form.utils'
 
 // NOTE: Refer to this for documentation: https://github.com/sideway/joi-date/blob/master/API.md
 const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
@@ -2720,6 +2724,8 @@ export const _handleUpdatePayments: ControllerHandler<
   // Step 1: Retrieve currently logged in user.
   return (
     UserService.getPopulatedUserById(sessionUserId)
+      // Step 2: Check if user has 'payment' betaflag
+      .andThen((user) => verifyUserBetaflag(user, 'payment'))
       .andThen((user) =>
         // Step 2: Retrieve form with write permission check.
         AuthService.getFormAfterPermissionChecks({

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -12,7 +12,7 @@ import {
   replaceAt,
 } from '../../../../../shared/utils/immutable-array-fns'
 import { EditFieldActions } from '../../../../shared/constants'
-import { FormFieldSchema, IPopulatedForm } from '../../../../types'
+import { FormFieldSchema, IPopulatedForm, IUserSchema } from '../../../../types'
 import { EditFormFieldParams } from '../../../../types/api'
 import config from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -483,4 +483,24 @@ export const verifyValidUnicodeString = (value: any, helpers: any) => {
     })
   }
   return value
+}
+
+/**
+ * Checks if the user has the specified beta flag enabled
+ * @param user
+ * @param flag which is the string representation of the beta flag
+ * @returns ok(user) if the user has the beta flag enabled
+ * @returns err(ForbiddenFormUser) to deny user access to the beta feature
+ */
+export const verifyUserBetaflag = (
+  user: IUserSchema,
+  betaFlag: keyof Exclude<IUserSchema['betaFlags'], undefined>,
+) => {
+  return user?.betaFlags?.[betaFlag]
+    ? ok(user)
+    : err(
+        new ForbiddenFormError(
+          `User ${user.email} is not authorized to access ${betaFlag} beta features`,
+        ),
+      )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Add payment beta flag to enable us to push payments to prod while isolating the use case to specific users

Closes #5801

## Solution
<!-- How did you solve the problem? -->
Script to add in payment beta flag
Remove rendering of payment sidebar and settings tab if payment flag is not enabled
Prevent calling of /strip and /payment apis if payment flag is not enabled

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="600" alt="image" src="https://user-images.githubusercontent.com/59867455/220861018-80872e14-eca5-46ef-b5ac-f27e36188976.png"><img width="60" alt="image" src="https://user-images.githubusercontent.com/59867455/220861069-8b2b41fb-ad8e-497a-add0-83c3c5122e82.png">


**AFTER**:
<!-- [insert screenshot here] -->
For users without a payment betaflag enabled, payment field does not render
<img width="700" alt="image" src="https://user-images.githubusercontent.com/59867455/220861246-df055fd9-f8d7-46ab-88b7-1c76d5bbfd67.png"><img width="50" alt="image" src="https://user-images.githubusercontent.com/59867455/220862848-84d8935c-cd71-4e2c-90b0-c6b58d4413b3.png">


Additionally, unable to use the API as well
<img width="843" alt="image" src="https://user-images.githubusercontent.com/59867455/220861502-3d121c56-5cac-4237-9e37-25177c2c127e.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
On an admin without payment beta flag:
- [x] Go to the settings tab of any form. Ensure that payments is not displayed
- [x] Go to the create tab of any form. Ensure that payments tab in the side bar is not displayed
- [x] Try calling the API for stripe Oauth at `/stripe`. Ensure that you receive an error
- [x] Try calling the API for payment update at `/payments`. Ensure that you receive an error

On an admin with payment beta flag (or add the payment flag):
- [x] Set up a storage mode form. Ensure you can connect your stripe account
- [x] Update payment fields
- [x] Open the form and make a successful payment. Ensure the results are logged in the result tab.

**New scripts**:

- `add-payment-flag.js` : mongo db calls to update payment beta flag for specified users