### PR TITLE
fix: check payments channel before updating payments field

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -29,3 +29,11 @@ export class InvalidCollaboratorError extends ApplicationError {
     super(message)
   }
 }
+
+export class PaymentChannelNotFoundError extends ApplicationError {
+  constructor(
+    message = 'Payment channel not found. Please connect your Payment account in Settings',
+  ) {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -32,7 +32,7 @@ export class InvalidCollaboratorError extends ApplicationError {
 
 export class PaymentChannelNotFoundError extends ApplicationError {
   constructor(
-    message = 'Payment channel not found. Please connect your Payment account in Settings',
+    message = 'Please ensure that you have connected your Stripe account in settings to save this field',
   ) {
     super(message)
   }

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -2,7 +2,7 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import { err, ok } from 'neverthrow'
-import { ErrorDto, PaymentsUpdateDto } from 'shared/types'
+import { ErrorDto, PaymentChannel, PaymentsUpdateDto } from 'shared/types'
 
 import { IEncryptedFormDocument } from 'src/types'
 
@@ -228,10 +228,7 @@ export const _handleUpdatePayments: ControllerHandler<
       .andThen(checkFormIsEncryptMode)
       // Step 3: Check that the payment form has a stripe account connected
       .andThen((form) => {
-        if (
-          !!form.payments_channel.publishable_key &&
-          !!form.payments_channel.target_account_id
-        ) {
+        if (form.payments_channel.channel === PaymentChannel.Unconnected) {
           return ok(form)
         } else {
           return err(new PaymentChannelNotFoundError())

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -2,10 +2,14 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import { err, ok } from 'neverthrow'
-import { ErrorDto, PaymentChannel, PaymentsUpdateDto } from 'shared/types'
 
 import { IEncryptedFormDocument } from 'src/types'
 
+import {
+  ErrorDto,
+  PaymentChannel,
+  PaymentsUpdateDto,
+} from '../../../../../shared/types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { createReqMeta } from '../../../utils/request'
 import { getFormAfterPermissionChecks } from '../../auth/auth.service'
@@ -228,7 +232,7 @@ export const _handleUpdatePayments: ControllerHandler<
       .andThen(checkFormIsEncryptMode)
       // Step 3: Check that the payment form has a stripe account connected
       .andThen((form) => {
-        if (form.payments_channel.channel === PaymentChannel.Unconnected) {
+        if (form.payments_channel.channel !== PaymentChannel.Unconnected) {
           return ok(form)
         } else {
           return err(new PaymentChannelNotFoundError())

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -231,13 +231,11 @@ export const _handleUpdatePayments: ControllerHandler<
       )
       .andThen(checkFormIsEncryptMode)
       // Step 3: Check that the payment form has a stripe account connected
-      .andThen((form) => {
-        if (form.payments_channel.channel !== PaymentChannel.Unconnected) {
-          return ok(form)
-        } else {
-          return err(new PaymentChannelNotFoundError())
-        }
-      })
+      .andThen((form) =>
+        form.payments_channel.channel === PaymentChannel.Unconnected
+          ? err(new PaymentChannelNotFoundError())
+          : ok(form),
+      )
       // Step 4: User has permissions, proceed to allow updating of start page
       .andThen(() => AdminFormService.updatePayments(formId, req.body))
       .map((updatedPayments) =>

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -51,6 +51,7 @@ import {
   FieldNotFoundError,
   InvalidCollaboratorError,
   InvalidFileTypeError,
+  PaymentChannelNotFoundError,
 } from './admin-form.errors'
 import {
   AssertFormFn,
@@ -167,6 +168,11 @@ export const mapRouteError = (
     case ResponseModeError:
       return {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+        errorMessage: error.message,
+      }
+    case PaymentChannelNotFoundError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,
       }
     default:

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -172,7 +172,7 @@ export const mapRouteError = (
       }
     case PaymentChannelNotFoundError:
       return {
-        statusCode: StatusCodes.BAD_REQUEST,
+        statusCode: StatusCodes.FORBIDDEN,
         errorMessage: error.message,
       }
     default:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #6257

## Solution
<!-- How did you solve the problem? -->

Check if payment channel is connected before updating payments field. Will return `403` if user attempts to update `payments_field` without a valid `payments_channel`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  


## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/59867455/235977676-680274c5-31d3-42cf-b10d-75010bf38dc4.png">



## Tests
<!-- What tests should be run to confirm functionality? -->
To ensure correct behaviour after fix
- [ ] create a storage mode form, connect payments
- [ ] go to build and design tab, enable payment fields
- [ ] ensure that the field is enabled by previewing the form
- [ ] go back to build and design tab, ensure this tab is remains open with the payment enabled toggle on
- [ ] on another window, go to the same form and disconnect payment
- [ ] return to the build and design tab and update payments with payment enabled toggled on
- [ ] it should fail and return 400

To check for regression
- [ ] after the steps above, go back to settings and connect payment
- [ ] you should be able to enable payment fields now
