### PR TITLE
feat: remove web flag from release script

### DIFF
--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -87,7 +87,6 @@ grep -v -E -- '- [a-z]+\(deps(-dev)?\)' ${pr_body_file} | grep -v -E -- '- build
 done
 
 gh pr create \
-  -w \
   -H ${release_branch} \
   -B release-al2 \
   -t "build: release ${release_version}" \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When running the `release_prep.sh` script, we get a `cannot open in browser: maximum URL length exceeded error` when the PR description is too long

## Solution
Create the PR directly using the CLI instead of opening it in the browser first. 

[GitHub docs](https://cli.github.com/manual/gh_pr_create)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
