### PR TITLE
perf: memoize field row containers

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -1,7 +1,16 @@
 import { AdminFormDto } from '~shared/types/form'
 
+import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
 import { augmentWithQuestionNo } from '~features/form/utils'
 import { FieldIdSet } from '~features/logic/types'
+
+import { useBuilderAndDesignContext } from '../BuilderAndDesignContext'
+import { PENDING_CREATE_FIELD_ID } from '../constants'
+import {
+  FieldBuilderState,
+  stateDataSelector,
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
 
 import FieldRow from './FieldRow'
 
@@ -17,6 +26,13 @@ export const BuilderFields = ({
   isDraggingOver,
 }: BuilderFieldsProps) => {
   const fieldsWithQuestionNos = augmentWithQuestionNo(fields)
+  const stateData = useFieldBuilderStore(stateDataSelector)
+
+  const { handleBuilderClick } = useCreatePageSidebar()
+  const {
+    deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
+  } = useBuilderAndDesignContext()
+
   return (
     <>
       {fieldsWithQuestionNos.map((f, i) => (
@@ -26,6 +42,16 @@ export const BuilderFields = ({
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
           isDraggingOver={isDraggingOver}
+          isActive={
+            stateData.state === FieldBuilderState.EditingField
+              ? f._id === stateData.field._id
+              : stateData.state === FieldBuilderState.CreatingField
+              ? f._id === PENDING_CREATE_FIELD_ID
+              : false
+          }
+          fieldBuilderState={stateData.state}
+          handleBuilderClick={handleBuilderClick}
+          onDeleteModalOpen={onDeleteModalOpen}
         />
       ))}
     </>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { FormProvider, useForm } from 'react-hook-form'
 import { BiCog, BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
@@ -12,7 +12,7 @@ import {
   Flex,
   Icon,
 } from '@chakra-ui/react'
-import { times } from 'lodash'
+import { isEqual, times } from 'lodash'
 
 import { FormColorTheme } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
@@ -47,7 +47,7 @@ import { MobileFieldInput } from '~templates/Field/Mobile'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
-import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
+import { CreatePageSidebarContextProps } from '~features/admin-form/create/common'
 import {
   augmentWithMyInfoDisplayValue,
   extractPreviewValue,
@@ -55,8 +55,7 @@ import {
   isMyInfo,
 } from '~features/myinfo/utils'
 
-import { useBuilderAndDesignContext } from '../../BuilderAndDesignContext'
-import { PENDING_CREATE_FIELD_ID } from '../../constants'
+import { BuilderAndDesignContextProps } from '../../BuilderAndDesignContext'
 import { useDeleteFormField } from '../../mutations/useDeleteFormField'
 import { useDuplicateFormField } from '../../mutations/useDuplicateFormField'
 import { useCreateTabForm } from '../../useCreateTabForm'
@@ -69,7 +68,6 @@ import { isDirtySelector, useDirtyFieldStore } from '../../useDirtyFieldStore'
 import {
   FieldBuilderState,
   setToInactiveSelector,
-  stateDataSelector,
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '../../useFieldBuilderStore'
@@ -84,34 +82,32 @@ export interface FieldRowContainerProps {
   index: number
   isHiddenByLogic: boolean
   isDraggingOver: boolean
+  isActive: boolean
+  fieldBuilderState: FieldBuilderState
+  handleBuilderClick: CreatePageSidebarContextProps['handleBuilderClick']
+  onDeleteModalOpen: BuilderAndDesignContextProps['deleteFieldModalDisclosure']['onOpen']
 }
 
-export const FieldRowContainer = ({
+const FieldRowContainer = ({
   field,
   index,
   isHiddenByLogic,
   isDraggingOver,
+  isActive,
+  fieldBuilderState,
+  handleBuilderClick,
+  onDeleteModalOpen,
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
   const { data: form } = useCreateTabForm()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
-  const { stateData, setToInactive, updateEditState } = useFieldBuilderStore(
-    useCallback(
-      (state) => ({
-        stateData: stateDataSelector(state),
-        setToInactive: setToInactiveSelector(state),
-        updateEditState: updateEditStateSelector(state),
-      }),
-      [],
-    ),
-  )
+  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
+  const updateEditState = useFieldBuilderStore(updateEditStateSelector)
 
   const isDirty = useDirtyFieldStore(isDirtySelector)
   const toast = useToast({ status: 'danger', isClosable: true })
 
   const setDesignState = useDesignStore(setStateSelector)
-
-  const { handleBuilderClick } = useCreatePageSidebar()
 
   const { duplicateFieldMutation } = useDuplicateFormField()
   const { deleteFieldMutation } = useDeleteFormField()
@@ -140,19 +136,6 @@ export const FieldRowContainer = ({
     mode: 'onChange',
     defaultValues: defaultFieldValues,
   })
-
-  const isActive = useMemo(() => {
-    if (stateData.state === FieldBuilderState.EditingField) {
-      return field._id === stateData.field._id
-    } else if (stateData.state === FieldBuilderState.CreatingField) {
-      return field._id === PENDING_CREATE_FIELD_ID
-    }
-    return false
-  }, [stateData, field])
-
-  const {
-    deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
-  } = useBuilderAndDesignContext()
 
   const ref = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
@@ -208,7 +191,7 @@ export const FieldRowContainer = ({
   const handleDuplicateClick = useCallback(() => {
     if (!form) return
     // Duplicate button should be hidden if field is not yet created, but guard here just in case
-    if (stateData.state === FieldBuilderState.CreatingField) return
+    if (fieldBuilderState === FieldBuilderState.CreatingField) return
     // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
     if (field.fieldType === BasicField.Attachment) {
       const existingAttachmentsSize = form.form_fields.reduce(
@@ -230,15 +213,15 @@ export const FieldRowContainer = ({
       }
     }
     duplicateFieldMutation.mutate(field._id)
-  }, [stateData.state, field, duplicateFieldMutation, form, toast])
+  }, [fieldBuilderState, field, duplicateFieldMutation, form, toast])
 
   const handleDeleteClick = useCallback(() => {
-    if (stateData.state === FieldBuilderState.CreatingField) {
+    if (fieldBuilderState === FieldBuilderState.CreatingField) {
       setToInactive()
-    } else if (stateData.state === FieldBuilderState.EditingField) {
+    } else if (fieldBuilderState === FieldBuilderState.EditingField) {
       onDeleteModalOpen()
     }
-  }, [setToInactive, stateData.state, onDeleteModalOpen])
+  }, [setToInactive, fieldBuilderState, onDeleteModalOpen])
 
   const isAnyMutationLoading = useMemo(
     () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
@@ -250,9 +233,9 @@ export const FieldRowContainer = ({
       !isActive ||
       isDirty ||
       !!numFormFieldMutations ||
-      stateData.state === FieldBuilderState.CreatingField
+      fieldBuilderState === FieldBuilderState.CreatingField
     )
-  }, [isActive, isDirty, numFormFieldMutations, stateData.state])
+  }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
 
   return (
     <Draggable
@@ -331,7 +314,7 @@ export const FieldRowContainer = ({
                     snapshot.isDragging ? 'secondary.300' : 'secondary.200'
                   }
                 >
-                  {stateData.state === FieldBuilderState.EditingField &&
+                  {fieldBuilderState === FieldBuilderState.EditingField &&
                   !isDragDisabled ? (
                     <Icon as={BiGridHorizontal} fontSize="1.5rem" />
                   ) : (
@@ -377,7 +360,7 @@ export const FieldRowContainer = ({
                     ) : null}
                     {
                       // Fields which are not yet created cannot be duplicated
-                      stateData.state !== FieldBuilderState.CreatingField && (
+                      fieldBuilderState !== FieldBuilderState.CreatingField && (
                         <Tooltip label="Duplicate field">
                           <IconButton
                             aria-label="Duplicate field"
@@ -409,6 +392,10 @@ export const FieldRowContainer = ({
     </Draggable>
   )
 }
+
+export const MemoizedFieldRow = memo(FieldRowContainer, (prevProps, newProps) =>
+  isEqual(prevProps, newProps),
+)
 
 type FieldRowProps = {
   field: FormFieldDto

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/index.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/index.ts
@@ -1,1 +1,1 @@
-export { FieldRowContainer as default } from './FieldRowContainer'
+export { MemoizedFieldRow as default } from './FieldRowContainer'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContext.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContext.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react'
 import { UseDisclosureReturn } from '@chakra-ui/react'
 
-type BuilderAndDesignContextProps = {
+export type BuilderAndDesignContextProps = {
   deleteFieldModalDisclosure: UseDisclosureReturn
 }
 

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -35,7 +35,7 @@ export enum DrawerTabs {
   EndPage,
 }
 
-type CreatePageSidebarContextProps = {
+export type CreatePageSidebarContextProps = {
   activeTab: DrawerTabs | null
   pendingTab?: DrawerTabs | null
   movePendingToActiveTab: () => void


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently we have a lot of unnecessary re-renders on our Build and Design Content. Many components are re-rendering despite no changes to their properties. This is caused by the large number of hooks we use in the component.

This causes extreme lag in large forms as the re-renders linearly increments the page rendering time for every single action (dragging, selecting, modifying fields in the admin-form view)

This is especially detrimental for dragging fields, as it can cause the admin view for large forms to be almost impossible to navigate.

Closes #6121

## Solution
<!-- How did you solve the problem? -->
Move out some of the hooks from `FieldRowContainer` to its parent `BuilderField` which are causing most of the unnecessary re-renders

Use react memo to memoize the `FieldRowContainer` with deep comparison of props.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Large amount of re-render time as seen in the right.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/59867455/234180183-759bb487-6896-43f7-8a96-bca87932c14a.png">

https://user-images.githubusercontent.com/59867455/234180873-e3a49ef3-79a2-4253-bf83-86cb4341680a.mov

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/59867455/234179924-bc88776a-1509-4175-a0a6-6c647e946ec0.png">

https://user-images.githubusercontent.com/59867455/234180987-39ea66be-7889-4b12-afa4-30c607de6e6c.mov

## Tests
<!-- What tests should be run to confirm functionality? -->

**To ensure the feature works**
Use react dev tool -> profiler
- [x] go to a form in your admin view
- [x] start profiler recording
- [x] shift some of the fields around
- [x] stop recording, you should see that most fields are not re-rendered at each step, and they are memoized at the FieldRow level

Go to a large form
- [x] try to drag a field. The dragging of the field (before dropping) should feel smooth, and there should be minimal jitters.

**To ensure core features are still intact**
- [x] In any storage form, ensure the following functionality is still working
    - [x] Create a new field
    - [x] Edit the field properties of any field
    - [x] Edit the field properties, do not save, click away (close the drawer or select another field) the discard editing modal should appear
    - [x] Drag a field to change its position, field id should be updated too
    - [x] Duplicate a field
    - [x] Attempt to delete a field, the modal should open, and can be cancelled
    - [x] Delete the field, modal should open, and field can be deleted
    - [x] Preview the form. Make a submission
    - [x] Open the form to respondents. Make a submission
- [x] Do the same steps above for an email form
- [x] Do the same steps on mobile 

## Notes
There are still a few unnecessary re-renders upon drag and dropping of the fields.

Ideally, only the fields affected (field id changed) should re-render and all other fields should be unaffected. However, currently there is still some existing hooks that causes a re-render for all the fields even if they are memoized