### PR TITLE
feat: payment max and min limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - PAYMENT_STRIPE_SECRET_KEY=secretKey
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
-      - PAYMENT_MAX_LIMIT=1000
+      - PAYMENT_MAX_PAYMENT_AMOUNT=1000
   mockpass:
     build: https://github.com/opengovsg/mockpass.git
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - PAYMENT_STRIPE_SECRET_KEY=secretKey
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
+      - PAYMENT_MAX_LIMIT=10000
   mockpass:
     build: https://github.com/opengovsg/mockpass.git
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - PAYMENT_STRIPE_SECRET_KEY=secretKey
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
-      - PAYMENT_MAX_PAYMENT_AMOUNT=1000
+      - PAYMENT_MAX_PAYMENT_AMOUNT_CENTS=100000
   mockpass:
     build: https://github.com/opengovsg/mockpass.git
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
       - PAYMENT_MAX_PAYMENT_AMOUNT_CENTS=100000
+      - PAYMENT_MIN_PAYMENT_AMOUNT_CENTS=50
+
   mockpass:
     build: https://github.com/opengovsg/mockpass.git
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - PAYMENT_STRIPE_SECRET_KEY=secretKey
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
-      - PAYMENT_MAX_LIMIT=10000
+      - PAYMENT_MAX_LIMIT=1000
   mockpass:
     build: https://github.com/opengovsg/mockpass.git
     depends_on:

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -131,7 +131,7 @@ export const PaymentInput = (): JSX.Element => {
 
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
-  const minPaymentAmount = 0.5 // stipulated by Stripe
+  const MIN_PAYMENT_AMOUNT = 0.5 // stipulated by Stripe
 
   const amountValidation: RegisterOptions<
     FormPaymentsDisplay,
@@ -151,9 +151,9 @@ export const PaymentInput = (): JSX.Element => {
         },
         validateMin: (val) => {
           return (
-            Number(val?.trim()) >= minPaymentAmount ||
+            Number(val?.trim()) >= MIN_PAYMENT_AMOUNT ||
             `Please enter a payment amount above ${formatCurrency(
-              minPaymentAmount,
+              MIN_PAYMENT_AMOUNT,
             )}`
           )
         },

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -56,7 +56,8 @@ export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
   const { paymentsMutation } = useMutateFormPage()
 
-  const { data: { maxPaymentAmountCents } = {} } = useEnv()
+  const { data: { maxPaymentAmountCents, minPaymentAmountCents } = {} } =
+    useEnv()
 
   const setIsDirty = useDirtyFieldStore(setIsDirtySelector)
 
@@ -131,8 +132,6 @@ export const PaymentInput = (): JSX.Element => {
 
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
-  const MIN_PAYMENT_AMOUNT = 0.5 // stipulated by Stripe
-
   const amountValidation: RegisterOptions<
     FormPaymentsDisplay,
     'display_amount'
@@ -150,10 +149,12 @@ export const PaymentInput = (): JSX.Element => {
           )
         },
         validateMin: (val) => {
+          if (minPaymentAmountCents === undefined) return true
           return (
-            Number(val?.trim()) >= MIN_PAYMENT_AMOUNT ||
+            // val is in dollars
+            Number(val?.trim()) >= minPaymentAmountCents / 100 ||
             `Please enter a payment amount above ${formatCurrency(
-              MIN_PAYMENT_AMOUNT,
+              minPaymentAmountCents / 100,
             )}`
           )
         },
@@ -169,7 +170,7 @@ export const PaymentInput = (): JSX.Element => {
         },
       },
     }),
-    [maxPaymentAmountCents],
+    [maxPaymentAmountCents, minPaymentAmountCents],
   )
 
   const handleUpdatePayments = handleSubmit(() => {

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -152,9 +152,10 @@ export const PaymentInput = (): JSX.Element => {
           if (minPaymentAmountCents === undefined) return true
           return (
             // val is in dollars
-            Number(val?.trim()) >= minPaymentAmountCents / 100 ||
+            Number(val?.trim()) >=
+              Number(centsToDollars(minPaymentAmountCents)) ||
             `Please enter a payment amount above ${formatCurrency(
-              minPaymentAmountCents / 100,
+              Number(centsToDollars(minPaymentAmountCents)),
             )}`
           )
         },
@@ -162,9 +163,10 @@ export const PaymentInput = (): JSX.Element => {
           if (maxPaymentAmountCents === undefined) return true
           return (
             // val is in dollars
-            Number(val?.trim()) <= maxPaymentAmountCents / 100 ||
+            Number(val?.trim()) <=
+              Number(centsToDollars(maxPaymentAmountCents)) ||
             `Please keep payment amount under ${formatCurrency(
-              maxPaymentAmountCents / 100,
+              Number(centsToDollars(maxPaymentAmountCents)),
             )}`
           )
         },

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -56,7 +56,7 @@ export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
   const { paymentsMutation } = useMutateFormPage()
 
-  const { data: { paymentMaxLimit } = {} } = useEnv()
+  const { data: { maxPaymentAmount } = {} } = useEnv()
 
   const setIsDirty = useDirtyFieldStore(setIsDirtySelector)
 
@@ -132,7 +132,6 @@ export const PaymentInput = (): JSX.Element => {
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
   const minPaymentAmount = 0.5 // stipulated by Stripe
-  const maxPaymentAmount = 1000 // due to IRAS requirements and agency financial institutions are expected to be in SG
 
   const amountValidation: RegisterOptions<
     FormPaymentsDisplay,
@@ -159,17 +158,17 @@ export const PaymentInput = (): JSX.Element => {
           )
         },
         validateMax: (val) => {
-          if (paymentMaxLimit === undefined) return true
+          if (maxPaymentAmount === undefined) return true
           return (
-            Number(val?.trim()) <= paymentMaxLimit ||
+            Number(val?.trim()) <= maxPaymentAmount ||
             `Please keep payment amount under ${formatCurrency(
-              paymentMaxLimit,
+              maxPaymentAmount,
             )}`
           )
         },
       },
     }),
-    [],
+    [maxPaymentAmount],
   )
 
   const handleUpdatePayments = handleSubmit(() => {

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -24,6 +24,7 @@ import Toggle from '~components/Toggle'
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'
 
+import { useEnv } from '../../../env/queries'
 import {
   setIsDirtySelector,
   useDirtyFieldStore,
@@ -54,6 +55,8 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
 export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
   const { paymentsMutation } = useMutateFormPage()
+
+  const { data: { paymentMaxLimit } = {} } = useEnv()
 
   const setIsDirty = useDirtyFieldStore(setIsDirtySelector)
 
@@ -156,10 +159,11 @@ export const PaymentInput = (): JSX.Element => {
           )
         },
         validateMax: (val) => {
+          if (paymentMaxLimit === undefined) return true
           return (
-            Number(val?.trim()) <= maxPaymentAmount ||
+            Number(val?.trim()) <= paymentMaxLimit ||
             `Please keep payment amount under ${formatCurrency(
-              maxPaymentAmount,
+              paymentMaxLimit,
             )}`
           )
         },

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -56,7 +56,7 @@ export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
   const { paymentsMutation } = useMutateFormPage()
 
-  const { data: { maxPaymentAmount } = {} } = useEnv()
+  const { data: { maxPaymentAmountCents } = {} } = useEnv()
 
   const setIsDirty = useDirtyFieldStore(setIsDirtySelector)
 
@@ -158,17 +158,17 @@ export const PaymentInput = (): JSX.Element => {
           )
         },
         validateMax: (val) => {
-          if (maxPaymentAmount === undefined) return true
+          if (maxPaymentAmountCents === undefined) return true
           return (
-            Number(val?.trim()) <= maxPaymentAmount ||
+            Number(val?.trim()) <= maxPaymentAmountCents ||
             `Please keep payment amount under ${formatCurrency(
-              maxPaymentAmount,
+              maxPaymentAmountCents,
             )}`
           )
         },
       },
     }),
-    [maxPaymentAmount],
+    [maxPaymentAmountCents],
   )
 
   const handleUpdatePayments = handleSubmit(() => {

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -160,9 +160,10 @@ export const PaymentInput = (): JSX.Element => {
         validateMax: (val) => {
           if (maxPaymentAmountCents === undefined) return true
           return (
-            Number(val?.trim()) <= maxPaymentAmountCents ||
+            // val is in dollars
+            Number(val?.trim()) <= maxPaymentAmountCents / 100 ||
             `Please keep payment amount under ${formatCurrency(
-              maxPaymentAmountCents,
+              maxPaymentAmountCents / 100,
             )}`
           )
         },

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -152,8 +152,7 @@ export const PaymentInput = (): JSX.Element => {
           if (minPaymentAmountCents === undefined) return true
           return (
             // val is in dollars
-            Number(val?.trim()) >=
-              Number(centsToDollars(minPaymentAmountCents)) ||
+            (val && dollarsToCents(val) >= minPaymentAmountCents) ||
             `Please enter a payment amount above ${formatCurrency(
               Number(centsToDollars(minPaymentAmountCents)),
             )}`
@@ -163,9 +162,8 @@ export const PaymentInput = (): JSX.Element => {
           if (maxPaymentAmountCents === undefined) return true
           return (
             // val is in dollars
-            Number(val?.trim()) <=
-              Number(centsToDollars(maxPaymentAmountCents)) ||
-            `Please keep payment amount under ${formatCurrency(
+            (val && dollarsToCents(val) <= maxPaymentAmountCents) ||
+            `Please enter a payment amount below ${formatCurrency(
               Number(centsToDollars(maxPaymentAmountCents)),
             )}`
           )

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -1,7 +1,7 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { createNricValidationRules } from '~utils/fieldValidation'

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -39,5 +39,5 @@ export type ClientEnvVars = {
   removeAdminInfoboxThreshold: number
   removeRespondentsInfoboxThreshold: number
   stripePublishableKey: string
-  maxPaymentAmount: number
+  maxPaymentAmountCents: number
 }

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -39,4 +39,5 @@ export type ClientEnvVars = {
   removeAdminInfoboxThreshold: number
   removeRespondentsInfoboxThreshold: number
   stripePublishableKey: string
+  paymentMaxLimit: number
 }

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -39,5 +39,5 @@ export type ClientEnvVars = {
   removeAdminInfoboxThreshold: number
   removeRespondentsInfoboxThreshold: number
   stripePublishableKey: string
-  paymentMaxLimit: number
+  maxPaymentAmount: number
 }

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -40,4 +40,5 @@ export type ClientEnvVars = {
   removeRespondentsInfoboxThreshold: number
   stripePublishableKey: string
   maxPaymentAmountCents: number
+  minPaymentAmountCents: number
 }

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -7,6 +7,7 @@ export interface IStripe {
   stripeClientID: string
   stripeWebhookSecret: string
   maxPaymentAmountCents: number
+  minPaymentAmountCents: number
 }
 
 const paymentFeature: Schema<IStripe> = {
@@ -45,6 +46,12 @@ const paymentFeature: Schema<IStripe> = {
     format: Number,
     default: 100000, // $1000, due to IRAS limit for invoice
     env: 'PAYMENT_MAX_PAYMENT_AMOUNT_CENTS',
+  },
+  minPaymentAmountCents: {
+    doc: 'Minimum that can be paid for a form',
+    format: Number,
+    default: 50, // $0.50, as specified by stripe
+    env: 'PAYMENT_MIN_PAYMENT_AMOUNT_CENTS',
   },
 }
 

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -6,7 +6,7 @@ export interface IStripe {
   stripeSecretKey: string
   stripeClientID: string
   stripeWebhookSecret: string
-  maxPaymentAmount: number
+  maxPaymentAmountCents: number
 }
 
 const paymentFeature: Schema<IStripe> = {
@@ -40,11 +40,11 @@ const paymentFeature: Schema<IStripe> = {
     default: '',
     env: 'PAYMENT_STRIPE_WEBHOOK_SECRET',
   },
-  maxPaymentAmount: {
+  maxPaymentAmountCents: {
     doc: 'Maximum amount that can be paid for a form',
     format: Number,
-    default: 1000,
-    env: 'PAYMENT_MAX_PAYMENT_AMOUNT',
+    default: 100000, // $1000, due to IRAS limit for invoice
+    env: 'PAYMENT_MAX_PAYMENT_AMOUNT_CENTS',
   },
 }
 

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -6,7 +6,7 @@ export interface IStripe {
   stripeSecretKey: string
   stripeClientID: string
   stripeWebhookSecret: string
-  paymentMaxLimit: number
+  maxPaymentAmount: number
 }
 
 const paymentFeature: Schema<IStripe> = {
@@ -40,11 +40,11 @@ const paymentFeature: Schema<IStripe> = {
     default: '',
     env: 'PAYMENT_STRIPE_WEBHOOK_SECRET',
   },
-  paymentMaxLimit: {
+  maxPaymentAmount: {
     doc: 'Maximum amount that can be paid for a form',
     format: Number,
     default: 1000,
-    env: 'PAYMENT_MAX_LIMIT',
+    env: 'PAYMENT_MAX_PAYMENT_AMOUNT',
   },
 }
 

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -6,6 +6,7 @@ export interface IStripe {
   stripeSecretKey: string
   stripeClientID: string
   stripeWebhookSecret: string
+  paymentMaxLimit: number
 }
 
 const paymentFeature: Schema<IStripe> = {
@@ -38,6 +39,12 @@ const paymentFeature: Schema<IStripe> = {
     format: String,
     default: '',
     env: 'PAYMENT_STRIPE_WEBHOOK_SECRET',
+  },
+  paymentMaxLimit: {
+    doc: 'Maximum amount that can be paid for a form',
+    format: Number,
+    default: 10000,
+    env: 'PAYMENT_MAX_LIMIT',
   },
 }
 

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -43,7 +43,7 @@ const paymentFeature: Schema<IStripe> = {
   paymentMaxLimit: {
     doc: 'Maximum amount that can be paid for a form',
     format: Number,
-    default: 10000,
+    default: 1000,
     env: 'PAYMENT_MAX_LIMIT',
   },
 }

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -3,6 +3,7 @@ import ejs from 'ejs'
 import config from '../../config/config'
 import { captchaConfig } from '../../config/features/captcha.config'
 import { googleAnalyticsConfig } from '../../config/features/google-analytics.config'
+import { paymentConfig } from '../../config/features/payment.config'
 import { sentryConfig } from '../../config/features/sentry.config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
 
@@ -33,6 +34,8 @@ const frontendVars = {
     config.reactMigration.respondentRolloutStorage,
   reactMigrationAdminRollout: config.reactMigration.adminRollout,
   reactMigrationAngularPhaseOutDate: config.reactMigration.angularPhaseOutDate,
+  // payment variables
+  paymentMaxLimit: paymentConfig.paymentMaxLimit,
 }
 const environment = ejs.render(
   `
@@ -64,6 +67,8 @@ const environment = ejs.render(
     var reactMigrationRespondentRolloutStorage = "<%= reactMigrationRespondentRolloutStorage%>"
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"
     var reactMigrationAngularPhaseOutDate = "<%= reactMigrationAngularPhaseOutDate%>"
+    // Payment
+    var paymentMaxLimit = "<%= paymentMaxLimit%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -36,6 +36,7 @@ const frontendVars = {
   reactMigrationAngularPhaseOutDate: config.reactMigration.angularPhaseOutDate,
   // payment variables
   maxPaymentAmountCents: paymentConfig.maxPaymentAmountCents,
+  minPaymentAmountCents: paymentConfig.minPaymentAmountCents,
 }
 const environment = ejs.render(
   `
@@ -69,6 +70,7 @@ const environment = ejs.render(
     var reactMigrationAngularPhaseOutDate = "<%= reactMigrationAngularPhaseOutDate%>"
     // Payment
     var maxPaymentAmountCents = "<%= maxPaymentAmountCents%>"
+    var minPaymentAmountCents = "<%= minPaymentAmountCents%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -35,7 +35,7 @@ const frontendVars = {
   reactMigrationAdminRollout: config.reactMigration.adminRollout,
   reactMigrationAngularPhaseOutDate: config.reactMigration.angularPhaseOutDate,
   // payment variables
-  maxPaymentAmount: paymentConfig.maxPaymentAmount,
+  maxPaymentAmountCents: paymentConfig.maxPaymentAmountCents,
 }
 const environment = ejs.render(
   `
@@ -68,7 +68,7 @@ const environment = ejs.render(
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"
     var reactMigrationAngularPhaseOutDate = "<%= reactMigrationAngularPhaseOutDate%>"
     // Payment
-    var maxPaymentAmount = "<%= maxPaymentAmount%>"
+    var maxPaymentAmountCents = "<%= maxPaymentAmountCents%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -35,7 +35,7 @@ const frontendVars = {
   reactMigrationAdminRollout: config.reactMigration.adminRollout,
   reactMigrationAngularPhaseOutDate: config.reactMigration.angularPhaseOutDate,
   // payment variables
-  paymentMaxLimit: paymentConfig.paymentMaxLimit,
+  maxPaymentAmount: paymentConfig.maxPaymentAmount,
 }
 const environment = ejs.render(
   `
@@ -68,7 +68,7 @@ const environment = ejs.render(
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"
     var reactMigrationAngularPhaseOutDate = "<%= reactMigrationAngularPhaseOutDate%>"
     // Payment
-    var paymentMaxLimit = "<%= paymentMaxLimit%>"
+    var maxPaymentAmount = "<%= maxPaymentAmount%>"
   `,
   frontendVars,
 )

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -69,8 +69,8 @@ const environment = ejs.render(
     var reactMigrationAdminRollout = "<%= reactMigrationAdminRollout%>"
     var reactMigrationAngularPhaseOutDate = "<%= reactMigrationAngularPhaseOutDate%>"
     // Payment
-    var maxPaymentAmountCents = "<%= maxPaymentAmountCents%>"
-    var minPaymentAmountCents = "<%= minPaymentAmountCents%>"
+    var maxPaymentAmountCents = <%= maxPaymentAmountCents%>
+    var minPaymentAmountCents = <%= minPaymentAmountCents%>
   `,
   frontendVars,
 )

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2647,7 +2647,7 @@ describe('admin-form.service', () => {
       payments: updatedPaymentSettings,
     }
 
-    it('return InvalidPaymentAmountError if payment amount exceeds maxPaymentAmountCents', async () => {
+    it('should return InvalidPaymentAmountError if payment amount exceeds maxPaymentAmountCents', async () => {
       // Arrange
 
       const updatedPaymentSettingsExceeded = {
@@ -2662,6 +2662,30 @@ describe('admin-form.service', () => {
       const actualResult = await AdminFormService.updatePayments(
         mockFormId,
         updatedPaymentSettingsExceeded,
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentAmountError,
+      )
+    })
+
+    it('should return InvalidPaymentAmountError if payment amount is below minPaymentAmountCents', async () => {
+      // Arrange
+
+      const updatedPaymentSettingsBelow = {
+        enabled: true,
+        target_account_id: 'someId',
+        publishable_key: 'somekey',
+        amount_cents: 49,
+        description: 'some description',
+      } as PaymentsUpdateDto
+
+      // Act
+      const actualResult = await AdminFormService.updatePayments(
+        mockFormId,
+        updatedPaymentSettingsBelow,
       )
 
       // Assert

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2712,7 +2712,7 @@ describe('admin-form.service', () => {
       // Arrange
       const putSpy = jest
         .spyOn(FormModel, 'updatePaymentsById')
-        .mockResolvedValueOnce()
+        .mockResolvedValueOnce(null)
 
       // Act
       const actualResult = await AdminFormService.updatePayments(

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -26,6 +26,7 @@ import { EditFieldActions } from 'src/shared/constants'
 import {
   FormLogicSchema,
   IEmailFormSchema,
+  IEncryptedFormDocument,
   IFormDocument,
   IFormSchema,
   IPopulatedForm,
@@ -2644,7 +2645,7 @@ describe('admin-form.service', () => {
 
     const mockUpdatedForm = {
       _id: mockFormId,
-      payments: updatedPaymentSettings,
+      payments_field: updatedPaymentSettings,
     }
 
     it('should return InvalidPaymentAmountError if payment amount exceeds maxPaymentAmountCents', async () => {
@@ -2692,8 +2693,10 @@ describe('admin-form.service', () => {
     it('should successfuly call updatePaymentsById with formId and newPayments and return the updated payment settings', async () => {
       // Arrange
       const putSpy = jest
-        .spyOn(FormModel, 'updatePaymentsById')
-        .mockResolvedValueOnce(mockUpdatedForm as unknown as IFormDocument)
+        .spyOn(EncryptFormModel, 'updatePaymentsById')
+        .mockResolvedValueOnce(
+          mockUpdatedForm as unknown as IEncryptedFormDocument,
+        )
 
       // Act
       const actualResult = await AdminFormService.updatePayments(
@@ -2712,7 +2715,7 @@ describe('admin-form.service', () => {
     it('should return PossibleDatabaseError if db update fails', async () => {
       // Arrange
       const putSpy = jest
-        .spyOn(FormModel, 'updatePaymentsById')
+        .spyOn(EncryptFormModel, 'updatePaymentsById')
         .mockRejectedValueOnce(new DatabaseError())
 
       // Act
@@ -2730,7 +2733,7 @@ describe('admin-form.service', () => {
     it('should return FormNotFoundError if no form is returned after updating db', async () => {
       // Arrange
       const putSpy = jest
-        .spyOn(FormModel, 'updatePaymentsById')
+        .spyOn(EncryptFormModel, 'updatePaymentsById')
         .mockResolvedValueOnce(null)
 
       // Act

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2647,7 +2647,7 @@ describe('admin-form.service', () => {
       payments: updatedPaymentSettings,
     }
 
-    it('return InvalidPaymentAmountError if payment amount exceeds maxPaymentAmount', async () => {
+    it('return InvalidPaymentAmountError if payment amount exceeds maxPaymentAmountCents', async () => {
       // Arrange
 
       const updatedPaymentSettingsExceeded = {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2651,11 +2651,8 @@ describe('admin-form.service', () => {
       // Arrange
 
       const updatedPaymentSettingsExceeded = {
-        enabled: true,
-        target_account_id: 'someId',
-        publishable_key: 'somekey',
+        ...updatedPaymentSettings,
         amount_cents: 500000,
-        description: 'some description',
       } as PaymentsUpdateDto
 
       // Act
@@ -2675,11 +2672,8 @@ describe('admin-form.service', () => {
       // Arrange
 
       const updatedPaymentSettingsBelow = {
-        enabled: true,
-        target_account_id: 'someId',
-        publishable_key: 'somekey',
+        ...updatedPaymentSettings,
         amount_cents: 49,
-        description: 'some description',
       } as PaymentsUpdateDto
 
       // Act
@@ -2696,6 +2690,7 @@ describe('admin-form.service', () => {
     })
 
     it('should successfuly call updatePaymentsById with formId and newPayments and return the updated payment settings', async () => {
+      // Arrange
       const putSpy = jest
         .spyOn(FormModel, 'updatePaymentsById')
         .mockResolvedValueOnce(mockUpdatedForm as unknown as IFormDocument)

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1527,14 +1527,14 @@ export const updatePayments = (
 > => {
   const { amount_cents } = newPayments
 
-  // Check if payment amount exceeds maxPaymentAmountCents
-  if (amount_cents && amount_cents > paymentConfig.maxPaymentAmountCents) {
-    return errAsync(new InvalidPaymentAmountError())
-  }
-
-  // Check if payment amount is below minPaymentAmountCents
-  if (amount_cents && amount_cents < paymentConfig.minPaymentAmountCents) {
-    return errAsync(new InvalidPaymentAmountError())
+  // Check if payment amount exceeds maxPaymentAmountCents or below minPaymentAmountCents
+  if (amount_cents) {
+    if (
+      amount_cents > paymentConfig.maxPaymentAmountCents ||
+      amount_cents < paymentConfig.minPaymentAmountCents
+    ) {
+      return errAsync(new InvalidPaymentAmountError())
+    }
   }
 
   return ResultAsync.fromPromise(

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1525,10 +1525,10 @@ export const updatePayments = (
   IFormDocument['payments'],
   PossibleDatabaseError | FormNotFoundError | InvalidPaymentAmountError
 > => {
-  // Check if payment amount exceeds maxPaymentAmount
+  // Check if payment amount exceeds maxPaymentAmountCents
   const { amount_cents } = newPayments
 
-  if (amount_cents && amount_cents / 100 > paymentConfig.maxPaymentAmount) {
+  if (amount_cents && amount_cents > paymentConfig.maxPaymentAmountCents) {
     return errAsync(new InvalidPaymentAmountError())
   }
 

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1525,10 +1525,15 @@ export const updatePayments = (
   IFormDocument['payments'],
   PossibleDatabaseError | FormNotFoundError | InvalidPaymentAmountError
 > => {
-  // Check if payment amount exceeds maxPaymentAmountCents
   const { amount_cents } = newPayments
 
+  // Check if payment amount exceeds maxPaymentAmountCents
   if (amount_cents && amount_cents > paymentConfig.maxPaymentAmountCents) {
+    return errAsync(new InvalidPaymentAmountError())
+  }
+
+  // Check if payment amount is below minPaymentAmountCents
+  if (amount_cents && amount_cents < paymentConfig.minPaymentAmountCents) {
     return errAsync(new InvalidPaymentAmountError())
   }
 

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -30,6 +30,7 @@ import {
   TwilioCacheError,
 } from '../../core/core.errors'
 import { ErrorResponseData } from '../../core/core.types'
+import { InvalidPaymentAmountError } from '../../payments/payment.errors'
 import {
   StripeAccountError,
   StripeAccountNotFoundError,
@@ -167,6 +168,11 @@ export const mapRouteError = (
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: coreErrorMessage ?? error.message,
+      }
+    case InvalidPaymentAmountError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
       }
     default:
       logger.error({

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -36,5 +36,6 @@ export const getClientEnvVars = (): ClientEnvVars => {
     removeRespondentsInfoboxThreshold:
       config.reactMigration.removeRespondentsInfoboxThreshold,
     stripePublishableKey: paymentConfig.stripePublishableKey,
+    paymentMaxLimit: paymentConfig.paymentMaxLimit,
   }
 }

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -36,6 +36,6 @@ export const getClientEnvVars = (): ClientEnvVars => {
     removeRespondentsInfoboxThreshold:
       config.reactMigration.removeRespondentsInfoboxThreshold,
     stripePublishableKey: paymentConfig.stripePublishableKey,
-    maxPaymentAmount: paymentConfig.maxPaymentAmount,
+    maxPaymentAmountCents: paymentConfig.maxPaymentAmountCents,
   }
 }

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -36,6 +36,6 @@ export const getClientEnvVars = (): ClientEnvVars => {
     removeRespondentsInfoboxThreshold:
       config.reactMigration.removeRespondentsInfoboxThreshold,
     stripePublishableKey: paymentConfig.stripePublishableKey,
-    paymentMaxLimit: paymentConfig.paymentMaxLimit,
+    maxPaymentAmount: paymentConfig.maxPaymentAmount,
   }
 }

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -37,5 +37,6 @@ export const getClientEnvVars = (): ClientEnvVars => {
       config.reactMigration.removeRespondentsInfoboxThreshold,
     stripePublishableKey: paymentConfig.stripePublishableKey,
     maxPaymentAmountCents: paymentConfig.maxPaymentAmountCents,
+    minPaymentAmountCents: paymentConfig.minPaymentAmountCents,
   }
 }

--- a/src/app/modules/payments/payment.errors.ts
+++ b/src/app/modules/payments/payment.errors.ts
@@ -5,3 +5,9 @@ export class PaymentNotFoundError extends ApplicationError {
     super(message)
   }
 }
+
+export class InvalidPaymentAmountError extends ApplicationError {
+  constructor(message = 'Invalid payment amount') {
+    super(message)
+  }
+}

--- a/src/app/modules/payments/payment.errors.ts
+++ b/src/app/modules/payments/payment.errors.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from '../core/core.errors'
+
+export class PaymentNotFoundError extends ApplicationError {
+  constructor(message = 'Payment not found') {
+    super(message)
+  }
+}

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -6,16 +6,12 @@ import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
-import { ApplicationError, DatabaseError } from '../core/core.errors'
+import { DatabaseError } from '../core/core.errors'
+
+import { PaymentNotFoundError } from './payment.errors'
 
 const logger = createLoggerWithLabel(module)
 const PaymentModel = getPaymentModel(mongoose)
-
-export class PaymentNotFoundError extends ApplicationError {
-  constructor(message = 'Payment not found') {
-    super(message)
-  }
-}
 
 /**
  * Retrieves submission document of the given SubmissionId.


### PR DESCRIPTION
## Problem

- Adds env var to set max payment limit for forms (default is $1000, to align with IRAS max limit for invoices)
- Adds env var to set min payment limit for forms (default is $0.50, set by stripe)
Closes #5869 

## Tests
- [ ] Create payment form. Attempt to set payment amount above $1000. Should fail on frontend.
- [ ] Attempt to set payment amount above $1000 via api call. Should fail.
- [ ] Setting payment amount of <=$1000 works.
- [ ] Repeat above for lower payment threshold of 50 cents.

**New environment variables**:

- `PAYMENT_MAX_PAYMENT_AMOUNT_CENTS`: Max amount that can be collected in each payment, in cents
- `PAYMENT_MIN_PAYMENT_AMOUNT_CENTS`: Min amount that can be collected in each payment, in cents