### PR TITLE
fix: add discriminator to pending submission collection, submission confirmation service

### DIFF
--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -1,6 +1,5 @@
 import Stripe from 'stripe'
 import { DateString } from './generic'
-import type { Opaque } from 'type-fest'
 
 export enum PaymentStatus {
   Failed = 'failed',
@@ -8,14 +7,12 @@ export enum PaymentStatus {
   Succeeded = 'succeeded',
 }
 
-export type PaymentId = Opaque<string, 'PaymentId'>
 export enum PaymentChannel {
   Stripe = 'Stripe',
   // for extensibility to future payment options
 }
 
 export type Payment = {
-  _id: PaymentId
   submissionId: string
   amount: number
   status: PaymentStatus

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -12,19 +12,37 @@ export enum PaymentChannel {
   // for extensibility to future payment options
 }
 
-export type Payment = {
+export type CompletedPaymentMeta = {
+  paymentDate: Date
   submissionId: string
-  amount: number
-  status: PaymentStatus
-  webhookLog: Stripe.Event[]
-  paymentIntentId: string
-  chargeIdLatest: string
-  payoutId: string
-  payoutDate: Date
-  created: DateString
   transactionFee: number
   receiptUrl: string
+}
+
+export type PayoutMeta = {
+  payoutId?: string
+  payoutDate?: Date
+}
+
+export type Payment = {
+  // Pre-payment metadata
+  pendingSubmissionId: string
   email: string
+  amount: number
+  paymentIntentId: string
+
+  // Payment status tracking
+  webhookLog: Stripe.Event[]
+  status: PaymentStatus
+  chargeIdLatest?: string
+
+  // Completed payment metadata
+  completedPayment?: CompletedPaymentMeta
+
+  // Payout metadata
+  payout?: PayoutMeta
+
+  created: DateString
 }
 
 export type PaymentReceiptStatusDto = {

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -12,7 +12,8 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
   {
     pendingSubmissionId: {
       type: Schema.Types.ObjectId,
-      ref: PENDING_SUBMISSION_SCHEMA_ID,
+      // Defer loading of the ref due to circular dependency on schema IDs.
+      ref: () => PENDING_SUBMISSION_SCHEMA_ID,
       required: true,
     },
     email: {
@@ -53,7 +54,8 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
         },
         submissionId: {
           type: Schema.Types.ObjectId,
-          ref: SUBMISSION_SCHEMA_ID,
+          // Defer loading of the ref due to circular dependency on schema IDs.
+          ref: () => SUBMISSION_SCHEMA_ID,
           required: true,
         },
         transactionFee: {

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -42,7 +42,7 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
       payoutDate: {
         type: Date,
       },
-      stripeTransactionFee: {
+      transactionFee: {
         type: Number,
       },
       receiptUrl: {
@@ -50,6 +50,7 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
       },
       email: {
         type: String,
+        required: true,
       },
     },
     {

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -3,6 +3,9 @@ import { Mongoose, Schema } from 'mongoose'
 import { PaymentStatus } from '../../../shared/types'
 import { IPaymentModel, IPaymentSchema } from '../../types'
 
+import { PENDING_SUBMISSION_SCHEMA_ID } from './pending_submission.server.model'
+import { SUBMISSION_SCHEMA_ID } from './submission.server.model'
+
 export const PAYMENT_SCHEMA_ID = 'Payment'
 
 const compilePaymentModel = (db: Mongoose): IPaymentModel => {
@@ -10,6 +13,7 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
     {
       pendingSubmissionId: {
         type: Schema.Types.ObjectId,
+        ref: PENDING_SUBMISSION_SCHEMA_ID,
         required: true,
       },
       email: {
@@ -50,6 +54,7 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
           },
           submissionId: {
             type: Schema.Types.ObjectId,
+            ref: SUBMISSION_SCHEMA_ID,
             required: true,
           },
           transactionFee: {

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -8,19 +8,23 @@ export const PAYMENT_SCHEMA_ID = 'Payment'
 const compilePaymentModel = (db: Mongoose): IPaymentModel => {
   const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
     {
-      submissionId: {
+      pendingSubmissionId: {
         type: Schema.Types.ObjectId,
+        required: true,
+      },
+      email: {
+        type: String,
         required: true,
       },
       amount: {
         type: Number,
         required: true,
       },
-      status: {
+      paymentIntentId: {
         type: String,
-        enum: Object.values(PaymentStatus),
         required: true,
       },
+
       webhookLog: {
         type: [
           {
@@ -29,28 +33,47 @@ const compilePaymentModel = (db: Mongoose): IPaymentModel => {
         ],
         default: [],
       },
-      paymentIntentId: {
+      status: {
         type: String,
+        enum: Object.values(PaymentStatus),
         required: true,
       },
       chargeIdLatest: {
         type: String,
       },
-      payoutId: {
-        type: String,
+
+      completedPayment: {
+        type: {
+          paymentDate: {
+            type: Date,
+            required: true,
+          },
+          submissionId: {
+            type: Schema.Types.ObjectId,
+            required: true,
+          },
+          transactionFee: {
+            type: Number,
+            required: true,
+          },
+          receiptUrl: {
+            type: String,
+            required: true,
+          },
+        },
       },
-      payoutDate: {
-        type: Date,
-      },
-      transactionFee: {
-        type: Number,
-      },
-      receiptUrl: {
-        type: String,
-      },
-      email: {
-        type: String,
-        required: true,
+
+      payout: {
+        type: {
+          payoutId: {
+            type: String,
+            required: true,
+          },
+          payoutDate: {
+            type: Date,
+            required: true,
+          },
+        },
       },
     },
     {

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -8,88 +8,88 @@ import { SUBMISSION_SCHEMA_ID } from './submission.server.model'
 
 export const PAYMENT_SCHEMA_ID = 'Payment'
 
+const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
+  {
+    pendingSubmissionId: {
+      type: Schema.Types.ObjectId,
+      ref: PENDING_SUBMISSION_SCHEMA_ID,
+      required: true,
+    },
+    email: {
+      type: String,
+      required: true,
+    },
+    amount: {
+      type: Number,
+      required: true,
+    },
+    paymentIntentId: {
+      type: String,
+      required: true,
+    },
+
+    webhookLog: {
+      type: [
+        {
+          type: String,
+        },
+      ],
+      default: [],
+    },
+    status: {
+      type: String,
+      enum: Object.values(PaymentStatus),
+      required: true,
+    },
+    chargeIdLatest: {
+      type: String,
+    },
+
+    completedPayment: {
+      type: {
+        paymentDate: {
+          type: Date,
+          required: true,
+        },
+        submissionId: {
+          type: Schema.Types.ObjectId,
+          ref: SUBMISSION_SCHEMA_ID,
+          required: true,
+        },
+        transactionFee: {
+          type: Number,
+          required: true,
+        },
+        receiptUrl: {
+          type: String,
+          required: true,
+        },
+      },
+    },
+
+    payout: {
+      type: {
+        payoutId: {
+          type: String,
+          required: true,
+        },
+        payoutDate: {
+          type: Date,
+          required: true,
+        },
+      },
+    },
+  },
+  {
+    timestamps: {
+      createdAt: 'created',
+      updatedAt: 'lastModified',
+    },
+    read: 'secondary',
+  },
+)
+
 const compilePaymentModel = (db: Mongoose): IPaymentModel => {
-  const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
-    {
-      pendingSubmissionId: {
-        type: Schema.Types.ObjectId,
-        ref: PENDING_SUBMISSION_SCHEMA_ID,
-        required: true,
-      },
-      email: {
-        type: String,
-        required: true,
-      },
-      amount: {
-        type: Number,
-        required: true,
-      },
-      paymentIntentId: {
-        type: String,
-        required: true,
-      },
-
-      webhookLog: {
-        type: [
-          {
-            type: String,
-          },
-        ],
-        default: [],
-      },
-      status: {
-        type: String,
-        enum: Object.values(PaymentStatus),
-        required: true,
-      },
-      chargeIdLatest: {
-        type: String,
-      },
-
-      completedPayment: {
-        type: {
-          paymentDate: {
-            type: Date,
-            required: true,
-          },
-          submissionId: {
-            type: Schema.Types.ObjectId,
-            ref: SUBMISSION_SCHEMA_ID,
-            required: true,
-          },
-          transactionFee: {
-            type: Number,
-            required: true,
-          },
-          receiptUrl: {
-            type: String,
-            required: true,
-          },
-        },
-      },
-
-      payout: {
-        type: {
-          payoutId: {
-            type: String,
-            required: true,
-          },
-          payoutDate: {
-            type: Date,
-            required: true,
-          },
-        },
-      },
-    },
-    {
-      timestamps: {
-        createdAt: 'created',
-        updatedAt: 'lastModified',
-      },
-      read: 'secondary',
-    },
-  )
-
   const PaymentModel = db.model<IPaymentSchema, IPaymentModel>(
     PAYMENT_SCHEMA_ID,
     PaymentSchema,

--- a/src/app/models/pending_submission.server.model.ts
+++ b/src/app/models/pending_submission.server.model.ts
@@ -9,6 +9,8 @@ import {
   ISubmissionSchema,
 } from 'src/types'
 
+import { SubmissionType } from '../../../shared/types'
+
 import {
   EmailSubmissionSchema,
   EncryptSubmissionSchema,
@@ -27,10 +29,12 @@ const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   PendingSubmission.discriminator(
     EMAIL_PENDING_SUBMISSION_SCHEMA_ID,
     EmailSubmissionSchema,
+    SubmissionType.Email,
   )
   PendingSubmission.discriminator(
     ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID,
     EncryptSubmissionSchema,
+    SubmissionType.Encrypt,
   )
   return PendingSubmission
 }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -181,7 +181,8 @@ export const EncryptSubmissionSchema = new Schema<
   },
   paymentId: {
     type: Schema.Types.ObjectId,
-    ref: PAYMENT_SCHEMA_ID,
+    // Defer loading of the ref due to circular dependency on schema IDs.
+    ref: () => PAYMENT_SCHEMA_ID,
   },
   webhookResponses: [webhookResponseSchema],
 })

--- a/src/app/modules/payments/payments.errors.ts
+++ b/src/app/modules/payments/payments.errors.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from '../core/core.errors'
+
+export class PaymentNotFoundError extends ApplicationError {
+  constructor(message = 'Payment not found') {
+    super(message)
+  }
+}

--- a/src/app/modules/payments/payments.errors.ts
+++ b/src/app/modules/payments/payments.errors.ts
@@ -5,3 +5,9 @@ export class PaymentNotFoundError extends ApplicationError {
     super(message)
   }
 }
+
+export class PaymentAlreadyConfirmedError extends ApplicationError {
+  constructor(message = 'Payment has already been confirmed') {
+    super(message)
+  }
+}

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -160,7 +160,7 @@ export const confirmPaymentPendingSubmission = (
     return (
       // Step 1: Retrieve the payment by payment id and check that the payment
       // has not already been confirmed.
-      findPaymentById(paymentId)
+      findPaymentById(paymentId, session)
         .andThen((payment) =>
           payment.completedPayment
             ? errAsync(new PaymentAlreadyConfirmedError())

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -6,15 +6,43 @@ import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
-import { ApplicationError, DatabaseError } from '../core/core.errors'
+import { DatabaseError } from '../core/core.errors'
+import { PendingSubmissionNotFoundError } from '../submission/submission.errors'
+import * as SubmissionService from '../submission/submission.service'
+
+import { PaymentNotFoundError } from './payments.errors'
 
 const logger = createLoggerWithLabel(module)
 const PaymentModel = getPaymentModel(mongoose)
 
-export class PaymentNotFoundError extends ApplicationError {
-  constructor(message = 'Payment not found') {
-    super(message)
-  }
+/**
+ * Retrieves payment by Id.
+ * @param paymentId the payment id of the payment to be retrieved
+ * @returns ok(payment) if payment exists
+ * @returns err(PaymentNotFoundError) if the payment does not exist
+ * @returns err(DatabaseError) if error occurs whilst querying the database
+ */
+export const findPaymentById = (
+  paymentId: IPaymentSchema['_id'],
+  session?: mongoose.ClientSession,
+): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
+  return ResultAsync.fromPromise(
+    PaymentModel.findById(paymentId).session(session ?? null),
+    (error) => {
+      logger.error({
+        message: 'Database error while finding payment by id',
+        meta: {
+          action: 'findPaymentById',
+          paymentId,
+        },
+        error,
+      })
+      return new DatabaseError(getMongoErrorMessage(error))
+    },
+  ).andThen((result) => {
+    if (!result) return errAsync(new PaymentNotFoundError())
+    return okAsync(result)
+  })
 }
 
 /**
@@ -81,41 +109,111 @@ export const findPaymentBySubmissionId = (
   })
 }
 
-export const updateReceiptUrlAndTransactionFee = (
+/**
+ * This function confirms a submission that is pending payment and updates the
+ * payment document with the new submission id, receipt URL and transaction fee.
+ * This is done within a single transaction, so that the information in the
+ * document is always consistent.
+ * @param paymentId payment id of the payment to be confirmed
+ * @param receiptUrl the payment's receipt URL
+ * @param transactionFee the transaction fee associated with the payment
+ *
+ * @returns ok(payment) if the confirmation transaction was successful
+ * @returns err(PaymentNotFoundError) if the paymentId was not valid
+ * @returns err(DatabaseError) if error occurs whilst querying the database
+ */
+export const confirmPaymentPendingSubmission = (
   paymentId: IPaymentSchema['_id'],
+  paymentDate: Date,
   receiptUrl: string,
-  stripeTransactionFee: number,
-): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
-  // Retrieve payment object from database and
-  // Update payment's receipt url
-  return ResultAsync.fromPromise(
-    PaymentModel.findByIdAndUpdate(
-      paymentId,
-      {
-        $set: {
-          receiptUrl,
-          stripeTransactionFee,
-        },
-      },
-      { new: true },
-    ).exec(),
-    (error) => {
-      logger.error({
-        message:
-          'Database error when updating payment with receipt url and transaction fee',
-        meta: {
-          action: 'updateReceiptUrl',
-          paymentId,
-        },
-        error,
-      })
+  transactionFee: number,
+): ResultAsync<
+  IPaymentSchema,
+  PaymentNotFoundError | PendingSubmissionNotFoundError | DatabaseError
+> => {
+  const logMeta = {
+    action: 'confirmPaymentPendingSubmission',
+    paymentId,
+  }
 
-      return new DatabaseError()
-    },
-  ).andThen((payment) => {
-    if (!payment) {
-      return errAsync(new PaymentNotFoundError())
-    }
-    return okAsync(payment as IPaymentSchema)
+  // Step 0: Set up the session and start the transaction
+  return ResultAsync.fromPromise(mongoose.startSession(), (error) => {
+    logger.error({
+      message: 'Database error while starting mongoose session',
+      meta: logMeta,
+      error,
+    })
+    return new DatabaseError(getMongoErrorMessage(error))
+  }).andThen((session) => {
+    session.startTransaction({
+      readPreference: 'primary',
+      readConcern: { level: 'snapshot' },
+      writeConcern: { w: 'majority' },
+    })
+
+    return (
+      findPaymentById(paymentId)
+        .andThen((payment) =>
+          // Step 2: Copy the pending submission to the submissions collection
+          SubmissionService.copyPendingSubmissionToSubmissions(
+            payment.pendingSubmissionId,
+            session,
+          ).andThen((submission) => {
+            // Step 3: Update the payment document with the metadata showing that
+            // the payment is complete and save it
+            payment.completedPayment = {
+              submissionId: submission._id,
+              paymentDate,
+              receiptUrl,
+              transactionFee,
+            }
+            return ResultAsync.fromPromise(
+              payment.save({ session }),
+              (error) => {
+                logger.error({
+                  message: 'Database error while saving payment document',
+                  meta: logMeta,
+                  error,
+                })
+                return new DatabaseError(getMongoErrorMessage(error))
+              },
+            )
+          }),
+        )
+        // Finally: Commit or abort depending on whether an error was caught,
+        // then end the session
+        .andThen((payment) => {
+          return ResultAsync.fromPromise(
+            session.commitTransaction(),
+            (error) => {
+              logger.error({
+                message: 'Database error while committing transaction',
+                meta: logMeta,
+                error,
+              })
+              return new DatabaseError(getMongoErrorMessage(error))
+            },
+          ).andThen(() => {
+            session.endSession()
+            return okAsync(payment)
+          })
+        })
+        .orElse((err) => {
+          return ResultAsync.fromPromise(
+            session.abortTransaction(),
+            (error) => {
+              logger.error({
+                message: 'Database error while aborting transaction',
+                meta: logMeta,
+                error,
+              })
+              return new DatabaseError(getMongoErrorMessage(error))
+            },
+          ).andThen(() => {
+            session.endSession()
+            return errAsync(err)
+          })
+        })
+    )
   })
 }

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -155,8 +155,10 @@ export const _handleStripeEventUpdates: ControllerHandler<
       await findPaymentAndUpdate(
         event.data.object.metadata,
         {
-          payoutId: event.data.object.id,
-          payoutDate: new Date(event.data.object.arrival_date),
+          payout: {
+            payoutId: event.data.object.id,
+            payoutDate: new Date(event.data.object.arrival_date),
+          },
         },
         event,
       )
@@ -174,6 +176,7 @@ export const handleStripeEventUpdates = [
   _handleStripeEventUpdates,
 ]
 
+// TODO: Refactor for use in static payment url implementation
 export const checkPaymentReceiptStatus: ControllerHandler<{
   formId: string
   submissionId: string
@@ -217,6 +220,7 @@ export const checkPaymentReceiptStatus: ControllerHandler<{
     })
 }
 
+// TODO: Refactor for use in static payment url implementation
 export const downloadPaymentReceipt: ControllerHandler<{
   formId: string
   submissionId: string
@@ -246,7 +250,7 @@ export const downloadPaymentReceipt: ControllerHandler<{
       // retrieve receiptURL as html
       return (
         axios
-          .get<string>(payment.receiptUrl)
+          .get<string>(payment.completedPayment?.receiptUrl ?? '')
           // convert to pdf and return
           .then((receiptUrlResponse) => {
             const html = receiptUrlResponse.data

--- a/src/app/modules/payments/stripe.errors.ts
+++ b/src/app/modules/payments/stripe.errors.ts
@@ -6,12 +6,6 @@ export class SubmissionNotFoundError extends ApplicationError {
   }
 }
 
-export class PaymentNotFoundError extends ApplicationError {
-  constructor(message = 'Payment not found') {
-    super(message)
-  }
-}
-
 export class SubmissionAndFormMismatchError extends ApplicationError {
   constructor(
     message = 'Submission id provided does not match the one linked to the form id',

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -850,7 +850,7 @@ describe('submission.service', () => {
       findSpy.mockImplementationOnce(
         () =>
           ({
-            exec: () => Promise.reject(new Error('boom')),
+            session: () => Promise.reject(new Error('boom')),
           } as unknown as mongoose.Query<any, any>),
       )
 

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -3,6 +3,7 @@ import { times } from 'lodash'
 import mongoose from 'mongoose'
 import { ok } from 'neverthrow'
 
+import getPendingSubmissionModel from 'src/app/models/pending_submission.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import {
   DatabaseError,
@@ -30,12 +31,16 @@ import {
   BasicField,
   SubmissionType,
 } from '../../../../../../shared/types'
-import { SendEmailConfirmationError } from '../../submission.errors'
+import {
+  PendingSubmissionNotFoundError,
+  SendEmailConfirmationError,
+} from '../../submission.errors'
 import { extractEmailConfirmationData } from '../../submission.utils'
 
 jest.mock('src/app/services/mail/mail.service')
 const MockMailService = jest.mocked(MailService)
 
+const PendingSubmission = getPendingSubmissionModel(mongoose)
 const Submission = getSubmissionModel(mongoose)
 
 const MOCK_FORM_ID = new ObjectId().toHexString()
@@ -781,6 +786,79 @@ describe('submission.service', () => {
       expect(existSpy).toHaveBeenCalledWith({
         _id: MOCK_SUBMISSION_ID,
       })
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+  })
+
+  describe('confirmPendingSubmission', () => {
+    const MOCK_PENDING_SUBMISSION_ID = MOCK_SUBMISSION._id
+
+    beforeEach(async () => {
+      await dbHandler.clearCollection(Submission.collection.name)
+    })
+    afterEach(() => jest.clearAllMocks())
+
+    it('should return a submission document if copying from pending submissions to submissions was successful', async () => {
+      const pendingSubmission = await PendingSubmission.create({
+        _id: MOCK_PENDING_SUBMISSION_ID,
+        submissionType: SubmissionType.Encrypt,
+        form: MOCK_FORM_ID,
+        encryptedContent: 'some random encrypted content',
+        version: 1,
+        responseHash: 'hash',
+        responseSalt: 'salt',
+      })
+
+      const result = await SubmissionService.confirmPendingSubmission(
+        MOCK_PENDING_SUBMISSION_ID,
+      )
+
+      expect(result.isOk()).toEqual(true)
+
+      const submission = result._unsafeUnwrap()
+
+      Object.keys(pendingSubmission).forEach((key) => {
+        if (['_id', 'created', 'lastModified'].includes(key)) return
+        expect(submission.get(key)).toEqual(pendingSubmission.get(key))
+      })
+    })
+
+    it('should return false if pendingSubmissionId does not exist', async () => {
+      await Submission.create({
+        _id: MOCK_PENDING_SUBMISSION_ID,
+        submissionType: SubmissionType.Encrypt,
+        form: MOCK_FORM_ID,
+        encryptedContent: 'some random encrypted content',
+        version: 1,
+        responseHash: 'hash',
+        responseSalt: 'salt',
+      })
+
+      const actualResult = await SubmissionService.confirmPendingSubmission(
+        new ObjectId().toHexString(),
+      )
+
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+        PendingSubmissionNotFoundError,
+      )
+    })
+
+    it('should return DatabaseError when error occurs whilst querying database', async () => {
+      const findSpy = jest.spyOn(PendingSubmission, 'findById')
+      findSpy.mockImplementationOnce(
+        () =>
+          ({
+            exec: () => Promise.reject(new Error('boom')),
+          } as unknown as mongoose.Query<any, any>),
+      )
+
+      const actualResult = await SubmissionService.confirmPendingSubmission(
+        MOCK_PENDING_SUBMISSION_ID,
+      )
+
+      expect(findSpy).toHaveBeenCalledWith(MOCK_PENDING_SUBMISSION_ID)
       expect(actualResult.isErr()).toEqual(true)
       expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
     })

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -791,7 +791,7 @@ describe('submission.service', () => {
     })
   })
 
-  describe('movePendingSubmissionToSubmissions', () => {
+  describe('copyPendingSubmissionToSubmissions', () => {
     const MOCK_PENDING_SUBMISSION_ID = MOCK_SUBMISSION._id
 
     beforeEach(async () => {
@@ -811,7 +811,7 @@ describe('submission.service', () => {
       })
 
       const session = await mongoose.startSession()
-      const result = await SubmissionService.movePendingSubmissionToSubmissions(
+      const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
         session,
       )
@@ -839,7 +839,7 @@ describe('submission.service', () => {
       })
 
       const session = await mongoose.startSession()
-      const result = await SubmissionService.movePendingSubmissionToSubmissions(
+      const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         new ObjectId().toHexString(),
         session,
       )
@@ -861,7 +861,7 @@ describe('submission.service', () => {
       )
 
       const session = await mongoose.startSession()
-      const result = await SubmissionService.movePendingSubmissionToSubmissions(
+      const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
         session,
       )

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -791,7 +791,7 @@ describe('submission.service', () => {
     })
   })
 
-  describe('confirmPendingSubmission', () => {
+  describe('movePendingSubmissionToSubmissions', () => {
     const MOCK_PENDING_SUBMISSION_ID = MOCK_SUBMISSION._id
 
     beforeEach(async () => {
@@ -810,9 +810,12 @@ describe('submission.service', () => {
         responseSalt: 'salt',
       })
 
-      const result = await SubmissionService.confirmPendingSubmission(
+      const session = await mongoose.startSession()
+      const result = await SubmissionService.movePendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
+        session,
       )
+      session.endSession()
 
       expect(result.isOk()).toEqual(true)
 
@@ -835,12 +838,15 @@ describe('submission.service', () => {
         responseSalt: 'salt',
       })
 
-      const actualResult = await SubmissionService.confirmPendingSubmission(
+      const session = await mongoose.startSession()
+      const result = await SubmissionService.movePendingSubmissionToSubmissions(
         new ObjectId().toHexString(),
+        session,
       )
+      session.endSession()
 
-      expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+      expect(result.isErr()).toEqual(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
         PendingSubmissionNotFoundError,
       )
     })
@@ -854,13 +860,16 @@ describe('submission.service', () => {
           } as unknown as mongoose.Query<any, any>),
       )
 
-      const actualResult = await SubmissionService.confirmPendingSubmission(
+      const session = await mongoose.startSession()
+      const result = await SubmissionService.movePendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
+        session,
       )
+      session.endSession()
 
       expect(findSpy).toHaveBeenCalledWith(MOCK_PENDING_SUBMISSION_ID)
-      expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+      expect(result.isErr()).toEqual(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
     })
   })
 })

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -17,6 +17,12 @@ export class SubmissionNotFoundError extends ApplicationError {
   }
 }
 
+export class PendingSubmissionNotFoundError extends ApplicationError {
+  constructor(message = 'Pending submission not found for given ID') {
+    super(message)
+  }
+}
+
 /**
  * A custom error class returned when given submission has invalid encryption encoding
  */

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -209,7 +209,7 @@ export const findSubmissionById = (
 }
 
 /**
- * Moves a pending submission by ID to the submission collection. For correctness,
+ * Copies a pending submission by ID to the submission collection. For correctness,
  * this should always be done within a transaction, thus a session must be provided.
  *
  * @param pendingSubmissionId the id of the pending submission to confirm
@@ -219,7 +219,7 @@ export const findSubmissionById = (
  * @returns err(PendingSubmissionNotFoundError) if pending submission does not exist in the database
  * @returns err(DatabaseError) if database errors occurs while copying the document over
  */
-export const movePendingSubmissionToSubmissions = (
+export const copyPendingSubmissionToSubmissions = (
   pendingSubmissionId: string,
   session: mongoose.ClientSession,
 ): ResultAsync<

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -209,16 +209,19 @@ export const findSubmissionById = (
 }
 
 /**
+ * Moves a pending submission by ID to the submission collection. For correctness,
+ * this should always be done within a transaction, thus a session must be provided.
+ *
  * @param pendingSubmissionId the id of the pending submission to confirm
- * @param session (optional) the mongoose transaction session to be used, if any
+ * @param session the mongoose transaction session to be used, if any
  *
  * @returns ok(submission document) if a submission document is successfully created
  * @returns err(PendingSubmissionNotFoundError) if pending submission does not exist in the database
  * @returns err(DatabaseError) if database errors occurs while copying the document over
  */
-export const confirmPendingSubmission = (
+export const movePendingSubmissionToSubmissions = (
   pendingSubmissionId: string,
-  session?: mongoose.ClientSession,
+  session: mongoose.ClientSession,
 ): ResultAsync<
   ISubmissionSchema,
   DatabaseError | PendingSubmissionNotFoundError
@@ -229,9 +232,7 @@ export const confirmPendingSubmission = (
   }
 
   return ResultAsync.fromPromise(
-    PendingSubmissionModel.findById(pendingSubmissionId).session(
-      session ?? null,
-    ),
+    PendingSubmissionModel.findById(pendingSubmissionId).session(session),
     (error) => {
       logger.error({
         message: 'Database find pending submission error',

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -210,6 +210,7 @@ export const findSubmissionById = (
 
 /**
  * @param pendingSubmissionId the id of the pending submission to confirm
+ * @param session (optional) the mongoose transaction session to be used, if any
  *
  * @returns ok(submission document) if a submission document is successfully created
  * @returns err(PendingSubmissionNotFoundError) if pending submission does not exist in the database
@@ -217,6 +218,7 @@ export const findSubmissionById = (
  */
 export const confirmPendingSubmission = (
   pendingSubmissionId: string,
+  session?: mongoose.ClientSession,
 ): ResultAsync<
   ISubmissionSchema,
   DatabaseError | PendingSubmissionNotFoundError
@@ -227,7 +229,9 @@ export const confirmPendingSubmission = (
   }
 
   return ResultAsync.fromPromise(
-    PendingSubmissionModel.findById(pendingSubmissionId).exec(),
+    PendingSubmissionModel.findById(pendingSubmissionId).session(
+      session ?? null,
+    ),
     (error) => {
       logger.error({
         message: 'Database find pending submission error',
@@ -248,7 +252,7 @@ export const confirmPendingSubmission = (
         omit(pendingSubmission, ['_id', 'created', 'lastModified']),
       )
 
-      return ResultAsync.fromPromise(submission.save(), (error) => {
+      return ResultAsync.fromPromise(submission.save({ session }), (error) => {
         logger.error({
           message: 'Database save submission error',
           meta: logMeta,

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,7 +1,7 @@
-import { Model } from 'mongoose'
+import { Document, Model } from 'mongoose'
 
 import { Payment } from '../../shared/types/payment'
 
-export type IPaymentSchema = Payment
+export interface IPaymentSchema extends Payment, Document {}
 
 export type IPaymentModel = Model<IPaymentSchema>


### PR DESCRIPTION
## Problem
This PR fixes a bug in the pending submission collection where the incorrect discriminator value is used.

## Solution
If a value (third argument) is not provided, the discriminator value defaults to the discriminated collection's schema ID. But this is not what we want, since we need the pending submissions schema IDs to be unique from that of the corresponding schema IDs from the submissions collection, but the values must be the same. So we add the third argument, which is the value of the discriminator key.

## Additional notes

Additionally, I took the opportunity to write the transaction as promised here.

<img width="249" alt="image" src="https://user-images.githubusercontent.com/25571626/227154662-20e2a76d-0b17-43f3-bfb1-a6a8122e7d32.png">

Due to a bunch of changes to the separation of concerns, I repurposed one of the functions and marked several other functions as being refactorable into functions that can be used later for our implementation. This will help us avoid duplicating work later.

AND THEN

Once I started writing I realized that the transaction is meant to guarantee that a bunch of stuff appears at the same time (i.e. the transaction fee, submission id etc) so I also refactored the payment model to group those data together. Hopefully this makes it more wieldy for us in the future to check if payments are completed and access the attributes without having to add `!` guards everywhere.

OK SO 

This pr has already had a ton of scope creep and I kind of want to stop it here. Hopefully the comments and TODOs are good enough markers so that future us remembers what else needs to be done, haha.

lesson learnt: just a bit of scope creep can become a lot of scope creep, so just don't creep at all
