### PR TITLE
chore(deps): bump @opengovsg/myinfo-gov-client from 4.0.1 to 4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
         "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
         "@opengovsg/formsg-sdk": "^0.10.0",
-        "@opengovsg/myinfo-gov-client": "^4.0.1",
+        "@opengovsg/myinfo-gov-client": "^4.0.2",
         "@opengovsg/ng-file-upload": "^12.2.15",
         "@opengovsg/sgid-client": "1.0.4",
         "@sentry/browser": "^7.28.1",
@@ -5481,12 +5481,13 @@
       }
     },
     "node_modules/@opengovsg/myinfo-gov-client": {
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-4.0.2.tgz",
+      "integrity": "sha512-x6EVG++Xv/+NId2wD64f7m3TSp+O6Jf/tmCXLdN5Q/mxW501fFEwUvtzp5a5DTX6RBSodXLP772rM6SCLkgEgQ==",
       "dependencies": {
         "axios": "^0.27.2",
         "jsonwebtoken": "^8.5.1",
-        "node-jose": "^2.1.1",
+        "node-jose": "^2.2.0",
         "qs": "^6.11.0"
       }
     },
@@ -31518,6 +31519,7 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -37397,8 +37399,7 @@
       }
     },
     "@opengovsg/angular-legacy-sortablejs-maintained": {
-      "version": "1.0.0",
-      "requires": {}
+      "version": "1.0.0"
     },
     "@opengovsg/angular-recaptcha-fallback": {
       "version": "5.0.0"
@@ -37449,11 +37450,13 @@
       }
     },
     "@opengovsg/myinfo-gov-client": {
-      "version": "4.0.1",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@opengovsg/myinfo-gov-client/-/myinfo-gov-client-4.0.2.tgz",
+      "integrity": "sha512-x6EVG++Xv/+NId2wD64f7m3TSp+O6Jf/tmCXLdN5Q/mxW501fFEwUvtzp5a5DTX6RBSodXLP772rM6SCLkgEgQ==",
       "requires": {
         "axios": "^0.27.2",
         "jsonwebtoken": "^8.5.1",
-        "node-jose": "^2.1.1",
+        "node-jose": "^2.2.0",
         "qs": "^6.11.0"
       },
       "dependencies": {
@@ -38817,8 +38820,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -38862,13 +38864,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -38900,8 +38900,7 @@
       "version": "1.8.3"
     },
     "angular-permission": {
-      "version": "1.1.1",
-      "requires": {}
+      "version": "1.1.1"
     },
     "angular-resource": {
       "version": "1.8.3"
@@ -42008,8 +42007,7 @@
         },
         "ws": {
           "version": "8.2.3",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -42502,8 +42500,7 @@
     },
     "eslint-config-prettier": {
       "version": "8.5.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -42756,8 +42753,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.12.0.tgz",
       "integrity": "sha512-KXuzQjVzca5irMT/7rvzJKsVDGbQr43oQPc8i+SLEBqmfrTxlwMwRqfv9vtZqh4hpU0jmrnA/EOfwtls+5QC1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -42770,8 +42766,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
       "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-typesafe": {
       "version": "0.5.2",
@@ -43474,8 +43469,7 @@
     "express-rate-limit": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
-      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
-      "requires": {}
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA=="
     },
     "express-request-id": {
       "version": "1.4.1",
@@ -45134,8 +45128,7 @@
       "dev": true
     },
     "intl-tel-input": {
-      "version": "12.4.0",
-      "requires": {}
+      "version": "12.4.0"
     },
     "ip": {
       "version": "1.1.5"
@@ -47804,8 +47797,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -48933,8 +48925,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "xml-name-validator": {
           "version": "4.0.0",
@@ -49882,8 +49873,7 @@
         },
         "ws": {
           "version": "8.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "xml-name-validator": {
           "version": "4.0.0",
@@ -50468,8 +50458,7 @@
       }
     },
     "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "requires": {}
+      "version": "1.0.2"
     },
     "morgan": {
       "version": "1.10.0",
@@ -51798,8 +51787,7 @@
     },
     "postcss-syntax": {
       "version": "0.36.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
@@ -52137,8 +52125,7 @@
           }
         },
         "ws": {
-          "version": "8.8.0",
-          "requires": {}
+          "version": "8.8.0"
         }
       }
     },
@@ -53001,8 +52988,7 @@
       "version": "1.0.1"
     },
     "slick-carousel": {
-      "version": "1.8.1",
-      "requires": {}
+      "version": "1.8.1"
     },
     "smart-buffer": {
       "version": "4.2.0"
@@ -53700,13 +53686,11 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz",
       "integrity": "sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended": {
       "version": "5.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-standard": {
       "version": "22.0.0",
@@ -54834,8 +54818,7 @@
     "ts-essentials": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.1.tgz",
-      "integrity": "sha512-9CChSvQMyVRo29Vb1A2jbs+LKo3d/bAf+ndSaX0T8cEiy/HChVaRN/HY5DqUryZ8hZ6uol9bEgCnGmnDbwBR9Q==",
-      "requires": {}
+      "integrity": "sha512-9CChSvQMyVRo29Vb1A2jbs+LKo3d/bAf+ndSaX0T8cEiy/HChVaRN/HY5DqUryZ8hZ6uol9bEgCnGmnDbwBR9Q=="
     },
     "ts-jest": {
       "version": "29.0.5",
@@ -55132,7 +55115,8 @@
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",
@@ -56393,8 +56377,7 @@
     },
     "ws": {
       "version": "7.5.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
     "@opengovsg/angular-recaptcha-fallback": "^5.0.0",
     "@opengovsg/formsg-sdk": "^0.10.0",
-    "@opengovsg/myinfo-gov-client": "^4.0.1",
+    "@opengovsg/myinfo-gov-client": "^4.0.2",
     "@opengovsg/ng-file-upload": "^12.2.15",
     "@opengovsg/sgid-client": "1.0.4",
     "@sentry/browser": "^7.28.1",


### PR DESCRIPTION
## Background
A high severity Snyk vulnerability was patched in the @opengovsg/myinfo-gov-client package in release 4.0.2. This PR upgrades to this new version.

## Tests

- [x] MyInfo forms can be submitted in email mode
- [x] Submitted MyInfo data is shown in email mode submissions