### PR TITLE
fix: submit admin feedback form

### DIFF
--- a/frontend/src/features/env/AdminFeedbackModal.tsx
+++ b/frontend/src/features/env/AdminFeedbackModal.tsx
@@ -68,9 +68,7 @@ export const AdminFeedbackModal = ({
   const feedbackMutation = useFeedbackMutation()
 
   const handleSubmitForm = handleSubmit((formInputs: AdminFeedbackFormDto) => {
-    if (!feedbackForm) {
-      return
-    }
+    if (!feedbackForm) return
     if (isUsableFeedback(formInputs.feedback)) {
       feedbackMutation.mutate({
         formInputs,

--- a/frontend/src/features/env/AdminFeedbackModal.tsx
+++ b/frontend/src/features/env/AdminFeedbackModal.tsx
@@ -68,7 +68,9 @@ export const AdminFeedbackModal = ({
   const feedbackMutation = useFeedbackMutation()
 
   const handleSubmitForm = handleSubmit((formInputs: AdminFeedbackFormDto) => {
-    if (!feedbackForm) return
+    if (!feedbackForm) {
+      return
+    }
     if (isUsableFeedback(formInputs.feedback)) {
       feedbackMutation.mutate({
         formInputs,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -88,17 +88,18 @@ export const submitSwitchEnvFormFeedback = async ({
 }): Promise<SuccessMessageDto | ErrorDto> => {
   const isAdmin = Object.keys(formInputs).includes('rating')
 
-  const formFields = [
-    'url',
-    'feedback',
-    'email',
-    'rumSessionId',
-    'attachmentType',
-    'userAgent',
-    'responseMode',
-    'authType',
-  ]
+  const formFields = ['feedback']
   if (isAdmin) formFields.push('rating')
+  if (!isAdmin)
+    formFields.push(
+      'url',
+      'email',
+      'rumSessionId',
+      'attachmentType',
+      'userAgent',
+      'responseMode',
+      'authType',
+    )
 
   const formData = createSwitchFeedbackSubmissionFormData(
     formFields,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -89,9 +89,15 @@ export const submitSwitchEnvFormFeedback = async ({
   const isAdmin = Object.keys(formInputs).includes('rating')
 
   const formFields = ['url', 'feedback', 'email', 'rumSessionId']
-  if (isAdmin) formFields.push('rating')
-  if (!isAdmin)
-    formFields.push('attachmentType', 'userAgent', 'responseMode', 'authType')
+  const adminFormFields = ['rating']
+  const publicFormFields = [
+    'attachmentType',
+    'userAgent',
+    'responseMode',
+    'authType',
+  ]
+  if (isAdmin) formFields.push(...adminFormFields)
+  else formFields.push(...publicFormFields)
 
   const formData = createSwitchFeedbackSubmissionFormData(
     formFields,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -88,18 +88,10 @@ export const submitSwitchEnvFormFeedback = async ({
 }): Promise<SuccessMessageDto | ErrorDto> => {
   const isAdmin = Object.keys(formInputs).includes('rating')
 
-  const formFields = ['feedback']
+  const formFields = ['url', 'email', 'rumSessionId', 'feedback']
   if (isAdmin) formFields.push('rating')
   if (!isAdmin)
-    formFields.push(
-      'url',
-      'email',
-      'rumSessionId',
-      'attachmentType',
-      'userAgent',
-      'responseMode',
-      'authType',
-    )
+    formFields.push('attachmentType', 'userAgent', 'responseMode', 'authType')
 
   const formData = createSwitchFeedbackSubmissionFormData(
     formFields,

--- a/frontend/src/features/env/EnvService.ts
+++ b/frontend/src/features/env/EnvService.ts
@@ -88,7 +88,7 @@ export const submitSwitchEnvFormFeedback = async ({
 }): Promise<SuccessMessageDto | ErrorDto> => {
   const isAdmin = Object.keys(formInputs).includes('rating')
 
-  const formFields = ['url', 'email', 'rumSessionId', 'feedback']
+  const formFields = ['url', 'feedback', 'email', 'rumSessionId']
   if (isAdmin) formFields.push('rating')
   if (!isAdmin)
     formFields.push('attachmentType', 'userAgent', 'responseMode', 'authType')


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The feedback form for admins (on admin pages) was not being submitted as there were some form fields that did not exist on the admin feedback form, e.g. `attachmentType`. These fields were returning `undefined` and prevented the form from being submitted successfully.

## Solution
<!-- How did you solve the problem? -->
Vary the form fields depending on whether the feedback form is an admin's or public user's.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**AFTER**:

![chrome-capture-2023-2-23](https://user-images.githubusercontent.com/56983748/227118052-560a6c5d-9082-48c0-bcd0-570d48d3a415.gif)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] On an admin page, click the speech bubble icon on the bottom right of the screen. Submit your feedback (make sure that any text entered is longer than 5 characters)
- [x] (To test that the public feedback form is also still working) Change `REACT_MIGRATION_RESP_ROLLOUT_EMAIL` to 99. Go to an email-mode public form and click the "switch back" banner at the bottom of the page. This should open a modal with long text field (and email field if not logged in as admin). Fill the form. It should submit successfully to the public feedback form.

