### PR TITLE
feat: payment preview banner

### DIFF
--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -44,7 +44,7 @@ interface PreviewFormBannerProps {
 export const PreviewFormBanner = ({
   isTemplate,
 }: PreviewFormBannerProps): JSX.Element => {
-  const { formId } = usePublicFormContext()
+  const { formId, isPaymentEnabled } = usePublicFormContext()
   const {
     isOpen: isModalOpen,
     onOpen: onModalOpen,
@@ -165,6 +165,19 @@ export const PreviewFormBanner = ({
           </DrawerContent>
         </Drawer>
       </Flex>
+      {isPaymentEnabled && (
+        <Flex backgroundColor={'#3A3E46'}>
+          <Text
+            textStyle="body-2"
+            color="white"
+            ml="2rem"
+            mt="0.5rem"
+            mb="0.5rem"
+          >
+            Payments made in Form Preview mode will not reflect on Stripe.
+          </Text>
+        </Flex>
+      )}
       <Divider />
     </>
   )

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -314,6 +314,10 @@ export const PreviewFormProvider = ({
     ],
   )
 
+  const isPaymentEnabled =
+    data?.form.responseMode === FormResponseMode.Encrypt &&
+    data.form.payments_field.enabled
+
   if (isNotFormId) {
     return <NotFoundErrorPage />
   }
@@ -329,6 +333,7 @@ export const PreviewFormProvider = ({
         expiryInMs,
         isLoading,
         handleLogout: undefined,
+        isPaymentEnabled,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -46,6 +46,9 @@ export interface PublicFormContextProps
    */
   onMobileDrawerOpen: () => void
   onMobileDrawerClose: () => void
+
+  /** Whether payment is enabled */
+  isPaymentEnabled: boolean
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -483,6 +483,10 @@ export const PublicFormProvider = ({
     [data?.form, data?.spcpSession],
   )
 
+  const isPaymentEnabled =
+    data?.form.responseMode === FormResponseMode.Encrypt &&
+    data.form.payments_field.enabled
+
   if (isNotFormId) {
     return <NotFoundErrorPage />
   }
@@ -499,6 +503,7 @@ export const PublicFormProvider = ({
         captchaContainerId: containerId,
         expiryInMs,
         isLoading: isLoading || (!!data?.form.hasCaptcha && !hasLoaded),
+        isPaymentEnabled,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -3,12 +3,7 @@ import { useFormState, UseFormTrigger, useWatch } from 'react-hook-form'
 import { Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
-import {
-  FormField,
-  FormResponseMode,
-  LogicDto,
-  MyInfoFormField,
-} from '~shared/types'
+import { FormField, LogicDto, MyInfoFormField } from '~shared/types'
 
 import { ThemeColorScheme } from '~theme/foundations/colours'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -47,7 +42,7 @@ export const PublicFormSubmitButton = ({
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
   const formInputs = useWatch<FormFieldValues>({}) as FormFieldValues
-  const { form, formId } = usePublicFormContext()
+  const { formId, isPaymentEnabled } = usePublicFormContext()
 
   const paymentEmailField = formInputs[
     PAYMENT_CONTACT_FIELD_ID
@@ -81,10 +76,6 @@ export const PublicFormSubmitButton = ({
       onOpen()
     }
   }
-
-  const isPaymentEnabled =
-    form?.responseMode === FormResponseMode.Encrypt &&
-    form?.payments_field?.enabled
 
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -11,8 +11,6 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types'
-
 import { useBrowserStm } from '~hooks/payments'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
@@ -27,13 +25,9 @@ import { usePublicFormContext } from '../../PublicFormContext'
  */
 export const PublicFormPaymentResumeModal = (): JSX.Element => {
   const isMobile = useIsMobile()
-  const { form, formId } = usePublicFormContext()
+  const { isPaymentEnabled, formId } = usePublicFormContext()
 
   const [lastPaymentMemory, , clearPaymentMemory] = useBrowserStm(formId)
-
-  const isPaymentEnabled =
-    form?.responseMode === FormResponseMode.Encrypt &&
-    form?.payments_field?.enabled
 
   const { isOpen, onClose } = useDisclosure({
     defaultIsOpen: Boolean(lastPaymentMemory && isPaymentEnabled),

--- a/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormStartPage.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react'
 
-import { FormResponseMode } from '~shared/types'
-
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { useFormSections } from '../FormFields/FormSectionsContext'
@@ -22,15 +20,13 @@ export const FormStartPage = ({
     miniHeaderRef,
     onMobileDrawerOpen,
     handleLogout,
+    isPaymentEnabled,
   } = usePublicFormContext()
   const { activeSectionId } = useFormSections()
 
   const showHeaderAndMiniHeader = useMemo(
-    () =>
-      !submissionData ||
-      (form?.responseMode === FormResponseMode.Encrypt &&
-        form?.payments_field?.enabled),
-    [submissionData, form],
+    () => !submissionData || isPaymentEnabled,
+    [submissionData, isPaymentEnabled],
   )
 
   const formHeaderProps = useFormHeader({ startPage: form?.startPage })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #6215

## Solution
<!-- How did you solve the problem? -->

Use `PublicFormContext` to provide payment enabled context. This also helps to reduce the amount of payment enabled checks (i.e. `form?.responseMode === FormResponseMode.Encrypt && form.payments_field.enabled`)

Changes a few other components to use payment enabled context `PublicFormSubmitButton`, `FormPaymentResumeModal`, `FormStartPage`

Did not modify `FormFields` as the payment field input requires typeguards

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/59867455/235571932-2f8f8f1e-5afc-46c7-8d75-0ce4e2ab3ef5.png">


## Tests
<!-- What tests should be run to confirm functionality? -->
**To check that the feature has been implemented correctly**
- [ ] go to a payment form. Click preview. Ensure that the banner is shown as per our design figma

**To ensure no regression problems**
Payment modals
- [ ] make a payment on a payment form. Check that payment modal is displayed. Complete payment
- [ ] make a duplicate payment on a payment form. check that duplicate payment modal is displayed. The link works to link back to previous payment page. Make payment intent but do not complete payment
- [ ] go back to form. Make sure payment resume modal is displayed and works correctly (restore previous + start over)

Non-payment
- [ ] go to a non-payment email form. make a submission
- [ ] go to a non-payment storage form. make a submission

Use-template (lets bring templates for payment form up for discussion next time)
- [ ] create a template on a non-payment form, no payment preview banner etc should be shown.