### PR TITLE
fix: decouple payment response from individual response page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
@@ -1,4 +1,4 @@
-import { Stack, Text } from '@chakra-ui/react'
+import { Skeleton, Stack, Text } from '@chakra-ui/react'
 
 import { useIndividualPaymentSubmission } from './queries'
 
@@ -7,8 +7,12 @@ export const IndividualPaymentResponse = (submissionId: {
 }): JSX.Element => {
   if (!submissionId) throw new Error('Missing submissionId')
 
-  // TODO: get paymentData from IndividualResponsePage through submission endpoint
-  const { data: paymentData } = useIndividualPaymentSubmission()
+  // TODO: get paymentData from IndividualResponsePage through submission endpoint when we refactor the endpoints
+  const {
+    data: paymentData,
+    isError,
+    isLoading,
+  } = useIndividualPaymentSubmission()
 
   return (
     <Stack>
@@ -21,7 +25,10 @@ export const IndividualPaymentResponse = (submissionId: {
       >
         Payment
       </Text>
-      {paymentData ? (
+      {isError || isLoading ? (
+        //TODO: check with design for skeleton layout
+        <Skeleton height="1.5rem" />
+      ) : paymentData ? (
         <>
           <Stack>
             <Stack direction={{ base: 'column', md: 'row' }}>
@@ -64,6 +71,7 @@ export const IndividualPaymentResponse = (submissionId: {
           </Stack>
         </>
       ) : (
+        //TODO: check with design for exact copy
         <Text>Payment data not found</Text>
       )}
     </Stack>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
@@ -1,0 +1,76 @@
+import { Stack, Text } from '@chakra-ui/react'
+
+import { useIndividualPaymentSubmission } from './queries'
+
+export const IndividualPaymentResponse = (submissionId: {
+  submissionId: string
+}): JSX.Element => {
+  if (!submissionId) throw new Error('Missing submissionId')
+
+  const {
+    data: paymentData,
+    isLoading: isPaymentLoading,
+    isError: isPaymentError,
+  } = useIndividualPaymentSubmission()
+
+  return (
+    <Stack>
+      <Text
+        textStyle="h2"
+        as="h2"
+        color="primary.500"
+        mb="0.5rem"
+        _notFirst={{ mt: '2.5rem' }}
+      >
+        Payment
+      </Text>
+      {isPaymentLoading || isPaymentError ? (
+        <Text>Payment was not enabled when this form was submitted</Text>
+      ) : paymentData ? (
+        <>
+          <Stack>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <Text textStyle="subhead-1">Payment amount:</Text>
+              <Text>
+                S$
+                {(paymentData.amount / 100).toLocaleString('en-GB', {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </Text>
+            </Stack>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <Text textStyle="subhead-1">Payment status:</Text>
+              <Text>{paymentData.status.toUpperCase()}</Text>
+            </Stack>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <Text textStyle="subhead-1">Payment date:</Text>
+              <Text>
+                {new Intl.DateTimeFormat('en-GB', {
+                  year: 'numeric',
+                  month: 'numeric',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  second: 'numeric',
+                  timeZoneName: 'shortOffset',
+                }).format(new Date(paymentData.created))}
+              </Text>
+            </Stack>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <Text textStyle="subhead-1">Payment intent ID:</Text>
+              <Text>{paymentData.paymentIntentId}</Text>
+            </Stack>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <Text textStyle="subhead-1">Transaction fee:</Text>
+              {/* TODO: Change this to actual transaction fee once application fee object has been added */}
+              <Text>$0.06</Text>
+            </Stack>
+          </Stack>
+        </>
+      ) : (
+        <Text>Payment data not found</Text>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
@@ -7,11 +7,8 @@ export const IndividualPaymentResponse = (submissionId: {
 }): JSX.Element => {
   if (!submissionId) throw new Error('Missing submissionId')
 
-  const {
-    data: paymentData,
-    isLoading: isPaymentLoading,
-    isError: isPaymentError,
-  } = useIndividualPaymentSubmission()
+  // TODO: get paymentData from IndividualResponsePage through submission endpoint
+  const { data: paymentData } = useIndividualPaymentSubmission()
 
   return (
     <Stack>
@@ -24,9 +21,7 @@ export const IndividualPaymentResponse = (submissionId: {
       >
         Payment
       </Text>
-      {isPaymentLoading || isPaymentError ? (
-        <Text>Payment was not enabled when this form was submitted</Text>
-      ) : paymentData ? (
+      {paymentData ? (
         <>
           <Stack>
             <Stack direction={{ base: 'column', md: 'row' }}>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -152,22 +152,20 @@ export const IndividualResponsePage = (): JSX.Element => {
             </Stack>
           )}
         </Stack>
-
-        <Stack>
-          {isLoading || isError ? (
-            <LoadingDecryption />
-          ) : (
+        {isLoading || isError ? (
+          <LoadingDecryption />
+        ) : (
+          <Stack>
             <Stack spacing="1.5rem" divider={<StackDivider />}>
               {data?.responses.map((r, idx) => (
                 <DecryptedRow row={r} secretKey={secretKey} key={idx} />
               ))}
               <Box />
             </Stack>
-          )}
-        </Stack>
-
-        {form?.payments?.enabled && (
-          <IndividualPaymentResponse submissionId={submissionId} />
+            {form?.payments?.enabled && (
+              <IndividualPaymentResponse submissionId={submissionId} />
+            )}
+          </Stack>
         )}
       </Stack>
     </Flex>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -22,12 +22,10 @@ import {
 } from '../ResponsesPage/storage'
 
 import { DecryptedRow } from './DecryptedRow'
+import { IndividualPaymentResponse } from './IndividualPaymentResponse'
 import { IndividualResponseNavbar } from './IndividualResponseNavbar'
 import { useMutateDownloadAttachments } from './mutations'
-import {
-  useIndividualPaymentSubmission,
-  useIndividualSubmission,
-} from './queries'
+import { useIndividualSubmission } from './queries'
 
 const LoadingDecryption = memo(() => {
   return (
@@ -56,11 +54,6 @@ export const IndividualResponsePage = (): JSX.Element => {
 
   const { secretKey } = useStorageResponsesContext()
   const { data, isLoading, isError } = useIndividualSubmission()
-  const {
-    data: paymentData,
-    isLoading: isPaymentLoading,
-    isError: isPaymentError,
-  } = useIndividualPaymentSubmission()
   const { data: form } = useAdminForm()
 
   const attachmentDownloadUrls = useMemo(() => {
@@ -173,66 +166,9 @@ export const IndividualResponsePage = (): JSX.Element => {
           )}
         </Stack>
 
-        {form?.payments?.enabled ? (
-          <Stack>
-            <Text
-              textStyle="h2"
-              as="h2"
-              color="primary.500"
-              mb="0.5rem"
-              _notFirst={{ mt: '2.5rem' }}
-            >
-              Payment
-            </Text>
-            {isPaymentLoading || isPaymentError ? (
-              <Text>Payment was not enabled when this form was submitted</Text>
-            ) : paymentData ? (
-              <>
-                <Stack>
-                  <Stack direction={{ base: 'column', md: 'row' }}>
-                    <Text textStyle="subhead-1">Payment amount:</Text>
-                    <Text>
-                      S$
-                      {(paymentData.amount / 100).toLocaleString('en-GB', {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </Text>
-                  </Stack>
-                  <Stack direction={{ base: 'column', md: 'row' }}>
-                    <Text textStyle="subhead-1">Payment status:</Text>
-                    <Text>{paymentData.status.toUpperCase()}</Text>
-                  </Stack>
-                  <Stack direction={{ base: 'column', md: 'row' }}>
-                    <Text textStyle="subhead-1">Payment date:</Text>
-                    <Text>
-                      {new Intl.DateTimeFormat('en-GB', {
-                        year: 'numeric',
-                        month: 'numeric',
-                        day: 'numeric',
-                        hour: 'numeric',
-                        minute: 'numeric',
-                        second: 'numeric',
-                        timeZoneName: 'shortOffset',
-                      }).format(new Date(paymentData.created))}
-                    </Text>
-                  </Stack>
-                  <Stack direction={{ base: 'column', md: 'row' }}>
-                    <Text textStyle="subhead-1">Payment intent ID:</Text>
-                    <Text>{paymentData.paymentIntentId}</Text>
-                  </Stack>
-                  <Stack direction={{ base: 'column', md: 'row' }}>
-                    <Text textStyle="subhead-1">Transaction fee:</Text>
-                    {/* TODO: Change this to actual transaction fee once application fee object has been added */}
-                    <Text>$0.06</Text>
-                  </Stack>
-                </Stack>
-              </>
-            ) : (
-              <Text>Payment data not found</Text>
-            )}
-          </Stack>
-        ) : null}
+        {form?.payments?.enabled && (
+          <IndividualPaymentResponse submissionId={submissionId} />
+        )}
       </Stack>
     </Flex>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, irregardless of whether the form has payment enabled, we will call the `/submission/{submissionId}/payment` endpoint. This returns a 500 error for non-payment enabled forms, as the payment object will not exist.

Closes #5857

## Solution
<!-- How did you solve the problem? -->

Decouple the payment response from the overall individual response page. We will only call the endpoint if payment has been enabled on the form.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before and After Screenshots

**Before**
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/59867455/223395510-eff4b080-1888-4a75-91ec-59b995e3e021.png">
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/59867455/223395701-24c44da0-60ad-485f-9a4d-c452be843bc1.png">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] go to a storage form without payments enabled. Try to access the individual response in the 'results' tab. There should not be any error.
- [ ] go to a storage form with payments enabled. Try to access the individual response in the 'results'' tab. There should not be be any error message and the payment details field should be visible
