### PR TITLE
fix: add auto-trimming for NRIC field

### DIFF
--- a/frontend/src/templates/Field/Nric/NricField.test.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.test.tsx
@@ -8,6 +8,9 @@ import * as stories from './NricField.stories'
 
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
 
+const VALID_NRIC = 'S0000002G'
+const INVALID_NRIC = 'S0000001B'
+
 describe('validation required', () => {
   it('renders error when field is not filled before submitting', async () => {
     // Arrange
@@ -38,12 +41,12 @@ describe('validation required', () => {
 
     // Act
     // Valid NRIC
-    await user.type(input, 'S0000002G')
+    await user.type(input, VALID_NRIC)
     await user.click(submitButton)
 
     // Assert
     // Should show success message.
-    const success = screen.getByText('You have submitted: S0000002G')
+    const success = screen.getByText(`You have submitted: ${VALID_NRIC}`)
     expect(success).not.toBeNull()
     const error = screen.queryByText('Please fill in required field')
     expect(error).toBeNull()
@@ -105,12 +108,61 @@ describe('NRIC validation', () => {
     expect(input.value).toBe('')
 
     // Act
-    await user.type(input, 'S0000001B')
+    await user.type(input, INVALID_NRIC)
     await user.click(submitButton)
 
     // Assert
     // Should show error message.
     const error = screen.getByText('Please enter a valid NRIC')
+    expect(error).not.toBeNull()
+  })
+})
+
+describe('NRIC field input', () => {
+  it('handles leading spaces', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
+    const submitButton = screen.getByText('Submit')
+
+    expect(input.value).toBe('')
+
+    // Act
+    await user.type(input, ` ${VALID_NRIC}`)
+
+    expect(input.value).toBe(VALID_NRIC)
+
+    await user.click(submitButton)
+
+    // Assert
+    // Should show error message.
+    const error = screen.getByText(`You have submitted: ${VALID_NRIC}`)
+    expect(error).not.toBeNull()
+  })
+
+  it('handles trailing spaces and renders no errors', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByLabelText(
+      `${schema!.questionNumber}. ${schema!.title}`,
+    ) as HTMLInputElement
+    const submitButton = screen.getByText('Submit')
+
+    expect(input.value).toBe('')
+
+    // Act
+    await user.type(input, `${VALID_NRIC} `)
+    await user.click(submitButton)
+
+    // Assert
+    // Should show error message.
+    const error = screen.getByText(`You have submitted: ${VALID_NRIC}`)
     expect(error).not.toBeNull()
   })
 })

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -1,7 +1,7 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { createNricValidationRules } from '~utils/fieldValidation'
@@ -20,6 +20,7 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
     [schema],
   )
 
+  const [value, setValue] = useState<string>('')
   const { register } = useFormContext<SingleAnswerFieldInput>()
 
   return (
@@ -28,7 +29,12 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
         aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
-        {...register(schema._id, validationRules)}
+        value={value}
+        {...register(schema._id, {
+          ...validationRules,
+          onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+            setValue(event.target.value.trim()),
+        })}
       />
     </FieldContainer>
   )

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -20,8 +20,7 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
     [schema],
   )
 
-  const [value, setValue] = useState<string>('')
-  const { register } = useFormContext<SingleAnswerFieldInput>()
+  const { register, setValue } = useFormContext<SingleAnswerFieldInput>()
 
   return (
     <FieldContainer schema={schema}>
@@ -29,11 +28,10 @@ export const NricField = ({ schema }: NricFieldProps): JSX.Element => {
         aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
-        value={value}
         {...register(schema._id, {
           ...validationRules,
           onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
-            setValue(event.target.value.trim()),
+            setValue(schema._id, event.target.value.trim()),
         })}
       />
     </FieldContainer>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Spaces could be unintentionally included by the user when they are entering their NRIC. This can be incredibly frustrating for the user to identify why their NRIC had failed the validation. This is a regression issue arising from the react-angular migration.

Closes #5854

## Solution
<!-- How did you solve the problem? -->
We can remove one potential source of frustration through the inclusion of trimming the NRIC as there are no need for trailing/leading spaces.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

<img width="862" alt="Screenshot 2023-02-28 at 7 17 20 PM" src="https://user-images.githubusercontent.com/12391617/221838677-6883a66a-e2dc-4390-87d9-92e03241b65b.png">


**AFTER**:
<img width="862" alt="Screenshot 2023-02-28 at 6 57 29 PM" src="https://user-images.githubusercontent.com/12391617/221834286-04c462ee-2514-4343-bec2-61752ed8f0f7.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] go to a form with an NRIC input. Attempt to enter a valid NRIC. It should pass validation without any error message appearing.
- [ ] go to a form with an NRIC input. Attempt to enter a valid NRIC with trailing or leading spaces. The input should not be updating with spaces present. It should pass validation without any error message appearing.