### PR TITLE
fix: invoice download 502

### DIFF
--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -349,7 +349,11 @@ export const downloadPaymentInvoice: ControllerHandler<{
               .business
 
             // we will still continute the invoice generation even if there's no address/gstregno
-            if (!businessInfo.address || !businessInfo.gstRegNo)
+            if (
+              !businessInfo ||
+              !businessInfo.address ||
+              !businessInfo.gstRegNo
+            )
               logger.warn({
                 message:
                   'Some business info not available during invoice generation',
@@ -361,8 +365,8 @@ export const downloadPaymentInvoice: ControllerHandler<{
                 },
               })
             const invoiceHtml = convertToInvoiceForrmat(html, {
-              address: businessInfo.address || '',
-              gstRegNo: businessInfo.gstRegNo || '',
+              address: businessInfo?.address || '',
+              gstRegNo: businessInfo?.gstRegNo || '',
             })
 
             const pdfBufferPromise = generatePdfFromHtml(invoiceHtml)

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -8,6 +8,8 @@ import mongoose from 'mongoose'
 import { errAsync, ok, Result, ResultAsync } from 'neverthrow'
 import Stripe from 'stripe'
 
+import { IPopulatedForm } from 'src/types'
+
 import { ErrorDto, GetPaymentInfoDto } from '../../../../shared/types'
 import config from '../../config/config'
 import { paymentConfig } from '../../config/features/payment.config'
@@ -343,7 +345,8 @@ export const downloadPaymentInvoice: ControllerHandler<{
           // convert to pdf and return
           .then((receiptUrlResponse) => {
             const html = receiptUrlResponse.data
-            const businessInfo = populatedForm.admin.agency.business
+            const businessInfo = (populatedForm as IPopulatedForm).admin.agency
+              .business
 
             // we will still continute the invoice generation even if there's no address/gstregno
             if (!businessInfo.address || !businessInfo.gstRegNo)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Upon clicking invoice download, users will be brought to see a page with `bad gateway`.

This was due to the server throwing an error
As the users are directed to an API endpoint, they will see 502.

## Solution
<!-- How did you solve the problem? -->
1. On TS, I've added the an explicit type to ensure that it is mapped correctly (not sure why `IPopulatedEncryptedForm` will cause `admin` to be untyped.

2. With the TS now able to rightly determine that `agency.businessInfo` can be undefined, the rest of the references are null checked with the existence of `businessInfo`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
- [] test that invoice can be downloaded (with your work email, ensure that `agency.businessInfo` is updated on db)