### PR TITLE
fix: add missing context provider on endpagedrawer and paymentdrawer

### DIFF
--- a/frontend/src/features/admin-form/create/common/CreatePageSideBarLayoutContext/CreatePageSideBarLayoutContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSideBarLayoutContext/CreatePageSideBarLayoutContext.tsx
@@ -16,7 +16,7 @@ export const useCreatePageSidebarLayout =
     const context = useContext(CreatePageSidebarLayoutContext)
     if (!context) {
       throw new Error(
-        `useCreatePageSidebar must be used within a CreatePageSideBarLayoutProvider component`,
+        `useCreatePageSidebarLayout must be used within a CreatePageSideBarLayoutProvider component`,
       )
     }
     return context

--- a/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
@@ -34,6 +34,7 @@ import {
 } from '../common'
 import { CreatePageDrawerCloseButton } from '../common/CreatePageDrawer/CreatePageDrawerCloseButton'
 import { CreatePageDrawerContainer } from '../common/CreatePageDrawer/CreatePageDrawerContainer'
+import { CreatePageSideBarLayoutProvider } from '../common/CreatePageSideBarLayoutContext'
 
 import {
   dataSelector,
@@ -217,19 +218,21 @@ export const EndPageDrawer = (): JSX.Element | null => {
   if (!endPageData) return null
 
   return (
-    <CreatePageDrawerContainer>
-      <Flex pos="relative" h="100%" display="flex" flexDir="column">
-        <Box pt="1rem" px="1.5rem" bg="white">
-          <Flex justify="space-between">
-            <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
-              Edit thank you page
-            </Text>
-            <CreatePageDrawerCloseButton />
-          </Flex>
-          <Divider w="auto" mx="-1.5rem" />
-        </Box>
-        <EndPageInput />
-      </Flex>
-    </CreatePageDrawerContainer>
+    <CreatePageSideBarLayoutProvider>
+      <CreatePageDrawerContainer>
+        <Flex pos="relative" h="100%" display="flex" flexDir="column">
+          <Box pt="1rem" px="1.5rem" bg="white">
+            <Flex justify="space-between">
+              <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
+                Edit thank you page
+              </Text>
+              <CreatePageDrawerCloseButton />
+            </Flex>
+            <Divider w="auto" mx="-1.5rem" />
+          </Box>
+          <EndPageInput />
+        </Flex>
+      </CreatePageDrawerContainer>
+    </CreatePageSideBarLayoutProvider>
   )
 }

--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -33,6 +33,7 @@ import {
   useCreatePageSidebar,
 } from '../common'
 import { CreatePageDrawerContainer } from '../common/CreatePageDrawer/CreatePageDrawerContainer'
+import { CreatePageSideBarLayoutProvider } from '../common/CreatePageSideBarLayoutContext'
 
 import { FormPaymentsDisplay } from './types'
 import {
@@ -293,25 +294,27 @@ export const PaymentDrawer = ({
   if (!paymentData && isEncryptMode) return null
 
   return (
-    <CreatePageDrawerContainer>
-      <Flex pos="relative" h="100%" display="flex" flexDir="column">
-        <Box pt="1rem" px="1.5rem" bg="white">
-          <Flex justify="space-between">
-            <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
-              Edit payment
-            </Text>
-          </Flex>
-          <Divider w="auto" mx="-1.5rem" />
-        </Box>
-        {isPaymentDisabled && (
-          <Box px="1.5rem" pt="2rem" pb="1.5rem">
-            <InlineMessage variant={'info'}>
-              <Text>{paymentDisabledMessage}</Text>
-            </InlineMessage>
+    <CreatePageSideBarLayoutProvider>
+      <CreatePageDrawerContainer>
+        <Flex pos="relative" h="100%" display="flex" flexDir="column">
+          <Box pt="1rem" px="1.5rem" bg="white">
+            <Flex justify="space-between">
+              <Text textStyle="subhead-3" color="secondary.500" mb="1rem">
+                Edit payment
+              </Text>
+            </Flex>
+            <Divider w="auto" mx="-1.5rem" />
           </Box>
-        )}
-        <PaymentInput isDisabled={isPaymentDisabled} />
-      </Flex>
-    </CreatePageDrawerContainer>
+          {isPaymentDisabled && (
+            <Box px="1.5rem" pt="2rem" pb="1.5rem">
+              <InlineMessage variant={'info'}>
+                <Text>{paymentDisabledMessage}</Text>
+              </InlineMessage>
+            </Box>
+          )}
+          <PaymentInput isDisabled={isPaymentDisabled} />
+        </Flex>
+      </CreatePageDrawerContainer>
+    </CreatePageSideBarLayoutProvider>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
`PaymentDrawer` and `EndPageDrawer` crashes with missing context provider.

Caused by #6160 and also slightly by `payment-mvp` (regression)

## Solution
<!-- How did you solve the problem? -->
Add ContextProvider to `PaymentDrawer` and `EndPageDrawer` 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
**Bug Fixes**:

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

<img width="1054" alt="Screenshot 2023-04-20 at 10 25 00 PM" src="https://user-images.githubusercontent.com/12391617/233396617-96b46e8a-8bb1-44e1-8788-374e7a1896d0.png">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1784" alt="Screenshot 2023-04-20 at 10 17 25 PM" src="https://user-images.githubusercontent.com/12391617/233394559-aba27fbc-0969-4307-9368-854409c3b79c.png">
<img width="1783" alt="Screenshot 2023-04-20 at 10 17 30 PM" src="https://user-images.githubusercontent.com/12391617/233394578-cd2ee321-adfd-4546-a3de-8470d24665d5.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Admin View storage forms
  - [x] with payments enabled, payment drawer should be able to open and close
  - [x] EndPageDrawer should be able to open and close
- [x] Admin View email forms
  - [x] EndPageDrawer should be able to open and close
- [x] Admin View general regression
  - [x] CreateAndBuildDrawer should be able to open and close
  - [x] Form Preview should render without errors