### PR TITLE
fix: update sms copy to remove link (policy)

### DIFF
--- a/src/app/services/sms/sms.service.ts
+++ b/src/app/services/sms/sms.service.ts
@@ -348,11 +348,7 @@ export const sendVerificationOtp = (
       TwilioConfig,
       SmsSendError | InvalidNumberError
     >(getTwilio(otpData.msgSrvcName, defaultConfig)).andThen((twilioConfig) => {
-      const message = renderVerificationSms(
-        otp,
-        otpPrefix,
-        new URL(config.app.appUrl).host,
-      )
+      const message = renderVerificationSms(otp, otpPrefix)
 
       return sendSms(
         twilioConfig,

--- a/src/app/services/sms/sms.util.ts
+++ b/src/app/services/sms/sms.util.ts
@@ -15,7 +15,6 @@ export const renderBouncedSubmissionSms = (formTitle: string): string => dedent`
 export const renderVerificationSms = (
   otp: string,
   otpPrefix: string,
-  appHost: string,
-): string => dedent`Use the OTP ${otpPrefix}-${otp} to submit on ${appHost}.
+): string => dedent`Use the OTP ${otpPrefix}-${otp} to submit on FormSG.
 
   Never share your OTP with anyone else. If you did not request this OTP, you can safely ignore this SMS.`


### PR DESCRIPTION
## Problem
The sms copy for OTPs include the appHost (likely done so we can distinguish staging/prod). 

While it is not a link, with no inclusion of a protocol or path AND sms can contain gov.sg sin Singapore, some agencies would rather not see any links at all to guarantee we comply to regulations.

## Solution
Update copy to remove `appHost` and instead use `FormSG` as a simple string.


The change is backward compatible

cc @amitogp @wanlingt 
