### PR TITLE
test: add stories for admin and public forms with payments

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 
-import { UserId } from '~shared/types'
+import { PaymentChannel, UserId } from '~shared/types'
 import {
   AdminFormDto,
   FormAuthType,
@@ -148,5 +148,28 @@ FormWithWebhook.parameters = {
 export const FormWithWebhookMobile = Template.bind({})
 FormWithWebhookMobile.parameters = {
   ...FormWithWebhook.parameters,
+  ...getMobileViewParameters(),
+}
+
+export const FormWithPayment = Template.bind({})
+FormWithPayment.parameters = {
+  msw: buildMswRoutes({
+    responseMode: FormResponseMode.Encrypt,
+    payments_channel: {
+      channel: PaymentChannel.Stripe,
+      target_account_id: 'acct_sampleid',
+      publishable_key: 'pk_samplekey',
+    },
+    payments_field: {
+      enabled: true,
+      amount_cents: 5000,
+      description: 'Test event registration fee',
+    },
+  }),
+}
+
+export const FormWithPaymentMobile = Template.bind({})
+FormWithPaymentMobile.parameters = {
+  ...FormWithPayment.parameters,
   ...getMobileViewParameters(),
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -83,13 +83,27 @@ export const PaymentView = () => {
   return (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
-        <PaymentPreview
-          colorTheme={form?.startPage.colorTheme}
-          paymentDetails={paymentDetails}
-          isBuilder
-          isActive={isActive}
-          onClick={handlePaymentClick}
-        />
+        <Box mt="2.5rem" bg="white" py="2.5rem" px="1.5rem">
+          <Box
+            transition="background 0.2s ease"
+            _hover={{ bg: 'secondary.100', cursor: 'pointer' }}
+            borderRadius="4px"
+            _active={{
+              bg: 'secondary.100',
+              boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
+            }}
+            data-active={isActive || undefined}
+            onClick={handlePaymentClick}
+          >
+            <Box p={{ base: '0.75rem', md: '1.5rem' }}>
+              <PaymentPreview
+                colorTheme={form?.startPage.colorTheme}
+                paymentDetails={paymentDetails}
+                isBuilder
+              />
+            </Box>
+          </Box>
+        </Box>
       </FormProvider>
     </Box>
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -226,7 +226,9 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
         isDisabled={!paymentIsEnabled}
         isRequired
       >
-        <FormLabel isRequired>Payment amount</FormLabel>
+        <FormLabel isRequired description="Amount should include GST">
+          Payment amount
+        </FormLabel>
         <Controller
           name="display_amount"
           control={control}

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -4,7 +4,11 @@ import { userEvent, waitFor, within } from '@storybook/testing-library'
 import dedent from 'dedent'
 
 import { BasicField } from '~shared/types/field'
-import { FormAuthType, FormColorTheme } from '~shared/types/form'
+import {
+  FormAuthType,
+  FormColorTheme,
+  FormResponseMode,
+} from '~shared/types/form'
 
 import {
   getPreviewFormErrorResponse,
@@ -376,4 +380,23 @@ export const FormNotFoundMobile = Template.bind({})
 FormNotFoundMobile.parameters = {
   ...FormNotFound.parameters,
   ...getMobileViewParameters(),
+}
+
+export const WithPayment = Template.bind({})
+WithPayment.parameters = {
+  msw: [
+    getPreviewFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          payments_field: {
+            enabled: true,
+            amount_cents: 5000,
+            description: 'Mock event registration',
+          },
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -132,12 +132,17 @@ const PaymentsSectionText = () => {
 }
 
 export const PaymentSettingsSection = (): JSX.Element => {
+  const { hasPaymentCapabilities } = useAdminFormPayments()
   return (
     <>
       <PaymentsSectionText />
       <StripeConnectButton />
-      <Divider my="2.5rem" />
-      <BusinessInfoSection />
+      {hasPaymentCapabilities && (
+        <>
+          <Divider my="2.5rem" />
+          <BusinessInfoSection />
+        </>
+      )}
     </>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
@@ -12,10 +12,10 @@ export const PaymentsUnsupportedMsg = (): JSX.Element => {
         Payments are not available in Email mode
       </Text>
       <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-        Collect payments through FormSG via integration with Stripe. This
-        feature is only available in Storage Mode.&nbsp;
+        Citizens can now make payment for fees or services directly on your
+        form. This feature is only available in Storage Mode.&nbsp;
         <Link isExternal href={GUIDE_PAYMENTS}>
-          Read more about payments
+          Learn more about payments
         </Link>
       </Text>
       <SettingsUnsupportedSvgr />

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -4,7 +4,11 @@ import { userEvent, waitFor, within } from '@storybook/testing-library'
 import dedent from 'dedent'
 
 import { BasicField } from '~shared/types/field'
-import { FormAuthType, FormColorTheme } from '~shared/types/form'
+import {
+  FormAuthType,
+  FormColorTheme,
+  FormResponseMode,
+} from '~shared/types/form'
 
 import { MOCK_PREFILLED_MYINFO_FIELDS } from '~/mocks/msw/handlers/admin-form'
 import { envHandlers } from '~/mocks/msw/handlers/env'
@@ -444,6 +448,25 @@ WithMyInfo.parameters = {
       overrides: {
         form: {
           form_fields: MOCK_PREFILLED_MYINFO_FIELDS,
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+export const WithPayment = Template.bind({})
+WithPayment.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          payments_field: {
+            enabled: true,
+            amount_cents: 5000,
+            description: 'Mock event registration',
+          },
         },
       },
     }),

--- a/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
@@ -40,12 +40,7 @@ export const FeedbackBlock = ({
 
   return (
     <Flex justify="center">
-      <chakra.form
-        w="42.5rem"
-        maxW="100%"
-        noValidate
-        onSubmit={handleFormSubmit}
-      >
+      <chakra.form w="100%" maxW="100%" noValidate onSubmit={handleFormSubmit}>
         <FormControl isInvalid={!!errors.rating} id="rating">
           <FormLabel isRequired>
             How was your form filling experience today?
@@ -56,6 +51,8 @@ export const FeedbackBlock = ({
             name="rating"
             render={({ field }) => (
               <Rating
+                isRequired
+                fieldTitle="Form feedback rating"
                 colorScheme={colorScheme}
                 numberOfRatings={5}
                 variant="star"

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -111,7 +111,7 @@ export const FormFields = ({
     <FormProvider {...formMethods}>
       <form noValidate>
         {!!formFields?.length && (
-          <Box bg={'white'} py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
+          <Box bg="white" py="2.5rem" px={{ base: '1rem', md: '2.5rem' }}>
             <Stack spacing="2.25rem">
               {!isEmpty(fieldPrefillMap) && (
                 <InlineMessage variant="warning">
@@ -132,10 +132,17 @@ export const FormFields = ({
           </Box>
         )}
         {form?.responseMode === FormResponseMode.Encrypt && (
-          <PaymentPreview
-            colorTheme={colorTheme}
-            paymentDetails={form?.payments_field}
-          />
+          <Box
+            mt="2.5rem"
+            bg="white"
+            py="2.5rem"
+            px={{ base: '1rem', md: '2.5rem' }}
+          >
+            <PaymentPreview
+              colorTheme={colorTheme}
+              paymentDetails={form?.payments_field}
+            />
+          </Box>
         )}
         <PublicFormPaymentResumeModal />
         <PublicFormSubmitButton

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.stories.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Meta, Story } from '@storybook/react'
+
+import { FormColorTheme } from '~shared/types'
+
+import { envHandlers } from '~/mocks/msw/handlers/env'
+import {
+  getPaymentInfoResponse,
+  getPaymentReceiptStatusResponse,
+} from '~/mocks/msw/handlers/payment'
+import { getPublicFormResponse } from '~/mocks/msw/handlers/public-form'
+
+import { StoryRouter } from '~utils/storybook'
+
+import { PublicFormProvider } from '~features/public-form/PublicFormProvider'
+
+import { CreatePaymentIntentFailureBlock } from './components/CreatePaymentIntentFailureBlock'
+import {
+  GenericMessageBlock as GenericMessageBlockComponent,
+  PaymentStack,
+} from './stripe/components'
+import { PaymentItemDetailsBlock } from './stripe/components/PaymentItemDetailsBlock'
+import { StripeReceiptContainer } from './stripe/StripeReceiptContainer'
+import { FormPaymentPage } from './FormPaymentPage'
+
+const DEFAULT_MSW_HANDLERS = [
+  ...envHandlers,
+  getPublicFormResponse(),
+  getPaymentInfoResponse(),
+]
+
+export default {
+  title: 'Pages/PublicFormPage/FormPaymentPage',
+  component: FormPaymentPage,
+  decorators: [
+    StoryRouter({
+      initialEntries: [
+        `/61540ece3d4a6e50ac0cc6ff/payment/61540ece3d4a6e50ac0cc700`,
+      ],
+      path: '/:formId/payment/:paymentId',
+    }),
+  ],
+  parameters: {
+    // Required so skeleton "animation" does not hide content.
+    chromatic: { pauseAnimationAtEnd: true },
+    layout: 'fullscreen',
+    msw: DEFAULT_MSW_HANDLERS,
+  },
+} as Meta
+
+const Template: (children: React.ReactElement) => Story = (children) => () =>
+  (
+    <PublicFormProvider formId="61540ece3d4a6e50ac0cc6ff">
+      <PaymentStack>{children}</PaymentStack>
+    </PublicFormProvider>
+  )
+
+export const PendingPaymentDetails = Template(
+  <PaymentItemDetailsBlock
+    paymentItemName="Mock event registration"
+    paymentAmount={1000}
+    colorTheme={FormColorTheme.Blue}
+  />,
+).bind({})
+
+export const PaymentFailure = Template(
+  <CreatePaymentIntentFailureBlock submissionId="MOCK_SUBMISSION_ID" />,
+).bind({})
+
+export const GenericMessage = Template(
+  <GenericMessageBlockComponent
+    submissionId="MOCK_SUBMISSION_ID"
+    title="This is an example title"
+    subtitle="This is a subtitle. Read me here."
+  />,
+).bind({})
+
+export const CompleteWithoutReceipt = Template(
+  <StripeReceiptContainer
+    formId="61540ece3d4a6e50ac0cc6ff"
+    submissionId="MOCK_SUBMISSION_ID"
+    paymentId="MOCK_PAYMENT_ID"
+  />,
+).bind({})
+CompleteWithoutReceipt.parameters = {
+  msw: [
+    ...DEFAULT_MSW_HANDLERS,
+    getPaymentReceiptStatusResponse({ delay: 'infinite' }),
+  ],
+}
+
+export const CompleteWithReceipt = Template(
+  <StripeReceiptContainer
+    formId="61540ece3d4a6e50ac0cc6ff"
+    submissionId="MOCK_SUBMISSION_ID"
+    paymentId="MOCK_PAYMENT_ID"
+  />,
+).bind({})
+CompleteWithReceipt.parameters = {
+  msw: [...DEFAULT_MSW_HANDLERS, getPaymentReceiptStatusResponse()],
+}

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -12,7 +12,7 @@ import FormStartPage from '~features/public-form/components/FormStartPage'
 import { PublicFormWrapper } from '~features/public-form/components/PublicFormWrapper'
 import { PublicFormProvider } from '~features/public-form/PublicFormProvider'
 
-import StripeElementWrapper from './stripe/StripeElementWrapper'
+import StripePaymentElement from './stripe/StripePaymentElement'
 
 export interface FormPaymentPageProps {
   submissionId: string
@@ -46,7 +46,7 @@ export const FormPaymentPage = () => {
                     </Skeleton>
                   }
                 >
-                  <StripeElementWrapper paymentId={paymentId} />
+                  <StripePaymentElement paymentId={paymentId} />
                 </Suspense>
               </Container>
             </Box>

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -14,13 +14,6 @@ import { PublicFormProvider } from '~features/public-form/PublicFormProvider'
 
 import StripePaymentElement from './stripe/StripePaymentElement'
 
-export interface FormPaymentPageProps {
-  submissionId: string
-  paymentClientSecret: string
-  publishableKey: string
-  isRetry?: boolean
-}
-
 export const FormPaymentPage = () => {
   const { formId, paymentId } = useParams()
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/CreatePaymentIntentFailureBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/CreatePaymentIntentFailureBlock.tsx
@@ -41,13 +41,10 @@ export const CreatePaymentIntentFailureBlock = ({
           <Text textStyle="h3" textColor="primary.500">
             There was an error preparing the payment.
           </Text>
-          <Text textStyle="body-2" textColor="secondary.500">
-            Please contact the agency which gave you this form link for
-            assistance and share with them the Response ID below.
-          </Text>
         </Box>
         <Text textStyle="body-1" textColor="secondary.700">
-          No payment has been made for this form.
+          For assistance, share the response ID with the agency that gave you
+          the form link. No payment has been taken.
         </Text>
 
         <Text textColor="secondary.300">Response ID: {submissionId}</Text>

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/CreatePaymentIntentFailureBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/CreatePaymentIntentFailureBlock.tsx
@@ -3,13 +3,11 @@ import { Box, Flex, Stack, Text, VisuallyHidden } from '@chakra-ui/react'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-import { FormPaymentPageProps } from '../FormPaymentPage'
-
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
 
-export interface CreatePaymentIntentFailureBlockProps
-  extends FormPaymentPageProps {
+export interface CreatePaymentIntentFailureBlockProps {
+  submissionId: string
   focusOnMount?: boolean
 }
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -19,7 +19,7 @@ import { useGetPaymentStatusFromStripe } from './queries'
 import { StripeReceiptContainer } from './StripeReceiptContainer'
 import { getPaymentViewStates, PaymentViewStates } from './utils'
 
-const StripeElementWrapper = ({ paymentId }: { paymentId: string }) => {
+const StripePaymentElement = ({ paymentId }: { paymentId: string }) => {
   const { data: paymentInfoData } = useGetPaymentInfo(paymentId)
 
   if (!paymentInfoData) {
@@ -132,4 +132,4 @@ const StripePaymentContainer = ({
   return renderViewState()
 }
 
-export default StripeElementWrapper
+export default StripePaymentElement

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -74,8 +74,6 @@ const StripePaymentContainer = ({
           <PaymentStack>
             <CreatePaymentIntentFailureBlock
               submissionId={paymentInfoData.submissionId}
-              paymentClientSecret={paymentInfoData.client_secret}
-              publishableKey={paymentInfoData.publishableKey}
             />
           </PaymentStack>
         )
@@ -94,8 +92,6 @@ const StripePaymentContainer = ({
           <PaymentStack>
             <StripePaymentBlock
               submissionId={paymentInfoData.submissionId}
-              paymentClientSecret={paymentInfoData.client_secret}
-              publishableKey={paymentInfoData.publishableKey}
               triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
             />
           </PaymentStack>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
@@ -8,13 +8,7 @@ import {
   Text,
   VisuallyHidden,
 } from '@chakra-ui/react'
-import {
-  Elements,
-  PaymentElement,
-  useElements,
-  useStripe,
-} from '@stripe/react-stripe-js'
-import { loadStripe } from '@stripe/stripe-js'
+import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js'
 
 import { FormColorTheme, FormResponseMode } from '~shared/types/form'
 
@@ -23,22 +17,17 @@ import Button from '~components/Button'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
-import { FormPaymentPageProps } from '../../FormPaymentPage'
-
 import { PaymentItemDetailsBlock } from './PaymentItemDetailsBlock'
 
-// Make sure to call `loadStripe` outside of a component’s render to avoid
-// recreating the `Stripe` object on every render.
-
-export interface PaymentPageBlockProps extends FormPaymentPageProps {
+interface PaymentPageBlockProps {
+  submissionId: string
+  isRetry?: boolean
   focusOnMount?: boolean
   triggerPaymentStatusRefetch: () => void
 }
 
-type StripeCheckoutFormProps = Pick<
-  PaymentPageBlockProps,
-  'submissionId' | 'isRetry'
-> & {
+interface StripeCheckoutFormProps {
+  isRetry?: boolean
   colorTheme: FormColorTheme
   triggerPaymentStatusRefetch: () => void
 }
@@ -132,8 +121,6 @@ const StripeCheckoutForm = ({
 
 export const StripePaymentBlock = ({
   submissionId,
-  paymentClientSecret,
-  publishableKey,
   focusOnMount,
   isRetry,
   triggerPaymentStatusRefetch,
@@ -142,11 +129,6 @@ export const StripePaymentBlock = ({
 
   const formTitle = form?.title
   const colorTheme = form?.startPage.colorTheme || FormColorTheme.Blue
-
-  const stripePromise = useMemo(
-    () => loadStripe(publishableKey),
-    [publishableKey],
-  )
 
   const focusRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -181,22 +163,11 @@ export const StripePaymentBlock = ({
             paymentAmount={form.payments_field?.amount_cents}
           />
         </Box>
-        {paymentClientSecret && (
-          <Elements
-            stripe={stripePromise}
-            options={{
-              // passing the client secret obtained from the server
-              clientSecret: paymentClientSecret,
-            }}
-          >
-            <StripeCheckoutForm
-              colorTheme={colorTheme}
-              submissionId={submissionId}
-              isRetry={isRetry}
-              triggerPaymentStatusRefetch={triggerPaymentStatusRefetch}
-            />
-          </Elements>
-        )}
+        <StripeCheckoutForm
+          colorTheme={colorTheme}
+          isRetry={isRetry}
+          triggerPaymentStatusRefetch={triggerPaymentStatusRefetch}
+        />
         <Text textColor="secondary.300">Response ID: {submissionId}</Text>
       </Stack>
     </Flex>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
@@ -23,7 +23,7 @@ export const PaymentItemDetailsBlock = ({
       borderRadius="4px"
       p="0.7rem"
     >
-      <Text textStyle="body-1" mb="0.5rem">
+      <Text textStyle="body-1" mb="0.75rem">
         {paymentItemName}
       </Text>
       <Box as="h2" textStyle="h2">{`${centsToDollars(

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -2,6 +2,7 @@ import cuid from 'cuid'
 import { merge } from 'lodash'
 import { rest } from 'msw'
 
+import { PaymentChannel } from '~shared/types'
 import { AgencyId } from '~shared/types/agency'
 import {
   AttachmentSize,
@@ -597,6 +598,8 @@ export const createMockForm = (
         submissionLimit: null,
         form_fields: [],
         form_logics: [],
+        payments_channel: { channel: PaymentChannel.Unconnected },
+        payments_field: { enabled: false },
         permissionList: [],
         title: 'Test form title',
         admin: {

--- a/frontend/src/mocks/msw/handlers/payment.ts
+++ b/frontend/src/mocks/msw/handlers/payment.ts
@@ -1,0 +1,45 @@
+import { rest } from 'msw'
+import { PartialDeep } from 'type-fest'
+
+import { GetPaymentInfoDto, PaymentReceiptStatusDto } from '~shared/types'
+
+const BASE_PAYMENT_INFO = {
+  client_secret: 'sample_client_secret',
+  publishableKey: 'sample_pub_key',
+  payment_intent_id: 'sample_piid',
+  submissionId: 'sample_responseid',
+}
+
+export const getPaymentInfoResponse = ({
+  delay = 0,
+  overrides,
+}: {
+  delay?: number | 'infinite'
+  overrides?: PartialDeep<GetPaymentInfoDto>
+} = {}) => {
+  return rest.get<GetPaymentInfoDto>(
+    '/api/v3/payments/:paymentId/getinfo',
+    (_req, res, ctx) => {
+      return res(
+        ctx.delay(delay),
+        ctx.json({
+          ...BASE_PAYMENT_INFO,
+          ...overrides,
+        }),
+      )
+    },
+  )
+}
+
+export const getPaymentReceiptStatusResponse = ({
+  delay = 0,
+}: {
+  delay?: number | 'infinite'
+} = {}) => {
+  return rest.get<PaymentReceiptStatusDto>(
+    '/api/v3/payments/:formId/:paymentId/receipt/status',
+    (_req, res, ctx) => {
+      return res(ctx.delay(delay), ctx.json({ isReady: true }))
+    },
+  )
+}

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -7,6 +7,7 @@ import {
   LogicConditionState,
   LogicIfValue,
   LogicType,
+  PaymentChannel,
   PreventSubmitLogicDto,
   ShowFieldLogicDto,
 } from '~shared/types'
@@ -364,6 +365,8 @@ export const BASE_FORM = {
     },
   ],
   form_logics: [],
+  payments_channel: { channel: PaymentChannel.Unconnected },
+  payments_field: { enabled: false },
   hasCaptcha: false,
   startPage: {
     colorTheme: 'blue',
@@ -401,6 +404,8 @@ export const BASE_FORM_WITHOUT_SECTIONS = {
     },
   ],
   form_logics: [],
+  payments_channel: { channel: PaymentChannel.Unconnected },
+  payments_field: { enabled: false },
   hasCaptcha: false,
   startPage: {
     colorTheme: 'blue',

--- a/frontend/src/mocks/msw/handlers/user.ts
+++ b/frontend/src/mocks/msw/handlers/user.ts
@@ -7,7 +7,7 @@ import { UserDto, UserId, VerifyUserContactOtpDto } from '~shared/types/user'
 
 import { DefaultRequestReturn, WithDelayProps } from './types'
 
-export const MOCK_USER = {
+export const MOCK_USER: UserDto = {
   _id: 'mock_id' as UserId,
   email: 'admin@example.com',
   agency: {
@@ -19,6 +19,7 @@ export const MOCK_USER = {
     logo: '/path/to/logo/example.jpg',
     created: '2017-09-15T06:03:58.792Z' as DateString,
   },
+  betaFlags: { payment: true },
   created: '2020-03-26T09:39:44.613Z' as DateString,
   contact: '+6598765432',
   lastAccessed: '2021-08-24T09:10:02.661Z' as DateString,

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -78,11 +78,13 @@ export const FieldContainer = ({
         >
           {schema.title}
         </FormLabel>
-        <Box hidden={!showMyInfoBadge} gridArea="myinfobadge">
-          <Badge variant="subtle" colorScheme="secondary">
-            MyInfo
-          </Badge>
-        </Box>
+        {showMyInfoBadge && (
+          <Box gridArea="myinfobadge">
+            <Badge variant="subtle" colorScheme="secondary">
+              MyInfo
+            </Badge>
+          </Box>
+        )}
       </Grid>
       {children}
       <FormErrorMessage>{error?.message}</FormErrorMessage>

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
 import {
@@ -23,65 +23,43 @@ type PaymentPreviewProps = {
   colorTheme?: FormColorTheme
   paymentDetails?: FormPaymentsField
   isBuilder?: boolean
-  isActive?: boolean
-  onClick?: () => void
 }
 
 export const PaymentPreview = ({
   colorTheme = FormColorTheme.Blue,
   paymentDetails,
   isBuilder,
-  isActive,
-  onClick,
 }: PaymentPreviewProps) => {
   const sectionColor = useSectionColor(colorTheme)
   const emailFieldSchema: VerifiableEmailFieldSchema = {
     ...(getFieldCreationMeta(BasicField.Email) as EmailFieldBase),
     title: 'Email Address',
     _id: PAYMENT_CONTACT_FIELD_ID,
-    description: 'For delivery of invoice',
+    description: 'Proof of payment will be sent to this email',
     isVerifiable: true,
   }
 
   if (!paymentDetails || !paymentDetails.enabled) return null
 
   return (
-    <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem">
-      <Box
-        bg={'white'}
-        py="2.5rem"
-        px={{ base: '1rem', md: '2.5rem' }}
-        {...(isBuilder && {
-          _hover: { bg: 'secondary.100', cursor: 'pointer' },
-          _active: {
-            bg: 'secondary.100',
-            boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
-            borderRadius: '4px',
-          },
-          'data-active': isActive || undefined,
-          transition: 'ease',
-          transitionDuration: '0.2s',
-          onClick,
-        })}
-      >
-        <Box as="h2" mb="1rem" textStyle="h2" color={sectionColor}>
-          Payment
-        </Box>
-        <Box mb="2rem">
-          <PaymentItemDetailsBlock
-            paymentItemName={paymentDetails.description}
-            colorTheme={colorTheme}
-            paymentAmount={paymentDetails.amount_cents}
-          />
-        </Box>
-        {isBuilder ? (
-          <VerifiableFieldBuilderContainer schema={emailFieldSchema}>
-            <EmailFieldInput schema={emailFieldSchema} />
-          </VerifiableFieldBuilderContainer>
-        ) : (
-          <VerifiableEmailField schema={emailFieldSchema} />
-        )}
+    <>
+      <Box as="h2" mb="1rem" textStyle="h2" color={sectionColor}>
+        Payment
       </Box>
-    </Stack>
+      <Box mb="2rem">
+        <PaymentItemDetailsBlock
+          paymentItemName={paymentDetails.description}
+          colorTheme={colorTheme}
+          paymentAmount={paymentDetails.amount_cents}
+        />
+      </Box>
+      {isBuilder ? (
+        <VerifiableFieldBuilderContainer schema={emailFieldSchema}>
+          <EmailFieldInput schema={emailFieldSchema} />
+        </VerifiableFieldBuilderContainer>
+      ) : (
+        <VerifiableEmailField schema={emailFieldSchema} />
+      )}
+    </>
   )
 }

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -67,7 +67,7 @@ export const PaymentPreview = ({
         <Box as="h2" mb="1rem" textStyle="h2" color={sectionColor}>
           Payment
         </Box>
-        <Box mb="1rem">
+        <Box mb="2rem">
           <PaymentItemDetailsBlock
             paymentItemName={paymentDetails.description}
             colorTheme={colorTheme}


### PR DESCRIPTION
## Problem
We want to add stories for our payments components.

Closes #6244 

## Solution
Add stories for admin form and public form views with payments.

**Breaking Changes** 
- No - this PR is backwards compatible  