### PR TITLE
feat: update encrypt submission controller to use pending submission collection

### DIFF
--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -40,6 +40,7 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
     status: {
       type: String,
       enum: Object.values(PaymentStatus),
+      default: PaymentStatus.Pending,
       required: true,
     },
     chargeIdLatest: {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -352,7 +352,11 @@ const submitEncryptModeForm: ControllerHandler<
   ) {
     const amount = form.payments_field.amount_cents
     // Step 1: Create payment without payment intent id and pending submission id.
-    if (!amount || amount <= 0) {
+    if (
+      !amount ||
+      amount < paymentConfig.minPaymentAmountCents ||
+      amount > paymentConfig.maxPaymentAmountCents
+    ) {
       logger.error({
         message:
           'Error when creating payment: amount is not a positive integer',

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -13,7 +13,6 @@ import {
   FormSubmissionMetadataQueryDto,
   Payment,
   PaymentChannel,
-  PaymentStatus,
   StorageModeSubmissionDto,
   StorageModeSubmissionMetadataList,
   SubmissionErrorDto,
@@ -24,6 +23,7 @@ import { paymentConfig } from '../../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { stripe } from '../../../loaders/stripe'
 import getPaymentModel from '../../../models/payment.server.model'
+import { getEncryptPendingSubmissionModel } from '../../../models/pending_submission.server.model'
 import { getEncryptSubmissionModel } from '../../../models/submission.server.model'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
@@ -62,6 +62,7 @@ import IncomingEncryptSubmission from './IncomingEncryptSubmission.class'
 
 const logger = createLoggerWithLabel(module)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+const EncryptPendingSubmission = getEncryptPendingSubmissionModel(mongoose)
 const Payment = getPaymentModel(mongoose)
 
 // NOTE: Refer to this for documentation: https://github.com/sideway/joi-date/blob/master/API.md
@@ -334,7 +335,7 @@ const submitEncryptModeForm: ControllerHandler<
     }
   }
 
-  const submission = new EncryptSubmission({
+  const submissionContent = {
     form: form._id,
     authType: form.authType,
     myInfoFields: form.getUniqueMyInfoAttrs(),
@@ -342,11 +343,202 @@ const submitEncryptModeForm: ControllerHandler<
     verifiedContent: verified,
     attachmentMetadata,
     version: req.body.version,
-  })
+  }
 
-  let savedSubmission
+  // Handle submissions for payments forms
+  if (
+    form.payments_field?.enabled &&
+    form.payments_channel?.channel === PaymentChannel.Stripe
+  ) {
+    const amount = form.payments_field.amount_cents
+    // Step 1: Create payment without payment intent id and pending submission id.
+    if (!amount || amount <= 0) {
+      logger.error({
+        message:
+          'Error when creating payment: amount is not a positive integer',
+        meta: logMeta,
+      })
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message:
+          "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+      })
+    }
+
+    const payment = new Payment({
+      amount,
+      email: req.body.paymentReceiptEmail,
+    })
+    const paymentId = payment.id
+
+    // Step 2: Create and save pending submission.
+    const pendingSubmission = new EncryptPendingSubmission({
+      ...submissionContent,
+      paymentId,
+    })
+
+    try {
+      await pendingSubmission.save()
+    } catch (err) {
+      logger.error({
+        message: 'Encrypt pending submission save error',
+        meta: {
+          action: 'onEncryptSubmissionFailure',
+          ...createReqMeta(req),
+        },
+        error: err,
+      })
+      // Block the submission so that user can try to resubmit
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        message:
+          'Could not save pending submission. For assistance, please contact the person who asked you to fill in this form.',
+      })
+    }
+
+    const pendingSubmissionId = pendingSubmission.id
+    logger.info({
+      message: 'Created pending submission in DB',
+      meta: {
+        ...logMeta,
+        pendingSubmissionId,
+      },
+    })
+
+    // Step 3: Create the payment intent via API call to stripe.
+    // Stripe requires the amount to be an integer in the smallest currency unit (i.e. cents)
+    const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
+      amount,
+      currency: paymentConfig.defaultCurrency,
+      payment_method_types: [
+        'card',
+        /* 'grabpay', 'paynow'*/
+      ],
+      description: form.payments_field.description,
+      receipt_email: req.body.paymentReceiptEmail,
+      metadata: {
+        formId,
+        paymentId,
+      },
+    }
+
+    let paymentIntent
+    try {
+      paymentIntent = await stripe.paymentIntents.create(
+        createPaymentIntentParams,
+        { stripeAccount: form.payments_channel.target_account_id },
+      )
+    } catch (err) {
+      logger.error({
+        message: 'Error when creating payment intent.',
+        meta: {
+          ...logMeta,
+          pendingSubmissionId,
+          createPaymentIntentParams,
+        },
+        error: err,
+      })
+      // Return a 502 error here since the issue was with Stripe.
+      return res.status(StatusCodes.BAD_GATEWAY).json({
+        message:
+          'There was a problem creating the payment intent. Please try again.',
+      })
+    }
+
+    const paymentIntentId = paymentIntent.id
+    logger.info({
+      message: 'Created payment intent from Stripe',
+      meta: {
+        ...logMeta,
+        pendingSubmissionId,
+        paymentIntentId,
+      },
+    })
+
+    // Step 4: Update payment document with payment intent id and pending submission id, and save it.
+    payment.paymentIntentId = paymentIntentId
+    payment.pendingSubmissionId = pendingSubmissionId
+    try {
+      await payment.save()
+    } catch (err) {
+      logger.error({
+        message: 'Error updating payment document with payment intent id',
+        meta: {
+          ...logMeta,
+          pendingSubmissionId,
+          paymentIntentId,
+        },
+        error: err,
+      })
+      // Cancel the payment intent if saving the document fails.
+      try {
+        await stripe.paymentIntents.cancel(paymentIntent.id, {
+          stripeAccount: form.payments_channel.target_account_id,
+        })
+      } catch (stripeErr) {
+        logger.error({
+          message: 'Failed to cancel Stripe payment intent',
+          meta: {
+            ...logMeta,
+            pendingSubmissionId,
+            paymentIntentId,
+          },
+          error: err,
+        })
+      }
+      // Regardless of whether the cancellation succeeded or failed, block the
+      // submission so that user can try to resubmit
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message:
+          'There was a problem updating the payment document. Please try again.',
+      })
+    }
+
+    logger.info({
+      message: 'Saved payment document to DB',
+      meta: {
+        ...logMeta,
+        pendingSubmissionId,
+        paymentIntentId,
+        paymentId,
+      },
+    })
+
+    // Step 5: Extract payment_client_secret from paymentIntent and return to client.
+    const paymentClientSecret = paymentIntent.client_secret
+
+    // if paymentClientSecret is null or undefined, log error
+    if (!paymentClientSecret) {
+      logger.error({
+        message: `No client secret provided with Stripe payment intent`,
+        meta: {
+          ...logMeta,
+          createPaymentIntentParams,
+          pendingSubmissionId,
+          paymentIntentId,
+          paymentId,
+        },
+      })
+    }
+
+    return res.json({
+      message: 'Form submission successful',
+      submissionId: pendingSubmissionId,
+      timestamp: (pendingSubmission.created || new Date()).getTime(),
+      // Attach required payment configs if client secret is present. Otherwise,
+      // client will display error message. We still return 200 OK because the
+      // state is recoverable.
+      ...(paymentClientSecret
+        ? {
+            paymentClientSecret,
+            paymentPublishableKey: form.payments_channel.publishable_key,
+          }
+        : {}),
+    })
+  }
+
+  const submission = new EncryptSubmission(submissionContent)
+
   try {
-    savedSubmission = await submission.save()
+    await submission.save()
   } catch (err) {
     logger.error({
       message: 'Encrypt submission save error',
@@ -363,7 +555,7 @@ const submitEncryptModeForm: ControllerHandler<
     })
   }
 
-  const submissionId = String(savedSubmission._id)
+  const submissionId = submission.id
   logger.info({
     message: 'Saved submission to MongoDB',
     meta: {
@@ -385,134 +577,17 @@ const submitEncryptModeForm: ControllerHandler<
     )
   }
 
-  // Client secret for stripe payments if payments are enabled
-  let paymentClientSecret
-  if (
-    form.payments_field?.enabled &&
-    form.payments_channel?.channel === PaymentChannel.Stripe
-  ) {
-    if (!form.payments_field.amount_cents) {
-      logger.error({
-        message:
-          'Error when creating payment intent, amount is not a positive integer',
-        meta: {
-          submissionId,
-          ...logMeta,
-        },
-      })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message:
-          "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
-      })
-    }
-
-    // Stripe requires the amount to be an integer in the smallest currency unit (i.e. cents)
-    const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
-      amount: form.payments_field.amount_cents,
-      currency: paymentConfig.defaultCurrency,
-      payment_method_types: [
-        'card',
-        /* 'grabpay', 'paynow'*/
-      ],
-      description: form.payments_field.description,
-      receipt_email: req.body.paymentReceiptEmail,
-      // on_behalf_of: form.payments.target_account_id,
-      metadata: {
-        formId,
-        submissionId,
-      },
-    }
-
-    // The business logic for payments is as follows.
-    // 1) If payment intent is created successfully, successfully saved to DB and paymentClientSecret is successfully extracted from payment intent, then paymentClientSecret will be returned in 200 to client
-    // 2) If payment intent creation fails, then 200 will be returned to client without paymentClientSecret. This is because failed creation of payment intent indicates possible incorrect admin payment setting. In that case, the submission is already saved, and we provide the submissionID to client and ask them to contact form admin for assistance to complete payment.
-    // 3) If payment intent is created successfully, but saving to DB fails, we return 500 to client. This allows client to resubmit the form / allows us to try to create a new payment intent and save to DB.
-    // 4) if payment intent is created successfully, successfully saved to DB but we fail to extract paymentClientSecret from payment intent, this indicates an error with stripe. A 200 will be returned to client without paymentClientSecret. In that case, the submission is already saved, and we provide the submissionID to client and ask them to contact form admin for assistance to complete payment.
-    let paymentIntent
-
-    try {
-      paymentIntent = await stripe.paymentIntents.create(
-        createPaymentIntentParams,
-        { stripeAccount: form.payments_channel.target_account_id },
-      )
-    } catch (err) {
-      logger.error({
-        message: 'Error when creating payment intent.',
-        meta: {
-          submissionId,
-          ...logMeta,
-        },
-        error: err,
-      })
-    }
-
-    if (paymentIntent) {
-      // Save payment to DB
-      const payment = new Payment({
-        submissionId,
-        amount: form.payments_field.amount_cents,
-        status: PaymentStatus.Pending,
-        paymentIntentId: paymentIntent.id,
-        email: req.body.paymentReceiptEmail,
-      })
-
-      try {
-        await payment.save()
-      } catch (err) {
-        logger.error({
-          message: 'Payment save error',
-          meta: {
-            paymentIntentId: paymentIntent.id,
-            submissionId,
-            ...logMeta,
-          },
-          error: err,
-        })
-
-        // Block the submission so that user can try to resubmit and create a new payment intent,
-        // because paymentIntent creation successful but this was a DB error.
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-          message:
-            'There was a problem preparing the payment. Please try again.',
-        })
-      }
-    }
-
-    // extract payment_client_secret from paymentIntent
-    paymentClientSecret = paymentIntent?.client_secret
-
-    // if paymentClientSecret is null or undefined, log error
-    if (!paymentClientSecret) {
-      logger.error({
-        message: `Client secret is ${paymentClientSecret}`,
-        meta: {
-          createPaymentIntentOptions: createPaymentIntentParams,
-          submissionId,
-          ...logMeta,
-        },
-      })
-    }
-  }
-
   // Send success back to client
   res.json({
     message: 'Form submission successful.',
-    submissionId: submission.id,
+    submissionId,
     timestamp: (submission.created || new Date()).getTime(),
-    // Attach paymentClientSecret if it is defined and non-null. Otherwise, client will display error message.
-    ...(paymentClientSecret
-      ? {
-          paymentClientSecret,
-          paymentPublishableKey: form.payments_channel?.publishable_key,
-        }
-      : {}),
   })
 
   // Send Email Confirmations
-
   return sendEmailConfirmations({
     form,
-    submission: savedSubmission,
+    submission,
     recipientData:
       extractEmailConfirmationDataFromIncomingSubmission(incomingSubmission),
   }).mapErr((error) => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -358,8 +358,7 @@ const submitEncryptModeForm: ControllerHandler<
       amount > paymentConfig.maxPaymentAmountCents
     ) {
       logger.error({
-        message:
-          'Error when creating payment: amount is not a positive integer',
+        message: 'Error when creating payment: amount is not within bounds',
         meta: logMeta,
       })
       return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -432,7 +431,7 @@ const submitEncryptModeForm: ControllerHandler<
       )
     } catch (err) {
       logger.error({
-        message: 'Error when creating payment intent.',
+        message: 'Error when creating payment intent',
         meta: {
           ...logMeta,
           pendingSubmissionId,


### PR DESCRIPTION
## Problem
The original version of our code did not use pending submissions collection and handle payments / pending submissions / payment intents in the correct order. This PR does this.

 Closes #5870

## Solution

The order of actions is payment created --(A)-> pending submission created --(B)-> pending submission saved --(C)-> payment intent created --(D)-> payment saved. The reason for this is primarily that to save a payment, we need the pending submission id and payment intent ids. However we also get a strong guarantee from this that whenever we check the payment document (i.e. our source of truth), we are assured that pending submission and payment intent exists.

What happens if things fail between each action? 

(A) and (B) No damage is done - nothing has been saved to DB. 
(C) We might have floating pending submissions in DB pointing to a bogus payment id which does not exist in DB. But this is not an issue since we can always clean it up. In any case, no payment intent is created, so no money can change hands. 
(D) This is where we might need to think about the right action. We have an open payment intent but no payment document to back it up. Since payment document creation failed, we don't have visibility on this payment intent which may be dangerous (could be scraped and used for attacks). Therefore, we have to proactively roll back the creation by cancelling the payment intent. We should also set an alarm on this branch of the code.

## Deploy Notes

Required downstreaam features before deployment
- updates to individual response page 
- dedicated payment page 

## Other notes

We will need to ensure that the post-submission actions get factored out and done when pending submissions are converted to real submissions:
- Webhooks get sent
- email confirmations get sent

Will create a new ticket for this. EDIT: See #6000 (wow 6000 liao! 🎉) 