### PR TITLE
fix: convert from seconds to miliseconds from epoch when saving Stripe dates

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -493,10 +493,8 @@ describe('stripe.service', () => {
       const updatedPayment = await Payment.findById(payment.id)
       expect(updatedPayment).toBeTruthy()
 
+      expect(updatedPayment!.payout).toBeTruthy()
       expect(updatedPayment!.payout?.payoutId).toEqual(payout.id)
-      expect(updatedPayment!.payout?.payoutDate).toEqual(
-        new Date(payout.arrival_date),
-      )
     })
 
     it('should remove the payout details when a payout.cancelled event is received', async () => {
@@ -516,7 +514,7 @@ describe('stripe.service', () => {
           ],
           status: PaymentStatus.Succeeded,
           payout: {
-            payoutDate: new Date(payoutCreated.arrival_date),
+            payoutDate: new Date(payoutCreated.arrival_date * 1000),
             payoutId: payoutCreated.id,
           },
         },

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -127,7 +127,7 @@ const confirmStripePaymentPendingSubmission = (
         .andThen((transactionFee) =>
           PaymentsService.confirmPaymentPendingSubmission(
             payment.id,
-            new Date(event.created),
+            new Date(event.created * 1000), // Convert to miliseconds from epoch
             receiptUrl,
             transactionFee,
           ),

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -281,7 +281,7 @@ const payoutStateReducer = (
       // Once created, we know it will happen, so update the payout
       return {
         payoutId: event.data.object.id,
-        payoutDate: new Date(event.data.object.arrival_date),
+        payoutDate: new Date(event.data.object.arrival_date * 1000), // Convert to miliseconds from epoch
       }
     case 'payout.canceled':
     case 'payout.failed':


### PR DESCRIPTION
## Problem
Dates are not appearing correctly on the individual response page because they are not being saved correctly in the DB in the first place. This was because Stripe is sending timestamps in s from epoch, and we did not convert them to ms from epoch.

## Solution
Convert Stripe dates to ms from epoch by `* 1000` before using the `Date` constructor on them.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

<img width="514" alt="image" src="https://user-images.githubusercontent.com/25571626/232984147-bcabb9c4-da82-46c3-b3db-afabc648ea44.png">
