### PR TITLE
fix: unawaited promises lint issues on session.end() on tests and stri…

### DIFF
--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -338,12 +338,18 @@ export const processStripeEvent = (
       },
     )
       .andThen(() => {
-        session.endSession()
-        return okAsync(undefined)
+        return ResultAsync.fromPromise(session.endSession(), (err) => {
+          // Throw all application errors to trigger an abort.
+          // eslint-disable-next-line typesafe/no-throw-sync-func
+          throw err
+        }).andThen(() => okAsync(undefined))
       })
       .orElse((err) => {
-        session.endSession()
-        return errAsync(err)
+        return ResultAsync.fromPromise(session.endSession(), (err) => {
+          // Throw all application errors to trigger an abort.
+          // eslint-disable-next-line typesafe/no-throw-sync-func
+          throw err
+        }).andThen(() => errAsync(err))
       }),
   )
 }

--- a/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission/submission.service.spec.ts
@@ -822,7 +822,7 @@ describe('submission.service', () => {
         MOCK_PENDING_SUBMISSION_ID,
         session,
       )
-      session.endSession()
+      await session.endSession()
 
       //Assert
       expect(result.isOk()).toEqual(true)
@@ -847,7 +847,7 @@ describe('submission.service', () => {
         MOCK_PENDING_SUBMISSION_ID,
         session,
       )
-      session.endSession()
+      await session.endSession()
 
       // Assert
       expect(result.isOk()).toEqual(true)
@@ -868,7 +868,7 @@ describe('submission.service', () => {
         new ObjectId().toHexString(),
         session,
       )
-      session.endSession()
+      await session.endSession()
 
       // Assert
       expect(result.isErr()).toEqual(true)
@@ -893,7 +893,7 @@ describe('submission.service', () => {
         MOCK_PENDING_SUBMISSION_ID,
         session,
       )
-      session.endSession()
+      await session.endSession()
 
       // Assert
       expect(findSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
Most of mongodb native functions are now [returning as promises instead of callback](https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_5.0.0.md#migrate-to-promise-based-api-recommended).

`session` functions are now async instead of sync with callback

**Fixes**
- `src/app/modules/payments/stripe.service.ts`: `session.endSession()` wrapping it with `ResultAsync.fromPromise` `src/app/modules/submission/__tests__/submission/submission.service.spec.ts`: `session.endSession()` here is awaited before the test concludes
