### PR TITLE
fix: disable payment resume and duplicate modals in preview

### DIFF
--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -34,8 +34,8 @@ export const PreviewFormPage = (): JSX.Element => {
           <FormStartPage />
           <PublicFormWrapper>
             <FormInstructions />
-            <FormFields isPreview />
-            <FormEndPage isPreview />
+            <FormFields />
+            <FormEndPage />
             <FormFooter />
           </PublicFormWrapper>
         </FormSectionsProvider>

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -334,6 +334,7 @@ export const PreviewFormProvider = ({
         isLoading,
         handleLogout: undefined,
         isPaymentEnabled,
+        isPreview: true,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/admin-form/template/TemplateFormPage.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.tsx
@@ -34,8 +34,8 @@ export const TemplateFormPage = (): JSX.Element => {
           <FormStartPage isTemplate />
           <PublicFormWrapper>
             <FormInstructions />
-            <FormFields isPreview />
-            <FormEndPage isPreview />
+            <FormFields />
+            <FormEndPage />
             <FormFooter />
           </PublicFormWrapper>
         </FormSectionsProvider>

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -88,6 +88,8 @@ export const TemplateFormProvider = ({
         expiryInMs,
         isLoading,
         handleLogout: undefined,
+        isPreview: true,
+        isPaymentEnabled: false,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -49,6 +49,9 @@ export interface PublicFormContextProps
 
   /** Whether payment is enabled */
   isPaymentEnabled: boolean
+
+  /** Whether it is a preview form */
+  isPreview?: boolean
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -51,7 +51,7 @@ export interface PublicFormContextProps
   isPaymentEnabled: boolean
 
   /** Whether it is a preview form */
-  isPreview?: boolean
+  isPreview: boolean
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -504,6 +504,7 @@ export const PublicFormProvider = ({
         expiryInMs,
         isLoading: isLoading || (!!data?.form.hasCaptcha && !hasLoaded),
         isPaymentEnabled,
+        isPreview: false,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -9,14 +9,8 @@ import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 import { FeedbackFormInput } from './components/FeedbackBlock'
 import { FormEndPage } from './FormEndPage'
 
-interface FormEndPageContainerProps {
-  isPreview?: boolean
-}
-
-export const FormEndPageContainer = ({
-  isPreview,
-}: FormEndPageContainerProps): JSX.Element | null => {
-  const { form, formId, submissionData } = usePublicFormContext()
+export const FormEndPageContainer = (): JSX.Element | null => {
+  const { form, formId, submissionData, isPreview } = usePublicFormContext()
   const { submitFormFeedbackMutation } = usePublicFormMutations(
     formId,
     submissionData?.id ?? '',

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -12,15 +12,15 @@ import { PublicSwitchEnvMessage } from '../PublicSwitchEnvMessage'
 import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
 
-interface FormFieldsContainerProps {
-  isPreview?: boolean
-}
-
-export const FormFieldsContainer = ({
-  isPreview,
-}: FormFieldsContainerProps): JSX.Element | null => {
-  const { form, isAuthRequired, isLoading, handleSubmitForm, submissionData } =
-    usePublicFormContext()
+export const FormFieldsContainer = (): JSX.Element | null => {
+  const {
+    form,
+    isAuthRequired,
+    isLoading,
+    handleSubmitForm,
+    submissionData,
+    isPreview,
+  } = usePublicFormContext()
 
   const renderFields = useMemo(() => {
     // Render skeleton when no data

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -42,7 +42,7 @@ export const PublicFormSubmitButton = ({
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
   const formInputs = useWatch<FormFieldValues>({}) as FormFieldValues
-  const { formId, isPaymentEnabled } = usePublicFormContext()
+  const { formId, isPaymentEnabled, isPreview } = usePublicFormContext()
 
   const paymentEmailField = formInputs[
     PAYMENT_CONTACT_FIELD_ID
@@ -63,6 +63,8 @@ export const PublicFormSubmitButton = ({
     const result = await trigger()
 
     if (result) {
+      // if isPreview mode do not get previous payment
+      if (isPreview) return onOpen()
       // get previous payment
       try {
         const paymentId = await getPreviousPaymentId(

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -63,8 +63,6 @@ export const PublicFormSubmitButton = ({
     const result = await trigger()
 
     if (result) {
-      // if isPreview mode do not get previous payment
-      if (isPreview) return onOpen()
       // get previous payment
       try {
         const paymentId = await getPreviousPaymentId(
@@ -106,7 +104,7 @@ export const PublicFormSubmitButton = ({
         isLoading={isSubmitting}
         isDisabled={!!preventSubmissionLogic || !onSubmit}
         loadingText="Submitting"
-        onClick={isPaymentEnabled ? checkBeforeOpen : onSubmit}
+        onClick={isPaymentEnabled && !isPreview ? checkBeforeOpen : onSubmit}
       >
         <VisuallyHidden>End of form.</VisuallyHidden>
         {preventSubmissionLogic

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -25,12 +25,12 @@ import { usePublicFormContext } from '../../PublicFormContext'
  */
 export const PublicFormPaymentResumeModal = (): JSX.Element => {
   const isMobile = useIsMobile()
-  const { isPaymentEnabled, formId } = usePublicFormContext()
+  const { isPaymentEnabled, formId, isPreview } = usePublicFormContext()
 
   const [lastPaymentMemory, , clearPaymentMemory] = useBrowserStm(formId)
 
   const { isOpen, onClose } = useDisclosure({
-    defaultIsOpen: Boolean(lastPaymentMemory && isPaymentEnabled),
+    defaultIsOpen: Boolean(lastPaymentMemory && isPaymentEnabled && !isPreview),
   })
 
   const navigate = useNavigate()
@@ -38,7 +38,7 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
     return <></>
   }
   const onSubmit = () => {
-    if (!lastPaymentMemory) {
+    if (!lastPaymentMemory || isPreview) {
       onClose()
       return
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently we show the `FormPaymentModal`, `FormPaymentResumeModal` and `DuplicatePaymentModal` in preview mode if the same browser or email is used in a public form submission.

This should be disabled when the admin is in preview mode

## Solution
<!-- How did you solve the problem? -->

Check if form is in preview mode before displaying the modals.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


**Improvements**:

- Shifted `isPreview` from a prop in `FormFieldsContainer` and `FormEndPageContainer` to a context in `usePublicFormContext`. As `isPreview` should be static, it can be inserted as a global context without much performance consideration (from hooks updates etc)

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![image](https://github.com/opengovsg/FormSG/assets/59867455/b48a8a01-95e0-4572-a6ad-7c1832fe1673)
![image](https://github.com/opengovsg/FormSG/assets/59867455/4dd8382d-59dd-4e6b-a828-b4687a717a47)


## Tests
<!-- What tests should be run to confirm functionality? -->
To ensure functionality within payments
- [ ] go to a payment form
- [ ] open the form, make a payment intent
- [ ] go to preview mode, there should be no resume modal that is shown
- [ ] go back to the public form, the resume modal should be shown
- [ ] resume session, make the payment
- [ ] go to preview mode, attempt to make a preview payment with the same email as above
- [ ] No payment modal should be shown
- [ ] go to public form, attempt to make a payment with the same email
- [ ] duplicate payment modal should be shown
- [ ] go to public form, attempt to make a payment with a new email
- [ ] proceed to pay modal should be shown

To ensure no regression problem
- [ ] go to a normal storage mode form
- [ ] go to preview mode, submit the form
- [ ] go to public form, submit the form
- [ ] do the same for an email mode form