### PR TITLE
feat: control payment methods through stripe dashboard

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -443,10 +443,10 @@ const submitEncryptModeForm: ControllerHandler<
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
       amount,
       currency: paymentConfig.defaultCurrency,
-      payment_method_types: [
-        'card',
-        /* 'grabpay', 'paynow'*/
-      ],
+      // determine payment methods available based on stripe settings
+      automatic_payment_methods: {
+        enabled: true,
+      },
       description: paymentReceiptDescription,
       receipt_email: paymentReceiptEmail,
       metadata,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We currently only allow card as a payment method. However, some agencies will want to accommodate other payment methods as well, such as PayNow and GrabPay.

Closes #6251

## Solution
<!-- How did you solve the problem? -->
Instead of explicitly setting payment method types on payment intent creation, enable `automatic_payment_methods` when creating our payment intent. This will show respondents payment methods based on what is set through the Stripe dashboard. User flow and processes required are included in the doc [here](https://docs.google.com/document/d/1Js4zR8guyT-gREK4yTC094UZlJ96zRELTVgiviFKDEM/edit#heading=h.iu22j47aesom).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible. Note: this change is applied on payment intent creation, so past payment intents that have already been created will not reflect this change.

## Screenshots

If connected account enabled both card and paynow:

### Card

<img width="699" alt="Screenshot 2023-05-05 at 3 23 20 PM" src="https://user-images.githubusercontent.com/37061143/236398974-e867ef39-3f7a-4022-91af-c7a1309c8fc4.png">

### PayNow: 

<img width="699" alt="Screenshot 2023-05-05 at 3 24 25 PM" src="https://user-images.githubusercontent.com/37061143/236399236-553094d6-36d0-4dd6-88a6-644ccd037c67.png">

#### PayNow successful payment:

https://user-images.githubusercontent.com/37061143/236401320-bf94ef5a-ee29-421d-aa0d-5642a8c8d321.mov

#### PayNow expired QR:

https://user-images.githubusercontent.com/37061143/236401340-3ce32799-60af-465c-9ee2-593a74247693.mov

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Connect a Stripe account to a payment form
- [ ] Go to Stripe dashboard for the connected stripe account and:
   - [ ] Click Settings (top right corner, ⚙️ )
   - [ ] Under Payments, click Payment methods
   - [ ] Under Your account, click Edit settings
- [ ] With only Cards on, go to your payment form and create a payment intent (ie after Proceed to pay at payment modal). There should only be card payment available.
- [ ] Go back to the connected stripe account page, turn on PayNow (bottom of page) and save.
- [ ] Go to your payment form and create a payment intent (ie after Proceed to pay at payment modal). There should be both card and paynow options available.
- [ ] Select paynow option and follow the instructions. You should be able to pay and complete the submission with payments just like when cards are used.
