### PR TITLE
feat: add some payment details to responses page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -194,7 +194,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                     <Text textStyle="subhead-1">Payment amount:</Text>
                     <Text>
                       S$
-                      {(paymentData.amount / 100).toLocaleString('en-IN', {
+                      {(paymentData.amount / 100).toLocaleString('en-GB', {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                       })}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -201,7 +201,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment status:</Text>
-                    <Text>{paymentData.status}</Text>
+                    <Text>{paymentData.status.toUpperCase()}</Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment date:</Text>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -184,18 +184,24 @@ export const IndividualResponsePage = (): JSX.Element => {
             >
               Payment
             </Text>
-            {isPaymentLoading || isPaymentError ? (
+            {isPaymentLoading || isPaymentError || !paymentData ? (
               <Text>Payment was not enabled when this form was submitted</Text>
             ) : (
               <>
                 <Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment amount:</Text>
-                    <Text>{paymentData?.amount}</Text>
+                    <Text>
+                      S$
+                      {(paymentData.amount / 100).toLocaleString('en-IN', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment status:</Text>
-                    <Text>{paymentData?.status}</Text>
+                    <Text>{paymentData.status}</Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment date:</Text>
@@ -204,7 +210,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment intent ID:</Text>
-                    <Text>{paymentData?.paymentIntentId}</Text>
+                    <Text>{paymentData.paymentIntentId}</Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Transaction fee:</Text>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -9,6 +9,7 @@ import {
   StackDivider,
   Text,
 } from '@chakra-ui/react'
+import moment from 'moment-timezone'
 import simplur from 'simplur'
 
 import Button from '~components/Button'
@@ -206,7 +207,11 @@ export const IndividualResponsePage = (): JSX.Element => {
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment date:</Text>
                     {/* TODO: Change this to date of submission */}
-                    <Text>{new Date().toLocaleDateString('en-sg')}</Text>
+                    <Text>
+                      {moment(paymentData.created)
+                        .tz('Asia/Singapore')
+                        .format('DD MMM YYYY')}
+                    </Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment intent ID:</Text>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -195,8 +195,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment status:</Text>
-                    {/* TODO: Change this to actual status */}
-                    <Text>Success</Text>
+                    <Text>{paymentData?.status}</Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment date:</Text>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -185,9 +185,9 @@ export const IndividualResponsePage = (): JSX.Element => {
             >
               Payment
             </Text>
-            {isPaymentLoading || isPaymentError || !paymentData ? (
+            {isPaymentLoading || isPaymentError ? (
               <Text>Payment was not enabled when this form was submitted</Text>
-            ) : (
+            ) : paymentData ? (
               <>
                 <Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
@@ -219,11 +219,13 @@ export const IndividualResponsePage = (): JSX.Element => {
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Transaction fee:</Text>
-                    {/* TODO: Change this to actual transaction fee */}
+                    {/* TODO: Change this to actual transaction fee once application fee object has been added */}
                     <Text>$0.06</Text>
                   </Stack>
                 </Stack>
               </>
+            ) : (
+              <Text>Payment data not found</Text>
             )}
           </Stack>
         ) : null}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -9,7 +9,6 @@ import {
   StackDivider,
   Text,
 } from '@chakra-ui/react'
-import moment from 'moment-timezone'
 import simplur from 'simplur'
 
 import Button from '~components/Button'
@@ -206,11 +205,16 @@ export const IndividualResponsePage = (): JSX.Element => {
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>
                     <Text textStyle="subhead-1">Payment date:</Text>
-                    {/* TODO: Change this to date of submission */}
                     <Text>
-                      {moment(paymentData.created)
-                        .tz('Asia/Singapore')
-                        .format('DD MMM YYYY')}
+                      {new Intl.DateTimeFormat('en-GB', {
+                        year: 'numeric',
+                        month: 'numeric',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: 'numeric',
+                        second: 'numeric',
+                        timeZoneName: 'shortOffset',
+                      }).format(new Date(paymentData.created))}
                     </Text>
                   </Stack>
                   <Stack direction={{ base: 'column', md: 'row' }}>

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -15,7 +15,7 @@ export type Payment = {
   paymentIntentId: string
   chargeIdLatest: string
   payoutId: string
-  payoutDate: Date
+  payoutDate: DateString
   created: DateString
 }
 

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -15,7 +15,7 @@ export type Payment = {
   paymentIntentId: string
   chargeIdLatest: string
   payoutId: string
-  payoutDate: DateString
+  payoutDate: Date
   created: DateString
 }
 

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe'
+import { DateString } from './generic'
 
 export enum PaymentStatus {
   Failed = 'failed',
@@ -15,6 +16,7 @@ export type Payment = {
   chargeIdLatest: string
   payoutId: string
   payoutDate: Date
+  created: DateString
 }
 
 export type PaymentReceiptDto = {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some payment details in the responses page have been hard-coded

Makes progress on #5803

## Solution
<!-- How did you solve the problem? -->
- Display payment amount in dollars
- Add payment date

Transaction fee is the remaining field that needs to be shown in the responses page. This will be done in a separate PR as we need to create a new transaction_fee property in the payments object, and also it requires refactoring of the `paymentIntents` Stripe API call (which is currently used in `getReceipt`).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Screenshots
**After**
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/56983748/221505412-369bfb18-bcbd-4e9d-94ca-37c70c414ef3.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Check that payment amount shows up in dollars and cents, instead of purely cents
- [ ] Check that the payment date displays the same date, time and timezone that the payment was made
