### PR TITLE
feat: invoice no background

### DIFF
--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -73,6 +73,7 @@ export type FormPaymentsChannel = {
   channel: PaymentChannel
   target_account_id: string
   publishable_key: string
+  invoice_background?: boolean
 }
 
 export type FormPaymentsField = {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -94,6 +94,7 @@ const PAYMENTS_DEFAULTS = {
     channel: PaymentChannel.Unconnected,
     target_account_id: '',
     publishable_key: '',
+    invoice_background: true,
   },
   payments_field: {
     enabled: false,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -150,6 +150,10 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       default: '',
       validate: [/^\S*$/i, 'publishable_key must not contain whitespace.'],
     },
+    invoice_background: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   payments_field: {

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -59,7 +59,7 @@ describe('stripe.controller', () => {
         ...mockBusinessInfo,
         formTitle: mockFormTitle,
         submissionId: mockSubmissionId,
-        background: false,
+        isBackgroundOn: false,
       }
       const mockForm = {
         _id: MOCK_FORM_ID,

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -59,6 +59,7 @@ describe('stripe.controller', () => {
         ...mockBusinessInfo,
         formTitle: mockFormTitle,
         submissionId: mockSubmissionId,
+        background: false,
       }
       const mockForm = {
         _id: MOCK_FORM_ID,

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -385,6 +385,7 @@ export const downloadPaymentInvoice: ControllerHandler<{
               gstRegNo: businessInfo?.gstRegNo || '',
               formTitle: populatedForm.title,
               submissionId: payment.completedPayment?.submissionId || '',
+              background: !!populatedForm.payments_channel?.invoice_background,
             })
 
             const pdfBufferPromise = generatePdfFromHtml(invoiceHtml)

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -385,7 +385,8 @@ export const downloadPaymentInvoice: ControllerHandler<{
               gstRegNo: businessInfo?.gstRegNo || '',
               formTitle: populatedForm.title,
               submissionId: payment.completedPayment?.submissionId || '',
-              background: !!populatedForm.payments_channel?.invoice_background,
+              isBackgroundOn:
+                !!populatedForm.payments_channel?.invoice_background,
             })
 
             const pdfBufferPromise = generatePdfFromHtml(invoiceHtml)

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -342,13 +342,13 @@ export const convertToInvoiceFormat = (
     gstRegNo,
     formTitle,
     submissionId,
-    background,
+    isBackgroundOn,
   }: {
     address: string
     gstRegNo: string
     formTitle: string
     submissionId: string
-    background: boolean
+    isBackgroundOn: boolean
   },
 ) => {
   // handle special characters in addresses
@@ -396,7 +396,7 @@ export const convertToInvoiceFormat = (
   while (toRemove--) {
     tables[tables.length - toRemove - 1].remove()
   }
-  if (!background) {
+  if (!isBackgroundOn) {
     document.querySelectorAll('td.Header-left a img')[0].remove()
     document.querySelectorAll('td.Header-right a img')[0].remove()
   }

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -342,11 +342,13 @@ export const convertToInvoiceFormat = (
     gstRegNo,
     formTitle,
     submissionId,
+    background,
   }: {
     address: string
     gstRegNo: string
     formTitle: string
     submissionId: string
+    background: boolean
   },
 ) => {
   // handle special characters in addresses
@@ -394,5 +396,10 @@ export const convertToInvoiceFormat = (
   while (toRemove--) {
     tables[tables.length - toRemove - 1].remove()
   }
+  if (!background) {
+    document.querySelectorAll('td.Header-left a img')[0].remove()
+    document.querySelectorAll('td.Header-right a img')[0].remove()
+  }
+
   return dom.serialize()
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Remove background shadow of invoice based on new flag in `payments_channel`

## Solution
<!-- How did you solve the problem? -->
Add `invoice_background` property to `payments_channel`
Remove background in `convertToInvoiceFormat` based on background flag

Currently the only method to remove the background is to go to db and manually set `invoice_background` as `false`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="792" alt="image" src="https://user-images.githubusercontent.com/59867455/234799169-73df344e-e978-4442-91db-9c968d404de8.png">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="792" alt="image" src="https://user-images.githubusercontent.com/59867455/234791356-906b514f-11c3-4780-93a8-89af44d65523.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
To ensure backwards compatibility
- [ ] use an old payment form
- [ ] make a payment
- [ ] the invoice should still look the same

To ensure new forms do not automatically have no background
- [ ] create a new payment form
- [ ] make a payment
- [ ] the invoice should still look the same

To test feature
- [ ] set `invoice_background` to `false` in a form from the DB
- [ ] make a payment
- [ ] the invoice should not have the shadows in the background