### PR TITLE
fix: move form title and response id to the end of invoice

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -49,7 +49,17 @@ describe('stripe.controller', () => {
         encryptedContent: 'some random encrypted content',
         version: 1,
       })
-      const mockBusinessInfo = { address: 'localhost', gstRegNo: 'G123456' }
+      const mockBusinessInfo = {
+        address: 'localhost',
+        gstRegNo: 'G123456',
+      }
+      const mockFormTitle = 'Mock Form Title'
+      const mockSubmissionId = 'MOCK_SUBMISSION_ID'
+      const mockInvoiceArgs = {
+        ...mockBusinessInfo,
+        formTitle: mockFormTitle,
+        submissionId: mockSubmissionId,
+      }
       const mockForm = {
         _id: MOCK_FORM_ID,
         admin: {
@@ -57,6 +67,7 @@ describe('stripe.controller', () => {
             business: mockBusinessInfo,
           },
         },
+        title: mockFormTitle,
       } as IPopulatedForm
 
       const payment = await Payment.create({
@@ -69,6 +80,7 @@ describe('stripe.controller', () => {
         email: 'formsg@tech.gov.sg',
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
+          submissionId: mockSubmissionId,
         },
       })
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
@@ -99,7 +111,7 @@ describe('stripe.controller', () => {
       expect(axiosSpy).toHaveBeenCalledOnce()
       expect(convertInvoiceSpy).toHaveBeenCalledWith(
         expect.any(String),
-        mockBusinessInfo,
+        mockInvoiceArgs,
       )
       expect(mockRes.send).toHaveBeenCalledOnce()
       expect(mockRes.status).toHaveBeenCalledWith(200)

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -86,7 +86,7 @@ describe('stripe.controller', () => {
 
       const convertInvoiceSpy = jest.spyOn(
         StripeUtils,
-        'convertToInvoiceForrmat',
+        'convertToInvoiceFormat',
       )
 
       // Act

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -383,6 +383,8 @@ export const downloadPaymentInvoice: ControllerHandler<{
             const invoiceHtml = convertToInvoiceFormat(html, {
               address: businessInfo?.address || '',
               gstRegNo: businessInfo?.gstRegNo || '',
+              formTitle: populatedForm.title,
+              submissionId: payment.completedPayment?.submissionId || '',
             })
 
             const pdfBufferPromise = generatePdfFromHtml(invoiceHtml)

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -28,7 +28,7 @@ import * as PaymentService from './payments.service'
 import { StripeFetchError } from './stripe.errors'
 import * as StripeService from './stripe.service'
 import {
-  convertToInvoiceForrmat,
+  convertToInvoiceFormat,
   getChargeIdFromNestedCharge,
   getMetadataPaymentId,
   mapRouteErr,
@@ -380,7 +380,7 @@ export const downloadPaymentInvoice: ControllerHandler<{
                   businessInfo: businessInfo,
                 },
               })
-            const invoiceHtml = convertToInvoiceForrmat(html, {
+            const invoiceHtml = convertToInvoiceFormat(html, {
               address: businessInfo?.address || '',
               gstRegNo: businessInfo?.gstRegNo || '',
             })

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -335,7 +335,7 @@ export const mapRouteErr = (error: ApplicationError) => {
  * Converts receipt sourced from Stripe into an invoice format
  * @param receiptHtmlSource
  */
-export const convertToInvoiceForrmat = (
+export const convertToInvoiceFormat = (
   receiptHtmlSource: string,
   { address, gstRegNo }: { address: string; gstRegNo: string },
 ) => {

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -360,7 +360,7 @@ export const convertToInvoiceFormat = (
       /Receipt (#[0-9-]+)/,
       `Invoice $1<br /><br />GST Reg No: ${GST_REG_NO}<br />Address: ${ADDRESS}`,
     )
-    .replace(/<br>\(This amount is inclusive of GST\)/, '') // not needed for real description (was added by Amit in his test)
+    .replace(/<br>\(This amount is inclusive of GST\)/, '')
     .replace(
       '<strong>Amount charged</strong>',
       '<strong>Amount charged</strong> <i>(includes GST)</i>',
@@ -377,7 +377,7 @@ export const convertToInvoiceFormat = (
   const dom = new JSDOM(edited)
   const { document } = dom.window
 
-  // select last 5 tables to remove, n = last index
+  // select last 3 tables to remove, n = last index
   /**
    * These are:
    * n-5  [Kept] Horizontal Rule

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -371,7 +371,7 @@ export const convertToInvoiceFormat = (
     )
     .replace(
       /<td class="Spacer Spacer--gutter" width="64" .+<\/td>/,
-      '<td class="st-Spacer st-Spacer--gutter" style="border: 0; margin: 0; padding: 0; font-size: 1px; line-height: 1px; mso-line-height-rule: exactly;" width="48"><div class="st-Spacer st-Spacer--filler"> </div></td>',
+      '<td class="st-Spacer st-Spacer--gutter" width="48"></td>',
     )
 
   const dom = new JSDOM(edited)

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -369,6 +369,10 @@ export const convertToInvoiceFormat = (
       /Something wrong with the email\? <a.+a>/,
       `FormSG Form: ${formTitle}<br>Response ID: ${submissionId}`,
     )
+    .replace(
+      /<td class="Spacer Spacer--gutter" width="64" .+<\/td>/,
+      '<td class="st-Spacer st-Spacer--gutter" style="border: 0; margin: 0; padding: 0; font-size: 1px; line-height: 1px; mso-line-height-rule: exactly;" width="48"><div class="st-Spacer st-Spacer--filler"> </div></td>',
+    )
 
   const dom = new JSDOM(edited)
   const { document } = dom.window

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -337,7 +337,17 @@ export const mapRouteErr = (error: ApplicationError) => {
  */
 export const convertToInvoiceFormat = (
   receiptHtmlSource: string,
-  { address, gstRegNo }: { address: string; gstRegNo: string },
+  {
+    address,
+    gstRegNo,
+    formTitle,
+    submissionId,
+  }: {
+    address: string
+    gstRegNo: string
+    formTitle: string
+    submissionId: string
+  },
 ) => {
   // handle special characters in addresses
   const ADDRESS = encode(address)
@@ -352,8 +362,12 @@ export const convertToInvoiceFormat = (
     )
     .replace(/<br>\(This amount is inclusive of GST\)/, '') // not needed for real description (was added by Amit in his test)
     .replace(
-      /<strong>Amount charged<\/strong>/,
+      '<strong>Amount charged</strong>',
       '<strong>Amount charged</strong> <i>(includes GST)</i>',
+    )
+    .replace(
+      /Something wrong with the email\? <a.+a>/,
+      `FormSG Form: ${formTitle}<br>Response ID: ${submissionId}`,
     )
 
   const dom = new JSDOM(edited)
@@ -371,7 +385,7 @@ export const convertToInvoiceFormat = (
    */
   const tables = document.querySelectorAll('table table table')
 
-  let toRemove = 5
+  let toRemove = 3
   while (toRemove--) {
     tables[tables.length - toRemove - 1].remove()
   }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -436,11 +436,7 @@ const submitEncryptModeForm: ControllerHandler<
       paymentContactEmail: paymentReceiptEmail,
     }
 
-    const paymentReceiptDescription = [
-      form.payments_field.description,
-      `FormSG form: ${form.title}`,
-      `Response ID: ${pendingSubmissionId}`,
-    ].join('\n')
+    const paymentReceiptDescription = form.payments_field.description
 
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
       amount,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Improve invoice UX.

Closes #6175

## Solution
<!-- How did you solve the problem? -->
Remove form title and response id from the item name, and append them at the end of the invoice.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible

**Improvements**:

- Also corrects typo for `convertToInvoiceForrmat`

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

![image](https://user-images.githubusercontent.com/37061143/233942275-b91c3bc1-e6bd-48dd-9e2c-da0a14db36fd.png)

**AFTER**:
<!-- [insert screenshot here] -->

<img width="630" alt="Screenshot 2023-04-24 at 5 11 19 PM" src="https://user-images.githubusercontent.com/37061143/233952510-0221df94-5f8f-494a-a82b-0e9551f50923.png">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Make a payment on a payment-enabled form
- [ ] The form title and submission id should be at the end of the invoices instead of in the item name when obtained through the following channels:
  - [ ] Admin dashboard's invoice download link
  - [ ] Email received by payee
