### PR TITLE
feat: prevent payment changes when stripe is unconnected

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -322,7 +322,6 @@ export const PaymentDrawer = ({
   isStripeConnected,
   paymentsField,
 }: PaymentDrawerProps): JSX.Element | null => {
-  const { isLoading } = useAdminForm()
   const { paymentData, setData, resetData } = usePaymentStore(
     useCallback(
       (state) => ({
@@ -342,7 +341,7 @@ export const PaymentDrawer = ({
   // Allows for payment data refresh in encrypt mode
   if (!paymentData && isEncryptMode && isStripeConnected) return null
 
-  const isDisabled = !(isEncryptMode && isStripeConnected) || isLoading
+  const isDisabled = !(isEncryptMode && isStripeConnected)
 
   return (
     <CreatePageDrawerContainer>

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -289,27 +289,6 @@ export const PaymentInput = ({
   )
 }
 
-// Will be extended for stripe unconnected messages too
-const PaymentDisabledMessage = ({
-  isEmailMode,
-  isStripeUnconnected,
-}: {
-  isEmailMode: boolean
-  isStripeUnconnected: boolean
-}): JSX.Element | null => {
-  return isEmailMode || isStripeUnconnected ? (
-    <Box px="1.5rem" pt="2rem" pb="1.5rem">
-      <InlineMessage variant={'info'}>
-        {isEmailMode ? (
-          <Text>Payments are not available in email mode forms.</Text>
-        ) : (
-          <Text>Connect your Stripe account in Settings.</Text>
-        )}
-      </InlineMessage>
-    </Box>
-  ) : null
-}
-
 type PaymentDrawerProps = {
   isEncryptMode: boolean
   isStripeConnected: boolean
@@ -342,12 +321,23 @@ export const PaymentDrawer = ({
   // Allows for payment data refresh in encrypt mode
   if (!paymentData && isPaymentEligible) return null
 
+  const isPaymentDisabled = !isPaymentEligible
+
+  const paymentDisabledMessage = !isEncryptMode
+    ? 'Payments are not available in email mode forms.'
+    : !isStripeConnected
+    ? 'Connect your Stripe account in Settings.'
+    : ''
+
   return (
     <CreatePageDrawerContainer>
-      <PaymentDisabledMessage
-        isEmailMode={!isEncryptMode}
-        isStripeUnconnected={!isStripeConnected}
-      />
+      {isPaymentDisabled && (
+        <Box px="1.5rem" pt="2rem" pb="1.5rem">
+          <InlineMessage variant={'info'}>
+            <Text>{paymentDisabledMessage}</Text>
+          </InlineMessage>
+        </Box>
+      )}
       <Flex pos="relative" h="100%" display="flex" flexDir="column">
         <Box pt="1rem" px="1.5rem" bg="white">
           <Flex justify="space-between">
@@ -358,7 +348,7 @@ export const PaymentDrawer = ({
           </Flex>
           <Divider w="auto" mx="-1.5rem" />
         </Box>
-        <PaymentInput isDisabled={!isPaymentEligible} />
+        <PaymentInput isDisabled={isPaymentDisabled} />
       </Flex>
     </CreatePageDrawerContainer>
   )

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -337,10 +337,10 @@ export const PaymentDrawer = ({
     return resetData
   }, [paymentsField, resetData, setData])
 
-  const isDisabled = !(isEncryptMode && isStripeConnected)
+  const isPaymentEligible = isEncryptMode && isStripeConnected
 
   // Allows for payment data refresh in encrypt mode
-  if (!paymentData && !isDisabled) return null
+  if (!paymentData && isPaymentEligible) return null
 
   return (
     <CreatePageDrawerContainer>
@@ -358,7 +358,7 @@ export const PaymentDrawer = ({
           </Flex>
           <Divider w="auto" mx="-1.5rem" />
         </Box>
-        <PaymentInput isDisabled={isDisabled} />
+        <PaymentInput isDisabled={!isPaymentEligible} />
       </Flex>
     </CreatePageDrawerContainer>
   )

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -316,18 +316,17 @@ export const PaymentDrawer = ({
     return resetData
   }, [paymentsField, resetData, setData])
 
-  const isPaymentEligible = isEncryptMode && isStripeConnected
-
-  // Allows for payment data refresh in encrypt mode
-  if (!paymentData && isPaymentEligible) return null
-
-  const isPaymentDisabled = !isPaymentEligible
-
   const paymentDisabledMessage = !isEncryptMode
     ? 'Payments are not available in email mode forms.'
     : !isStripeConnected
     ? 'Connect your Stripe account in Settings.'
     : ''
+
+  // payment eligibility will be dependent on whether paymentDisabledMessage is non empty
+  const isPaymentDisabled = !!paymentDisabledMessage
+
+  // Allows for payment data refresh in encrypt mode
+  if (!paymentData && !isPaymentDisabled) return null
 
   return (
     <CreatePageDrawerContainer>

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -23,7 +23,6 @@ import MoneyInput from '~components/MoneyInput'
 import Toggle from '~components/Toggle'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
-import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { useEnv } from '../../../env/queries'
 import {
@@ -338,10 +337,10 @@ export const PaymentDrawer = ({
     return resetData
   }, [paymentsField, resetData, setData])
 
-  // Allows for payment data refresh in encrypt mode
-  if (!paymentData && isEncryptMode && isStripeConnected) return null
-
   const isDisabled = !(isEncryptMode && isStripeConnected)
+
+  // Allows for payment data refresh in encrypt mode
+  if (!paymentData && !isDisabled) return null
 
   return (
     <CreatePageDrawerContainer>

--- a/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
@@ -10,17 +10,24 @@ export const PaymentTab = (): JSX.Element => {
 
   const isEncryptMode = form?.responseMode === FormResponseMode.Encrypt
 
-  return isEncryptMode ? (
+  const isStripeConnected =
+    isEncryptMode && !!form.payments_channel?.target_account_id
+
+  return isEncryptMode && isStripeConnected ? (
     <>
       <PaymentDrawer
         isEncryptMode={isEncryptMode}
+        isStripeConnected={isStripeConnected}
         paymentsField={form.payments_field}
       />
       <PaymentContent paymentsField={form.payments_field} />
     </>
   ) : (
     <>
-      <PaymentDrawer isEncryptMode={isEncryptMode} />
+      <PaymentDrawer
+        isEncryptMode={isEncryptMode}
+        isStripeConnected={isStripeConnected}
+      />
       <PaymentContent />
     </>
   )

--- a/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
@@ -1,4 +1,4 @@
-import { FormResponseMode } from '~shared/types'
+import { FormResponseMode, PaymentChannel } from '~shared/types'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
@@ -11,7 +11,7 @@ export const PaymentTab = (): JSX.Element => {
   const isEncryptMode = form?.responseMode === FormResponseMode.Encrypt
 
   const isStripeConnected =
-    isEncryptMode && !!form.payments_channel?.target_account_id
+    isEncryptMode && form.payments_channel.channel === PaymentChannel.Stripe
 
   return isEncryptMode && isStripeConnected ? (
     <>

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -360,17 +360,23 @@ export const useMutateTwilioCreds = () => {
 export const useMutateStripeAccount = () => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
-
   const queryClient = useQueryClient()
 
-  const linkStripeAccountMutation = useMutation(() =>
-    createStripeAccount(formId),
+  const linkStripeAccountMutation = useMutation(
+    () => createStripeAccount(formId),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(adminFormKeys.id(formId))
+        queryClient.invalidateQueries(adminFormSettingsKeys.id(formId))
+      },
+    },
   )
 
   const unlinkStripeAccountMutation = useMutation(
     () => unlinkStripeAccount(formId),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries(adminFormKeys.id(formId))
         queryClient.invalidateQueries(adminFormSettingsKeys.id(formId))
       },
     },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, admin can still update payment fields when their stripe account isn't connected. This can cause confusion to the admin as they are able to 'enable' payment without stripe connected, but no payment can be processed. 

Closes #5849 

## Solution
<!-- How did you solve the problem? -->
Display info message when stripe isn't connected on the payment drawer,
and also invalidate query client when linking/unlinking stripe account to initiate refetch.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Screenshots

**AFTER**:
<img width="596" alt="image" src="https://user-images.githubusercontent.com/59867455/229694346-610ed6bf-da64-41aa-9cdd-a26446e36936.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
Go to a storage mode form with payment beta flag and stripe unconnected
- [ ] Check payment drawer, you should not be able to edit it
- [ ] Connect stripe account
- [ ] Check payment drawer, you should be able to edit it, edit and save
- [ ] Unconnect stripe account
- [ ] Check payment drawer, you should not be able to edit it again
