### PR TITLE
build: release 6.50.0 hotfix

### DIFF
--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -25,6 +25,7 @@ import Button, { ButtonProps } from '~components/Button'
 import Link from '~components/Link'
 
 import { UseTemplateModal } from '~features/admin-form/template/UseTemplateModal'
+import { useEnv } from '~features/env/queries'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 import { DuplicateFormModal } from '~features/workspace/components/DuplicateFormModal'
 
@@ -55,6 +56,7 @@ export const PreviewFormBanner = ({
   isTemplate,
 }: PreviewFormBannerProps): JSX.Element => {
   const { formId, isPaymentEnabled } = usePublicFormContext()
+  const { data: { secretEnv } = {} } = useEnv()
   const {
     isOpen: isModalOpen,
     onOpen: onModalOpen,
@@ -177,7 +179,7 @@ export const PreviewFormBanner = ({
       </Flex>
       {isPaymentEnabled && (
         <Flex backgroundColor="neutral.900">
-          {process.env.SECRET_ENV === 'production' ? (
+          {secretEnv === 'production' ? (
             <Text {...textProps}>
               To test your payment form, replicate this form on our{' '}
               <Link isExternal color="white" href={FORMSG_UAT}>

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -5,6 +5,7 @@ import { Box, Container, Flex, Skeleton, Text } from '@chakra-ui/react'
 import { fillMinHeightCss } from '~utils/fillHeightCss'
 import InlineMessage from '~components/InlineMessage'
 
+import { useEnv } from '~features/env/queries'
 import { FormBanner } from '~features/public-form/components/FormBanner'
 import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
 import { FormFooter } from '~features/public-form/components/FormFooter'
@@ -17,6 +18,7 @@ import StripePaymentElement from './stripe/StripePaymentElement'
 
 export const FormPaymentPage = () => {
   const { formId, paymentId } = useParams()
+  const { data: { secretEnv } = {} } = useEnv()
 
   if (!formId) throw new Error('No formId provided')
   if (!paymentId) throw new Error('No paymentId provided')
@@ -40,7 +42,7 @@ export const FormPaymentPage = () => {
                     </Skeleton>
                   }
                 >
-                  {process.env.SECRET_ENV === 'production' ? null : (
+                  {secretEnv === 'production' ? null : (
                     <InlineMessage variant="warning" mb="1rem">
                       Use '4242 4242 4242 4242' as your card number to test
                       payments on this form. Payments made on this form will

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -37,4 +37,5 @@ export type ClientEnvVars = {
   minPaymentAmountCents: number
   // TODO (#5826): Toggle to use fetch for submissions instead of axios. Remove once network error is resolved
   useFetchForSubmissions: boolean
+  secretEnv: string
 }

--- a/src/app/loaders/express/locals.ts
+++ b/src/app/loaders/express/locals.ts
@@ -28,6 +28,7 @@ const frontendVars = {
     config.reactMigration.useFetchForSubmissions,
   maxPaymentAmountCents: paymentConfig.maxPaymentAmountCents,
   minPaymentAmountCents: paymentConfig.minPaymentAmountCents,
+  secretEnv: config.secretEnv,
 }
 const environment = ejs.render(
   `

--- a/src/app/modules/frontend-old/frontend.service.ts
+++ b/src/app/modules/frontend-old/frontend.service.ts
@@ -33,5 +33,7 @@ export const getClientEnvVars = (): ClientEnvVars => {
 
     // TODO (#5826): Toggle to use fetch for submissions instead of axios. Remove once network error is resolved
     useFetchForSubmissions: config.reactMigration.useFetchForSubmissions,
+
+    secretEnv: config.secretEnv,
   }
 }


### PR DESCRIPTION
## Problem

- In release [6.50.0](https://github.com/opengovsg/FormSG/pull/6347), we introduced a bug ([f4f5998](https://github.com/opengovsg/FormSG/pull/6349/commits/f4f59984d13054f60ffeb0c770bfabf56500d4a3)) where payment-related copy meant for non-production environments shown on production environments.
- This PR fixes it by making the `SECRET_ENV` environment variable accessible on frontend through `useEnv`.

## Tests

- [x] On a storage-mode form that does not have payments enabled, go to payment settings page and check that the copy is correct and links to the guide.
- [x] When the `SECRET_ENV` is set as `production`:
   - [x] Go to a storage-mode form with payment enabled and preview the form. There should be a banner and check that the copy is expected as above.
    - [x] Go to a storage-mode form with payment enabled, open the form and try to pay as a respondent. On the payment page, check that there is **no infobox** above the payment element.
- [x] When the `SECRET_ENV` is _not_ set as `production` (e.g. `staging`):
   - [x] Go to a storage-mode form with payment enabled and preview the form. There should be a banner and check that the copy is expected as above.
   - [x] Go to a storage-mode form with payment enabled, open the form and try to pay as a respondent. On the payment page, check that there is an infobox with the expected copy on the test card.
