### PR TITLE
feat: shift payment acc id details from drawer to settings

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -178,18 +178,6 @@ export const PaymentInput = (): JSX.Element => {
                 {errors?.description?.message}
               </FormErrorMessage>
             </FormControl>
-
-            <FormControl
-              isRequired
-              isReadOnly={paymentsMutation.isLoading}
-              isInvalid={!!errors.target_account_id}
-            >
-              <FormLabel>Target account ID</FormLabel>
-              <Textarea {...register('target_account_id')} />
-              <FormErrorMessage>
-                {errors?.target_account_id?.message}
-              </FormErrorMessage>
-            </FormControl>
           </>
         )}
       </Stack>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,6 +1,8 @@
-import { Flex, Icon, Skeleton, Text } from '@chakra-ui/react'
+import { Flex, FormControl, Icon, Skeleton, Text } from '@chakra-ui/react'
 
 import { BxsCheckCircle, BxsError, BxsInfoCircle } from '~assets/icons'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
 
 import { useAdminFormPayments, useAdminFormSettings } from '../../queries'
 
@@ -70,11 +72,37 @@ const PaymentsAccountValidation = () => {
   )
 }
 
+const PaymentsAccountInformation = () => {
+  const { data: settings, isLoading } = useAdminFormSettings()
+
+  return (
+    <Skeleton isLoaded={!isLoading}>
+      <FormControl mb="2.5rem">
+        <FormLabel mb="0.75rem" isRequired>
+          <Text textStyle="subhead-1">Target Account ID</Text>
+          <Text textStyle="body-2" textColor="secondary.400">
+            This is the account ID connected to this form.
+          </Text>
+        </FormLabel>
+        <Input
+          isDisabled={true}
+          value={settings?.payments?.target_account_id}
+        ></Input>
+      </FormControl>
+    </Skeleton>
+  )
+}
+
 const PaymentsSectionText = () => {
   const { data: settings, isLoading } = useAdminFormSettings()
 
   if (settings?.payments?.enabled && settings?.payments?.target_account_id) {
-    return <PaymentsAccountValidation />
+    return (
+      <>
+        <PaymentsAccountValidation />
+        <PaymentsAccountInformation />
+      </>
+    )
   }
 
   return (

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -76,20 +76,20 @@ const PaymentsAccountInformation = () => {
   const { data: settings, isLoading } = useAdminFormSettings()
 
   return (
-    <Skeleton isLoaded={!isLoading}>
-      <FormControl mb="2.5rem">
-        <FormLabel mb="0.75rem" isRequired>
-          <Text textStyle="subhead-1">Target Account ID</Text>
-          <Text textStyle="body-2" textColor="secondary.400">
-            This is the account ID connected to this form.
-          </Text>
-        </FormLabel>
+    <FormControl mb="2.5rem">
+      <FormLabel
+        description="This is the account ID connected to this form."
+        isRequired
+      >
+        Target Account ID
+      </FormLabel>
+      <Skeleton isLoaded={!isLoading}>
         <Input
           isDisabled={true}
           value={settings?.payments?.target_account_id}
         ></Input>
-      </FormControl>
-    </Skeleton>
+      </Skeleton>
+    </FormControl>
   )
 }
 

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -72,9 +72,13 @@ const PaymentsAccountValidation = () => {
   )
 }
 
-const PaymentsAccountInformation = () => {
-  const { data: settings, isLoading } = useAdminFormSettings()
-
+const PaymentsAccountInformation = ({
+  account_id,
+  isLoading,
+}: {
+  account_id: string
+  isLoading: boolean
+}) => {
   return (
     <FormControl mb="2.5rem">
       <FormLabel
@@ -84,10 +88,7 @@ const PaymentsAccountInformation = () => {
         Target Account ID
       </FormLabel>
       <Skeleton isLoaded={!isLoading}>
-        <Input
-          isDisabled={true}
-          value={settings?.payments?.target_account_id}
-        ></Input>
+        <Input isDisabled={true} value={account_id}></Input>
       </Skeleton>
     </FormControl>
   )
@@ -100,7 +101,10 @@ const PaymentsSectionText = () => {
     return (
       <>
         <PaymentsAccountValidation />
-        <PaymentsAccountInformation />
+        <PaymentsAccountInformation
+          account_id={settings.payments.target_account_id}
+          isLoading={isLoading}
+        />
       </>
     )
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Payment account id shouldn't be shown in the payment drawer field and instead should displayed in the payment settings. User should also be unable to update payment account id directly through the frontend 

Closes #5813, #5812

## Solution
<!-- How did you solve the problem? -->
Remove payment account id information from PaymentDrawer
Add payment accound id infromation to PaymentSettings based on design master

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="531" alt="image" src="https://user-images.githubusercontent.com/59867455/223610794-6bab954b-a363-45be-950e-8c8d52a9d208.png">
<img width="648" alt="image" src="https://user-images.githubusercontent.com/59867455/223610818-f68c6982-5098-4055-8ffd-a2c7f6ab1a30.png">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="533" alt="image" src="https://user-images.githubusercontent.com/59867455/223610878-ba893c18-8c21-438a-a51b-f6231d4a51da.png">
<img width="727" alt="image" src="https://user-images.githubusercontent.com/59867455/223621759-59931481-151c-4060-8a05-bf4ea000c018.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Go to a form with payments enabled. Connect your stripe account, the payment account id should be visible (but greyed out/unselectable) in the payment settings page
- [ ] Go to a form with payments enabled. Go to create -> payment drawer, ensure that there is no account id field
