### PR TITLE
feat: add rate limiting for receipt download

### DIFF
--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -334,6 +334,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 60,
       env: 'SEND_AUTH_OTP_RATE_LIMIT',
     },
+    downloadPaymentReceipt: {
+      doc: 'Per-minute, per-IP request limit to download the payment receipt from Stripe',
+      format: 'int',
+      default: 10,
+      env: 'DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT',
+    },
   },
   reactMigration: {
     respondentRolloutEmail: {

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express'
 
+import { rateLimitConfig } from '../../../../config/config'
 import * as StripeController from '../../../../modules/payments/stripe.controller'
+import { limitRate } from '../../../../utils/limit-rate'
 
 export const PaymentsRouter = Router()
 
@@ -26,7 +28,10 @@ PaymentsRouter.route(
 // TODO: consider rate limiting this endpoint #5924
 PaymentsRouter.route(
   '/receipt/:formId([a-fA-F0-9]{24})/:submissionId([a-fA-F0-9]{24})/download',
-).get(StripeController.downloadPaymentReceipt)
+).get(
+  limitRate({ max: rateLimitConfig.downloadPaymentReceipt }),
+  StripeController.downloadPaymentReceipt,
+)
 
 PaymentsRouter.route('/stripe/callback').get(
   StripeController.handleConnectOauthCallback,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -51,6 +51,7 @@ export type MailConfig = {
 export type RateLimitConfig = {
   submissions: number
   sendAuthOtp: number
+  downloadPaymentReceipt: number
 }
 
 export type ReactMigrationConfig = {
@@ -180,6 +181,7 @@ export interface IOptionalVarsSchema {
   rateLimit: {
     submissions: number
     sendAuthOtp: number
+    downloadPaymentReceipt: number
   }
   reactMigration: {
     respondentRolloutEmail: number


### PR DESCRIPTION
## Context
<!-- What problem are you trying to solve? What issue does this close? -->
This PR adds rate limits to the payment receipt download endpoint, because:

- endpoint does external calls to stripe, so we want to make sure we can't be used as a source of abuse
- pdf generation is heavy, so we should protect our capacity

Closes #5924

## Solution
<!-- How did you solve the problem? -->
Add a new config `rateLimit.downloadPaymentReceipt` - the default is set at 10

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Production environment is updated with the environment variables `DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT=10` (any other thoughts on a recommended number?)
- (FYI from #389) In production, an alarm has been set for any occurrence of the "Rate limit exceeded" log message.
- In the staging environment, set `DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT=2`
    - [x] On the payment thank you page, try to download the payment receipt as many times as you can within 60s. Ensure that you are able to download the receipt only twice, and that a "Rate limit exceeded" message gets logged with metadata about the rate limit (IP address, endpoint, current number of requests).
    - [x] Set `DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT=10`

## Deploy Notes

**New environment variables**:

- `DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT` : Per-minute, per-IP request limit to download the payment receipt from Stripe
