### PR TITLE
fix: update payment received subtitle copy

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -56,7 +56,7 @@ export const StripeReceiptContainer = ({
       <PaymentStack>
         <GenericMessageBlock
           title="Your payment has been received."
-          subtitle="We are confirming your payment with Stripe. You may come back to the same link to download your receipt later."
+          subtitle="We are waiting to get your proof of payment from our payment provider."
           paymentId={paymentId}
         />
       </PaymentStack>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -56,7 +56,7 @@ export const StripeReceiptContainer = ({
       <PaymentStack>
         <GenericMessageBlock
           title="Your payment has been received."
-          subtitle="We are waiting to get your proof of payment from our payment provider."
+          subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your receipt later."
           paymentId={paymentId}
         />
       </PaymentStack>


### PR DESCRIPTION
## Solution
<!-- How did you solve the problem? -->
We want to update the copy for the message block that appears when a payment has been received 

## Before & After Screenshots

**AFTER**:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/56983748/232983158-d5736f4f-6719-4445-86c7-2bd3adc4719b.png">

