### PR TITLE
fix(FRM-768): add missing fields to sample-submission endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.332.0",
         "@babel/runtime": "^7.20.13",
+        "@faker-js/faker": "^8.0.1",
         "@joi/date": "^2.1.0",
         "@opengovsg/angular-daterangepicker-webpack": "^1.1.5",
         "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
@@ -136,7 +137,6 @@
         "@babel/core": "^7.20.7",
         "@babel/plugin-transform-runtime": "^7.21.4",
         "@babel/preset-env": "^7.20.2",
-        "@faker-js/faker": "^8.0.1",
         "@opengovsg/mockpass": "^3.1.0",
         "@playwright/test": "^1.29.1",
         "@types/bcrypt": "^5.0.0",
@@ -3799,7 +3799,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
       "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -37308,8 +37307,7 @@
     "@faker-js/faker": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
-      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
-      "dev": true
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA=="
     },
     "@hapi/hoek": {
       "version": "9.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
         "@babel/core": "^7.20.7",
         "@babel/plugin-transform-runtime": "^7.21.4",
         "@babel/preset-env": "^7.20.2",
+        "@faker-js/faker": "^8.0.1",
         "@opengovsg/mockpass": "^3.1.0",
         "@playwright/test": "^1.29.1",
         "@types/bcrypt": "^5.0.0",
@@ -3795,12 +3796,19 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
-      "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -6202,6 +6210,15 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@stoplight/prism-http/node_modules/@faker-js/faker": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
+      "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
     },
     "node_modules/@stoplight/prism-http/node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -37289,9 +37306,10 @@
       }
     },
     "@faker-js/faker": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
-      "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
+      "dev": true
     },
     "@hapi/hoek": {
       "version": "9.2.1"
@@ -39064,6 +39082,11 @@
         "uri-template-lite": "^22.9.0"
       },
       "dependencies": {
+        "@faker-js/faker": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
+          "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ=="
+        },
         "@tootallnate/once": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "@babel/core": "^7.20.7",
     "@babel/plugin-transform-runtime": "^7.21.4",
     "@babel/preset-env": "^7.20.2",
+    "@faker-js/faker": "^8.0.1",
     "@opengovsg/mockpass": "^3.1.0",
     "@playwright/test": "^1.29.1",
     "@types/bcrypt": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.332.0",
     "@babel/runtime": "^7.20.13",
+    "@faker-js/faker": "^8.0.1",
     "@joi/date": "^2.1.0",
     "@opengovsg/angular-daterangepicker-webpack": "^1.1.5",
     "@opengovsg/angular-legacy-sortablejs-maintained": "^1.0.0",
@@ -182,7 +183,6 @@
     "@babel/core": "^7.20.7",
     "@babel/plugin-transform-runtime": "^7.21.4",
     "@babel/preset-env": "^7.20.2",
-    "@faker-js/faker": "^8.0.1",
     "@opengovsg/mockpass": "^3.1.0",
     "@playwright/test": "^1.29.1",
     "@types/bcrypt": "^5.0.0",

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -402,6 +402,11 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       }
       sampleValue = tableSampleValue
       break
+    case BasicField.Checkbox:
+      noOfOptions = field.fieldOptions.length
+      randomSelectedOption = Math.floor(Math.random() * noOfOptions)
+      sampleValue = field.fieldOptions[randomSelectedOption]
+      break
     default:
       break
   }

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
@@ -357,8 +358,7 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
   switch (field.fieldType) {
     case BasicField.LongText:
     case BasicField.ShortText:
-      sampleValue =
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+      sampleValue = faker.lorem.sentence()
       break
     case BasicField.Radio:
     case BasicField.Dropdown:
@@ -367,25 +367,26 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       sampleValue = field.fieldOptions[randomSelectedOption]
       break
     case BasicField.Email:
-      sampleValue = 'hello@example.com'
+      sampleValue = faker.internet.email()
       break
     case BasicField.Decimal:
-      sampleValue = 1.234
+      sampleValue = faker.number.float({ precision: 0.1 })
       break
     case BasicField.Number:
-      sampleValue = 1234
+      sampleValue = faker.number.int(100)
       break
     case BasicField.Mobile:
-      sampleValue = '+6598765432'
+      sampleValue = faker.phone.number('+659#######')
       break
     case BasicField.HomeNo:
-      sampleValue = '+6567890123'
+      sampleValue = faker.phone.number('+656#######')
       break
     case BasicField.YesNo:
       sampleValue = 'yes'
       break
     case BasicField.Rating:
-      sampleValue = 1
+      noOfOptions = field.ratingOptions.steps
+      sampleValue = faker.number.int({ min: 1, max: noOfOptions })
       break
     case BasicField.Attachment:
       sampleValue = 'attachmentFileName'

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -351,6 +351,9 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
   let sampleValue = null
   let noOfOptions = 0
   let randomSelectedOption = 0
+  let noOfRows
+  let noOfCols
+  const tableSampleValue = []
   switch (field.fieldType) {
     case BasicField.LongText:
     case BasicField.ShortText:
@@ -386,6 +389,18 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       break
     case BasicField.Attachment:
       sampleValue = 'attachmentFileName'
+      break
+    case BasicField.Table:
+      noOfRows = field.minimumRows
+      noOfCols = field.columns.length
+      for (let row = 0; row < noOfRows; row++) {
+        const rowSampleValue = []
+        for (let col = 0; col < noOfCols; col++) {
+          rowSampleValue.push(`row${row + 1}col${col + 1}`)
+        }
+        tableSampleValue.push(rowSampleValue)
+      }
+      sampleValue = tableSampleValue
       break
     default:
       break

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import {
+  BasicField,
   FormAuthType,
   FormField,
   FormFieldDto,
@@ -351,39 +352,39 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
   let noOfOptions = 0
   let randomSelectedOption = 0
   switch (field.fieldType) {
-    case 'textarea':
-    case 'textfield':
+    case BasicField.LongText:
+    case BasicField.ShortText:
       sampleValue =
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
       break
-    case 'radiobutton':
-    case 'dropdown':
+    case BasicField.Radio:
+    case BasicField.Dropdown:
       noOfOptions = field.fieldOptions.length
       randomSelectedOption = Math.floor(Math.random() * noOfOptions)
       sampleValue = field.fieldOptions[randomSelectedOption]
       break
-    case 'email':
+    case BasicField.Email:
       sampleValue = 'hello@example.com'
       break
-    case 'decimal':
+    case BasicField.Decimal:
       sampleValue = 1.234
       break
-    case 'number':
+    case BasicField.Number:
       sampleValue = 1234
       break
-    case 'mobile':
+    case BasicField.Mobile:
       sampleValue = '+6598765432'
       break
-    case 'homeno':
+    case BasicField.HomeNo:
       sampleValue = '+6567890123'
       break
-    case 'yes_no':
+    case BasicField.YesNo:
       sampleValue = 'yes'
       break
-    case 'rating':
+    case BasicField.Rating:
       sampleValue = 1
       break
-    case 'attachment':
+    case BasicField.Attachment:
       sampleValue = 'attachmentFileName'
       break
     default:

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -350,30 +350,28 @@ export const retrievePublicFormsWithSmsVerification = (
 
 export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
   let sampleValue = null
-  let noOfOptions = 0
-  let randomSelectedOption = 0
-  let noOfRows
-  let noOfCols
+  let noOfTableRows
+  let noOfTableCols
   const tableSampleValue = []
   switch (field.fieldType) {
     case BasicField.LongText:
-    case BasicField.ShortText:
       sampleValue = faker.lorem.sentence()
+      break
+    case BasicField.ShortText:
+      sampleValue = faker.lorem.word()
       break
     case BasicField.Radio:
     case BasicField.Dropdown:
-      noOfOptions = field.fieldOptions.length
-      randomSelectedOption = Math.floor(Math.random() * noOfOptions)
-      sampleValue = field.fieldOptions[randomSelectedOption]
+      sampleValue = faker.helpers.arrayElement(field.fieldOptions)
       break
     case BasicField.Email:
       sampleValue = faker.internet.email()
       break
     case BasicField.Decimal:
-      sampleValue = faker.number.float({ precision: 0.1 })
+      sampleValue = faker.number.float({ precision: 0.1 }).toString()
       break
     case BasicField.Number:
-      sampleValue = faker.number.int(100)
+      sampleValue = faker.number.int(100).toString()
       break
     case BasicField.Mobile:
       sampleValue = faker.phone.number('+659#######')
@@ -382,21 +380,22 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       sampleValue = faker.phone.number('+656#######')
       break
     case BasicField.YesNo:
-      sampleValue = 'yes'
+      sampleValue = faker.helpers.arrayElement(['Yes', 'No'])
       break
     case BasicField.Rating:
-      noOfOptions = field.ratingOptions.steps
-      sampleValue = faker.number.int({ min: 1, max: noOfOptions })
+      sampleValue = faker.number
+        .int({ min: 1, max: field.ratingOptions.steps })
+        .toString()
       break
     case BasicField.Attachment:
       sampleValue = 'attachmentFileName'
       break
     case BasicField.Table:
-      noOfRows = field.minimumRows
-      noOfCols = field.columns.length
-      for (let row = 0; row < noOfRows; row++) {
+      noOfTableRows = field.minimumRows
+      noOfTableCols = field.columns.length
+      for (let row = 0; row < noOfTableRows; row++) {
         const rowSampleValue = []
-        for (let col = 0; col < noOfCols; col++) {
+        for (let col = 0; col < noOfTableCols; col++) {
           rowSampleValue.push(`row${row + 1}col${col + 1}`)
         }
         tableSampleValue.push(rowSampleValue)
@@ -404,9 +403,7 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       sampleValue = tableSampleValue
       break
     case BasicField.Checkbox:
-      noOfOptions = field.fieldOptions.length
-      randomSelectedOption = Math.floor(Math.random() * noOfOptions)
-      sampleValue = field.fieldOptions[randomSelectedOption]
+      sampleValue = faker.helpers.arrayElements(field.fieldOptions)
       break
     case BasicField.Date:
       sampleValue = new Date(Date.now()).toLocaleDateString('en-SG', {

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -416,7 +416,10 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       })
       break
     case BasicField.Nric:
-      sampleValue = 'S9999999A'
+      sampleValue = faker.helpers.replaceSymbols('S9######A')
+      break
+    case BasicField.Uen:
+      sampleValue = faker.helpers.replaceSymbols('#########A')
       break
     default:
       break

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -407,6 +407,16 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       randomSelectedOption = Math.floor(Math.random() * noOfOptions)
       sampleValue = field.fieldOptions[randomSelectedOption]
       break
+    case BasicField.Date:
+      sampleValue = new Date(Date.now()).toLocaleDateString('en-SG', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })
+      break
+    case BasicField.Nric:
+      sampleValue = 'S9999999A'
+      break
     default:
       break
   }

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -355,10 +355,10 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
   const tableSampleValue = []
   switch (field.fieldType) {
     case BasicField.LongText:
-      sampleValue = faker.lorem.sentence()
+      sampleValue = faker.lorem.text()
       break
     case BasicField.ShortText:
-      sampleValue = faker.lorem.word()
+      sampleValue = faker.lorem.words()
       break
     case BasicField.Radio:
     case BasicField.Dropdown:
@@ -406,7 +406,7 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       sampleValue = faker.helpers.arrayElements(field.fieldOptions)
       break
     case BasicField.Date:
-      sampleValue = new Date(Date.now()).toLocaleDateString('en-SG', {
+      sampleValue = faker.date.anytime().toLocaleDateString('en-SG', {
         day: 'numeric',
         month: 'long',
         year: 'numeric',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The sample submission endpoint was returning `null` for some fields.

Closes FRM-768

## Solution
<!-- How did you solve the problem? -->
- Add the remaining fields - Table, Checkbox, UEN, Date, NRIC
- Also, took the chance to use [faker](https://www.npmjs.com/package/@faker-js/faker) to generate random data

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:
- Use `BasicField` types

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a form with all answerable field types (so excluding Heading, Paragraph, Image). Make the form public, and send a GET request to http://form.gov.sg/api/v3/forms/:formId/sample-submission. Check that an answer is returned for each field.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->


**New dependencies**:

- `@faker-js/faker` : Generate fake (but realistic) data

