### PR TITLE
chore: local dev stripe webhook listener

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       - REACT_MIGRATION_USE_FETCH_FOR_SUBMISSIONS=false
       # env vars for stripe payment integration
       - PAYMENT_STRIPE_PUBLISHABLE_KEY=publishableKey
+      # duplicate PAYMENT_STRIPE_SECRET_KEY to STRIPE_API_KEY in stripe-webhook-listener container
       - PAYMENT_STRIPE_SECRET_KEY=secretKey
       - PAYMENT_STRIPE_CLIENT_ID=clientId
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
@@ -156,6 +157,14 @@ services:
     ports:
       - '1080:1080'
 
+  stripe-cli:
+    image: stripe/stripe-cli
+    container_name: stripe-webhook-listener
+    command: "listen --api-key ${STRIPE_API_KEY} --device-name ${STRIPE_DEVICE_NAME} --forward-to host.docker.internal:5001/api/v3/notifications/stripe"
+    environment:
+     - STRIPE_API_KEY=secretKey
+     - STRIPE_DEVICE_NAME=StripeWebhookListener
+     
 volumes:
   mongodb_data:
     driver: local


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, in local development, we have to manually install stripe-cli and set up a listener after authenticating, in order to forward stripe webhooks to test payment flow.

## Solution
<!-- How did you solve the problem? -->
This PR creates a docker container using [stripe-cli ](https://stripe.com/docs/cli/docker)image.

Which listens to stripe events and forwards it to our BE.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
On local env
- [ ] Update docker-compose with stripe keys and webhook secret
- [ ] Make a test payment
- [ ] Webhook should respond with success and an invoice should be created and downloadable
- [ ] Check responses, your payment details / submission should be viewable

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables for local docker-compose**:

- `STRIPE_API_KEY` : Same key as PAYMENT_STRIPE_SECRET_KEY
- Also remember to update webhook secret in backend (seems like the webhook secret is persistent when using `--api-key` instead of `stripe login`)
