### PR TITLE
fix: add description to verify payment email field

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPreview/FormPaymentPreview.tsx
@@ -28,6 +28,7 @@ export const FormPaymentPreview = ({
   const emailFieldSchema: VerifiableEmailFieldSchema = {
     ...(getFieldCreationMeta(BasicField.Email) as EmailFieldBase),
     _id: PAYMENT_CONTACT_FIELD_ID,
+    description: 'Proof of payment will be sent to this email',
     isVerifiable: true,
   }
   return (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #6174 

## Solution
<!-- How did you solve the problem? -->
Add a description to inform users that proof of payment will be sent to the email provided.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots
**AFTER**:
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/56983748/233912007-f7896b79-2ba0-46ff-a0dd-9839058ff748.png">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] On the payment form, check that the Email field in the Payment component has the description "Proof of payment will be sent to this email"
