### PR TITLE
fix(AttachmentField): correctly clear attachment on upload error

### DIFF
--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -52,7 +52,11 @@ export const AttachmentField = ({
     (onChange: ControllerRenderProps['onChange']) =>
       async (file: File | undefined) => {
         clearErrors(fieldName)
-        let clone = file
+        // Case where attachment is cleared.
+        if (!file) {
+          onChange(undefined)
+          return
+        }
         // Clone file due to bug where attached file may be empty or corrupted if the
         // file is a Google Drive file selected from Android's native file picker.
         // Cloning the file ensures that the file can be read (and/or not mutated by Android)
@@ -61,22 +65,22 @@ export const AttachmentField = ({
         // See https://bugs.chromium.org/p/chromium/issues/detail?id=1063576#c79
         // and https://stackoverflow.com/questions/62714319/attached-from-google-drivecloud-storage-in-android-file-gives-err-upload-file
         // as possible sources of the error (still not confirmed it is the same thing).
-        if (file) {
-          try {
-            const buffer = await fileArrayBuffer(file)
-            clone = new File([buffer], file.name, { type: file.type })
-          } catch (error) {
-            setErrorMessage(
-              'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
-            )
+        try {
+          const buffer = await fileArrayBuffer(file)
+          const clone = new File([buffer], file.name, { type: file.type })
+          return onChange(clone)
+        } catch (error) {
+          setErrorMessage(
+            'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+          )
 
-            // For RUM error tracking
-            datadogLogs.logger.error(
-              `handleFileChange error: ${(error as Error)?.message}`,
-            )
-          }
+          // For RUM error tracking
+          datadogLogs.logger.error(
+            `handleFileChange error: ${(error as Error)?.message}`,
+          )
+
+          return onChange(undefined) // Clear attachment and return
         }
-        onChange(clone)
       },
     [clearErrors, fieldName, setErrorMessage],
   )


### PR DESCRIPTION
Fix introduced in #6042 only displays the error, but still sets the invalid file on the attachment field.
This PR correctly clears the invalid attachment when there is an upload error.