### PR TITLE
fix: update payment page to include submission ID

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
@@ -51,8 +51,9 @@ const StripePaymentContainer = ({
 }: {
   paymentInfoData: GetPaymentInfoDto
 }) => {
-  const { formId } = useParams()
+  const { formId, paymentId } = useParams()
   if (!formId) throw new Error('No formId provided')
+  if (!paymentId) throw new Error('No paymentId provided')
 
   const stripe = useStripe()
   if (!stripe) throw Promise.reject('Stripe is not ready')
@@ -115,7 +116,8 @@ const StripePaymentContainer = ({
             <PaymentSuccessSvgr maxW="100%" />
             <StripeReceiptContainer
               formId={formId}
-              paymentId={paymentInfoData.submissionId}
+              paymentId={paymentId}
+              submissionId={paymentInfoData.submissionId}
             />
           </>
         )

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeElementWrapper.tsx
@@ -51,9 +51,8 @@ const StripePaymentContainer = ({
 }: {
   paymentInfoData: GetPaymentInfoDto
 }) => {
-  const { formId, paymentId } = useParams()
+  const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
-  if (!paymentId) throw new Error('No paymentId provided')
 
   const stripe = useStripe()
   if (!stripe) throw Promise.reject('Stripe is not ready')
@@ -73,7 +72,7 @@ const StripePaymentContainer = ({
         return (
           <PaymentStack>
             <CreatePaymentIntentFailureBlock
-              submissionId={paymentId}
+              submissionId={paymentInfoData.submissionId}
               paymentClientSecret={paymentInfoData.client_secret}
               publishableKey={paymentInfoData.publishableKey}
             />
@@ -83,7 +82,7 @@ const StripePaymentContainer = ({
         return (
           <PaymentStack>
             <GenericMessageBlock
-              paymentId={paymentId}
+              submissionId={paymentInfoData.submissionId}
               title="Payment request was canceled."
               subtitle="The payment request has been canceled. If any payment has been completed, the payment will be refunded."
             />
@@ -93,7 +92,7 @@ const StripePaymentContainer = ({
         return (
           <PaymentStack>
             <StripePaymentBlock
-              submissionId={paymentId}
+              submissionId={paymentInfoData.submissionId}
               paymentClientSecret={paymentInfoData.client_secret}
               publishableKey={paymentInfoData.publishableKey}
               triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
@@ -104,7 +103,7 @@ const StripePaymentContainer = ({
         return (
           <PaymentStack>
             <GenericMessageBlock
-              paymentId={paymentId}
+              submissionId={paymentInfoData.submissionId}
               title="Stripe is still processing your payment."
               subtitle="Hold tight, your payment is still being processed by stripe."
             />
@@ -114,7 +113,10 @@ const StripePaymentContainer = ({
         return (
           <>
             <PaymentSuccessSvgr maxW="100%" />
-            <StripeReceiptContainer formId={formId} paymentId={paymentId} />
+            <StripeReceiptContainer
+              formId={formId}
+              paymentId={paymentInfoData.submissionId}
+            />
           </>
         )
       default: {

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -17,14 +17,16 @@ import {
 
 export const StripeReceiptContainer = ({
   formId,
+  submissionId,
   paymentId,
 }: {
   formId: string
+  submissionId: string
   paymentId: string
 }) => {
   const { data, isLoading, error } = useGetPaymentReceiptStatus(
     formId,
-    paymentId,
+    submissionId,
   )
 
   const toast = useToast()
@@ -32,7 +34,7 @@ export const StripeReceiptContainer = ({
 
   const { submitFormFeedbackMutation } = usePublicFormMutations(
     formId,
-    paymentId,
+    submissionId,
   )
 
   const handleSubmitFeedback = useCallback(
@@ -57,7 +59,7 @@ export const StripeReceiptContainer = ({
         <GenericMessageBlock
           title="Your payment has been received."
           subtitle="We are confirming your payment with Stripe. You may come back to the same link to download your receipt later."
-          paymentId={paymentId}
+          submissionId={submissionId}
         />
       </PaymentStack>
     )
@@ -67,7 +69,11 @@ export const StripeReceiptContainer = ({
      * PaymentStack is explictly added in this component due to https://github.com/chakra-ui/chakra-ui/issues/6757
      */
     <PaymentStack>
-      <DownloadReceiptBlock formId={formId} paymentId={paymentId} />
+      <DownloadReceiptBlock
+        formId={formId}
+        submissionId={submissionId}
+        paymentId={paymentId}
+      />
       {!isFeedbackSubmitted && (
         <FeedbackBlock onSubmit={handleSubmitFeedback} />
       )}

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -17,14 +17,16 @@ import {
 
 export const StripeReceiptContainer = ({
   formId,
+  submissionId,
   paymentId,
 }: {
   formId: string
+  submissionId: string
   paymentId: string
 }) => {
   const { data, isLoading, error } = useGetPaymentReceiptStatus(
     formId,
-    paymentId,
+    submissionId,
   )
 
   const toast = useToast()
@@ -32,7 +34,7 @@ export const StripeReceiptContainer = ({
 
   const { submitFormFeedbackMutation } = usePublicFormMutations(
     formId,
-    paymentId,
+    submissionId,
   )
 
   const handleSubmitFeedback = useCallback(
@@ -57,7 +59,7 @@ export const StripeReceiptContainer = ({
         <GenericMessageBlock
           title="Your payment has been received."
           subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your receipt later."
-          paymentId={paymentId}
+          submissionId={submissionId}
         />
       </PaymentStack>
     )
@@ -67,7 +69,11 @@ export const StripeReceiptContainer = ({
      * PaymentStack is explictly added in this component due to https://github.com/chakra-ui/chakra-ui/issues/6757
      */
     <PaymentStack>
-      <DownloadReceiptBlock formId={formId} paymentId={paymentId} />
+      <DownloadReceiptBlock
+        formId={formId}
+        submissionId={submissionId}
+        paymentId={paymentId}
+      />
       {!isFeedbackSubmitted && (
         <FeedbackBlock onSubmit={handleSubmitFeedback} />
       )}

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -12,11 +12,13 @@ import { GenericMessageBlock } from './GenericMessageBlock'
 
 type DownloadReceiptBlockProps = {
   formId: string
+  submissionId: string
   paymentId: string
 }
 
 export const DownloadReceiptBlock = ({
   formId,
+  submissionId,
   paymentId,
 }: DownloadReceiptBlockProps) => {
   const toast = useToast({ status: 'success', isClosable: true })
@@ -38,7 +40,7 @@ export const DownloadReceiptBlock = ({
     <GenericMessageBlock
       title={'Your payment has been made successfully.'}
       subtitle={'Your form has been submitted and payment has been made.'}
-      paymentId={paymentId}
+      submissionId={submissionId}
     >
       <>
         <Button

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/GenericMessageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/GenericMessageBlock.tsx
@@ -1,13 +1,13 @@
 import { Box, Stack, Text } from '@chakra-ui/react'
 
 type StripePaymentGenericMessageBlockProps = {
-  paymentId: string
+  submissionId: string
   title: string
   subtitle?: string
   children?: JSX.Element
 }
 export const GenericMessageBlock = ({
-  paymentId,
+  submissionId,
   title,
   subtitle,
   children,
@@ -23,7 +23,7 @@ export const GenericMessageBlock = ({
         </Text>
       </Stack>
       <Text textColor="secondary.300" mt="2rem">
-        Response ID: {paymentId}
+        Response ID: {submissionId}
       </Text>
       {children}
     </Box>

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -59,4 +59,5 @@ export type GetPaymentInfoDto = {
   client_secret: string
   publishableKey: string
   payment_intent_id: string
+  submissionId: string
 }

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -578,6 +578,7 @@ export const getPaymentInfo: ControllerHandler<
               client_secret: paymentIntent.client_secret || '',
               publishableKey: form.payments_channel?.publishable_key ?? '',
               payment_intent_id: payment.paymentIntentId,
+              submissionId: payment.pendingSubmissionId,
             })
           })
         })

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -585,6 +585,7 @@ export const getPaymentInfo: ControllerHandler<
               client_secret: paymentIntent.client_secret || '',
               publishableKey: form.payments_channel?.publishable_key ?? '',
               payment_intent_id: payment.paymentIntentId,
+              submissionId: payment.pendingSubmissionId,
             })
           })
         })


### PR DESCRIPTION
## Problem
The payment page now contains the payment ID. This PR allows the submission ID to be shown.

## Solution

Pass submission id to the frontend in getData. Use it instead of the original payment id.

**Breaking Changes** 
- No - this PR is backwards compatible  
