### PR TITLE
fix: switch captcha to download from globally accessible domain

### DIFF
--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -80,7 +80,7 @@ export const useRecaptcha = ({
   useEnterprise = true,
   badge = 'inline',
   size = 'invisible',
-  useRecaptchaNet,
+  useRecaptchaNet = true,
 }: UseRecaptchaProps) => {
   useScript(getRecaptchaUrl({ useEnterprise, useRecaptchaNet }))
 

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -54,7 +54,7 @@ const getRecaptchaUrl = ({
   useEnterprise,
   useRecaptchaNet,
 }: Pick<UseRecaptchaProps, 'useEnterprise' | 'useRecaptchaNet'>) => {
-  const hostname = useRecaptchaNet ? 'recaptcha.net' : 'www.google.com'
+  const hostname = useRecaptchaNet ? 'www.recaptcha.net' : 'www.google.com'
   return `https://${hostname}/recaptcha/${
     useEnterprise ? 'enterprise' : 'api'
   }.js?render=explicit`


### PR DESCRIPTION
## Problem
React is failing to render for users in CN. But angular was working fine.

Note: this is part of the effort to deprecate angular.

## Solution
<!-- How did you solve the problem? -->

Switch `www.google.com` to `www.recaptcha.net` as we are [using recaptcha globally](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Also fixes a small typo in missing `www.` subdomain in `recaptcha.net`
