### PR TITLE
fix: move permission list validation from model level to service layer

### DIFF
--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -229,8 +229,12 @@ export const useMutateCollaborators = () => {
         } has been updated to the ${permissionsToRole(permissionToUpdate)} role`
         handleSuccess({ newData, toastDescription })
       },
-      onError: (error: Error) => {
-        handleError(error, FormCollaboratorAction.UPDATE)
+      onError: (error: Error, { permissionToUpdate }) => {
+        handleError(
+          error,
+          FormCollaboratorAction.UPDATE,
+          permissionToUpdate.email,
+        )
       },
     },
   )

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -370,12 +370,10 @@ describe('Form Model', () => {
         )
       })
 
-      it('should reject when form permissionList[].email is not in the Agency collection', async () => {
+      it('should reject when form permissionList[].email is not a valid email', async () => {
         // Arrange
         // permissionList has an email domain not inside Agency collection
-        const invalidPermissionList = [
-          { email: 'test@example2.com', write: true },
-        ]
+        const invalidPermissionList = [{ email: 'not an email', write: true }]
         const malformedParams = merge({}, MOCK_FORM_PARAMS, {
           permissionList: invalidPermissionList,
         })
@@ -653,12 +651,10 @@ describe('Form Model', () => {
         )
       })
 
-      it('should reject when form permissionList[].email is not in the Agency collection', async () => {
+      it('should reject when form permissionList[].email is not a valid email', async () => {
         // Arrange
         // permissionList has an email domain not inside Agency collection
-        const invalidPermissionList = [
-          { email: 'test@example2.com', write: true },
-        ]
+        const invalidPermissionList = [{ email: 'not an email', write: true }]
         const malformedParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
           permissionList: invalidPermissionList,
         })
@@ -973,12 +969,10 @@ describe('Form Model', () => {
         )
       })
 
-      it('should reject when form permissionList[].email is not in the Agency collection', async () => {
+      it('should reject when form permissionList[].email is not a valid email', async () => {
         // Arrange
         // permissionList has an email domain not inside Agency collection
-        const invalidPermissionList = [
-          { email: 'test@example2.com', write: true },
-        ]
+        const invalidPermissionList = [{ email: 'not an email', write: true }]
         const malformedParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           permissionList: invalidPermissionList,
         })
@@ -2738,7 +2732,7 @@ describe('Form Model', () => {
         // Arrange
         const newCollaborators = [
           {
-            email: `fakeuser@fakeemail.com`,
+            email: 'string that is not an email',
             write: false,
           },
         ]

--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -1223,7 +1223,7 @@ describe('admin-form.routes', () => {
           emails: defaultUser.email,
           responseMode: 'email',
           title: 'email mode form test should fail',
-          permissionList: [{ email: 'invalidEmailDomain@example.com' }],
+          permissionList: [{ email: 'not a valid email' }],
         },
       }
 

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -23,3 +23,9 @@ export class FieldNotFoundError extends ApplicationError {
     super(message)
   }
 }
+
+export class InvalidCollaboratorError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -43,6 +43,7 @@ import {
 import { EditFormFieldParams, FormUpdateParams } from '../../../../types/api'
 import config, { aws as AwsConfig } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
+import getAgencyModel from '../../../models/agency.server.model'
 import getFormModel from '../../../models/form.server.model'
 import * as SmsService from '../../../services/sms/sms.service'
 import { twilioClientCache } from '../../../services/sms/sms.service'
@@ -83,6 +84,7 @@ import {
   CreatePresignedUrlError,
   EditFieldError,
   FieldNotFoundError,
+  InvalidCollaboratorError,
   InvalidFileTypeError,
 } from './admin-form.errors'
 import {
@@ -94,6 +96,7 @@ import {
 
 const logger = createLoggerWithLabel(module)
 const FormModel = getFormModel(mongoose)
+const AgencyModel = getAgencyModel(mongoose)
 
 export const secretsManager = new SecretsManager({
   region: config.aws.region,
@@ -751,26 +754,70 @@ export const updateForm = (
  *
  * @returns ok(collaborators) if form updates successfully
  * @returns err(PossibleDatabaseError) if any database errors occurs
+ * @returns err(InvalidCollaboratorError) if a newly-added collaborator email is not whitelisted
  */
 export const updateFormCollaborators = (
   form: IPopulatedForm,
   updatedCollaborators: FormPermission[],
-): ResultAsync<FormPermission[], PossibleDatabaseError> => {
+): ResultAsync<
+  FormPermission[],
+  PossibleDatabaseError | InvalidCollaboratorError
+> => {
+  const logMeta = {
+    action: 'updateFormCollaborators',
+    formId: form._id,
+  }
+
+  // Get the newly-added collaborator emails.
+  const newCollaboratorEmails = updatedCollaborators
+    .filter(
+      ({ email: newEmail }) =>
+        !form.permissionList.some(
+          ({ email: oldEmail }) => oldEmail === newEmail,
+        ),
+    )
+    .map((collaborator) => collaborator.email)
+
   return ResultAsync.fromPromise(
-    form.updateFormCollaborators(updatedCollaborators),
+    // Check that all new collaborator domains exist in the Agency collection.
+    Promise.all(
+      newCollaboratorEmails.map(async (email) => {
+        const emailDomain = email.split('@').pop()
+        const result = await AgencyModel.findOne({ emailDomain })
+        return !!result
+      }),
+    ),
     (error) => {
       logger.error({
-        message: 'Error encountered while updating form collaborators',
-        meta: {
-          action: 'updateFormCollaborators',
-          formId: form._id,
-        },
+        message: 'Error encountered while validating new form collaborators',
+        meta: logMeta,
         error,
       })
-
       return transformMongoError(error)
     },
-  ).andThen(({ permissionList }) => okAsync(permissionList))
+  )
+    .andThen((doNewCollaboratorsExist) => {
+      const falseIdx = doNewCollaboratorsExist.findIndex((exists) => !exists)
+      return falseIdx < 0
+        ? okAsync(undefined)
+        : errAsync(
+            new InvalidCollaboratorError(newCollaboratorEmails[falseIdx]),
+          )
+    })
+    .andThen(() =>
+      ResultAsync.fromPromise(
+        form.updateFormCollaborators(updatedCollaborators),
+        (error) => {
+          logger.error({
+            message: 'Error encountered while updating form collaborators',
+            meta: logMeta,
+            error,
+          })
+          return transformMongoError(error)
+        },
+      ),
+    )
+    .andThen(({ permissionList }) => okAsync(permissionList))
 }
 
 /**

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -46,6 +46,7 @@ import {
   CreatePresignedUrlError,
   EditFieldError,
   FieldNotFoundError,
+  InvalidCollaboratorError,
   InvalidFileTypeError,
 } from './admin-form.errors'
 import {
@@ -104,6 +105,7 @@ export const mapRouteError = (
     case EditFieldError:
     case DatabaseValidationError:
     case MissingUserError:
+    case InvalidCollaboratorError:
       return {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
         errorMessage: error.message,

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -481,7 +481,7 @@ describe('admin-form.form.routes', () => {
           emails: defaultUser.email,
           responseMode: 'email',
           title: 'email mode form test should fail',
-          permissionList: [{ email: 'invalidEmailDomain@example.com' }],
+          permissionList: [{ email: 'not a valid email' }],
         },
       }
 


### PR DESCRIPTION
## Problem
Whenever agencies change email domains, we remove their domain from the Agency collection. However, this means that if they had any collaborators in their form collaborator list whose emails were from the old domain, their form is forever locked. They cannot make changes to their form anymore, since the form document cannot be saved with invalid collaborators. 

![image](https://user-images.githubusercontent.com/25571626/226315098-fbd97d76-e0de-4ed3-9b7d-747f3e9fbbc1.png)


The reason for this occurring is validation that is applied at the model level. The validation is thus run on every document save, and the database rejects the invalid save on change.

## Solution
Even though we would _like_ for there to be model-level validation, this is not practical or informative. The model validations should specify invariants of the model over all operations throughout the system. However, the `agency` collection is always subject to change, and the validator will certainly not be invariant over time. Therefore, we should not in principle validate based on the `agency` collection at the model level. All we can guarantee is that the list of collaborators are emails. What we would _really_ like is that all _new_ collaborators are whitelisted.

Therefore, this PR removes the model-level validation based on the `agency` collection. In replacement, the validation occurs at the service layer. Any new collaborators added are extracted and checked for validity, while old collaborators are left untouched.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://user-images.githubusercontent.com/25571626/226308884-e7524156-844b-4fa1-ba6f-12a146c9c0b2.mov

https://user-images.githubusercontent.com/25571626/226308964-6cdee75e-ff02-4da4-b145-6f97b80946d7.mov

## Tests

- [ ] Ensure that the email domain `data.gov.sg` is not in the `govtech` agency. Try to add `leonard@data.gov.sg` email as a collaborator. This should fail. 
- [ ] Add the `data.gov.sg` email domain to the `govtech` agency. Now add `leonard@data.gov.sg` and `formsg@data.gov.sg` email as collaborators. Then, remove the `data.gov.sg` email domain from the `govtech` agency. Perform the following actions in order. 
    - Try modifying some form fields. This should work.
    - Remove `formsg@data.gov.sg` as a collaborator. This should work.
    - Modify the read/write permission of `leonard@data.gov.sg`. This should fail.
    - Add `leonard@open.gov.sg` as a collaborator. This should work.
    - Remove `leonard@data.gov.sg` as a collaborator. This should work.

## Notes

Separately, I found an existing bug with transfer ownership. We currently allow ownership to be transferred to users whose emails are no longer valid domains belonging to any agency. You can see this in the second video clip, right at the end. I'll open a ticket for it after looking through the existing issues to see if it's duplicated.