### PR TITLE
feat: add unlisted agency issued UENs list

### DIFF
--- a/shared/utils/uen-validation.ts
+++ b/shared/utils/uen-validation.ts
@@ -2,7 +2,7 @@
  * Validate entity-type indicators, as per
  * https://www.uen.gov.sg/ueninternet/faces/pages/admin/aboutUEN.jspx
  */
-const VALID_ENTITY_TYPE_INDICATORS = new Set([
+const VALID_ENTITY_TYPE_INDICATORS = [
   'LP',
   'LL',
   'FC',
@@ -41,6 +41,15 @@ const VALID_ENTITY_TYPE_INDICATORS = new Set([
   'SS',
   'MC',
   'SM',
+]
+
+const UNLISTED_AGENCY_ISSUED_ENTITY_TYPE_INDICATORS = [
+  'EC', // issued by MOE
+]
+
+const ENTITY_TYPE_INDICATORS = new Set([
+  ...VALID_ENTITY_TYPE_INDICATORS,
+  ...UNLISTED_AGENCY_ISSUED_ENTITY_TYPE_INDICATORS,
 ])
 
 /**
@@ -119,7 +128,7 @@ export const isUenValid = (uen: string): boolean => {
 
   // check entity-type indicator
   const entityTypeIndicator = uen.slice(3, 5)
-  if (!VALID_ENTITY_TYPE_INDICATORS.has(entityTypeIndicator)) {
+  if (!ENTITY_TYPE_INDICATORS.has(entityTypeIndicator)) {
     return false
   }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We discovered that are instance of agencies publishing their own Entity Type Indicators which are not listed under [ARCA's UEN list](https://www.uen.gov.sg/ueninternet/faces/pages/admin/aboutUEN.jspx)

## Solution
<!-- How did you solve the problem? -->
Add our own list of known Entity Type Indicators, which currently contains `["EC"]`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="604" alt="Screenshot 2023-03-09 at 11 06 03 AM" src="https://user-images.githubusercontent.com/12391617/223905983-657a633f-9d05-4244-9923-aeddd72232dd.png">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="802" alt="Screenshot 2023-03-09 at 10 58 34 AM" src="https://user-images.githubusercontent.com/12391617/223905918-5dc7f84e-156e-4ddc-abc2-3dfc5e631520.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] In the UEN Field, inputing `S68EC0001C` should be valid
- [ ] In the UEN Field, inputing `S68ED0001C` should not be valid
