### PR TITLE
feat: direct admins to payments settings page

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -112,9 +112,11 @@ export const AppRouter = (): JSX.Element => {
         >
           <Route index element={<CreatePage />} />
           <Route
-            path={ADMINFORM_SETTINGS_SUBROUTE}
+            path={`${ADMINFORM_SETTINGS_SUBROUTE}`}
             element={<SettingsPage />}
-          />
+          >
+            <Route path={':settingsTab'} element={<SettingsPage />} />
+          </Route>
           <Route
             path={ADMINFORM_RESULTS_SUBROUTE}
             element={<FormResultsLayout />}

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -111,10 +111,7 @@ export const AppRouter = (): JSX.Element => {
           element={<PrivateElement element={<AdminFormLayout />} />}
         >
           <Route index element={<CreatePage />} />
-          <Route
-            path={`${ADMINFORM_SETTINGS_SUBROUTE}`}
-            element={<SettingsPage />}
-          >
+          <Route path={ADMINFORM_SETTINGS_SUBROUTE} element={<SettingsPage />}>
             <Route path={':settingsTab'} element={<SettingsPage />} />
           </Route>
           <Route

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -6,8 +6,9 @@ import {
   useForm,
   useWatch,
 } from 'react-hook-form'
+import { Link as ReactLink } from 'react-router-dom'
 import { useDebounce } from 'react-use'
-import { Box, FormControl, Text } from '@chakra-ui/react'
+import { Box, FormControl, Link, Text } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import {
@@ -288,11 +289,17 @@ export const PaymentsInputPanel = (): JSX.Element | null => {
     }
   }, [paymentsField, resetData, setData, setToEditingPayment, setToInactive])
 
-  const paymentDisabledMessage = !isEncryptMode
-    ? 'Payments are not available in email mode forms.'
-    : !isStripeConnected
-    ? 'Connect your Stripe account in Settings to save this field.'
-    : ''
+  const paymentDisabledMessage = !isEncryptMode ? (
+    <Text>Payments are not available in email mode forms.</Text>
+  ) : !isStripeConnected ? (
+    <Text>
+      Connect your Stripe account in{' '}
+      <Link as={ReactLink} to={`settings/payments`}>
+        Settings
+      </Link>{' '}
+      to add payment field.
+    </Text>
+  ) : null
 
   // payment eligibility will be dependent on whether paymentDisabledMessage is non empty
   const isPaymentDisabled = !!paymentDisabledMessage
@@ -303,9 +310,7 @@ export const PaymentsInputPanel = (): JSX.Element | null => {
     <>
       {isPaymentDisabled && (
         <Box px="1.5rem" pt="2rem" pb="1.5rem">
-          <InlineMessage variant="info">
-            <Text>{paymentDisabledMessage}</Text>
-          </InlineMessage>
+          <InlineMessage variant="info">{paymentDisabledMessage}</InlineMessage>
         </Box>
       )}
       <PaymentInput isDisabled={isPaymentDisabled} />

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -28,16 +28,8 @@ import { SettingsPaymentsPage } from './SettingsPaymentsPage'
 import { SettingsTwilioPage } from './SettingsTwilioPage'
 import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
-const settingsTabsOrder = [
-  'general',
-  'singpass',
-  'twilio',
-  'webhooks',
-  'payments',
-]
-
 export const SettingsPage = (): JSX.Element => {
-  const { formId, settingsTab = settingsTabsOrder[0] } = useParams()
+  const { formId, settingsTab } = useParams()
   const { user } = useUser()
   const { data: flags } = useFeatureFlags()
 
@@ -58,7 +50,15 @@ export const SettingsPage = (): JSX.Element => {
   const displayPayments =
     user?.betaFlags?.payment || flags?.has(featureFlags.payment)
 
-  const tabIndex = settingsTabsOrder.indexOf(settingsTab)
+  const settingsTabsOrder = [
+    'general',
+    'singpass',
+    'twilio',
+    'webhooks',
+    ...(displayPayments ? ['payments'] : []),
+  ]
+
+  const tabIndex = settingsTabsOrder.indexOf(settingsTab ?? '')
 
   return (
     <Box overflow="auto" flex={1}>

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { BiCodeBlock, BiCog, BiDollar, BiKey, BiMessage } from 'react-icons/bi'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -28,6 +28,8 @@ import { SettingsPaymentsPage } from './SettingsPaymentsPage'
 import { SettingsTwilioPage } from './SettingsTwilioPage'
 import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
+const settingsTabsOrder = ['general', 'singpass', 'twilio', 'webhooks']
+
 export const SettingsPage = (): JSX.Element => {
   const { formId, settingsTab } = useParams()
   const { user } = useUser()
@@ -50,15 +52,24 @@ export const SettingsPage = (): JSX.Element => {
   const displayPayments =
     user?.betaFlags?.payment || flags?.has(featureFlags.payment)
 
-  const settingsTabsOrder = [
-    'general',
-    'singpass',
-    'twilio',
-    'webhooks',
-    ...(displayPayments ? ['payments'] : []),
-  ]
+  // Note: Admins are not redirected to /general on invalid settings tabs.
+  useEffect(() => {
+    if (displayPayments) {
+      settingsTabsOrder.push('payments')
+      setTabIndex(settingsTabsOrder.indexOf(settingsTab ?? ''))
+    }
+  }, [displayPayments, settingsTab])
 
-  const tabIndex = settingsTabsOrder.indexOf(settingsTab ?? '')
+  const [tabIndex, setTabIndex] = useState(
+    settingsTabsOrder.indexOf(settingsTab ?? ''),
+  )
+
+  const handleTabChange = (index: number) => {
+    setTabIndex(index)
+    navigate(
+      `${ADMINFORM_ROUTE}/${formId}/settings/${settingsTabsOrder[index]}`,
+    )
+  }
 
   return (
     <Box overflow="auto" flex={1}>
@@ -69,7 +80,8 @@ export const SettingsPage = (): JSX.Element => {
         variant="line"
         py={{ base: '2.5rem', lg: '3.125rem' }}
         px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
-        defaultIndex={tabIndex === -1 ? 0 : tabIndex}
+        index={tabIndex === -1 ? 0 : tabIndex}
+        onChange={handleTabChange}
       >
         <Flex
           h="max-content"

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -28,8 +28,16 @@ import { SettingsPaymentsPage } from './SettingsPaymentsPage'
 import { SettingsTwilioPage } from './SettingsTwilioPage'
 import { SettingsWebhooksPage } from './SettingsWebhooksPage'
 
+const settingsTabsOrder = [
+  'general',
+  'singpass',
+  'twilio',
+  'webhooks',
+  'payments',
+]
+
 export const SettingsPage = (): JSX.Element => {
-  const { formId } = useParams()
+  const { formId, settingsTab = settingsTabsOrder[0] } = useParams()
   const { user } = useUser()
   const { data: flags } = useFeatureFlags()
 
@@ -50,6 +58,8 @@ export const SettingsPage = (): JSX.Element => {
   const displayPayments =
     user?.betaFlags?.payment || flags?.has(featureFlags.payment)
 
+  const tabIndex = settingsTabsOrder.indexOf(settingsTab)
+
   return (
     <Box overflow="auto" flex={1}>
       <Tabs
@@ -59,6 +69,7 @@ export const SettingsPage = (): JSX.Element => {
         variant="line"
         py={{ base: '2.5rem', lg: '3.125rem' }}
         px={{ base: '1.5rem', md: '1.75rem', lg: '2rem' }}
+        defaultIndex={tabIndex === -1 ? 0 : tabIndex}
       >
         <Flex
           h="max-content"

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -52,17 +52,20 @@ export const SettingsPage = (): JSX.Element => {
   const displayPayments =
     user?.betaFlags?.payment || flags?.has(featureFlags.payment)
 
-  // Note: Admins are not redirected to /general on invalid settings tabs.
+  const [tabIndex, setTabIndex] = useState(
+    settingsTabsOrder.indexOf(settingsTab ?? ''),
+  )
+
+  // Note: Admins are not redirected to /general on invalid settings tabs as we
+  // don't want to do this prematurely before displayPayments can be determined.
   useEffect(() => {
     if (displayPayments) {
+      // Dynamically push payments tab to settings tab order as needed, in case
+      // there may be multiple hidden tabs in the future.
       settingsTabsOrder.push('payments')
       setTabIndex(settingsTabsOrder.indexOf(settingsTab ?? ''))
     }
   }, [displayPayments, settingsTab])
-
-  const [tabIndex, setTabIndex] = useState(
-    settingsTabsOrder.indexOf(settingsTab ?? ''),
-  )
 
   const handleTabChange = (index: number) => {
     setTabIndex(index)

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -516,7 +516,7 @@ const _handleConnectOauthCallback: ControllerHandler<
 
   // Step 1: Retrieve formId from state.
   const formId = state.split('.')[0]
-  const redirectUrl = `${config.app.appUrl}/admin/form/${formId}/settings`
+  const redirectUrl = `${config.app.appUrl}/admin/form/${formId}/settings/payments`
   // Step 2: Retrieve currently logged in user.
   return (
     FormService.retrieveFullFormById(formId)

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -448,8 +448,8 @@ export const createAccountLink = (
   return ResultAsync.fromPromise(
     stripe.accountLinks.create({
       account: accountId,
-      refresh_url: `${config.app.appUrl}/admin/form/${redirectFormId}/settings`,
-      return_url: `${config.app.appUrl}/admin/form/${redirectFormId}/settings`,
+      refresh_url: `${config.app.appUrl}/admin/form/${redirectFormId}/settings/payments`,
+      return_url: `${config.app.appUrl}/admin/form/${redirectFormId}/settings/payments`,
       type: 'account_onboarding',
     }),
     (error) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The current way the settings page is routed does not allow us to direct users to specific tabs. This will be disorienting for users, especially for Payments when they are navigated away then redirected back to us.

Closes FRM-753

## Solution
<!-- How did you solve the problem? -->

Set up routing for the different tabs on the Settings page, then update payment-related settings links to the payments tab in the settings page directly (previously we could only direct them to the generic settings page).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/37061143/43ec4f06-e5ae-4505-a87e-4c22be5ace41

**AFTER**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/37061143/4bedff81-cde0-42eb-bb6d-8f7fb42d0ddc

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Check that opening specific settings tabs through URL path is possible:
   - [ ] Go to `/admin/form/:formId/settings`. You should see the generic settings page with the general tab open.
   - [ ] Go to `/admin/form/:formId/settings/general`. You should see the generic settings page with the general tab open.
   - [ ] Go to `/admin/form/:formId/settings/singpass`. You should see the settings page with the singpass tab open.
   - [ ] Go to `/admin/form/:formId/settings/twilio`. You should see the settings page with the twilio tab open.
   - [ ] Go to `/admin/form/:formId/settings/webhooks`. You should see the settings page with the webhooks tab open.
   - [ ] Go to `/admin/form/:formId/settings/payments`. You should see the settings page with the payments tab open.
   - [ ] Go to `/admin/form/:formId/settings/<invalid_payment_tab_str>`. You should see the generic settings page with the general tab open.
- [ ] On a storage-mode form that is not connected to stripe, go to the payment input panel. 
   - [ ] There should be an infobox with the copy "Connect your Stripe account in Settings to add payment field.". 
   - [ ] "Settings" in the copy should be a link. 
   - [ ] Clicking on the Settings link should lead the admin to the payment settings page.
- [ ] Try to connect a stripe account to the form.
   - [ ] Admin should be redirected to payment settings page after stripe has been connected.
