### PR TITLE
fix: add missing env var in docker_compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
       - PAYMENT_MAX_PAYMENT_AMOUNT_CENTS=100000
       - PAYMENT_MIN_PAYMENT_AMOUNT_CENTS=50
+      - SSM_ENV_SITE_NAME=development
 
   mockpass:
     build: https://github.com/opengovsg/mockpass.git


### PR DESCRIPTION
## Problem

There's a missing environment variable made mandatory by https://github.com/opengovsg/FormSG/pull/6234.

## Solution
Add missing environment variable.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  
