### PR TITLE
chore: update previous payment typing and hooks

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -75,10 +75,8 @@ export const PublicFormSubmitButton = ({
           paymentEmailField.value,
           formId,
         )
-        if (payment) {
-          setDuplicate(true)
-          setPaymentId(payment._id)
-        }
+        setDuplicate(true)
+        setPaymentId(payment._id)
       } catch (err) {
         setDuplicate(false)
       }

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -42,8 +42,7 @@ export const PublicFormSubmitButton = ({
   onSubmit,
   trigger,
 }: PublicFormSubmitButtonProps): JSX.Element => {
-  const [isDuplicate, setDuplicate] = useState(false)
-  const [paymentId, setPaymentId] = useState('')
+  const [prevPaymentId, setPrevPaymentId] = useState('')
 
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
@@ -75,10 +74,9 @@ export const PublicFormSubmitButton = ({
           paymentEmailField.value,
           formId,
         )
-        setDuplicate(true)
-        setPaymentId(payment._id)
+        setPrevPaymentId(payment._id)
       } catch (err) {
-        setDuplicate(false)
+        setPrevPaymentId('')
       }
       onOpen()
     }
@@ -91,13 +89,13 @@ export const PublicFormSubmitButton = ({
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
       {isOpen ? (
-        isDuplicate ? (
+        prevPaymentId ? (
           <DuplicatePaymentModal
             onSubmit={onSubmit}
             onClose={onClose}
             isSubmitting={isSubmitting}
             formId={formId}
-            paymentId={paymentId}
+            paymentId={prevPaymentId}
           />
         ) : (
           <FormPaymentModal

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentService.ts
@@ -47,9 +47,9 @@ export const getPaymentInfo = async (paymentId: string) => {
 export const getPreviousPayment = async (
   email: string,
   formId: string,
-): Promise<PaymentDto | undefined> => {
+): Promise<PaymentDto> => {
   const emailData = { email }
-  return ApiService.post<PaymentDto | undefined>(
+  return ApiService.post<PaymentDto>(
     `${PAYMENTS_ENDPOINT}/${formId}/payments/previous/`,
     emailData,
   ).then(({ data }) => data)

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -65,7 +65,7 @@ export const _handleGetPreviousPayment: ControllerHandler<
             error,
           },
         })
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send()
+        return res.sendStatus(StatusCodes.INTERNAL_SERVER_ERROR)
       })
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
A typing issue was introduced in #6170 due to the change from 200->404 for payment not found case and `isDuplicate` is an unneeded state as we can get the truthy value of `paymentId`

Additionally, the internal state error case of `handleGetPreviousPayment`, currently separates `status` and `send` which is undesirable as there is no payload.

## Solution
<!-- How did you solve the problem? -->
Remove `undefined` from `getPreviousPayment` and `isDuplicated` from `PublicFormSubmitButton` in FE
And uses `sendStatus` for internal server error in handlePrevPayment in BE

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Previous payment check should still work correctly, duplicating test cases from #6170 
**To check basic functionality**
Go to a payment form
- [x] make a payment successfully
- [x] attempt to make a second payment with the same email
- [x] you should see the modal directing you to your previous payment page
- [x] click the link and ensure you are the same payment page from when you made a successful payment

**To check that we get the latest successful payment**
all of these are done with the same email as above
- [x] go back and make a second payment with the same email again (take note of your payment id/payment page link)
- [x] make a payment successfully
- [x] go back to the form
- [x] make a payment intent (but do not pay)
- [x] go back to the form
- [x] fill in the form and click proceed to pay, the duplicate payment modal should show, directing you to the **second** payment that you made. Check that the payment id/payment page link is equivalent to your second payment

**To check that we do not erroneously show the duplicate payment modal**
On the same form
- [x] make a payment with a different email
- [x] you should not see the duplicate payment modal at proceed to pay

On a different form
- [x] make a payment with the original email form above
- [x] you should not see the duplicate payment modal at proceed to pay

**To ensure no regression issues on non-payment forms**
(As changes was made to PublicFormSubmitButton)
- [x] go to a non-payment storage mode form
- [x] make a submission
- [x] go to an email mode form
- [x] make a submission
