### PR TITLE
fix: update payment page to include submission ID

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
@@ -72,9 +72,8 @@ const StripePaymentContainer = ({
   paymentInfoData: GetPaymentInfoDto
   stripe: Stripe
 }) => {
-  const { formId, paymentId } = useParams()
+  const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
-  if (!paymentId) throw new Error('No paymentId provided')
 
   const [refetchKey, setRefetchKey] = useState<number>(0)
   const { data } = useGetPaymentStatusFromStripe({
@@ -90,7 +89,7 @@ const StripePaymentContainer = ({
       return (
         <PaymentBox>
           <CreatePaymentIntentFailureBlock
-            submissionId={paymentId}
+            submissionId={paymentInfoData.submissionId}
             paymentClientSecret={paymentInfoData.client_secret}
             publishableKey={paymentInfoData.publishableKey}
           />
@@ -107,7 +106,7 @@ const StripePaymentContainer = ({
       return (
         <PaymentBox>
           <StripePaymentBlock
-            submissionId={paymentId}
+            submissionId={paymentInfoData.submissionId}
             paymentClientSecret={paymentInfoData.client_secret}
             publishableKey={paymentInfoData.publishableKey}
             triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
@@ -119,7 +118,10 @@ const StripePaymentContainer = ({
         <>
           <PaymentSuccessSvgr maxW="100%" />
           <PaymentBox>
-            <StripeReceiptContainer formId={formId} paymentId={paymentId} />
+            <StripeReceiptContainer
+              formId={formId}
+              paymentId={paymentInfoData.submissionId}
+            />
           </PaymentBox>
         </>
       )

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -59,4 +59,5 @@ export type GetPaymentInfoDto = {
   client_secret: string
   publishableKey: string
   payment_intent_id: string
+  submissionId: string
 }

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -578,6 +578,7 @@ export const getPaymentInfo: ControllerHandler<
               client_secret: paymentIntent.client_secret || '',
               publishableKey: form.payments_channel?.publishable_key ?? '',
               payment_intent_id: payment.paymentIntentId,
+              submissionId: payment.pendingSubmissionId,
             })
           })
         })


### PR DESCRIPTION
## Problem
The payment page now contains the payment ID. This PR allows the submission ID to be shown.

## Solution

Pass submission id to the frontend in getData. Use it instead of the original payment id.

**Breaking Changes** 
- No - this PR is backwards compatible  
