### PR TITLE
fix: check form error on first proceed to pay

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -95,6 +95,7 @@ export const FormFields = ({
   const {
     reset,
     formState: { isDirty },
+    trigger,
   } = formMethods
 
   // Reset default values when they change
@@ -143,6 +144,7 @@ export const FormFields = ({
           formFields={augmentedFormFields}
           formLogics={formLogics}
           colorTheme={colorTheme}
+          trigger={trigger}
         />
       </form>
     </FormProvider>

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler, useMemo } from 'react'
-import { useFormState, useWatch } from 'react-hook-form'
+import { useFormState, UseFormTrigger, useWatch } from 'react-hook-form'
 import { Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 
 import {
@@ -25,6 +25,7 @@ interface PublicFormSubmitButtonProps {
   formLogics: LogicDto[]
   colorTheme: string
   onSubmit: MouseEventHandler<HTMLButtonElement> | undefined
+  trigger: UseFormTrigger<FormFieldValues>
 }
 
 /**
@@ -36,6 +37,7 @@ export const PublicFormSubmitButton = ({
   formLogics,
   colorTheme,
   onSubmit,
+  trigger,
 }: PublicFormSubmitButtonProps): JSX.Element => {
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
@@ -52,6 +54,11 @@ export const PublicFormSubmitButton = ({
 
   // For payments submit and pay modal
   const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: false })
+
+  const checkBeforeOpen = async () => {
+    const result = await trigger()
+    if (result) onOpen()
+  }
 
   const isPaymentEnabled =
     form?.responseMode === FormResponseMode.Encrypt &&
@@ -74,7 +81,7 @@ export const PublicFormSubmitButton = ({
         isLoading={isSubmitting}
         isDisabled={!!preventSubmissionLogic || !onSubmit}
         loadingText="Submitting"
-        onClick={isPaymentEnabled ? onOpen : onSubmit}
+        onClick={isPaymentEnabled ? checkBeforeOpen : onSubmit}
       >
         <VisuallyHidden>End of form.</VisuallyHidden>
         {preventSubmissionLogic


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
On payment forms, form only highlights invalid form inputs to users after they click the second "proceed to pay". This is inconvenient for the user to close the modal to figure out what is wrong.

## Solution
<!-- How did you solve the problem? -->
Validate form fields when first "proceed to pay" is clicked. If no errors are flagged, open the modal.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? 
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/37061143/233023146-65afb34c-cc3c-4cb2-b871-117312d7b334.mov

**AFTER**:

https://user-images.githubusercontent.com/37061143/233022938-1ba56b1e-bb25-4f5c-a506-79a90d0fbf79.mov

## Tests
<!-- What tests should be run to confirm functionality? -->
Test that payment form submission is stopped at the first "proceed to pay"
- [ ] Create a form
- [ ] Enable payment on the form
- [ ] Add at least a required field in the form
- [ ] Without filling in anything, click "proceed to pay". The required fields should be highlighted and modal should not appear.
- [ ] Refresh the page. Fill in the required forms in the normal form. Click "proceed to pay". The payment contact field should be highlighted and modal should not appear.
- [ ] Refresh the page. Fill in the payment contact email field and verify the email. Click "proceed to pay". The required form fields should be highlighted and modal should not appear.
- [ ] Fill in all the required fields. Click "proceed to pay". The payment modal should show up. After clicking the "proceed to pay" in the modal, user should proceed to payment page and be able to complete payment.
