### PR TITLE
feat: inject normalised response time to DD

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../../shared/types'
 import { IPopulatedEmailForm } from '../../../../types'
 import { ParsedEmailModeSubmissionBody } from '../../../../types/api'
+import { statsdClient } from '../../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
@@ -25,7 +26,10 @@ import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import * as EmailSubmissionMiddleware from '../email-submission/email-submission.middleware'
 import * as SubmissionService from '../submission.service'
-import { extractEmailConfirmationData } from '../submission.utils'
+import {
+  extractEmailConfirmationData,
+  getNormalisedResponseTime,
+} from '../submission.utils'
 
 import * as EmailSubmissionService from './email-submission.service'
 import { IPopulatedEmailFormWithResponsesAndHash } from './email-submission.types'
@@ -316,6 +320,20 @@ const submitEmailModeForm: ControllerHandler<
             message: 'Sending admin mail',
             meta: logMetaWithSubmission,
           })
+          if (responseMetadata)
+            statsdClient.distribution(
+              'formsg.submissions.normalisedReponseTime',
+              getNormalisedResponseTime(
+                responseMetadata.responseTimeMs,
+                responseMetadata.numVisibleFields,
+              ),
+              1,
+              {
+                mode: 'email',
+                responseTimeMs: '${responseMetadata.responseTimeMs}',
+                numOfVisibleFields: '${responseMetadata.numVisibleFields}',
+              },
+            )
 
           // Send response to admin
           // NOTE: This should short circuit in the event of an error.

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -322,7 +322,7 @@ const submitEmailModeForm: ControllerHandler<
           })
           if (responseMetadata)
             statsdClient.distribution(
-              'formsg.submissions.normalisedReponseTime',
+              'formsg.submissions.normResponseTimeMetadata',
               getNormalisedResponseTime(
                 responseMetadata.responseTimeMs,
                 responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -320,6 +320,8 @@ const submitEmailModeForm: ControllerHandler<
             message: 'Sending admin mail',
             meta: logMetaWithSubmission,
           })
+
+          // TODO 6395 make responseMetadata mandatory
           if (responseMetadata)
             statsdClient.distribution(
               'formsg.submissions.normResponseTimeMetadata',

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -436,7 +436,7 @@ const submitEncryptModeForm: ControllerHandler<
 
     if (responseMetadata)
       statsdClient.distribution(
-        'formsg.submissions.normalisedReponseTime',
+        'formsg.submissions.normResponseTimeMetadata',
         getNormalisedResponseTime(
           responseMetadata.responseTimeMs,
           responseMetadata.numVisibleFields,
@@ -599,7 +599,7 @@ const submitEncryptModeForm: ControllerHandler<
 
   if (responseMetadata)
     statsdClient.distribution(
-      'formsg.submissions.normalisedReponseTime',
+      'formsg.submissions.normResponseTimeMetadata',
       getNormalisedResponseTime(
         responseMetadata.responseTimeMs,
         responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -434,6 +434,7 @@ const submitEncryptModeForm: ControllerHandler<
       },
     })
 
+    // TODO 6395 make responseMetadata mandatory
     if (responseMetadata)
       statsdClient.distribution(
         'formsg.submissions.normResponseTimeMetadata',
@@ -444,7 +445,7 @@ const submitEncryptModeForm: ControllerHandler<
         1,
         {
           mode: 'encrypt',
-          payment: 'true',
+          payment: true as unknown as string,
           responseTimeMs: '${responseMetadata.responseTimeMs}',
           numOfVisibleFields: '${responseMetadata.numVisibleFields}',
         },
@@ -597,6 +598,7 @@ const submitEncryptModeForm: ControllerHandler<
     },
   })
 
+  // TODO 6395 make responseMetadata mandatory
   if (responseMetadata)
     statsdClient.distribution(
       'formsg.submissions.normResponseTimeMetadata',
@@ -607,7 +609,7 @@ const submitEncryptModeForm: ControllerHandler<
       1,
       {
         mode: 'encrypt',
-        payment: 'false',
+        payment: false as unknown as string,
         responseTimeMs: '${responseMetadata.responseTimeMs}',
         numOfVisibleFields: '${responseMetadata.numVisibleFields}',
       },

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -148,3 +148,10 @@ export const getFilteredResponses = (
   }
   return ok(results as FilteredResponse[])
 }
+
+export const getNormalisedResponseTime = (
+  responseTimeMs: number,
+  numVisibleFields: number,
+) => {
+  return (10 * responseTimeMs) / numVisibleFields
+}

--- a/src/types/api/email_submission.ts
+++ b/src/types/api/email_submission.ts
@@ -27,6 +27,6 @@ export type ParsedEmailModeSubmissionBody = Merge<
   EmailModeSubmissionContentDto,
   {
     responses: ParsedEmailFormFieldResponse[]
-    responseMetadata: ResponseMetadata
+    responseMetadata?: ResponseMetadata
   }
 >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Now that #6377 injects the `responseMetadata` to DB, we should also compute and provide the normalised response time to datadog as our metrics

Closes FRM-499

## Solution
<!-- How did you solve the problem? -->
Use datadog `statsdClient.distribution` and added in a new method in `submissions.util.ts` to compute normalised response time using the formula 10 * responseTime / numVisibleFields. To note, time is currently returned in miliseconds.

Consideration for pending submissions:
- Decided to return response time at creation of pending submission instead of at webhook confirmation
- Reason being that this set of metrics is for the general form filling time (disincluding payments), and if the user have a made a pending submission - it means they have filled up the form
- Side note: we should probably have another metric to track payment time 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Make a couple of submissions
- [ ] go to dd metrics explorer
- [ ] look for `formsg.submissions.normalisedResponseTime` 
- [ ] your submissions' response time data should be visible