### PR TITLE
feat: payment invoice

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
@@ -13,7 +13,7 @@ export const getPaymentReceiptStatus = async (
   paymentId: string,
 ): Promise<PaymentReceiptStatusDto> => {
   return ApiService.get<PaymentReceiptStatusDto>(
-    `payments/receipt/${formId}/${paymentId}/status`,
+    `payments/${formId}/${paymentId}/receipt/status`,
   ).then(({ data }) => data)
 }
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
@@ -22,6 +22,13 @@ export const DownloadReceiptBlock = ({
     })
     window.location.href = `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download`
   }
+
+  const handleInvoiceClick = () => {
+    toast({
+      description: 'Invoice download started',
+    })
+    window.location.href = `${API_BASE_URL}/payments/${formId}/${paymentId}/invoice/download`
+  }
   return (
     <Box>
       <Stack tabIndex={-1} spacing="1rem">
@@ -37,11 +44,20 @@ export const DownloadReceiptBlock = ({
       </Text>
 
       <Button
+        hidden // Currently hidden for JTC
         mt="2.25rem"
+        mr="2.25rem"
         leftIcon={<BiDownload fontSize="1.5rem" />}
         onClick={handleReceiptClick}
       >
         Save payment receipt
+      </Button>
+      <Button
+        mt="2.25rem"
+        leftIcon={<BiDownload fontSize="1.5rem" />}
+        onClick={handleInvoiceClick}
+      >
+        Save payment invoice
       </Button>
     </Box>
   )

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
@@ -2,8 +2,12 @@ import { BiDownload } from 'react-icons/bi'
 import { Box, Stack, Text } from '@chakra-ui/react'
 
 import { useToast } from '~hooks/useToast'
-import { API_BASE_URL } from '~services/ApiService'
 import Button from '~components/Button'
+
+import {
+  getPaymentInvoiceDownloadUrl,
+  getPaymentReceiptDownloadUrl,
+} from '~features/public-form/utils/urls'
 
 type DownloadReceiptBlockProps = {
   formId: string
@@ -20,14 +24,14 @@ export const DownloadReceiptBlock = ({
     toast({
       description: 'Receipt download started',
     })
-    window.location.href = `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download`
+    window.location.href = getPaymentReceiptDownloadUrl(formId, paymentId)
   }
 
   const handleInvoiceClick = () => {
     toast({
       description: 'Invoice download started',
     })
-    window.location.href = `${API_BASE_URL}/payments/${formId}/${paymentId}/invoice/download`
+    window.location.href = getPaymentInvoiceDownloadUrl(formId, paymentId)
   }
   return (
     <Box>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripeDownloadReceiptBlock.tsx
@@ -16,11 +16,11 @@ export const DownloadReceiptBlock = ({
 }: DownloadReceiptBlockProps) => {
   const toast = useToast({ status: 'success', isClosable: true })
 
-  const handleClick = () => {
+  const handleReceiptClick = () => {
     toast({
       description: 'Receipt download started',
     })
-    window.location.href = `${API_BASE_URL}/payments/receipt/${formId}/${paymentId}/download`
+    window.location.href = `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download`
   }
   return (
     <Box>
@@ -39,7 +39,7 @@ export const DownloadReceiptBlock = ({
       <Button
         mt="2.25rem"
         leftIcon={<BiDownload fontSize="1.5rem" />}
-        onClick={handleClick}
+        onClick={handleReceiptClick}
       >
         Save payment receipt
       </Button>

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -1,3 +1,19 @@
+import { API_BASE_URL } from '~services/ApiService'
+
 export const getPaymentPageUrl = (formId: string, paymentId: string) => {
-  return `/${formId}/payment/${paymentId}`
+  return `/${formId}/payment/${paymentId}` as const
+}
+
+export const getPaymentReceiptDownloadUrl = (
+  formId: string,
+  paymentId: string,
+) => {
+  return `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download` as const
+}
+
+export const getPaymentInvoiceDownloadUrl = (
+  formId: string,
+  paymentId: string,
+) => {
+  return `${API_BASE_URL}/payments/${formId}/${paymentId}/invoice/download` as const
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "fp-ts": "^2.13.1",
         "helmet": "^6.0.1",
         "hot-shots": "^9.3.0",
+        "html-entities": "^2.3.3",
         "html-escaper": "^3.0.3",
         "http-errors": "^2.0.0",
         "http-status-codes": "^2.2.0",
@@ -16205,6 +16206,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
@@ -44790,6 +44796,11 @@
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "html-escaper": {
       "version": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "fp-ts": "^2.13.1",
     "helmet": "^6.0.1",
     "hot-shots": "^9.3.0",
+    "html-entities": "^2.3.3",
     "html-escaper": "^3.0.3",
     "http-errors": "^2.0.0",
     "http-status-codes": "^2.2.0",

--- a/shared/types/agency.ts
+++ b/shared/types/agency.ts
@@ -13,10 +13,12 @@ export const AgencyBase = z.object({
   fullName: z.string(),
   shortName: z.string(),
   logo: z.string(),
-  business: z.object({
-    address: z.string().optional(),
-    gstRegNo: z.string().optional(),
-  }),
+  business: z
+    .object({
+      address: z.string(),
+      gstRegNo: z.string(),
+    })
+    .optional(),
 })
 export type AgencyBase = z.infer<typeof AgencyBase>
 

--- a/shared/types/agency.ts
+++ b/shared/types/agency.ts
@@ -13,6 +13,10 @@ export const AgencyBase = z.object({
   fullName: z.string(),
   shortName: z.string(),
   logo: z.string(),
+  business: z.object({
+    address: z.string().optional(),
+    gstRegNo: z.string().optional(),
+  }),
 })
 export type AgencyBase = z.infer<typeof AgencyBase>
 

--- a/src/app/models/agency.server.model.ts
+++ b/src/app/models/agency.server.model.ts
@@ -46,6 +46,10 @@ const AgencySchema = new Schema<
       required: true,
       trim: true,
     },
+    business: {
+      address: { type: String, required: true, trim: true },
+      gstRegNo: { type: String, required: true, trim: true },
+    },
   },
   {
     timestamps: {

--- a/src/app/models/agency.server.model.ts
+++ b/src/app/models/agency.server.model.ts
@@ -47,8 +47,10 @@ const AgencySchema = new Schema<
       trim: true,
     },
     business: {
-      address: { type: String, required: true, trim: true },
-      gstRegNo: { type: String, required: true, trim: true },
+      type: {
+        address: { type: String, required: true, trim: true },
+        gstRegNo: { type: String, required: true, trim: true },
+      },
     },
   },
   {

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -1,6 +1,5 @@
 // Use 'stripe-event-types' for better type discrimination.
 /// <reference types="stripe-event-types" />
-import fs from 'fs'
 import { encode } from 'html-entities'
 import { StatusCodes } from 'http-status-codes'
 import { JSDOM } from 'jsdom'
@@ -336,12 +335,14 @@ export const mapRouteErr = (error: ApplicationError) => {
  * Converts receipt sourced from Stripe into an invoice format
  * @param receiptHtmlSource
  */
-export const convertToInvoiceForrmat = (receiptHtmlSource: string) => {
+export const convertToInvoiceForrmat = (
+  receiptHtmlSource: string,
+  { address, gstRegNo }: { address: string; gstRegNo: string },
+) => {
   // handle special characters in addresses
-  const ADDRESS = encode('8 Jurong Town Hall Road; Singapore 609434')
-  const GST_REG_NO = encode('M91234567X')
+  const ADDRESS = encode(address)
+  const GST_REG_NO = encode(gstRegNo)
 
-  fs.writeFileSync('./' + Date.now(), receiptHtmlSource)
   const edited = receiptHtmlSource
     .replace(/(<title>.*?)receipt(.*?<\/title>)/, '$1invoice$2')
     .replace(/Receipt from /g, 'Invoice from ')

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -16,18 +16,18 @@ PaymentsRouter.get('/stripe')
  * @returns 404 if receipt URL does not exist or payment does not exist
  */
 PaymentsRouter.route(
-  '/receipt/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/status',
+  '/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/receipt/status',
 ).get(StripeController.checkPaymentReceiptStatus)
 
 /**
  * Downloads the receipt pdf
- * @route GET /payments/receipt/:formId/:paymentId/download
+ * @route GET /payments/:formId/:paymentId/receipt/download
  *
  * @returns 200 with receipt attatchment as content in PDF
  * @returns 404 if receipt url doesn't exist or payment does not exist
  */
 PaymentsRouter.route(
-  '/receipt/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/download',
+  '/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/receipt/download',
 ).get(
   limitRate({ max: rateLimitConfig.downloadPaymentReceipt }),
   StripeController.downloadPaymentReceipt,

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -10,7 +10,7 @@ PaymentsRouter.get('/stripe')
 
 /**
  * Checks if the payment receipt is ready
- * @route GET /payments/receipt/:formId/:paymentId/status
+ * @route GET /payments/:formId/:paymentId/receipt/status
  *
  * @returns 200 if receipt URL exists
  * @returns 404 if receipt URL does not exist or payment does not exist
@@ -31,6 +31,20 @@ PaymentsRouter.route(
 ).get(
   limitRate({ max: rateLimitConfig.downloadPaymentReceipt }),
   StripeController.downloadPaymentReceipt,
+)
+
+/**
+ * Downloads the invoice pdf
+ * @route GET /payments/:formId/:paymentId/invoice/download
+ *
+ * @returns 200 with receipt attatchment as content in PDF
+ * @returns 404 if receipt url doesn't exist or payment does not exist
+ */
+PaymentsRouter.route(
+  '/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/invoice/download',
+).get(
+  limitRate({ max: rateLimitConfig.downloadPaymentReceipt }),
+  StripeController.downloadPaymentInvoice,
 )
 
 PaymentsRouter.route('/stripe/callback').get(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
JTC needs us to issue invoices for payees. The default receipt doesn't contain enough information for payees to regard it as an invoice.

Closes #6052, #6078

## Solution
<!-- How did you solve the problem? -->
Integrating Tim's Script to preprocess the receipt before returning it out to the user to download.

This feature requires another issue to be resolved:
- #6051 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Additional Notes**
1. The receipt download functionality is merely hidden, and can be easily toggle back on. As we are not definite on whether customizing our invoices this way and whether all payees require this specific invoice format, it is best that we keep our receipt functionality, in the event that we need to switch back.

2. I've also updated the receipt urls to better match RESTful API design pattern (although it's still not looking the best with `:formId` in the middle of nowhere

**After Screenshots**
<img width="791" alt="Screenshot 2023-04-06 at 9 26 24 PM" src="https://user-images.githubusercontent.com/12391617/230425964-08ba030e-bad0-4769-a399-da7d8686405b.png">
