### PR TITLE
fix: order of parser middleware

### DIFF
--- a/src/app/loaders/express/parser.ts
+++ b/src/app/loaders/express/parser.ts
@@ -3,17 +3,6 @@ import { RequestHandler } from 'express'
 import { set } from 'lodash'
 
 const parserMiddlewares = () => {
-  const saveStripeWebhookRawBody = bodyParser.json({
-    // Because Stripe needs the raw body, we compute it but only when hitting the Stripe callback URL.
-    limit: '40mb',
-    verify: function (req, _res, buf) {
-      const url = req.url
-      if (url?.endsWith('/api/v3/notifications/stripe')) {
-        set(req, 'rawBody', buf.toString())
-      }
-    },
-  })
-
   // Convert to application/json before bodyParser to handle SNS
   const convertSnsMessageType: RequestHandler = function (req, res, next) {
     if (req.get('x-amz-sns-message-type')) {
@@ -22,19 +11,26 @@ const parserMiddlewares = () => {
     return next()
   }
 
-  const bodyParserMiddleWare = bodyParser.urlencoded({
+  const bodyParserUrlMiddleWare = bodyParser.urlencoded({
     extended: true,
     limit: '100mb',
   })
 
-  // In particular, this enforces that encrypted content of submissions be less than 10MB
-  // const limitJsonLimit = bodyParser.json({ limit: '40mb' })
+  const bodyParserJsonMiddleware = bodyParser.json({
+    limit: '40mb',
+    // Because Stripe needs the raw body, we compute it but only when hitting the Stripe callback URL.
+    verify: function (req, _res, buf) {
+      const url = req.url
+      if (url?.endsWith('/api/v3/notifications/stripe')) {
+        set(req, 'rawBody', buf.toString())
+      }
+    },
+  })
 
   return [
-    saveStripeWebhookRawBody,
     convertSnsMessageType,
-    bodyParserMiddleWare,
-    // limitJsonLimit,
+    bodyParserUrlMiddleWare,
+    bodyParserJsonMiddleware,
   ]
 }
 

--- a/src/app/loaders/express/parser.ts
+++ b/src/app/loaders/express/parser.ts
@@ -11,6 +11,9 @@ const parserMiddlewares = () => {
     return next()
   }
 
+  // processes that must be done before any other middlewares
+  const preMiddlewareProcesses = [convertSnsMessageType]
+
   const bodyParserUrlMiddleWare = bodyParser.urlencoded({
     extended: true,
     limit: '100mb',
@@ -28,7 +31,7 @@ const parserMiddlewares = () => {
   })
 
   return [
-    convertSnsMessageType,
+    ...preMiddlewareProcesses,
     bodyParserUrlMiddleWare,
     bodyParserJsonMiddleware,
   ]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Wrong order of parser middleware causing body of SNS response body not being converted to JSON though it should be (and originally was before hotfix 6.42.1 (https://github.com/opengovsg/FormSG/pull/6155)). This caused SNS notifications to not be parsed properly, resulting in 401 errors when emails bounce.

## Solution
<!-- How did you solve the problem? -->
Correct the order of middlewares in parser middleware, ensuring that `preMiddlewareProcesses` such as `convertSnsMessageType` are done before other middlewares (e.g. body parsing steps).

## Tests
- [x] Ensure that you are on a deployed app (i.e. prod / staging[|-alt|-alt2] / uat).
- [x] Create an email mode form, add a field and open the form.
- [x] Add an email that will bounce (e.g. an invalid email, such as hq@open.gov.sg).
- [x] Open the form as a respondent and make a submission.
- [x] Go to [datadog dashboard](https://app.datadoghq.com/dashboard/b3u-egb-apu/formsg?fullscreen_end_ts=1682001534625&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1681828734625&fullscreen_widget=8560075761416440&tpl_var_env%5B0%5D=staging-alt&from_ts=1681827281843&to_ts=1682000081843&live=true). If the issue is not fixed, there will be a 401 error flagged for the endpoint `/api/v3/notifications/bounces/email`. If it is fixed, there should be no error.

Additional test case:
- [x] email form with attachments
  - [x] 7MB
  - [x] 1MB
  
Regression case (since there was changes to json parser ordering)
- [x] successful responder payment flow with attachments
  - [x] 1MB
  - [x] 20MB