### PR TITLE
feat: track nodejs runtime metrics in APM

### DIFF
--- a/src/app/loaders/datadog-tracer.ts
+++ b/src/app/loaders/datadog-tracer.ts
@@ -2,6 +2,7 @@ import tracer from 'dd-trace'
 
 tracer.init({
   logInjection: true, // https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/
+  runtimeMetrics: true, // https://datadoghq.dev/dd-trace-js/interfaces/traceroptions.html#runtimemetrics
 })
 
 // setup express to not track middlewares as spans


### PR DESCRIPTION
## Problem
We have no visibility of the health of the nodejs process. We track CPU and memory for the hosts, but we should also have data about the health of the runtime, like garbage collection cycles and lock times, and delay in the event loop.

Turns our `dd-trace` supports reporting these metrics out of the box (see [doc](https://datadoghq.dev/dd-trace-js/interfaces/traceroptions.html#runtimemetrics)), so this PR turns that on.


## Solution
Enable `runtimeMetrics` in the `tracer.init()` call.

**Breaking Changes** 
considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

## Risk
There could be an increase in CPU load for `dd-trace` to track and report metrics.


## Tests
- [ ] Go to the APM FormSG service page in DataDog, enter the tab `Node.JS Runtime Metrics` and verify data is being reported
- [ ] Check graphs for CPU load after release, to verify we are still in acceptable range

