### PR TITLE
feat: auto trim uen field

### DIFF
--- a/frontend/src/templates/Field/Uen/UenField.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.tsx
@@ -20,7 +20,7 @@ export const UenField = ({ schema }: UenFieldProps): JSX.Element => {
     [schema],
   )
 
-  const { register } = useFormContext<SingleAnswerFieldInput>()
+  const { register, setValue } = useFormContext<SingleAnswerFieldInput>()
 
   return (
     <FieldContainer schema={schema}>
@@ -28,7 +28,11 @@ export const UenField = ({ schema }: UenFieldProps): JSX.Element => {
         aria-label={`${schema.questionNumber}. ${schema.title}`}
         defaultValue=""
         preventDefaultOnEnter
-        {...register(schema._id, validationRules)}
+        {...register(schema._id, {
+          ...validationRules,
+          onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+            setValue(schema._id, event.target.value.trim()),
+        })}
       />
     </FieldContainer>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
If the user inputs an UEN with whitespaces into the UEN field, they will be met with the invalid UEN error.

Closes #5867

## Solution
<!-- How did you solve the problem? -->
Adding trim whenever the text changes.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="834" alt="Screenshot 2023-03-01 at 3 35 14 PM" src="https://user-images.githubusercontent.com/12391617/222073755-018754cd-c9ea-4272-9f3e-e4819a96916a.png">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="790" alt="Screenshot 2023-03-09 at 10 19 26 AM" src="https://user-images.githubusercontent.com/12391617/223898940-2d36aca0-b823-4db8-89fd-13a4a400e1fa.png">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Go to a form with UEN field and key in ` 201704480N` (with spaces). The spaces should not be able to be entered
