### PR TITLE
fix: pin MockPass version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - SSM_ENV_SITE_NAME=development
 
   mockpass:
-    build: https://github.com/opengovsg/mockpass.git
+    build: https://github.com/opengovsg/mockpass.git#v3.1.3
     depends_on:
       - backend
     environment:


### PR DESCRIPTION
## Problem
Not pinning MockPass in our docker builds could cause us problems if we are incompatible with certain MockPass versions.

Closes #6321

## Solution
Pin to a certain release tag.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

