### PR TITLE
feat: required copy updates for payment launch on prod

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -78,3 +78,5 @@ export const OGP_FORMSG_COLLATE = 'https://collate.form.gov.sg'
 export const OGP_SGID = 'https://go.gov.sg/sgid-formsg'
 
 export const OGP_FORMSG_REPO = 'https://github.com/opengovsg/formsg'
+
+export const FORMSG_UAT = 'https://uat.form.gov.sg'

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -15,6 +15,7 @@ import {
   Slide,
   Stack,
   Text,
+  TextProps,
   useDisclosure,
 } from '@chakra-ui/react'
 
@@ -39,6 +40,14 @@ export const StickyPreviewHeader = ({
 )
 interface PreviewFormBannerProps {
   isTemplate?: boolean
+}
+
+const textProps: TextProps = {
+  textStyle: 'body-2',
+  color: 'white',
+  ml: '2rem',
+  mt: '0.5rem',
+  mb: '0.5rem',
 }
 
 export const PreviewFormBanner = ({
@@ -167,27 +176,15 @@ export const PreviewFormBanner = ({
       </Flex>
       {isPaymentEnabled && (
         <Flex backgroundColor="neutral.900">
-          {process.env.SECRET_ENV === 'production' ? (
-            <Text
-              textStyle="body-2"
-              color="white"
-              ml="2rem"
-              mt="0.5rem"
-              mb="0.5rem"
-            >
+          {process.env.SECRET_ENV !== 'production' ? (
+            <Text {...textProps}>
               To test your payment form, replicate this form on our{' '}
               <Link isExternal color="white" href="https://uat.form.gov.sg">
                 testing platform.
               </Link>
             </Text>
           ) : (
-            <Text
-              textStyle="body-2"
-              color="white"
-              ml="2rem"
-              mt="0.5rem"
-              mb="0.5rem"
-            >
+            <Text {...textProps}>
               You will not be able to make a test payment in Form Preview mode.
               Open your form to make a test payment.
             </Text>

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -166,16 +166,32 @@ export const PreviewFormBanner = ({
         </Drawer>
       </Flex>
       {isPaymentEnabled && (
-        <Flex backgroundColor={'#3A3E46'}>
-          <Text
-            textStyle="body-2"
-            color="white"
-            ml="2rem"
-            mt="0.5rem"
-            mb="0.5rem"
-          >
-            Payments made in Form Preview mode will not reflect on Stripe.
-          </Text>
+        <Flex backgroundColor="neutral.900">
+          {process.env.SECRET_ENV === 'production' ? (
+            <Text
+              textStyle="body-2"
+              color="white"
+              ml="2rem"
+              mt="0.5rem"
+              mb="0.5rem"
+            >
+              To test your payment form, replicate this form on our{' '}
+              <Link isExternal color="white" href="https://uat.form.gov.sg">
+                testing platform.
+              </Link>
+            </Text>
+          ) : (
+            <Text
+              textStyle="body-2"
+              color="white"
+              ml="2rem"
+              mt="0.5rem"
+              mb="0.5rem"
+            >
+              You will not be able to make a test payment in Form Preview mode.
+              Open your form to make a test payment.
+            </Text>
+          )}
         </Flex>
       )}
       <Divider />

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -19,6 +19,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
+import { FORMSG_UAT } from '~constants/links'
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button, { ButtonProps } from '~components/Button'
 import Link from '~components/Link'
@@ -179,7 +180,7 @@ export const PreviewFormBanner = ({
           {process.env.SECRET_ENV !== 'production' ? (
             <Text {...textProps}>
               To test your payment form, replicate this form on our{' '}
-              <Link isExternal color="white" href="https://uat.form.gov.sg">
+              <Link isExternal color="white" href={FORMSG_UAT}>
                 testing platform.
               </Link>
             </Text>

--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -177,7 +177,7 @@ export const PreviewFormBanner = ({
       </Flex>
       {isPaymentEnabled && (
         <Flex backgroundColor="neutral.900">
-          {process.env.SECRET_ENV !== 'production' ? (
+          {process.env.SECRET_ENV === 'production' ? (
             <Text {...textProps}>
               To test your payment form, replicate this form on our{' '}
               <Link isExternal color="white" href={FORMSG_UAT}>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -302,7 +302,7 @@ export const PaymentsInputPanel = (): JSX.Element | null => {
   return (
     <>
       {isPaymentDisabled && (
-        <Box pt="2rem" pb="1.5rem">
+        <Box px="1.5rem" pt="2rem" pb="1.5rem">
           <InlineMessage variant="info">
             <Text>{paymentDisabledMessage}</Text>
           </InlineMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -302,7 +302,7 @@ export const PaymentsInputPanel = (): JSX.Element | null => {
   return (
     <>
       {isPaymentDisabled && (
-        <Box px="1.5rem" pt="2rem" pb="1.5rem">
+        <Box pt="2rem" pb="1.5rem">
           <InlineMessage variant="info">
             <Text>{paymentDisabledMessage}</Text>
           </InlineMessage>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Divider,
   Flex,
   FormControl,
@@ -10,8 +11,11 @@ import {
 import { FormResponseMode, PaymentChannel } from '~shared/types'
 
 import { BxsCheckCircle, BxsError, BxsInfoCircle } from '~assets/icons'
+import { GUIDE_PAYMENTS } from '~constants/links'
 import FormLabel from '~components/FormControl/FormLabel'
+import InlineMessage from '~components/InlineMessage'
 import Input from '~components/Input'
+import Link from '~components/Link'
 
 import { useAdminFormPayments, useAdminFormSettings } from '../../queries'
 
@@ -125,8 +129,17 @@ const PaymentsSectionText = () => {
   return (
     <Skeleton isLoaded={!isLoading} mb="2.5rem">
       <Text>
-        Link your form to a Stripe account to start collecting payments.
+        Connect your Stripe account to this form to start collecting payments.
       </Text>
+      <InlineMessage variant="info" mt="2rem">
+        <Text>
+          Don't have a Stripe account? Follow{' '}
+          <Link isExternal href={GUIDE_PAYMENTS}>
+            this guide
+          </Link>{' '}
+          to create one.
+        </Text>
+      </InlineMessage>
     </Skeleton>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Divider,
   Flex,
   FormControl,

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -133,7 +133,7 @@ const PaymentsSectionText = () => {
       <InlineMessage variant="info" mt="2rem">
         <Text>
           Don't have a Stripe account? Follow{' '}
-          <Link isExternal href={GUIDE_PAYMENTS}>
+          <Link target="_blank" href={GUIDE_PAYMENTS}>
             this guide
           </Link>{' '}
           to create one.

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { Box, Container, Flex, Skeleton, Text } from '@chakra-ui/react'
 
 import { fillMinHeightCss } from '~utils/fillHeightCss'
+import InlineMessage from '~components/InlineMessage'
 
 import { FormBanner } from '~features/public-form/components/FormBanner'
 import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
@@ -28,7 +29,7 @@ export const FormPaymentPage = () => {
           <PublicFormLogo />
           <FormStartPage />
           <PublicFormWrapper>
-            <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
+            <Box py="1rem" w="100%">
               <Container w="42.5rem" maxW="100%" p={0}>
                 <Suspense
                   fallback={
@@ -39,6 +40,13 @@ export const FormPaymentPage = () => {
                     </Skeleton>
                   }
                 >
+                  {process.env.SECRET_ENV === 'production' ? null : (
+                    <InlineMessage variant="warning" mb="1rem">
+                      Use '4242 4242 4242 4242' as your card number to test
+                      payments on this form. Payments made on this form will
+                      only show in test mode in Stripe.
+                    </InlineMessage>
+                  )}
                   <StripePaymentElement paymentId={paymentId} />
                 </Suspense>
               </Container>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Admins will need more information to self-onboard when we launch payments on production.

Closes https://github.com/opengovsg/FormSG/issues/6245

## Solution
<!-- How did you solve the problem? -->

Make the relevant copy changes to help admins along.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible

**Improvements**:

- Update copy for form preview banners on production and UAT
- Add infobox for test card instructions on the payment page for UAT
- Update copy for payment settings page for storage-mode forms

## Screenshots

### Form Preview Banner

#### Production environment

Desktop:

<img width="1512" alt="Screenshot 2023-05-15 at 8 37 55 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/afffe3a2-955e-4e28-a77d-1ca55aa64665">

Mobile: 

<img width="331" alt="Screenshot 2023-05-15 at 8 37 38 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/4dbc1a10-661f-4456-b82d-e5fdc55c247d">

#### UAT (and other non-production) environments

Desktop:

<img width="1512" alt="Screenshot 2023-05-15 at 7 00 42 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/bc2fa4e0-896a-461f-a0f6-1a165cb02f6f">

Mobile: 

<img width="331" alt="Screenshot 2023-05-15 at 7 01 17 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/8acb363c-28b5-4539-895b-d4771db821e2">

### Test card information on payments page (only on UAT and other non-production environments)

Desktop:

<img width="1512" alt="Screenshot 2023-05-15 at 6 57 16 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/50172605-9976-4394-82c5-f723447417bc">

Mobile: 

<img width="331" alt="Screenshot 2023-05-15 at 6 57 35 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/6f4713d1-8e85-4a39-9b06-dd2a1d9f1684">

### Storage-mode forms payments settings page

Desktop:

<img width="1512" alt="Screenshot 2023-05-16 at 9 20 39 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/e2919f82-9219-42c3-8d35-c861892122f9">

Mobile: 

<img width="331" alt="Screenshot 2023-05-16 at 9 20 57 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/e727cdce-b5f0-492c-a041-46fd02d5ded4">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] On a storage-mode form that does not have payments enabled, go to payment settings page and check that the copy is correct and links to the guide.
- [ ] When the `SECRET_ENV` is set as `production`:
   - [ ] Go to a storage-mode form with payment enabled and preview the form. There should be a banner and check that the copy is expected as above.
- [ ] When the `SECRET_ENV` is _not_ set as `production`:
   - [ ] Go to a storage-mode form with payment enabled and preview the form. There should be a banner and check that the copy is expected as above.
   - [ ] Go to a storage-mode form with payment enabled, open the form and try to pay as a respondent. On the payment page, check that there is an infobox with the expected copy on the test card.