### PR TITLE
feat: add response time to submission

### DIFF
--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -1,5 +1,11 @@
 // Contains all the shared props that will probably be passed down.
-import { createContext, RefObject, useContext } from 'react'
+import {
+  createContext,
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useContext,
+} from 'react'
 import { UseQueryResult } from 'react-query'
 
 import { PublicFormViewDto } from '~shared/types/form'
@@ -52,6 +58,9 @@ export interface PublicFormContextProps
 
   /** Whether it is a preview form */
   isPreview: boolean
+
+  /** Sets the current number of visible fields in the form */
+  setNumVisibleFields: Dispatch<SetStateAction<number>>
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -59,8 +59,8 @@ export interface PublicFormContextProps
   /** Whether it is a preview form */
   isPreview: boolean
 
-  /** Sets the current number of visible fields in the form */
-  setNumVisibleFields: Dispatch<SetStateAction<number>>
+  /** Sets the current number of visible fields in the form in public forms only*/
+  setNumVisibleFields?: Dispatch<SetStateAction<number>>
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -19,8 +19,11 @@ export const PublicFormPage = (): JSX.Element => {
 
   if (!formId) throw new Error('No formId provided')
 
+  // Get date time in miliseconds when user first loads the form
+  const startTime = Date.now()
+
   return (
-    <PublicFormProvider formId={formId}>
+    <PublicFormProvider formId={formId} startTime={startTime}>
       <FormSectionsProvider>
         <Flex direction="column" css={fillMinHeightCss}>
           <FormBanner />

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -108,6 +108,10 @@ export const PublicFormProvider = ({
 }: PublicFormProviderProps): JSX.Element => {
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
+  const [numVisibleFields, setNumVisibleFields] = useState(-1)
+
+  // Get date time in miliseconds when user first loads the form
+  const startTime = Date.now()
 
   const { data, isLoading, error, ...rest } = usePublicFormView(
     formId,
@@ -226,7 +230,14 @@ export const PublicFormProvider = ({
         formLogics: form.form_logics,
         formInputs,
         captchaResponse,
+        submissionMetadata: {
+          submissionTimeMs: differenceInMilliseconds(Date.now(), startTime),
+          numVisibleFields,
+        },
       }
+
+      // TODO remove logging
+      console.log(formData.submissionMetadata)
 
       const logMeta = {
         action: 'handleSubmitForm',
@@ -465,6 +476,8 @@ export const PublicFormProvider = ({
       submitEmailModeFormFetchMutation,
       submitStorageModeFormFetchMutation,
       useFetchForSubmissions,
+      numVisibleFields,
+      startTime,
     ],
   )
 
@@ -505,6 +518,7 @@ export const PublicFormProvider = ({
         isLoading: isLoading || (!!data?.form.hasCaptcha && !hasLoaded),
         isPaymentEnabled,
         isPreview: false,
+        setNumVisibleFields,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -110,7 +110,7 @@ export const PublicFormProvider = ({
 }: PublicFormProviderProps): JSX.Element => {
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
-  const [numVisibleFields, setNumVisibleFields] = useState(-1)
+  const [numVisibleFields, setNumVisibleFields] = useState(0)
 
   const { data, isLoading, error, ...rest } = usePublicFormView(
     formId,
@@ -234,9 +234,6 @@ export const PublicFormProvider = ({
           numVisibleFields,
         },
       }
-
-      // TODO remove logging
-      console.log(formData.responseMetadata)
 
       const logMeta = {
         action: 'handleSubmitForm',

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -56,6 +56,7 @@ import { axiosDebugFlow } from './utils'
 interface PublicFormProviderProps {
   formId: string
   children: React.ReactNode
+  startTime: number
 }
 
 export function useCommonFormProvider(formId: string) {
@@ -105,13 +106,11 @@ export function useCommonFormProvider(formId: string) {
 export const PublicFormProvider = ({
   formId,
   children,
+  startTime,
 }: PublicFormProviderProps): JSX.Element => {
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
   const [numVisibleFields, setNumVisibleFields] = useState(-1)
-
-  // Get date time in miliseconds when user first loads the form
-  const startTime = Date.now()
 
   const { data, isLoading, error, ...rest } = usePublicFormView(
     formId,
@@ -230,14 +229,14 @@ export const PublicFormProvider = ({
         formLogics: form.form_logics,
         formInputs,
         captchaResponse,
-        submissionMetadata: {
-          submissionTimeMs: differenceInMilliseconds(Date.now(), startTime),
+        responseMetadata: {
+          responseTimeMs: differenceInMilliseconds(Date.now(), startTime),
           numVisibleFields,
         },
       }
 
       // TODO remove logging
-      console.log(formData.submissionMetadata)
+      console.log(formData.responseMetadata)
 
       const logMeta = {
         action: 'handleSubmitForm',

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -81,7 +81,7 @@ export type SubmitEmailFormArgs = {
   formFields: FormFieldDto[]
   formLogics: FormDto['form_logics']
   formInputs: FormFieldValues
-  responseMetadata: ResponseMetadata
+  responseMetadata?: ResponseMetadata
   paymentReceiptEmail?: string
 }
 

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -10,7 +10,10 @@ import {
   FormDto,
   PublicFormViewDto,
 } from '~shared/types/form/form'
-import { SubmissionResponseDto } from '~shared/types/submission'
+import {
+  ResponseMetadata,
+  SubmissionResponseDto,
+} from '~shared/types/submission'
 
 import { transformAllIsoStringsToDate } from '~utils/date'
 import {
@@ -78,6 +81,7 @@ export type SubmitEmailFormArgs = {
   formFields: FormFieldDto[]
   formLogics: FormDto['form_logics']
   formInputs: FormFieldValues
+  responseMetadata: ResponseMetadata
   paymentReceiptEmail?: string
 }
 
@@ -89,13 +93,18 @@ export const submitEmailModeForm = async ({
   formInputs,
   formId,
   captchaResponse = null,
+  responseMetadata,
 }: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
   const filteredInputs = filterHiddenInputs({
     formFields,
     formInputs,
     formLogics,
   })
-  const formData = createEmailSubmissionFormData(formFields, filteredInputs)
+  const formData = createEmailSubmissionFormData(
+    formFields,
+    filteredInputs,
+    responseMetadata,
+  )
 
   return ApiService.post<SubmissionResponseDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email`,
@@ -116,6 +125,7 @@ export const submitStorageModeForm = async ({
   publicKey,
   captchaResponse = null,
   paymentReceiptEmail,
+  responseMetadata,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -126,6 +136,7 @@ export const submitStorageModeForm = async ({
     formFields,
     filteredInputs,
     publicKey,
+    responseMetadata,
     paymentReceiptEmail,
   )
 
@@ -147,13 +158,18 @@ export const submitEmailModeFormWithFetch = async ({
   formInputs,
   formId,
   captchaResponse = null,
+  responseMetadata,
 }: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
   const filteredInputs = filterHiddenInputs({
     formFields,
     formInputs,
     formLogics,
   })
-  const formData = createEmailSubmissionFormData(formFields, filteredInputs)
+  const formData = createEmailSubmissionFormData(
+    formFields,
+    filteredInputs,
+    responseMetadata,
+  )
 
   // Add captcha response to query string
   const queryString = new URLSearchParams({
@@ -183,6 +199,7 @@ export const submitStorageModeFormWithFetch = async ({
   publicKey,
   captchaResponse = null,
   paymentReceiptEmail,
+  responseMetadata,
 }: SubmitStorageFormArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -193,6 +210,7 @@ export const submitStorageModeFormWithFetch = async ({
     formFields,
     filteredInputs,
     publicKey,
+    responseMetadata,
     paymentReceiptEmail,
   )
 

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -51,6 +51,7 @@ export const VisibleFormFields = ({
     setVisibleFormFields(visibleFieldsWithQuestionNo)
 
     // set the number of visible fields in the context for public forms
+    // the setter will only exist for public forms and will be undefined for preview
     if (setNumVisibleFields)
       setNumVisibleFields(visibleFieldsWithQuestionNo.length)
   }, [

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -8,6 +8,7 @@ import { FormFieldValues } from '~templates/Field'
 import { FormFieldWithQuestionNo } from '~features/form/types'
 import { augmentWithQuestionNo } from '~features/form/utils'
 import { getVisibleFieldIds } from '~features/logic/utils'
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FieldFactory } from './FieldFactory'
 import { PrefillMap } from './FormFields'
@@ -35,6 +36,7 @@ export const VisibleFormFields = ({
   const watchedValues = useWatch({ control })
   const { setVisibleFieldIdsForScrollData } = useFormSections()
   const [visibleFormFields, setVisibleFormFields] = useState(formFields)
+  const { setNumVisibleFields } = usePublicFormContext()
 
   useEffect(() => {
     const visibleFieldIds = getVisibleFieldIds(watchedValues, {
@@ -47,7 +49,16 @@ export const VisibleFormFields = ({
     )
     const visibleFieldsWithQuestionNo = augmentWithQuestionNo(visibleFields)
     setVisibleFormFields(visibleFieldsWithQuestionNo)
-  }, [formFields, formLogics, setVisibleFieldIdsForScrollData, watchedValues])
+
+    // set the number of visible fields in the context
+    setNumVisibleFields(visibleFieldsWithQuestionNo.length)
+  }, [
+    formFields,
+    formLogics,
+    setVisibleFieldIdsForScrollData,
+    watchedValues,
+    setNumVisibleFields,
+  ])
 
   return (
     <>

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -50,8 +50,9 @@ export const VisibleFormFields = ({
     const visibleFieldsWithQuestionNo = augmentWithQuestionNo(visibleFields)
     setVisibleFormFields(visibleFieldsWithQuestionNo)
 
-    // set the number of visible fields in the context
-    setNumVisibleFields(visibleFieldsWithQuestionNo.length)
+    // set the number of visible fields in the context for public forms
+    if (setNumVisibleFields)
+      setNumVisibleFields(visibleFieldsWithQuestionNo.length)
   }, [
     formFields,
     formLogics,

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -9,6 +9,7 @@ import {
   MobileResponse,
 } from '~shared/types/response'
 import {
+  ResponseMetadata,
   StorageModeAttachment,
   StorageModeAttachmentsMap,
   StorageModeSubmissionContentDto,
@@ -35,6 +36,7 @@ export const createEncryptedSubmissionData = async (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
   publicKey: string,
+  responseMetadata: ResponseMetadata,
   paymentReceiptEmail?: string,
 ): Promise<StorageModeSubmissionContentDto> => {
   const responses = createResponsesArray(formFields, formInputs)
@@ -58,6 +60,7 @@ export const createEncryptedSubmissionData = async (
     encryptedContent,
     paymentReceiptEmail,
     version: ENCRYPT_VERSION,
+    responseMetadata,
   }
 }
 
@@ -68,13 +71,14 @@ export const createEncryptedSubmissionData = async (
 export const createEmailSubmissionFormData = (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
+  responseMetadata: ResponseMetadata,
 ) => {
   const responses = createResponsesArray(formFields, formInputs)
   const attachments = getAttachmentsMap(formFields, formInputs)
 
   // Convert content to FormData object.
   const formData = new FormData()
-  formData.append('body', JSON.stringify({ responses }))
+  formData.append('body', JSON.stringify({ responses, responseMetadata }))
 
   if (!isEmpty(attachments)) {
     forOwn(attachments, (attachment, fieldId) => {

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -36,7 +36,7 @@ export const createEncryptedSubmissionData = async (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
   publicKey: string,
-  responseMetadata: ResponseMetadata,
+  responseMetadata?: ResponseMetadata,
   paymentReceiptEmail?: string,
 ): Promise<StorageModeSubmissionContentDto> => {
   const responses = createResponsesArray(formFields, formInputs)
@@ -71,7 +71,7 @@ export const createEncryptedSubmissionData = async (
 export const createEmailSubmissionFormData = (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
-  responseMetadata: ResponseMetadata,
+  responseMetadata?: ResponseMetadata,
 ) => {
   const responses = createResponsesArray(formFields, formInputs)
   const attachments = getAttachmentsMap(formFields, formInputs)

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -187,7 +187,7 @@ export type StorageModeSubmissionContentDto = {
   attachments?: StorageModeAttachmentsMap
   paymentReceiptEmail?: string
   version: number
-  responseMetadata: ResponseMetadata
+  responseMetadata?: ResponseMetadata
 }
 
 export type PaymentSubmissionData = {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -131,9 +131,6 @@ export type SubmissionResponseDto = {
   // Timestamp is given as ms from epoch
   timestamp: number
 
-  // response metadata to track form filling time
-  responseMetadata: ResponseMetadata
-
   // payment form only fields
   paymentData?: PaymentSubmissionData
 }

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -23,6 +23,12 @@ export const SubmissionBase = z.object({
 })
 export type SubmissionBase = z.infer<typeof SubmissionBase>
 
+export type ResponseMetadata = {
+  // time taken to submit the form in miliseconds
+  responseTimeMs: number
+  numVisibleFields: number
+}
+
 /**
  * Email mode submission typings as stored in the database.
  */
@@ -87,6 +93,7 @@ export type StorageModeSubmissionDto = {
   attachmentMetadata: Record<string, string>
   payment?: SubmissionPaymentDto
   version: number
+  responseMetadata: ResponseMetadata
 }
 
 export const StorageModeSubmissionStreamDto = StorageModeSubmissionBase.pick({
@@ -121,6 +128,9 @@ export type SubmissionResponseDto = {
   submissionId: string
   // Timestamp is given as ms from epoch
   timestamp: number
+
+  // response metadata to track form filling time
+  responseMetadata: ResponseMetadata
 
   // payment form only fields
   paymentData?: PaymentSubmissionData
@@ -175,6 +185,7 @@ export type StorageModeSubmissionContentDto = {
   attachments?: StorageModeAttachmentsMap
   paymentReceiptEmail?: string
   version: number
+  responseMetadata: ResponseMetadata
 }
 
 export type PaymentSubmissionData = {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -95,7 +95,7 @@ export type StorageModeSubmissionDto = {
   attachmentMetadata: Record<string, string>
   payment?: SubmissionPaymentDto
   version: number
-  responseMetadata: ResponseMetadata
+  responseMetadata?: ResponseMetadata
 }
 
 export const StorageModeSubmissionStreamDto = StorageModeSubmissionBase.pick({

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -15,19 +15,21 @@ export enum SubmissionType {
   Encrypt = 'encryptSubmission',
 }
 
+export const ResponseMetadata = z.object({
+  responseTimeMs: z.number(),
+  numVisibleFields: z.number(),
+})
+
+export type ResponseMetadata = z.infer<typeof ResponseMetadata>
+
 export const SubmissionBase = z.object({
   form: z.string(),
   authType: z.nativeEnum(FormAuthType),
   myInfoFields: z.array(z.nativeEnum(MyInfoAttribute)).optional(),
   submissionType: z.nativeEnum(SubmissionType),
+  responseMetadata: ResponseMetadata.optional(),
 })
 export type SubmissionBase = z.infer<typeof SubmissionBase>
-
-export type ResponseMetadata = {
-  // time taken to submit the form in miliseconds
-  responseTimeMs: number
-  numVisibleFields: number
-}
 
 /**
  * Email mode submission typings as stored in the database.

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -95,7 +95,6 @@ export type StorageModeSubmissionDto = {
   attachmentMetadata: Record<string, string>
   payment?: SubmissionPaymentDto
   version: number
-  responseMetadata?: ResponseMetadata
 }
 
 export const StorageModeSubmissionStreamDto = StorageModeSubmissionBase.pick({

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -94,12 +94,12 @@ describe('Submission Model', () => {
       })
 
       it('email schema should create and save successfully with responseMetadata', async () => {
-        const submissionParamWithResponseMetadata = merge(
+        const emailSubmissionWithResponseMetadata = merge(
           { responseMetadata: { responseTimeMs: 1000, numVisibleFields: 10 } },
           MOCK_EMAIL_SUBMISSION_PARAMS,
         )
         const validSubmission = new Submission(
-          submissionParamWithResponseMetadata,
+          emailSubmissionWithResponseMetadata,
         )
         const saved = await validSubmission.save()
 
@@ -115,9 +115,10 @@ describe('Submission Model', () => {
           '__v',
         ])
 
-        const expectedObject = merge({}, submissionParamWithResponseMetadata)
+        const expectedObject = merge({}, emailSubmissionWithResponseMetadata)
         expect(actualSavedObject).toEqual(expectedObject)
       })
+
       it('encrypt schema should create and save successfully', async () => {
         const validSubmission = new Submission(MOCK_ENCRYPT_SUBMISSION_PARAMS)
         const saved = await validSubmission.save()
@@ -134,6 +135,32 @@ describe('Submission Model', () => {
         ])
 
         const expectedObject = merge({}, MOCK_ENCRYPT_SUBMISSION_PARAMS)
+        expect(actualSavedObject).toEqual(expectedObject)
+      })
+
+      it('encrypt schema should create and save successfully with responseMetadata', async () => {
+        const encryptSubmissionWithResponseMetadata = merge(
+          { responseMetadata: { responseTimeMs: 1000, numVisibleFields: 10 } },
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+        const validSubmission = new Submission(
+          encryptSubmissionWithResponseMetadata,
+        )
+        const saved = await validSubmission.save()
+
+        // Assert
+        expect(saved._id).toBeDefined()
+        expect(saved.created).toBeInstanceOf(Date)
+        expect(saved.responseMetadata).toBeDefined()
+
+        const actualSavedObject = omit(saved.toObject(), [
+          '_id',
+          'created',
+          'lastModified',
+          '__v',
+        ])
+
+        const expectedObject = merge({}, encryptSubmissionWithResponseMetadata)
         expect(actualSavedObject).toEqual(expectedObject)
       })
     })

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -58,6 +58,14 @@ export const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
       enum: Object.values(SubmissionType),
       required: true,
     },
+    responseMetadata: {
+      responseTimeMs: {
+        type: Number,
+      },
+      numVisibleFields: {
+        type: Number,
+      },
+    },
   },
   {
     timestamps: {

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.service.spec.ts
@@ -21,6 +21,7 @@ import {
 import {
   BasicField,
   FormAuthType,
+  ResponseMetadata,
   SubmissionType,
 } from '../../../../../../shared/types'
 import { ProcessedSingleAnswerResponse } from '../../submission.types'
@@ -330,6 +331,10 @@ describe('email-submission.service', () => {
       getUniqueMyInfoAttrs: () => MYINFO_ATTRS,
       emails: ['a@abc.com', 'b@cde.com'],
     } as IEmailFormSchema
+    const MOCK_RESPONSE_METADATA = {
+      responseTimeMs: 1000,
+      numVisibleFields: 3,
+    } as ResponseMetadata
 
     it('should create an email submission with the correct parameters', async () => {
       const mockSubmission = 'mockSubmission'
@@ -341,6 +346,7 @@ describe('email-submission.service', () => {
       const result = await EmailSubmissionService.saveSubmissionMetadata(
         MOCK_EMAIL_FORM as IPopulatedEmailForm,
         { hash: MOCK_HASH.toString(), salt: MOCK_SALT.toString() },
+        MOCK_RESPONSE_METADATA,
       )
       expect(createEmailSubmissionSpy).toHaveBeenCalledWith({
         form: MOCK_EMAIL_FORM._id,
@@ -350,6 +356,7 @@ describe('email-submission.service', () => {
         responseHash: MOCK_HASH.toString(),
         responseSalt: MOCK_SALT.toString(),
         submissionType: SubmissionType.Email,
+        responseMetadata: MOCK_RESPONSE_METADATA,
       })
       expect(result._unsafeUnwrap()).toEqual(mockSubmission)
     })

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -2,7 +2,6 @@ import { ok, okAsync, ResultAsync } from 'neverthrow'
 
 import {
   FormAuthType,
-  ResponseMetadata,
   SubmissionErrorDto,
   SubmissionResponseDto,
 } from '../../../../../shared/types'
@@ -269,7 +268,7 @@ const submitEmailModeForm: ControllerHandler<
         )
 
         // Get response metadata from the request body
-        const responseMetadata = req.body.responseMetadata as ResponseMetadata
+        const { responseMetadata } = req.body
 
         // Save submission to database
         return EmailSubmissionService.hashSubmission(

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -2,6 +2,7 @@ import { ok, okAsync, ResultAsync } from 'neverthrow'
 
 import {
   FormAuthType,
+  ResponseMetadata,
   SubmissionErrorDto,
   SubmissionResponseDto,
 } from '../../../../../shared/types'
@@ -267,19 +268,27 @@ const submitEmailModeForm: ControllerHandler<
           form.authType,
         )
 
+        // Get response metadata from the request body
+        const responseMetadata = req.body.responseMetadata as ResponseMetadata
+
         // Save submission to database
         return EmailSubmissionService.hashSubmission(
           emailData.formData,
           attachments,
         )
           .andThen((submissionHash) =>
-            EmailSubmissionService.saveSubmissionMetadata(form, submissionHash),
+            EmailSubmissionService.saveSubmissionMetadata(
+              form,
+              submissionHash,
+              responseMetadata,
+            ),
           )
           .map((submission) => ({
             form,
             parsedResponses,
             submission,
             emailData,
+            responseMetadata,
           }))
           .mapErr((error) => {
             logger.error({
@@ -290,46 +299,55 @@ const submitEmailModeForm: ControllerHandler<
             return error
           })
       })
-      .andThen(({ form, parsedResponses, submission, emailData }) => {
-        const logMetaWithSubmission = {
-          ...logMeta,
-          submissionId: submission._id,
-        }
-
-        logger.info({
-          message: 'Sending admin mail',
-          meta: logMetaWithSubmission,
-        })
-
-        // Send response to admin
-        // NOTE: This should short circuit in the event of an error.
-        // This is why sendSubmissionToAdmin is separated from sendEmailConfirmations in 2 blocks
-        return MailService.sendSubmissionToAdmin({
-          replyToEmails: EmailSubmissionService.extractEmailAnswers(
-            parsedResponses.getAllResponses(),
-          ),
+      .andThen(
+        ({
           form,
+          parsedResponses,
           submission,
-          attachments,
-          dataCollationData: emailData.dataCollationData,
-          formData: emailData.formData,
-        })
-          .map(() => ({
-            form,
-            parsedResponses,
-            submission,
-            emailData,
-            logMetaWithSubmission,
-          }))
-          .mapErr((error) => {
-            logger.error({
-              message: 'Error sending submission to admin',
-              meta: logMetaWithSubmission,
-              error,
-            })
-            return error
+          emailData,
+          responseMetadata,
+        }) => {
+          const logMetaWithSubmission = {
+            ...logMeta,
+            submissionId: submission._id,
+            responseMetadata,
+          }
+
+          logger.info({
+            message: 'Sending admin mail',
+            meta: logMetaWithSubmission,
           })
-      })
+
+          // Send response to admin
+          // NOTE: This should short circuit in the event of an error.
+          // This is why sendSubmissionToAdmin is separated from sendEmailConfirmations in 2 blocks
+          return MailService.sendSubmissionToAdmin({
+            replyToEmails: EmailSubmissionService.extractEmailAnswers(
+              parsedResponses.getAllResponses(),
+            ),
+            form,
+            submission,
+            attachments,
+            dataCollationData: emailData.dataCollationData,
+            formData: emailData.formData,
+          })
+            .map(() => ({
+              form,
+              parsedResponses,
+              submission,
+              emailData,
+              logMetaWithSubmission,
+            }))
+            .mapErr((error) => {
+              logger.error({
+                message: 'Error sending submission to admin',
+                meta: logMetaWithSubmission,
+                error,
+              })
+              return error
+            })
+        },
+      )
       .map(
         ({
           form,

--- a/src/app/modules/submission/email-submission/email-submission.middleware.ts
+++ b/src/app/modules/submission/email-submission/email-submission.middleware.ts
@@ -76,6 +76,10 @@ export const validateResponseParams = celebrate({
           .with('filename', 'content'), // if filename is present, content must be present
       )
       .required(),
+    responseMetadata: Joi.object({
+      responseTimeMs: Joi.number(),
+      numVisibleFields: Joi.number(),
+    }),
     /**
      * @deprecated unused key, but frontend still sends it.
      */

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -5,6 +5,7 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import {
   BasicField,
   FormResponseMode,
+  ResponseMetadata,
   SubmissionType,
 } from '../../../../../shared/types'
 import {
@@ -142,6 +143,7 @@ export const hashSubmission = (
 export const saveSubmissionMetadata = (
   form: IPopulatedEmailForm,
   submissionHash: SubmissionHash,
+  responseMetadata?: ResponseMetadata,
 ): ResultAsync<IEmailSubmissionSchema, DatabaseError> => {
   const params = {
     form: form._id,
@@ -151,6 +153,7 @@ export const saveSubmissionMetadata = (
     responseHash: submissionHash.hash,
     responseSalt: submissionHash.salt,
     submissionType: SubmissionType.Email,
+    responseMetadata,
   }
   return ResultAsync.fromPromise(
     EmailSubmissionModel.create(params),

--- a/src/app/modules/submission/email-submission/email-submission.types.ts
+++ b/src/app/modules/submission/email-submission/email-submission.types.ts
@@ -1,3 +1,5 @@
+import { ResponseMetadata } from 'shared/types'
+
 import { FieldResponse, IPopulatedEmailForm } from '../../../../types'
 import { ProcessedResponse } from '../submission.types'
 
@@ -11,6 +13,7 @@ export type ResponseFormattedForEmail = Omit<FieldResponse, 'answerArray'> & {
 
 export interface ParsedMultipartForm {
   responses: FieldResponse[]
+  responseMetadata: ResponseMetadata
 }
 
 export interface SubmissionHash {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -177,7 +177,7 @@ const submitEncryptModeForm: ControllerHandler<
   }
 
   // Create Incoming Submission
-  const { encryptedContent, responses } = req.body
+  const { encryptedContent, responses, responseMetadata } = req.body
   const incomingSubmissionResult = IncomingEncryptSubmission.init(
     form,
     responses,
@@ -345,6 +345,7 @@ const submitEncryptModeForm: ControllerHandler<
     verifiedContent: verified,
     attachmentMetadata,
     version: req.body.version,
+    responseMetadata,
   }
 
   // Handle submissions for payments forms
@@ -427,6 +428,7 @@ const submitEncryptModeForm: ControllerHandler<
       meta: {
         ...logMeta,
         pendingSubmissionId,
+        responseMetadata,
       },
     })
 
@@ -573,6 +575,7 @@ const submitEncryptModeForm: ControllerHandler<
       ...logMeta,
       submissionId,
       formId,
+      responseMetadata,
     },
   })
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -48,14 +48,14 @@ export const validateEncryptSubmissionParams = celebrate({
       )
       .optional(),
     paymentReceiptEmail: Joi.string(),
-    /**
-     * @deprecated unused key, but frontend may still send it.
-     */
-    isPreview: Joi.boolean(),
     version: Joi.number().required(),
     responseMetadata: Joi.object({
       responseTimeMs: Joi.number(),
       numVisibleFields: Joi.number(),
     }),
+    /**
+     * @deprecated unused key, but frontend may still send it.
+     */
+    isPreview: Joi.boolean(),
   }),
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -53,5 +53,9 @@ export const validateEncryptSubmissionParams = celebrate({
      */
     isPreview: Joi.boolean(),
     version: Joi.number().required(),
+    responseMetadata: Joi.object({
+      responseTimeMs: Joi.number(),
+      numVisibleFields: Joi.number(),
+    }),
   }),
 })

--- a/src/types/api/email_submission.ts
+++ b/src/types/api/email_submission.ts
@@ -4,6 +4,7 @@ import {
   AttachmentResponse,
   EmailModeSubmissionContentDto,
   FieldResponse,
+  ResponseMetadata,
 } from '../../../shared/types'
 
 /**
@@ -24,5 +25,8 @@ export type ParsedEmailFormFieldResponse =
  */
 export type ParsedEmailModeSubmissionBody = Merge<
   EmailModeSubmissionContentDto,
-  { responses: ParsedEmailFormFieldResponse[] }
+  {
+    responses: ParsedEmailFormFieldResponse[]
+    responseMetadata: ResponseMetadata
+  }
 >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to be able to track respondent's normalised response time (response time normalised by fields available). However, currently, we do not collect nor store any information regarding response time.

Closes FRM-917

## Solution
<!-- How did you solve the problem? -->

We have to collect two metrics for every submission 
1. `responseTime` - time taken for the respondent from page load to submission
2. `numVisibleFields` - number of fields actually visible and potentially filled by the respondent at submission time

**Implementation options discussed for response time**
Option 1:
- Calculate time taken on client side, get time at start of page load in react and compare the delta when submitting
- However, client data is unreliable and can be modified

Option 2:
- Calculate the time taken on our BE, which makes it more robust
- However, we have to potentially add in a session token or some other ways to track the session of a respondent

We have decided to take Option 1 for now to expedite the collation of response time data. But will KIV option 2 for the future.

**For number of visible fields**
- `numVisibleFields` have to reside in `PublicFormProvider` as it has to be used on our `handleSubmitForm` method which is defined there
- currently we will set the visible fields whenever there is any updates in `VisibleFields.ts`, this will trigger a re-render to our `PublicFormProvider` and some of its non-memoised children. This should incur a flat performance cost of about 9-10ms every update of visible fields. The performance cost is uniform as only the contexts and containers are being updated, the variable fields are re-rendered anyway upon `VisibleFields.ts` changes.
   - Side note but if public form performance is an issue, we should look at how we handle re-renders for public form fields. There are some unnecessary mass re-renders for visible fields too, despite the memo-isation made

**Misc**

Additionally, have looked at potentially using google analytics (GA) to track engagement time instead but this poses two problems
1. GA tracks unique URLs -> each form is uniquely tracked
2. GA wouldn't be able to know the visible form fields of each respondents, which makes it very difficult to get a normalised response time

Hence, have ruled out the option

Lastly, have included the `responseMetadata` in the submissions (email & encrypt) logger. Thus, in the interim, before addressing usage of datadog metrics distributions, we could get the logger information from handle submissions, and draw our the metadata.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible, `responseMetadata` is intentionally left as optional to allow for any backwards compatibility issues between the rolling update of FE and BE.

## Tests
<!-- What tests should be run to confirm functionality? -->
**To ensure functionality**
- [ ] 1. Go to a public storage mode form with logic, fill in the form and submit
- [ ] 2. The submission should have been logged with the response time and number of visible fields (and the submission document in DB should reflect it too)
- [ ] 3. Repeat the steps for email mode form

Set toggle in `PublicFormProvider` for `useFetchForSubmission`
- [ ] 4. Repeat the steps 1 and 2 above for storage mode form with fetch for submission
- [ ] 5. Repeat the steps 1 and 2 above for email mode form with fetch for submission

For payment forms
- [ ] 6. Go to a payment form, fill in the form and submit
- [ ] 7. The pending submission should have been logged with the response time and number of visible fields (and the pending submission document in DB should reflect it too)
- [ ] 8. Complete the payment
- [ ] 9. The completed submission document for the payment should still contain the response metadata

**To check for regression**
- [ ] Submit a storage mode form without logic
- [ ] Submit an email mode form without logic
- [ ] Submit a preview mode, storage mode form with logic
- [ ] Submit a preview mode, email mode form with logic
- [ ] Create a use-template form with logic

Testing without `responseMetadata`
- [ ] 6. Try and call the email submission api endpoint without a `responseMetadata` in the body (can use an empty form), the submission should still be successful 
- [ ] 7. Try and call the encrypt submission api endpoint without a `responseMetadata` in the body (can use an empty form), the submission should still be successful 