### PR TITLE
fix(AttachmentField): clone attachment to (hopefully) fix NetworkError

### DIFF
--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useMemo } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import {
+  Controller,
+  ControllerRenderProps,
+  useFormContext,
+} from 'react-hook-form'
 
 import { MB } from '~shared/constants/file'
 import { FormColorTheme } from '~shared/types'
@@ -42,6 +46,35 @@ export const AttachmentField = ({
     [fieldName, setError],
   )
 
+  const handleFileChange = useCallback(
+    (onChange: ControllerRenderProps['onChange']) =>
+      async (file: File | undefined) => {
+        clearErrors(fieldName)
+        let clone = file
+        // Clone file due to bug where attached file may be empty or corrupted if the
+        // file is a Google Drive file selected from Android's native file picker.
+        // Cloning the file ensures that the file can be read (and/or not mutated by Android)
+        // and throws an error if the file cannot be read instead of silently failing and only throw
+        // an error during form submission.
+        // See https://bugs.chromium.org/p/chromium/issues/detail?id=1063576#c79
+        // and https://stackoverflow.com/questions/62714319/attached-from-google-drivecloud-storage-in-android-file-gives-err-upload-file
+        // as possible sources of the error  (still not confirmed it is the same thing).
+        if (file) {
+          try {
+            const buffer = await file.arrayBuffer()
+            clone = new File([buffer], file.name, { type: file.type })
+          } catch (error) {
+            setErrorMessage(
+              'Error uploading file. Please try again or choose another file.',
+            )
+            console.error(error) // For RUM error tracking
+          }
+        }
+        onChange(clone)
+      },
+    [clearErrors, fieldName, setErrorMessage],
+  )
+
   return (
     <FieldContainer schema={schema}>
       <Controller
@@ -53,10 +86,7 @@ export const AttachmentField = ({
             maxSize={maxSizeInBytes}
             accept={VALID_EXTENSIONS}
             showFileSize
-            onChange={(file) => {
-              clearErrors(fieldName)
-              onChange(file)
-            }}
+            onChange={handleFileChange(onChange)}
             onError={setErrorMessage}
             title={`${schema.questionNumber}. ${schema.title}`}
           />

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -61,7 +61,6 @@ export const AttachmentField = ({
         // See https://bugs.chromium.org/p/chromium/issues/detail?id=1063576#c79
         // and https://stackoverflow.com/questions/62714319/attached-from-google-drivecloud-storage-in-android-file-gives-err-upload-file
         // as possible sources of the error (still not confirmed it is the same thing).
-        datadogLogs.logger.log(`handleFileChange running`)
         if (file) {
           try {
             const buffer = await fileArrayBuffer(file)
@@ -70,28 +69,12 @@ export const AttachmentField = ({
             setErrorMessage(
               'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
             )
-            datadogLogs.logger.error('handleFileChange', {
-              meta: {
-                action: 'handleFileChange',
-                error: {
-                  message: error?.message,
-                  stack: error?.stack,
-                },
-              },
-            }) // For RUM error tracking
-          }
 
-          datadogLogs.logger.warn(`handleFileChange ran`, {
-            meta: {
-              action: 'handleFileChange',
-              file: {
-                name: clone?.name,
-                size: clone?.size,
-                type: clone?.type,
-                buffer: clone && (await fileArrayBuffer(clone)),
-              },
-            },
-          })
+            // For RUM error tracking
+            datadogLogs.logger.error(
+              `handleFileChange error: ${(error as Error)?.message}`,
+            )
+          }
         }
         onChange(clone)
       },

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -60,6 +60,7 @@ export const AttachmentField = ({
         // See https://bugs.chromium.org/p/chromium/issues/detail?id=1063576#c79
         // and https://stackoverflow.com/questions/62714319/attached-from-google-drivecloud-storage-in-android-file-gives-err-upload-file
         // as possible sources of the error (still not confirmed it is the same thing).
+        console.log('handleFileChange running')
         if (file) {
           try {
             const buffer = await fileArrayBuffer(file)

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -10,6 +10,7 @@ import { FormColorTheme } from '~shared/types'
 import { VALID_EXTENSIONS } from '~shared/utils/file-validation'
 
 import { createAttachmentValidationRules } from '~utils/fieldValidation'
+import fileArrayBuffer from '~utils/fileArrayBuffer'
 import Attachment from '~components/Field/Attachment'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -61,7 +62,7 @@ export const AttachmentField = ({
         // as possible sources of the error (still not confirmed it is the same thing).
         if (file) {
           try {
-            const buffer = await file.arrayBuffer()
+            const buffer = await fileArrayBuffer(file)
             clone = new File([buffer], file.name, { type: file.type })
           } catch (error) {
             setErrorMessage(

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -58,16 +58,16 @@ export const AttachmentField = ({
         // an error during form submission.
         // See https://bugs.chromium.org/p/chromium/issues/detail?id=1063576#c79
         // and https://stackoverflow.com/questions/62714319/attached-from-google-drivecloud-storage-in-android-file-gives-err-upload-file
-        // as possible sources of the error  (still not confirmed it is the same thing).
+        // as possible sources of the error (still not confirmed it is the same thing).
         if (file) {
           try {
             const buffer = await file.arrayBuffer()
             clone = new File([buffer], file.name, { type: file.type })
           } catch (error) {
             setErrorMessage(
-              'Error uploading file. Please try again or choose another file.',
+              'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
             )
-            console.error(error) // For RUM error tracking
+            console.error('handleFileChange', error) // For RUM error tracking
           }
         }
         onChange(clone)

--- a/frontend/src/utils/fileArrayBuffer.ts
+++ b/frontend/src/utils/fileArrayBuffer.ts
@@ -1,0 +1,29 @@
+// Backward-compatible version of of array buffer function.
+
+function promisifyFile(obj: FileReader): Promise<ArrayBuffer> {
+  return new Promise(function (resolve, reject) {
+    obj.onload = obj.onerror = function (evt) {
+      obj.onload = obj.onerror = null
+      console.log(obj.result)
+      evt.type === 'load' && obj.result
+        ? resolve(obj.result as ArrayBuffer)
+        : reject(new Error('Failed to read the blob/file'))
+    }
+  })
+}
+
+const fileArrayBuffer = async (file: File): Promise<ArrayBuffer> => {
+  let buffer
+  // arrayBuffer is only compatible with Safari 14 onwards
+  // for older browsers, use readAsArrayBuffer
+  if (!file.arrayBuffer) {
+    const fr = new FileReader()
+    fr.readAsArrayBuffer(file)
+    buffer = await promisifyFile(fr)
+  } else {
+    buffer = await file.arrayBuffer()
+  }
+  return buffer
+}
+
+export default fileArrayBuffer

--- a/frontend/src/utils/fileArrayBuffer.ts
+++ b/frontend/src/utils/fileArrayBuffer.ts
@@ -14,14 +14,14 @@ function promisifyFile(obj: FileReader): Promise<ArrayBuffer> {
 
 const fileArrayBuffer = async (file: File): Promise<ArrayBuffer> => {
   let buffer
-  // arrayBuffer is only compatible with Safari 14 onwards
-  // for older browsers, use readAsArrayBuffer
-  if (!file.arrayBuffer) {
+  if (file.arrayBuffer) {
+    buffer = await file.arrayBuffer()
+  } else {
+    // arrayBuffer is only compatible with Safari 14 onwards
+    // for older browsers, use readAsArrayBuffer
     const fr = new FileReader()
     fr.readAsArrayBuffer(file)
     buffer = await promisifyFile(fr)
-  } else {
-    buffer = await file.arrayBuffer()
   }
   return buffer
 }


### PR DESCRIPTION
Old bug has come to haunt us in React, see https://github.com/opengovsg/FormSG/pull/121

This is a possible fix, still requires testing on an Android phone. 

TODO: Add tests, but first need @justynoh to test whether the bug is fixed on an Android phone first (and whether it broke anything else). Feel free to take over this PR too.

EDIT: also also may have perf implications, but i think cloning max 50MB should be ok la