### PR TITLE
fix: lowercase collaborator endpoint emails

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.routes.spec.ts
@@ -2246,7 +2246,7 @@ describe('admin-form.routes', () => {
 
     it('should return 400 when the new owner is not in the database', async () => {
       // Arrange
-      const emailNotInDb = 'notInDb@example.com'
+      const emailNotInDb = 'notindb@example.com'
       const formToTransfer = await EncryptFormModel.create({
         title: 'Original form title',
         admin: defaultUser._id,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -174,12 +174,9 @@ const transferFormOwnershipValidator = celebrate({
   [Segments.BODY]: {
     email: Joi.string()
       .required()
-      .email({
-        minDomainSegments: 2, // Number of segments required for the domain
-        tlds: { allow: true }, // TLD (top level domain) validation
-        multiple: false, // Disallow multiple emails
-      })
-      .message('Please enter a valid email'),
+      .email()
+      .message('Please enter a valid email')
+      .lowercase(),
   },
 })
 
@@ -2354,7 +2351,8 @@ export const handleUpdateCollaborators = [
         email: Joi.string()
           .required()
           .email()
-          .message('Please enter a valid email'),
+          .message('Please enter a valid email')
+          .lowercase(),
         write: Joi.bool().optional(),
         _id: Joi.string().optional(),
       }),

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1303,7 +1303,7 @@ describe('admin-form.form.routes', () => {
 
     it('should return 400 when the new owner is not in the database', async () => {
       // Arrange
-      const emailNotInDb = 'notInDb@example.com'
+      const emailNotInDb = 'notindb@example.com'
       const formToTransfer = await EncryptFormModel.create({
         title: 'Original form title',
         admin: defaultUser._id,


### PR DESCRIPTION
## Problem
Email inputs on the collaborator endpoints are guaranteed to be trimmed, but not lowercased as brought up in [this comment](https://github.com/opengovsg/FormSG/pull/5946#discussion_r1148771485). This PR adds middleware validation to ensure they are forced to lowercase, a la `auth.middlewares`.

## Solution

Add `.lowercase()` to the middleware validators, which forces the emails to lowercase.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

**Updating collaborators**

- [X] **Updating collaborators via the frontend still works.** Add a collaborator for an existing agency via the frontend. This should still work.
- [X] **Request succeeds on trimmed, lowercased email.** Send a PUT `/:formId/collaborators` with a trimmed, lowercased email such as `[{"write":true,"email":"abc@open.gov.sg"}]`. This should return a 200 OK.
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/25571626/227846431-f947616e-8428-4c7d-b257-96f1d5b35aa7.png">

- [X] **Request succeeds on trimmed, mixed-case email.** Send a PUT `/:formId/collaborators` with a trimmed, mixed-case email such as `[{"write":true,"email":"dEF@opEn.gOV.sG"}]`. This should return a 200 OK, but with the email cast to lowercase.
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/25571626/227846211-f493be69-3e72-4038-a779-f4c9dbc0dc0b.png">

- [X] **Request fails on untrimmed email.** Send a PUT `/:formId/collaborators` with an untrimmed email such as `[{"write":true,"email":" abc@open.gov.sg"}]`. This should return a 400 Validation failed.
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/25571626/227846322-5f552e10-7b11-4e45-902c-ffe47b6880ec.png">

**Transfer ownership**

- [x] **Transferring ownership via the frontend still works.** Transfer ownership to a collaborator via the frontend. This should still work.
- [x] **Request succeeds on trimmed, lowercased email.** Send a POST `/:formId/collaborators/transfer-owner` with a trimmed, lowercased email such as `{"email":"abc@open.gov.sg"}`. This should return a 200 OK.
- [X] **Request succeeds on trimmed, mixed-case email.** Send a POST `/:formId/collaborators` with a trimmed, mixed-case email such as `{"email":"abc@opEn.gOV.sG"}`. This should return a 200 OK, but with the email cast to lowercase.
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/25571626/227846072-14079931-9ff5-49f0-bdd7-0e41eb786b35.png">


- [x] **Request fails on untrimmed email.** Send a POST `/:formId/collaborators` with an untrimmed email such as `{"email":" abc@open.gov.sg "}`. This should return a 400 Validation failed.
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/25571626/227846792-6348f200-e2d0-421c-9e26-ec9d3b0fbe65.png">

