### PR TITLE
fix: rm white box for payment preview when disabled

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -80,7 +80,7 @@ export const PaymentView = () => {
     setFieldListTabIndex(FieldListTabIndex.Payments)
   }
 
-  return (
+  return paymentDetails.enabled ? (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
         <Box mt="2.5rem" bg="white" py="2.5rem" px="1.5rem">
@@ -106,5 +106,5 @@ export const PaymentView = () => {
         </Box>
       </FormProvider>
     </Box>
-  )
+  ) : null
 }

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -163,19 +163,20 @@ export const FormFields = ({
             </Stack>
           </Box>
         )}
-        {form?.responseMode === FormResponseMode.Encrypt && (
-          <Box
-            mt="2.5rem"
-            bg="white"
-            py="2.5rem"
-            px={{ base: '1rem', md: '2.5rem' }}
-          >
-            <PaymentPreview
-              colorTheme={colorTheme}
-              paymentDetails={form?.payments_field}
-            />
-          </Box>
-        )}
+        {form?.responseMode === FormResponseMode.Encrypt &&
+          form?.payments_field.enabled && (
+            <Box
+              mt="2.5rem"
+              bg="white"
+              py="2.5rem"
+              px={{ base: '1rem', md: '2.5rem' }}
+            >
+              <PaymentPreview
+                colorTheme={colorTheme}
+                paymentDetails={form?.payments_field}
+              />
+            </Box>
+          )}
         <PublicFormPaymentResumeModal />
         <PublicFormSubmitButton
           onSubmit={onSubmit ? formMethods.handleSubmit(onSubmit) : undefined}

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -21,7 +21,7 @@ import {
 
 type PaymentPreviewProps = {
   colorTheme?: FormColorTheme
-  paymentDetails?: FormPaymentsField
+  paymentDetails: FormPaymentsField
   isBuilder?: boolean
 }
 
@@ -38,8 +38,6 @@ export const PaymentPreview = ({
     description: 'Proof of payment will be sent to this email',
     isVerifiable: true,
   }
-
-  if (!paymentDetails || !paymentDetails.enabled) return null
 
   return (
     <>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

White box is still shown where payment preview is rendered when payment is enabled.

Closes https://github.com/opengovsg/FormSG/issues/6340

## Solution
<!-- How did you solve the problem? -->

Only show the white box that wraps payment preview when payment is enabled.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Moves `payment.enabled` check up to include the white box wrapping payment preview

## Before & After Screenshots

**BEFORE**:

Builder mode:

<img width="1511" alt="Screenshot 2023-05-17 at 1 40 26 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/c248231b-f71c-4337-a834-262e3d60277c">

Preview mode:

<img width="1511" alt="Screenshot 2023-05-17 at 1 40 33 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/915d6db4-a422-49fb-83e9-8be227d825a3">

Public form:

<img width="1511" alt="Screenshot 2023-05-17 at 1 40 43 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/e10001a2-7bb7-4730-93a7-66cc43e65ec9">

**AFTER**:

Builder mode:

<img width="1511" alt="Screenshot 2023-05-17 at 1 37 42 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/684d2a26-f819-401e-8587-1bb52373c4ec">

Preview mode:

<img width="1511" alt="Screenshot 2023-05-17 at 1 38 27 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/be26e1eb-a6d6-4f97-92b3-49d79de9779d">

Public form:

<img width="1511" alt="Screenshot 2023-05-17 at 1 37 55 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/ef219964-0a9a-49aa-abcd-77a1fafbb105">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a storage-mode form
- [ ] With payment disabled, go to builder mode. There should be no white box or payment preview shown to the right.
- [ ] Enable payment. The payment preview should appear (builder mode).
- [ ] Go to preview the form in preview mode. There should be no white box or payment preview at the bottom of the form.
- [ ] Open the form. Go to the respondent view of the form. There should be no white box or payment preview at the bottom of the form.
