### PR TITLE
fix: migrate to withTransaction for retries

### DIFF
--- a/src/app/constants/mongo-error.ts
+++ b/src/app/constants/mongo-error.ts
@@ -1,4 +1,5 @@
 export const MONGO_ERROR_CODE = {
+  WriteConflict: 112,
   DuplicateKey: 11000,
   InvalidBSON: 10334,
 }

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -51,6 +51,12 @@ export class DatabaseDuplicateKeyError extends ApplicationError {
   }
 }
 
+export class DatabaseWriteConflictError extends ApplicationError {
+  constructor(message: string) {
+    super(message)
+  }
+}
+
 export class SecretsManagerError extends ApplicationError {
   constructor(message?: string) {
     super(message)
@@ -84,6 +90,7 @@ export type PossibleDatabaseError =
   | DatabaseConflictError
   | DatabasePayloadSizeError
   | DatabaseDuplicateKeyError
+  | DatabaseWriteConflictError
 
 export class MalformedParametersError extends ApplicationError {
   constructor(message: string, meta?: unknown) {

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -6,13 +6,18 @@ import { PaymentStatus } from '../../../../shared/types'
 import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
+import { MailSendError } from '../../services/mail/mail.errors'
 import MailService from '../../services/mail/mail.service'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
 import { DatabaseError } from '../core/core.errors'
+import { FormNotFoundError } from '../form/form.errors'
 import { retrieveFormById } from '../form/form.service'
 import { performEncryptPostSubmissionActions } from '../submission/encrypt-submission/encrypt-submission.service'
 import { isSubmissionEncryptMode } from '../submission/encrypt-submission/encrypt-submission.utils'
-import { PendingSubmissionNotFoundError } from '../submission/submission.errors'
+import {
+  PendingSubmissionNotFoundError,
+  SubmissionNotFoundError,
+} from '../submission/submission.errors'
 import * as SubmissionService from '../submission/submission.service'
 import { findSubmissionById } from '../submission/submission.service'
 
@@ -167,59 +172,54 @@ export const confirmPaymentPendingSubmission = (
     SubmissionService.copyPendingSubmissionToSubmissions(
       payment.pendingSubmissionId,
       session,
-    )
-      .andThen((submission) => {
-        // Step 3: Update the payment document with the metadata showing that
-        // the payment is complete and save it
-        payment.completedPayment = {
-          submissionId: submission._id,
-          paymentDate,
-          receiptUrl,
-          transactionFee,
-        }
-        return okAsync(submission)
-      })
-      // Post-submission: fire webhooks and send email confirmations.
-      .andThen((submission) => {
-        if (isSubmissionEncryptMode(submission)) {
-          return performEncryptPostSubmissionActions(
-            submission,
-            payment.responses,
-          )
-            .andThen(() => {
-              // If successfully sent email confirmations, delete response data from payment document.
-              payment.responses = []
-              return okAsync(payment)
-            })
-            .orElse(() => okAsync(payment))
-        }
-        return okAsync(payment)
-      })
+    ).andThen((submission) => {
+      // Step 3: Update the payment document with the metadata showing that
+      // the payment is complete and save it
+      payment.completedPayment = {
+        submissionId: submission._id,
+        paymentDate,
+        receiptUrl,
+        transactionFee,
+      }
+      return okAsync(payment)
+    })
   )
 }
 
 /**
- * This function sends a payment confirmation email
+ * This function sends performs payment post-submission actions. In particular,
+ * it fires webhooks, sends email confirmations to respondents and a payment
+ * confirmation email to the payer.
  * @param paymentId payment id of the payment that has been completed
  *
  * @returns ok(true) if the payment confirmation email has been sent
+ * @returns err(PaymentNotFoundError) if the payment does not exist
  * @returns err(ConfirmedPaymentNotFoundError) if the paymentId does not have a submission ID associated with a completed payment
+ * @returns err(SubmissionNotFoundError) if submission does not exist in the database
+ * @returns err(FormNotFoundError) if the form or form admin does not exist
+ * @returns err(MailSendError) if error occurs while sending the mail
+ * @returns err(DatabaseError) if error occurs whilst querying the database
  */
-export const sendPaymentConfirmationEmailByPaymentId = (
+export const performPaymentPostSubmissionActions = (
   paymentId: IPaymentSchema['_id'],
-): ResultAsync<true, ConfirmedPaymentNotFoundError> => {
+): ResultAsync<
+  true,
+  | PaymentNotFoundError
+  | ConfirmedPaymentNotFoundError
+  | SubmissionNotFoundError
+  | FormNotFoundError
+  | MailSendError
+  | DatabaseError
+> => {
   const logMeta = {
-    action: 'sendPaymentConfirmationEmail',
+    action: 'performPaymentPostSubmissionActions',
     paymentId,
   }
 
-  // Step 1: Find payment object
+  // Step 1: Find payment document
   return findPaymentById(paymentId)
-    .map((payment) => ({
-      submissionId: payment.completedPayment?.submissionId,
-      recipient: payment.email,
-    }))
-    .andThen(({ submissionId, recipient }) => {
+    .andThen((payment) => {
+      const submissionId = payment.completedPayment?.submissionId
       if (!submissionId) {
         logger.warn({
           message: 'Submission ID from completed payment could not be found',
@@ -230,19 +230,50 @@ export const sendPaymentConfirmationEmailByPaymentId = (
       // Step 2: Find submission document
       return (
         findSubmissionById(submissionId)
+          // Step 3: fire webhooks and send email confirmations.
+          .andThen((submission) => {
+            if (isSubmissionEncryptMode(submission)) {
+              return (
+                performEncryptPostSubmissionActions(
+                  submission,
+                  payment.responses,
+                )
+                  .andThen(() =>
+                    // If successfully sent email confirmations, delete response data from payment document.
+                    ResultAsync.fromPromise(
+                      PaymentModel.findByIdAndUpdate(paymentId, {
+                        responses: [],
+                      }),
+                      (error) => {
+                        logger.error({
+                          message: 'Database error while finding payment by id',
+                          meta: logMeta,
+                          error,
+                        })
+                        return new DatabaseError(getMongoErrorMessage(error))
+                      },
+                    ).map(() => submission),
+                  )
+                  // Ignore failures as they will be logged, but should not be
+                  // considered a failed webhook.
+                  .orElse(() => okAsync(submission))
+              )
+            }
+            return okAsync(submission)
+          })
           // Step 3: Find form document
           .andThen((submission) => retrieveFormById(submission.form))
           .map((form) => ({
             formTitle: form.title,
             formId: form._id,
             responseId: submissionId,
-            recipient,
+            recipient: payment.email,
           }))
       )
     })
     .andThen(({ formTitle, formId, responseId, recipient }) => {
       logger.info({
-        message: 'sendPaymentConfirmationEmail',
+        message: 'Sending payment confirmation email',
         meta: logMeta,
       })
       // Step 4: Send payment confirmation email

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -257,7 +257,8 @@ export const performPaymentPostSubmissionActions = (
               )
             }
             return okAsync(submission)
-          }) // Step 3: Find form document
+          })
+          // Step 4: Find form document
           .andThen((submission) => retrieveFormById(submission.form))
           .map((form) => ({
             formTitle: form.title,
@@ -272,7 +273,7 @@ export const performPaymentPostSubmissionActions = (
         message: 'Sending payment confirmation email',
         meta: { ...logMeta, submissionId, email },
       })
-      // Step 4: Send payment confirmation email
+      // Step 5: Send payment confirmation email
       return MailService.sendPaymentConfirmationEmail({
         email,
         formTitle,

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -13,12 +13,15 @@ import { MapRouteError, StripePaymentMetadataDto } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ApplicationError, DatabaseError } from '../core/core.errors'
+import { FormNotFoundError } from '../form/form.errors'
 import {
   PendingSubmissionNotFoundError,
   ResponseModeError,
+  SubmissionNotFoundError,
 } from '../submission/submission.errors'
 
 import {
+  ConfirmedPaymentNotFoundError,
   PaymentAccountInformationError,
   PaymentAlreadyConfirmedError,
   PaymentNotFoundError,
@@ -51,6 +54,9 @@ export const mapRouteError: MapRouteError = (error: ApplicationError) => {
       }
     case PaymentNotFoundError:
     case PendingSubmissionNotFoundError:
+    case ConfirmedPaymentNotFoundError:
+    case SubmissionNotFoundError:
+    case FormNotFoundError:
       return {
         statusCode: StatusCodes.NOT_FOUND,
         errorMessage: error.message,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -44,6 +44,7 @@ import {
 import { WebhookFactory } from '../../webhook/webhook.factory'
 import {
   ResponseModeError,
+  SendEmailConfirmationError,
   SubmissionNotFoundError,
 } from '../submission.errors'
 import { sendEmailConfirmations } from '../submission.service'
@@ -471,6 +472,7 @@ export const createEncryptSubmissionWithoutSave = ({
  * @returns err(WebhookValidationError) if the webhook URL failed validation
  * @returns err(WebhookPushToQueueError) if the webhook was failed to be pushed to SQS
  * @returns err(SubmissionNotFoundError) if there was an error updating the submission with the webhook record
+ * @returns err(SendEmailConfirmationError) if any email failed to be sent
  * @returns err(PossibleDatabaseError) if error occurs whilst querying the database
  */
 export const performEncryptPostSubmissionActions = (
@@ -482,6 +484,7 @@ export const performEncryptPostSubmissionActions = (
   | ResponseModeError
   | WebhookValidationError
   | WebhookPushToQueueError
+  | SendEmailConfirmationError
   | SubmissionNotFoundError
   | PossibleDatabaseError
 > => {

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -783,34 +783,34 @@ export class MailService {
 
   /**
    * Sends a payment confirmation to a valid email
-   * @param recipient the recipient email address
+   * @param email the recipient email address
    * @param formTitle the form title of the payment form
-   * @param responseId the response ID
+   * @param submissionId the response ID
    * @param formId the payment form ID
    * @param paymentId the payment ID
    * @throws error if mail fails, to be handled by the caller
    */
   sendPaymentConfirmationEmail = ({
-    recipient,
+    email,
     formTitle,
-    responseId,
+    submissionId,
     formId,
     paymentId,
   }: {
-    recipient: string
+    email: string
     formTitle: string
-    responseId: string
+    submissionId: string
     formId: string
     paymentId: string
   }): ResultAsync<true, MailSendError> => {
     const mail: MailOptions = {
-      to: recipient,
+      to: email,
       from: this.#senderFromString,
       subject: `Your payment on ${this.#appName} was successful`,
       html: generatePaymentConfirmationHtml({
         appName: this.#appName,
         formTitle,
-        responseId,
+        submissionId,
         invoiceUrl: `${this.#appUrl}/api/v3/${getPaymentInvoiceDownloadUrlPath(
           formId,
           paymentId,

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -269,12 +269,12 @@ export const generateSmsVerificationWarningHtmlForCollab = (
 
 export const generatePaymentConfirmationHtml = ({
   formTitle,
-  responseId,
+  submissionId,
   appName,
   invoiceUrl,
 }: {
   formTitle: string
-  responseId: string
+  submissionId: string
   appName: string
   invoiceUrl: string
 }): string => {
@@ -282,7 +282,7 @@ export const generatePaymentConfirmationHtml = ({
     <p>Hello there,</p>
     <p>
       Your payment on ${appName} form: ${formTitle} has been received successfully.
-      Your response ID is ${responseId} and your payment invoice can be found 
+      Your response ID is ${submissionId} and your payment invoice can be found 
       <a href="${invoiceUrl}">here</a>.
     </p>
     <p>Regards,

--- a/src/app/utils/handle-mongo-error.ts
+++ b/src/app/utils/handle-mongo-error.ts
@@ -7,6 +7,7 @@ import {
   DatabaseError,
   DatabasePayloadSizeError,
   DatabaseValidationError,
+  DatabaseWriteConflictError,
   PossibleDatabaseError,
 } from '../modules/core/core.errors'
 
@@ -105,6 +106,13 @@ export const transformMongoError = (error: unknown): PossibleDatabaseError => {
     return new DatabaseDuplicateKeyError(errorMessage)
   }
 
+  if (
+    error instanceof MongoError &&
+    error.code === MONGO_ERROR_CODE.WriteConflict
+  ) {
+    return new DatabaseWriteConflictError(errorMessage)
+  }
+
   return new DatabaseError(errorMessage)
 }
 
@@ -114,6 +122,8 @@ export const isMongoError = (error: Error): boolean => {
     case DatabaseError:
     case DatabasePayloadSizeError:
     case DatabaseValidationError:
+    case DatabaseDuplicateKeyError:
+    case DatabaseWriteConflictError:
       return true
     default:
       return false


### PR DESCRIPTION
## Problem
A payment webhook failure occurred on 2 May around 1317hrs on a live form. After investigation, the bug was deemed to have been caused by a missing retry mechanism on the payment update transaction.

At the point of `payment.save()` within the transaction, mongo threw the following error:
```
MongoError: WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.
```
This was found to be due to a `TransientTransactionError` caused by a race condition between simultaneous incoming webhooks being processed by different servers. The presumption was that mongo issues a blocking lock at the start of the transaction, causing the entire document to not be accessible during the transaction period. This would avoid the desync that would occur when two servers read the same version and write the same (incremented) version simultaneously.

However, this was not the case. It turns out the mongo does not use this method, and instead throws an error if a write operation fails.
![image](https://user-images.githubusercontent.com/25571626/236130957-19895174-95b9-4af8-bc24-eeedd06387cf.png) 
Ref: https://medium.com/mongodb-performance-tuning/tuning-mongodb-transactions-354311ab9ed6

The recommended recovery mechanism is to retry the operation. This is encapsulated by the `withTransaction` api, as explained in the mongoose documentation.

![image](https://user-images.githubusercontent.com/25571626/236131299-ee4a53e6-f89f-48c9-af74-dfbf64cceaab.png)

## Solution
An additional type of mongo error is detected (112 WriteConflict) and if the error is thrown by mongo, it is intercepted and manually upward-propagated via throw/catch to trigger `withTransaction` to retry the operation. All other application errors are propagated upward via `neverthrow`'s `errAsync` api. At the top level, since we have to rely on `withTransaction` to abort the transaction in the event of any application error, the application errors also have to be thrown/caught (to exit and re-enter the `ResultAsync` monad).

And we can see this works. Within 10 seconds, three webhooks were sent `payment_intent.created`, `payment_intent.succeeded` and `charge.succeeded`.  We can see that as expected, the `payment_intent.succeeded` webhook retried once, and the `charge.succeeded` retried twice. 

![image](https://user-images.githubusercontent.com/25571626/236150125-bee651bc-2a5f-445c-869d-cd59b109d424.png)

At the end, the completed submission is visible in the individual response pages. 

![image](https://user-images.githubusercontent.com/25571626/236151871-edcb40fc-ed3a-4af6-97e1-cfd8c60a6e75.png)

It also handles application errors correctly, as being distinguished from transient transaction errors. The following screenshot is a payment not found error, triggered by an incoming webhook from another environment:

![image](https://user-images.githubusercontent.com/25571626/236152353-538a6277-5cc0-431b-8202-99cd543b8648.png)


**Breaking Changes** 
- No - this PR is backwards compatible  
