### PR TITLE
fix: getting payment response through submissionId from completedPayment

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualPaymentResponse.tsx
@@ -28,7 +28,7 @@ export const IndividualPaymentResponse = (submissionId: {
       {isError || isLoading ? (
         //TODO: check with design for skeleton layout
         <Skeleton height="1.5rem" />
-      ) : paymentData ? (
+      ) : paymentData?.completedPayment ? (
         <>
           <Stack>
             <Stack direction={{ base: 'column', md: 'row' }}>
@@ -67,13 +67,12 @@ export const IndividualPaymentResponse = (submissionId: {
               <Text textStyle="subhead-1">Transaction fee:</Text>
               <Text>
                 S$
-                {(paymentData.stripeTransactionFee / 100).toLocaleString(
-                  'en-GB',
-                  {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  },
-                )}
+                {(
+                  paymentData.completedPayment.transactionFee / 100
+                ).toLocaleString('en-GB', {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
               </Text>
             </Stack>
           </Stack>

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb'
 import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
@@ -67,7 +68,10 @@ export const findBySubmissionIdAndUpdate = (
     | mongoose.UpdateQuery<IPaymentSchema>,
 ): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
   return ResultAsync.fromPromise(
-    PaymentModel.findOneAndUpdate({ submissionId }, update).exec(),
+    PaymentModel.findOneAndUpdate(
+      { 'completedPayment.submissionId': new ObjectId(submissionId) },
+      update,
+    ).exec(),
     (error) => {
       logger.error({
         message: 'Error updating payment in database',
@@ -96,7 +100,9 @@ export const findPaymentBySubmissionId = (
   submissionId: string,
 ): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
   return ResultAsync.fromPromise(
-    PaymentModel.findOne({ submissionId }),
+    PaymentModel.findOne({
+      'completedPayment.submissionId': new ObjectId(submissionId),
+    }),
     (error) => {
       logger.error({
         message: 'Database find payment submissionId error',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, going into Individual Response Page with payment will result in DB 500 errors. This is because we are trying to find the payment document by using submissionId

However, the submissionId is now nested within a 'completedPayment' object instead

## Solution
<!-- How did you solve the problem? -->
Find the payment document by comparing completedPayment.submissionId

Update individual payment response to access transaction fee data from completedPayment object

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] go to a payment form, submit the form, ensure success
- [ ] go to results page in form admin, ensure that you can see the payment details & there are no errors
