### PR TITLE
feat: add respondent email to receive receipts

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -216,12 +216,15 @@ export const PaymentInput = (): JSX.Element => {
             <FormControl
               isReadOnly={paymentsMutation.isLoading}
               isInvalid={!!errors.description}
+              isRequired
             >
               <FormLabel>Description</FormLabel>
-              <Textarea {...register('description')} />
-              <FormErrorMessage>
-                {errors?.description?.message}
-              </FormErrorMessage>
+              <Textarea
+                {...register('description', {
+                  required: 'Please enter a payment message',
+                })}
+              />
+              <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
             </FormControl>
           </>
         )}

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -221,7 +221,7 @@ export const PaymentInput = (): JSX.Element => {
               <FormLabel>Description</FormLabel>
               <Textarea
                 {...register('description', {
-                  required: 'Please enter a payment message',
+                  required: 'Please enter a payment description',
                 })}
               />
               <FormErrorMessage>{errors.description?.message}</FormErrorMessage>

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -188,8 +188,10 @@ export const PublicFormProvider = ({
 
   const { handleLogoutMutation } = usePublicAuthMutations(formId)
 
-  const handleSubmitForm: SubmitHandler<FormFieldValues> = useCallback(
-    async (formInputs) => {
+  const handleSubmitForm: SubmitHandler<
+    FormFieldValues & { payment_receipt_email_field?: { value: string } }
+  > = useCallback(
+    async ({ payment_receipt_email_field, ...formInputs }) => {
       const { form } = data ?? {}
       if (!form) return
 
@@ -254,6 +256,7 @@ export const PublicFormProvider = ({
                   formInputs,
                   publicKey: form.publicKey,
                   captchaResponse,
+                  paymentReceiptEmail: payment_receipt_email_field?.value,
                 },
                 {
                   onSuccess: ({

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -74,6 +74,7 @@ export type SubmitEmailFormArgs = {
   formFields: FormFieldDto[]
   formLogics: FormDto['form_logics']
   formInputs: FormFieldValues
+  paymentReceiptEmail?: string
 }
 
 export type SubmitStorageFormArgs = SubmitEmailFormArgs & { publicKey: string }
@@ -110,6 +111,7 @@ export const submitStorageModeForm = async ({
   formId,
   publicKey,
   captchaResponse = null,
+  paymentReceiptEmail = undefined,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -120,6 +122,7 @@ export const submitStorageModeForm = async ({
     formFields,
     filteredInputs,
     publicKey,
+    paymentReceiptEmail,
   )
 
   return ApiService.post<SubmissionResponseDto>(

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -111,7 +111,7 @@ export const submitStorageModeForm = async ({
   formId,
   publicKey,
   captchaResponse = null,
-  paymentReceiptEmail = undefined,
+  paymentReceiptEmail,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentPageBlock.tsx
@@ -112,7 +112,7 @@ const StripeCheckoutForm = ({
           isLoading={isStripeProcessing}
           mt="2.5rem"
         >
-          Pay now
+          Submit payment
         </Button>
       </FormControl>
     </form>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -17,6 +17,9 @@ import {
   hasExistingFieldValue,
 } from '~features/myinfo/utils'
 import { useFetchPrefillQuery } from '~features/public-form/hooks/useFetchPrefillQuery'
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+
+import { FormPaymentPreview } from '../FormPaymentPreview/FormPaymentPreview'
 
 import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
@@ -100,6 +103,8 @@ export const FormFields = ({
     }
   }, [defaultFormValues, isDirty, reset])
 
+  const { form } = usePublicFormContext()
+
   return (
     <FormProvider {...formMethods}>
       <form noValidate>
@@ -123,6 +128,12 @@ export const FormFields = ({
               />
             </Stack>
           </Box>
+        )}
+        {form?.payments?.enabled && (
+          <FormPaymentPreview
+            colorTheme={colorTheme}
+            paymentDetails={form.payments}
+          />
         )}
         <PublicFormSubmitButton
           onSubmit={onSubmit ? formMethods.handleSubmit(onSubmit) : undefined}

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useContext, useMemo } from 'react'
+import { MouseEventHandler, useMemo } from 'react'
 import { useFormState, useWatch } from 'react-hook-form'
 import { Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -71,7 +71,7 @@ export const PublicFormSubmitButton = ({
         {preventSubmissionLogic
           ? 'Submission disabled'
           : form?.payments?.enabled
-          ? 'Submit and pay'
+          ? 'Proceed to pay'
           : 'Submit now'}
       </Button>
       {preventSubmissionLogic ? (

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -28,7 +28,7 @@ export const FormPaymentModal = ({
         <ModalOverlay />
         <ModalContent>
           <ModalCloseButton />
-          <ModalHeader>Submit form and proceed to pay</ModalHeader>
+          <ModalHeader>You are about to make payment</ModalHeader>
           <ModalBody whiteSpace="pre-line">
             {
               'Please ensure that your form information is accurate. You will not be able to edit your form after you proceed.'
@@ -44,7 +44,7 @@ export const FormPaymentModal = ({
                 loadingText="Submitting"
                 onClick={onSubmit}
               >
-                Submit form and proceed to pay
+                Proceed to pay
               </Button>
             </ButtonGroup>
           </ModalFooter>

--- a/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
@@ -57,7 +57,7 @@ export const FormPaymentPreview = ({
             letterSpacing="-0.019em"
           >{`${centsToDollars(paymentDetails.amount_cents ?? 0)} SGD`}</Box>
         </Box>
-        <EmailField schema={emailFieldSchema}></EmailField>
+        <EmailField schema={emailFieldSchema} />
       </Box>
     </Stack>
   )

--- a/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
@@ -40,22 +40,12 @@ export const FormPaymentPreview = ({
           p="0.7rem"
           mb="2rem"
         >
-          <Text
-            textStyle="body-1"
-            fontSize="16px"
-            fontWeight="400"
-            letterSpacing="-0.011em"
-            mb="0.5rem"
-          >
+          <Text textStyle="body-1" mb="0.5rem">
             {paymentDetails.description}
           </Text>
-          <Box
-            as="h2"
-            fontSize="24px"
-            lineHeight="32px"
-            fontWeight="600"
-            letterSpacing="-0.019em"
-          >{`${centsToDollars(paymentDetails.amount_cents ?? 0)} SGD`}</Box>
+          <Box as="h2" textStyle="h2">{`${centsToDollars(
+            paymentDetails.amount_cents ?? 0,
+          )} SGD`}</Box>
         </Box>
         <EmailField schema={emailFieldSchema} />
       </Box>

--- a/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
@@ -1,0 +1,64 @@
+import { Box, Stack, Text } from '@chakra-ui/react'
+
+import {
+  BasicField,
+  EmailFieldBase,
+  FormColorTheme,
+  FormPayments,
+} from '~shared/types'
+
+import { centsToDollars } from '~utils/payments'
+import { EmailFieldSchema } from '~templates/Field'
+import EmailField from '~templates/Field/Email'
+import { useSectionColor } from '~templates/Field/Section/SectionField'
+
+import { getFieldCreationMeta } from '~features/admin-form/create/builder-and-design/utils/fieldCreation'
+
+export const FormPaymentPreview = ({
+  colorTheme = FormColorTheme.Blue,
+  paymentDetails,
+}: {
+  colorTheme: FormColorTheme
+  paymentDetails: FormPayments
+}): JSX.Element => {
+  const sectionColor = useSectionColor(colorTheme)
+  const emailFieldSchema: EmailFieldSchema = {
+    _id: 'payment_receipt_email_field',
+    ...(getFieldCreationMeta(BasicField.Email) as EmailFieldBase),
+  }
+  return (
+    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem">
+      <Box bg={'white'} py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
+        <Box as="h2" mb="1rem" textStyle="h2" color={sectionColor}>
+          Payment
+        </Box>
+        <Box
+          backgroundColor={`theme-${colorTheme}.100`}
+          borderWidth="1px"
+          borderColor={`theme-${colorTheme}.300`}
+          borderRadius="4px"
+          p="0.7rem"
+          mb="2rem"
+        >
+          <Text
+            textStyle="body-1"
+            fontSize="16px"
+            fontWeight="400"
+            letterSpacing="-0.011em"
+            mb="0.5rem"
+          >
+            {paymentDetails.description}
+          </Text>
+          <Box
+            as="h2"
+            fontSize="24px"
+            lineHeight="32px"
+            fontWeight="600"
+            letterSpacing="-0.019em"
+          >{`${centsToDollars(paymentDetails.amount_cents ?? 0)} SGD`}</Box>
+        </Box>
+        <EmailField schema={emailFieldSchema}></EmailField>
+      </Box>
+    </Stack>
+  )
+}

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -33,6 +33,7 @@ export const createEncryptedSubmissionData = async (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
   publicKey: string,
+  paymentReceiptEmail?: string,
 ): Promise<StorageModeSubmissionContentDto> => {
   const responses = createResponsesArray(formFields, formInputs)
   const encryptedContent = formsgSdk.crypto.encrypt(responses, publicKey)
@@ -53,6 +54,7 @@ export const createEncryptedSubmissionData = async (
     attachments,
     responses: filteredResponses,
     encryptedContent,
+    paymentReceiptEmail,
     version: ENCRYPT_VERSION,
   }
 }

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -17,6 +17,7 @@ export type Payment = {
   payoutId: string
   payoutDate: Date
   created: DateString
+  email: string
 }
 
 export type PaymentReceiptStatusDto = {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -156,6 +156,7 @@ export type StorageModeSubmissionContentDto = {
   >[]
   encryptedContent: string
   attachments?: StorageModeAttachmentsMap
+  paymentReceiptEmail?: string
   version: number
 }
 

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -42,6 +42,9 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
       payoutDate: {
         type: Date,
       },
+      email: {
+        type: String,
+      },
     },
     {
       timestamps: {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -413,7 +413,7 @@ const submitEncryptModeForm: ControllerHandler<
         /* 'grabpay', 'paynow'*/
       ],
       description: form.payments.description,
-      receipt_email: 'form+receipt@open.gov.sg',
+      receipt_email: req.body.paymentReceiptEmail,
       // on_behalf_of: form.payments.target_account_id,
       metadata: {
         formId,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -413,6 +413,7 @@ const submitEncryptModeForm: ControllerHandler<
         /* 'grabpay', 'paynow'*/
       ],
       description: form.payments.description,
+      receipt_email: 'form+receipt@open.gov.sg',
       // on_behalf_of: form.payments.target_account_id,
       metadata: {
         formId,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -451,6 +451,7 @@ const submitEncryptModeForm: ControllerHandler<
         amount: form.payments.amount_cents,
         status: PaymentStatus.Pending,
         paymentIntentId: paymentIntent.id,
+        email: req.body.paymentReceiptEmail,
       })
 
       try {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -47,11 +47,11 @@ export const validateEncryptSubmissionParams = celebrate({
         }),
       )
       .optional(),
+    paymentReceiptEmail: Joi.string(),
     /**
      * @deprecated unused key, but frontend may still send it.
      */
     isPreview: Joi.boolean(),
-    paymentReceiptEmail: Joi.string(),
     version: Joi.number().required(),
   }),
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -51,6 +51,7 @@ export const validateEncryptSubmissionParams = celebrate({
      * @deprecated unused key, but frontend may still send it.
      */
     isPreview: Joi.boolean(),
+    paymentReceiptEmail: Joi.string(),
     version: Joi.number().required(),
   }),
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, users have no way of confirming that their submission and/or payment has been received, other than manually contacting the admins or if the admins follow up with their form response.

Closes #5814, closes #5897, closes #5898

## Solution
<!-- How did you solve the problem? -->
Add an email input field at the end of the payment form for respondents to input the email that will receive any receipts.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - When a new UI tries to send a `:formId/submission/encrypt` POST request to an old server to submit a form with payment, the body would include the `paymentReceiptEmail` which is unexpected by the old server, causing a validation error. 
    - Fortunately, the impact of this is will be limited as this only affect forms with payments, and only a few users from JTC has the beta flag required to unlock the payment feature.

**Features**:

- Upcoming payment preview at the end of the form
- Email field in payment preview to input email for receipts
- Use email input in payment preview as email address to receive stripe receipt

**Improvements**:

- Updated copy for:
  - button at the end of the form
  - payment modal

## Before & After Screenshots

**BEFORE**:

Form with payment enabled:

<img width="1512" alt="Screenshot 2023-03-10 at 5 14 26 PM" src="https://user-images.githubusercontent.com/37061143/224275103-d31983c3-23b9-4686-a4a5-76b672ac3c3a.png">

Payment modal:

<img width="1512" alt="Screenshot 2023-03-10 at 5 14 33 PM" src="https://user-images.githubusercontent.com/37061143/224275147-b1309700-1c30-424f-974b-fa97d3654622.png">

**AFTER**:

Form with payment enabled:

<img width="1512" alt="Screenshot 2023-03-10 at 5 15 21 PM" src="https://user-images.githubusercontent.com/37061143/224275256-be443bde-6c18-4316-ad7b-c4af1a69bbb2.png">

Payment modal:

<img width="1512" alt="Screenshot 2023-03-10 at 5 15 28 PM" src="https://user-images.githubusercontent.com/37061143/224275265-b5027589-11ea-4b8d-8d41-a47c16fb46a4.png">

Payment Flow with Email Receipt:

https://user-images.githubusercontent.com/37061143/224479954-fb88ad37-1952-40f4-aa3f-74e485470c8c.mp4

## Tests
<!-- What tests should be run to confirm functionality? -->

Can be checked with stripe's test credentials:
- [ ] Check that the payment preview is the same as screenshot above.
- [ ] Check that the payment modal is the same as screenshot above.
- [ ] Check that the payment block is the same as screenshot above.

Requires stripe's live credentials to run:
- [ ] 1. Input an email address that has an inbox you have access to in the payment preview portion
       2. Click "proceed to pay" at the end of the form and then on the payment modal.
       3. On the payment block, key in card details and click "Submit payment".
       4. If payment succeeds, you should receive a receipt email in the inbox of the email address you entered.