### PR TITLE
fix: use payment Id to get payment receipt

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -26,7 +26,7 @@ export const StripeReceiptContainer = ({
 }) => {
   const { data, isLoading, error } = useGetPaymentReceiptStatus(
     formId,
-    submissionId,
+    paymentId,
   )
 
   const toast = useToast()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently we are not refreshing paymentpage as we are using the wrong Id to get Payment Receipt

Introduced in:
- https://github.com/opengovsg/FormSG/pull/6116

## Solution
<!-- How did you solve the problem? -->
Use PaymentId for useGetPaymentReceiptStatus

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Test webhook works
- [ ] ensure payment page shows receipt/invoice download
