### PR TITLE
feat: connect DataDog RUM and traces

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -47,8 +47,9 @@ jobs:
           REACT_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
           REACT_APP_FORMSG_SDK_MODE: ${{ secrets.REACT_APP_FORMSG_SDK_MODE }}
         run: |
-          sed -i -e "s/@REACT_APP_DD_RUM_APP_ID/$REACT_APP_DD_RUM_APP_ID/g" -e "s/@REACT_APP_DD_RUM_CLIENT_TOKEN/$REACT_APP_DD_RUM_CLIENT_TOKEN/g" -e "s/@REACT_APP_DD_RUM_ENV/$REACT_APP_DD_RUM_ENV/g" -e "s/@REACT_APP_VERSION/${{env.APP_VERSION}}/g" -e "s/@REACT_APP_DD_SAMPLE_RATE/$REACT_APP_DD_SAMPLE_RATE/g" frontend/datadog-chunk.ts
+          sed -i -e "s/@REACT_APP_DD_RUM_APP_ID/$REACT_APP_DD_RUM_APP_ID/g" -e "s/@REACT_APP_DD_RUM_CLIENT_TOKEN/$REACT_APP_DD_RUM_CLIENT_TOKEN/g" -e "s/@REACT_APP_DD_RUM_ENV/$REACT_APP_DD_RUM_ENV/g" -e "s/@REACT_APP_VERSION/${{env.APP_VERSION}}/g" -e "s/@REACT_APP_URL/${{env.APP_URL}}/g" -e "s/@REACT_APP_DD_SAMPLE_RATE/$REACT_APP_DD_SAMPLE_RATE/g" frontend/datadog-chunk.ts
           echo REACT_APP_VERSION=${{env.APP_VERSION}} > frontend/.env
+          echo REACT_APP_URL=${{env.APP_URL}} > frontend/.env
           echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
           echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
           echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -46,10 +46,11 @@ jobs:
           REACT_APP_DD_SAMPLE_RATE: ${{ secrets.DD_SAMPLE_RATE }}
           REACT_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
           REACT_APP_FORMSG_SDK_MODE: ${{ secrets.REACT_APP_FORMSG_SDK_MODE }}
+          REACT_APP_URL: ${{ secrets.APP_URL }}
         run: |
-          sed -i -e "s/@REACT_APP_DD_RUM_APP_ID/$REACT_APP_DD_RUM_APP_ID/g" -e "s/@REACT_APP_DD_RUM_CLIENT_TOKEN/$REACT_APP_DD_RUM_CLIENT_TOKEN/g" -e "s/@REACT_APP_DD_RUM_ENV/$REACT_APP_DD_RUM_ENV/g" -e "s/@REACT_APP_VERSION/${{env.APP_VERSION}}/g" -e "s/@REACT_APP_URL/${{env.APP_URL}}/g" -e "s/@REACT_APP_DD_SAMPLE_RATE/$REACT_APP_DD_SAMPLE_RATE/g" frontend/datadog-chunk.ts
+          sed -i -e "s|@REACT_APP_URL|${{secrets.APP_URL}}|g" -e "s/@REACT_APP_DD_RUM_APP_ID/$REACT_APP_DD_RUM_APP_ID/g" -e "s/@REACT_APP_DD_RUM_CLIENT_TOKEN/$REACT_APP_DD_RUM_CLIENT_TOKEN/g" -e "s/@REACT_APP_DD_RUM_ENV/$REACT_APP_DD_RUM_ENV/g" -e "s/@REACT_APP_VERSION/${{env.APP_VERSION}}/g" -e "s/@REACT_APP_DD_SAMPLE_RATE/$REACT_APP_DD_SAMPLE_RATE/g" frontend/datadog-chunk.ts
           echo REACT_APP_VERSION=${{env.APP_VERSION}} > frontend/.env
-          echo REACT_APP_URL=${{env.APP_URL}} > frontend/.env
+          echo REACT_APP_URL=$REACT_APP_URL > frontend/.env
           echo REACT_APP_GA_TRACKING_ID=$REACT_APP_GA_TRACKING_ID >> frontend/.env
           echo REACT_APP_FORMSG_SDK_MODE=$REACT_APP_FORMSG_SDK_MODE >> frontend/.env
           echo REACT_APP_DD_RUM_CLIENT_TOKEN=$REACT_APP_DD_RUM_CLIENT_TOKEN >> frontend/.env

--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -37,7 +37,7 @@ datadogRum.init({
   env: '@REACT_APP_DD_RUM_ENV',
   site: 'datadoghq.com',
   service: 'formsg-react',
-  allowedTracingUrls: ['https://form.gov.sg'],
+  allowedTracingUrls: ['@REACT_APP_URL'],
 
   // Specify a version number to identify the deployed version of your application in Datadog
   version: '@REACT_APP_VERSION',

--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -37,6 +37,7 @@ datadogRum.init({
   env: '@REACT_APP_DD_RUM_ENV',
   site: 'datadoghq.com',
   service: 'formsg-react',
+  allowedTracingUrls: ['https://form.gov.sg'],
 
   // Specify a version number to identify the deployed version of your application in Datadog
   version: '@REACT_APP_VERSION',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.6",
         "@datadog/browser-logs": "^4.28.1",
-        "@datadog/browser-rum": "^4.14.0",
+        "@datadog/browser-rum": "^4.34.1",
         "@emotion/react": "^11.7.0",
         "@emotion/styled": "^11.6.0",
         "@floating-ui/react-dom-interactions": "^0.9.3",
@@ -3222,9 +3222,9 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
-      "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.34.1.tgz",
+      "integrity": "sha512-xZUMxSEUlzXVGU8fvIG5J4xGGBShrxgTTmCd9p7Ju/rUPnWV0hTqhPIXwSgbMvHgmX1vNwoNvydmlzhNVpKr3g=="
     },
     "node_modules/@datadog/browser-logs": {
       "version": "4.28.1",
@@ -3248,20 +3248,28 @@
       "integrity": "sha512-BmMJA3SpZtI5VVukuxMKYc7ALBLcydnG+tRh5pXP/Tjjejh9sx611TdspeAd00rfpYQ4c51CcHkhem3oU/WJCQ=="
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.14.0.tgz",
-      "integrity": "sha512-C4vl+lo6XugpcydZb4Fo+iRBs04D8+Z3k+aXcnbGkRBFKvr0ZXY1Z8ZaC60ZHDiiJq2WzmphxVvm0Q6UI5R0YQ==",
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.34.1.tgz",
+      "integrity": "sha512-fKw1EUwlPNliUJnOftsIgNGbW70+pZGwt2BbiUsWxp+CBHsw+MRFENUJybAK2l4PqNm+AZKVkvultiCDGvo3gg==",
       "dependencies": {
-        "@datadog/browser-core": "4.14.0",
-        "@datadog/browser-rum-core": "4.14.0"
+        "@datadog/browser-core": "4.34.1",
+        "@datadog/browser-rum-core": "4.34.1"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "4.34.1"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.14.0.tgz",
-      "integrity": "sha512-BoO3Q9AyNd5NahnjKWPBt+HqMCIp5EskirGp91KGXUYFsXROsTu0DqpQlr70CVwqPCbKUhG219P+AR7vHHaPQw==",
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.34.1.tgz",
+      "integrity": "sha512-s1nHAXREKRlTl2EOn+J/786D7pvQ2lg9MunhmC5Juh9DeNrYrmAooxbrXCaCy0gKRBHbm68HM4h59FXuA5iNGg==",
       "dependencies": {
-        "@datadog/browser-core": "4.14.0"
+        "@datadog/browser-core": "4.34.1"
       }
     },
     "node_modules/@design-systems/utils": {
@@ -53324,9 +53332,9 @@
       "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
     },
     "@datadog/browser-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
-      "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.34.1.tgz",
+      "integrity": "sha512-xZUMxSEUlzXVGU8fvIG5J4xGGBShrxgTTmCd9p7Ju/rUPnWV0hTqhPIXwSgbMvHgmX1vNwoNvydmlzhNVpKr3g=="
     },
     "@datadog/browser-logs": {
       "version": "4.28.1",
@@ -53344,20 +53352,20 @@
       }
     },
     "@datadog/browser-rum": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.14.0.tgz",
-      "integrity": "sha512-C4vl+lo6XugpcydZb4Fo+iRBs04D8+Z3k+aXcnbGkRBFKvr0ZXY1Z8ZaC60ZHDiiJq2WzmphxVvm0Q6UI5R0YQ==",
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.34.1.tgz",
+      "integrity": "sha512-fKw1EUwlPNliUJnOftsIgNGbW70+pZGwt2BbiUsWxp+CBHsw+MRFENUJybAK2l4PqNm+AZKVkvultiCDGvo3gg==",
       "requires": {
-        "@datadog/browser-core": "4.14.0",
-        "@datadog/browser-rum-core": "4.14.0"
+        "@datadog/browser-core": "4.34.1",
+        "@datadog/browser-rum-core": "4.34.1"
       }
     },
     "@datadog/browser-rum-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.14.0.tgz",
-      "integrity": "sha512-BoO3Q9AyNd5NahnjKWPBt+HqMCIp5EskirGp91KGXUYFsXROsTu0DqpQlr70CVwqPCbKUhG219P+AR7vHHaPQw==",
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.34.1.tgz",
+      "integrity": "sha512-s1nHAXREKRlTl2EOn+J/786D7pvQ2lg9MunhmC5Juh9DeNrYrmAooxbrXCaCy0gKRBHbm68HM4h59FXuA5iNGg==",
       "requires": {
-        "@datadog/browser-core": "4.14.0"
+        "@datadog/browser-core": "4.34.1"
       }
     },
     "@design-systems/utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.6",
     "@datadog/browser-logs": "^4.28.1",
-    "@datadog/browser-rum": "^4.14.0",
+    "@datadog/browser-rum": "^4.34.1",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
     "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -227,6 +227,7 @@ export const PublicFormProvider = ({
                     datadogLogs.logger.warn('Test dd traces', {
                       meta: {
                         action: 'dd traces',
+                        allowedTracingUrl: process.env.REACT_APP_URL,
                       },
                     })
                   },
@@ -270,6 +271,7 @@ export const PublicFormProvider = ({
                     datadogLogs.logger.warn('Test dd traces', {
                       meta: {
                         action: 'dd traces',
+                        allowedTracingUrl: 'process.env.REACT_APP_URL',
                       },
                     })
                   },

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -224,6 +224,11 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
+                    datadogLogs.logger.warn('Test dd traces', {
+                      meta: {
+                        action: 'dd traces',
+                      },
+                    })
                   },
                 },
               )
@@ -262,6 +267,11 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
+                    datadogLogs.logger.warn('Test dd traces', {
+                      meta: {
+                        action: 'dd traces',
+                      },
+                    })
                   },
                 },
               )

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -224,12 +224,6 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
-                    datadogLogs.logger.warn('Test dd traces', {
-                      meta: {
-                        action: 'dd traces',
-                        allowedTracingUrl: process.env.REACT_APP_URL,
-                      },
-                    })
                   },
                 },
               )
@@ -268,12 +262,6 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
-                    datadogLogs.logger.warn('Test dd traces', {
-                      meta: {
-                        action: 'dd traces',
-                        allowedTracingUrl: 'process.env.REACT_APP_URL',
-                      },
-                    })
                   },
                 },
               )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We'd like to connect DataDog RUM and traces for better traceability, in order to see logs in a unified way.

Closes #5834

## Solution
<!-- How did you solve the problem? -->

Add the `allowedTracingUrl` property to the initialisation of `datadogRum`

Note: 100% of the traces coming from browser requests are sent to Datadog as `traceSampleRate` has not been set

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
- [ ] Track datadog daily expenditure to determine how this changes our billing
