### PR TITLE
chore: add script for post-release steps

### DIFF
--- a/scripts/post_release_prep.sh
+++ b/scripts/post_release_prep.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -x
+
+# To be executed after release has been deployed to prod
+# pre-requisites: install github CLI
+# - github documentation: https://github.com/cli/cli#installation
+
+git fetch --all --tags
+git checkout release-al2
+git reset --hard origin/release-al2
+
+# get latest release version
+release_version=$(git ls-remote --tags --sort=creatordate | grep -o 'v.*' | tail -1)
+echo ${release_version}
+
+# push latest release to UAT
+git push -f origin release-al2:uat
+
+# Create PR to merge release-al2 to develop
+gh pr create \
+  -H release-al2 \
+  -B develop \
+  -t "build: merge release ${release_version} to develop" \
+  -b ""
+
+# Create new GitHub release from release tag
+gh release create ${release_version} \
+  --generate-notes


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The post-release steps are still done manually

## Solution
<!-- How did you solve the problem? -->
Create a script which:
1. Pushes the latest release on `release-al2` to `uat`
2. Creates a PR to merge `release-al2` to `develop`
3. Creates a new Github release from the release tag

Simply run `bash scripts/post_release_prep.sh` to execute these steps
