### PR TITLE
feat: add strong typing for stripe metadata fields, add more metadata fields

### DIFF
--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -34,7 +34,7 @@ const isStripeMetadata = (
   hasProp(obj, 'formTitle') &&
   hasProp(obj, 'formId') &&
   hasProp(obj, 'paymentId') &&
-  hasProp(obj, 'paymentReceiptEmail')
+  hasProp(obj, 'paymentContactEmail')
 
 /**
  * Extracts the payment id from the metadata field of objects expected to have

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -2,12 +2,12 @@
 /// <reference types="stripe-event-types" />
 import mongoose from 'mongoose'
 import { err, Ok, ok, Result } from 'neverthrow'
-import { hasProp } from 'shared/utils/has-prop'
 import Stripe from 'stripe'
 
 import { StripePaymentMetadataDto } from 'src/types'
 
 import { Payment, PaymentStatus } from '../../../../shared/types'
+import { hasProp } from '../../../../shared/utils/has-prop'
 import { createLoggerWithLabel } from '../../config/logger'
 
 import {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -428,7 +428,7 @@ const submitEncryptModeForm: ControllerHandler<
       formTitle: form.title,
       formId,
       paymentId,
-      paymentReceiptEmail,
+      paymentContactEmail: paymentReceiptEmail,
     }
 
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,7 +1,15 @@
 import { Document, Model } from 'mongoose'
+import Stripe from 'stripe'
 
 import { Payment } from '../../shared/types/payment'
 
 export interface IPaymentSchema extends Payment, Document {}
 
 export type IPaymentModel = Model<IPaymentSchema>
+
+export interface StripePaymentMetadataDto extends Stripe.Metadata {
+  formTitle: string
+  formId: string
+  paymentId: string
+  paymentReceiptEmail: string
+}

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -11,5 +11,5 @@ export interface StripePaymentMetadataDto extends Stripe.Metadata {
   formTitle: string
   formId: string
   paymentId: string
-  paymentReceiptEmail: string
+  paymentContactEmail: string
 }


### PR DESCRIPTION
## Problem
We wanted to add more fields to stripe metadata for better linkage between stripe payments and submissions. At the same time, we wanted to extract the metadata fields into a type so that we can avoid hardcoding key names.

Closes #5960 

## Solution

Extract stripe metadata fields into a type, and add a typeguard for it. Use the typeguard in places where metadata is referenced, and replace usage of lodash get with typescript key access instead.

Discussion item: We don't have access to the submission id when the metadata is injected... how?
