### PR TITLE
fix: type change due to upgrade in types/express to 4.17.17

### DIFF
--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -81,7 +81,7 @@ const loadExpressApp = async (connection: Connection) => {
     compression({
       // only compress files for the following content types
       filter: function (_req, res) {
-        return /json|text|javascript|css/.test(res.get('content-type'))
+        return /json|text|javascript|css/.test(res.get('content-type') ?? '')
       },
       // zlib option for compression level
       level: 9,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Type definition change due to upgrade of types/express to 4.17.17 in https://github.com/opengovsg/FormSG/pull/6311. This type definition prevents the backend from being built (ie `npm run build` fails).

## Solution
<!-- How did you solve the problem? -->

When the content-type value is nullish, use an empty string instead.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? 
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  