### PR TITLE
feat: add frontend datadog logging to CSV responses download

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -105,6 +105,7 @@ const useDecryptionWorkers = ({
         action: 'downloadEncryptedReponses',
         formId: adminForm._id,
         formTitle: adminForm.title,
+        downloadAttachments: downloadAttachments,
         num_workers: numWorkers,
         expectedNumSubmissions: NUM_OF_METADATA_ROWS,
         adminId: user?._id,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -322,7 +322,7 @@ const useDecryptionWorkers = ({
           })
       })
     },
-    [adminForm, onProgress, workers],
+    [adminForm, onProgress, user?._id, workers],
   )
 
   const handleExportCsvMutation = useMutation(

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMutation, UseMutationOptions } from 'react-query'
+import { datadogLogs } from '@datadog/browser-logs'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 import {
@@ -9,6 +10,7 @@ import {
   trackDownloadResponseSuccess,
   trackPartialDecryptionFailure,
 } from '~features/analytics/AnalyticsService'
+import { useUser } from '~features/user/queries'
 
 import { downloadResponseAttachment } from './utils/downloadCsv'
 import { EncryptedResponseCsvGenerator } from './utils/EncryptedResponseCsvGenerator'
@@ -53,6 +55,7 @@ const useDecryptionWorkers = ({
   const abortControllerRef = useRef(new AbortController())
 
   const { data: adminForm } = useAdminForm()
+  const { user } = useUser()
 
   useEffect(() => {
     return () => killWorkers(workers)
@@ -98,8 +101,21 @@ const useDecryptionWorkers = ({
       let attachmentErrorCount = 0
       let receivedRecordCount = 0
 
+      const logMeta = {
+        action: 'downloadEncryptedReponses',
+        formId: adminForm._id,
+        formTitle: adminForm.title,
+        num_workers: numWorkers,
+        expectedNumSubmissions: NUM_OF_METADATA_ROWS,
+        adminId: user?._id,
+      }
       // Trigger analytics here before starting decryption worker
       trackDownloadResponseStart(adminForm, numWorkers, NUM_OF_METADATA_ROWS)
+      datadogLogs.logger.info('Download response start', {
+        meta: {
+          ...logMeta,
+        },
+      })
 
       const workerPool: CleanableDecryptionWorkerApi[] = []
 
@@ -182,11 +198,32 @@ const useDecryptionWorkers = ({
           .catch((err) => {
             if (!downloadStartTime) {
               // No start time, means did not even start http request.
-
+              datadogLogs.logger.info('Download network failure', {
+                meta: {
+                  ...logMeta,
+                  error: {
+                    message: err.message,
+                    name: err.name,
+                    stack: err.stack,
+                  },
+                },
+              })
               trackDownloadNetworkFailure(adminForm, err)
             } else {
               const downloadFailedTime = performance.now()
               const timeDifference = downloadFailedTime - downloadStartTime
+
+              datadogLogs.logger.info('Download response failure', {
+                meta: {
+                  ...logMeta,
+                  duration: timeDifference,
+                  error: {
+                    message: err.message,
+                    name: err.name,
+                    stack: err.stack,
+                  },
+                },
+              })
 
               trackDownloadResponseFailure(
                 adminForm,
@@ -210,6 +247,16 @@ const useDecryptionWorkers = ({
               if (errorCount + unverifiedCount === responsesCount) {
                 const failureEndTime = performance.now()
                 const timeDifference = failureEndTime - downloadStartTime
+
+                datadogLogs.logger.info('Partial decryption failure', {
+                  meta: {
+                    ...logMeta,
+                    duration: timeDifference,
+                    error_count: errorCount,
+                    unverified_count: unverifiedCount,
+                    attachment_error_count: attachmentErrorCount,
+                  },
+                })
 
                 trackPartialDecryptionFailure(
                   adminForm,
@@ -244,6 +291,13 @@ const useDecryptionWorkers = ({
 
                 const downloadEndTime = performance.now()
                 const timeDifference = downloadEndTime - downloadStartTime
+
+                datadogLogs.logger.info('Download response success', {
+                  meta: {
+                    ...logMeta,
+                    duration: timeDifference,
+                  },
+                })
 
                 trackDownloadResponseSuccess(
                   adminForm,

--- a/frontend/src/features/analytics/AnalyticsService.ts
+++ b/frontend/src/features/analytics/AnalyticsService.ts
@@ -127,7 +127,7 @@ export const trackDownloadResponseFailure = (
   errorMessage: string,
 ) => {
   GA().gtag('event', 'storage_mode', {
-    event_action: 'download_success',
+    event_action: 'download_failure',
     form_title: adminForm.title,
     form_id: adminForm._id,
     num_workers: numWorkers,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
While investigating a support ticket, I realised we didn't have logging for CSV response downloads.

## Solution
<!-- How did you solve the problem? -->
Add datadog logging to `useDecryptionWorkers`


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Fixed a typo in `AnalyticsService`

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/56983748/236187120-daeadb5c-7dfb-40ba-97c0-9fb7d5b730a4.png)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On a storage mode results page, download 'CSV only'. Check if logs show up in Datadog (search for `service:formsg` `env:staging` `@meta.action:downloadEncryptedReponses`).
- [ ] Repeat the same for 'CSV with attachments'