### PR TITLE
fix: allow disabling payment in payment drawer

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
@@ -9,6 +9,7 @@ interface FormFieldDrawerActionsProps {
   handleClick: ReturnType<UseFormHandleSubmit<FieldValues>>
   handleCancel: () => void
   buttonText: string
+  isDisabled?: boolean
 }
 
 export const FormFieldDrawerActions = ({
@@ -16,8 +17,10 @@ export const FormFieldDrawerActions = ({
   handleClick,
   handleCancel,
   buttonText,
+  isDisabled,
 }: FormFieldDrawerActionsProps): JSX.Element => {
   const isMobile = useIsMobile()
+  const isSavingDisabled = isDisabled || isLoading
 
   return (
     <Stack
@@ -28,7 +31,7 @@ export const FormFieldDrawerActions = ({
     >
       <Button
         isFullWidth={isMobile}
-        isDisabled={isLoading}
+        isDisabled={isSavingDisabled}
         isLoading={isLoading}
         onClick={handleClick}
       >

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -204,19 +204,11 @@ export const PaymentInput = ({
         isReadOnly={paymentsMutation.isLoading}
         isDisabled={isDisabled}
       >
-        {isDisabled ? (
-          <Toggle
-            description={ENABLE_PAYMENT_INFORMATION}
-            value={1}
-            label={paymentToggleLabel}
-          />
-        ) : (
-          <Toggle
-            {...register('enabled')}
-            description={ENABLE_PAYMENT_INFORMATION}
-            label={paymentToggleLabel}
-          />
-        )}
+        <Toggle
+          {...register('enabled')}
+          description={ENABLE_PAYMENT_INFORMATION}
+          label={paymentToggleLabel}
+        />
       </FormControl>
       <FormControl
         isReadOnly={paymentsMutation.isLoading}

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -12,9 +12,7 @@ import { cloneDeep } from 'lodash'
 
 import { FormPaymentsField } from '~shared/types'
 
-import { useIsMobile } from '~hooks/useIsMobile'
 import { centsToDollars, dollarsToCents } from '~utils/payments'
-import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import InlineMessage from '~components/InlineMessage'
@@ -65,7 +63,6 @@ export const PaymentInput = ({
 }: {
   isDisabled: boolean
 }): JSX.Element => {
-  const isMobile = useIsMobile()
   const { paymentsMutation } = useMutateFormPage()
 
   const { data: { maxPaymentAmountCents, minPaymentAmountCents } = {} } =
@@ -130,11 +127,6 @@ export const PaymentInput = ({
   const clonedWatchedInputs = useMemo(
     () => cloneDeep(watchedInputs),
     [watchedInputs],
-  )
-
-  const watchedEnabled = useMemo(
-    () => clonedWatchedInputs.enabled,
-    [clonedWatchedInputs.enabled],
   )
 
   useDebounce(() => handlePaymentsChanges(clonedWatchedInputs), 300, [
@@ -304,7 +296,7 @@ export const PaymentDrawer = ({
   const paymentDisabledMessage = !isEncryptMode
     ? 'Payments are not available in email mode forms.'
     : !isStripeConnected
-    ? 'Connect your Stripe account in Settings.'
+    ? 'Connect your Stripe account in Settings to save this field.'
     : ''
 
   // payment eligibility will be dependent on whether paymentDisabledMessage is non empty

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -196,7 +196,7 @@ export const PaymentInput = ({
   })
 
   const paymentToggleLabel = 'Enable Payment'
-  const buttonText = 'Save payment settings'
+  const buttonText = 'Save payment field'
 
   return (
     <CreatePageDrawerContentContainer>
@@ -296,6 +296,7 @@ export const PaymentDrawer = ({
     : !isStripeConnected
     ? 'Connect your Stripe account in Settings to save this field.'
     : ''
+
   // payment eligibility will be dependent on whether paymentDisabledMessage is non empty
   const isPaymentDisabled = !!paymentDisabledMessage
 

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -222,7 +222,6 @@ export const PaymentInput = ({
         isReadOnly={paymentsMutation.isLoading}
         isInvalid={!!errors.description}
         isRequired
-        isDisabled={isDisabled}
       >
         <FormLabel description={NAME_INFORMATION}>Name</FormLabel>
         <Input
@@ -235,7 +234,6 @@ export const PaymentInput = ({
       <FormControl
         isReadOnly={paymentsMutation.isLoading}
         isInvalid={!!errors.display_amount}
-        isDisabled={isDisabled}
       >
         <FormLabel isRequired>Payment Amount</FormLabel>
         <Controller
@@ -298,12 +296,11 @@ export const PaymentDrawer = ({
     : !isStripeConnected
     ? 'Connect your Stripe account in Settings to save this field.'
     : ''
-
   // payment eligibility will be dependent on whether paymentDisabledMessage is non empty
   const isPaymentDisabled = !!paymentDisabledMessage
 
   // Allows for payment data refresh in encrypt mode
-  if (!paymentData && !isPaymentDisabled) return null
+  if (!paymentData && isEncryptMode) return null
 
   return (
     <CreatePageDrawerContainer>

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -7,7 +7,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useDebounce } from 'react-use'
-import { Box, Divider, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
+import { Box, Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import { FormPaymentsField } from '~shared/types'
@@ -25,6 +25,7 @@ import Toggle from '~components/Toggle'
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 
 import { useEnv } from '../../../env/queries'
+import { FormFieldDrawerActions } from '../builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions'
 import {
   setIsDirtySelector,
   useDirtyFieldStore,
@@ -33,7 +34,6 @@ import {
   CreatePageDrawerContentContainer,
   useCreatePageSidebar,
 } from '../common'
-import { CreatePageDrawerCloseButton } from '../common/CreatePageDrawer/CreatePageDrawerCloseButton'
 import { CreatePageDrawerContainer } from '../common/CreatePageDrawer/CreatePageDrawerContainer'
 
 import { FormPaymentsDisplay } from './types'
@@ -204,97 +204,71 @@ export const PaymentInput = ({
   })
 
   const paymentToggleLabel = 'Enable Payment'
+  const buttonText = 'Save payment settings'
 
   return (
     <CreatePageDrawerContentContainer>
-      <Stack gap="2rem">
-        <FormControl
-          isReadOnly={paymentsMutation.isLoading}
-          isDisabled={isDisabled}
-        >
-          {isDisabled ? (
-            <Toggle
-              description={ENABLE_PAYMENT_INFORMATION}
-              value={1}
-              label={paymentToggleLabel}
-            />
-          ) : (
-            <Toggle
-              {...register('enabled')}
-              description={ENABLE_PAYMENT_INFORMATION}
-              label={paymentToggleLabel}
+      <FormControl
+        isReadOnly={paymentsMutation.isLoading}
+        isDisabled={isDisabled}
+      >
+        {isDisabled ? (
+          <Toggle
+            description={ENABLE_PAYMENT_INFORMATION}
+            value={1}
+            label={paymentToggleLabel}
+          />
+        ) : (
+          <Toggle
+            {...register('enabled')}
+            description={ENABLE_PAYMENT_INFORMATION}
+            label={paymentToggleLabel}
+          />
+        )}
+      </FormControl>
+      <FormControl
+        isReadOnly={paymentsMutation.isLoading}
+        isInvalid={!!errors.description}
+        isRequired
+        isDisabled={isDisabled}
+      >
+        <FormLabel description={NAME_INFORMATION}>Name</FormLabel>
+        <Input
+          {...register('description', {
+            required: 'Please enter a payment description',
+          })}
+        />
+        <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
+      </FormControl>
+      <FormControl
+        isReadOnly={paymentsMutation.isLoading}
+        isInvalid={!!errors.display_amount}
+        isDisabled={isDisabled}
+      >
+        <FormLabel isRequired>Payment Amount</FormLabel>
+        <Controller
+          name="display_amount"
+          control={control}
+          rules={amountValidation}
+          render={({ field }) => (
+            <MoneyInput
+              flex={1}
+              step={0}
+              inputMode="decimal"
+              placeholder="0.00"
+              {...field}
             />
           )}
-        </FormControl>
+        />
+        <FormErrorMessage>{errors.display_amount?.message}</FormErrorMessage>
+      </FormControl>
 
-        {watchedEnabled && (
-          <>
-            <FormControl
-              isReadOnly={paymentsMutation.isLoading}
-              isInvalid={!!errors.description}
-              isRequired
-              isDisabled={isDisabled}
-            >
-              <FormLabel description={NAME_INFORMATION}>Name</FormLabel>
-              <Input
-                {...register('description', {
-                  required: 'Please enter a payment description',
-                })}
-              />
-              <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
-            </FormControl>
-            <Divider />
-            <FormControl
-              isReadOnly={paymentsMutation.isLoading}
-              isInvalid={!!errors.display_amount}
-              isDisabled={isDisabled}
-            >
-              <FormLabel isRequired>Payment Amount</FormLabel>
-              <Controller
-                name="display_amount"
-                control={control}
-                rules={amountValidation}
-                render={({ field }) => (
-                  <MoneyInput
-                    flex={1}
-                    step={0}
-                    inputMode="decimal"
-                    placeholder="0.00"
-                    {...field}
-                  />
-                )}
-              />
-              <FormErrorMessage>
-                {errors.display_amount?.message}
-              </FormErrorMessage>
-            </FormControl>
-          </>
-        )}
-      </Stack>
-
-      <Stack
-        direction={{ base: 'column', md: 'row-reverse' }}
-        justifyContent="end"
-        spacing="1rem"
-      >
-        <Button
-          isFullWidth={isMobile}
-          onClick={handleUpdatePayments}
-          isLoading={paymentsMutation.isLoading}
-          isDisabled={isDisabled}
-        >
-          Save payment settings
-        </Button>
-        <Button
-          isFullWidth={isMobile}
-          variant="clear"
-          colorScheme="secondary"
-          isDisabled={paymentsMutation.isLoading}
-          onClick={handleCloseDrawer}
-        >
-          Cancel
-        </Button>
-      </Stack>
+      <FormFieldDrawerActions
+        isLoading={paymentsMutation.isLoading}
+        handleClick={handleUpdatePayments}
+        handleCancel={handleCloseDrawer}
+        buttonText={buttonText}
+      ></FormFieldDrawerActions>
     </CreatePageDrawerContentContainer>
   )
 }
@@ -340,23 +314,22 @@ export const PaymentDrawer = ({
 
   return (
     <CreatePageDrawerContainer>
-      {isPaymentDisabled && (
-        <Box px="1.5rem" pt="2rem" pb="1.5rem">
-          <InlineMessage variant={'info'}>
-            <Text>{paymentDisabledMessage}</Text>
-          </InlineMessage>
-        </Box>
-      )}
       <Flex pos="relative" h="100%" display="flex" flexDir="column">
         <Box pt="1rem" px="1.5rem" bg="white">
           <Flex justify="space-between">
             <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
               Edit payment
             </Text>
-            <CreatePageDrawerCloseButton />
           </Flex>
           <Divider w="auto" mx="-1.5rem" />
         </Box>
+        {isPaymentDisabled && (
+          <Box px="1.5rem" pt="2rem" pb="1.5rem">
+            <InlineMessage variant={'info'}>
+              <Text>{paymentDisabledMessage}</Text>
+            </InlineMessage>
+          </Box>
+        )}
         <PaymentInput isDisabled={isPaymentDisabled} />
       </Flex>
     </CreatePageDrawerContainer>

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -268,6 +268,7 @@ export const PaymentInput = ({
         handleClick={handleUpdatePayments}
         handleCancel={handleCloseDrawer}
         buttonText={buttonText}
+        isDisabled={isDisabled}
       ></FormFieldDrawerActions>
     </CreatePageDrawerContentContainer>
   )

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -57,6 +57,8 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
  * Whilst description will still be used in the backend for consistency with Stripe's API
  */
 const NAME_INFORMATION = 'Name will be reflected on payment receipt'
+const ENABLE_PAYMENT_INFORMATION =
+  'Payment field will not be shown when this is toggled off. Respondents can still submit the form.'
 
 export const PaymentInput = ({
   isDisabled,
@@ -211,9 +213,17 @@ export const PaymentInput = ({
           isDisabled={isDisabled}
         >
           {isDisabled ? (
-            <Toggle value={1} label={paymentToggleLabel} />
+            <Toggle
+              description={ENABLE_PAYMENT_INFORMATION}
+              value={1}
+              label={paymentToggleLabel}
+            />
           ) : (
-            <Toggle {...register('enabled')} label={paymentToggleLabel} />
+            <Toggle
+              {...register('enabled')}
+              description={ENABLE_PAYMENT_INFORMATION}
+              label={paymentToggleLabel}
+            />
           )}
         </FormControl>
 

--- a/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentTab.tsx
@@ -13,7 +13,7 @@ export const PaymentTab = (): JSX.Element => {
   const isStripeConnected =
     isEncryptMode && form.payments_channel.channel === PaymentChannel.Stripe
 
-  return isEncryptMode && isStripeConnected ? (
+  return isEncryptMode ? (
     <>
       <PaymentDrawer
         isEncryptMode={isEncryptMode}

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -253,26 +253,8 @@ export const handleUpdatePayments = [
   celebrate({
     [Segments.BODY]: {
       enabled: Joi.boolean().required(),
-      amount_cents: Joi.alternatives().conditional('enabled', [
-        {
-          is: true,
-          then: Joi.number().integer().positive(),
-        },
-        {
-          is: false,
-          then: Joi.forbidden(),
-        },
-      ]),
-      description: Joi.alternatives().conditional('enabled', [
-        {
-          is: true,
-          then: Joi.string().allow(''),
-        },
-        {
-          is: false,
-          then: Joi.forbidden(),
-        },
-      ]),
+      amount_cents: Joi.number().integer().positive().required(),
+      description: Joi.string().required(),
     },
   }),
   _handleUpdatePayments,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently we are unable to disable payment from payment drawer, this PR fixes that

And also minor UI improvements to payment drawer

Closes #6041 

## Solution
<!-- How did you solve the problem? -->
Loosen validation for update payment endpoint. Previously saved details  (description and amount) should still persist even after disabling payments

Improve UI based on new figma changes:
1. Do not remove 'Name' and 'Payment Amount' components upon disabling payments (users would still like to see whats required in a payment)
2. Add description for 'Enable' toggle, waiting for @staceytan1998 to confirm the copy with Shanty
3. Remove unneeded components (stack and button) and rely on existing `FormFieldDrawerActions` and `CreatePageDrawerContainer` components
4. Minor edit to `FormFieldDrawerActions` to allow for disabling of update button
5. Shifted `paymentDisabledMessage` to after `Edit Payment` block (thanks @justynoh)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
| Unconnected | Connected but disabled | Connected and enabled|
| --- | --- | ---|
| <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230332296-9b8711cf-c730-4249-aeac-01a88ba7c28b.png"> | <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230332440-2d20c709-529e-448c-ad16-da2d087f885e.png"> | <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230332389-5ee988ed-fed4-4594-97b0-af2e720fc703.png"> |

**AFTER**:
<!-- [insert screenshot here] -->
| Unconnected | Connected but disabled | Connected and enabled|
| --- | --- | ---|
| <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230331990-48081eea-002d-4a84-86a5-2dee224c7990.png"> | <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230332791-4fb884a4-78cc-4f91-b2df-def1ffd8f373.png"> | <img width="537" alt="image" src="https://user-images.githubusercontent.com/59867455/230332524-7b524c92-3299-4a27-a009-12e31206c3d3.png"> |


## Tests
<!-- What tests should be run to confirm functionality? -->

Ensure that payment can be disabled
- [ ] go to a payment form, connect stripe account, enable payment
- [ ] go to payment drawer and try to disable payment. It should succeed, and the previous 'Name' and 'Payment Amount' should still be captured.
- [ ] open the form and try to make a submission, there should be no payment field
- [ ] enable payment again, try to make a submission, with payment

Ensure that previous functionality is kept
- [ ] go to a payment form without stripe connected, you should see an info message in payment drawer
- [ ] you should not be able to update payment field from payment drawer
- [ ] go to an email mode form, you should not be able to update payment fields from payment drawer
