### PR TITLE
ci: use different payments secrets for separate staging environments

### DIFF
--- a/.ebextensions/env-file-creation.config
+++ b/.ebextensions/env-file-creation.config
@@ -12,7 +12,7 @@ files:
         # Reach into the undocumented container config
         AWS_REGION='`{"Ref": "AWS::Region"}`'
         ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
-        ACTUAL_ENV_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ACTUAL_ENV_NAME)
+        ENV_SITE_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ENV_SITE_NAME)
         TARGET_DIR=/etc/formsg
 
         echo "Checking if ${TARGET_DIR} exists..."
@@ -27,16 +27,15 @@ files:
             echo "Directory ${TARGET_DIR} already exists!"
         fi
 
-        echo "Creating ENV_NAME config..."
-        if [ -n "${ACTUAL_ENV_NAME}" ]; then
-            echo "setting ENV_NAME as ACTUAL_ENV_NAME"
-            ENV_NAME=${ACTUAL_ENV_NAME}
+        echo "Setting ENV_SITE_NAME config for payment credentials..."
+        if [ -z "${ENV_SITE_NAME}" ]; then
+            echo "setting ENV_SITE_NAME as ENV_TYPE (${ENV_TYPE})"
+            ENV_SITE_NAME=${ENV_TYPE}
         else
-            echo "ACTUAL_ENV_NAME not present, setting ENV_NAME as ENV_TYPE instead..."
-            ENV_NAME=${ENV_TYPE}
+          echo "ENV_SITE_NAME already set as ${ENV_SITE_NAME} using SSM_ENV_SITE_NAME"
         fi
 
-        echo "Creating config for ${ENV_TYPE} in ${AWS_REGION}"
+        echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"
         aws ssm get-parameter --name "${ENV_TYPE}-general" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' > $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-captcha" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-ga" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
@@ -47,7 +46,7 @@ files:
         aws ssm get-parameter --name "${ENV_TYPE}-sgid" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-verified-fields" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-webhook-verified-content" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-payment" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}-payment" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
 
 packages:
   yum: 

--- a/.ebextensions/env-file-creation.config
+++ b/.ebextensions/env-file-creation.config
@@ -11,7 +11,8 @@ files:
         #!/bin/bash
         # Reach into the undocumented container config
         AWS_REGION='`{"Ref": "AWS::Region"}`'
-        ENV_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+        ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+        ACTUAL_ENV_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ACTUAL_ENV_NAME)
         TARGET_DIR=/etc/formsg
 
         echo "Checking if ${TARGET_DIR} exists..."
@@ -25,17 +26,26 @@ files:
         else
             echo "Directory ${TARGET_DIR} already exists!"
         fi
-        echo "Creating config for ${ENV_NAME} in ${AWS_REGION}"
-        aws ssm get-parameter --name "${ENV_NAME}-general" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' > $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-captcha" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-ga" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-intranet" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-sentry" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-sms" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-ndi" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-sgid" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-verified-fields" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_NAME}-webhook-verified-content" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+
+        echo "Creating ENV_NAME config..."
+        ENV_NAME=${ACTUAL_ENV_NAME:-ENV_TYPE}
+        if [ ! -z ${ACTUAL_ENV_NAME} ]; then
+            echo "ACTUAL_ENV_NAME not present, setting ENV_TYPE as ENV_NAME instead..."
+        else
+            echo "setting ACTUAL_ENV_NAME as ENV_NAME"
+        fi
+
+        echo "Creating config for ${ENV_TYPE} in ${AWS_REGION}"
+        aws ssm get-parameter --name "${ENV_TYPE}-general" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' > $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-captcha" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-ga" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-intranet" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-sentry" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-sms" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-ndi" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-sgid" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-verified-fields" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_TYPE}-webhook-verified-content" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_NAME}-payment" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
 
 packages:

--- a/.ebextensions/env-file-creation.config
+++ b/.ebextensions/env-file-creation.config
@@ -28,11 +28,12 @@ files:
         fi
 
         echo "Creating ENV_NAME config..."
-        ENV_NAME=${ACTUAL_ENV_NAME:-ENV_TYPE}
-        if [ ! -z ${ACTUAL_ENV_NAME} ]; then
-            echo "ACTUAL_ENV_NAME not present, setting ENV_TYPE as ENV_NAME instead..."
+        if [ -n "${ACTUAL_ENV_NAME}" ]; then
+            echo "setting ENV_NAME as ACTUAL_ENV_NAME"
+            ENV_NAME=${ACTUAL_ENV_NAME}
         else
-            echo "setting ACTUAL_ENV_NAME as ENV_NAME"
+            echo "ACTUAL_ENV_NAME not present, setting ENV_NAME as ENV_TYPE instead..."
+            ENV_NAME=${ENV_TYPE}
         fi
 
         echo "Creating config for ${ENV_TYPE} in ${AWS_REGION}"

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -102,7 +102,7 @@ Store of AWS Service Manager. These groups have names formatted as `<environment
 The environment for each group is user-defined, and should be specified in the Elastic Beanstalk configuration
 as the environment variable `SSM_PREFIX`.
 The specific environment is user-defined, and should be specified in the Elastic Beanstalk configuration
-as the environment variable `SSM_ACTUAL_ENV_NAME`. This variable is optional.
+as the environment variable `SSM_ENV_SITE_NAME`. This variable is optional.
 
 The list of categories can be inferred by looking at the file `.ebextensions/env-file-creation.config`.
 
@@ -114,7 +114,7 @@ The list of categories can be inferred by looking at the file `.ebextensions/env
 | :----------- | --------------------------------------------------------------------------------------------------------------------- |
 | `SSM_PREFIX` | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG.          |
 | `SECRET_ENV` | String (typically the environment name) to be used in building of AWS Secrets Manager keys in different environments. (`staging`, `prod`)|
-| `SSM_ACTUAL_ENV_NAME` | String (the specific environment name) to be used in building of AWS Secrets Manager keys in different environments. Optional. (`staging-alt`, `staging-alt2`)|
+| `SSM_ENV_SITE_NAME` | String (the specific environment site name) to be used in building of AWS Secrets Manager keys in different environments. Optional. (`staging-alt`, `staging-alt2`)|
 
 #### App Config
 

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -19,7 +19,7 @@ Infrastructure
 - AWS Elastic Beanstalk / EC2 for hosting and deployment
 - AWS Elastic File System for mounting files (i.e. SingPass/MyInfo private keys into the `/certs` directory)
 - AWS S3 for image and logo hosting, attachments for Storage Mode forms
-- AWS Service Manager - Parameter Store, for holding environment variable configuration
+- AWS Systems Manager - Parameter Store, for holding environment variable configuration
 
 DevOps
 
@@ -101,17 +101,20 @@ Store of AWS Service Manager. These groups have names formatted as `<environment
 
 The environment for each group is user-defined, and should be specified in the Elastic Beanstalk configuration
 as the environment variable `SSM_PREFIX`.
+The specific environment is user-defined, and should be specified in the Elastic Beanstalk configuration
+as the environment variable `SSM_ACTUAL_ENV_NAME`. This variable is optional.
 
 The list of categories can be inferred by looking at the file `.ebextensions/env-file-creation.config`.
 
 ### Core Features
 
-#### AWS Service Manager
+#### AWS Systems Manager
 
 | Variable     | Description                                                                                                           |
 | :----------- | --------------------------------------------------------------------------------------------------------------------- |
 | `SSM_PREFIX` | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG.          |
-| `SECRET_ENV` | String (typically the environment name) to be used in building of AWS Secrets Manager keys in different environments. |
+| `SECRET_ENV` | String (typically the environment name) to be used in building of AWS Secrets Manager keys in different environments. (`staging`, `prod`)|
+| `SSM_ACTUAL_ENV_NAME` | String (the specific environment name) to be used in building of AWS Secrets Manager keys in different environments. Optional. (`staging-alt`, `staging-alt2`)|
 
 #### App Config
 

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -112,8 +112,8 @@ The list of categories can be inferred by looking at the file `.ebextensions/env
 
 | Variable     | Description                                                                                                           |
 | :----------- | --------------------------------------------------------------------------------------------------------------------- |
-| `SSM_PREFIX` | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG.          |
-| `SECRET_ENV` | String (typically the environment name) to be used in building of AWS Secrets Manager keys in different environments. (`staging`, `prod`)|
+| `SSM_PREFIX` | String prefix (typically the environment name) for AWS SSM parameter names to create a .env file for FormSG. (`staging`, `prod`)|
+| `SECRET_ENV` | String (typically the environment name) to be used in building of AWS Secrets Manager keys in different environments.|
 | `SSM_ENV_SITE_NAME` | String (the specific environment site name) to be used in building of AWS Secrets Manager keys in different environments. Optional. (`staging-alt`, `staging-alt2`)|
 
 #### App Config


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, all the staging environments shared a single parameter store for `payments` secrets. This meant that we were **unable** to:
1. Use different Stripe accounts for each environment 
(relevant env vars: `PAYMENT_STRIPE_PUBLISHABLE_KEY`, `PAYMENT_STRIPE_SECRET_KEY`, `PAYMENT_STRIPE_CLIENT_ID`)
2. Even within the same Stripe account, use different webhook endpoints for each staging environment as each endpoint has a different signing secret.
(relevant env var: `PAYMENT_STRIPE_WEBHOOK_SECRET`)

Closes #6167, closes #6168

## Solution
<!-- How did you solve the problem? -->
- In AWS, add additional payments [parameter stores](https://ap-southeast-1.console.aws.amazon.com/systems-manager/parameters/?region=ap-southeast-1&tab=Table) for the different staging environments (1 for each - so now there's `staging-payment`, `staging-alt-payment`, `staging-alt2-payment`)
- On the Stripe dashboard, create different accounts for each staging environment
- Rename `ENV_NAME` to `ENV_TYPE` to better describe its function (`prod`, `staging` or `uat`)
- Use a new env var `ENV_NAME` in `.ebextensions/env-file-creation.config`, which determines the name of the parameter store for payments secrets. `ENV_NAME` is taken from `ACTUAL_ENV_NAME` if it's available, otherwise it defaults to`ENV_TYPE`
  - This allows us to have separation of payments secrets. Each staging environment now has its own parameter store, which means that different Stripe accounts and different webhook endpoints can be used.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] All 3 staging sites (`staging`, `staging-alt`, `staging-alt2`) should be working with payments. To double check that the deployment was successful, retrieve the logs from the EC2 instances. The echo commands can be found in `cfn-init-cmd.log`.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `SSM_ENV_SITE_NAME` : env var in ELB which provides the actual name of the specific environment e.g. `staging-alt`, `staging-alt2`. This is not necessary for `prod`, `staging` and `uat`.

