### PR TITLE
chore: Update sgID client API version

### DIFF
--- a/__tests__/setup/.test-env
+++ b/__tests__/setup/.test-env
@@ -21,7 +21,7 @@ MYINFO_CLIENT_SECRET=mockClientSecret
 MYINFO_JWT_SECRET=mockJwtSecret
 SINGPASS_ESRVC_ID=Test-eServiceId-Sp # Needed for MyInfo
 
-SGID_HOSTNAME=http://localhost:5156/sgid
+SGID_HOSTNAME=http://localhost:5156
 SGID_CLIENT_ID=sgidclientid
 SGID_CLIENT_SECRET=sgidclientsecret
 SGID_REDIRECT_URI=http://localhost:5000/sgid/login

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - SSM_ENV_SITE_NAME=development
 
   mockpass:
-    build: https://github.com/opengovsg/mockpass.git#v3.1.3
+    build: https://github.com/opengovsg/mockpass.git#v4.0.4
     depends_on:
       - backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - MYINFO_CLIENT_ID=mockClientId
       - MYINFO_CLIENT_SECRET=mockClientSecret
       - MYINFO_JWT_SECRET=mockJwtSecret
-      - SGID_HOSTNAME=http://localhost:5156/sgid
+      - SGID_HOSTNAME=http://localhost:5156
       - SGID_CLIENT_ID=sgidclientid
       - SGID_CLIENT_SECRET=sgidclientsecret
       - SGID_REDIRECT_URI=http://localhost:5001/sgid/login

--- a/src/app/modules/sgid/sgid.service.ts
+++ b/src/app/modules/sgid/sgid.service.ts
@@ -49,6 +49,7 @@ export class SgidServiceClass {
       hostname: hostname || undefined,
       ...sgidOptions,
       privateKey: this.privateKey,
+      apiVersion: 2,
     })
     this.publicKey = fs.readFileSync(publicKeyPath)
     this.cookieDomain = cookieDomain


### PR DESCRIPTION
## Problem
sgID client API needs updating from v1 to v2.

Closes FRM-899

## Solution

For dev:
- Update Mockpass.
- Update dev env vars.
- For all devs: **please delete your old docker build and container for mockpass before running the dev script**

For prod:
- Update prod env vars.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] Yes - this PR contains breaking changes
    - It's not breaking for users, but might be breaking for our own development. Mockpass updates sgID to use version 2 instead of version 1. So we need to ensure that our sgID code still works (it should).


## Deploy Notes
Existing env vars for sgID hostname need updating to version 2 of the API. In both testing and prod.

**New environment variables**:

Nothing new but please see deploy notes. **This PR needs updated env vars**
