### PR TITLE
feat: perform post-submission actions when payment is completed

### DIFF
--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -35,7 +35,6 @@ export type Payment = {
   email: string
   amount: number
   paymentIntentId: string
-  responses: any[] // Will be typed as FilteredResponse[]
 
   // Payment status tracking
   webhookLog: Stripe.Event[]

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -35,6 +35,7 @@ export type Payment = {
   email: string
   amount: number
   paymentIntentId: string
+  responses: any[] // Will be typed as FilteredResponse[]
 
   // Payment status tracking
   webhookLog: Stripe.Event[]

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -28,6 +28,7 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
       type: String,
       required: true,
     },
+    responses: [],
 
     webhookLog: [],
     status: {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -6141,11 +6141,9 @@ describe('admin-form.controller', () => {
           responses: MOCK_RESPONSES,
           form: MOCK_FORM,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
-        } as IncomingEncryptSubmission),
+        } as unknown as IncomingEncryptSubmission),
       )
-      MockSubmissionUtils.extractEmailConfirmationDataFromIncomingSubmission.mockReturnValue(
-        [],
-      )
+      MockSubmissionUtils.extractEmailConfirmationData.mockReturnValue([])
       MockEncryptSubmissionService.createEncryptSubmissionWithoutSave.mockReturnValue(
         MOCK_SUBMISSION,
       )

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -74,10 +74,7 @@ import * as EncryptSubmissionService from '../../submission/encrypt-submission/e
 import { mapRouteError as mapEncryptSubmissionError } from '../../submission/encrypt-submission/encrypt-submission.utils'
 import IncomingEncryptSubmission from '../../submission/encrypt-submission/IncomingEncryptSubmission.class'
 import * as SubmissionService from '../../submission/submission.service'
-import {
-  extractEmailConfirmationData,
-  extractEmailConfirmationDataFromIncomingSubmission,
-} from '../../submission/submission.utils'
+import { extractEmailConfirmationData } from '../../submission/submission.utils'
 import * as UserService from '../../user/user.service'
 import { PrivateFormError } from '../form.errors'
 import * as FormService from '../form.service'
@@ -1491,10 +1488,10 @@ export const submitEncryptPreview: ControllerHandler<
       void SubmissionService.sendEmailConfirmations({
         form,
         submission,
-        recipientData:
-          extractEmailConfirmationDataFromIncomingSubmission(
-            incomingSubmission,
-          ),
+        recipientData: extractEmailConfirmationData(
+          incomingSubmission.responses,
+          form.form_fields,
+        ),
       })
 
       // Return the reply early to the submitter

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -160,102 +160,119 @@ export const confirmPaymentPendingSubmission = (
   }
 
   // Step 0: Set up the session and start the transaction
-  return ResultAsync.fromPromise(mongoose.startSession(), (error) => {
-    logger.error({
-      message: 'Database error while starting mongoose session',
-      meta: logMeta,
-      error,
-    })
-    return new DatabaseError(getMongoErrorMessage(error))
-  })
-    .andThen((session) => {
-      session.startTransaction({
-        readPreference: 'primary',
-        readConcern: { level: 'snapshot' },
-        writeConcern: { w: 'majority' },
+  return (
+    ResultAsync.fromPromise(mongoose.startSession(), (error) => {
+      logger.error({
+        message: 'Database error while starting mongoose session',
+        meta: logMeta,
+        error,
       })
+      return new DatabaseError(getMongoErrorMessage(error))
+    })
+      .andThen((session) => {
+        session.startTransaction({
+          readPreference: 'primary',
+          readConcern: { level: 'snapshot' },
+          writeConcern: { w: 'majority' },
+        })
 
-      return (
-        // Step 1: Retrieve the payment by payment id and check that the payment
-        // has not already been confirmed.
-        findPaymentById(paymentId, session)
-          .andThen((payment) =>
-            payment.completedPayment
-              ? errAsync(new PaymentAlreadyConfirmedError())
-              : okAsync(payment),
-          )
-          .andThen((payment) =>
-            // Step 2: Copy the pending submission to the submissions collection
-            SubmissionService.copyPendingSubmissionToSubmissions(
-              payment.pendingSubmissionId,
-              session,
-            ).andThen((submission) => {
-              // Step 3: Update the payment document with the metadata showing that
-              // the payment is complete and save it
-              payment.completedPayment = {
-                submissionId: submission._id,
-                paymentDate,
-                receiptUrl,
-                transactionFee,
-              }
+        return (
+          // Step 1: Retrieve the payment by payment id and check that the payment
+          // has not already been confirmed.
+          findPaymentById(paymentId, session)
+            .andThen((payment) =>
+              payment.completedPayment
+                ? errAsync(new PaymentAlreadyConfirmedError())
+                : okAsync(payment),
+            )
+            .andThen((payment) =>
+              // Step 2: Copy the pending submission to the submissions collection
+              SubmissionService.copyPendingSubmissionToSubmissions(
+                payment.pendingSubmissionId,
+                session,
+              ).andThen((submission) => {
+                // Step 3: Update the payment document with the metadata showing that
+                // the payment is complete and save it
+                payment.completedPayment = {
+                  submissionId: submission._id,
+                  paymentDate,
+                  receiptUrl,
+                  transactionFee,
+                }
+                return ResultAsync.fromPromise(
+                  payment.save({ session }),
+                  (error) => {
+                    logger.error({
+                      message: 'Database error while saving payment document',
+                      meta: logMeta,
+                      error,
+                    })
+                    return new DatabaseError(getMongoErrorMessage(error))
+                  },
+                ).andThen(() => okAsync(submission))
+              }),
+            )
+            // Finally: Commit or abort depending on whether an error was caught,
+            // then end the session
+            .andThen((submission) => {
               return ResultAsync.fromPromise(
-                payment.save({ session }),
+                session.commitTransaction(),
                 (error) => {
                   logger.error({
-                    message: 'Database error while saving payment document',
+                    message: 'Database error while committing transaction',
                     meta: logMeta,
                     error,
                   })
                   return new DatabaseError(getMongoErrorMessage(error))
                 },
-              ).andThen((payment) => okAsync({ payment, submission }))
-            }),
-          )
-          // Finally: Commit or abort depending on whether an error was caught,
-          // then end the session
-          .andThen(({ payment, submission }) => {
-            return ResultAsync.fromPromise(
-              session.commitTransaction(),
-              (error) => {
-                logger.error({
-                  message: 'Database error while committing transaction',
-                  meta: logMeta,
-                  error,
-                })
-                return new DatabaseError(getMongoErrorMessage(error))
-              },
-            ).andThen(() => {
-              session.endSession()
-              return okAsync({ payment, submission })
+              ).andThen(() => {
+                session.endSession()
+                return okAsync(submission)
+              })
             })
-          })
-          .orElse((err) => {
-            return ResultAsync.fromPromise(
-              session.abortTransaction(),
-              (error) => {
-                logger.error({
-                  message: 'Database error while aborting transaction',
-                  meta: logMeta,
-                  error,
-                })
-                return new DatabaseError(getMongoErrorMessage(error))
-              },
-            ).andThen(() => {
-              session.endSession()
-              return errAsync(err)
+            .orElse((err) => {
+              return ResultAsync.fromPromise(
+                session.abortTransaction(),
+                (error) => {
+                  logger.error({
+                    message: 'Database error while aborting transaction',
+                    meta: logMeta,
+                    error,
+                  })
+                  return new DatabaseError(getMongoErrorMessage(error))
+                },
+              ).andThen(() => {
+                session.endSession()
+                return errAsync(err)
+              })
             })
-          })
-      )
-    })
-    .andThen(({ payment, submission }) => {
-      if (isSubmissionEncryptMode(submission)) {
-        return performEncryptPostSubmissionActions(
-          submission,
-          payment.responses,
         )
-          .andThen(() => okAsync(payment))
-          .orElse(() => okAsync(payment))
-      }
-      return okAsync(payment)
-    })
+      })
+      // Post-submission: fire webhooks and send email confirmations.
+      .andThen((submission) =>
+        findPaymentById(paymentId).andThen((payment) => {
+          if (isSubmissionEncryptMode(submission)) {
+            return performEncryptPostSubmissionActions(
+              submission,
+              payment.responses,
+            )
+              .andThen(() => {
+                // If successfully sent email confirmations, delete response data from payment document.
+                payment.responses = []
+                return ResultAsync.fromPromise(payment.save(), (error) => {
+                  logger.error({
+                    message:
+                      'Database error while deleting responses from payment',
+                    meta: logMeta,
+                    error,
+                  })
+                  return new DatabaseError(getMongoErrorMessage(error))
+                }).andThen(() => okAsync(payment))
+              })
+              .orElse(() => okAsync(payment))
+          }
+          return okAsync(payment)
+        }),
+      )
+  )
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -41,10 +41,7 @@ import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { getPopulatedUserById } from '../../user/user.service'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
-import { WebhookFactory } from '../../webhook/webhook.factory'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
-import { sendEmailConfirmations } from '../submission.service'
-import { extractEmailConfirmationDataFromIncomingSubmission } from '../submission.utils'
 
 import {
   addPaymentDataStream,
@@ -54,6 +51,7 @@ import {
   getSubmissionMetadata,
   getSubmissionMetadataList,
   getSubmissionPaymentDto,
+  performEncryptPostSubmissionActions,
   transformAttachmentMetasToSignedUrls,
   transformAttachmentMetaStream,
   uploadAttachments,
@@ -391,6 +389,7 @@ const submitEncryptModeForm: ControllerHandler<
     const payment = new Payment({
       amount,
       email: paymentReceiptEmail,
+      responses: incomingSubmission.responses,
     })
     const paymentId = payment.id
 
@@ -571,18 +570,6 @@ const submitEncryptModeForm: ControllerHandler<
     },
   })
 
-  // Fire webhooks if available
-  // To avoid being coupled to latency of receiving system,
-  // do not await on webhook
-  const webhookUrl = form.webhook?.url
-  if (webhookUrl) {
-    void WebhookFactory.sendInitialWebhook(
-      submission,
-      webhookUrl,
-      !!form.webhook?.isRetryEnabled,
-    )
-  }
-
   // Send success back to client
   res.json({
     message: 'Form submission successful.',
@@ -590,21 +577,10 @@ const submitEncryptModeForm: ControllerHandler<
     timestamp: (submission.created || new Date()).getTime(),
   })
 
-  // Send Email Confirmations
-  return sendEmailConfirmations({
-    form,
+  return await performEncryptPostSubmissionActions(
     submission,
-    recipientData:
-      extractEmailConfirmationDataFromIncomingSubmission(incomingSubmission),
-  }).mapErr((error) => {
-    logger.error({
-      message: 'Error while sending email confirmations',
-      meta: {
-        action: 'sendEmailAutoReplies',
-      },
-      error,
-    })
-  })
+    incomingSubmission.responses,
+  )
 }
 
 export const handleEncryptedSubmission = [

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -4,8 +4,14 @@ import moment from 'moment-timezone'
 import {
   StorageModeSubmissionDto,
   SubmissionPaymentDto,
+  SubmissionType,
 } from '../../../../../shared/types'
-import { MapRouteErrors, SubmissionData } from '../../../../types'
+import {
+  IEncryptedSubmissionSchema,
+  ISubmissionSchema,
+  MapRouteErrors,
+  SubmissionData,
+} from '../../../../types'
 import { MapRouteError } from '../../../../types/routing'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { MalformedVerifiedContentError } from '../../../modules/verified-content/verified-content.errors'
@@ -198,6 +204,17 @@ const errorMapper: MapRouteError = (
 
 export const mapRouteError: MapRouteErrors =
   genericMapRouteErrorTransform(errorMapper)
+
+/**
+ * Typeguard to check if given submission is an encrypt mode submission.
+ * @param submission the submission to check
+ * @returns true if submission is encrypt mode submission, false otherwise.
+ */
+export const isSubmissionEncryptMode = (
+  submission: ISubmissionSchema,
+): submission is IEncryptedSubmissionSchema => {
+  return submission.submissionType === SubmissionType.Encrypt
+}
 
 /**
  * Creates and returns an EncryptedSubmissionDto object from submissionData and

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -10,7 +10,6 @@ import {
 import { FieldResponse, FormFieldSchema, IFormDocument } from '../../../types'
 import { AutoReplyMailData } from '../../services/mail/mail.types'
 
-import { IncomingSubmission } from './IncomingSubmission.class'
 import { ConflictError } from './submission.errors'
 import { FilteredResponse } from './submission.types'
 
@@ -81,7 +80,6 @@ export const getFormFieldModeFilter = (
  * @param formFields Fields from form object
  * @returns Array of data for email confirmations
  */
-// TODO: Migrate to extractEmailConfirmationDataFromIncomingSubmission
 export const extractEmailConfirmationData = (
   responses: FieldResponse[],
   formFields: FormFieldSchema[] | undefined,
@@ -108,19 +106,6 @@ export const extractEmailConfirmationData = (
     }
     return acc
   }, [])
-}
-
-/**
- * Extracts response data to be sent in email confirmations
- * @param responses Responses from form filler
- * @param formFields Fields from form object
- * @returns Array of data for email confirmations
- */
-export const extractEmailConfirmationDataFromIncomingSubmission = (
-  incomingSubmission: IncomingSubmission,
-): AutoReplyMailData[] => {
-  const { responses, form } = incomingSubmission
-  return extractEmailConfirmationData(responses, form.form_fields)
 }
 
 /**

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -3,7 +3,13 @@ import Stripe from 'stripe'
 
 import { Payment } from '../../shared/types/payment'
 
-export interface IPaymentSchema extends Payment, Document {}
+export interface IPaymentSchema extends Payment, Document {
+  /**
+   * Additional field to store responses for sending email confirmations post-payment.
+   * Will be used to store FilteredResponse[], allows for population.
+   */
+  responses: any[]
+}
 
 export type IPaymentModel = Model<IPaymentSchema>
 


### PR DESCRIPTION
## Problem
Previously, webhooks will be fired and email confirmations will be sent once the submission is complete. This was not done in the payment flow.

Closes #6000

## Solution
Shard out the post-submission actions into a new service layer function `performEncryptPostSubmissionActions`. This is now called both in the encrypt submission controller and the payment confirmation function.

In principle, this sounds easy, but e2ee has bitten us again! We send the information required for email confirmations in the clear from FE to BE in `responses`, and then we don't store the information beyond that. Therefore, there is no persistent storage of this information that allows us to delay the sending of email confirmations.

<img width="897" alt="image" src="https://user-images.githubusercontent.com/25571626/231407245-27b7f4af-82ff-48be-831c-f5757e5f45b3.png">

With that in mind, there's only one way forward - store the responses somewhere, somehow in the DB. See below for details, but to cut a long story short, I decided to store in the payment collection for now, in the clear just because it's the least effort to do. That's why there are modifications to the payment model and types.

Feel free to give your opinions on the following two questions! Thanks 🙏  

## Discussion points

**Where to store `responses`?**
1. In the pending submissions collection. This means there will be a divergence in schema between pending submissions and submissions collection. This seems like the most natural place to put it, but will require some additional instrumentation with new services and utils for type-guarding encrypt pending submissions and email pending submissions, a la submissions currently. I don't think it's _that_ much work, but didn't want to invest effort until we decided on something.
2. In the payments collection. This means that for the first time we store actual submission data in the payments collection. This is the easiest to implement, since the payment collection is independent from everything else. And it makes _some_ sense (storing the information required only for "delayed completed submissions" in the metadata for _why_ it's delayed). [TODO: If we proceed with this, we will need to delete the data from the payment collection once the email confirmations are sent.]
3. In an entirely separate collection. This is similar to the logic of OTP verifications - we have a separate collection, but we don't expect the data to be stored there for long, and once we're done we later delete it. This isn't very high in effort, but will require us to keep track of more collections, all related to payments. Besides, payments and submissions are 1 to 1, so I don't think there's any tangible benefit of this option above option 2 in any case.

**How to store `responses`?**
1. In the clear. Of course, this "breaks" our promise of e2ee **on the form responses** (we already store the payment contact email in the clear). Are we willing to accept this?
2. Masked. This is similar to the approach for OTPs. The difference is that OTPs don't need to be "unhashed" - we just compare the hash values, so we don't store OTPs in the clear. In contrast, for responses, if we want to mask the data, the only option is an encryption mechanism, which we could do but require some effort (generate key, store in secret, etc. etc.).