### PR TITLE
build: hotfix 6.50.3 add missing enum value to BounceType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FormSG",
-  "version": "6.50.2",
+  "version": "6.50.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
-  "version": "6.50.2",
+  "version": "6.50.3",
   "homepage": "https://form.gov.sg",
   "authors": [
     "FormSG <formsg@data.gov.sg>"

--- a/src/types/sns.ts
+++ b/src/types/sns.ts
@@ -38,6 +38,7 @@ export interface IEmailNotification {
 export enum BounceType {
   Permanent = 'Permanent',
   Transient = 'Transient',
+  Undetermined = 'Undetermined',
 }
 
 export interface IBounceNotification extends IEmailNotification {


### PR DESCRIPTION
## Problem

The errors on bounce have been identified as 

```bash
`Undetermined` is not a valid enum value for path `bounceType`.
```

## Solution

1. Add missing value `Undetermined` to enum
2. Bump hotfix version to 6.50.3

## Risk 

Possible risk because we have code path that do check for the `bouynceType` and act conditionally, but assuming missing value did happen in the past and code could handle it fine anyway (even it that meant type safety may have been a little broken -_-)

cc @justynoh 
