### PR TITLE
chore: prune error logs for ndi oidc key retrieval error

### DIFF
--- a/src/app/modules/spcp/spcp.oidc.util.ts
+++ b/src/app/modules/spcp/spcp.oidc.util.ts
@@ -46,7 +46,7 @@ export const retryPromiseThreeAttempts = <T>(
           },
         })
         return result
-      } catch (e) {
+      } catch (e: any) {
         logger.warn({
           message: 'Promise rejected',
           meta: {
@@ -54,7 +54,11 @@ export const retryPromiseThreeAttempts = <T>(
             promise: promiseName,
             attemptNo,
           },
-          error: e,
+          error: {
+            message: e.message,
+            stack: e.stack,
+            code: e.code,
+          },
         })
         return retry(e)
       }
@@ -102,7 +106,7 @@ export const retryPromiseForever = <T>(
           },
         })
         return result
-      } catch (e) {
+      } catch (e: any) {
         logger.warn({
           message: 'Promise rejected',
           meta: {
@@ -110,7 +114,11 @@ export const retryPromiseForever = <T>(
             promise: promiseName,
             attemptNo,
           },
-          error: e,
+          error: {
+            message: e.message,
+            stack: e.stack,
+            code: e.code,
+          },
         })
         return retry(e)
       }

--- a/src/app/modules/spcp/spcp.oidc.util.ts
+++ b/src/app/modules/spcp/spcp.oidc.util.ts
@@ -55,9 +55,9 @@ export const retryPromiseThreeAttempts = <T>(
             attemptNo,
           },
           error: {
-            message: e.message,
-            stack: e.stack,
-            code: e.code,
+            message: e?.message,
+            stack: e?.stack,
+            code: e?.code,
           },
         })
         return retry(e)
@@ -115,9 +115,9 @@ export const retryPromiseForever = <T>(
             attemptNo,
           },
           error: {
-            message: e.message,
-            stack: e.stack,
-            code: e.code,
+            message: e?.message,
+            stack: e?.stack,
+            code: e?.code,
           },
         })
         return retry(e)


### PR DESCRIPTION
## Problem
- We use `promise-retry` to refresh ahead for our cached ndi jwks key
- If the promise fails, `promise-retry` throws the entire retryable promise, and not just the error
- This PR adjusts the logger so that only error information is logged on exception