### PR TITLE
feat: email check for previous payment 

### DIFF
--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -1,0 +1,72 @@
+import { MouseEvent, MouseEventHandler } from 'react'
+import {
+  Button,
+  ButtonGroup,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react'
+
+import { getPaymentPageUrl } from '~features/public-form/utils/urls'
+
+type FormPaymentModalProps = {
+  onSubmit: MouseEventHandler<HTMLButtonElement> | undefined
+  onClose: () => void
+  isSubmitting: boolean
+  formId: string
+  paymentId: string
+}
+
+export const FormPaymentModal = ({
+  onSubmit,
+  onClose,
+  isSubmitting,
+  formId,
+  paymentId,
+}: FormPaymentModalProps): JSX.Element => {
+  const paymentUrl = getPaymentPageUrl(formId, paymentId)
+
+  // We need to dismiss the Modal to release the scroll lock that affects the captcha
+  const closeAndSubmit = (event: MouseEvent<HTMLButtonElement>) => {
+    onClose()
+    if (onSubmit) {
+      onSubmit(event)
+    }
+  }
+  return (
+    <>
+      <Modal isOpen onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader>Proceed to pay again?</ModalHeader>
+          <ModalBody>
+            We noticed a successful payment made on this form by your email
+            address.
+            <Link href={paymentUrl}>View your previous payment</Link>
+          </ModalBody>
+          <ModalBody>Do you wish to proceed to make another payment?</ModalBody>
+          <ModalFooter>
+            <ButtonGroup>
+              <Button variant="clear" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                isLoading={isSubmitting}
+                loadingText="Submitting"
+                onClick={closeAndSubmit}
+              >
+                Proceed to pay
+              </Button>
+            </ButtonGroup>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -10,6 +10,8 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Stack,
+  Text,
 } from '@chakra-ui/react'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
@@ -46,10 +48,14 @@ export const DuplicatePaymentModal = ({
           <ModalCloseButton />
           <ModalHeader>Proceed to pay again?</ModalHeader>
           <ModalBody>
-            We noticed a successful payment made on this form by your email
-            address.
-            <Link href={paymentUrl}>View your previous payment</Link>
-            {'\n'}Do you wish to proceed to make another payment?
+            <Stack>
+              <Text>
+                We noticed a successful payment made on this form by your email
+                address.
+                <Link href={paymentUrl}>View your previous payment</Link>
+              </Text>
+              <Text>Do you wish to proceed to make another payment?</Text>
+            </Stack>
           </ModalBody>
           <ModalFooter>
             <ButtonGroup>

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -51,9 +51,10 @@ export const DuplicatePaymentModal = ({
             <Stack>
               <Text>
                 We noticed a successful payment made on this form by your email
-                address.
+                address.&nbsp;
                 <Link href={paymentUrl}>View your previous payment ↪</Link>
               </Text>
+              <br />
               <Text>Do you wish to proceed to make another payment?</Text>
             </Stack>
           </ModalBody>

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -22,7 +22,7 @@ type FormPaymentModalProps = {
   paymentId: string
 }
 
-export const FormPaymentModal = ({
+export const DuplicatePaymentModal = ({
   onSubmit,
   onClose,
   isSubmitting,

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -52,7 +52,7 @@ export const DuplicatePaymentModal = ({
               <Text>
                 We noticed a successful payment made on this form by your email
                 address.
-                <Link href={paymentUrl}>View your previous payment</Link>
+                <Link href={paymentUrl}>View your previous payment ↪</Link>
               </Text>
               <Text>Do you wish to proceed to make another payment?</Text>
             </Stack>

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -14,7 +14,7 @@ import {
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 
-type FormPaymentModalProps = {
+type DuplicatePaymentModalProps = {
   onSubmit: MouseEventHandler<HTMLButtonElement> | undefined
   onClose: () => void
   isSubmitting: boolean
@@ -28,7 +28,7 @@ export const DuplicatePaymentModal = ({
   isSubmitting,
   formId,
   paymentId,
-}: FormPaymentModalProps): JSX.Element => {
+}: DuplicatePaymentModalProps): JSX.Element => {
   const paymentUrl = getPaymentPageUrl(formId, paymentId)
 
   // We need to dismiss the Modal to release the scroll lock that affects the captcha
@@ -49,8 +49,8 @@ export const DuplicatePaymentModal = ({
             We noticed a successful payment made on this form by your email
             address.
             <Link href={paymentUrl}>View your previous payment</Link>
+            {'\n'}Do you wish to proceed to make another payment?
           </ModalBody>
-          <ModalBody>Do you wish to proceed to make another payment?</ModalBody>
           <ModalFooter>
             <ButtonGroup>
               <Button variant="clear" onClick={onClose}>

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -18,6 +18,7 @@ import { FormFieldValues } from '~templates/Field'
 import { getLogicUnitPreventingSubmit } from '~features/logic/utils'
 
 import { usePublicFormContext } from '../../PublicFormContext'
+import { DuplicatePaymentModal } from '../DuplicatePaymentModal/DuplicatePaymentModal'
 import { FormPaymentModal } from '../FormPaymentModal/FormPaymentModal'
 
 interface PublicFormSubmitButtonProps {
@@ -42,7 +43,7 @@ export const PublicFormSubmitButton = ({
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
   const formInputs = useWatch<FormFieldValues>({}) as FormFieldValues
-  const { form } = usePublicFormContext()
+  const { form, formId } = usePublicFormContext()
 
   const preventSubmissionLogic = useMemo(() => {
     return getLogicUnitPreventingSubmit({
@@ -64,14 +65,26 @@ export const PublicFormSubmitButton = ({
     form?.responseMode === FormResponseMode.Encrypt &&
     form?.payments_field?.enabled
 
+  const isDuplicate = true
+
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
       {isOpen ? (
-        <FormPaymentModal
-          onSubmit={onSubmit}
-          onClose={onClose}
-          isSubmitting={isSubmitting}
-        />
+        isDuplicate ? (
+          <DuplicatePaymentModal
+            onSubmit={onSubmit}
+            onClose={onClose}
+            isSubmitting={isSubmitting}
+            formId={formId}
+            paymentId={'413243243'}
+          />
+        ) : (
+          <FormPaymentModal
+            onSubmit={onSubmit}
+            onClose={onClose}
+            isSubmitting={isSubmitting}
+          />
+        )
       ) : null}
       <Button
         isFullWidth={isMobile}

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -80,7 +80,7 @@ export const PublicFormSubmitButton = ({
       onOpen()
     }
   }
-  console.log(paymentId)
+
   const isPaymentEnabled =
     form?.responseMode === FormResponseMode.Encrypt &&
     form?.payments_field?.enabled

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -8,7 +8,6 @@ import {
   FormResponseMode,
   LogicDto,
   MyInfoFormField,
-  PaymentStatus,
 } from '~shared/types'
 
 import { ThemeColorScheme } from '~theme/foundations/colours'

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -71,11 +71,17 @@ export const PublicFormSubmitButton = ({
 
     if (result) {
       // get previous payment
-      const payment = await getPreviousPayment(paymentEmailField.value, formId)
-      // check if duplicate
-      if (payment) {
-        setDuplicate(payment.status === PaymentStatus.Succeeded)
-        setPaymentId(payment._id)
+      try {
+        const payment = await getPreviousPayment(
+          paymentEmailField.value,
+          formId,
+        )
+        if (payment) {
+          setDuplicate(true)
+          setPaymentId(payment._id)
+        }
+      } catch (err) {
+        setDuplicate(false)
       }
       onOpen()
     }

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
@@ -1,6 +1,12 @@
-import { GetPaymentInfoDto, PaymentReceiptStatusDto } from '~shared/types'
+import {
+  GetPaymentInfoDto,
+  Payment,
+  PaymentReceiptStatusDto,
+} from '~shared/types'
 
 import { ApiService } from '~services/ApiService'
+
+const PAYMENTS_ENDPOINT = '/payments'
 
 /**
  * Obtain payment receipt status for a given submission.
@@ -13,7 +19,7 @@ export const getPaymentReceiptStatus = async (
   paymentId: string,
 ): Promise<PaymentReceiptStatusDto> => {
   return ApiService.get<PaymentReceiptStatusDto>(
-    `payments/${formId}/${paymentId}/receipt/status`,
+    `${PAYMENTS_ENDPOINT}/${formId}/${paymentId}/receipt/status`,
   ).then(({ data }) => data)
 }
 
@@ -26,6 +32,23 @@ export const getPaymentReceiptStatus = async (
  */
 export const getPaymentInfo = async (paymentId: string) => {
   return ApiService.get<GetPaymentInfoDto>(
-    `payments/${paymentId}/getinfo`,
+    `${PAYMENTS_ENDPOINT}/${paymentId}/getinfo`,
+  ).then(({ data }) => data)
+}
+
+/**
+ * Obtain the payment object if the respondent has already
+ * made a payment on a specific form before.
+ * @param email the email of the user making the payment
+ * @param formId the id of the form
+ * @returns payment object is the respondent has made a payment
+ * @returns undefined if the respondent has yet to make payment
+ */
+export const getPreviousPayment = async (
+  email: string,
+  formId: string,
+): Promise<Payment | undefined> => {
+  return ApiService.get<Payment | undefined>(
+    `${PAYMENTS_ENDPOINT}/${formId}/payments/previous/${email}`,
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
@@ -48,7 +48,9 @@ export const getPreviousPayment = async (
   email: string,
   formId: string,
 ): Promise<PaymentDto | undefined> => {
-  return ApiService.get<PaymentDto | undefined>(
-    `${PAYMENTS_ENDPOINT}/${formId}/payments/previous/${email}`,
+  const emailData = { email }
+  return ApiService.post<PaymentDto | undefined>(
+    `${PAYMENTS_ENDPOINT}/${formId}/payments/previous/`,
+    emailData,
   ).then(({ data }) => data)
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
@@ -1,6 +1,6 @@
 import {
   GetPaymentInfoDto,
-  Payment,
+  PaymentDto,
   PaymentReceiptStatusDto,
 } from '~shared/types'
 
@@ -47,8 +47,8 @@ export const getPaymentInfo = async (paymentId: string) => {
 export const getPreviousPayment = async (
   email: string,
   formId: string,
-): Promise<Payment | undefined> => {
-  return ApiService.get<Payment | undefined>(
+): Promise<PaymentDto | undefined> => {
+  return ApiService.get<PaymentDto | undefined>(
     `${PAYMENTS_ENDPOINT}/${formId}/payments/previous/${email}`,
   ).then(({ data }) => data)
 }

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -30,8 +30,6 @@ export type PayoutMeta = {
 }
 
 export type Payment = {
-  _id: string
-
   // Pre-payment metadata
   pendingSubmissionId: string
   formId: string
@@ -53,6 +51,8 @@ export type Payment = {
   created: DateString
   lastModified: DateString
 }
+
+export type PaymentDto = Payment & { _id: string }
 
 export type PaymentReceiptStatusDto = {
   isReady: boolean

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -30,6 +30,8 @@ export type PayoutMeta = {
 }
 
 export type Payment = {
+  _id: string
+
   // Pre-payment metadata
   pendingSubmissionId: string
   formId: string

--- a/src/app/modules/payments/__tests__/payment.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payment.controller.spec.ts
@@ -1,0 +1,113 @@
+import { ObjectId } from 'bson'
+import mongoose from 'mongoose'
+import { PaymentStatus } from 'shared/types'
+
+import getPaymentModel from 'src/app/models/payment.server.model'
+
+import dbHandler from 'tests/unit/backend/helpers/jest-db'
+import expressHandler from 'tests/unit/backend/helpers/jest-express'
+
+import * as PaymentsController from '../payments.controller'
+
+const Payment = getPaymentModel(mongoose)
+const MOCK_FORM_ID = new ObjectId().toHexString()
+
+describe('payments.controller', () => {
+  beforeAll(async () => await dbHandler.connect())
+  afterAll(async () => await dbHandler.closeDatabase())
+  beforeEach(() => jest.clearAllMocks())
+  describe('handleGetPreviousPayment', () => {
+    beforeEach(async () => {
+      await dbHandler.clearCollection(Payment.collection.name)
+    })
+    it('should return a payment document if there is a previous payment', async () => {
+      const email = 'formsg@tech.gov.sg'
+      const payment = await Payment.create({
+        formId: MOCK_FORM_ID,
+        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: email,
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+        },
+      })
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: payment.formId },
+        body: { email },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await PaymentsController._handleGetPreviousPayment(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.send).toHaveBeenCalledOnce()
+    })
+    it('should return 404 if there are no previous payments by the specific email', async () => {
+      const payment = await Payment.create({
+        formId: MOCK_FORM_ID,
+        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: 'formsg@tech.gov.sg',
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+        },
+      })
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: payment.formId },
+        body: { email: 'another@email.com' },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await PaymentsController._handleGetPreviousPayment(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(404)
+    })
+    it('should return 404 if there are no previous payments by the email in the specific formId', async () => {
+      const payment = await Payment.create({
+        formId: MOCK_FORM_ID,
+        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: 'formsg@tech.gov.sg',
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+        },
+      })
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: new ObjectId().toHexString() },
+        body: { email: payment.email },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await PaymentsController._handleGetPreviousPayment(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(404)
+    })
+  })
+})

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -53,7 +53,7 @@ export const _handleGetPreviousPayment: ControllerHandler<
               error,
             },
           })
-          return res.status(StatusCodes.NOT_FOUND).send()
+          return res.sendStatus(StatusCodes.NOT_FOUND)
         }
         // Database error
         logger.error({

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -1,0 +1,88 @@
+import { celebrate, Joi, Segments } from 'celebrate'
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../config/logger'
+import { ControllerHandler } from '../core/core.types'
+
+import { PaymentNotFoundError } from './payments.errors'
+import { findLatestSuccessfulPaymentByEmailAndFormId } from './payments.service'
+
+const logger = createLoggerWithLabel(module)
+
+const _handleGetPreviousPayment: ControllerHandler<{
+  email: string
+  formId: string
+}> = (req, res) => {
+  const { email, formId } = req.params
+  // Step 1 get Payment document from email and formId
+  return (
+    findLatestSuccessfulPaymentByEmailAndFormId(email, formId)
+      // If payment found, return payment
+      .map((payment) => {
+        logger.info({
+          message:
+            'Found latest successful payment document from email and formId',
+          meta: {
+            action: 'handleGetPreviousPayment',
+            email,
+            formId,
+            payment,
+          },
+        })
+        return res.send(payment)
+      })
+      // If payment is not found, there is no previous payment
+      // If database error, return 500
+      .mapErr((error) => {
+        // if payment isn't found, return empty response
+        if (error instanceof PaymentNotFoundError) {
+          logger.info({
+            message:
+              'Did not find previous successful payment from email and formId',
+            meta: {
+              action: 'handleGetPreviousPayment',
+              email,
+              formId,
+              error,
+            },
+          })
+          return res.send()
+        }
+        // Database error
+        logger.error({
+          message: 'Error retrieving payment documents using email and formId',
+          meta: {
+            action: 'handleGetPreviousPayment',
+            email,
+            formId,
+            error,
+          },
+        })
+        return res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Database error' })
+          .send()
+      })
+  )
+}
+
+/**
+ * Handler for GET /api/v3/:formId/payments/previous/:email
+ * Finds and return the latest successful payment made by the
+ * specific respondent based on their email.
+ *
+ * @params formId formId of related form to retrieve payment
+ * @params email email of respondents to retrieve payment
+ *
+ * @returns 200 with payment document if successful payment is found
+ * @returns 200 without data if no payment has been made
+ * @returns 500 if there is an unexpected error
+ */ export const handleGetPreviousPayment = [
+  celebrate({
+    [Segments.QUERY]: {
+      formId: Joi.string().required,
+      email: Joi.string().required,
+    },
+  }),
+  _handleGetPreviousPayment,
+] as ControllerHandler[]

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -36,7 +36,7 @@ export const _handleGetPreviousPayment: ControllerHandler<
             payment,
           },
         })
-        return res.send(payment)
+        return res.status(StatusCodes.OK).send(payment)
       })
       // If payment is not found, there is no previous payment
       // If database error, return 500
@@ -53,7 +53,7 @@ export const _handleGetPreviousPayment: ControllerHandler<
               error,
             },
           })
-          return res.send()
+          return res.status(StatusCodes.NOT_FOUND).send()
         }
         // Database error
         logger.error({
@@ -79,7 +79,7 @@ export const _handleGetPreviousPayment: ControllerHandler<
  * @params formId formId of related form to retrieve payment
  *
  * @returns 200 with payment document if successful payment is found
- * @returns 200 without data if no payment has been made
+ * @returns 404 without data if no payment has been made
  * @returns 500 if there is an unexpected error
  */ export const handleGetPreviousPayment = [
   celebrate({

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -282,6 +282,7 @@ export const findLatestSuccessfulPaymentByEmailAndFormId = (
           'Database error while finding latest payment by email and FormId',
         meta: {
           action: 'findLatestPaymentByEmailAndFormId',
+          formId,
           email,
         },
         error,

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -2,6 +2,7 @@ import { ObjectId } from 'mongodb'
 import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
+import { PaymentStatus } from '../../../../shared/types'
 import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
@@ -263,7 +264,7 @@ export const sendPaymentConfirmationEmailByPaymentId = (
  * @returns err(PaymentNotFoundError) if the payment does not exist
  * @returns err(DatabaseError) if error occurs whilst querying the database
  */
-export const findLatestPaymentByEmailAndFormId = (
+export const findLatestSuccessfulPaymentByEmailAndFormId = (
   email: IPaymentSchema['email'],
   formId: string,
 ): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
@@ -271,8 +272,9 @@ export const findLatestPaymentByEmailAndFormId = (
     PaymentModel.findOne({
       email: email,
       formId: formId,
+      status: PaymentStatus.Succeeded,
     })
-      .sort({ created_at: -1 })
+      .sort({ _id: -1 })
       .exec(),
     (error) => {
       logger.error({

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -254,3 +254,40 @@ export const sendPaymentConfirmationEmailByPaymentId = (
       })
     })
 }
+
+/**
+ * Retrieves the latest payment document by email and formId.
+ * @param email the email of the payment to be retrieved
+ * @param formId the formId of the payment to be retrieved
+ * @returns ok(payment) if payment exists
+ * @returns err(PaymentNotFoundError) if the payment does not exist
+ * @returns err(DatabaseError) if error occurs whilst querying the database
+ */
+export const findLatestPaymentByEmailAndFormId = (
+  email: IPaymentSchema['email'],
+  formId: string,
+): ResultAsync<IPaymentSchema, PaymentNotFoundError | DatabaseError> => {
+  return ResultAsync.fromPromise(
+    PaymentModel.findOne({
+      email: email,
+      formId: formId,
+    })
+      .sort({ created_at: -1 })
+      .exec(),
+    (error) => {
+      logger.error({
+        message:
+          'Database error while finding latest payment by email and FormId',
+        meta: {
+          action: 'findLatestPaymentByEmailAndFormId',
+          email,
+        },
+        error,
+      })
+      return new DatabaseError(getMongoErrorMessage(error))
+    },
+  ).andThen((result) => {
+    if (!result) return errAsync(new PaymentNotFoundError())
+    return okAsync(result)
+  })
+}

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -627,6 +627,16 @@ const _handleGetPreviousPayment: ControllerHandler<{
     findLatestSuccessfulPaymentByEmailAndFormId(email, formId)
       // If payment found, return payment
       .map((payment) => {
+        logger.info({
+          message:
+            'Found latest successful payment document from email and formId',
+          meta: {
+            action: 'handleGetPreviousPayment',
+            email,
+            formId,
+            payment,
+          },
+        })
         return res.send(payment)
       })
       // If payment is not found, there is no previous payment
@@ -634,9 +644,28 @@ const _handleGetPreviousPayment: ControllerHandler<{
       .mapErr((error) => {
         // if payment isn't found, return empty response
         if (error instanceof PaymentNotFoundError) {
+          logger.info({
+            message:
+              'Did not find previous successful payment from email and formId',
+            meta: {
+              action: 'handleGetPreviousPayment',
+              email,
+              formId,
+              error,
+            },
+          })
           return res.send()
         }
         // Database error
+        logger.error({
+          message: 'Error retrieving payment documents using email and formId',
+          meta: {
+            action: 'handleGetPreviousPayment',
+            email,
+            formId,
+            error,
+          },
+        })
         return res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
           .json({ message: 'Database error' })

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -645,8 +645,18 @@ const _handleGetPreviousPayment: ControllerHandler<{
   )
 }
 
-// Handler for GET /:formId/duplicate/payments/:email
-export const handleGetPreviousPayment = [
+/**
+ * Handler for GET /api/v3/:formId/payments/previous/:email
+ * Finds and return the latest successful payment made by the
+ * specific respondent based on their email.
+ *
+ * @params formId formId of related form to retrieve payment
+ * @params email email of respondents to retrieve payment
+ *
+ * @returns 200 with payment document if successful payment is found
+ * @returns 200 without data if no payment has been made
+ * @returns 500 if there is an unexpected error
+ */ export const handleGetPreviousPayment = [
   celebrate({
     [Segments.QUERY]: {
       formId: Joi.string().required,

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import { rateLimitConfig } from '../../../../config/config'
+import * as PaymentsController from '../../../../modules/payments/payments.controller'
 import * as StripeController from '../../../../modules/payments/stripe.controller'
 import { limitRate } from '../../../../utils/limit-rate'
 
@@ -76,5 +77,5 @@ PaymentsRouter.route('/:paymentId([a-fA-F0-9]{24})/getinfo').get(
 PaymentsRouter.get(
   '/:formId([a-fA-F0-9]{24})/payments/previous/:email',
   limitRate({ max: rateLimitConfig.submissions }),
-  StripeController.handleGetPreviousPayment,
+  PaymentsController.handleGetPreviousPayment,
 )

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -64,3 +64,17 @@ PaymentsRouter.route('/stripe/callback').get(
 PaymentsRouter.route('/:paymentId([a-fA-F0-9]{24})/getinfo').get(
   StripeController.getPaymentInfo,
 )
+
+/**
+ * Get previous latest successful payment document if it exists
+ * @route GET /:formId/payments/previous/:email
+ *
+ * @returns 200 with payment if it exists
+ * @returns 200 without payment if it doesnt exists
+ * @returns 500 when database error occurs
+ */
+PaymentsRouter.get(
+  '/:formId([a-fA-F0-9]{24})/payments/previous/:email',
+  limitRate({ max: rateLimitConfig.submissions }),
+  StripeController.handleGetPreviousPayment,
+)

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -71,8 +71,8 @@ PaymentsRouter.route('/:paymentId([a-fA-F0-9]{24})/getinfo').get(
  * Uses post request to collect the email data from the request body
  * @route POST /:formId/payments/previous
  *
- * @returns 200 with payment if it exists
- * @returns 200 without payment if it doesnt exists
+ * @returns 200 if previous payment exists
+ * @returns 404 if previous payment doesnt exists
  * @returns 500 when database error occurs
  */
 PaymentsRouter.route('/:formId([a-fA-F0-9]{24})/payments/previous').post(

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -68,14 +68,14 @@ PaymentsRouter.route('/:paymentId([a-fA-F0-9]{24})/getinfo').get(
 
 /**
  * Get previous latest successful payment document if it exists
- * @route GET /:formId/payments/previous/:email
+ * Uses post request to collect the email data from the request body
+ * @route POST /:formId/payments/previous
  *
  * @returns 200 with payment if it exists
  * @returns 200 without payment if it doesnt exists
  * @returns 500 when database error occurs
  */
-PaymentsRouter.get(
-  '/:formId([a-fA-F0-9]{24})/payments/previous/:email',
+PaymentsRouter.route('/:formId([a-fA-F0-9]{24})/payments/previous').post(
   limitRate({ max: rateLimitConfig.submissions }),
   PaymentsController.handleGetPreviousPayment,
 )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Users might face crashes or forgot that they have already made a payment. As we collect their email information, we can use that as an identifier for the users. Hence, if they attempt to make a payment on the same form after successfully making a payment - we will provide them with a warning and a link back to their previous payment.

Closes #5973

## Solution
<!-- How did you solve the problem? -->
Find latest successful payment (Payment Status === succeeded) based on email and formId
Endpoint :formId/payments/previous/:email will return 200 when a payment document is found and 404 when it is not

On Frontend, we will check an isDuplicate state based on whether the endpoint has returned a payment document or not. Accordingly it will choose to display PaymentModal or the new DuplicatePaymentModal with the link to the previous latest payment

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/59867455/233926056-585ceed4-de9a-4b04-834d-dca21dcb5df7.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
**To check basic functionality**
Go to a payment form
- [x] make a payment successfully
- [x] attempt to make a second payment with the same email
- [x] you should see the modal directing you to your previous payment page
- [x] click the link and ensure you are the same payment page from when you made a successful payment

**To check that we get the latest successful payment**
all of these are done with the same email as above
- [x] go back and make a second payment with the same email again (take note of your payment id/payment page link)
- [x] make a payment successfully
- [x] go back to the form
- [x] make a payment intent (but do not pay)
- [x] go back to the form
- [x] fill in the form and click proceed to pay, the duplicate payment modal should show, directing you to the **second** payment that you made. Check that the payment id/payment page link is equivalent to your second payment

**To check that we do not erroneously show the duplicate payment modal**
On the same form
- [x] make a payment with a different email
- [x] you should not see the duplicate payment modal at proceed to pay

On a different form
- [x] make a payment with the original email form above
- [x] you should not see the duplicate payment modal at proceed to pay

**To ensure no regression issues on non-payment forms**
(As changes was made to PublicFormSubmitButton)
- [x] go to a non-payment storage mode form
- [x] make a submission
- [x] go to an email mode form
- [x] make a submission