### PR TITLE
refactor: simplify payment amount regex

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -201,6 +201,7 @@ export const PaymentInput = (): JSX.Element => {
                 render={({ field }) => (
                   <MoneyInput
                     flex={1}
+                    step={0}
                     inputMode="decimal"
                     placeholder="0.00"
                     {...field}

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -142,11 +142,9 @@ export const PaymentInput = (): JSX.Element => {
             /* Regex allows: 
                - leading and trailing spaces
                - max 2dp
-               - strictly positive (>0)
             */
-            /^\s*0*([1-9]\d*(\.\d{0,2})?|0\.(0[1-9]|[1-9]\d?))\s*$/.test(
-              val ?? '',
-            ) || 'Please enter a valid payment amount'
+            /^\s*\d*\.?\d{0,2}\s*$/.test(val ?? '') ||
+            'Please enter a valid payment amount'
           )
         },
         validateMin: (val) => {

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -143,7 +143,7 @@ export const PaymentInput = (): JSX.Element => {
                - leading and trailing spaces
                - max 2dp
             */
-            /^\s*\d*\.?\d{0,2}\s*$/.test(val ?? '') ||
+            /^\s*(\d+)(\.\d{0,2})?\s*$/.test(val ?? '') ||
             'Please enter a valid payment amount'
           )
         },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Payment amount regex was more complicated as it mandated a non-zero positive amount to be entered. However, we have since decided to use `useForm`'s validation rules to mandate the minimum and maximum amounts for cleaner implementation.

## Solution
<!-- How did you solve the problem? -->
Simplified the regex to limit input to 2 decimal places.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Disabled steppers for payment amount input field in payment drawer

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Any of the following valid payment amounts (`x` where `0.50 <= x <= 100` should be accepted by the payment amount field and saved successfully thereafter:
  - [ ] Whole numbers.
  - [ ] Whole numbers followed by `.`.
  - [ ] Numbers with 1 decimal place.
  - [ ] Numbers with 2 decimal places.
  - [ ] Any input other than what is defined above (i.e. valid payment amount) should be rejected.
- [ ] When in the payment amount input field, pressing the arrow keys should not change the value in the field.