### PR TITLE
fix: missing paymentReceiptEmail for fetch fallback submissions

### DIFF
--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -182,6 +182,7 @@ export const submitStorageModeFormWithFetch = async ({
   formId,
   publicKey,
   captchaResponse = null,
+  paymentReceiptEmail,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -192,6 +193,7 @@ export const submitStorageModeFormWithFetch = async ({
     formFields,
     filteredInputs,
     publicKey,
+    paymentReceiptEmail,
   )
 
   // Add captcha response to query string


### PR DESCRIPTION
## Problem

- Adds in missing paymentReceiptEmail when using fetch fallback to submit payment forms
