### PR TITLE
fix: update payment modal to be fullpage on mobile

### DIFF
--- a/frontend/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,33 @@
+import {
+  ButtonGroup as CharkaButtonGroup,
+  ButtonGroupProps as ChakraButtonGroupProps,
+} from '@chakra-ui/react'
+
+export interface ButtonGroupProps extends ChakraButtonGroupProps {
+  /**
+   * If `true`, the button group will take up the full width of its container,
+   * and its children (<Button />) will be arranged in the reverse order
+   */
+  isFullWidth: boolean
+}
+
+export const ButtonGroup = ({
+  isFullWidth,
+  children,
+  ...rest
+}: ButtonGroupProps) => {
+  const buttonGrpResponsiveLayoutProps = isFullWidth
+    ? ({
+        flexDir: 'column-reverse',
+        w: '100%',
+        spacing: 0,
+        pt: '2rem',
+        rowGap: '0.75rem',
+      } as const)
+    : ({} as const)
+  return (
+    <CharkaButtonGroup {...buttonGrpResponsiveLayoutProps} {...rest}>
+      {children}
+    </CharkaButtonGroup>
+  )
+}

--- a/frontend/src/components/ButtonGroup/index.ts
+++ b/frontend/src/components/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { ButtonGroup as default } from './ButtonGroup'

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, MouseEventHandler } from 'react'
 import {
   Button,
   ButtonGroup,
+  ButtonGroupProps,
   Link,
   Modal,
   ModalBody,
@@ -13,6 +14,8 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
+
+import { useIsMobile } from '~hooks/useIsMobile'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 
@@ -40,14 +43,25 @@ export const DuplicatePaymentModal = ({
       onSubmit(event)
     }
   }
+  const isMobile = useIsMobile()
+  const modalResponsiveLayoutProps = isMobile ? { size: 'full' } : {}
+  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
+    ? {
+        flexDir: 'column-reverse',
+        w: '100%',
+        spacing: 0,
+        pt: '2rem',
+        rowGap: '0.75rem',
+      }
+    : {}
   return (
     <>
-      <Modal isOpen onClose={onClose}>
+      <Modal {...modalResponsiveLayoutProps} isOpen onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalCloseButton />
-          <ModalHeader>Proceed to pay again?</ModalHeader>
-          <ModalBody>
+          {!isMobile && <ModalCloseButton />}
+          <ModalHeader pb={'2rem'}>Proceed to pay again?</ModalHeader>
+          <ModalBody flexGrow={0}>
             <Stack>
               <Text>
                 We noticed a successful payment made on this form by your email
@@ -59,7 +73,7 @@ export const DuplicatePaymentModal = ({
             </Stack>
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup>
+            <ButtonGroup {...buttonGrpResponsiveLayoutProps}>
               <Button variant="clear" onClick={onClose}>
                 Cancel
               </Button>

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -1,8 +1,6 @@
 import { MouseEvent, MouseEventHandler } from 'react'
 import {
   Button,
-  ButtonGroup,
-  ButtonGroupProps,
   Link,
   Modal,
   ModalBody,
@@ -16,6 +14,7 @@ import {
 } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import ButtonGroup from '~components/ButtonGroup'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 
@@ -44,19 +43,10 @@ export const DuplicatePaymentModal = ({
     }
   }
   const isMobile = useIsMobile()
-  const modalResponsiveLayoutProps = isMobile ? { size: 'full' } : {}
-  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
-    ? {
-        flexDir: 'column-reverse',
-        w: '100%',
-        spacing: 0,
-        pt: '2rem',
-        rowGap: '0.75rem',
-      }
-    : {}
+
   return (
     <>
-      <Modal {...modalResponsiveLayoutProps} isOpen onClose={onClose}>
+      <Modal isOpen onClose={onClose} size={isMobile ? 'full' : undefined}>
         <ModalOverlay />
         <ModalContent>
           {!isMobile && <ModalCloseButton />}
@@ -73,7 +63,7 @@ export const DuplicatePaymentModal = ({
             </Stack>
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup {...buttonGrpResponsiveLayoutProps}>
+            <ButtonGroup isFullWidth={isMobile}>
               <Button variant="clear" onClick={onClose}>
                 Cancel
               </Button>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent, MouseEventHandler } from 'react'
 import {
-  Button,
   ButtonGroup,
+  ButtonGroupProps,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -10,6 +10,9 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '@chakra-ui/react'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
 
 type FormPaymentModalProps = {
   onSubmit: MouseEventHandler<HTMLButtonElement> | undefined
@@ -29,26 +32,40 @@ export const FormPaymentModal = ({
       onSubmit(event)
     }
   }
+
+  const isMobile = useIsMobile()
+  const props = { size: isMobile ? 'full' : undefined }
+  const responsiveProps: ButtonGroupProps = isMobile
+    ? {
+        flexDir: 'column-reverse',
+        w: '100%',
+        spacing: 0,
+        pt: '2rem',
+        rowGap: '0.75rem',
+      }
+    : {}
+
   return (
     <>
-      <Modal isOpen onClose={onClose}>
+      <Modal {...props} isOpen onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalCloseButton />
+          {!isMobile && <ModalCloseButton />}
           <ModalHeader>You are about to make payment</ModalHeader>
-          <ModalBody>
+          <ModalBody flexGrow={0}>
             Please ensure that your form information is accurate. You will not
             be able to edit your form after you proceed.
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup>
-              <Button variant="clear" onClick={onClose}>
+            <ButtonGroup {...responsiveProps}>
+              <Button variant="clear" onClick={onClose} isFullWidth={isMobile}>
                 Cancel
               </Button>
               <Button
                 isLoading={isSubmitting}
                 loadingText="Submitting"
                 onClick={closeAndSubmit}
+                isFullWidth={isMobile}
               >
                 Proceed to pay
               </Button>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -34,8 +34,8 @@ export const FormPaymentModal = ({
   }
 
   const isMobile = useIsMobile()
-  const props = { size: isMobile ? 'full' : undefined }
-  const responsiveProps: ButtonGroupProps = isMobile
+  const modalResponsiveLayoutProps = { size: isMobile ? 'full' : undefined }
+  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
     ? {
         flexDir: 'column-reverse',
         w: '100%',
@@ -47,17 +47,17 @@ export const FormPaymentModal = ({
 
   return (
     <>
-      <Modal {...props} isOpen onClose={onClose}>
+      <Modal {...modalResponsiveLayoutProps} isOpen onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           {!isMobile && <ModalCloseButton />}
-          <ModalHeader>You are about to make payment</ModalHeader>
+          <ModalHeader pb={'2rem'}>You are about to make payment</ModalHeader>
           <ModalBody flexGrow={0}>
             Please ensure that your form information is accurate. You will not
             be able to edit your form after you proceed.
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup {...responsiveProps}>
+            <ButtonGroup {...buttonGrpResponsiveLayoutProps}>
               <Button variant="clear" onClick={onClose} isFullWidth={isMobile}>
                 Cancel
               </Button>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -1,7 +1,5 @@
 import { MouseEvent, MouseEventHandler } from 'react'
 import {
-  ButtonGroup,
-  ButtonGroupProps,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -13,6 +11,7 @@ import {
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
+import ButtonGroup from '~components/ButtonGroup'
 
 type FormPaymentModalProps = {
   onSubmit: MouseEventHandler<HTMLButtonElement> | undefined
@@ -34,20 +33,10 @@ export const FormPaymentModal = ({
   }
 
   const isMobile = useIsMobile()
-  const modalResponsiveLayoutProps = { size: isMobile ? 'full' : undefined }
-  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
-    ? {
-        flexDir: 'column-reverse',
-        w: '100%',
-        spacing: 0,
-        pt: '2rem',
-        rowGap: '0.75rem',
-      }
-    : {}
 
   return (
     <>
-      <Modal {...modalResponsiveLayoutProps} isOpen onClose={onClose}>
+      <Modal isOpen onClose={onClose} size={isMobile ? 'full' : undefined}>
         <ModalOverlay />
         <ModalContent>
           {!isMobile && <ModalCloseButton />}
@@ -57,7 +46,7 @@ export const FormPaymentModal = ({
             be able to edit your form after you proceed.
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup {...buttonGrpResponsiveLayoutProps}>
+            <ButtonGroup isFullWidth={isMobile}>
               <Button variant="clear" onClick={onClose} isFullWidth={isMobile}>
                 Cancel
               </Button>

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -1,7 +1,5 @@
 import { useNavigate } from 'react-router-dom'
 import {
-  ButtonGroup,
-  ButtonGroupProps,
   Modal,
   ModalBody,
   ModalContent,
@@ -17,6 +15,7 @@ import { FormResponseMode } from '~shared/types'
 import { useBrowserStm } from '~hooks/payments'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
+import ButtonGroup from '~components/ButtonGroup'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 
@@ -57,20 +56,10 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
     onClose()
   }
 
-  const modalResponsiveLayoutProps = isMobile ? { size: 'full' } : {}
-  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
-    ? {
-        flexDir: 'column-reverse',
-        w: '100%',
-        spacing: 0,
-        pt: '2rem',
-        rowGap: '0.75rem',
-      }
-    : {}
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
       <Modal
-        {...modalResponsiveLayoutProps}
+        size={isMobile ? 'full' : undefined}
         isOpen
         onClose={() => {
           // do nothing, prevent dismissal through backdrop touch
@@ -84,10 +73,7 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
             previous session and complete payment.
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup
-              {...buttonGrpResponsiveLayoutProps}
-              justifyContent="end"
-            >
+            <ButtonGroup isFullWidth={isMobile} justifyContent="end">
               <Button
                 variant="clear"
                 onClick={handleStartOver}

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import {
   ButtonGroup,
+  ButtonGroupProps,
   Modal,
   ModalBody,
   ModalContent,
@@ -55,9 +56,21 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
     clearPaymentMemory()
     onClose()
   }
+
+  const modalResponsiveLayoutProps = isMobile ? { size: 'full' } : {}
+  const buttonGrpResponsiveLayoutProps: ButtonGroupProps = isMobile
+    ? {
+        flexDir: 'column-reverse',
+        w: '100%',
+        spacing: 0,
+        pt: '2rem',
+        rowGap: '0.75rem',
+      }
+    : {}
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
       <Modal
+        {...modalResponsiveLayoutProps}
         isOpen
         onClose={() => {
           // do nothing, prevent dismissal through backdrop touch
@@ -66,13 +79,13 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
         <ModalOverlay />
         <ModalContent>
           <ModalHeader pb={'2rem'}>Restore previous session?</ModalHeader>
-          <ModalBody>
+          <ModalBody flexGrow={0}>
             We noticed an incomplete session on this form. You can restore your
             previous session and complete payment.
           </ModalBody>
-          <ModalFooter pt={'2.5rem'} pb={'2.5rem'}>
+          <ModalFooter>
             <ButtonGroup
-              flexWrap={isMobile ? 'wrap-reverse' : 'wrap'}
+              {...buttonGrpResponsiveLayoutProps}
               justifyContent="end"
             >
               <Button

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -73,7 +73,7 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
             previous session and complete payment.
           </ModalBody>
           <ModalFooter>
-            <ButtonGroup isFullWidth={isMobile} justifyContent="end">
+            <ButtonGroup isFullWidth={isMobile}>
               <Button
                 variant="clear"
                 onClick={handleStartOver}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Inconsistencies with design

Closes #6216

## Solution

Changes to three modals that relates to payment when on a mobile browser UA.
- `DuplicatePaymentModal.tsx`
- `FormPaymentModal.tsx`
- `FormPaymentResumeModal.tsx`

**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

| Name | Mobile | PC |
|--------|--------|--------|
| `DuplicatePaymentModal` | <img width="399" alt="Screenshot 2023-04-28 at 3 09 51 PM" src="https://user-images.githubusercontent.com/12391617/235117077-a1038cc8-2f32-4d37-81b6-fcfeea1af646.png"> | <img width="703" alt="Screenshot 2023-04-28 at 6 05 32 PM" src="https://user-images.githubusercontent.com/12391617/235119236-3d7e1cb0-a0f5-4315-8370-cd722599b13e.png"> |
| `FormPaymentModal` | <img width="412" alt="Screenshot 2023-04-28 at 6 06 58 PM" src="https://user-images.githubusercontent.com/12391617/235119496-05c01a65-dc72-4f5f-9e4c-75bf72bb4569.png"> | <img width="704" alt="Screenshot 2023-04-28 at 6 05 09 PM" src="https://user-images.githubusercontent.com/12391617/235119281-175ce804-239f-4b81-b348-69444689e34e.png"> |
| `FormPaymentResumeModal` |<img width="392" alt="Screenshot 2023-04-28 at 3 52 32 PM" src="https://user-images.githubusercontent.com/12391617/235117032-a04ed857-a8df-47a0-be16-814fb3deeb2a.png"> | <img width="695" alt="Screenshot 2023-04-28 at 6 04 59 PM" src="https://user-images.githubusercontent.com/12391617/235119320-d4039374-5fbd-461b-9a06-ba60a0327a0e.png"> | 

**AFTER**:
<!-- [insert screenshot here] -->

| Name | Mobile | PC |
|--------|--------|--------|
| `DuplicatePaymentModal` | <img width="392" alt="Screenshot 2023-04-28 at 3 12 40 PM" src="https://user-images.githubusercontent.com/12391617/235117828-0e049f62-bbf7-4fec-9d98-66febcb579cf.png">| <img width="710" alt="Screenshot 2023-04-28 at 6 03 00 PM" src="https://user-images.githubusercontent.com/12391617/235118647-f469a071-979f-4101-af58-1984883e5613.png"> |
| `FormPaymentModal` | <img width="380" alt="Screenshot 2023-04-28 at 1 01 01 PM" src="https://user-images.githubusercontent.com/12391617/235117735-6c36cdd3-8871-4133-86c2-d2266de2f422.png"> | <img width="706" alt="Screenshot 2023-04-28 at 6 01 26 PM" src="https://user-images.githubusercontent.com/12391617/235118506-ed9d30d8-b629-4e90-96da-96a19eab9b51.png"> |
| `FormPaymentResumeModal` |<img width="402" alt="Screenshot 2023-04-28 at 6 00 13 PM" src="https://user-images.githubusercontent.com/12391617/235118141-5a19547a-9f86-4a8b-b831-be2415c8d1b0.png"> |<img width="713" alt="Screenshot 2023-04-28 at 6 01 18 PM" src="https://user-images.githubusercontent.com/12391617/235118452-ca485358-d268-431a-a5d4-7f3de5b4502f.png"> |
 
## Tests
<!-- What tests should be run to confirm functionality? -->
Changes on Payment forms
  - [ ] Mobile mode
    - [ ] `DuplicatePaymentModal` should show correctly in full screen with buttons in correct order
      - [ ] Cancel button should dismiss modal and remain on page
      - [ ] Proceed to pay button should lead to new payment intent created
    - [ ] `FormPaymentModal` should show correctly in full screen with buttons in correct order
      - [ ] Cancel button should dismiss modal and remain on page
      - [ ] Proceed to pay button should lead to new payment intent created
    - [ ] `FormPaymentResumeModal` should show correctly in full screen with buttons in correct order
      - [ ] Start over again button should lead to new payment intent created
      - [ ] Restore previous session button should lead to previous payment page
      - [ ] There should be no `X` button
  - [ ] PC mode
    - [ ] `DuplicatePaymentModal` should show correctly as a modal with buttons in correct order
    - [ ] `FormPaymentModal` should show correctly as a modal with buttons in correct order
    - [ ] `FormPaymentResumeModal` should show correctly as a modal with buttons in correct order

Regressions tests
- [ ] Expect submission on non-payment forms to have no issues
