### PR TITLE
feat: rename receipt to invoice

### DIFF
--- a/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
+++ b/frontend/src/features/admin-form/create/payment/PaymentDrawer.tsx
@@ -208,7 +208,7 @@ export const PaymentInput = ({
         isDisabled={!paymentIsEnabled}
         isRequired
       >
-        <FormLabel description="This will be reflected on the payment receipt">
+        <FormLabel description="This will be reflected on the payment invoice">
           Product/service name
         </FormLabel>
         <Input

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -54,7 +54,7 @@ export const getPaymentDataView = (
     { key: 'email', name: 'Payer', value: payment.email },
     {
       key: 'receiptUrl',
-      name: 'Receipt',
+      name: 'Invoice',
       value: getFullInvoiceDownloadUrl(hostOrigin, formId, payment.id),
     },
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -58,7 +58,7 @@ export const StripeReceiptContainer = ({
       <PaymentStack>
         <GenericMessageBlock
           title="Your payment has been received."
-          subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your receipt later."
+          subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your invoice later."
           submissionId={submissionId}
         />
       </PaymentStack>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Closes #6177

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![image (2)](https://user-images.githubusercontent.com/12391617/233938354-16c6e77e-3e30-49f1-aad4-13117b7e6b19.png)
![image (1)](https://user-images.githubusercontent.com/12391617/233938361-f03c30bf-5f01-4804-a95e-f142a175077f.png)


**AFTER**:
<!-- [insert screenshot here] -->

<img width="1107" alt="Screenshot 2023-04-24 at 3 58 08 PM" src="https://user-images.githubusercontent.com/12391617/233935500-b4e3c245-19a4-465a-ac19-2b438eb94941.png">
<img width="1383" alt="Screenshot 2023-04-24 at 4 00 34 PM" src="https://user-images.githubusercontent.com/12391617/233935516-64a4b6a1-9532-41cb-9899-c141ed242377.png">
<img width="508" alt="Screenshot 2023-04-24 at 4 14 49 PM" src="https://user-images.githubusercontent.com/12391617/233938509-119a0f22-6dee-4aa8-8fa4-210a617ad4c2.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
New features tests
- [ ] Admin Form Response Page for payment storage forms
  - [ ] Able to successfully download csv
  - [ ] Expect CSV invoice field populated and with header `invoice`
  - [ ] Expect Individual Response Page/Payment Section to render with `Invoice` label
- [ ] Admin Form Edit Payment Drawer
  - [ ] Expect copy to be `invoice`

Regression tests
- [ ] Admin Form Response Page for non-payment storage forms
  - [ ] Able to successfully download csv
  - [ ] Expect Individual Response Page to render without errors 