### PR TITLE
feat: add business field mutation to form-level

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -4,6 +4,7 @@ import {
   EmailFormSettings,
   FormSettings,
   SettingsUpdateDto,
+  StorageFormSettings,
 } from '~shared/types/form/form'
 
 import { ApiService } from '~services/ApiService'
@@ -14,6 +15,11 @@ import { ADMIN_FORM_ENDPOINT } from '../common/AdminViewFormService'
 type UpdateEmailFormFn<T extends keyof EmailFormSettings> = (
   formId: string,
   settingsToUpdate: EmailFormSettings[T],
+) => Promise<FormSettings>
+
+type UpdateStorageFormFn<T extends keyof StorageFormSettings> = (
+  formId: string,
+  settingsToUpdate: StorageFormSettings[T],
 ) => Promise<FormSettings>
 
 type UpdateFormFn<T extends keyof FormSettings> = (
@@ -104,6 +110,13 @@ export const updateFormWebhookRetries = async (
       isRetryEnabled: nextEnabled,
     },
   })
+}
+
+export const updateBusinessInfo: UpdateStorageFormFn<'business'> = async (
+  formId,
+  newBusinessField: StorageFormSettings['business'],
+) => {
+  return updateFormSettings(formId, { business: newBusinessField })
 }
 
 /**

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -1,0 +1,111 @@
+import {
+  ChangeEventHandler,
+  Dispatch,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from 'react'
+import { FormControl } from '@chakra-ui/react'
+
+import { FormResponseMode, StorageFormSettings } from '~shared/types'
+
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { useMutateFormSettings } from '../../mutations'
+import { useAdminFormSettings } from '../../queries'
+
+interface BusinessFieldInputProps {
+  initialValue: string
+  handleMutation: (newAddress: string) => void
+}
+const BusinessFieldInput = ({
+  initialValue,
+  handleMutation,
+}: BusinessFieldInputProps): JSX.Element => {
+  const [value, setValue] = useState(initialValue)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleValueChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      setValue(e.target.value.trim())
+    },
+    [],
+  )
+
+  const handleBlur = useCallback(() => {
+    if (value === initialValue) return
+    handleMutation(value)
+  }, [handleMutation, value, initialValue])
+
+  const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        inputRef.current?.blur()
+      }
+    },
+    [],
+  )
+
+  return (
+    <Input
+      ref={inputRef}
+      value={value}
+      onChange={handleValueChange}
+      onKeyDown={handleKeydown}
+      onBlur={handleBlur}
+      placeholder={'Using Agency Defaults'}
+    />
+  )
+}
+
+const BusinessInfoBlock = ({ settings }: { settings: StorageFormSettings }) => {
+  const { mutateFormBusiness } = useMutateFormSettings()
+  const handleAddressMutation = (newAddress: string) => {
+    mutateFormBusiness.mutate({ address: newAddress })
+  }
+  const handleGstRegNoMutation = (newGstRegNo: string) => {
+    mutateFormBusiness.mutate({ gstRegNo: newGstRegNo })
+  }
+  return (
+    <>
+      <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
+        <FormLabel description="Leave empty to use your agency defaults.">
+          GST Registration Number
+        </FormLabel>
+        <BusinessFieldInput
+          initialValue={settings.business?.gstRegNo || ''}
+          handleMutation={handleGstRegNoMutation}
+        />
+      </FormControl>
+      <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
+        <FormLabel description="Leave empty to use your agency defaults.">
+          Business Address
+        </FormLabel>
+        <BusinessFieldInput
+          initialValue={settings.business?.address || ''}
+          handleMutation={handleAddressMutation}
+        />
+      </FormControl>
+    </>
+  )
+}
+
+export const BusinessInfoSection = () => {
+  const { data: settings, isLoading } = useAdminFormSettings()
+
+  if (
+    isLoading ||
+    !settings ||
+    settings.responseMode !== FormResponseMode.Encrypt
+  ) {
+    return <></>
+  }
+
+  return <BusinessInfoBlock settings={settings} />
+}

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -29,14 +29,16 @@ const BusinessFieldInput = ({
 
   const handleValueChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      setValue(e.target.value.trim())
+      setValue(e.target.value)
     },
     [],
   )
 
   const handleBlur = useCallback(() => {
     if (value === initialValue) return
-    handleMutation(value)
+    const trimmedValue = value.trim()
+    handleMutation(trimmedValue)
+    setValue(trimmedValue)
   }, [handleMutation, value, initialValue])
 
   const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -1,9 +1,6 @@
 import {
   ChangeEventHandler,
-  Dispatch,
-  FocusEventHandler,
   KeyboardEventHandler,
-  SetStateAction,
   useCallback,
   useRef,
   useState,

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,4 +1,11 @@
-import { Flex, FormControl, Icon, Skeleton, Text } from '@chakra-ui/react'
+import {
+  Divider,
+  Flex,
+  FormControl,
+  Icon,
+  Skeleton,
+  Text,
+} from '@chakra-ui/react'
 
 import { FormResponseMode, PaymentChannel } from '~shared/types'
 
@@ -8,6 +15,7 @@ import Input from '~components/Input'
 
 import { useAdminFormPayments, useAdminFormSettings } from '../../queries'
 
+import { BusinessInfoSection } from './BusinessInfoSection'
 import { StripeConnectButton } from './StripeConnectButton'
 
 const PaymentsAccountValidation = () => {
@@ -128,6 +136,8 @@ export const PaymentSettingsSection = (): JSX.Element => {
     <>
       <PaymentsSectionText />
       <StripeConnectButton />
+      <Divider my="2.5rem" />
+      <BusinessInfoSection />
     </>
   )
 }

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -9,6 +9,7 @@ import {
   FormResponseMode,
   FormSettings,
   FormStatus,
+  StorageFormSettings,
 } from '~shared/types/form/form'
 import { TwilioCredentials } from '~shared/types/twilio'
 
@@ -25,6 +26,7 @@ import {
   createStripeAccount,
   deleteTwilioCredentials,
   unlinkStripeAccount,
+  updateBusinessInfo,
   updateFormAuthType,
   updateFormCaptcha,
   updateFormEmails,
@@ -287,6 +289,20 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateFormBusiness = useMutation(
+    (businessInfo: StorageFormSettings['business']) =>
+      updateBusinessInfo(formId, businessInfo),
+    {
+      onSuccess: (newData) => {
+        handleSuccess({
+          newData,
+          toastDescription: `Business information have been updated.`,
+        })
+      },
+      onError: handleError,
+    },
+  )
+
   return {
     mutateWebhookRetries,
     mutateFormWebhookUrl,
@@ -298,6 +314,7 @@ export const useMutateFormSettings = () => {
     mutateFormTitle,
     mutateFormAuthType,
     mutateFormEsrvcId,
+    mutateFormBusiness,
   }
 }
 

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -296,7 +296,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Business information have been updated.`,
+          toastDescription: `Business information has been updated.`,
         })
       },
       onError: handleError,

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -41,6 +41,7 @@ export const STORAGE_FORM_SETTINGS_FIELDS = <const>[
   'payments_channel',
   'payments_field',
   'publicKey',
+  'business',
 ]
 
 export const ADMIN_FORM_META_FIELDS = <const>[

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -81,6 +81,11 @@ export type FormPaymentsField = {
   description?: string
 }
 
+export type FormBusinessField = {
+  address?: string
+  gstRegNo?: string
+}
+
 export interface FormBase {
   title: string
   admin: UserDto['_id']
@@ -120,6 +125,7 @@ export interface StorageFormBase extends FormBase {
   publicKey: string
   payments_channel: FormPaymentsChannel
   payments_field: FormPaymentsField
+  business?: FormBusinessField
 }
 
 /**
@@ -246,6 +252,7 @@ export type EndPageUpdateDto = FormEndPage
 export type FormPermissionsDto = FormPermission[]
 export type PermissionsUpdateDto = FormPermission[]
 export type PaymentsUpdateDto = FormPaymentsField
+export type BusinessUpdateDto = FormBusinessField
 
 export type SendFormOtpResponseDto = {
   otpPrefix: string

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -173,6 +173,13 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       },
     },
   },
+
+  business: {
+    type: {
+      address: { type: String, required: true, trim: true },
+      gstRegNo: { type: String, required: true, trim: true },
+    },
+  },
 })
 
 const EncryptedFormDocumentSchema =

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -28,6 +28,10 @@ export const updateSettingsValidator = celebrate({
       url: Joi.string().uri().allow(''),
       isRetryEnabled: Joi.boolean(),
     }).min(1),
+    business: Joi.object({
+      address: Joi.string().allow(''),
+      gstRegNo: Joi.string().allow(''),
+    }),
   })
     .min(1)
     .custom((value, helpers) => verifyValidUnicodeString(value, helpers)),

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -361,28 +361,36 @@ export const downloadPaymentInvoice: ControllerHandler<{
           // convert to pdf and return
           .then((receiptUrlResponse) => {
             const html = receiptUrlResponse.data
-            const businessInfo = (populatedForm as IPopulatedForm).admin.agency
-              .business
+            const agencyBusinessInfo = (populatedForm as IPopulatedForm).admin
+              .agency.business
+            const formBusinessInfo = populatedForm.business
+
+            const businessAddress = [
+              formBusinessInfo?.address,
+              agencyBusinessInfo?.address,
+            ].find(Boolean)
+
+            const businessGstRegNo = [
+              formBusinessInfo?.gstRegNo,
+              agencyBusinessInfo?.gstRegNo,
+            ].find(Boolean)
 
             // we will still continute the invoice generation even if there's no address/gstregno
-            if (
-              !businessInfo ||
-              !businessInfo.address ||
-              !businessInfo.gstRegNo
-            )
+            if (!businessAddress || !businessGstRegNo)
               logger.warn({
                 message:
-                  'Some business info not available during invoice generation',
+                  'Some business info not available during invoice generation. Expecting either agency or form to have business info',
                 meta: {
                   action: 'downloadPaymentInvoice',
                   payment,
                   agencyName: populatedForm.admin.agency.fullName,
-                  businessInfo: businessInfo,
+                  agencyBusinessInfo,
+                  formBusinessInfo,
                 },
               })
             const invoiceHtml = convertToInvoiceFormat(html, {
-              address: businessInfo?.address || '',
-              gstRegNo: businessInfo?.gstRegNo || '',
+              address: businessAddress || '',
+              gstRegNo: businessGstRegNo || '',
               formTitle: populatedForm.title,
               submissionId: payment.completedPayment?.submissionId || '',
             })

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -13,6 +13,7 @@ import type { Merge, SetOptional } from 'type-fest'
 import {
   AdminDashboardFormMetaDto,
   FormBase,
+  FormBusinessField,
   FormEndPage,
   FormField,
   FormFieldDto,
@@ -276,6 +277,7 @@ export interface IEncryptedForm extends IForm {
   // are not defined in DB. See https://github.com/Automattic/mongoose/issues/5310
   payments_channel: FormPaymentsChannel
   payments_field: FormPaymentsField
+  business?: FormBusinessField
   emails?: never
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The GST Reg No, and Business Address are read during invoice generation on the payment page (after responder has successfully paid and we've received the receipt url from stripe).

This two fields are currently stored and read from form-level details. However, as we expect large agencies (i.e., MOH, MOE) to have different GST Reg No, and Business Address, we want to add support to store and alter them at the form-level.

Storing at the form-level also supports the edge case where the form is transferred to a different agency, but the payment channel information should still remain the same.


Closes #6085

## Solution
<!-- How did you solve the problem? -->

Introducing form-level overrides.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Adds options for form admins to enter their own business information at the form level
- Invoice will respect form-level overrides before reading agency-level information

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="483" alt="Screenshot 2023-05-03 at 12 37 17 AM" src="https://user-images.githubusercontent.com/12391617/235729738-3ee07225-d502-471f-9879-fdb73ff92ae9.png">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="743" alt="Screenshot 2023-05-03 at 12 37 30 AM" src="https://user-images.githubusercontent.com/12391617/235729799-d1d1f08f-3ae3-4b0b-bf5c-9593c7472f1f.png">


<img width="443" alt="Screenshot 2023-05-03 at 12 37 04 AM" src="https://user-images.githubusercontent.com/12391617/235729721-25fb33ea-0f1d-4134-b44b-f502a423e268.png">

![Screenshot 2023-05-03 at 10 56 42 AM](https://user-images.githubusercontent.com/12391617/235824886-f030b8af-5494-4289-9955-b121733f2ba6.png)

## Tests

<!-- What tests should be run to confirm functionality? -->
**Form Level Overrides**
Payment form business fields can be changed
- [ ] change `gstRegNo` field to `foobar`, expect that a toast appears confirming change
- [ ] change `gstRegNo` field to ` foobar` (with leading/trailing spaces), expect that a toast appears confirming change
- [ ] field is populated with `foobar` after a refresh

Agency default is shown as placeholder if form business info is not present
- [ ] change `gstRegNo` field to `` (empty string), expect that a toast appears confirming change and showing placeholder message
  - [ ] field is populated with agency defaults (OGP's agency gstRegNo/address is used)
  - [ ] data retrieved for `form.business.gstRegNo` and `*.address` is ``

Generated Invoice should use form-level business field if present
- [ ] prepare payment form with form-level overrides on `gstRegNo` + `address` fields with `foobar`
- [ ] generated invoice should show `GST Reg No: foobar` and `Address: foobar`

Business Info Fields will trim
- [ ] change `gstRegNo` and `address` field to ` foobar` (with leading/trailing spaces), expect that a toast appears confirming change
- [ ] field is populated with `foobar` (without leading/trailing spaces) after a refresh

**Regression tests**
- [ ] payment forms without overrides
  - [ ] other fields (Form Name) should be able editable
  - [ ] generated invoice should fallback to agency's business info