### PR TITLE
feat(db): add pending submissions collection

### DIFF
--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -20,9 +20,6 @@ export const SubmissionBase = z.object({
   authType: z.nativeEnum(FormAuthType),
   myInfoFields: z.array(z.nativeEnum(MyInfoAttribute)).optional(),
   submissionType: z.nativeEnum(SubmissionType),
-  paymentPending: z.boolean().optional(),
-  // TODO: change to object if string doesn't work
-  paymentId: z.string(),
 })
 export type SubmissionBase = z.infer<typeof SubmissionBase>
 
@@ -60,6 +57,7 @@ export const StorageModeSubmissionBase = SubmissionBase.extend({
   attachmentMetadata: z.map(z.string(), z.string()).optional(),
   version: z.number(),
   webhookResponses: z.array(WebhookResponse).optional(),
+  paymentId: z.string().optional(),
 })
 export type StorageModeSubmissionBase = z.infer<
   typeof StorageModeSubmissionBase

--- a/src/app/models/pending_submission.server.model.ts
+++ b/src/app/models/pending_submission.server.model.ts
@@ -16,8 +16,8 @@ import {
 } from './submission.server.model'
 
 export const PENDING_SUBMISSION_SCHEMA_ID = 'PendingSubmission'
-export const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'emailPendingSubmission'
-export const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'encryptPendingSubmission'
+const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'emailPendingSubmission'
+const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'encryptPendingSubmission'
 
 const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const PendingSubmission = db.model<ISubmissionSchema, ISubmissionModel>(

--- a/src/app/models/pending_submission.server.model.ts
+++ b/src/app/models/pending_submission.server.model.ts
@@ -16,8 +16,8 @@ import {
 } from './submission.server.model'
 
 export const PENDING_SUBMISSION_SCHEMA_ID = 'PendingSubmission'
-const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'emailPendingSubmission'
-const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'encryptPendingSubmission'
+const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'EmailPendingSubmission'
+const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'EncryptPendingSubmission'
 
 const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const PendingSubmission = db.model<ISubmissionSchema, ISubmissionModel>(

--- a/src/app/models/pending_submission.server.model.ts
+++ b/src/app/models/pending_submission.server.model.ts
@@ -1,0 +1,40 @@
+import { Mongoose } from 'mongoose'
+import { SubmissionType } from 'shared/types'
+
+import { ISubmissionModel, ISubmissionSchema } from 'src/types'
+
+import {
+  EmailSubmissionSchema,
+  EncryptSubmissionSchema,
+  SubmissionSchema,
+} from './submission.server.model'
+
+export const PENDING_SUBMISSION_SCHEMA_ID = 'PendingSubmission'
+
+const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
+  const PendingSubmission = db.model<ISubmissionSchema, ISubmissionModel>(
+    PENDING_SUBMISSION_SCHEMA_ID,
+    SubmissionSchema,
+  )
+  PendingSubmission.discriminator(SubmissionType.Email, EmailSubmissionSchema)
+  PendingSubmission.discriminator(
+    SubmissionType.Encrypt,
+    EncryptSubmissionSchema,
+  )
+  return db.model<ISubmissionSchema, ISubmissionModel>(
+    PENDING_SUBMISSION_SCHEMA_ID,
+    SubmissionSchema,
+  )
+}
+
+const getPendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
+  try {
+    return db.model<ISubmissionSchema, ISubmissionModel>(
+      PENDING_SUBMISSION_SCHEMA_ID,
+    )
+  } catch {
+    return compilePendingSubmissionModel(db)
+  }
+}
+
+export default getPendingSubmissionModel

--- a/src/app/models/pending_submission.server.model.ts
+++ b/src/app/models/pending_submission.server.model.ts
@@ -1,7 +1,13 @@
 import { Mongoose } from 'mongoose'
-import { SubmissionType } from 'shared/types'
 
-import { ISubmissionModel, ISubmissionSchema } from 'src/types'
+import {
+  IEmailSubmissionModel,
+  IEmailSubmissionSchema,
+  IEncryptedSubmissionSchema,
+  IEncryptSubmissionModel,
+  ISubmissionModel,
+  ISubmissionSchema,
+} from 'src/types'
 
 import {
   EmailSubmissionSchema,
@@ -10,21 +16,23 @@ import {
 } from './submission.server.model'
 
 export const PENDING_SUBMISSION_SCHEMA_ID = 'PendingSubmission'
+export const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'emailPendingSubmission'
+export const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'encryptPendingSubmission'
 
 const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const PendingSubmission = db.model<ISubmissionSchema, ISubmissionModel>(
     PENDING_SUBMISSION_SCHEMA_ID,
     SubmissionSchema,
   )
-  PendingSubmission.discriminator(SubmissionType.Email, EmailSubmissionSchema)
   PendingSubmission.discriminator(
-    SubmissionType.Encrypt,
+    EMAIL_PENDING_SUBMISSION_SCHEMA_ID,
+    EmailSubmissionSchema,
+  )
+  PendingSubmission.discriminator(
+    ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID,
     EncryptSubmissionSchema,
   )
-  return db.model<ISubmissionSchema, ISubmissionModel>(
-    PENDING_SUBMISSION_SCHEMA_ID,
-    SubmissionSchema,
-  )
+  return PendingSubmission
 }
 
 const getPendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
@@ -37,4 +45,21 @@ const getPendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   }
 }
 
+export const getEmailPendingSubmissionModel = (
+  db: Mongoose,
+): IEmailSubmissionModel => {
+  getPendingSubmissionModel(db)
+  return db.model<IEmailSubmissionSchema, IEmailSubmissionModel>(
+    EMAIL_PENDING_SUBMISSION_SCHEMA_ID,
+  )
+}
+
+export const getEncryptPendingSubmissionModel = (
+  db: Mongoose,
+): IEncryptSubmissionModel => {
+  getPendingSubmissionModel(db)
+  return db.model<IEncryptedSubmissionSchema, IEncryptSubmissionModel>(
+    ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID,
+  )
+}
 export default getPendingSubmissionModel

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -27,6 +27,7 @@ import {
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
+import { PAYMENT_SCHEMA_ID } from './payment.server.model'
 
 export const SUBMISSION_SCHEMA_ID = 'Submission'
 
@@ -180,7 +181,7 @@ export const EncryptSubmissionSchema = new Schema<
   },
   paymentId: {
     type: Schema.Types.ObjectId,
-    ref: 'Payment',
+    ref: PAYMENT_SCHEMA_ID,
   },
   webhookResponses: [webhookResponseSchema],
 })

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -30,7 +30,8 @@ import { FORM_SCHEMA_ID } from './form.server.model'
 
 export const SUBMISSION_SCHEMA_ID = 'Submission'
 
-const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
+// Exported for use in pending submissions model
+export const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
   {
     form: {
       type: Schema.Types.ObjectId,
@@ -55,13 +56,6 @@ const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
       type: String,
       enum: Object.values(SubmissionType),
       required: true,
-    },
-    paymentPending: {
-      type: Boolean,
-    },
-    paymentId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Payment',
     },
   },
   {
@@ -101,7 +95,8 @@ SubmissionSchema.statics.findFormsWithSubsAbove = function (
   ]).exec()
 }
 
-const EmailSubmissionSchema = new Schema<IEmailSubmissionSchema>({
+// Exported for use in pending submissions model
+export const EmailSubmissionSchema = new Schema<IEmailSubmissionSchema>({
   recipientEmails: {
     type: [
       {
@@ -161,7 +156,8 @@ const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
   },
 )
 
-const EncryptSubmissionSchema = new Schema<
+// Exported for use in pending submissions model
+export const EncryptSubmissionSchema = new Schema<
   IEncryptedSubmissionSchema,
   IEncryptSubmissionModel
 >({
@@ -181,6 +177,10 @@ const EncryptSubmissionSchema = new Schema<
   version: {
     type: Number,
     required: true,
+  },
+  paymentId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Payment',
   },
   webhookResponses: [webhookResponseSchema],
 })
@@ -389,7 +389,7 @@ EncryptSubmissionSchema.statics.findEncryptedSubmissionById = function (
 
 const compileSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const Submission = db.model<ISubmissionSchema, ISubmissionModel>(
-    'Submission',
+    SUBMISSION_SCHEMA_ID,
     SubmissionSchema,
   )
   Submission.discriminator(SubmissionType.Email, EmailSubmissionSchema)


### PR DESCRIPTION
## Problem
We want a pending submissions collection. We don't have a pending submissions collection.

## Solution
We make a pending submissions collection.

This is done via sharing schemas with submissions which gives us all the benefits of the statics + type guarantees of the submissions model a la [this suggestion](https://stackoverflow.com/questions/13337155/mongoose-same-schema-for-different-collections-in-mongodb).

`paymentId` is added to the storage mode submissions only.

The old implementation of pending submissions (with the pending flag in the submissions collection) is removed.

**Breaking Changes** 
- No - this PR is backwards compatible  