### PR TITLE
fix: add payout pending section to individual response page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -1,4 +1,5 @@
 import { BiCheck } from 'react-icons/bi'
+import { IconType } from 'react-icons/lib'
 import { Box, Divider, Flex, Icon, Link, Text } from '@chakra-ui/react'
 import { keyBy } from 'lodash'
 
@@ -7,6 +8,95 @@ import { PaymentStatus, SubmissionPaymentDto } from '~shared/types'
 import { Tag } from '~components/Tag'
 
 import { getPaymentDataView } from '../common/utils/getPaymentDataView'
+
+type PaymentSectionProps = {
+  payment: SubmissionPaymentDto
+  formId: string
+}
+
+export const PaymentSection = ({
+  payment,
+  formId,
+}: PaymentSectionProps): JSX.Element | null => {
+  if (!payment) return null
+
+  const paymentDataMap = keyBy(
+    getPaymentDataView(window.location.origin, payment, formId),
+    'key',
+  )
+
+  const paymentTagProps =
+    payment.status === PaymentStatus.Succeeded
+      ? { label: 'Success', colorScheme: 'success', rightIcon: BiCheck }
+      : payment.status === PaymentStatus.PartiallyRefunded
+      ? { label: 'Partially refunded', colorScheme: 'secondary' }
+      : payment.status === PaymentStatus.FullyRefunded
+      ? { label: 'Fully refunded', colorScheme: 'secondary' }
+      : payment.status === PaymentStatus.Disputed
+      ? { label: 'Disputed', colorScheme: 'warning' }
+      : undefined // The remaining options should never appear.
+
+  const payoutTagProps =
+    payment.payoutId || payment.payoutDate
+      ? { label: 'Success', colorScheme: 'success', rightIcon: BiCheck }
+      : { label: 'Pending', colorScheme: 'secondary' }
+
+  // Error: the payment is invalid and should not reach this state
+  if (!paymentTagProps) return null
+
+  return (
+    <Flex flexDir="column" gap="4rem">
+      <Flex flexDir="column" gap="1.25rem">
+        <PaymentDataHeader name="Payment" {...paymentTagProps} />
+        <Flex flexDir="column" gap="0.75rem">
+          <PaymentDataItem {...paymentDataMap['email']} />
+          <PaymentDataItem {...paymentDataMap['receiptUrl']} isUrl />
+          <Box py="0.75rem">
+            <Divider />
+          </Box>
+          <PaymentDataItem {...paymentDataMap['paymentIntentId']} isMonospace />
+          <PaymentDataItem {...paymentDataMap['amount']} />
+          <PaymentDataItem {...paymentDataMap['paymentDate']} />
+          <Box py="0.75rem">
+            <Divider />
+          </Box>
+          <PaymentDataItem {...paymentDataMap['transactionFee']} />
+        </Flex>
+      </Flex>
+      <Flex flexDir="column" gap="1.25rem">
+        <PaymentDataHeader name="Payout" {...payoutTagProps} />
+        <Flex flexDir="column" gap="0.75rem">
+          <PaymentDataItem {...paymentDataMap['payoutId']} isMonospace />
+          <PaymentDataItem {...paymentDataMap['payoutDate']} />
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}
+
+type PaymentDataHeaderProps = {
+  name: string
+  label: string
+  colorScheme: string
+  rightIcon?: IconType
+}
+
+const PaymentDataHeader = ({
+  name,
+  label,
+  colorScheme,
+  rightIcon,
+}: PaymentDataHeaderProps) => (
+  <Flex gap="1.5rem">
+    <Text textStyle="h2" as="h2" color="primary.500">
+      {name}
+    </Text>
+    <Tag colorScheme={colorScheme}>
+      <Text textStyle="caption-1">{label}</Text>
+      {rightIcon && <Icon as={rightIcon} ml="0.25rem" />}
+    </Tag>
+  </Flex>
+)
 
 type PaymentDataItemProps = {
   name: string
@@ -33,82 +123,6 @@ const PaymentDataItem = ({
           value
         )}
       </Text>
-    </Flex>
-  )
-}
-
-type PaymentSectionProps = {
-  payment: SubmissionPaymentDto
-  formId: string
-}
-
-export const PaymentSection = ({
-  payment,
-  formId,
-}: PaymentSectionProps): JSX.Element | null => {
-  if (!payment) return null
-
-  const displayPayoutSection = payment.payoutId || payment.payoutDate
-
-  const paymentDataMap = keyBy(
-    getPaymentDataView(window.location.origin, payment, formId),
-    'key',
-  )
-
-  const paymentTagProps =
-    payment.status === PaymentStatus.Succeeded
-      ? { label: 'Success', colorScheme: 'success', rightIcon: BiCheck }
-      : payment.status === PaymentStatus.PartiallyRefunded
-      ? { label: 'Partially refunded', colorScheme: 'secondary' }
-      : payment.status === PaymentStatus.FullyRefunded
-      ? { label: 'Fully refunded', colorScheme: 'secondary' }
-      : payment.status === PaymentStatus.Disputed
-      ? { label: 'Disputed', colorScheme: 'warning' }
-      : undefined // The remaining options should never appear.
-
-  // Error: the payment is invalid and should not reach this state
-  if (!paymentTagProps) return null
-
-  return (
-    <Flex flexDir="column" gap="2rem">
-      <Flex flexDir="column" gap="1.25rem">
-        <Flex gap="1.5rem">
-          <Text textStyle="h2" as="h2" color="primary.500">
-            Payment
-          </Text>
-          <Tag colorScheme={paymentTagProps.colorScheme}>
-            <Text textStyle="caption-1">{paymentTagProps.label}</Text>
-            {paymentTagProps.rightIcon && (
-              <Icon as={paymentTagProps.rightIcon} ml="0.25rem" />
-            )}
-          </Tag>
-        </Flex>
-        <Flex flexDir="column" gap="0.5rem">
-          <PaymentDataItem {...paymentDataMap['email']} />
-          <PaymentDataItem {...paymentDataMap['receiptUrl']} isUrl />
-          <Box py="0.75rem">
-            <Divider />
-          </Box>
-          <PaymentDataItem {...paymentDataMap['paymentIntentId']} isMonospace />
-          <PaymentDataItem {...paymentDataMap['amount']} />
-          <PaymentDataItem {...paymentDataMap['paymentDate']} />
-          <Box py="0.75rem">
-            <Divider />
-          </Box>
-          <PaymentDataItem {...paymentDataMap['transactionFee']} />
-        </Flex>
-      </Flex>
-      {displayPayoutSection && (
-        <Flex flexDir="column" gap="1rem">
-          <Text textStyle="h2" as="h2" color="primary.500">
-            Payout
-          </Text>
-          <Flex flexDir="column" gap="0.5rem">
-            <PaymentDataItem {...paymentDataMap['payoutId']} isMonospace />
-            <PaymentDataItem {...paymentDataMap['payoutDate']} />
-          </Flex>
-        </Flex>
-      )}
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -80,23 +80,14 @@ export const getPaymentDataView = (
       value: centsToDollarString(payment.transactionFee),
     },
 
-    ...(payment.payoutId
-      ? [
-          {
-            key: 'payoutId' as keyof SubmissionPaymentDto,
-            name: 'Payout ID',
-            value: payment.payoutId,
-          },
-        ]
-      : []),
-
-    ...(payment.payoutDate
-      ? [
-          {
-            key: 'payoutDate' as keyof SubmissionPaymentDto,
-            name: 'Payout date and time',
-            value: payment.payoutDate,
-          },
-        ]
-      : []),
+    {
+      key: 'payoutId',
+      name: 'Payout ID',
+      value: payment.payoutId ?? '-',
+    },
+    {
+      key: 'payoutDate',
+      name: 'Payout date and time',
+      value: payment.payoutDate ?? '-',
+    },
   ]


### PR DESCRIPTION
## Problem
We want to display the payout pending section even when payout details have not come in.

Closes #6143 

## Solution
Change the value of the payout details to "-" when no payout details are sent to the frontend. Display these with the appropriate tag for the payout "status", as per [figma](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?node-id=16608-163982&t=QhakbMRTzLni6fwD-4).

**Breaking Changes** 
- No - this PR is backwards compatible  

## Before & After Screenshots

Payout pending
![Screenshot 2023-04-28 at 10 53 24 AM](https://user-images.githubusercontent.com/25571626/235045497-6c69473e-1c55-4ac2-aed8-1187bd0eabdf.png)

Payout success
![Screenshot 2023-04-28 at 10 53 16 AM](https://user-images.githubusercontent.com/25571626/235045508-ecc8a1be-ba88-405f-a899-34b37182f985.png)
