### PR TITLE
fix: remove payment account id from payment updates

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -178,18 +178,6 @@ export const PaymentInput = (): JSX.Element => {
                 {errors?.description?.message}
               </FormErrorMessage>
             </FormControl>
-
-            <FormControl
-              isRequired
-              isReadOnly={paymentsMutation.isLoading}
-              isInvalid={!!errors.target_account_id}
-            >
-              <FormLabel>Target account ID</FormLabel>
-              <Textarea {...register('target_account_id')} />
-              <FormErrorMessage>
-                {errors?.target_account_id?.message}
-              </FormErrorMessage>
-            </FormControl>
           </>
         )}
       </Stack>

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -10,7 +10,7 @@ import { useDebounce } from 'react-use'
 import { Box, Divider, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
-import { FormPayments } from '~shared/types'
+import { PaymentsUpdateDto } from '~shared/types'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
@@ -67,7 +67,7 @@ export const PaymentInput = (): JSX.Element => {
     formState: { errors, dirtyFields },
     control,
     handleSubmit,
-  } = useForm<FormPayments>({
+  } = useForm<PaymentsUpdateDto>({
     mode: 'onBlur',
     defaultValues: paymentsData,
   })
@@ -83,14 +83,14 @@ export const PaymentInput = (): JSX.Element => {
 
   const handlePaymentsChanges = useCallback(
     (paymentsInputs) => {
-      setData({ ...(paymentsInputs as FormPayments) })
+      setData({ ...(paymentsInputs as PaymentsUpdateDto) })
     },
     [setData],
   )
 
   const watchedInputs = useWatch({
     control: control,
-  }) as UnpackNestedValue<FormPayments>
+  }) as UnpackNestedValue<PaymentsUpdateDto>
 
   const clonedWatchedInputs = useMemo(
     () => cloneDeep(watchedInputs),
@@ -108,7 +108,7 @@ export const PaymentInput = (): JSX.Element => {
 
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
-  const amountValidation: RegisterOptions<FormPayments, 'amount_cents'> =
+  const amountValidation: RegisterOptions<PaymentsUpdateDto, 'amount_cents'> =
     useMemo(
       () => ({
         validate: {

--- a/frontend/src/features/admin-form/create/payment/usePaymentStore.tsx
+++ b/frontend/src/features/admin-form/create/payment/usePaymentStore.tsx
@@ -2,7 +2,7 @@ import { isEqual } from 'lodash'
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
-import { FormPayments } from '~shared/types'
+import { PaymentsUpdateDto } from '~shared/types'
 
 export enum PaymentState {
   EditingPayment,
@@ -12,9 +12,9 @@ export enum PaymentState {
 export type PaymentStore = {
   state: PaymentState
   holdingState: PaymentState | null
-  data?: FormPayments
+  data?: PaymentsUpdateDto
   setToEditingPayment: (holding?: boolean) => void
-  setData: (payment?: FormPayments) => void
+  setData: (payment?: PaymentsUpdateDto) => void
   resetData: () => void
   setToInactive: (holding?: boolean) => void
   clearHoldingState: () => void

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -240,4 +240,4 @@ export type StartPageUpdateDto = FormStartPage
 export type EndPageUpdateDto = FormEndPage
 export type FormPermissionsDto = FormPermission[]
 export type PermissionsUpdateDto = FormPermission[]
-export type PaymentsUpdateDto = FormPayments
+export type PaymentsUpdateDto = Omit<FormPayments, 'target_account_id'>

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -68,13 +68,18 @@ export enum FormResponseMode {
   Email = 'email',
 }
 
-export type FormPayments = {
+type FormPaymentsAccount = {
+  target_account_id: string
+  publishable_key: string
+}
+
+type FormPaymentsField = {
   enabled: boolean
-  target_account_id?: string
-  publishable_key?: string
   amount_cents?: number
   description?: string
 }
+
+export type FormPayments = Partial<FormPaymentsAccount> & FormPaymentsField
 
 export interface FormBase {
   title: string
@@ -240,5 +245,4 @@ export type StartPageUpdateDto = FormStartPage
 export type EndPageUpdateDto = FormEndPage
 export type FormPermissionsDto = FormPermission[]
 export type PermissionsUpdateDto = FormPermission[]
-// target account id should only be changed through Stripe's OAuth Callback
-export type PaymentsUpdateDto = Omit<FormPayments, 'target_account_id'>
+export type PaymentsUpdateDto = FormPaymentsField

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -240,4 +240,5 @@ export type StartPageUpdateDto = FormStartPage
 export type EndPageUpdateDto = FormEndPage
 export type FormPermissionsDto = FormPermission[]
 export type PermissionsUpdateDto = FormPermission[]
+// target account id should only be changed through Stripe's OAuth Callback
 export type PaymentsUpdateDto = Omit<FormPayments, 'target_account_id'>

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -37,6 +37,7 @@ import {
   LogicConditionState,
   LogicDto,
   LogicType,
+  PaymentsUpdateDto,
   StorageFormSettings,
 } from '../../../shared/types'
 import { reorder } from '../../../shared/utils/immutable-array-fns'
@@ -903,7 +904,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
   FormSchema.statics.updatePaymentsById = async function (
     formId: string,
-    newPayments: FormPayments,
+    newPayments: PaymentsUpdateDto,
   ) {
     return this.findByIdAndUpdate(
       formId,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -22,6 +22,7 @@ import {
   FormStartPage,
   LogicDto,
   MyInfoAttribute,
+  PaymentsUpdateDto,
   PublicFormDto,
 } from '../../shared/types'
 import { OverrideProps } from '../app/modules/form/admin-form/admin-form.types'
@@ -360,7 +361,7 @@ export interface IFormModel extends Model<IFormSchema> {
    */
   updatePaymentsById(
     formId: string,
-    newPayments: FormPayments,
+    newPayments: PaymentsUpdateDto,
   ): Promise<IFormDocument | null>
 
   updateFormLogic(


### PR DESCRIPTION
Closed in favour of #5929 and #5903 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently we show and allow changes to payment account id by the admin through the payments drawer tab.

However, this behaviour should not be allowed, and payment account id should only be modifiable throught the Stripe OAuth API

Closes #5812, #5822

## Solution
<!-- How did you solve the problem? -->
Removed the target account id field in payments drawer tab
Decouple account id and publishable key from payments update

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  .

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="535" alt="image" src="https://user-images.githubusercontent.com/59867455/221462272-fc18723f-81d4-4678-b39f-1d27d4ee06ac.png">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="535" alt="image" src="https://user-images.githubusercontent.com/59867455/221462177-d22fa758-141d-48dd-8d85-f01ce647dd97.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] go to a form with payments enabled. Go to the payment drawer tab, ensure that there isn't an account id field present.
- [ ] go to a form with payments enabled. Attempt to change the account id through the `/payment` endpoint. Your request should be rejected