### PR TITLE
feat: update payment settings copy for production launch

### DIFF
--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -48,6 +48,7 @@ const BeforeConnectionInstructions = ({
             send your Stripe account ID and raise a purchase order to Stripe.
           </Text>
         </InlineMessage>
+        {/* Stripe connect button should only be enabled when checkbox is checked. */}
         <Checkbox
           isChecked={allowConnect}
           mb="2rem"

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -169,10 +169,13 @@ const PaymentsSectionText = () => {
 }
 
 export const PaymentSettingsSection = (): JSX.Element => {
-  const { hasPaymentCapabilities } = useAdminFormPayments()
+  const { hasPaymentCapabilities, data } = useAdminFormPayments()
   return (
     <>
       <PaymentsSectionText />
+      {data?.account ? (
+        <StripeConnectButton stripeAccount={data?.account} />
+      ) : null}
       {hasPaymentCapabilities && (
         <>
           <Divider my="2.5rem" />

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
@@ -1,16 +1,19 @@
 import { useCallback } from 'react'
-import Stripe from 'stripe'
 
 import Button from '~components/Button'
 
 import { useMutateStripeAccount } from '../../mutations'
 
+export const enum StripeConnectButtonStates {
+  DISABLED,
+  ENABLED,
+  LINKED,
+}
+
 export const StripeConnectButton = ({
-  stripeAccount,
-  isDisabled = false,
+  connectState,
 }: {
-  stripeAccount?: Stripe.Response<Stripe.Account> | null
-  isDisabled?: boolean
+  connectState: StripeConnectButtonStates
 }): JSX.Element => {
   const { linkStripeAccountMutation, unlinkStripeAccountMutation } =
     useMutateStripeAccount()
@@ -30,10 +33,10 @@ export const StripeConnectButton = ({
     [unlinkStripeAccountMutation],
   )
 
-  if (!stripeAccount) {
+  if (connectState !== StripeConnectButtonStates.LINKED) {
     return (
       <Button
-        isDisabled={isDisabled}
+        isDisabled={connectState === StripeConnectButtonStates.DISABLED}
         isLoading={linkStripeAccountMutation.isLoading}
         onClick={onLinkAccountClick}
         colorScheme="primary"
@@ -41,15 +44,15 @@ export const StripeConnectButton = ({
         Connect with my Stripe account
       </Button>
     )
+  } else {
+    return (
+      <Button
+        colorScheme="danger"
+        onClick={onUnlinkAccountClick}
+        isLoading={unlinkStripeAccountMutation.isLoading}
+      >
+        Disconnect Stripe
+      </Button>
+    )
   }
-
-  return (
-    <Button
-      colorScheme="danger"
-      onClick={onUnlinkAccountClick}
-      isLoading={unlinkStripeAccountMutation.isLoading}
-    >
-      Disconnect Stripe
-    </Button>
-  )
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
@@ -1,25 +1,17 @@
 import { useCallback } from 'react'
-import { Icon, Skeleton, VisuallyHidden } from '@chakra-ui/react'
+import Stripe from 'stripe'
 
-import { FaStripe } from '~assets/icons/FaStripe'
 import Button from '~components/Button'
 
 import { useMutateStripeAccount } from '../../mutations'
-import { useAdminFormPayments } from '../../queries'
-
-const StripeIcon = () => {
-  return (
-    <Icon as={FaStripe} top="1px" ml="-2px" pos="relative" fontSize="2.5rem" />
-  )
-}
 
 export const StripeConnectButton = ({
+  stripeAccount,
   isDisabled = false,
 }: {
+  stripeAccount?: Stripe.Response<Stripe.Account> | null
   isDisabled?: boolean
 }): JSX.Element => {
-  const { data, isLoading } = useAdminFormPayments()
-
   const { linkStripeAccountMutation, unlinkStripeAccountMutation } =
     useMutateStripeAccount()
 
@@ -38,22 +30,16 @@ export const StripeConnectButton = ({
     [unlinkStripeAccountMutation],
   )
 
-  if (!data?.account) {
+  if (!stripeAccount) {
     return (
-      <Skeleton isLoaded={!isLoading} w="fit-content">
-        <Button
-          isDisabled={isDisabled}
-          isLoading={linkStripeAccountMutation.isLoading}
-          onClick={onLinkAccountClick}
-          title="Connect with Stripe"
-          bg="#635bff"
-          _hover={{
-            bg: '#7a73ff',
-          }}
-        >
-          Connect with my Stripe Account
-        </Button>
-      </Skeleton>
+      <Button
+        isDisabled={isDisabled}
+        isLoading={linkStripeAccountMutation.isLoading}
+        onClick={onLinkAccountClick}
+        colorScheme="primary"
+      >
+        Connect with my Stripe account
+      </Button>
     )
   }
 
@@ -62,10 +48,8 @@ export const StripeConnectButton = ({
       colorScheme="danger"
       onClick={onUnlinkAccountClick}
       isLoading={unlinkStripeAccountMutation.isLoading}
-      rightIcon={<StripeIcon />}
     >
-      Disconnect
-      <VisuallyHidden>Stripe</VisuallyHidden>
+      Disconnect Stripe
     </Button>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
@@ -13,7 +13,11 @@ const StripeIcon = () => {
   )
 }
 
-export const StripeConnectButton = (): JSX.Element => {
+export const StripeConnectButton = ({
+  isDisabled = false,
+}: {
+  isDisabled?: boolean
+}): JSX.Element => {
   const { data, isLoading } = useAdminFormPayments()
 
   const { linkStripeAccountMutation, unlinkStripeAccountMutation } =
@@ -38,6 +42,7 @@ export const StripeConnectButton = (): JSX.Element => {
     return (
       <Skeleton isLoaded={!isLoading} w="fit-content">
         <Button
+          isDisabled={isDisabled}
           isLoading={linkStripeAccountMutation.isLoading}
           onClick={onLinkAccountClick}
           title="Connect with Stripe"
@@ -45,10 +50,8 @@ export const StripeConnectButton = (): JSX.Element => {
           _hover={{
             bg: '#7a73ff',
           }}
-          rightIcon={<StripeIcon />}
         >
-          Connect with
-          <VisuallyHidden>Stripe</VisuallyHidden>
+          Connect with my Stripe Account
         </Button>
       </Skeleton>
     )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We're still dependent on product ops to onboard users. We want to improve our copy so users can self-serve instead.

Closes FRM-763, works towards FRM-440

## Solution
<!-- How did you solve the problem? -->

Change copy so that users can self-serve. 

FRM-440 is almost completed, other than the replacing of the guide link with a guide download link so that bulk tender rates will not be accessible on the web.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Features**:

- Add checkbox on production payment settings page before admin can connect to Stripe account
- Update text copy for the payment settings screen under the following conditions:
   - Production env
      - Before Stripe is connected
      - After Stripe is connected
   - Non-production env
      - Before Stripe is connected
      - After Stripe account connection is skipped
      - After Stripe account is connected

## Screenshots

### Production

https://github.com/opengovsg/FormSG/assets/37061143/59b7b6f5-094e-4c52-ad7e-0f479a5c10af

### Non-production

#### When Stripe account connection skipped

https://github.com/opengovsg/FormSG/assets/37061143/f7384afb-8628-482a-8a32-5cf4f42c2825

#### When Stripe account connection done

https://github.com/opengovsg/FormSG/assets/37061143/abcc67d7-e0f9-41d6-b883-f1aa11e50c95

## Tests
<!-- What tests should be run to confirm functionality? -->

Check that the payment settings page has the right copy under the following conditions:
- [ ] Production env (set `SECRET_ENV=production`)
   - [ ] Before Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17472-182345&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17472-182590&t=zFqLebTBv4x4zIfc-0))
- [ ] Non-production env (set `SECRET_ENV=staging` or `development` or `test`)
   - [ ] Before Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17202-179867&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17213-180740&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account connection is skipped ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17226-180896&t=zFqLebTBv4x4zIfc-0))
