### PR TITLE
fix: make captcha in payment scrollable

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -41,7 +41,12 @@ export const FormPaymentModal = ({
               <Button
                 isLoading={isSubmitting}
                 loadingText="Submitting"
-                onClick={onSubmit}
+                onClick={(event) => {
+                  onClose()
+                  if (onSubmit) {
+                    onSubmit(event)
+                  }
+                }}
               >
                 Proceed to pay
               </Button>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -22,6 +22,7 @@ export const FormPaymentModal = ({
   onClose,
   isSubmitting,
 }: FormPaymentModalProps): JSX.Element => {
+  // We need to dismiss the FormPaymentModal to release the scroll lock that affects the captcha
   const closeAndSubmit = (event: MouseEvent<HTMLButtonElement>) => {
     onClose()
     if (onSubmit) {

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react'
+import { MouseEvent, MouseEventHandler } from 'react'
 import {
   Button,
   ButtonGroup,
@@ -22,6 +22,12 @@ export const FormPaymentModal = ({
   onClose,
   isSubmitting,
 }: FormPaymentModalProps): JSX.Element => {
+  const closeAndSubmit = (event: MouseEvent<HTMLButtonElement>) => {
+    onClose()
+    if (onSubmit) {
+      onSubmit(event)
+    }
+  }
   return (
     <>
       <Modal isOpen onClose={onClose}>
@@ -41,12 +47,7 @@ export const FormPaymentModal = ({
               <Button
                 isLoading={isSubmitting}
                 loadingText="Submitting"
-                onClick={(event) => {
-                  onClose()
-                  if (onSubmit) {
-                    onSubmit(event)
-                  }
-                }}
+                onClick={closeAndSubmit}
               >
                 Proceed to pay
               </Button>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, for payment enabled forms, we are unable to scroll the captcha, resulting in difficulties submitting the form unless the user knows to zoom out.

This is caused by chakra modal which locks scrolling when a modal is opened.

Closes #6002 

## Solution
<!-- How did you solve the problem? -->
Two potential methods were discussed:
1. Overwrite chakra modal's props to allow scrolling ([this is not recommended by chakra](https://chakra-ui.com/docs/components/modal/usage#block-scrolling-when-modal-opens) as it might lead to problem with accessibility in the future)
2. **Close the modal before submitting** (have gotten design's okay to do so)

Have decided on the second option.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="401" alt="image" src="https://user-images.githubusercontent.com/59867455/230836125-c8c1d1fd-8469-4e14-9c39-c2a19f3bd940.png">


**AFTER**:
<!-- [insert screenshot here] -->
Note the scroll at the side and lack of modal
<img width="401" alt="image" src="https://user-images.githubusercontent.com/59867455/230841591-d27b96ab-2edf-4d6c-b916-2fef49654396.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] submit a form with payments enabled, make sure captcha is shown ([can do this](https://stackoverflow.com/questions/48431361/force-google-recaptcha-challenge))
- [ ] The payment modal should close before captcha is displayed
- [ ] The captcha should be scrollable (zoom in to check if form is too short)
- [ ] Submit the payment (To check original functionality is kept)