### PR TITLE
feat: retain image metadata after compression

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@stripe/stripe-js": "^1.44.1",
         "axios": "^1.2.1",
         "broadcast-channel": "^4.13.0",
-        "browser-image-compression": "^2.0.0",
+        "browser-image-compression": "^2.0.2",
         "comlink": "^4.3.1",
         "country-flag-icons": "^1.4.19",
         "csv-string": "^4.1.0",
@@ -18442,9 +18442,9 @@
       "dev": true
     },
     "node_modules/browser-image-compression": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
-      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
       "dependencies": {
         "uzip": "0.20201231.0"
       }
@@ -62058,9 +62058,9 @@
       "dev": true
     },
     "browser-image-compression": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
-      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
       "requires": {
         "uzip": "0.20201231.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "@stripe/stripe-js": "^1.44.1",
     "axios": "^1.2.1",
     "broadcast-channel": "^4.13.0",
-    "browser-image-compression": "^2.0.0",
+    "browser-image-compression": "^2.0.2",
     "comlink": "^4.3.1",
     "country-flag-icons": "^1.4.19",
     "csv-string": "^4.1.0",

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -155,6 +155,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             maxWidthOrHeight: 1440,
             initialQuality: 0.8,
             useWebWorker: false,
+            preserveExif: true,
           }).then((blob) =>
             onChange(
               new File([blob], acceptedFile.name, {


### PR DESCRIPTION
## Problem
In React, our image compression does not retain EXIF metadata of images, as it strips the data before compressing it with html canvas. 

As some of our users rely on image metadata, this feature will help retain their workflow even if submission size of images is large. Our previous version in angularjs retains this metadata.

Closes #5754

## Solution
in version 2.0.2 of `browser-image-compression` a new feature to preserve exif for JPEG images is added.

Thus, this PR bumps the version of `browser-image-compression` and add `preserveExif` flag to `Attachment.tsx`

This follows up on #5800, which originally swaps out the compression library, but that is no longer required.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:
EXIF data of JPEG images will now be preserved even after compression.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="517" alt="image" src="https://user-images.githubusercontent.com/59867455/220352762-8ad96f89-d793-4b9c-aea5-64325b85daaf.png">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="517" alt="image" src="https://user-images.githubusercontent.com/59867455/220353015-1e568eb4-99d9-46f4-872b-541070861574.png">

## Tests
<!-- What tests should be run to confirm functionality? -->
**In a storage mode form**
- [ ] Go to a form with an attachment field. Attempt to upload a jpeg, with metadata, that has a file size larger than the attachment field. The image should be successfully compressed. Submit the form.
- [ ] On admin side, download the submitted image and check that the metadata of the original image is preserved in the compressed image, which was submitted to the form.
- [ ] Go to a form with an attachment field. Attempt to upload a png that has a file size larger than the attachment field. The image should be successfully compressed. Submit the form. 
- [ ] On admin side, download the submitted image, and check that the image size is less than the max attachment size

To test for regression
- [ ] Submit a form with an image < max attachment size

**In an email mode form**
- [ ] Go to a form with an attachment field. Attempt to upload a jpeg, with metadata, that has a file size larger than the attachment field. The image should be successfully compressed. Submit the form.
- [ ] On admin side, download the submitted image and check that the metadata of the original image is preserved in the compressed image, which was submitted to the form.
- [ ] Go to a form with an attachment field. Attempt to upload a png that has a file size larger than the attachment field. The image should be successfully compressed. Submit the form. 
- [ ] On admin side, download the submitted image, and check that the image size is less than the max attachment size

To test for regression
- [ ] Submit a form with an image < max attachment size