### PR TITLE
feat: reference implementation for Shifting encryption boundary

### DIFF
--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -182,6 +182,7 @@ export const submitStorageModeFormWithFetch = async ({
   formId,
   publicKey,
   captchaResponse = null,
+  paymentReceiptEmail,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -192,6 +193,7 @@ export const submitStorageModeFormWithFetch = async ({
     formFields,
     filteredInputs,
     publicKey,
+    paymentReceiptEmail,
   )
 
   // Add captcha response to query string

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -21,6 +21,7 @@ import {
 import { FormFieldValues } from '~templates/Field'
 
 import {
+  createdStorageModeUnencryptedSubmissionData,
   createEmailSubmissionFormData,
   createEncryptedSubmissionData,
 } from './utils/createSubmission'
@@ -113,7 +114,6 @@ export const submitStorageModeForm = async ({
   formLogics,
   formInputs,
   formId,
-  publicKey,
   captchaResponse = null,
   paymentReceiptEmail,
 }: SubmitStorageFormArgs) => {
@@ -122,10 +122,9 @@ export const submitStorageModeForm = async ({
     formInputs,
     formLogics,
   })
-  const submissionContent = await createEncryptedSubmissionData(
+  const submissionContent = await createdStorageModeUnencryptedSubmissionData(
     formFields,
     filteredInputs,
-    publicKey,
     paymentReceiptEmail,
   )
 
@@ -180,7 +179,6 @@ export const submitStorageModeFormWithFetch = async ({
   formLogics,
   formInputs,
   formId,
-  publicKey,
   captchaResponse = null,
   paymentReceiptEmail,
 }: SubmitStorageFormArgs) => {
@@ -189,10 +187,10 @@ export const submitStorageModeFormWithFetch = async ({
     formInputs,
     formLogics,
   })
-  const submissionContent = await createEncryptedSubmissionData(
+
+  const submissionContent = await createdStorageModeUnencryptedSubmissionData(
     formFields,
     filteredInputs,
-    publicKey,
     paymentReceiptEmail,
   )
 

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -62,6 +62,33 @@ export const createEncryptedSubmissionData = async (
 }
 
 /**
+ * @returns StorageModeSubmissionContentDto
+ * @throw Error if form inputs are invalid.
+ */
+export const createdStorageModeUnencryptedSubmissionData = async (
+  formFields: FormFieldDto[],
+  formInputs: FormFieldValues,
+  paymentReceiptEmail?: string,
+) => {
+  const responses = createResponsesArray(formFields, formInputs)
+  const attachments = getAttachmentsMap(formFields, formInputs)
+
+  // Convert content to FormData object.
+  const formData = new FormData()
+  formData.append('body', JSON.stringify({ responses, paymentReceiptEmail }))
+
+  if (!isEmpty(attachments)) {
+    forOwn(attachments, (attachment, fieldId) => {
+      if (attachment) {
+        formData.append(attachment.name, attachment, fieldId)
+      }
+    })
+  }
+
+  return formData
+}
+
+/**
  * @returns formData containing form responses and attachments.
  * @throws Error if form inputs are invalid.
  */

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -1,6 +1,90 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 
-import { BasicField } from '../../../../../shared/types'
+import { BasicField, FieldResponse } from '../../../../../shared/types'
+import { createLoggerWithLabel } from '../../../config/logger'
+import { createReqMeta } from '../../../utils/request'
+import { ControllerHandler } from '../../core/core.types'
+// TODO (Encrypt Boundary): Rename email-submission.receiver as more generic submission receiver
+import * as SubmissionReceiver from '../email-submission/email-submission.receiver'
+
+import { mapRouteError } from './encrypt-submission.utils'
+
+const logger = createLoggerWithLabel(module)
+
+/**
+ * Parses multipart-form data request from createdStorageModeUnencryptedSubmissionData. Parsed attachments are
+ * placed into req.attachments and parsed fields are placed into
+ * req.body.
+ *
+ * TODO (Encrypt Boundary): Check that paymentReceiptEmail is properly handled
+ *
+ * @param req - Express request object
+ * @param res - Express response object
+ * @param next - Express next middleware function
+ */
+export const receiveEncryptSubmission: ControllerHandler<
+  unknown,
+  { message: string },
+  { responses: FieldResponse[]; paymentReceiptEmail?: string }
+> = async (req, res, next) => {
+  const logMeta = {
+    action: 'receiveEncryptSubmission',
+    ...createReqMeta(req),
+  }
+  return SubmissionReceiver.createMultipartReceiver(req.headers)
+    .asyncAndThen((receiver) => {
+      const result = SubmissionReceiver.configureMultipartReceiver(receiver)
+      req.pipe(receiver)
+      return result
+    })
+    .map((parsed) => {
+      req.body = parsed
+      return next()
+    })
+    .mapErr((error) => {
+      logger.error({
+        message: 'Error while receiving multipart data',
+        meta: logMeta,
+        error,
+      })
+      const { errorMessage, statusCode } = mapRouteError(error)
+      return res.status(statusCode).json({ message: errorMessage })
+    })
+}
+
+/**
+ * Celebrate middleware for verifying shape of unencrypted storage mode submisison
+ */
+export const validateUnencryptedSubmissionParams = celebrate({
+  body: Joi.object({
+    responses: Joi.array()
+      .items(
+        Joi.object()
+          .keys({
+            _id: Joi.string().required(),
+            question: Joi.string(),
+            fieldType: Joi.string()
+              .required()
+              .valid(...Object.values(BasicField)),
+            answer: Joi.string().allow(''),
+            answerArray: Joi.array(),
+            filename: Joi.string(),
+            content: Joi.binary(),
+            isHeader: Joi.boolean(),
+            myInfo: Joi.object(),
+            signature: Joi.string().allow(''),
+          })
+          .xor('answer', 'answerArray') // only answer or answerArray can be present at once
+          .with('filename', 'content'), // if filename is present, content must be present
+      )
+      .required(),
+    paymentReceiptEmail: Joi.string().email().optional(),
+    /**
+     * @deprecated unused key, but frontend still sends it.
+     */
+    isPreview: Joi.boolean(),
+  }),
+})
 
 /**
  * Celebrate middleware for verifying shape of encrypted submission


### PR DESCRIPTION
**No merge, reference implementation**

WIP reference implementation, for the RFC on shifting encryption boundary (see link in working doc).

This PR demonstrates how shifting of encryption boundary will allow us to put in place backend validation on storage mode responses; eventually opening up the way for more server-side actions on storage mode form data as envisioned in the RFC (e.g. virus scanning, confirmation emails, etc).

## Demo steps
- Create storage mode form. Add a few short text fields. Submit. Observe that the network call is sent without e2e encryption.
- Add field validation (e.g. minimum number of chars). Submit with valid answer. Clone the network call. Modify the answer to be invalid in the network call. Submit the invalid network call. Backend should reject with `Invalid answer`.
- Check that the valid submissions have been correctly saved in the DB with encryption and can be retrieved in responses tab.