### PR TITLE
fix: payment settings copy - business details, icon and rendering

### DIFF
--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -90,7 +90,7 @@ const BusinessInfoBlock = ({
     <>
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
         <FormLabel
-          description="Leave empty to use your agency defaults."
+          description="Leave blank to use your agency's GST Registration Number"
           isRequired
         >
           GST Registration Number
@@ -103,7 +103,7 @@ const BusinessInfoBlock = ({
       </FormControl>
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
         <FormLabel
-          description="Leave empty to use your agency defaults."
+          description="Leave blank to use your agency's business address"
           isRequired
         >
           Business Address

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types'
+import { FormResponseMode, PaymentChannel } from '~shared/types'
 
 import { BxsCheckCircle, BxsError, BxsInfoCircle } from '~assets/icons'
 import { GUIDE_PAYMENTS } from '~constants/links'
@@ -200,11 +200,9 @@ const PaymentsAccountInformation = ({
 export const PaymentSettingsSection = (): JSX.Element => {
   const {
     hasPaymentCapabilities,
-    data,
     isLoading: adminFormPaymentsLoading,
     isError: adminFormPaymentsError,
   } = useAdminFormPayments()
-  const stripeAccount = data?.account
 
   const { data: settings, isLoading: settingsIsLoading } =
     useAdminFormSettings()
@@ -212,11 +210,11 @@ export const PaymentSettingsSection = (): JSX.Element => {
   const isProductionEnv = secretEnv === 'production'
 
   return settings?.responseMode === FormResponseMode.Encrypt ? (
-    <Skeleton isLoaded={!adminFormPaymentsLoading}>
-      {!stripeAccount ? (
+    <Skeleton isLoaded={!settingsIsLoading}>
+      {settings.payments_channel.channel === PaymentChannel.Unconnected ? (
         <BeforeConnectionInstructions isProductionEnv={isProductionEnv} />
       ) : (
-        <Skeleton isLoaded={!settingsIsLoading}>
+        <Skeleton isLoaded={!adminFormPaymentsLoading}>
           <AfterConnectionInfo
             isProductionEnv={isProductionEnv}
             hasPaymentCapabilities={hasPaymentCapabilities}
@@ -224,7 +222,7 @@ export const PaymentSettingsSection = (): JSX.Element => {
             adminFormPaymentsError={adminFormPaymentsError}
           />
           <PaymentsAccountInformation
-            account_id={settings?.payments_channel?.target_account_id}
+            account_id={settings.payments_channel.target_account_id}
             isLoading={settingsIsLoading}
           />
           <StripeConnectButton

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -107,12 +107,10 @@ const ConnectionStatusText = ({
 const AfterConnectionInfo = ({
   isProductionEnv,
   hasPaymentCapabilities,
-  adminFormPaymentsLoading,
   adminFormPaymentsError,
 }: {
   isProductionEnv: boolean
   hasPaymentCapabilities: boolean
-  adminFormPaymentsLoading: boolean
   adminFormPaymentsError: boolean
 }): JSX.Element => {
   let connectionInfo: JSX.Element
@@ -168,11 +166,7 @@ const AfterConnectionInfo = ({
     }
   }
 
-  return (
-    <Skeleton isLoaded={!adminFormPaymentsLoading}>
-      <Flex mb="2.5rem">{connectionInfo}</Flex>
-    </Skeleton>
-  )
+  return <Flex mb="2.5rem">{connectionInfo}</Flex>
 }
 
 const PaymentsAccountInformation = ({
@@ -218,7 +212,6 @@ export const PaymentSettingsSection = (): JSX.Element => {
           <AfterConnectionInfo
             isProductionEnv={isProductionEnv}
             hasPaymentCapabilities={hasPaymentCapabilities}
-            adminFormPaymentsLoading={adminFormPaymentsLoading}
             adminFormPaymentsError={adminFormPaymentsError}
           />
           <PaymentsAccountInformation

--- a/frontend/src/features/admin-form/settings/queries.ts
+++ b/frontend/src/features/admin-form/settings/queries.ts
@@ -47,6 +47,7 @@ export const useAdminFormPayments = () => {
         // Factors can be found here: https://stripe.com/docs/api/accounts/object#account_object-requirements
         setHasPaymentCapabilities(!!account && account.charges_enabled)
       },
+      staleTime: 0,
     },
   )
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There were 3 issues with the payment settings page that went out for release v6.54.0 (#6385):

1. Payment account connection was not rendered correctly - it always shows the copy for when the account has no payment capabilities. The correct status will only show after a re-render. 
2. Icon for when account connection is skipped in test mode is wrong (it should be a green check instead of a warning icon).
3. Business details helper text was not updated.

Closes FRM-945

## Solution
<!-- How did you solve the problem? -->

1. Wrap the block that shows payment connection status with a `Skeleton` wrapper that only loads wrapped content when data has been successfully loaded.
2. Updated icon.
3. Updated business details helper text.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Screenshots

### Account Connection Status Rendering on staging environment

#### When `SECRET_ENV=production`

https://github.com/opengovsg/FormSG/assets/37061143/d60579d9-177b-4852-b904-2808a2f60edd

#### When `SECRET_ENV` is not 'production'

https://github.com/opengovsg/FormSG/assets/37061143/9b5d9dd6-41e8-458a-b61e-5f68b8c3bfd0

### Connection Status Icon (Should be green check when account connection skipped)

<img width="697" alt="Screenshot 2023-05-29 at 11 59 52 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/b13b1e2d-d6da-4d8f-91a3-8f67340a894a">

### Business Details Helper Text
<!-- [insert screenshot here] -->

<img width="699" alt="Screenshot 2023-05-29 at 11 47 04 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/31ca6fc5-7665-4360-a290-6214876407e0">

## Tests
<!-- What tests should be run to confirm functionality? -->

Check that the payment settings page has the right copy under the following conditions (on a **staging** environment):
- [ ] Production env (set `SECRET_ENV=production`)
   - [ ] Before Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17472-182345&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17472-182590&t=zFqLebTBv4x4zIfc-0))
- [ ] Non-production env (set `SECRET_ENV=staging` or `development` or `test`)
   - [ ] Before Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17202-179867&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account is connected ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17213-180740&t=zFqLebTBv4x4zIfc-0))
   - [ ] After Stripe account connection is skipped ([design](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=17226-180896&t=zFqLebTBv4x4zIfc-0))