### PR TITLE
chore: make hsts header follow recommendation from csa

### DIFF
--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -122,7 +122,7 @@ describe('helmetMiddlewares', () => {
     if (hstsFn) {
       hstsFn(mockReq, mockRes, mockNext)
     }
-    expect(mockHelmet.hsts).toHaveBeenCalledWith({ maxAge: 5184000 })
+    expect(mockHelmet.hsts).toHaveBeenCalledWith({ maxAge: 400 * 24 * 60 * 60 }) // 400 days
     expect(mockNext).not.toHaveBeenCalled()
   })
 

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -9,7 +9,7 @@ const helmetMiddlewares = () => {
   // Only add the "Strict-Transport-Security" header if request is https.
   const hstsMiddleware: RequestHandler = (req, res, next) => {
     if (req.secure) {
-      helmet.hsts({ maxAge: 5184000 })(req, res, next) // 60 days
+      helmet.hsts({ maxAge: 400 * 24 * 60 * 60 })(req, res, next) // 400 days
     } else next()
   }
 


### PR DESCRIPTION
## Problem
We want to increase our domain score on CSA: https://ihp.csa.gov.sg/home

form.gov.sg is failing the HSTS check because our header `Strict-Transport-Security` has a max-age of 60 days instead of the recommendation of >= 1 year.

## Solution
Extend `max-age` of `Strict-Transport-Security` header to 400 days, to be greater than a year.

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

