### PR TITLE
ci: remove staging-al2 branch

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -2,13 +2,12 @@ name: Deploy to AWS Elastic Beanstalk
 on:
   push:
     # There should be 7 environments in github actions secrets:
-    # release, release-al2, staging, staging-al2, staging-alt, staging-alt2, uat.
+    # release, release-al2, staging, staging-alt, staging-alt2, uat.
     # This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name.
     branches:
       - release
       - release-al2
       - staging
-      - staging-al2
       - staging-alt
       - staging-alt2
       - uat

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -47,7 +47,7 @@ git checkout -b ${release_branch}
 git branch -D ${temp_release_branch}
 
 git push origin ${may_force_push} HEAD:${release_branch}
-git push -f origin HEAD:staging-al2
+git push -f origin HEAD:staging
 git push origin ${release_version}
 
 # extract changelog to inject into the PR


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Many staging branches, some with the `alt\d` suffix while others have `al\d` suffix.

## Solution
<!-- How did you solve the problem? -->

Remove `staging-al2` branch from the deployment scripts. Also set up GitHub environment for `staging`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  