### PR TITLE
fix: add staging-alt2 to deployment script

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS Elastic Beanstalk
 on:
   push:
     # There should be 7 environments in github actions secrets:
-    # release, release-al2, staging, staging-al2, staging-alt, uat.
+    # release, release-al2, staging, staging-al2, staging-alt, staging-alt2, uat.
     # This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name.
     branches:
       - release
@@ -10,6 +10,7 @@ on:
       - staging
       - staging-al2
       - staging-alt
+      - staging-alt2
       - uat
 
 permissions:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want another staging environment for developers

Closes #6007

## Solution
<!-- How did you solve the problem? -->
Add `staging-alt2` as an additional staging environment, accessible at [staging-alt2.form.gov.sg](https://staging-alt2.form.gov.sg/). This uses the same mongo cluster as `staging-alt`.
