### PR TITLE
chore: dont update index.html after dd chunk build

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -30,3 +30,6 @@ build-storybook.log
 
 #Datadog chunk files
 datadog-chunk.*.js
+
+# temp directory for modified index.htm;
+/temp

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const CracoAlias = require('craco-alias')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 const merge = require('lodash/merge')
 const path = require('path')
 
@@ -69,6 +70,15 @@ module.exports = {
               },
             },
           })
+
+          // use pre-processed temp/index.html that has datadog script added to it
+          const htmlWebpackPluginInstance = webpackConfig.plugins.find(
+            (webpackPlugin) => webpackPlugin instanceof HtmlWebpackPlugin,
+          )
+          if (htmlWebpackPluginInstance) {
+            htmlWebpackPluginInstance.userOptions.template =
+              path.resolve('temp/index.html')
+          }
 
           return webpackConfig
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "postinstall": "patch-package && npm run gen:theme-typings && npm run clean:emotion-types && npm --prefix ../shared install",
     "start": "env-cmd -f .buildtime-env craco --openssl-legacy-provider start",
     "build": "npm run build:dd-chunk && cross-env CI=false BUILD_PATH='../dist/frontend' INLINE_RUNTIME_CHUNK=false SKIP_PREFLIGHT_CHECK=true craco build && cd ../ && cp -rf frontend/static/js dist/frontend/static",
-    "build:dd-chunk": "webpack --config webpack.dd.config.js",
+    "build:dd-chunk": "webpack --config webpack.dd.config.js && git checkout -- public/index.html",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test --silent",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",

--- a/frontend/webpack.dd.config.js
+++ b/frontend/webpack.dd.config.js
@@ -33,7 +33,7 @@ module.exports = {
   // inject the datadog chunk filename into the head of the existing index.html and overwrites index.html
   plugins: [
     new HtmlWebpackPlugin({
-      filename: path.resolve('public/index.html'),
+      filename: path.resolve('temp/index.html'),
       template: path.resolve('public/index.html'),
       inject: 'head',
       minify: false, // Retain non-minified html formatting for readability


### PR DESCRIPTION
## Problem
Not a big issue, just some ergonomic updates to build command. When building the app locally, the file frontend/public/index.html is modified when webpack injects markup to load the datadog chunk. Git reflects that as a local change, which is confusing for developers, and there is a risk to commit the change accidentally.

## Solution
2 options proposed
1. reset index.html after dd build (may need to test in CI env where git might not exist?)

2. write output index.html to temp directory and modify webpack config to reference temp output in final cra build

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:
- will not accidentally commit unwanted changes to index.html, and prevent confusion as to whether changes should be committed
