### PR TITLE
feat: log network error

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -241,16 +241,17 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
-                const env = await fetch(
-                  `${process.env.REACT_APP_URL}/api/v3/client/env`,
-                )
-                datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
-                  meta: {
-                    action: 'handleSubmitForm',
-                    envFetchSuccess: !!env,
-                    env: await env.json(),
-                  },
-                })
+                if (error.message.match(/Network Error/)) {
+                  const env = await fetch(
+                    `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                  )
+                  datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
+                    meta: {
+                      action: 'handleSubmitForm',
+                      envFetchSuccess: env.ok, // returns true if the response returned successfully
+                    },
+                  })
+                }
               })
           )
         case FormResponseMode.Encrypt:
@@ -289,16 +290,17 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
-                const env = await fetch(
-                  `${process.env.REACT_APP_URL}/api/v3/client/env`,
-                )
-                datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
-                  meta: {
-                    action: 'handleSubmitForm',
-                    envFetchSuccess: !!env,
-                    env: await env.json(),
-                  },
-                })
+                if (error.message.match(/Network Error/)) {
+                  const env = await fetch(
+                    `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                  )
+                  datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
+                    meta: {
+                      action: 'handleSubmitForm',
+                      envFetchSuccess: env.ok, // returns true if the response returned successfully
+                    },
+                  })
+                }
               })
           )
       }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -241,7 +241,7 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
-                if (error.message.match(/Network Error/)) {
+                if (error.message.match(/Network Error/i) && fetch) {
                   const env = await fetch(
                     `${process.env.REACT_APP_URL}/api/v3/client/env`,
                   )
@@ -290,7 +290,7 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
-                if (error.message.match(/Network Error/)) {
+                if (error.message.match(/Network Error/i) && fetch) {
                   const env = await fetch(
                     `${process.env.REACT_APP_URL}/api/v3/client/env`,
                   )

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -224,19 +224,6 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
-                    const env = fetch(
-                      `${process.env.REACT_APP_URL}/api/v3/client/env`,
-                    )
-                    datadogLogs.logger.warn(
-                      `handleSubmitForm: fetch env vars`,
-                      {
-                        meta: {
-                          action: 'handleSubmitForm',
-                          envFetchSuccess: !!env,
-                          env: env,
-                        },
-                      },
-                    )
                   },
                 },
               )
@@ -261,7 +248,7 @@ export const PublicFormProvider = ({
                   meta: {
                     action: 'handleSubmitForm',
                     envFetchSuccess: !!env,
-                    env: env,
+                    env: await env.json(),
                   },
                 })
               })
@@ -285,19 +272,6 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
-                    const env = fetch(
-                      `${process.env.REACT_APP_URL}/api/v3/client/env`,
-                    )
-                    datadogLogs.logger.warn(
-                      `handleSubmitForm: fetch env vars`,
-                      {
-                        meta: {
-                          action: 'handleSubmitForm',
-                          envFetchSuccess: !!env,
-                          env: env,
-                        },
-                      },
-                    )
                   },
                 },
               )
@@ -322,7 +296,7 @@ export const PublicFormProvider = ({
                   meta: {
                     action: 'handleSubmitForm',
                     envFetchSuccess: !!env,
-                    env: env,
+                    env: await env.json(),
                   },
                 })
               })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -228,7 +228,7 @@ export const PublicFormProvider = ({
                 },
               )
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
-              .catch((error) => {
+              .catch(async (error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
@@ -241,6 +241,16 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
+                const env = await fetch(
+                  `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                )
+                datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
+                  meta: {
+                    action: 'handleSubmitForm',
+                    envFetchSuccess: !!env,
+                    env: env,
+                  },
+                })
               })
           )
         case FormResponseMode.Encrypt:
@@ -266,7 +276,7 @@ export const PublicFormProvider = ({
                 },
               )
               // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
-              .catch((error) => {
+              .catch(async (error) => {
                 // TODO: Remove when we have resolved the Network Error and t.arrayBuffer issues.
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
@@ -279,6 +289,16 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(error, form)
+                const env = await fetch(
+                  `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                )
+                datadogLogs.logger.warn(`handleSubmitForm: fetch env vars`, {
+                  meta: {
+                    action: 'handleSubmitForm',
+                    envFetchSuccess: !!env,
+                    env: env,
+                  },
+                })
               })
           )
       }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -224,6 +224,19 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
+                    const env = fetch(
+                      `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                    )
+                    datadogLogs.logger.warn(
+                      `handleSubmitForm: fetch env vars`,
+                      {
+                        meta: {
+                          action: 'handleSubmitForm',
+                          envFetchSuccess: !!env,
+                          env: env,
+                        },
+                      },
+                    )
                   },
                 },
               )
@@ -272,6 +285,19 @@ export const PublicFormProvider = ({
                       timestamp,
                     })
                     trackSubmitForm(form)
+                    const env = fetch(
+                      `${process.env.REACT_APP_URL}/api/v3/client/env`,
+                    )
+                    datadogLogs.logger.warn(
+                      `handleSubmitForm: fetch env vars`,
+                      {
+                        meta: {
+                          action: 'handleSubmitForm',
+                          envFetchSuccess: !!env,
+                          env: env,
+                        },
+                      },
+                    )
                   },
                 },
               )


### PR DESCRIPTION
## Context
<!-- How did you solve the problem? -->
We want to retrieve the front end env vars via `fetch` when there's a `handleSubmitForm` error, so we can confirm if there is truly a network error on the user's end.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Monitor DD logs

