### PR TITLE
feat: send payment confirmation email with payment invoice

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -1,11 +1,12 @@
 import { BiDownload } from 'react-icons/bi'
 
-import { getPaymentInvoiceDownloadUrl } from '~shared/utils/urls'
-
 import { useToast } from '~hooks/useToast'
 import Button from '~components/Button'
 
-import { getPaymentReceiptDownloadUrl } from '~features/public-form/utils/urls'
+import {
+  getPaymentInvoiceDownloadUrl,
+  getPaymentReceiptDownloadUrl,
+} from '~features/public-form/utils/urls'
 
 import { GenericMessageBlock } from './GenericMessageBlock'
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -1,12 +1,11 @@
 import { BiDownload } from 'react-icons/bi'
 
+import { getPaymentInvoiceDownloadUrl } from '~shared/utils/urls'
+
 import { useToast } from '~hooks/useToast'
 import Button from '~components/Button'
 
-import {
-  getPaymentInvoiceDownloadUrl,
-  getPaymentReceiptDownloadUrl,
-} from '~features/public-form/utils/urls'
+import { getPaymentReceiptDownloadUrl } from '~features/public-form/utils/urls'
 
 import { GenericMessageBlock } from './GenericMessageBlock'
 

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -10,10 +10,3 @@ export const getPaymentReceiptDownloadUrl = (
 ) => {
   return `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download` as const
 }
-
-export const getPaymentInvoiceDownloadUrl = (
-  formId: string,
-  paymentId: string,
-) => {
-  return `${API_BASE_URL}/payments/${formId}/${paymentId}/invoice/download` as const
-}

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -1,3 +1,5 @@
+import { getPaymentInvoiceDownloadUrlPath } from '~shared/utils/urls'
+
 import { API_BASE_URL } from '~services/ApiService'
 
 export const getPaymentPageUrl = (formId: string, paymentId: string) => {
@@ -9,4 +11,11 @@ export const getPaymentReceiptDownloadUrl = (
   paymentId: string,
 ) => {
   return `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download` as const
+}
+
+export const getPaymentInvoiceDownloadUrl = (
+  formId: string,
+  paymentId: string,
+) => {
+  return `${API_BASE_URL}/${getPaymentInvoiceDownloadUrlPath}` as const
 }

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -17,5 +17,8 @@ export const getPaymentInvoiceDownloadUrl = (
   formId: string,
   paymentId: string,
 ) => {
-  return `${API_BASE_URL}/${getPaymentInvoiceDownloadUrlPath}` as const
+  return `${API_BASE_URL}/${getPaymentInvoiceDownloadUrlPath(
+    formId,
+    paymentId,
+  )}` as const
 }

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -1,0 +1,6 @@
+export const getPaymentInvoiceDownloadUrl = (
+  formId: string,
+  paymentId: string,
+) => {
+  return `${process.env.appUrl}/api/v3/payments/${formId}/${paymentId}/invoice/download` as const
+}

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -1,6 +1,6 @@
-export const getPaymentInvoiceDownloadUrl = (
+export const getPaymentInvoiceDownloadUrlPath = (
   formId: string,
   paymentId: string,
 ) => {
-  return `${process.env.appUrl}/api/v3/payments/${formId}/${paymentId}/invoice/download` as const
+  return `payments/${formId}/${paymentId}/invoice/download` as const
 }

--- a/src/app/modules/payments/payments.errors.ts
+++ b/src/app/modules/payments/payments.errors.ts
@@ -12,6 +12,12 @@ export class PaymentNotFoundError extends ApplicationError {
   }
 }
 
+export class ConfirmedPaymentNotFoundError extends ApplicationError {
+  constructor(message = 'Confirmed payment not found') {
+    super(message)
+  }
+}
+
 export class PaymentAlreadyConfirmedError extends ApplicationError {
   constructor(message = 'Payment has already been confirmed') {
     super(message)

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -5,14 +5,18 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
+import MailService from '../../services/mail/mail.service'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
 import { DatabaseError } from '../core/core.errors'
+import { retrieveFormById } from '../form/form.service'
 import { performEncryptPostSubmissionActions } from '../submission/encrypt-submission/encrypt-submission.service'
 import { isSubmissionEncryptMode } from '../submission/encrypt-submission/encrypt-submission.utils'
 import { PendingSubmissionNotFoundError } from '../submission/submission.errors'
 import * as SubmissionService from '../submission/submission.service'
+import { findSubmissionById } from '../submission/submission.service'
 
 import {
+  ConfirmedPaymentNotFoundError,
   PaymentAlreadyConfirmedError,
   PaymentNotFoundError,
 } from './payments.errors'
@@ -275,4 +279,59 @@ export const confirmPaymentPendingSubmission = (
         }),
       )
   )
+}
+
+/**
+ * This function sends a payment confirmation email
+ * @param paymentId
+ */
+export const sendPaymentConfirmationEmailByPaymentId = (
+  paymentId: IPaymentSchema['_id'],
+): ResultAsync<true, ConfirmedPaymentNotFoundError> => {
+  const logMeta = {
+    action: 'sendPaymentConfirmationEmail',
+    paymentId,
+  }
+
+  // Step 1: Find payment object
+  return findPaymentById(paymentId)
+    .map((payment) => ({
+      submissionId: payment.completedPayment?.submissionId,
+      recipient: payment.email,
+    }))
+    .andThen(({ submissionId, recipient }) => {
+      if (!submissionId) {
+        logger.warn({
+          message: 'Submission ID from completed payment could not be found',
+          meta: logMeta,
+        })
+        return errAsync(new ConfirmedPaymentNotFoundError())
+      }
+      // Step 2: Find submission document
+      return (
+        findSubmissionById(submissionId)
+          // Step 3: Find form document
+          .andThen((submission) => retrieveFormById(submission.form))
+          .map((form) => ({
+            formTitle: form.title,
+            formId: form.id,
+            responseId: submissionId,
+            recipient,
+          }))
+      )
+    })
+    .andThen(({ formTitle, formId, responseId, recipient }) => {
+      logger.info({
+        message: 'sendPaymentConfirmationEmail',
+        meta: logMeta,
+      })
+      // Step 4: Send payment confirmation email
+      return MailService.sendPaymentConfirmationEmail({
+        recipient,
+        formTitle,
+        responseId,
+        formId,
+        paymentId,
+      })
+    })
 }

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -314,7 +314,7 @@ export const sendPaymentConfirmationEmailByPaymentId = (
           .andThen((submission) => retrieveFormById(submission.form))
           .map((form) => ({
             formTitle: form.title,
-            formId: form.id,
+            formId: form._id,
             responseId: submissionId,
             recipient,
           }))

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -283,7 +283,10 @@ export const confirmPaymentPendingSubmission = (
 
 /**
  * This function sends a payment confirmation email
- * @param paymentId
+ * @param paymentId payment id of the payment that has been completed
+ *
+ * @returns ok(true) if the payment confirmation email has been sent
+ * @returns err(ConfirmedPaymentNotFoundError) if the paymentId does not have a submission ID associated with a completed payment
  */
 export const sendPaymentConfirmationEmailByPaymentId = (
   paymentId: IPaymentSchema['_id'],

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -131,7 +131,7 @@ const _handleStripeEventUpdates: ControllerHandler<
         return StripeService.processStripeEvent(paymentId, event)
       })
 
-      if (result) {
+      if (result.isOk() && event.type === 'charge.succeeded') {
         const mailSent =
           await PaymentService.sendPaymentConfirmationEmailByPaymentId(
             paymentIdForEmail,

--- a/src/app/services/mail/mail.constants.ts
+++ b/src/app/services/mail/mail.constants.ts
@@ -20,4 +20,5 @@ export enum EmailType {
   VerificationOtp = 'Verification OTP',
   EmailConfirmation = 'Email confirmation',
   AdminBounce = 'Admin (bounce notification)',
+  PaymentConfirmation = 'Payment confirmation',
 }

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -46,6 +46,7 @@ import {
   generateAutoreplyPdf,
   generateBounceNotificationHtml,
   generateLoginOtpHtml,
+  generatePaymentConfirmationHtml,
   generateSmsVerificationDisabledHtmlForAdmin,
   generateSmsVerificationDisabledHtmlForCollab,
   generateSmsVerificationWarningHtmlForAdmin,
@@ -777,6 +778,47 @@ export class MailService {
           ),
         ).map(() => true as const)
       })
+  }
+
+  /**
+   * Sends a payment confirmation to a valid email
+   * @param recipient the recipient email address
+   * @param formTitle the form title of the payment form
+   * @param responseId the response ID
+   * @param formId the payment form ID
+   * @param paymentId the payment ID
+   * @throws error if mail fails, to be handled by the caller
+   */
+  sendPaymentConfirmationEmail = ({
+    recipient,
+    formTitle,
+    responseId,
+    formId,
+    paymentId,
+  }: {
+    recipient: string
+    formTitle: string
+    responseId: string
+    formId: string
+    paymentId: string
+  }): ResultAsync<true, MailSendError> => {
+    const mail: MailOptions = {
+      to: recipient,
+      from: this.#senderFromString,
+      subject: `Your payment on ${this.#appName} was successful`,
+      html: generatePaymentConfirmationHtml({
+        appName: this.#appName,
+        formTitle,
+        responseId,
+        invoiceUrl: `${
+          this.#appUrl
+        }/api/v3/payments/${formId}/${paymentId}/invoice/download`,
+      }),
+      headers: {
+        [EMAIL_HEADERS.emailType]: EmailType.PaymentConfirmation,
+      },
+    }
+    return this.#sendNodeMail(mail, { mailId: 'paymentConfirmation' })
   }
 
   // Utility method to send a warning mail to the collaborators of a form.

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -6,7 +6,7 @@ import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
-import { getPaymentInvoiceDownloadUrl } from '../../../../shared/utils/urls'
+import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import {
   HASH_EXPIRE_AFTER_SECONDS,
   stringifiedSmsWarningTiers,
@@ -811,7 +811,10 @@ export class MailService {
         appName: this.#appName,
         formTitle,
         responseId,
-        invoiceUrl: `${getPaymentInvoiceDownloadUrl(formId, paymentId)}`,
+        invoiceUrl: `${this.#appUrl}/api/v3/${getPaymentInvoiceDownloadUrlPath(
+          formId,
+          paymentId,
+        )}`,
       }),
       headers: {
         [EMAIL_HEADERS.emailType]: EmailType.PaymentConfirmation,

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -6,6 +6,7 @@ import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
+import { getPaymentInvoiceDownloadUrl } from '../../../../shared/utils/urls'
 import {
   HASH_EXPIRE_AFTER_SECONDS,
   stringifiedSmsWarningTiers,
@@ -810,9 +811,7 @@ export class MailService {
         appName: this.#appName,
         formTitle,
         responseId,
-        invoiceUrl: `${
-          this.#appUrl
-        }/api/v3/payments/${formId}/${paymentId}/invoice/download`,
+        invoiceUrl: `${getPaymentInvoiceDownloadUrl(formId, paymentId)}`,
       }),
       headers: {
         [EMAIL_HEADERS.emailType]: EmailType.PaymentConfirmation,

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -283,7 +283,7 @@ export const generatePaymentConfirmationHtml = ({
     <p>
       Your payment on ${appName} form: ${formTitle} has been received successfully.
       Your response ID is ${responseId} and your payment invoice can be found 
-      <a href="${invoiceUrl}">here</a>
+      <a href="${invoiceUrl}">here</a>.
     </p>
     <p>Regards,
     <br />

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -266,3 +266,27 @@ export const generateSmsVerificationWarningHtmlForCollab = (
   })
   return safeRenderFile(pathToTemplate, htmlData)
 }
+
+export const generatePaymentConfirmationHtml = ({
+  formTitle,
+  responseId,
+  appName,
+  invoiceUrl,
+}: {
+  formTitle: string
+  responseId: string
+  appName: string
+  invoiceUrl: string
+}): string => {
+  return dedent`
+    <p>Hello there,</p>
+    <p>
+      Your payment on ${appName} form: ${formTitle} has been received successfully.
+      Your response ID is ${responseId} and your payment invoice can be found 
+      <a href="${invoiceUrl}">here</a>
+    </p>
+    <p>Regards,
+    <br />
+    <p>${appName} team</p>   
+  `
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #6053

## Solution
<!-- How did you solve the problem? -->
Send a payment confirmation email to the public form user when a `charge.succeeded` webhook event is received. This email is sent after the Stripe event has been processed.

**Details**
- `sendPaymentConfirmationEmail` in `mail.service.ts` is used to send the payment confirmation email to the user using nodemailer
- `sendPaymentConfirmationEmailByPaymentId` retrieves the form and submission ID using payment ID, and uses these as parameters for `MailService.sendPaymentConfirmationEmail`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
No payment confirmation email was sent.

**AFTER**:
<!-- [insert screenshot here] -->

https://user-images.githubusercontent.com/56983748/233272783-b656355d-c21f-4c5e-bea9-efd69fd0a038.mov

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/56983748/233273575-73737196-298e-4d67-be57-f54c4e96dc40.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
Submit a payment on a payment form. Then,
- [ ] Upon successful payment, you should be able to save the payment invoice on the "Your payment has been made successfully" page.
- [ ] Upon successful payment, you should also receive an email titled `Your payment on FormSG was successful`. The email contents should include the **form title**, **response ID** and a **link to the payment invoice**.
  - [ ] Clicking the link to the payment invoice should download it to your device
