### PR TITLE
docs: improve contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,15 @@ Welcome to FormSG! The following are guidelines for contribution. Use your best 
 
 ## Getting started
 
-To contribute, you can start by taking a look at our open issues marked 'contribute' under GitHub's 'Issues' tab. Feel free to assign yourself to any 'contribute' issue that interests you, and comment with questions or clarifications. 
+To contribute, you can start by taking a look at our open issues marked 'contribute' under GitHub's 'Issues' tab. Feel free to assign yourself to any 'contribute' issue that interests you, and comment with questions or clarifications.
 
-Otherwise, please **first discuss the change you wish to make via GitHub issue**, [email](mailto:support@form.gov.sg), or any other method with the repository owners beforehand.
+Before starting work on a PR, please **first discuss the change you wish to make via GitHub issue**, [email](mailto:contribute@form.gov.sg), or any other method with the repository owners beforehand. This will give us the opportunity to provide feedback, and avoid wasted effort subsequently.
+
+For other changes which are not currently in our open issues, please file an issue first for discussion, before starting work on the PR. We strongly encourage contributors not to open unsolicited PRs, as we may not be able to review or accept them.
 
 ## Security reports
 
-Please do not file an open issue for ongoing security bugs. Instead, email us directly with your findings at [support@form.gov.sg](mailto:support@form.gov.sg).
+Please do not file an open issue for ongoing security bugs. Instead, email us directly with your findings at [contribute@form.gov.sg](mailto:contribute@form.gov.sg).
 
 ## Bug reports and feature requests
 
@@ -40,7 +42,7 @@ If you're submitting a pull request, some points to note:
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build. Refer to [README.md](https://go.gov.sg/formsg-readme) for more details
 2. Update the [README.md](https://go.gov.sg/formsg-readme) with details of changes to the interface, including new environment variables, exposed ports, useful file locations and container parameters.
 <!---Increase the version numbers of the packages in any example files and the [README.md](https://github.com/opengovsg/formsg/blob/master/README.md) to the new version that this Pull Request would represent.--->
-3. Write [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/). See past [PRs](https://github.com/opengovsg/FormSG/pulls) for examples. 
+3. Write [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/). See past [PRs](https://github.com/opengovsg/FormSG/pulls) for examples.
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement
@@ -52,4 +54,4 @@ You generally only need to submit a CLA once, so if you've already submitted one
 
 ## Contact us
 
-Have questions? Feel free to reach out to us at [support@form.gov.sg](mailto:support@form.gov.sg).
+Have questions? Feel free to reach out to us at [contribute@form.gov.sg](mailto:contribute@form.gov.sg).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - [FormSG](#formsg)
   - [Table of Contents](#table-of-contents)
+  - [Contributing](#contributing)
   - [Features](#features)
   - [Local Development (Docker)](#local-development-docker)
     - [Prerequisites](#prerequisites)
@@ -26,9 +27,15 @@
       - [End-to-end tests](#end-to-end-tests)
   - [Architecture](#architecture)
   - [MongoDB Scripts](#mongodb-scripts)
-  - [Contributing](#contributing)
   - [Support](#support)
   - [Acknowledgements](#acknowledgements)
+
+## Contributing
+
+We welcome all contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas to code open sourced by the Government Technology Agency of Singapore. Contributors will also be asked to sign a Contributor License Agreement (CLA) to ensure that everybody is free to use their contributions.
+
+#####IMPORTANT NOTE TO ALL CONTRIBUTORS
+Before contributing, please read [CONTRIBUTING.md](CONTRIBUTING.md). In particular, we strongly encourage contributors to please **first discuss the change you wish to make via GitHub issue**, [email](mailto:contribute@form.gov.sg), or any other method with the repository owners beforehand. Otherwise, we may not be able to review or accept your PR.
 
 ## Features
 
@@ -206,10 +213,6 @@ The architecture overview is [here](docs/ARCHITECTURE.md).
 ## MongoDB Scripts
 
 Scripts for common tasks in MongoDB can be found [here](docs/MONGODB.md).
-
-## Contributing
-
-We welcome all contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas to code open sourced by the Government Technology Agency of Singapore. Contributors should read [CONTRIBUTING.md](CONTRIBUTING.md) and will also be asked to sign a Contributor License Agreement (CLA) to ensure that everybody is free to use their contributions.
 
 ## Support
 


### PR DESCRIPTION
- Beefs up contribution guidelines, to provide more guidance to potential contributors
  - Shifts up contribution section on `readme.md`
  - Adds advisory to contributors to please contact us beforehand via github issue or email, before starting work on any PR