### PR TITLE
feat: more logging on fetch fallback

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -11,7 +11,11 @@ import {
 
 import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { transformAllIsoStringsToDate } from '~utils/date'
-import { API_BASE_URL, ApiService } from '~services/ApiService'
+import {
+  API_BASE_URL,
+  ApiService,
+  processFetchResponse,
+} from '~services/ApiService'
 
 import { augmentWithMyInfoDisplayValue } from '~features/myinfo/utils'
 import {
@@ -221,7 +225,7 @@ export const submitEmailModeFormPreviewWithFetch = async ({
       body: formData,
     },
   )
-  return response.json()
+  return processFetchResponse(response)
 }
 
 /**
@@ -256,5 +260,5 @@ export const submitStorageModeFormPreviewWithFetch = async ({
       },
     },
   )
-  return response.json()
+  return processFetchResponse(response)
 }

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -27,7 +27,7 @@ import {
 import { PREVIEW_MOCK_UINFIN } from '../preview/constants'
 
 // endpoint exported for testing
-export const ADMIN_FORM_ENDPOINT = 'admin/forms'
+export const ADMIN_FORM_ENDPOINT = '/admin/forms'
 
 /**
  * Gets admin view of form.
@@ -215,7 +215,7 @@ export const submitEmailModeFormPreviewWithFetch = async ({
   const formData = createEmailSubmissionFormData(formFields, filteredInputs)
 
   const response = await fetch(
-    `${API_BASE_URL}/${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/email`,
+    `${API_BASE_URL}${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/email`,
     {
       method: 'POST',
       body: formData,
@@ -247,7 +247,7 @@ export const submitStorageModeFormPreviewWithFetch = async ({
   )
 
   const response = await fetch(
-    `${API_BASE_URL}/${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/encrypt`,
+    `${API_BASE_URL}${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/encrypt`,
     {
       method: 'POST',
       body: JSON.stringify(submissionContent),

--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -223,6 +223,9 @@ export const submitEmailModeFormPreviewWithFetch = async ({
     {
       method: 'POST',
       body: formData,
+      headers: {
+        Accept: 'application/json',
+      },
     },
   )
   return processFetchResponse(response)
@@ -257,6 +260,7 @@ export const submitStorageModeFormPreviewWithFetch = async ({
       body: JSON.stringify(submissionContent),
       headers: {
         'Content-Type': 'application/json',
+        Accept: 'application/json',
       },
     },
   )

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -162,6 +162,9 @@ export const submitEmailModeFormWithFetch = async ({
     {
       method: 'POST',
       body: formData,
+      headers: {
+        Accept: 'application/json',
+      },
     },
   )
 
@@ -200,6 +203,7 @@ export const submitStorageModeFormWithFetch = async ({
       body: JSON.stringify(submissionContent),
       headers: {
         'Content-Type': 'application/json',
+        Accept: 'application/json',
       },
     },
   )

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -13,7 +13,11 @@ import {
 import { SubmissionResponseDto } from '~shared/types/submission'
 
 import { transformAllIsoStringsToDate } from '~utils/date'
-import { API_BASE_URL, ApiService } from '~services/ApiService'
+import {
+  API_BASE_URL,
+  ApiService,
+  processFetchResponse,
+} from '~services/ApiService'
 import { FormFieldValues } from '~templates/Field'
 
 import {
@@ -161,7 +165,7 @@ export const submitEmailModeFormWithFetch = async ({
     },
   )
 
-  return response.json()
+  return processFetchResponse(response)
 }
 
 // TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
@@ -200,7 +204,7 @@ export const submitStorageModeFormWithFetch = async ({
     },
   )
 
-  return response.json()
+  return processFetchResponse(response)
 }
 
 /**

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -154,7 +154,7 @@ export const submitEmailModeFormWithFetch = async ({
   }).toString()
 
   const response = await fetch(
-    `${API_BASE_URL}/${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email?${queryString}`,
+    `${API_BASE_URL}${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email?${queryString}`,
     {
       method: 'POST',
       body: formData,
@@ -190,7 +190,7 @@ export const submitStorageModeFormWithFetch = async ({
   }).toString()
 
   const response = await fetch(
-    `${API_BASE_URL}/${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt?${queryString}`,
+    `${API_BASE_URL}${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt?${queryString}`,
     {
       method: 'POST',
       body: JSON.stringify(submissionContent),

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -81,10 +81,13 @@ ApiService.interceptors.response.use(
 
 export const processFetchResponse = async (response: Response) => {
   try {
-    const data = await response.json()
-
-    // TODO: data may be present but if response is non 2XX, transform to error and throw
-    return data
+    // throw if response status not 2XX
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Non-2XX response: ${response.status}`)
+    } else {
+      const data = await response.json()
+      return data
+    }
   } catch (error) {
     if (error instanceof Error) {
       datadogLogs.logger.warn(`Fetch error: ${error.message}`, {

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -78,3 +78,32 @@ ApiService.interceptors.response.use(
     throw transformedError
   },
 )
+
+export const processFetchResponse = async (response: Response) => {
+  try {
+    const data = response.json()
+
+    // TODO: data may be present but if response is non 2XX, transform to error and throw
+    return data
+  } catch (error) {
+    datadogLogs.logger.warn(`Fetch error: ${error.message}`, {
+      meta: {
+        action: 'processFetchResponse',
+        response: {
+          status: response.status,
+          statusText: response.statusText,
+          headers: [...(response.headers?.entries() || [])],
+          body: response.body,
+        },
+        error: {
+          code: error?.code,
+          message: error?.message,
+          stack: error?.stack,
+          dump: error?.toJSON ? error.toJSON() : undefined,
+        },
+      },
+    })
+
+    throw error
+  }
+}

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -88,27 +88,26 @@ export const processFetchResponse = async (response: Response) => {
       const data = await response.json()
       return data
     }
-  } catch (error) {
-    if (error instanceof Error) {
-      datadogLogs.logger.warn(`Fetch error: ${error.message}`, {
-        meta: {
-          action: 'processFetchResponse',
-          response: {
-            status: response.status,
-            statusText: response.statusText,
-            headers: [...(response.headers?.entries() || [])],
-            body: await response.text(),
-          },
-          error: {
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-            dump: JSON.stringify(error),
-          },
+  } catch (error: any) {
+    // No guarantee that error is an Error object
+    datadogLogs.logger.warn(`Fetch error: ${error.message}`, {
+      meta: {
+        action: 'processFetchResponse',
+        response: {
+          status: response.status,
+          statusText: response.statusText,
+          headers: [...(response.headers?.entries() || [])],
+          body: await response.text(),
         },
-      })
+        error: {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+          dump: JSON.stringify(error),
+        },
+      },
+    })
 
-      throw error
-    }
+    throw error
   }
 }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -94,7 +94,7 @@ export const processFetchResponse = async (response: Response) => {
             status: response.status,
             statusText: response.statusText,
             headers: [...(response.headers?.entries() || [])],
-            body: response.body,
+            body: await response.text(),
           },
           error: {
             name: error.name,

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -103,6 +103,7 @@ export const processFetchResponse = async (response: Response) => {
           name: error.name,
           message: error.message,
           stack: error.stack,
+          code: error.code,
           dump: JSON.stringify(error),
         },
       },

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -97,8 +97,9 @@ export const processFetchResponse = async (response: Response) => {
             body: response.body,
           },
           error: {
-            message: error?.message,
-            stack: error?.stack,
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
             dump: JSON.stringify(error),
           },
         },


### PR DESCRIPTION
## Context

Adding more comprehensive logging and minor fixes prior to releasing the axios fallback.

We have noticed that when there is a fetch error (e.g. json parse error), we do not have a handle to the response object to query and log more data from it.

Also, we spotted some minor issue with fetch URLs using double slashes like this:
```
POST /api/v3//forms/6423c090f88d780012a8c162/submissions/encrypt?captchaResponse=null 200 158ms
```

## Approach

Add minor fixes and more verbose logging

