### PR TITLE
chore: remove support for legacy stripe metadata

### DIFF
--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -87,7 +87,7 @@ export const getChargeIdFromNestedCharge = (
 const isStripeMetadata = (
   obj: Stripe.Metadata,
 ): obj is StripePaymentMetadataDto =>
-  // hasProp(obj, 'env') && // TODO: Make this required later
+  hasProp(obj, 'env') &&
   hasProp(obj, 'formTitle') &&
   hasProp(obj, 'formId') &&
   hasProp(obj, 'submissionId') &&
@@ -129,10 +129,7 @@ export const getMetadataPaymentId = (
     })
     return err(new StripeMetadataValidPaymentIdNotFoundError())
   }
-  // Explicit check for metadata.env to ensure that legacy metadata which does
-  // not have the env value still gets processed.
-  // TODO: remove the existence check later.
-  if (metadata.env && metadata.env !== config.envSiteName) {
+  if (metadata.env !== config.envSiteName) {
     return err(new StripeMetadataIncorrectEnvError())
   }
   return ok(metadata.paymentId)


### PR DESCRIPTION
## Problem
This PR removes support for legacy stripe metadata without the `env` variable in #6234.

## Solution
**Breaking Changes** 
- No - this PR is backwards compatible  