### PR TITLE
chore: enforce payment channel keys to be required

### DIFF
--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -101,7 +101,7 @@ const PaymentsSectionText = () => {
 
   if (
     settings?.responseMode === FormResponseMode.Encrypt &&
-    settings?.payments_channel?.target_account_id
+    settings?.payments_channel
   ) {
     return (
       <>

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -71,8 +71,8 @@ export enum FormResponseMode {
 
 export type FormPaymentsChannel = {
   channel: PaymentChannel
-  target_account_id?: string
-  publishable_key?: string
+  target_account_id: string
+  publishable_key: string
 }
 
 export type FormPaymentsField = {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1,5 +1,5 @@
 import BSON, { ObjectId } from 'bson-ext'
-import { compact, merge, omit, pick, uniq } from 'lodash'
+import { compact, omit, pick, uniq } from 'lodash'
 import mongoose, {
   ClientSession,
   Mongoose,
@@ -184,22 +184,24 @@ EncryptedFormDocumentSchema.methods.addPaymentAccountId = async function ({
   accountId: FormPaymentsChannel['target_account_id']
   publishableKey: FormPaymentsChannel['publishable_key']
 }) {
-  this.payments_channel = merge(this.payments_channel, {
-    target_account_id: accountId,
-    publishable_key: publishableKey,
-    enabled: true,
-  })
+  if (!this.payments_channel) {
+    this.payments_channel = {
+      // Definitely Stripe for now, may be different later on.
+      channel: PaymentChannel.Stripe,
+      target_account_id: accountId,
+      publishable_key: publishableKey,
+    }
+  }
   return this.save()
 }
 
 EncryptedFormDocumentSchema.methods.removePaymentAccount = async function () {
-  if (this.payments_channel?.target_account_id) {
-    this.payments_channel.target_account_id = undefined
+  if (this.payments_channel) {
+    this.payments_channel = undefined
     if (this.payments_field) {
       this.payments_field.enabled = false
     }
   }
-
   return this.save()
 }
 

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -313,7 +313,7 @@ export const linkStripeAccountToForm = (
   },
 ): ResultAsync<string, DatabaseError> => {
   // Check if form already has account id
-  if (form.payments_channel?.target_account_id) {
+  if (form.payments_channel) {
     return okAsync(form.payments_channel.target_account_id)
   }
 
@@ -338,7 +338,7 @@ export const linkStripeAccountToForm = (
 }
 
 export const unlinkStripeAccountFromForm = (form: IPopulatedEncryptedForm) => {
-  if (!form.payments_channel?.target_account_id) {
+  if (!form.payments_channel) {
     return okAsync(true)
   }
 


### PR DESCRIPTION
## Problem
Payment_channel itself is already allowed to be undefined, so we should not allow it's keys to be undefined either.

## Solution
Removed `?` from `target_account_id` and `publishable_key` definition. Change conditions throughout code that used optional chaining to just checking the `payment_channel` property instead.
