### PR TITLE
fix: lift mongoose sessions for copying submissions to Stripe webhook handler level

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -251,6 +251,18 @@ describe('stripe.service', () => {
       await pendingSubmission.updateOne({
         paymentId: payment._id,
       })
+
+      // Calls to processStripeEvent should skip the transaction handler steps
+      // and directly into the main body of the function.
+      jest
+        .spyOn(StripeService, 'processStripeEvent')
+        .mockImplementationOnce((paymentId, event) =>
+          StripeService.processStripeEventWithinSession(
+            paymentId,
+            event,
+            null as unknown as mongoose.ClientSession,
+          ),
+        )
     })
     afterEach(() => jest.clearAllMocks())
 

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -131,7 +131,7 @@ export const findPaymentBySubmissionId = (
  * document is always consistent.
  * @requires paymentId must reference a payment document such that payment.completedPayment is undefined
  *
- * @param paymentId payment id of the payment to be confirmed
+ * @param payment the payment to be confirmed
  * @param paymentDate date of the charge success
  * @param receiptUrl the payment's receipt URL
  * @param transactionFee the transaction fee associated with the payment

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -135,6 +135,7 @@ export const findPaymentBySubmissionId = (
  * @param paymentDate date of the charge success
  * @param receiptUrl the payment's receipt URL
  * @param transactionFee the transaction fee associated with the payment
+ * @param {mongoose.ClientSession} session the mongoose session to use for all db operations
  *
  * @returns ok(payment) if the confirmation transaction was successful
  * @returns err(PendingSubmissionNotFoundError) if the pending submission being referenced by the payment document does not exist

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -42,6 +42,7 @@ const logger = createLoggerWithLabel(module)
  *
  * @param {Stripe.Event} event the new Stripe Event causing the operation to occur
  * @param {IPaymentSchema} payment the payment to be confirmed
+ * @param {mongoose.ClientSession} session the mongoose session to use for all db operations
  *
  * @returns ok(payment) if payment exists
  * @returns err(MalformedStripeChargeObjectError) if the shape of the charge object returned by Stripe does not have expected fields


### PR DESCRIPTION
## Problem
As identified in issue #6022, we wanted to see how often this happens before we fix it. Well, the time has come as we know it happens reasonably often that we need to fix it.

Closes #6022

## Solution
We issue a lock on payments throughout the entire processing of a single event, so that events are always only processed one at a time.

**Breaking Changes** 
- No - this PR is backwards compatible  
