### PR TITLE
chore: update payment guide in payment unsupported msg

### DIFF
--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
@@ -1,5 +1,8 @@
 import { Flex, Text } from '@chakra-ui/react'
 
+import { GUIDE_PAYMENTS } from '~constants/links'
+import Link from '~components/Link'
+
 import { SettingsUnsupportedSvgr } from '~features/admin-form/settings/svgrs/SettingsUnsupportedSvgr'
 
 export const PaymentsUnsupportedMsg = (): JSX.Element => {
@@ -10,7 +13,10 @@ export const PaymentsUnsupportedMsg = (): JSX.Element => {
       </Text>
       <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
         Collect payments through FormSG via integration with Stripe. This
-        feature is only available in Storage Mode.
+        feature is only available in Storage Mode.&nbsp;
+        <Link isExternal href={GUIDE_PAYMENTS}>
+          Read more about payments
+        </Link>
       </Text>
       <SettingsUnsupportedSvgr />
     </Flex>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Payment guide has been updated, we can publish it now

Closes #6014
 
## Solution
Update `PaymentsUnsupportedMsg`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/59867455/234460979-fda001e8-61c5-4596-b907-bbd10337d5fe.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] go to an email mode form. Go to settings, make sure that the settings page is as seen in the screenshot
- [ ] go to the payment guide link, make sure that it can open 