### PR TITLE
fix: payment email missing in BE

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -15,6 +15,7 @@ import { differenceInMilliseconds, isPast } from 'date-fns'
 import get from 'lodash/get'
 import simplur from 'simplur'
 
+import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
 import {
   FormAuthType,
   FormResponseMode,
@@ -199,9 +200,12 @@ export const PublicFormProvider = ({
   const navigate = useNavigate()
   const [, storePaymentMemory] = useBrowserStm(formId)
   const handleSubmitForm: SubmitHandler<
-    FormFieldValues & { payment_receipt_email_field?: { value: string } }
+    FormFieldValues & { [PAYMENT_CONTACT_FIELD_ID]?: { value: string } }
   > = useCallback(
-    async ({ payment_receipt_email_field, ...formInputs }) => {
+    async ({
+      [PAYMENT_CONTACT_FIELD_ID]: paymentReceiptEmailField,
+      ...formInputs
+    }) => {
       const { form } = data ?? {}
       if (!form) return
 
@@ -335,7 +339,7 @@ export const PublicFormProvider = ({
                   ...formData,
                   publicKey: form.publicKey,
                   captchaResponse,
-                  paymentReceiptEmail: payment_receipt_email_field?.value,
+                  paymentReceiptEmail: paymentReceiptEmailField?.value,
                 },
                 {
                   onSuccess: ({
@@ -394,7 +398,7 @@ export const PublicFormProvider = ({
                     ...formData,
                     publicKey: form.publicKey,
                     captchaResponse,
-                    paymentReceiptEmail: payment_receipt_email_field?.value,
+                    paymentReceiptEmail: paymentReceiptEmailField?.value,
                   },
                   {
                     onSuccess: ({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
BE strictly requires payment email field. However, FE wasn't able to reference the correct schema ID, resulting in the error of `Error when creating payment: payment receipt email not provided` on the BE as the field, referenced by BE, `paymentReceiptEmail` is now empty.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- fix to reference `const PAYMENT_CONTACT_FIELD_ID` when extracting the field in `PublicFormProvider` on FE

**Tests**
- [ ] check if FE is passing the correct field to be BE
  - [ ] able to reach payment page successfully