### PR TITLE
fix: test card banner to show when pending payment and non-prod

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -11,14 +11,8 @@ import { FormFields } from './FormFields'
 import { FormFieldsSkeleton } from './FormFieldsSkeleton'
 
 export const FormFieldsContainer = (): JSX.Element | null => {
-  const {
-    form,
-    isAuthRequired,
-    isLoading,
-    handleSubmitForm,
-    submissionData,
-    isPreview,
-  } = usePublicFormContext()
+  const { form, isAuthRequired, isLoading, handleSubmitForm, submissionData } =
+    usePublicFormContext()
 
   const renderFields = useMemo(() => {
     // Render skeleton when no data

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -3,9 +3,7 @@ import { useParams } from 'react-router-dom'
 import { Box, Container, Flex, Skeleton, Text } from '@chakra-ui/react'
 
 import { fillMinHeightCss } from '~utils/fillHeightCss'
-import InlineMessage from '~components/InlineMessage'
 
-import { useEnv } from '~features/env/queries'
 import { FormBanner } from '~features/public-form/components/FormBanner'
 import { FormSectionsProvider } from '~features/public-form/components/FormFields/FormSectionsContext'
 import { FormFooter } from '~features/public-form/components/FormFooter'
@@ -18,7 +16,6 @@ import StripePaymentElement from './stripe/StripePaymentElement'
 
 export const FormPaymentPage = () => {
   const { formId, paymentId } = useParams()
-  const { data: { secretEnv } = {} } = useEnv()
 
   if (!formId) throw new Error('No formId provided')
   if (!paymentId) throw new Error('No paymentId provided')
@@ -42,13 +39,6 @@ export const FormPaymentPage = () => {
                     </Skeleton>
                   }
                 >
-                  {secretEnv === 'production' ? null : (
-                    <InlineMessage variant="warning" mb="1rem">
-                      Use '4242 4242 4242 4242' as your card number to test
-                      payments on this form. Payments made on this form will
-                      only show in test mode in Stripe.
-                    </InlineMessage>
-                  )}
                   <StripePaymentElement paymentId={paymentId} />
                 </Suspense>
               </Container>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -6,6 +6,10 @@ import { loadStripe } from '@stripe/stripe-js'
 
 import { GetPaymentInfoDto } from '~shared/types'
 
+import InlineMessage from '~components/InlineMessage'
+
+import { useEnv } from '~features/env/queries'
+
 import { CreatePaymentIntentFailureBlock } from '../components/CreatePaymentIntentFailureBlock'
 import { PaymentSuccessSvgr } from '../components/PaymentSuccessSvgr'
 import { useGetPaymentInfo } from '../queries'
@@ -55,6 +59,8 @@ const StripePaymentContainer = ({
   if (!formId) throw new Error('No formId provided')
   if (!paymentId) throw new Error('No paymentId provided')
 
+  const { data: { secretEnv } = {} } = useEnv()
+
   const stripe = useStripe()
   if (!stripe) throw Promise.reject('Stripe is not ready')
 
@@ -89,12 +95,21 @@ const StripePaymentContainer = ({
         )
       case PaymentViewStates.PendingPayment:
         return (
-          <PaymentStack>
-            <StripePaymentBlock
-              submissionId={paymentInfoData.submissionId}
-              triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
-            />
-          </PaymentStack>
+          <>
+            {secretEnv === 'production' ? null : (
+              <InlineMessage variant="warning" mb="1rem">
+                Use '4242 4242 4242 4242' as your card number to test payments
+                on this form. Payments made on this form will only show in test
+                mode in Stripe.
+              </InlineMessage>
+            )}
+            <PaymentStack>
+              <StripePaymentBlock
+                submissionId={paymentInfoData.submissionId}
+                triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
+              />
+            </PaymentStack>
+          </>
         )
       case PaymentViewStates.Processing:
         return (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Test card banner was showing on the payment page regardless of payment status.

Closes FRM-764

## Solution
<!-- How did you solve the problem? -->

Shift test card banner to block that only renders when pending payment.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

<img width="1920" alt="Screenshot 2023-05-23 at 12 48 41 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/8d2dbf11-38f2-4931-83a4-1309f1baa074">

**AFTER**:
<!-- [insert screenshot here] -->

<img width="1920" alt="Screenshot 2023-05-23 at 11 34 04 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/d265f637-f21a-4ee3-a26f-49e656f77da7">

## Tests
<!-- What tests should be run to confirm functionality? -->

On non-production environments:
- [ ] Go to a public form with payment enabled for any environment that does not have `SECRET_ENV` set to "production".
- [ ] When pending payment, the banner informing users of test card details should show.
- [ ] After payment has been made, the test card banner should not be seen.

On production environments:
- [ ] Go to a public form with payment enabled for an environment where `SECRET_ENV` is set to "production".
- [ ] Throughout the payment, the test card banner should not show up.
