### PR TITLE
feat: add formId to payment document

### DIFF
--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -32,6 +32,7 @@ export type PayoutMeta = {
 export type Payment = {
   // Pre-payment metadata
   pendingSubmissionId: string
+  formId: string
   email: string
   amount: number
   paymentIntentId: string

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -3,6 +3,7 @@ import { Mongoose, Schema } from 'mongoose'
 import { PaymentStatus } from '../../../shared/types'
 import { IPaymentModel, IPaymentSchema } from '../../types'
 
+import { FORM_SCHEMA_ID } from './form.server.model'
 import { PENDING_SUBMISSION_SCHEMA_ID } from './pending_submission.server.model'
 import { SUBMISSION_SCHEMA_ID } from './submission.server.model'
 
@@ -14,6 +15,11 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
       type: Schema.Types.ObjectId,
       // Defer loading of the ref due to circular dependency on schema IDs.
       ref: () => PENDING_SUBMISSION_SCHEMA_ID,
+      required: true,
+    },
+    formId: {
+      type: Schema.Types.ObjectId,
+      ref: () => FORM_SCHEMA_ID,
       required: true,
     },
     email: {

--- a/src/app/modules/payments/__tests__/payment.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payment.service.spec.ts
@@ -8,6 +8,7 @@ import dbHandler from 'tests/unit/backend/helpers/jest-db'
 import * as PaymentsService from '../payments.service'
 
 const Payment = getPaymentModel(mongoose)
+const MOCK_FORM_ID = new ObjectId().toHexString()
 
 describe('payments.service', () => {
   beforeEach(async () => {
@@ -27,6 +28,7 @@ describe('payments.service', () => {
       const expectedObjectId = new ObjectId()
       await Payment.create({
         _id: expectedObjectId,
+        formId: MOCK_FORM_ID,
         pendingSubmissionId: new ObjectId(),
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -241,6 +241,7 @@ describe('stripe.service', () => {
         responseSalt: 'salt',
       })
       payment = await Payment.create({
+        formId: MOCK_FORM_ID,
         target_account_id: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: pendingSubmission._id,
         amount: 12345,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -386,6 +386,7 @@ const submitEncryptModeForm: ControllerHandler<
 
     // Step 1: Create payment without payment intent id and pending submission id.
     const payment = new Payment({
+      formId,
       amount,
       email: paymentReceiptEmail,
       responses: incomingSubmission.responses,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
There will be cases where we need to lookup formId and other payment fields simultaneously.

For instance, when checking if a respondents has made a duplicate payments on a form. 

Previously we will have to find the payment document, then the submission from the submission Id, then compare the formId from submission with the req formId.

## Solution
<!-- How did you solve the problem? -->
Add formId to payment schema and update it when payment document is created upon proceed to Pay

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - adds a new property to the payment schema
   
## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Fill in a payment form, select proceed to pay
- [ ] Go to DB and ensure the payment document has formId in it and that its the correct form
- [ ] Complete the payment (make sure webhook listener is on)
- [ ] Go to DB and check that payment document has been successfully updated with completedPayment. And that formId still exists
