### PR TITLE
feat: disable description and amount fields for admin when the payment field is disabled

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -49,14 +49,6 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 }).format
-/**
- * Description in payment field will be rendered as 'Name' in the Frontend, but kept as description in the backend
- * This is for design purpose as 'Name' conveys clearer information to the users,
- * Whilst description will still be used in the backend for consistency with Stripe's API
- */
-const NAME_INFORMATION = 'Name will be reflected on payment receipt'
-const ENABLE_PAYMENT_INFORMATION =
-  'Payment field will not be shown when this is toggled off. Respondents can still submit the form.'
 
 export const PaymentInput = ({
   isDisabled,
@@ -205,8 +197,8 @@ export const PaymentInput = ({
             // Retrigger validation to remove errors when payment is toggled from enabled -> disabled
             onChange: () => paymentIsEnabled && trigger(),
           })}
-          description={ENABLE_PAYMENT_INFORMATION}
-          label="Enable Payment"
+          description="Payment field will not be shown when this is toggled off. Respondents can still submit the form."
+          label="Enable payment"
         />
       </FormControl>
       <FormControl
@@ -215,8 +207,11 @@ export const PaymentInput = ({
         isDisabled={!paymentIsEnabled}
         isRequired
       >
-        <FormLabel description={NAME_INFORMATION}>Name</FormLabel>
+        <FormLabel description="This will be reflected on the payment receipt">
+          Product/service name
+        </FormLabel>
         <Input
+          placeholder="Product/service name"
           {...register('description', {
             required: paymentIsEnabled && 'Please enter a payment description',
           })}
@@ -229,7 +224,7 @@ export const PaymentInput = ({
         isDisabled={!paymentIsEnabled}
         isRequired
       >
-        <FormLabel isRequired>Payment Amount</FormLabel>
+        <FormLabel isRequired>Payment amount</FormLabel>
         <Controller
           name="display_amount"
           control={control}

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -98,6 +98,7 @@ const PAYMENTS_DEFAULTS = {
   payments_field: {
     enabled: false,
     description: '',
+    amount_cents: 0,
   },
 }
 
@@ -793,7 +794,7 @@ describe('Form Model', () => {
 
         // Assert
         await expect(invalidForm.save()).rejects.toThrow(
-          'Payment amount must be at least 50 cents and an integer.',
+          'amount_cents must be a non-negative integer.',
         )
       })
 
@@ -812,26 +813,7 @@ describe('Form Model', () => {
 
         // Assert
         await expect(invalidForm.save()).rejects.toThrow(
-          'Payment amount must be at least 50 cents and an integer.',
-        )
-      })
-
-      it('should reject when amount is less than 50', async () => {
-        // Arrange
-        const invalidFormParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-          payments_field: {
-            enabled: true,
-            amount_cents: 49,
-            description: 'some payment',
-          },
-        })
-
-        // Act
-        const invalidForm = new Form(invalidFormParams)
-
-        // Assert
-        await expect(invalidForm.save()).rejects.toThrow(
-          'Payment amount must be at least 50 cents and an integer.',
+          'amount_cents must be a non-negative integer.',
         )
       })
     })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -169,7 +169,7 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
         validator: (amount_cents: number) => {
           return amount_cents >= 0 && Number.isInteger(amount_cents)
         },
-        message: 'Payment amount must be a non-negative integer',
+        message: 'amount_cents must be a non-negative integer.',
       },
     },
   },

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -164,12 +164,7 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
     },
     amount_cents: {
       type: Number,
-      validate: {
-        validator: (amount_cents: number) => {
-          return amount_cents >= 50 && Number.isInteger(amount_cents)
-        },
-        message: 'Payment amount must be at least 50 cents and an integer.',
-      },
+      default: 0,
     },
   },
 })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -165,6 +165,12 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
     amount_cents: {
       type: Number,
       default: 0,
+      validate: {
+        validator: (amount_cents: number) => {
+          return amount_cents >= 0 && Number.isInteger(amount_cents)
+        },
+        message: 'Payment amount must be a non-negative integer',
+      },
     },
   },
 })

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -253,8 +253,16 @@ export const handleUpdatePayments = [
   celebrate({
     [Segments.BODY]: {
       enabled: Joi.boolean().required(),
-      amount_cents: Joi.number().integer().positive().required(),
-      description: Joi.string().required(),
+      amount_cents: Joi.when('enabled', {
+        is: Joi.equal(true),
+        then: Joi.number().integer().positive().required(),
+        otherwise: Joi.number().integer(),
+      }),
+      description: Joi.when('enabled', {
+        is: Joi.equal(true),
+        then: Joi.string().required(),
+        otherwise: Joi.string().allow(''),
+      }),
     },
   }),
   _handleUpdatePayments,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1577,10 +1577,10 @@ export const updatePayments = (
   IEncryptedFormDocument['payments_field'],
   PossibleDatabaseError | FormNotFoundError | InvalidPaymentAmountError
 > => {
-  const { amount_cents } = newPayments
+  const { enabled, amount_cents } = newPayments
 
-  // Check if payment amount exceeds maxPaymentAmountCents or below minPaymentAmountCents
-  if (amount_cents) {
+  // Check if payment amount exceeds maxPaymentAmountCents or below minPaymentAmountCents if the payment is enabled
+  if (enabled && amount_cents !== undefined) {
     if (
       amount_cents > paymentConfig.maxPaymentAmountCents ||
       amount_cents < paymentConfig.minPaymentAmountCents


### PR DESCRIPTION
## Problem
We want to disable the `description` and `amount_cents` field in the payment drawer when the payment field is disabled.

## Solution
Currently, our middlewares block empty `description`s and zero `amount_cents`. This validation has to be relaxed, so that it is only triggered when `enabled` is `true`. Also, remove model-layer validation on `amount_cents` and make it a controller validation instead.

**Breaking Changes** 
- No - this PR is backwards compatible  
