### PR TITLE
feat: add payment description significance

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -208,30 +208,6 @@ export const PaymentInput = (): JSX.Element => {
           <>
             <FormControl
               isReadOnly={paymentsMutation.isLoading}
-              isInvalid={!!errors.display_amount}
-            >
-              <FormLabel isRequired>Payment Amount</FormLabel>
-              <Controller
-                name="display_amount"
-                control={control}
-                rules={amountValidation}
-                render={({ field }) => (
-                  <MoneyInput
-                    flex={1}
-                    step={0}
-                    inputMode="decimal"
-                    placeholder="0.00"
-                    {...field}
-                  />
-                )}
-              />
-              <FormErrorMessage>
-                {errors.display_amount?.message}
-              </FormErrorMessage>
-            </FormControl>
-
-            <FormControl
-              isReadOnly={paymentsMutation.isLoading}
               isInvalid={!!errors.description}
               isRequired
             >
@@ -252,6 +228,30 @@ export const PaymentInput = (): JSX.Element => {
                 })}
               />
               <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
+            </FormControl>
+            <Divider />
+            <FormControl
+              isReadOnly={paymentsMutation.isLoading}
+              isInvalid={!!errors.display_amount}
+            >
+              <FormLabel isRequired>Payment Amount</FormLabel>
+              <Controller
+                name="display_amount"
+                control={control}
+                rules={amountValidation}
+                render={({ field }) => (
+                  <MoneyInput
+                    flex={1}
+                    step={0}
+                    inputMode="decimal"
+                    placeholder="0.00"
+                    {...field}
+                  />
+                )}
+              />
+              <FormErrorMessage>
+                {errors.display_amount?.message}
+              </FormErrorMessage>
             </FormControl>
           </>
         )}

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -62,7 +62,12 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
   maximumFractionDigits: 2,
 }).format
 
-const DESCRIPTION_TOOLTIP = 'Description will be reflected on payment receipt'
+/**
+ * Description in payment field will be rendered as 'Name' in the Frontend, but kept as description in the backend
+ * This is for design purpose as 'Name' conveys clearer information to the users,
+ * Whilst description will still be used in the backend for consistency with Stripe's API
+ */
+const NAME_TOOLTIP = 'Name will be reflected on payment receipt'
 
 export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
@@ -212,10 +217,10 @@ export const PaymentInput = (): JSX.Element => {
               isRequired
             >
               <Flex>
-                <FormLabel>Description</FormLabel>
+                <FormLabel>Name</FormLabel>
                 <Spacer />
                 <Tooltip
-                  label={DESCRIPTION_TOOLTIP}
+                  label={NAME_TOOLTIP}
                   placement="top"
                   textAlign="center"
                 >

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -27,8 +27,8 @@ import { centsToDollars, dollarsToCents } from '~utils/payments'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
 import MoneyInput from '~components/MoneyInput'
-import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 import Tooltip from '~components/Tooltip'
 
@@ -222,7 +222,7 @@ export const PaymentInput = (): JSX.Element => {
                   <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
                 </Tooltip>
               </Flex>
-              <Textarea
+              <Input
                 {...register('description', {
                   required: 'Please enter a payment description',
                 })}

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -7,21 +7,11 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useDebounce } from 'react-use'
-import {
-  Box,
-  Divider,
-  Flex,
-  FormControl,
-  Icon,
-  Spacer,
-  Stack,
-  Text,
-} from '@chakra-ui/react'
+import { Box, Divider, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import { FormPaymentsField } from '~shared/types'
 
-import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { centsToDollars, dollarsToCents } from '~utils/payments'
 import Button from '~components/Button'
@@ -30,7 +20,6 @@ import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
 import MoneyInput from '~components/MoneyInput'
 import Toggle from '~components/Toggle'
-import Tooltip from '~components/Tooltip'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 
@@ -67,7 +56,7 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
  * This is for design purpose as 'Name' conveys clearer information to the users,
  * Whilst description will still be used in the backend for consistency with Stripe's API
  */
-const NAME_TOOLTIP = 'Name will be reflected on payment receipt'
+const NAME_INFORMATION = 'Name will be reflected on payment receipt'
 
 export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
@@ -216,17 +205,7 @@ export const PaymentInput = (): JSX.Element => {
               isInvalid={!!errors.description}
               isRequired
             >
-              <Flex>
-                <FormLabel>Name</FormLabel>
-                <Spacer />
-                <Tooltip
-                  label={NAME_TOOLTIP}
-                  placement="top"
-                  textAlign="center"
-                >
-                  <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
-                </Tooltip>
-              </Flex>
+              <FormLabel description={NAME_INFORMATION}>Name</FormLabel>
               <Input
                 {...register('description', {
                   required: 'Please enter a payment description',

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -7,11 +7,21 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useDebounce } from 'react-use'
-import { Box, Divider, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Divider,
+  Flex,
+  FormControl,
+  Icon,
+  Spacer,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import { FormPaymentsField } from '~shared/types'
 
+import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { centsToDollars, dollarsToCents } from '~utils/payments'
 import Button from '~components/Button'
@@ -20,6 +30,7 @@ import FormLabel from '~components/FormControl/FormLabel'
 import MoneyInput from '~components/MoneyInput'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
+import Tooltip from '~components/Tooltip'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 
@@ -50,6 +61,8 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 }).format
+
+const DESCRIPTION_TOOLTIP = 'Description will be reflected on payment receipt'
 
 export const PaymentInput = (): JSX.Element => {
   const isMobile = useIsMobile()
@@ -222,7 +235,17 @@ export const PaymentInput = (): JSX.Element => {
               isInvalid={!!errors.description}
               isRequired
             >
-              <FormLabel>Description</FormLabel>
+              <Flex>
+                <FormLabel>Description</FormLabel>
+                <Spacer />
+                <Tooltip
+                  label={DESCRIPTION_TOOLTIP}
+                  placement="top"
+                  textAlign="center"
+                >
+                  <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
+                </Tooltip>
+              </Flex>
               <Textarea
                 {...register('description', {
                   required: 'Please enter a payment description',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We should let our admins know that the description in the payments drawer will be reflected in the receipt.

Closes #5956

## Solution
<!-- How did you solve the problem? -->
Add tooltip to payment drawer

And minor changes to UI based on design master figma:
1. Shift description to before pay amount
2. Add divider between description and pay amount
3. Rename description to 'Name'

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/228106381-33ae0f39-675b-446b-9011-615ce28ecba7.png">

**AFTER**:
<img width="536" alt="image" src="https://user-images.githubusercontent.com/59867455/228133256-8ee6ee4a-8e13-439e-b37d-4977ef616784.png">

## Tests
- [ ] go to form will payment enabled. Ensure that the payment drawer in 'create' has the description 'Name is reflected on payment receipt' below 'Name' field. (This is to ensure UI changes are done and correct)
- [ ] update the payment field of the form (This is to ensure that payment update features are not compromised)