### PR TITLE
feat: stable submission id

### DIFF
--- a/src/app/constants/mongo-error.ts
+++ b/src/app/constants/mongo-error.ts
@@ -1,0 +1,4 @@
+export const MONGO_ERROR_CODE = {
+  DuplicateKey: 11000,
+  InvalidBSON: 10334,
+}

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -45,6 +45,12 @@ export class DatabasePayloadSizeError extends ApplicationError {
   }
 }
 
+export class DatabaseDuplicateKeyError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}
+
 export class SecretsManagerError extends ApplicationError {
   constructor(message?: string) {
     super(message)
@@ -77,6 +83,7 @@ export type PossibleDatabaseError =
   | DatabaseValidationError
   | DatabaseConflictError
   | DatabasePayloadSizeError
+  | DatabaseDuplicateKeyError
 
 export class MalformedParametersError extends ApplicationError {
   constructor(message: string, meta?: unknown) {

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -7,10 +7,9 @@ import mongoose from 'mongoose'
 import { err, Ok, ok, Result } from 'neverthrow'
 import Stripe from 'stripe'
 
-import { StripePaymentMetadataDto } from 'src/types'
-
 import { Payment, PaymentStatus } from '../../../../shared/types'
 import { hasProp } from '../../../../shared/utils/has-prop'
+import { StripePaymentMetadataDto } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ApplicationError } from '../core/core.errors'
 import {
@@ -46,6 +45,7 @@ const isStripeMetadata = (
 ): obj is StripePaymentMetadataDto =>
   hasProp(obj, 'formTitle') &&
   hasProp(obj, 'formId') &&
+  hasProp(obj, 'submissionId') &&
   hasProp(obj, 'paymentId') &&
   hasProp(obj, 'paymentContactEmail')
 

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -839,7 +839,7 @@ describe('submission.service', () => {
       const pendingSubmission = await PendingSubmission.create(
         MOCK_PENDING_SUBMISSION,
       )
-      await Submission.create(MOCK_SUBMISSION)
+      await Submission.create(MOCK_PENDING_SUBMISSION)
 
       // Act
       const session = await mongoose.startSession()

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -794,22 +794,29 @@ describe('submission.service', () => {
   describe('copyPendingSubmissionToSubmissions', () => {
     const MOCK_PENDING_SUBMISSION_ID = MOCK_SUBMISSION._id
 
+    const MOCK_PENDING_SUBMISSION = {
+      _id: MOCK_PENDING_SUBMISSION_ID,
+      submissionType: SubmissionType.Encrypt,
+      form: MOCK_FORM_ID,
+      encryptedContent: 'some random encrypted content',
+      version: 1,
+      responseHash: 'hash',
+      responseSalt: 'salt',
+    }
+
     beforeEach(async () => {
+      await dbHandler.clearCollection(PendingSubmission.collection.name)
       await dbHandler.clearCollection(Submission.collection.name)
     })
     afterEach(() => jest.clearAllMocks())
 
-    it('should return a submission document if copying from pending submissions to submissions was successful', async () => {
-      const pendingSubmission = await PendingSubmission.create({
-        _id: MOCK_PENDING_SUBMISSION_ID,
-        submissionType: SubmissionType.Encrypt,
-        form: MOCK_FORM_ID,
-        encryptedContent: 'some random encrypted content',
-        version: 1,
-        responseHash: 'hash',
-        responseSalt: 'salt',
-      })
+    it('should return a submission document with the same ObjectID if copying from pending submissions to submissions was successful', async () => {
+      // Arrange
+      const pendingSubmission = await PendingSubmission.create(
+        MOCK_PENDING_SUBMISSION,
+      )
 
+      // Act
       const session = await mongoose.startSession()
       const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
@@ -817,27 +824,45 @@ describe('submission.service', () => {
       )
       session.endSession()
 
+      //Assert
       expect(result.isOk()).toEqual(true)
 
       const submission = result._unsafeUnwrap()
+      Object.keys(pendingSubmission).forEach((key) => {
+        if (['created', 'lastModified'].includes(key)) return
+        expect(submission.get(key)).toEqual(pendingSubmission.get(key))
+      })
+    })
 
+    it('should return a submission document with a different ObjectID if an ObjectID collision occurs while copying the pending submission to the submissions collection', async () => {
+      // Arrange
+      const pendingSubmission = await PendingSubmission.create(
+        MOCK_PENDING_SUBMISSION,
+      )
+      await Submission.create(MOCK_SUBMISSION)
+
+      // Act
+      const session = await mongoose.startSession()
+      const result = await SubmissionService.copyPendingSubmissionToSubmissions(
+        MOCK_PENDING_SUBMISSION_ID,
+        session,
+      )
+      session.endSession()
+
+      // Assert
+      expect(result.isOk()).toEqual(true)
+
+      const submission = result._unsafeUnwrap()
+      // Explicitly check the '_id' field to be different
+      expect(submission.get('_id')).not.toEqual(pendingSubmission._id)
       Object.keys(pendingSubmission).forEach((key) => {
         if (['_id', 'created', 'lastModified'].includes(key)) return
         expect(submission.get(key)).toEqual(pendingSubmission.get(key))
       })
     })
 
-    it('should return false if pendingSubmissionId does not exist', async () => {
-      await Submission.create({
-        _id: MOCK_PENDING_SUBMISSION_ID,
-        submissionType: SubmissionType.Encrypt,
-        form: MOCK_FORM_ID,
-        encryptedContent: 'some random encrypted content',
-        version: 1,
-        responseHash: 'hash',
-        responseSalt: 'salt',
-      })
-
+    it('should return PendingSubmissionNotFoundError if pendingSubmissionId does not exist', async () => {
+      // Act
       const session = await mongoose.startSession()
       const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         new ObjectId().toHexString(),
@@ -845,6 +870,7 @@ describe('submission.service', () => {
       )
       session.endSession()
 
+      // Assert
       expect(result.isErr()).toEqual(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(
         PendingSubmissionNotFoundError,
@@ -852,6 +878,7 @@ describe('submission.service', () => {
     })
 
     it('should return DatabaseError when error occurs whilst querying database', async () => {
+      // Arrange
       const findSpy = jest.spyOn(PendingSubmission, 'findById')
       findSpy.mockImplementationOnce(
         () =>
@@ -860,6 +887,7 @@ describe('submission.service', () => {
           } as unknown as mongoose.Query<any, any>),
       )
 
+      // Act
       const session = await mongoose.startSession()
       const result = await SubmissionService.copyPendingSubmissionToSubmissions(
         MOCK_PENDING_SUBMISSION_ID,
@@ -867,6 +895,7 @@ describe('submission.service', () => {
       )
       session.endSession()
 
+      // Assert
       expect(findSpy).toHaveBeenCalledWith(
         MOCK_PENDING_SUBMISSION_ID,
         null,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -8,8 +8,6 @@ import { okAsync } from 'neverthrow'
 import Stripe from 'stripe'
 import type { SetOptional } from 'type-fest'
 
-import { StripePaymentMetadataDto } from 'src/types'
-
 import {
   ErrorDto,
   FormAuthType,
@@ -21,6 +19,7 @@ import {
   SubmissionErrorDto,
   SubmissionResponseDto,
 } from '../../../../../shared/types'
+import { StripePaymentMetadataDto } from '../../../../types'
 import { EncryptSubmissionDto } from '../../../../types/api'
 import { paymentConfig } from '../../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -432,9 +431,12 @@ const submitEncryptModeForm: ControllerHandler<
     const metadata: StripePaymentMetadataDto = {
       formTitle: form.title,
       formId,
+      submissionId: pendingSubmissionId,
       paymentId,
       paymentContactEmail: paymentReceiptEmail,
     }
+
+    const paymentReceiptDescription = `${form.payments_field.description}\nFormSG form: ${form.title}\nResponse ID: ${pendingSubmissionId}`
 
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
       amount,
@@ -443,7 +445,7 @@ const submitEncryptModeForm: ControllerHandler<
         'card',
         /* 'grabpay', 'paynow'*/
       ],
-      description: form.payments_field.description,
+      description: paymentReceiptDescription,
       receipt_email: paymentReceiptEmail,
       metadata,
     }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -436,7 +436,11 @@ const submitEncryptModeForm: ControllerHandler<
       paymentContactEmail: paymentReceiptEmail,
     }
 
-    const paymentReceiptDescription = `${form.payments_field.description}\nFormSG form: ${form.title}\nResponse ID: ${pendingSubmissionId}`
+    const paymentReceiptDescription = [
+      form.payments_field.description,
+      `FormSG form: ${form.title}`,
+      `Response ID: ${pendingSubmissionId}`,
+    ].join('\n')
 
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
       amount,

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -265,8 +265,8 @@ export const copyPendingSubmissionToSubmissions = (
       ])
       const submission = new SubmissionModel({
         // Explicitly copy over the pending submission's _id
-        _id: pendingSubmissionId,
         ...submissionContent,
+        _id: pendingSubmissionId,
       })
 
       return ResultAsync.fromPromise(submission.save({ session }), (error) => {

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -14,8 +14,15 @@ import getSubmissionModel from '../../models/submission.server.model'
 import MailService from '../../services/mail/mail.service'
 import { AutoReplyMailData } from '../../services/mail/mail.types'
 import { createQueryWithDateParam, isMalformedDate } from '../../utils/date'
-import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
-import { DatabaseError, MalformedParametersError } from '../core/core.errors'
+import {
+  getMongoErrorMessage,
+  transformMongoError,
+} from '../../utils/handle-mongo-error'
+import {
+  DatabaseDuplicateKeyError,
+  DatabaseError,
+  MalformedParametersError,
+} from '../core/core.errors'
 import { InvalidSubmissionIdError } from '../feedback/feedback.errors'
 
 import {
@@ -251,9 +258,16 @@ export const copyPendingSubmissionToSubmissions = (
       return okAsync(submission)
     })
     .andThen((pendingSubmission) => {
-      const submission = new SubmissionModel(
-        omit(pendingSubmission, ['_id', 'created', 'lastModified']),
-      )
+      const submissionContent = omit(pendingSubmission, [
+        '_id',
+        'created',
+        'lastModified',
+      ])
+      const submission = new SubmissionModel({
+        // Explicitly copy over the pending submission's _id
+        _id: pendingSubmissionId,
+        ...submissionContent,
+      })
 
       return ResultAsync.fromPromise(submission.save({ session }), (error) => {
         logger.error({
@@ -261,7 +275,47 @@ export const copyPendingSubmissionToSubmissions = (
           meta: logMeta,
           error,
         })
-        return new DatabaseError(getMongoErrorMessage(error))
+
+        const databaseError = transformMongoError(error)
+
+        return databaseError instanceof DatabaseDuplicateKeyError
+          ? databaseError
+          : new DatabaseError(getMongoErrorMessage(error))
+      }).orElse((error) => {
+        if (error instanceof DatabaseDuplicateKeyError) {
+          // Failed to save due to duplicate keys.
+          logger.error({
+            message:
+              'Failed to move pending submission to submission: duplicate key error in submission collection',
+            meta: logMeta,
+            error,
+          })
+          // Recover by attempting to save with a different id.
+          const recoverySubmission = new SubmissionModel(submissionContent)
+          // TODO: Set alarms for both branches
+          return ResultAsync.fromPromise(
+            recoverySubmission.save({ session }),
+            (error) => {
+              logger.error({
+                message: 'Failed to recover from duplicate key error',
+                meta: logMeta,
+                error,
+              })
+              return new DatabaseError(getMongoErrorMessage(error))
+            },
+          ).andThen((recoverySubmission) => {
+            logger.warn({
+              message: `Successfully recovered from duplicate key error`,
+              meta: {
+                submissionId: recoverySubmission._id,
+                ...logMeta,
+              },
+              error,
+            })
+            return okAsync(recoverySubmission)
+          })
+        }
+        return errAsync(error)
       })
     })
 }

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -10,6 +10,7 @@ export type IPaymentModel = Model<IPaymentSchema>
 export interface StripePaymentMetadataDto extends Stripe.Metadata {
   formTitle: string
   formId: string
+  submissionId: string
   paymentId: string
   paymentContactEmail: string
 }


### PR DESCRIPTION
## Problem
This PR implements the stable submission ID required for identification of submissions throughout the lifecycle. Closes #6080

Additionally, took the opportunity to do two items that were blocked by stable submission id. Closes #5960 and #5965

## Solution

Explicitly copy over the pending submission ID into the submission collection. Add duplicate key error handling and recovery.

## Screenshots

Receipt

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/25571626/231378511-de1cd402-dfd8-46aa-bf5d-fab450edfccd.png">

Stripe dashboard

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/25571626/231379200-de852b3d-3d4c-439e-8fe6-2f794d9339f5.png">

Stripe metadata

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/25571626/231379107-ca875032-cd98-4a1a-8d00-0137ca67ef49.png">
