### PR TITLE
chore: fix release prep script

### DIFF
--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -96,4 +96,5 @@ gh pr create \
 # cleanup
 rm ${pr_body_file}
 rm ${pr_body_file_groupped}
+git checkout develop
 git branch -D ${release_branch}


### PR DESCRIPTION
## Problem
The release prep script doesn't checkout develop before trying to delete the release branch, so the deletion always fails. This PR fixes that.

## Solution
Add `git checkout develop` before deleting the release branch.
