### PR TITLE
perf: conditionally use hooks based on activeness of field row

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -50,7 +50,7 @@ export const BuilderFields = ({
           key={f._id}
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
-          isDraggingOver={f._id === activeFieldId ? isDraggingOver : false}
+          isDraggingOver={f._id === activeFieldId && isDraggingOver}
           fieldBuilderState={
             f._id === activeFieldId ? stateData.state : undefined
           }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -4,13 +4,14 @@ import { useCreatePageSidebar } from '~features/admin-form/create/common/CreateP
 import { augmentWithQuestionNo } from '~features/form/utils'
 import { FieldIdSet } from '~features/logic/types'
 
-import { useBuilderAndDesignContext } from '../BuilderAndDesignContext'
 import { PENDING_CREATE_FIELD_ID } from '../constants'
+import { isDirtySelector, useDirtyFieldStore } from '../useDirtyFieldStore'
 import {
   FieldBuilderState,
   stateDataSelector,
   useFieldBuilderStore,
 } from '../useFieldBuilderStore'
+import { useDesignColorTheme } from '../utils/useDesignColorTheme'
 
 import FieldRow from './FieldRow'
 
@@ -29,9 +30,17 @@ export const BuilderFields = ({
   const stateData = useFieldBuilderStore(stateDataSelector)
 
   const { handleBuilderClick } = useCreatePageSidebar()
-  const {
-    deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
-  } = useBuilderAndDesignContext()
+
+  const activeFieldNumber =
+    stateData.state === FieldBuilderState.EditingField
+      ? stateData.field._id
+      : stateData.state === FieldBuilderState.CreatingField
+      ? PENDING_CREATE_FIELD_ID
+      : null
+
+  const colorTheme = useDesignColorTheme()
+
+  const isDirty = useDirtyFieldStore(isDirtySelector)
 
   return (
     <>
@@ -42,16 +51,12 @@ export const BuilderFields = ({
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
           isDraggingOver={isDraggingOver}
-          isActive={
-            stateData.state === FieldBuilderState.EditingField
-              ? f._id === stateData.field._id
-              : stateData.state === FieldBuilderState.CreatingField
-              ? f._id === PENDING_CREATE_FIELD_ID
-              : false
+          fieldBuilderState={
+            f._id === activeFieldNumber ? stateData.state : undefined
           }
-          fieldBuilderState={stateData.state}
           handleBuilderClick={handleBuilderClick}
-          onDeleteModalOpen={onDeleteModalOpen}
+          isDirty={isDirty}
+          colorTheme={colorTheme}
         />
       ))}
     </>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -31,7 +31,7 @@ export const BuilderFields = ({
 
   const { handleBuilderClick } = useCreatePageSidebar()
 
-  const activeFieldNumber =
+  const activeFieldId =
     stateData.state === FieldBuilderState.EditingField
       ? stateData.field._id
       : stateData.state === FieldBuilderState.CreatingField
@@ -50,9 +50,9 @@ export const BuilderFields = ({
           key={f._id}
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
-          isDraggingOver={f._id === activeFieldNumber ? isDraggingOver : false}
+          isDraggingOver={f._id === activeFieldId ? isDraggingOver : false}
           fieldBuilderState={
-            f._id === activeFieldNumber ? stateData.state : undefined
+            f._id === activeFieldId ? stateData.state : undefined
           }
           handleBuilderClick={handleBuilderClick}
           isDirty={isDirty}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -50,7 +50,7 @@ export const BuilderFields = ({
           key={f._id}
           field={f}
           isHiddenByLogic={!visibleFieldIds.has(f._id)}
-          isDraggingOver={isDraggingOver}
+          isDraggingOver={f._id === activeFieldNumber ? isDraggingOver : false}
           fieldBuilderState={
             f._id === activeFieldNumber ? stateData.state : undefined
           }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderFields.tsx
@@ -44,21 +44,27 @@ export const BuilderFields = ({
 
   return (
     <>
-      {fieldsWithQuestionNos.map((f, i) => (
-        <FieldRow
-          index={i}
-          key={f._id}
-          field={f}
-          isHiddenByLogic={!visibleFieldIds.has(f._id)}
-          isDraggingOver={f._id === activeFieldId && isDraggingOver}
-          fieldBuilderState={
-            f._id === activeFieldId ? stateData.state : undefined
-          }
-          handleBuilderClick={handleBuilderClick}
-          isDirty={isDirty}
-          colorTheme={colorTheme}
-        />
-      ))}
+      {fieldsWithQuestionNos.map((f, i) => {
+        const activeFieldExtraProps =
+          f._id === activeFieldId
+            ? {
+                isDraggingOver,
+                fieldBuilderState: stateData.state,
+              }
+            : {}
+        return (
+          <FieldRow
+            index={i}
+            key={f._id}
+            field={f}
+            isHiddenByLogic={!visibleFieldIds.has(f._id)}
+            handleBuilderClick={handleBuilderClick}
+            isDirty={isDirty}
+            colorTheme={colorTheme}
+            {...activeFieldExtraProps}
+          />
+        )
+      })}
     </>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -55,7 +55,7 @@ import {
   isMyInfo,
 } from '~features/myinfo/utils'
 
-import { BuilderAndDesignContextProps } from '../../BuilderAndDesignContext'
+import { useBuilderAndDesignContext } from '../../BuilderAndDesignContext'
 import {
   setToInactiveSelector as setPaymentToInactiveSelector,
   usePaymentStore,
@@ -68,7 +68,6 @@ import {
   setStateSelector as setDesignStateSelector,
   useDesignStore,
 } from '../../useDesignStore'
-import { isDirtySelector, useDirtyFieldStore } from '../../useDirtyFieldStore'
 import {
   FieldBuilderState,
   setToInactiveSelector,
@@ -76,7 +75,6 @@ import {
   useFieldBuilderStore,
 } from '../../useFieldBuilderStore'
 import { getAttachmentSizeLimit } from '../../utils/getAttachmentSizeLimit'
-import { useDesignColorTheme } from '../../utils/useDesignColorTheme'
 
 import { SectionFieldRow } from './SectionFieldRow'
 import { VerifiableFieldBuilderContainer } from './VerifiableFieldBuilderContainer'
@@ -86,10 +84,12 @@ export interface FieldRowContainerProps {
   index: number
   isHiddenByLogic: boolean
   isDraggingOver: boolean
-  isActive: boolean
-  fieldBuilderState: FieldBuilderState
+  // Field only needs to know fieldBuilderState if it is active, else it is agnostic to state
+  fieldBuilderState?: FieldBuilderState
+  isDirty: boolean
+  colorTheme?: FormColorTheme
+  // handleBuilderClick is passed down to prevent unnecessary re-renders from useContext
   handleBuilderClick: CreatePageSidebarContextProps['handleBuilderClick']
-  onDeleteModalOpen: BuilderAndDesignContextProps['deleteFieldModalDisclosure']['onOpen']
 }
 
 const FieldRowContainer = ({
@@ -97,30 +97,25 @@ const FieldRowContainer = ({
   index,
   isHiddenByLogic,
   isDraggingOver,
-  isActive,
   fieldBuilderState,
+  isDirty,
+  colorTheme,
   handleBuilderClick,
-  onDeleteModalOpen,
 }: FieldRowContainerProps): JSX.Element => {
   const isMobile = useIsMobile()
-  const { data: form } = useCreateTabForm()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
-  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
   const updateEditState = useFieldBuilderStore(updateEditStateSelector)
-
-  const isDirty = useDirtyFieldStore(isDirtySelector)
-  const toast = useToast({ status: 'danger', isClosable: true })
 
   const setDesignState = useDesignStore(setDesignStateSelector)
   const setPaymentStateToInactive = usePaymentStore(
     setPaymentToInactiveSelector,
   )
-  const { duplicateFieldMutation } = useDuplicateFormField()
-  const { deleteFieldMutation } = useDeleteFormField()
-
-  const colorTheme = useDesignColorTheme()
 
   const isMyInfoField = useMemo(() => isMyInfo(field), [field])
+
+  // Explicitly defining isActive here to prevent constant checks to undefined
+  // due to falsy nature of FieldBuilderState.CreatingField = 0
+  const isActive = fieldBuilderState !== undefined
 
   const defaultFieldValues = useMemo(() => {
     if (field.fieldType === BasicField.Table) {
@@ -189,52 +184,6 @@ const FieldRowContainer = ({
       }
     },
     [handleFieldClick],
-  )
-
-  const handleEditFieldClick = useCallback(() => {
-    if (isMobile) {
-      handleBuilderClick(false)
-    }
-  }, [handleBuilderClick, isMobile])
-
-  const handleDuplicateClick = useCallback(() => {
-    if (!form) return
-    // Duplicate button should be hidden if field is not yet created, but guard here just in case
-    if (fieldBuilderState === FieldBuilderState.CreatingField) return
-    // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
-    if (field.fieldType === BasicField.Attachment) {
-      const existingAttachmentsSize = form.form_fields.reduce(
-        (sum, ff) =>
-          ff.fieldType === BasicField.Attachment
-            ? sum + Number(ff.attachmentSize)
-            : sum,
-        0,
-      )
-      const remainingAvailableSize =
-        getAttachmentSizeLimit(form.responseMode) - existingAttachmentsSize
-      const thisAttachmentSize = Number(field.attachmentSize)
-      if (thisAttachmentSize > remainingAvailableSize) {
-        toast({
-          useMarkdown: true,
-          description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${remainingAvailableSize} MB**.`,
-        })
-        return
-      }
-    }
-    duplicateFieldMutation.mutate(field._id)
-  }, [fieldBuilderState, field, duplicateFieldMutation, form, toast])
-
-  const handleDeleteClick = useCallback(() => {
-    if (fieldBuilderState === FieldBuilderState.CreatingField) {
-      setToInactive()
-    } else if (fieldBuilderState === FieldBuilderState.EditingField) {
-      onDeleteModalOpen()
-    }
-  }, [setToInactive, fieldBuilderState, onDeleteModalOpen])
-
-  const isAnyMutationLoading = useMemo(
-    () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
-    [duplicateFieldMutation, deleteFieldMutation],
   )
 
   const isDragDisabled = useMemo(() => {
@@ -347,52 +296,14 @@ const FieldRowContainer = ({
                 </FormProvider>
               </Box>
               <Collapse in={isActive} style={{ width: '100%' }}>
-                <Flex
-                  px={{ base: '0.75rem', md: '1.5rem' }}
-                  flex={1}
-                  borderTop="1px solid var(--chakra-colors-neutral-300)"
-                  justify="flex-end"
-                >
-                  <ButtonGroup
-                    variant="clear"
-                    colorScheme="secondary"
-                    spacing={0}
-                  >
-                    {isMobile ? (
-                      <IconButton
-                        variant="clear"
-                        colorScheme="secondary"
-                        aria-label="Edit field"
-                        icon={<BiCog fontSize="1.25rem" />}
-                        onClick={handleEditFieldClick}
-                      />
-                    ) : null}
-                    {
-                      // Fields which are not yet created cannot be duplicated
-                      fieldBuilderState !== FieldBuilderState.CreatingField && (
-                        <Tooltip label="Duplicate field">
-                          <IconButton
-                            aria-label="Duplicate field"
-                            isDisabled={isAnyMutationLoading}
-                            onClick={handleDuplicateClick}
-                            isLoading={duplicateFieldMutation.isLoading}
-                            icon={<BiDuplicate fontSize="1.25rem" />}
-                          />
-                        </Tooltip>
-                      )
-                    }
-                    <Tooltip label="Delete field">
-                      <IconButton
-                        colorScheme="danger"
-                        aria-label="Delete field"
-                        icon={<BiTrash fontSize="1.25rem" />}
-                        onClick={handleDeleteClick}
-                        isLoading={deleteFieldMutation.isLoading}
-                        isDisabled={isAnyMutationLoading}
-                      />
-                    </Tooltip>
-                  </ButtonGroup>
-                </Flex>
+                {isActive && fieldBuilderState !== undefined && (
+                  <FieldButtonGroup
+                    field={field}
+                    fieldBuilderState={fieldBuilderState}
+                    isMobile={isMobile}
+                    handleBuilderClick={handleBuilderClick}
+                  />
+                )}
               </Collapse>
             </Flex>
           </Tooltip>
@@ -405,6 +316,130 @@ const FieldRowContainer = ({
 export const MemoizedFieldRow = memo(FieldRowContainer, (prevProps, newProps) =>
   isEqual(prevProps, newProps),
 )
+
+type FieldButtonGroupProps = {
+  field: FormFieldDto
+  fieldBuilderState: FieldBuilderState
+  isMobile: boolean
+  handleBuilderClick: CreatePageSidebarContextProps['handleBuilderClick']
+}
+
+const FieldButtonGroup = ({
+  field,
+  fieldBuilderState,
+  isMobile,
+  handleBuilderClick,
+}: FieldButtonGroupProps) => {
+  const setToInactive = useFieldBuilderStore(setToInactiveSelector)
+
+  const { data: form } = useCreateTabForm()
+
+  const toast = useToast({ status: 'danger', isClosable: true })
+
+  const { duplicateFieldMutation } = useDuplicateFormField()
+  const { deleteFieldMutation } = useDeleteFormField()
+  const {
+    deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
+  } = useBuilderAndDesignContext()
+
+  // Get remaining available attachment size limit
+  const availableAttachmentSize = form
+    ? getAttachmentSizeLimit(form.responseMode) -
+      form.form_fields.reduce(
+        (sum, ff) =>
+          ff.fieldType === BasicField.Attachment
+            ? sum + Number(ff.attachmentSize)
+            : sum,
+        0,
+      )
+    : 0
+
+  const handleEditFieldClick = useCallback(() => {
+    if (isMobile) {
+      handleBuilderClick(false)
+    }
+  }, [handleBuilderClick, isMobile])
+
+  const isAnyMutationLoading = useMemo(
+    () => duplicateFieldMutation.isLoading || deleteFieldMutation.isLoading,
+    [duplicateFieldMutation, deleteFieldMutation],
+  )
+  const handleDuplicateClick = useCallback(() => {
+    // Duplicate button should be hidden if field is not yet created, but guard here just in case
+    if (fieldBuilderState === FieldBuilderState.CreatingField) return
+    // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
+    if (field.fieldType === BasicField.Attachment) {
+      const thisAttachmentSize = Number(field.attachmentSize)
+      if (thisAttachmentSize > availableAttachmentSize) {
+        toast({
+          useMarkdown: true,
+          description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${availableAttachmentSize} MB**.`,
+        })
+        return
+      }
+    }
+    duplicateFieldMutation.mutate(field._id)
+  }, [
+    fieldBuilderState,
+    field,
+    duplicateFieldMutation,
+    availableAttachmentSize,
+    toast,
+  ])
+
+  const handleDeleteClick = useCallback(() => {
+    if (fieldBuilderState === FieldBuilderState.CreatingField) {
+      setToInactive()
+    } else if (fieldBuilderState === FieldBuilderState.EditingField) {
+      onDeleteModalOpen()
+    }
+  }, [setToInactive, fieldBuilderState, onDeleteModalOpen])
+
+  return (
+    <Flex
+      px={{ base: '0.75rem', md: '1.5rem' }}
+      flex={1}
+      borderTop="1px solid var(--chakra-colors-neutral-300)"
+      justify="flex-end"
+    >
+      <ButtonGroup variant="clear" colorScheme="secondary" spacing={0}>
+        {isMobile ? (
+          <IconButton
+            variant="clear"
+            colorScheme="secondary"
+            aria-label="Edit field"
+            icon={<BiCog fontSize="1.25rem" />}
+            onClick={handleEditFieldClick}
+          />
+        ) : null}
+        {
+          // Fields which are not yet created cannot be duplicated
+          fieldBuilderState !== FieldBuilderState.CreatingField && (
+            <Tooltip label="Duplicate field">
+              <IconButton
+                aria-label="Duplicate field"
+                isDisabled={isAnyMutationLoading}
+                onClick={handleDuplicateClick}
+                isLoading={duplicateFieldMutation.isLoading}
+                icon={<BiDuplicate fontSize="1.25rem" />}
+              />
+            </Tooltip>
+          )
+        }
+        <Tooltip label="Delete field">
+          <IconButton
+            colorScheme="danger"
+            aria-label="Delete field"
+            icon={<BiTrash fontSize="1.25rem" />}
+            onClick={handleDeleteClick}
+            isLoading={deleteFieldMutation.isLoading}
+            isDisabled={isAnyMutationLoading}
+          />
+        </Tooltip>
+      </ButtonGroup>
+    </Flex>
+  )
+}
 
 type FieldRowProps = {
   field: FormFieldDto

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -296,7 +296,7 @@ const FieldRowContainer = ({
                 </FormProvider>
               </Box>
               <Collapse in={isActive} style={{ width: '100%' }}>
-                {isActive && fieldBuilderState !== undefined && (
+                {isActive && (
                   <FieldButtonGroup
                     field={field}
                     fieldBuilderState={fieldBuilderState}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -83,7 +83,7 @@ export interface FieldRowContainerProps {
   field: FormFieldDto
   index: number
   isHiddenByLogic: boolean
-  isDraggingOver: boolean
+  isDraggingOver?: boolean
   // Field only needs to know fieldBuilderState if it is active, else it is agnostic to state
   fieldBuilderState?: FieldBuilderState
   isDirty: boolean

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -342,18 +342,6 @@ const FieldButtonGroup = ({
     deleteFieldModalDisclosure: { onOpen: onDeleteModalOpen },
   } = useBuilderAndDesignContext()
 
-  // Get remaining available attachment size limit
-  const availableAttachmentSize = form
-    ? getAttachmentSizeLimit(form.responseMode) -
-      form.form_fields.reduce(
-        (sum, ff) =>
-          ff.fieldType === BasicField.Attachment
-            ? sum + Number(ff.attachmentSize)
-            : sum,
-        0,
-      )
-    : 0
-
   const handleEditFieldClick = useCallback(() => {
     if (isMobile) {
       handleBuilderClick(false)
@@ -368,7 +356,19 @@ const FieldButtonGroup = ({
     // Duplicate button should be hidden if field is not yet created, but guard here just in case
     if (fieldBuilderState === FieldBuilderState.CreatingField) return
     // Disallow duplicating attachment fields if after the dupe, the filesize exceeds the limit
+
     if (field.fieldType === BasicField.Attachment) {
+      // Get remaining available attachment size limit
+      const availableAttachmentSize = form
+        ? getAttachmentSizeLimit(form.responseMode) -
+          form.form_fields.reduce(
+            (sum, ff) =>
+              ff.fieldType === BasicField.Attachment
+                ? sum + Number(ff.attachmentSize)
+                : sum,
+            0,
+          )
+        : 0
       const thisAttachmentSize = Number(field.attachmentSize)
       if (thisAttachmentSize > availableAttachmentSize) {
         toast({
@@ -379,13 +379,7 @@ const FieldButtonGroup = ({
       }
     }
     duplicateFieldMutation.mutate(field._id)
-  }, [
-    fieldBuilderState,
-    field,
-    duplicateFieldMutation,
-    availableAttachmentSize,
-    toast,
-  ])
+  }, [form, fieldBuilderState, field, duplicateFieldMutation, toast])
 
   const handleDeleteClick = useCallback(() => {
     if (fieldBuilderState === FieldBuilderState.CreatingField) {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Despite #6189 improving performance of dragging and updating field rows slightly, users can still face significant lags when attempting to:
1. Create new field
2. Edit fields
3. Dragging / reordering fields 

This is because of existing hooks still causing re-renders of all field rows from various user actions.

Closes #6045

## Solution
<!-- How did you solve the problem? -->

Currently, all of the field rows are too 'smart' and knows a lot of unnecessary global states/contexts, such as field builder states, entire form data (just to compute attachment size limits), and mutation methods to duplicate/delete fields. 

Firstly, we identify properties that all field rows **must** know. These properties are mostly used in the logic for `handleFieldClick` in `FieldRowContainer`.

There are specifically two properties that all fields need to keep track of:
1. `handleBuilderClick`: As the builder must be displayed upon click, thus, non-active fields must also have the correct/updated method to display the Builder
2. `isDirty`: This is to ensure if user click to another field, upon any existing unsaved changes, the dirty modal will still be registered and displayed. 

Except for the two above, all the other properties can be conditionally called based on `isActive`


**Steps done in this PR to abstract unnecessary properties out of `FieldRowContainer`**

1. Currently the `Collapse`-isble button group containing Edit (in mobile), Duplicate, and Delete, always exists for ALL field rows even if they are not displayed. This button group will only be displayed upon a field being selected (active). Hence, will conditionally render this button group based on whether the field row is active
2. As many of the hooks (such as `useDuplicateFieldMutation`) are being used for `handleDuplicateClick` and `handleDeleteClick`, we can abstract out the entire button group as its own component. Then move these hooks into that specific component. As this component will ONLY be rendered for **one** field (the active field), all re-renders from these hooks will be isolated to this `FieldRowButtonGroup` component for only one `FieldRowContainer`.
3. Additionally, as `fieldBuilderState` of the `FieldRowContainer` is primarily used when the field is active, have made it into an optional prop. This will prevent unnecessary re-renders from the updating of `fieldBuilderState`, hence making most of the fields more 'stupid'. 
4. Lastly, we are currently passing `isDraggingOver` to all field rows, however, from testing it seems that it only impacts the active field. Hence, have made it tied to activeness of the field. Allowing for faster start and drop of dragging action, as only the field being activated will be re-rendered

Other optimizations: 
1. Shifting `isDirty` hook to `BuilderFields`, for better debugging of prop changes. Now all major re-renders of `FieldRowContainers` should be seen from the change in props at the React profiler. Allowing for easier debugging of performance issues in the future
3. Shifting `colorTheme` hook to `BuilderFields`, as the underlying logic uses `useCreateTabForm` that causes re-renders upon any form definition changes (such as saving a field), despite the value remaining static without any design tab changes

Remaining re-renders that cannot be trivially solved:
1. Upon selecting any field (opening drawer)
2. First changes to a field (isDirty)
3. Saving a field (isDirty and drawer change)
4. Deleting a field (index changes, drawer change)
5. Dropping a field (index changes)

On why I did not conditionally render the drag icon:
1. Too little time saving, the chakra drag button is a lot cheaper than the button group
2. Causes issues with the formatting -> will need conditional changes to display an empty component to mimic the hidden component, as `Fade` keeps the margins of the hidden component. 

**There is likely no more trivial improvements we can make to field rows performance after this PR**

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

Video capture performing a simple process of:
1. Creating a new field
2. Reordering the field
3. Editing the field
4. Deleting the field

**BEFORE**:
<!-- [insert screenshot here] -->
takes 1min

https://github.com/opengovsg/FormSG/assets/59867455/c57a9660-381b-4e1b-bc28-a9c2ec021966


**AFTER**:
<!-- [insert screenshot here] -->
takes 35seconds

https://github.com/opengovsg/FormSG/assets/59867455/da4db689-6e3c-43b9-b015-93d99aac341c



## Tests
<!-- What tests should be run to confirm functionality? -->
**To ensure no regression issues**
All the behaviours below should work as intended
- [x] create a new field, delete it
- [x] create a new field, save the field details
- [x] create a new field by dragging from builder to preview
- [x] edit a new field, the field in the preview content should update as well
- [x] edit a new field, do not save, attempt to select another field. Dirty modal should display
- [x] edit a new field, do not save, attempt to refresh, browser should prompt that it is dirty
- [x] edit a new field, save, builder should go back to the list of fields. And the preview content should reflect the edits
- [x] delete a field, the delete modal should show up, you should be able to delete the field
- [x] duplicate a field
- [x] drag a field, the field should hover over the potential droppable locations
- [x] drop the field, all affected fields should have their question numbers updated
- [x] add logic that conditionally displays the field. The fields hidden by logic should be translucent
- [x] the fields hidden by logic can be edited successfully
- [x] the fields hidden by logic can be dragged and dropped successfully
- [x] preview the form, all your changes should be reflected in the preview

On mobile
- [x] repeat the tests (except dragging from builder & selecting another field while editing)
