### PR TITLE
chore: add gdrive error message for failed fetch after network error

### DIFF
--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -140,9 +140,11 @@ export const PreviewFormProvider = ({
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitEmailFormWithFetch = function (
-            isAxiosFallback?: boolean,
-          ) {
+          const submitEmailFormWithFetch = function ({
+            isAxiosFallback,
+          }: {
+            isAxiosFallback: boolean
+          }) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
@@ -178,7 +180,7 @@ export const PreviewFormProvider = ({
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitEmailFormWithFetch(false)
+            return submitEmailFormWithFetch({ isAxiosFallback: false })
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
@@ -210,7 +212,7 @@ export const PreviewFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitEmailFormWithFetch(true)
+                    return submitEmailFormWithFetch({ isAxiosFallback: true })
                   } else {
                     // Show error toast from axios mutation if not network error
                     showErrorToast(error)
@@ -222,9 +224,11 @@ export const PreviewFormProvider = ({
         case FormResponseMode.Encrypt: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitStorageFormWithFetch = function (
-            isAxiosFallback?: boolean,
-          ) {
+          const submitStorageFormWithFetch = function ({
+            isAxiosFallback,
+          }: {
+            isAxiosFallback: boolean
+          }) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
@@ -268,7 +272,7 @@ export const PreviewFormProvider = ({
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitStorageFormWithFetch(false)
+            return submitStorageFormWithFetch({ isAxiosFallback: false })
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
@@ -308,7 +312,7 @@ export const PreviewFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitStorageFormWithFetch(true)
+                    return submitStorageFormWithFetch({ isAxiosFallback: true })
                   } else {
                     // Show error toast from axios mutation if not network error
                     showErrorToast(error)

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -140,11 +140,13 @@ export const PreviewFormProvider = ({
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitEmailFormWithFetch = function () {
+          const submitEmailFormWithFetch = function (
+            isAxiosFallback?: boolean,
+          ) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
-                responseMode: 'email',
+                responseMode: form.responseMode,
                 method: 'fetch',
               },
             })
@@ -155,7 +157,7 @@ export const PreviewFormProvider = ({
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
-                    responseMode: 'email',
+                    responseMode: form.responseMode,
                     method: 'fetch',
                     error: {
                       message: error.message,
@@ -165,21 +167,23 @@ export const PreviewFormProvider = ({
                   },
                 })
                 showErrorToast(
-                  new Error(
-                    'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
-                  ),
+                  isAxiosFallback
+                    ? new Error(
+                        'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                      )
+                    : error,
                 )
               })
           }
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitEmailFormWithFetch()
+            return submitEmailFormWithFetch(false)
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
                 ...logMeta,
-                responseMode: 'email',
+                responseMode: form.responseMode,
                 method: 'axios',
               },
             })
@@ -195,7 +199,7 @@ export const PreviewFormProvider = ({
                     {
                       meta: {
                         ...logMeta,
-                        responseMode: 'email',
+                        responseMode: form.responseMode,
                         method: 'axios',
                         error: {
                           message: error.message,
@@ -206,7 +210,7 @@ export const PreviewFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitEmailFormWithFetch()
+                    return submitEmailFormWithFetch(true)
                   } else {
                     // Show error toast from axios mutation if not network error
                     showErrorToast(error)
@@ -218,11 +222,13 @@ export const PreviewFormProvider = ({
         case FormResponseMode.Encrypt: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitStorageFormWithFetch = function () {
+          const submitStorageFormWithFetch = function (
+            isAxiosFallback?: boolean,
+          ) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
-                responseMode: 'storage',
+                responseMode: form.responseMode,
                 method: 'fetch',
               },
             })
@@ -241,7 +247,7 @@ export const PreviewFormProvider = ({
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
-                    responseMode: 'storage',
+                    responseMode: form.responseMode,
                     method: 'fetch',
                     error: {
                       message: error.message,
@@ -250,18 +256,24 @@ export const PreviewFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error)
+                showErrorToast(
+                  isAxiosFallback
+                    ? new Error(
+                        'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                      )
+                    : error,
+                )
               })
           }
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitStorageFormWithFetch()
+            return submitStorageFormWithFetch(false)
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
                 ...logMeta,
-                responseMode: 'storage',
+                responseMode: form.responseMode,
                 method: 'axios',
               },
             })
@@ -285,7 +297,7 @@ export const PreviewFormProvider = ({
                     {
                       meta: {
                         ...logMeta,
-                        responseMode: 'storage',
+                        responseMode: form.responseMode,
                         method: 'axios',
                         error: {
                           message: error.message,
@@ -296,7 +308,7 @@ export const PreviewFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitStorageFormWithFetch()
+                    return submitStorageFormWithFetch(true)
                   } else {
                     // Show error toast from axios mutation if not network error
                     showErrorToast(error)

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -164,7 +164,9 @@ export const PreviewFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error)
+                showErrorToast(
+                  'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                )
               })
           }
 

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -165,7 +165,9 @@ export const PreviewFormProvider = ({
                   },
                 })
                 showErrorToast(
-                  'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                  new Error(
+                    'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                  ),
                 )
               })
           }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -265,7 +265,9 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(
-                  'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                  new Error(
+                    'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                  ),
                   form,
                 )
               })

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -240,11 +240,13 @@ export const PublicFormProvider = ({
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitEmailFormWithFetch = function () {
+          const submitEmailFormWithFetch = function (
+            isAxiosFallback?: boolean,
+          ) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
-                responseMode: 'email',
+                responseMode: form.responseMode,
                 method: 'fetch',
               },
             })
@@ -255,7 +257,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
-                    responseMode: 'email',
+                    responseMode: form.responseMode,
                     method: 'fetch',
                     error: {
                       message: error.message,
@@ -265,9 +267,11 @@ export const PublicFormProvider = ({
                   },
                 })
                 showErrorToast(
-                  new Error(
-                    'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
-                  ),
+                  isAxiosFallback
+                    ? new Error(
+                        'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                      )
+                    : error,
                   form,
                 )
               })
@@ -275,12 +279,12 @@ export const PublicFormProvider = ({
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitEmailFormWithFetch()
+            return submitEmailFormWithFetch(false)
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
                 ...logMeta,
-                responseMode: 'email',
+                responseMode: form.responseMode,
                 method: 'axios',
               },
             })
@@ -296,7 +300,7 @@ export const PublicFormProvider = ({
                     {
                       meta: {
                         ...logMeta,
-                        responseMode: 'email',
+                        responseMode: form.responseMode,
                         method: 'axios',
                         error: {
                           message: error.message,
@@ -307,7 +311,7 @@ export const PublicFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitEmailFormWithFetch()
+                    return submitEmailFormWithFetch(true)
                   } else {
                     showErrorToast(error, form)
                   }
@@ -318,11 +322,13 @@ export const PublicFormProvider = ({
         case FormResponseMode.Encrypt: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitStorageFormWithFetch = function () {
+          const submitStorageFormWithFetch = function (
+            isAxiosFallback?: boolean,
+          ) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
-                responseMode: 'storage',
+                responseMode: form.responseMode,
                 method: 'fetch',
               },
             })
@@ -341,7 +347,7 @@ export const PublicFormProvider = ({
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
-                    responseMode: 'storage',
+                    responseMode: form.responseMode,
                     method: 'fetch',
                     error: {
                       message: error.message,
@@ -350,18 +356,25 @@ export const PublicFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error, form)
+                showErrorToast(
+                  isAxiosFallback
+                    ? new Error(
+                        'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                      )
+                    : error,
+                  form,
+                )
               })
           }
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitStorageFormWithFetch()
+            return submitStorageFormWithFetch(false)
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
                 ...logMeta,
-                responseMode: 'storage',
+                responseMode: form.responseMode,
                 method: 'axios',
               },
             })
@@ -385,7 +398,7 @@ export const PublicFormProvider = ({
                     {
                       meta: {
                         ...logMeta,
-                        responseMode: 'storage',
+                        responseMode: form.responseMode,
                         method: 'axios',
                         error: {
                           message: error.message,
@@ -397,7 +410,7 @@ export const PublicFormProvider = ({
 
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitStorageFormWithFetch()
+                    return submitStorageFormWithFetch(true)
                   } else {
                     showErrorToast(error, form)
                   }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -240,9 +240,11 @@ export const PublicFormProvider = ({
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitEmailFormWithFetch = function (
-            isAxiosFallback?: boolean,
-          ) {
+          const submitEmailFormWithFetch = function ({
+            isAxiosFallback,
+          }: {
+            isAxiosFallback: boolean
+          }) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
@@ -279,7 +281,7 @@ export const PublicFormProvider = ({
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitEmailFormWithFetch(false)
+            return submitEmailFormWithFetch({ isAxiosFallback: false })
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
@@ -311,7 +313,7 @@ export const PublicFormProvider = ({
                   )
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitEmailFormWithFetch(true)
+                    return submitEmailFormWithFetch({ isAxiosFallback: true })
                   } else {
                     showErrorToast(error, form)
                   }
@@ -322,9 +324,11 @@ export const PublicFormProvider = ({
         case FormResponseMode.Encrypt: {
           // Using mutateAsync so react-hook-form goes into loading state.
 
-          const submitStorageFormWithFetch = function (
-            isAxiosFallback?: boolean,
-          ) {
+          const submitStorageFormWithFetch = function ({
+            isAxiosFallback,
+          }: {
+            isAxiosFallback: boolean
+          }) {
             datadogLogs.logger.info(`handleSubmitForm: submitting via fetch`, {
               meta: {
                 ...logMeta,
@@ -369,7 +373,7 @@ export const PublicFormProvider = ({
 
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
-            return submitStorageFormWithFetch(false)
+            return submitStorageFormWithFetch({ isAxiosFallback: false })
           } else {
             datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
               meta: {
@@ -410,7 +414,7 @@ export const PublicFormProvider = ({
 
                   if (/Network Error/i.test(error.message)) {
                     axiosDebugFlow()
-                    return submitStorageFormWithFetch(true)
+                    return submitStorageFormWithFetch({ isAxiosFallback: true })
                   } else {
                     showErrorToast(error, form)
                   }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -264,7 +264,10 @@ export const PublicFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error, form)
+                showErrorToast(
+                  'Failed to submit. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+                  form,
+                )
               })
           }
 


### PR DESCRIPTION
## Problem
- Some instances of unknown network error could be due to gdrive uploading
- Adds appropriate error message to prompt user to download gdrive file before uploading