### PR TITLE
fix: date-picker bug for negative UTC timezones

### DIFF
--- a/frontend/src/components/DatePicker/DatePickerContext.tsx
+++ b/frontend/src/components/DatePicker/DatePickerContext.tsx
@@ -20,7 +20,6 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
 
 import { ThemeColorScheme } from '~theme/foundations/colours'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -84,7 +83,6 @@ const useProvideDatePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
   locale,
   isDateUnavailable,
   allowManualInput = true,
@@ -120,9 +118,9 @@ const useProvideDatePicker = ({
   const formatInputValue = useCallback(
     (date: Date | null) => {
       if (!date || !isValid(date)) return ''
-      return format(zonedTimeToUtc(date, timeZone), displayFormat, { locale })
+      return format(date, displayFormat, { locale })
     },
-    [displayFormat, locale, timeZone],
+    [displayFormat, locale],
   )
 
   // What is rendered as a string in the input according to given display format.
@@ -142,11 +140,7 @@ const useProvideDatePicker = ({
 
   const handleInputBlur: FocusEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      const date = parse(
-        internalInputValue,
-        dateFormat,
-        zonedTimeToUtc(new Date(), timeZone),
-      )
+      const date = parse(internalInputValue, dateFormat, new Date())
       // Clear if input is invalid on blur if invalid dates are not allowed.
       if (!allowInvalidDates && !isValid(date)) {
         setInternalValue(null)
@@ -161,7 +155,6 @@ const useProvideDatePicker = ({
       onBlur,
       setInternalInputValue,
       setInternalValue,
-      timeZone,
     ],
   )
 
@@ -179,12 +172,11 @@ const useProvideDatePicker = ({
 
   const handleDateChange = useCallback(
     (date: Date | null) => {
-      const zonedDate = date ? zonedTimeToUtc(date, timeZone) : null
-      if (allowInvalidDates || isValid(zonedDate) || !zonedDate) {
-        setInternalValue(zonedDate)
+      if (allowInvalidDates || isValid(date) || !date) {
+        setInternalValue(date)
       }
-      if (zonedDate) {
-        setInternalInputValue(format(zonedDate, displayFormat, { locale }))
+      if (date) {
+        setInternalInputValue(format(date, displayFormat, { locale }))
       } else {
         setInternalInputValue('')
       }
@@ -198,23 +190,18 @@ const useProvideDatePicker = ({
       locale,
       setInternalInputValue,
       setInternalValue,
-      timeZone,
     ],
   )
 
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const date = parse(
-        event.target.value,
-        dateFormat,
-        zonedTimeToUtc(new Date(), timeZone),
-      )
+      const date = parse(event.target.value, dateFormat, new Date())
       setInternalInputValue(event.target.value)
       if (isValid(date)) {
         setInternalValue(date)
       }
     },
-    [dateFormat, setInternalInputValue, setInternalValue, timeZone],
+    [dateFormat, setInternalInputValue, setInternalValue],
   )
 
   const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(

--- a/frontend/src/components/DatePicker/types.ts
+++ b/frontend/src/components/DatePicker/types.ts
@@ -33,10 +33,4 @@ export interface DatePickerBaseProps
   refocusOnClose?: boolean
   /** date-fns's Locale of the date to be applied if provided. */
   locale?: Locale
-  /**
-   * Time zone of date created.
-   * Defaults to `'UTC'`.
-   * Accepts all possible `Intl.Locale.prototype.timeZones` values
-   */
-  timeZone?: string
 }

--- a/frontend/src/components/DateRangePicker/DateRangePickerContext.tsx
+++ b/frontend/src/components/DateRangePicker/DateRangePickerContext.tsx
@@ -21,7 +21,6 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
 
 import { ThemeColorScheme } from '~theme/foundations/colours'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -92,7 +91,6 @@ const useProvideDateRangePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
   locale,
   isDateUnavailable,
   allowManualInput = true,
@@ -129,13 +127,13 @@ const useProvideDateRangePicker = ({
   // What is rendered as a string in the start date range input according to given display format.
   const [startInputDisplay, setStartInputDisplay] = useState(
     startDate && isValid(startDate)
-      ? format(zonedTimeToUtc(startDate, timeZone), displayFormat, { locale })
+      ? format(startDate, displayFormat, { locale })
       : '',
   )
   // What is rendered as a string in the end date range input according to given display format.
   const [endInputDisplay, setEndInputDisplay] = useState(
     endDate && isValid(endDate)
-      ? format(zonedTimeToUtc(endDate, timeZone), displayFormat, { locale })
+      ? format(endDate, displayFormat, { locale })
       : '',
   )
 
@@ -151,24 +149,18 @@ const useProvideDateRangePicker = ({
       ) as DateRangeValue
 
       const [nextStart, nextEnd] = sortedRange
-      const zonedStartDate = nextStart
-        ? zonedTimeToUtc(nextStart, timeZone)
-        : null
-      const zonedEndDate = nextEnd ? zonedTimeToUtc(nextEnd, timeZone) : null
-      if (zonedStartDate) {
-        if (isValid(zonedStartDate)) {
-          setStartInputDisplay(
-            format(zonedStartDate, displayFormat, { locale }),
-          )
+      if (nextStart) {
+        if (isValid(nextStart)) {
+          setStartInputDisplay(format(nextStart, displayFormat, { locale }))
         } else if (!allowInvalidDates) {
           setStartInputDisplay('')
         }
       } else {
         setStartInputDisplay('')
       }
-      if (zonedEndDate) {
-        if (isValid(zonedEndDate)) {
-          setEndInputDisplay(format(zonedEndDate, displayFormat, { locale }))
+      if (nextEnd) {
+        if (isValid(nextEnd)) {
+          setEndInputDisplay(format(nextEnd, displayFormat, { locale }))
         } else if (!allowInvalidDates) {
           setEndInputDisplay('')
         }
@@ -177,7 +169,7 @@ const useProvideDateRangePicker = ({
       }
       setInternalValue(validRange)
     },
-    [allowInvalidDates, displayFormat, locale, setInternalValue, timeZone],
+    [allowInvalidDates, displayFormat, locale, setInternalValue],
   )
 
   const fcProps = useFormControlProps({
@@ -274,11 +266,8 @@ const useProvideDateRangePicker = ({
 
   const handleCalendarDateChange = useCallback(
     (date: DateRangeValue) => {
-      const zonedDateRange = date.map((d) =>
-        d ? zonedTimeToUtc(d, timeZone) : null,
-      ) as DateRangeValue
-      const [nextStartDate, nextEndDate] = zonedDateRange
-      setInternalValue(zonedDateRange)
+      const [nextStartDate, nextEndDate] = date
+      setInternalValue(date)
       setStartInputDisplay(
         nextStartDate ? format(nextStartDate, displayFormat, { locale }) : '',
       )
@@ -296,7 +285,6 @@ const useProvideDateRangePicker = ({
       displayFormat,
       locale,
       setInternalValue,
-      timeZone,
     ],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -53,14 +53,10 @@ const transformDateFieldToEditForm = (field: DateFieldBase): EditDateInputs => {
     selectedDateValidation:
       field.dateValidation.selectedDateValidation ?? ('' as const),
     customMaxDate: field.dateValidation.selectedDateValidation
-      ? field.dateValidation.customMaxDate
-        ? loadDateFromNormalizedDate(field.dateValidation.customMaxDate)
-        : null
+      ? loadDateFromNormalizedDate(field.dateValidation.customMaxDate)
       : null,
     customMinDate: field.dateValidation.selectedDateValidation
-      ? field.dateValidation.customMinDate
-        ? loadDateFromNormalizedDate(field.dateValidation.customMinDate)
-        : null
+      ? loadDateFromNormalizedDate(field.dateValidation.customMinDate)
       : null,
   }
   return {
@@ -112,16 +108,12 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         ...output,
         dateValidation: {
           ...inputs.dateValidation,
-          ...(inputs.dateValidation.customMinDate !== null && {
-            customMinDate: normalizeDateToUtc(
-              inputs.dateValidation.customMinDate,
-            ),
-          }),
-          ...(inputs.dateValidation.customMaxDate !== null && {
-            customMaxDate: normalizeDateToUtc(
-              inputs.dateValidation.customMaxDate,
-            ),
-          }),
+          customMinDate: normalizeDateToUtc(
+            inputs.dateValidation.customMinDate,
+          ),
+          customMaxDate: normalizeDateToUtc(
+            inputs.dateValidation.customMaxDate,
+          ),
         },
       } as DateFieldBase
     },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -107,7 +107,10 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
       return {
         ...output,
         dateValidation: {
-          ...inputs.dateValidation,
+          selectedDateValidation:
+            inputs.dateValidation.selectedDateValidation === ''
+              ? null
+              : inputs.dateValidation.selectedDateValidation,
           customMinDate: normalizeDateToUtc(
             inputs.dateValidation.customMinDate,
           ),

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -51,9 +51,11 @@ export const DateField = ({
           const { customMinDate, customMaxDate } = schema.dateValidation
           // customMinDate and customMaxDate are in UTC from the server,
           // need to convert to local time but with the same date as UTC.
-          const customMinNoTime = loadDateFromNormalizedDate(customMinDate)
-          const customMaxNoTime = loadDateFromNormalizedDate(customMaxDate)
-          return isDateOutOfRange(date, customMinNoTime, customMaxNoTime)
+          return isDateOutOfRange(
+            date,
+            loadDateFromNormalizedDate(customMinDate),
+            loadDateFromNormalizedDate(customMaxDate),
+          )
         }
         default:
           return false

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -5,10 +5,10 @@ import { FormColorTheme } from '~shared/types'
 import { DateSelectedValidation } from '~shared/types/field'
 
 import {
-  fromUtcToLocalDate,
   isDateAfterToday,
   isDateBeforeToday,
   isDateOutOfRange,
+  loadDateFromNormalizedDate,
 } from '~utils/date'
 import { createDateValidationRules } from '~utils/fieldValidation'
 import { DatePicker } from '~components/DatePicker'
@@ -51,11 +51,13 @@ export const DateField = ({
           const { customMinDate, customMaxDate } = schema.dateValidation
           // customMinDate and customMaxDate are in UTC from the server,
           // need to convert to local time but with the same date as UTC.
-          return isDateOutOfRange(
-            date,
-            fromUtcToLocalDate(customMinDate),
-            fromUtcToLocalDate(customMaxDate),
-          )
+          const customMinNoTime = customMinDate
+            ? loadDateFromNormalizedDate(customMinDate)
+            : null
+          const customMaxNoTime = customMaxDate
+            ? loadDateFromNormalizedDate(customMaxDate)
+            : null
+          return isDateOutOfRange(date, customMinNoTime, customMaxNoTime)
         }
         default:
           return false

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -51,12 +51,8 @@ export const DateField = ({
           const { customMinDate, customMaxDate } = schema.dateValidation
           // customMinDate and customMaxDate are in UTC from the server,
           // need to convert to local time but with the same date as UTC.
-          const customMinNoTime = customMinDate
-            ? loadDateFromNormalizedDate(customMinDate)
-            : null
-          const customMaxNoTime = customMaxDate
-            ? loadDateFromNormalizedDate(customMaxDate)
-            : null
+          const customMinNoTime = loadDateFromNormalizedDate(customMinDate)
+          const customMaxNoTime = loadDateFromNormalizedDate(customMaxDate)
           return isDateOutOfRange(date, customMinNoTime, customMaxNoTime)
         }
         default:

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -38,10 +38,12 @@ export const isDateAfterToday = (date: number | Date) => {
   return isAfter(date, endOfToday())
 }
 
-// Converts UTC time to the same date in local time, ignoring original timezone.
-export const fromUtcToLocalDate = (date?: Date | null) => {
-  if (!date) return date
-  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+export const normalizeDateToUtc = (date: Date) => {
+  return new Date(date.valueOf() - date.getTimezoneOffset() * 60 * 1000)
+}
+
+export const loadDateFromNormalizedDate = (date: Date) => {
+  return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)
 }
 
 /**

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -38,11 +38,13 @@ export const isDateAfterToday = (date: number | Date) => {
   return isAfter(date, endOfToday())
 }
 
-export const normalizeDateToUtc = (date: Date) => {
+export const normalizeDateToUtc = (date: Date | null) => {
+  if (!date) return date
   return new Date(date.valueOf() - date.getTimezoneOffset() * 60 * 1000)
 }
 
-export const loadDateFromNormalizedDate = (date: Date) => {
+export const loadDateFromNormalizedDate = (date: Date | null) => {
+  if (!date) return date
   return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)
 }
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -40,12 +40,12 @@ export const isDateAfterToday = (date: number | Date) => {
 
 export const normalizeDateToUtc = (date: Date | null) => {
   if (!date) return date
-  return new Date(date.valueOf() - date.getTimezoneOffset() * 60 * 1000)
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
 }
 
 export const loadDateFromNormalizedDate = (date: Date | null) => {
   if (!date) return date
-  return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)
+  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
 }
 
 /**

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -431,12 +431,8 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
         }
 
         const { customMinDate, customMaxDate } = schema.dateValidation ?? {}
-        const customMinNoTime = customMinDate
-          ? loadDateFromNormalizedDate(customMinDate)
-          : null
-        const customMaxNoTime = customMaxDate
-          ? loadDateFromNormalizedDate(customMaxDate)
-          : null
+        const customMinNoTime = loadDateFromNormalizedDate(customMinDate)
+        const customMaxNoTime = loadDateFromNormalizedDate(customMaxDate)
         return (
           !isDateOutOfRange(parseDate(val), customMinNoTime, customMaxNoTime) ||
           'Selected date is not within the allowed date range'

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -53,10 +53,10 @@ import {
 import { VerifiableFieldBase } from '~features/verifiable-fields/types'
 
 import {
-  fromUtcToLocalDate,
   isDateAfterToday,
   isDateBeforeToday,
   isDateOutOfRange,
+  loadDateFromNormalizedDate,
 } from './date'
 import { formatNumberToLocaleString } from './stringFormat'
 
@@ -431,12 +431,15 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
         }
 
         const { customMinDate, customMaxDate } = schema.dateValidation ?? {}
+        const customMinNoTime = customMinDate
+          ? loadDateFromNormalizedDate(customMinDate)
+          : null
+        const customMaxNoTime = customMaxDate
+          ? loadDateFromNormalizedDate(customMaxDate)
+          : null
         return (
-          !isDateOutOfRange(
-            parseDate(val),
-            fromUtcToLocalDate(customMinDate),
-            fromUtcToLocalDate(customMaxDate),
-          ) || 'Selected date is not within the allowed date range'
+          !isDateOutOfRange(parseDate(val), customMinNoTime, customMaxNoTime) ||
+          'Selected date is not within the allowed date range'
         )
       },
     },

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -431,11 +431,12 @@ export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
         }
 
         const { customMinDate, customMaxDate } = schema.dateValidation ?? {}
-        const customMinNoTime = loadDateFromNormalizedDate(customMinDate)
-        const customMaxNoTime = loadDateFromNormalizedDate(customMaxDate)
         return (
-          !isDateOutOfRange(parseDate(val), customMinNoTime, customMaxNoTime) ||
-          'Selected date is not within the allowed date range'
+          !isDateOutOfRange(
+            parseDate(val),
+            loadDateFromNormalizedDate(customMinDate),
+            loadDateFromNormalizedDate(customMaxDate),
+          ) || 'Selected date is not within the allowed date range'
         )
       },
     },

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -45,7 +45,7 @@ const pastOnlyValidator: DateValidator = (response) => {
   // Add 14 hours here to account for up to UTC + 14 timezone
   // This allows validation to pass as long as user is on the correct date (locally)
   // Even if they are in a different timezone
-  const todayMax = moment().utc().add(14, 'hours').startOf('day')
+  const todayMax = moment()
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)
 
@@ -62,7 +62,7 @@ const futureOnlyValidator: DateValidator = (response) => {
   // Subtract 12 hours here to account for up to UTC - 12 timezone
   // This allows validation to pass as long as user is on the correct date (locally)
   // Even if they are in a different timezone
-  const todayMin = moment().utc().subtract(12, 'hours').startOf('day')
+  const todayMin = moment()
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)
 

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -42,8 +42,9 @@ const dateFormatValidator: DateValidator = (response) => {
  */
 const pastOnlyValidator: DateValidator = (response) => {
   // Today takes two possible values - a min (in makeFutureOnlyValidator) and max (here)
-  // Dates are converted to use local timezones when loaded by the DateField so no conversion required
-  const todayMax = moment()
+  // Compares the input date with the maximum date for today anywhere in the world so
+  // respondent can be from any timezone.
+  const todayMax = moment().zone('+14:00').startOf('day')
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)
 
@@ -57,8 +58,9 @@ const pastOnlyValidator: DateValidator = (response) => {
  */
 const futureOnlyValidator: DateValidator = (response) => {
   // Today takes two possible values - a min (here) and max (in makePastOnlyValidator)
-  // Dates are converted to use local timezones when loaded by the DateField so no conversion required
-  const todayMin = moment()
+  // Compares the input date with the minimum date for today anywhere in the world so
+  // respondent can be from any timezone.
+  const todayMin = moment().zone('-12:00').startOf('day')
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)
 

--- a/src/app/utils/field-validation/validators/dateValidator.ts
+++ b/src/app/utils/field-validation/validators/dateValidator.ts
@@ -42,9 +42,7 @@ const dateFormatValidator: DateValidator = (response) => {
  */
 const pastOnlyValidator: DateValidator = (response) => {
   // Today takes two possible values - a min (in makeFutureOnlyValidator) and max (here)
-  // Add 14 hours here to account for up to UTC + 14 timezone
-  // This allows validation to pass as long as user is on the correct date (locally)
-  // Even if they are in a different timezone
+  // Dates are converted to use local timezones when loaded by the DateField so no conversion required
   const todayMax = moment()
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)
@@ -59,9 +57,7 @@ const pastOnlyValidator: DateValidator = (response) => {
  */
 const futureOnlyValidator: DateValidator = (response) => {
   // Today takes two possible values - a min (here) and max (in makePastOnlyValidator)
-  // Subtract 12 hours here to account for up to UTC - 12 timezone
-  // This allows validation to pass as long as user is on the correct date (locally)
-  // Even if they are in a different timezone
+  // Dates are converted to use local timezones when loaded by the DateField so no conversion required
   const todayMin = moment()
   const { answer } = response
   const answerDate = createMomentFromDateString(answer)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

> (taken from #6025) 
> Date picker was using the midnight of the date picked and taking into account the timezone where the user is filling in the form. However, it does not make sense to do so as users will be picking particular dates rather than timings, and the understanding of the different timezones should be established as part of the question.

However, bug fix in PR #6025 almost caused an incident as the fix removed converting to UTC on the date picker itself, which was causing [the selection offset bug](https://formsg.zendesk.com/agent/tickets/42733). 

## Solution
<!-- How did you solve the problem? -->
Puts back the local time to UTC conversion right before submission so that dates saved in the DB are normalised to be in UTC time.

Note: local time to UTC conversion does not have to be restored for `DateField` as the responses for `DateField` are in string when encrypted anyway.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Cast time to UTC only right before submitting custom date so the conversion will be completely invisible to users
- Cast time to local timezone before being shown on the frontend so the frontend timezone will be consistent

**Bug Fixes**:

- Users with negative UTC timezones will now have their date fields correctly reflecting the dates selected on their date pickers
- `zonedTimeToUTC` was converting the timings to UTC and thus the actual date being referred to will not be preserved for respondents in negative UTC timezones. Implemented `normalizeDateToUtc` to ensure the actual date numbers are are preserved.
  - We now cast time from local timezone to UTC timezone using `Date.UTC` instead of converting time using `zonedTimeToUTC` (which we were using wrong anyway, as pointed out by @darrelhong in #5731)

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

https://user-images.githubusercontent.com/37061143/229051162-f3d111a4-d7ce-406f-b6eb-b659891296c7.mov

**AFTER**:
<!-- [insert screenshot here] -->

Disallow past dates:

https://user-images.githubusercontent.com/37061143/231920965-0295168f-ea05-4fad-a3fe-bf6d890350cc.mov

Disallow future dates:

https://user-images.githubusercontent.com/37061143/231939426-16e43f97-7810-4429-b393-fc62d86d963c.mov

Custom date range:

https://user-images.githubusercontent.com/37061143/231940842-d14a3731-7d50-41d4-8a54-326581fd2135.mov

## Tests
<!-- What tests should be run to confirm functionality? -->

To ensure that all our bases are covered, try to test the most extreme timezones. Here are the suggested timezones: 
- Most common use case: Singapore - Singapore (UTC +08)
- Negative: Alofi - Niue (UTC -11)
- Positive: Wellington - New Zealand (UTC +12)

Preparation:
- [x] Create a form with a date field and open the form.

For the tests below, timezones A and B refer to the positive and negative timezones mentioned above, in any order.

Ensure that date picker for date field with "Disallow past dates" option exhibits expected behaviour:
1. - [x] Set your timezone as A.
2. - [x] On the admin panel, refresh, select and save the "Disallow past dates" option for the date field.
3. - [x] On the respondent form, refresh and open the date picker. Only the current and future dates of the timezone should be shown.
4. - [x] Select a date. The appropriate date should be reflected in the date field.
5. - [x] Change your device's timezone to B.
6. - [x] Repeat tasks 3-4.
7. - [x] Repeat tasks 2-4.
9. - [x] Change your device's timezone to A.
10. - [x] Repeat tasks 3-4.

Ensure that date picker for date field with "Disallow future dates" option exhibits expected behaviour:
1. - [x] Set your timezone as A.
2. - [x] On the admin panel, refresh, select and save the "Disallow future dates" option for the date field.
3. - [x] On the respondent form, refresh and open the date picker. Only the current and future dates of the timezone should be shown.
4. - [x] Select a date. The appropriate date should be reflected in the date field.
5. - [x] Change your device's timezone to B.
6. - [x] Repeat tasks 3-4.
7. - [x] Repeat tasks 2-4.
9. - [x] Change your device's timezone to A.
10. - [x] Repeat tasks 3-4.

Ensure that date picker for date field with "Custom date range" option exhibits expected behaviour:
1. - [x] Set your timezone as A.
2. - [x] On the admin panel, refresh and select the "Custom date range" option for the date field.
3. - [x] Select a start date.
4. - [x] Open the end date field date picker. Only the dates on or after the selected start date should be selectable.
5. - [x] Select an end date.
6. - [x] Save the selected date range. Optionally, check that the dates saved in the DB are in UTC.
7. - [x] On the respondent form, refresh and open the date picker. Only the dates in the selected date range should be selectable.
8. - [x] Select a date. The respective date should be reflected in the date field.
9. - [x] Change your device's timezone to B.
10. - [x] Repeat tasks 7-8.
11. - [x] Repeat task 2. Ensure that the start and end dates remain the same.
12. - [x] Update the start and end dates for the date field. Save it.
13. - [x] Repeat tasks 7-8.
14. - [x] Change your device's timezone to A.
15. - [x] Repeat tasks 7-8.

Note: Here's [how to set your Mac's timezone](https://support.apple.com/en-gb/guide/mac-help/mchlp2996/mac).

Design/ product question: Should "Disallow past dates" and "Disallow future dates" be taking the past / future based on the admins' timezone, specified timezone or the users' timezone? Also, even when we have decided on the previous question, does it even make sense if the concept of time is not considered? E.g. if the recurring event I want to organise is at 10am, our date picker won't be able to know that so if we have a timezone in mind, it won't "filter" properly. Currently, it's simply implemented based on the users' timezone so its not disorienting.