### PR TITLE
feat: add target account id directly to payment documents

### DIFF
--- a/scripts/20230519_add_target_account_id/script.js
+++ b/scripts/20230519_add_target_account_id/script.js
@@ -1,0 +1,24 @@
+/* eslint-disable */
+
+// BEFORE
+// Count total number of payments with no received webhooks. This should be 0.
+db.getCollection('payments').countDocuments({ webhookLog: { $size: 0 } }) === 0
+
+// Count total number of payments.
+const total = db.getCollection('payments').countDocuments({})
+
+// Count total number of payments with no targetAccountId value. This should be equal to the total number of payments.
+db.getCollection('payments').countDocuments({ targetAccountId: { $exists: false } }) === total
+
+// UPDATE
+db.getCollection('payments').update(
+  {},
+  { $set: { targetAccountId: { $first: '$webhookLog.account' } } },
+)
+
+// AFTER
+// Count total number of payments with targetAccountId value. This should be equal to the total number of payments.
+db.getCollection('payments').countDocuments({ targetAccountId: { $exists: true } }) === total
+
+// Count total number of payments with no targetAccountId value. This should be equal to 0
+db.getCollection('payments').countDocuments({ targetAccountId: { $exists: false } }) === 0

--- a/scripts/20230519_add_target_account_id/script.js
+++ b/scripts/20230519_add_target_account_id/script.js
@@ -11,9 +11,9 @@ const total = db.getCollection('payments').countDocuments({})
 db.getCollection('payments').countDocuments({ targetAccountId: { $exists: false } }) === total
 
 // UPDATE
-db.getCollection('payments').update(
+db.getCollection('payments').updateMany(
   {},
-  { $set: { targetAccountId: { $first: '$webhookLog.account' } } },
+  [ { $set: { targetAccountId: { $first: '$webhookLog.account' } } } ],
 )
 
 // AFTER

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -33,6 +33,7 @@ export type Payment = {
   // Pre-payment metadata
   pendingSubmissionId: string
   formId: string
+  targetAccountId: string
   email: string
   amount: number
   paymentIntentId: string

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -22,6 +22,10 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
       ref: () => FORM_SCHEMA_ID,
       required: true,
     },
+    targetAccountId: {
+      type: String,
+      required: true,
+    },
     email: {
       type: String,
       required: true,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2681,13 +2681,11 @@ describe('admin-form.service', () => {
   describe('updatePayments', () => {
     // Arrange
     const mockFormId = new ObjectId().toString()
-    const updatedPaymentSettings = {
+    const updatedPaymentSettings: PaymentsUpdateDto = {
       enabled: true,
-      target_account_id: 'someId',
-      publishable_key: 'somekey',
       amount_cents: 5000,
       description: 'some description',
-    } as PaymentsUpdateDto
+    }
 
     const mockUpdatedForm = {
       _id: mockFormId,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1562,9 +1562,9 @@ const deleteTwilioTransaction = async (
 }
 
 /**
- * Update the payments of the given form
+ * Update the payments field of the given form
  * @param formId the id of the form to update the end page for
- * @param newStartPage the new start page object to replace the current one
+ * @param newPayments the new payments field to replace the current one
  * @returns ok(updated start page object) when update is successful
  * @returns err(FormNotFoundError) if form cannot be found
  * @returns err(PossibleDatabaseError) if start page update fails

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1565,7 +1565,7 @@ const deleteTwilioTransaction = async (
  * Update the payments field of the given form
  * @param formId the id of the form to update the end page for
  * @param newPayments the new payments field to replace the current one
- * @returns ok(updated start page object) when update is successful
+ * @returns ok(updated payments object) when update is successful
  * @returns err(FormNotFoundError) if form cannot be found
  * @returns err(PossibleDatabaseError) if start page update fails
  * @returns err(InvalidPaymentAmountError) if payment amount exceeds MAX_PAYMENT_AMOUNT

--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -24,7 +24,7 @@ describe('payments.controller', () => {
       const email = 'formsg@tech.gov.sg'
       const payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         amount: 12345,
         status: PaymentStatus.Succeeded,
@@ -54,7 +54,7 @@ describe('payments.controller', () => {
     it('should return 404 if there are no previous payments by the specific email', async () => {
       const payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         amount: 12345,
         status: PaymentStatus.Succeeded,
@@ -83,7 +83,7 @@ describe('payments.controller', () => {
     it('should return 404 if there are no previous payments by the email in the specific formId', async () => {
       const payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         amount: 12345,
         status: PaymentStatus.Succeeded,
@@ -112,7 +112,7 @@ describe('payments.controller', () => {
     it('should return 500 if there is an internal server error', async () => {
       const payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         amount: 12345,
         status: PaymentStatus.Succeeded,

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -30,6 +30,7 @@ describe('payments.service', () => {
       await Payment.create({
         _id: expectedObjectId,
         formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
@@ -70,6 +71,7 @@ describe('payments.service', () => {
       await Payment.create({
         _id: expectedObjectId,
         formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
@@ -97,6 +99,7 @@ describe('payments.service', () => {
       await Payment.create({
         _id: latestId,
         formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
@@ -145,6 +148,7 @@ describe('payments.service', () => {
       await Payment.create({
         _id: newId,
         formId: newFormId,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: new ObjectId(),
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -72,7 +72,7 @@ describe('stripe.controller', () => {
 
       const payment = await Payment.create({
         formId: mockForm._id,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: pendingSubmission._id,
         amount: 12345,
         status: PaymentStatus.Succeeded,
@@ -132,7 +132,7 @@ describe('stripe.controller', () => {
       })
       const payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: pendingSubmission._id,
         amount: 12345,
         status: PaymentStatus.Succeeded,

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -242,7 +242,7 @@ describe('stripe.service', () => {
       })
       payment = await Payment.create({
         formId: MOCK_FORM_ID,
-        target_account_id: 'acct_MOCK_ACCOUNT_ID',
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
         pendingSubmissionId: pendingSubmission._id,
         amount: 12345,
         status: PaymentStatus.Pending,

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -40,7 +40,9 @@ const MOCK_STRIPE_METADATA = {
 const MOCK_STRIPE_EVENTS = [
   {
     id: 'evt_PAYMENT_INTENT_CREATED',
+    object: 'event',
     created: 1677205503,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'pi_MOCK_PAYMENT_INTENT',
@@ -55,7 +57,9 @@ const MOCK_STRIPE_EVENTS = [
   },
   {
     id: 'evt_CHARGE_FAILED',
+    object: 'event',
     created: 1677205563,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'ch_MOCK_FAILED_CHARGE',
@@ -71,7 +75,9 @@ const MOCK_STRIPE_EVENTS = [
   },
   {
     id: 'evt_PAYMENT_INTENT_FAILED',
+    object: 'event',
     created: 1677205563,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'pi_MOCK_PAYMENT_INTENT',
@@ -87,7 +93,9 @@ const MOCK_STRIPE_EVENTS = [
   },
   {
     id: 'evt_PAYMENT_INTENT_SUCCEEDED',
+    object: 'event',
     created: 1677205663,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'pi_MOCK_PAYMENT_INTENT',
@@ -105,6 +113,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_CHARGE_SUCCEEDED',
     object: 'event',
     created: 1677205663,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'ch_MOCK_SUCCEEDED_CHARGE',
@@ -125,6 +134,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_CHARGE_PARTIALLY_REFUNDED',
     object: 'event',
     created: 1677205763,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'ch_MOCK_SUCCEEDED_CHARGE',
@@ -144,6 +154,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_CHARGE_FULLY_REFUNDED',
     object: 'event',
     created: 1677205863,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'ch_MOCK_SUCCEEDED_CHARGE',
@@ -163,6 +174,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_CHARGE_DISPUTE_CREATED',
     object: 'event',
     created: 1677205963,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'dp_MOCK_DISPUTE',
@@ -179,6 +191,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_PAYOUT_CREATED',
     object: 'event',
     created: 1677205973,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'po_MOCK_PAYOUT',
@@ -195,6 +208,7 @@ const MOCK_STRIPE_EVENTS = [
     id: 'evt_PAYOUT_CANCELLED',
     object: 'event',
     created: 1677205983,
+    account: 'acct_MOCK_ACCOUNT_ID',
     data: {
       object: {
         id: 'po_MOCK_PAYOUT',

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -564,12 +564,15 @@ export const getPaymentInfo: ControllerHandler<
   GetPaymentInfoDto | ErrorDto
 > = async (req, res) => {
   const { paymentId } = req.params
+
+  const logMeta = {
+    action: 'getPaymentInfo',
+    paymentId,
+  }
+
   logger.info({
     message: 'getPaymentInfo endpoint called',
-    meta: {
-      action: 'getPaymentInfo',
-      paymentId,
-    },
+    meta: logMeta,
   })
 
   return PaymentService.findPaymentById(paymentId)
@@ -582,15 +585,13 @@ export const getPaymentInfo: ControllerHandler<
         )
         .andThen(checkFormIsEncryptMode) // Payment forms are encrypted
         .andThen((form) => {
-          const stripeAccount = form.payments_channel?.target_account_id
+          const stripeAccount = payment.targetAccountId
           // Early termination to prevent consumption of QPS limit to stripe
-          if (!stripeAccount) {
+          if (stripeAccount !== form.payments_channel.target_account_id) {
             logger.error({
-              message: 'Missing payments_channel on this form',
-              meta: {
-                action: 'getPaymentInfo',
-                paymentId,
-              },
+              message:
+                'Target stripe account for this form has changed, unable to get payment info',
+              meta: logMeta,
             })
             return errAsync(new PaymentAccountInformationError())
           }
@@ -602,10 +603,9 @@ export const getPaymentInfo: ControllerHandler<
             }),
             (error) => {
               logger.error({
-                message: 'stripe.paymentIntents.retrieve called',
+                message: 'Calling stripe.paymentIntents.retrieve failed',
                 meta: {
-                  action: 'getPaymentInfo',
-                  paymentId,
+                  ...logMeta,
                   paymentIntentId,
                   error,
                 },
@@ -615,7 +615,7 @@ export const getPaymentInfo: ControllerHandler<
           ).map((paymentIntent) => {
             return res.status(StatusCodes.OK).json({
               client_secret: paymentIntent.client_secret || '',
-              publishableKey: form.payments_channel?.publishable_key ?? '',
+              publishableKey: form.payments_channel.publishable_key,
               payment_intent_id: payment.paymentIntentId,
               submissionId: payment.pendingSubmissionId,
             })

--- a/src/app/modules/payments/stripe.errors.ts
+++ b/src/app/modules/payments/stripe.errors.ts
@@ -18,6 +18,12 @@ export class MalformedStripeChargeObjectError extends ApplicationError {
   }
 }
 
+export class MalformedStripeEventObjectError extends ApplicationError {
+  constructor(message = 'Data missing from event object') {
+    super(message)
+  }
+}
+
 export class StripeMetadataInvalidError extends ApplicationError {
   constructor(message = 'Invalid shape found for Stripe metadata') {
     super(message)

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -29,6 +29,7 @@ import {
 import {
   ComputePaymentStateError,
   MalformedStripeChargeObjectError,
+  MalformedStripeEventObjectError,
   StripeFetchError,
   StripeMetadataIncorrectEnvError,
   StripeMetadataInvalidError,
@@ -40,6 +41,7 @@ const logger = createLoggerWithLabel(module)
 export const mapRouteError: MapRouteError = (error: ApplicationError) => {
   switch (error.constructor) {
     case StripeMetadataInvalidError:
+    case MalformedStripeEventObjectError:
     case MalformedStripeChargeObjectError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -385,9 +385,12 @@ const submitEncryptModeForm: ControllerHandler<
       })
     }
 
+    const targetAccountId = form.payments_channel.target_account_id
+
     // Step 1: Create payment without payment intent id and pending submission id.
     const payment = new Payment({
       formId,
+      targetAccountId,
       amount,
       email: paymentReceiptEmail,
       responses: incomingSubmission.responses,
@@ -438,8 +441,6 @@ const submitEncryptModeForm: ControllerHandler<
       paymentContactEmail: paymentReceiptEmail,
     }
 
-    const paymentReceiptDescription = form.payments_field.description
-
     const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
       amount,
       currency: paymentConfig.defaultCurrency,
@@ -447,7 +448,7 @@ const submitEncryptModeForm: ControllerHandler<
       automatic_payment_methods: {
         enabled: true,
       },
-      description: paymentReceiptDescription,
+      description: form.payments_field.description,
       receipt_email: paymentReceiptEmail,
       metadata,
     }
@@ -456,7 +457,7 @@ const submitEncryptModeForm: ControllerHandler<
     try {
       paymentIntent = await stripe.paymentIntents.create(
         createPaymentIntentParams,
-        { stripeAccount: form.payments_channel.target_account_id },
+        { stripeAccount: targetAccountId },
       )
     } catch (err) {
       logger.error({
@@ -503,7 +504,7 @@ const submitEncryptModeForm: ControllerHandler<
       // Cancel the payment intent if saving the document fails.
       try {
         await stripe.paymentIntents.cancel(paymentIntent.id, {
-          stripeAccount: form.payments_channel.target_account_id,
+          stripeAccount: targetAccountId,
         })
       } catch (stripeErr) {
         logger.error({


### PR DESCRIPTION
## Problem

In order to account for linking and re-linking of Stripe accounts to forms, we should ensure that we store the associated stripe Account with the payment documents, rather than going back to the original form. This will also be required in preparation for the async CRON job which will be implemented in #6102.

## Solution

There are several options that can be considered.
1. Don't save the target account id explicitly at all, and rely on the webhooks `account` value. 
2. Save the target account id only explicitly.
3. Save the target account id and publishable key explicitly (i.e. duplicate of `FormPaymentChannel`).

Considerations:
1. We (forms) should be responsible for saving the target account id, since we generate the initial request to stripe. We should also ensure that the webhooks all belong to the same target account id, which is the one that we initiated the payment for. Relying on the incoming webhooks is not preferred.
2. The only time the publishable key is needed is when we pass it to the frontend to call stripe's API directly. And also, in any case, holding the pub key is kind of like saying "I give you access to make API calls for me". If the form's stripe account has changed, then we should no longer be able to do things "for" this stripe account.

With these considerations, option 2 is chosen with the following benefits:
1. Validation that stripe event account contains the same account id as the associated payment document.
2. Still prevents pending payments from being completed when the stripe account on the form is changed (publishable key is not available).

**Breaking Changes** 
- **Yes - this PR contains breaking changes**

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New scripts**:

- `20230519_add_target_account_id`: adds `targetAccountId` to payment collection, by extracting the account id from the first value in the webhook log (assumes that Stripe has been correct so far).
