### PR TITLE
feat: couple payment field enablement with payment channel connection

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -161,7 +161,6 @@ FormWithPayment.parameters = {
       publishable_key: 'pk_samplekey',
     },
     payments_field: {
-      enabled: true,
       amount_cents: 5000,
       description: 'Test event registration fee',
     },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -62,6 +62,8 @@ export const PaymentView = () => {
   const isActive = paymentState === PaymentState.EditingPayment
 
   const paymentDetails = paymentFromStore ?? form.payments_field
+  paymentDetails.description =
+    paymentDetails.description || 'Product/service name'
 
   const isDirtyAndPaymentInactive =
     isDirty && paymentState === PaymentState.Inactive
@@ -80,9 +82,7 @@ export const PaymentView = () => {
     setFieldListTabIndex(FieldListTabIndex.Payments)
   }
 
-  return form.payments_channel.channel !== PaymentChannel.Unconnected &&
-    !!form.payments_field.amount_cents &&
-    !!form.payments_field.description ? (
+  return form.payments_channel.channel !== PaymentChannel.Unconnected ? (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
         <Box mt="2.5rem" bg="white" py="2.5rem" px="1.5rem">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -80,7 +80,9 @@ export const PaymentView = () => {
     setFieldListTabIndex(FieldListTabIndex.Payments)
   }
 
-  return form.payments_channel.channel !== PaymentChannel.Unconnected ? (
+  return form.payments_channel.channel !== PaymentChannel.Unconnected &&
+    !!form.payments_field.amount_cents &&
+    !!form.payments_field.description ? (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
         <Box mt="2.5rem" bg="white" py="2.5rem" px="1.5rem">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Box } from '@chakra-ui/react'
 
-import { FormFieldDto, FormResponseMode } from '~shared/types'
+import { FormFieldDto, FormResponseMode, PaymentChannel } from '~shared/types'
 
 import { PaymentPreview } from '~templates/Field/PaymentPreview/PaymentPreview'
 
@@ -80,7 +80,7 @@ export const PaymentView = () => {
     setFieldListTabIndex(FieldListTabIndex.Payments)
   }
 
-  return paymentDetails.enabled ? (
+  return form.payments_channel.channel !== PaymentChannel.Unconnected ? (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
         <Box mt="2.5rem" bg="white" py="2.5rem" px="1.5rem">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -57,7 +57,6 @@ const formatCurrency = new Intl.NumberFormat('en-SG', {
 }).format
 
 type FormPaymentsInput = {
-  enabled: boolean
   description: string
   display_amount: string
 }
@@ -88,7 +87,6 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
     formState: { errors, dirtyFields },
     control,
     handleSubmit,
-    trigger,
   } = useForm<FormPaymentsInput>({
     mode: 'onChange',
     defaultValues: {
@@ -131,12 +129,10 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
     Object.values(clonedWatchedInputs),
   ])
 
-  const paymentIsEnabled = clonedWatchedInputs.enabled
-
   const amountValidation: RegisterOptions<FormPaymentsInput, 'display_amount'> =
     {
       validate: (val) => {
-        if (!paymentIsEnabled) return true
+        if (isDisabled) return true
 
         // Validate that it is a money value.
         // Regex allows leading and trailing spaces, max 2dp
@@ -191,22 +187,8 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
     <CreatePageDrawerContentContainer>
       <FormControl
         isReadOnly={paymentsMutation.isLoading}
-        isDisabled={isDisabled}
-      >
-        <Toggle
-          {...register('enabled', {
-            // Retrigger validation to remove errors when payment is toggled from enabled -> disabled
-            onChange: () => paymentIsEnabled && trigger(),
-          })}
-          description="Payment field will not be shown when this is toggled off. Respondents can still submit the form."
-          label="Enable payment"
-        />
-      </FormControl>
-
-      <FormControl
-        isReadOnly={paymentsMutation.isLoading}
         isInvalid={!!errors.description}
-        isDisabled={!paymentIsEnabled}
+        isDisabled={isDisabled}
         isRequired
       >
         <FormLabel description="This will be reflected on the payment invoice">
@@ -215,7 +197,7 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
         <Input
           placeholder="Product/service name"
           {...register('description', {
-            required: paymentIsEnabled && 'Please enter a payment description',
+            required: !isDisabled && 'Please enter a payment description',
           })}
         />
         <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
@@ -224,7 +206,7 @@ export const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
       <FormControl
         isReadOnly={paymentsMutation.isLoading}
         isInvalid={!!errors.display_amount}
-        isDisabled={!paymentIsEnabled}
+        isDisabled={isDisabled}
         isRequired
       >
         <FormLabel isRequired description="Amount should include GST">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel.tsx
@@ -23,7 +23,6 @@ import FormLabel from '~components/FormControl/FormLabel'
 import InlineMessage from '~components/InlineMessage'
 import Input from '~components/Input'
 import MoneyInput from '~components/MoneyInput'
-import Toggle from '~components/Toggle'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { userEvent, waitFor, within } from '@storybook/testing-library'
 import dedent from 'dedent'
 
+import { PaymentChannel } from '~shared/types'
 import { BasicField } from '~shared/types/field'
 import {
   FormAuthType,
@@ -390,9 +391,11 @@ WithPayment.parameters = {
         form: {
           responseMode: FormResponseMode.Encrypt,
           payments_field: {
-            enabled: true,
             amount_cents: 5000,
             description: 'Mock event registration',
+          },
+          payments_channel: {
+            channel: PaymentChannel.Stripe,
           },
         },
       },

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -5,6 +5,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import get from 'lodash/get'
 import simplur from 'simplur'
 
+import { PaymentChannel } from '~shared/types'
 import { FormAuthType, FormResponseMode } from '~shared/types/form'
 
 import { usePreviewForm } from '~/features/admin-form/common/queries'
@@ -316,7 +317,7 @@ export const PreviewFormProvider = ({
 
   const isPaymentEnabled =
     data?.form.responseMode === FormResponseMode.Encrypt &&
-    data.form.payments_field.enabled
+    data.form.payments_channel.channel !== PaymentChannel.Unconnected
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -317,7 +317,9 @@ export const PreviewFormProvider = ({
 
   const isPaymentEnabled =
     data?.form.responseMode === FormResponseMode.Encrypt &&
-    data.form.payments_channel.channel !== PaymentChannel.Unconnected
+    data.form.payments_channel.channel !== PaymentChannel.Unconnected &&
+    !!data.form.payments_field.amount_cents &&
+    !!data.form.payments_field.description
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { userEvent, waitFor, within } from '@storybook/testing-library'
 import dedent from 'dedent'
 
+import { PaymentChannel } from '~shared/types'
 import { BasicField } from '~shared/types/field'
 import {
   FormAuthType,
@@ -522,9 +523,11 @@ WithPayment.parameters = {
         form: {
           responseMode: FormResponseMode.Encrypt,
           payments_field: {
-            enabled: true,
             amount_cents: 5000,
             description: 'Mock event registration',
+          },
+          payments_channel: {
+            channel: PaymentChannel.Stripe,
           },
         },
       },

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -16,6 +16,7 @@ import get from 'lodash/get'
 import simplur from 'simplur'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
+import { PaymentChannel } from '~shared/types'
 import {
   FormAuthType,
   FormResponseMode,
@@ -494,7 +495,7 @@ export const PublicFormProvider = ({
 
   const isPaymentEnabled =
     data?.form.responseMode === FormResponseMode.Encrypt &&
-    data.form.payments_field.enabled
+    data.form.payments_channel.channel !== PaymentChannel.Unconnected
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -495,7 +495,9 @@ export const PublicFormProvider = ({
 
   const isPaymentEnabled =
     data?.form.responseMode === FormResponseMode.Encrypt &&
-    data.form.payments_channel.channel !== PaymentChannel.Unconnected
+    data.form.payments_channel.channel !== PaymentChannel.Unconnected &&
+    !!data.form.payments_field.amount_cents &&
+    !!data.form.payments_field.description
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
 import { isEmpty, times } from 'lodash'
 
+import { PaymentChannel } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, FormResponseMode, LogicDto } from '~shared/types/form'
 
@@ -164,7 +165,7 @@ export const FormFields = ({
           </Box>
         )}
         {form?.responseMode === FormResponseMode.Encrypt &&
-          form?.payments_field.enabled && (
+          form?.payments_channel.channel !== PaymentChannel.Unconnected && (
             <Box
               mt="2.5rem"
               bg="white"

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -165,7 +165,9 @@ export const FormFields = ({
           </Box>
         )}
         {form?.responseMode === FormResponseMode.Encrypt &&
-          form?.payments_channel.channel !== PaymentChannel.Unconnected && (
+          form?.payments_channel.channel !== PaymentChannel.Unconnected &&
+          !!form.payments_field.amount_cents &&
+          !!form.payments_field.description && (
             <Box
               mt="2.5rem"
               bg="white"

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -164,8 +164,9 @@ export const FormFields = ({
             </Stack>
           </Box>
         )}
-        {form?.responseMode === FormResponseMode.Encrypt &&
-          form?.payments_channel.channel !== PaymentChannel.Unconnected &&
+        {form &&
+          form.responseMode === FormResponseMode.Encrypt &&
+          form.payments_channel.channel !== PaymentChannel.Unconnected &&
           !!form.payments_field.amount_cents &&
           !!form.payments_field.description && (
             <Box

--- a/scripts/20230529_rm_payment_enabled/script.js
+++ b/scripts/20230529_rm_payment_enabled/script.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+
+// BEFORE
+// Count total number of forms with payment_fields that have enabled value. This should be > 0.
+db.getCollection('forms').countDocuments({ "payments_field.enabled": { $exists: true } })
+
+// UPDATE - remove payments_field.enabled
+db.getCollection('forms').updateMany(
+  {},
+  [ { $unset: { "payments_field.enabled": true } } ],
+)
+
+// AFTER
+// Count total number of forms with payment_fields that have enabled value. This should be 0.
+db.getCollection('forms').countDocuments({ "payments_field.enabled": { $exists: true } }) === 0

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -17,6 +17,7 @@ export const EMAIL_PUBLIC_FORM_FIELDS = PUBLIC_FORM_FIELDS
 export const STORAGE_PUBLIC_FORM_FIELDS = <const>[
   ...PUBLIC_FORM_FIELDS,
   'payments_field',
+  'payments_channel',
   'publicKey',
 ]
 

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -76,7 +76,6 @@ export type FormPaymentsChannel = {
 }
 
 export type FormPaymentsField = {
-  enabled: boolean
   amount_cents?: number
   description?: string
 }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -95,7 +95,6 @@ const PAYMENTS_DEFAULTS = {
     publishable_key: '',
   },
   payments_field: {
-    enabled: false,
     description: '',
     amount_cents: 0,
   },
@@ -734,7 +733,6 @@ describe('Form Model', () => {
         // Arrange
         const validFormParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
           payments_field: {
-            enabled: true,
             amount_cents: 50,
             description: 'some payment',
           },
@@ -782,7 +780,6 @@ describe('Form Model', () => {
         // Arrange
         const invalidFormParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
           payments_field: {
-            enabled: true,
             amount_cents: -50,
             description: 'some payment',
           },

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -153,10 +153,6 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
   },
 
   payments_field: {
-    enabled: {
-      type: Boolean,
-      default: false,
-    },
     description: {
       type: String,
       trim: true,
@@ -208,9 +204,6 @@ EncryptedFormDocumentSchema.methods.removePaymentAccount = async function () {
     channel: PaymentChannel.Unconnected,
     target_account_id: '',
     publishable_key: '',
-  }
-  if (this.payments_field) {
-    this.payments_field.enabled = false
   }
   return this.save()
 }

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -315,17 +315,8 @@ export const _handleUpdatePayments: ControllerHandler<
 export const handleUpdatePayments = [
   celebrate({
     [Segments.BODY]: {
-      enabled: Joi.boolean().required(),
-      amount_cents: Joi.when('enabled', {
-        is: Joi.equal(true),
-        then: Joi.number().integer().positive().required(),
-        otherwise: Joi.number().integer(),
-      }),
-      description: Joi.when('enabled', {
-        is: Joi.equal(true),
-        then: Joi.string().required(),
-        otherwise: Joi.string().allow(''),
-      }),
+      amount_cents: Joi.number().integer().positive(),
+      description: Joi.string(),
     },
   }),
   _handleUpdatePayments,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1588,10 +1588,10 @@ export const updatePayments = (
   IEncryptedFormDocument['payments_field'],
   PossibleDatabaseError | FormNotFoundError | InvalidPaymentAmountError
 > => {
-  const { enabled, amount_cents } = newPayments
+  const { amount_cents } = newPayments
 
-  // Check if payment amount exceeds maxPaymentAmountCents or below minPaymentAmountCents if the payment is enabled
-  if (enabled && amount_cents !== undefined) {
+  // Check if payment amount exceeds maxPaymentAmountCents or below minPaymentAmountCents
+  if (amount_cents !== undefined) {
     if (
       amount_cents > paymentConfig.maxPaymentAmountCents ||
       amount_cents < paymentConfig.minPaymentAmountCents

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -349,10 +349,7 @@ const submitEncryptModeForm: ControllerHandler<
   }
 
   // Handle submissions for payments forms
-  if (
-    form.payments_field?.enabled &&
-    form.payments_channel.channel === PaymentChannel.Stripe
-  ) {
+  if (form.payments_channel.channel === PaymentChannel.Stripe) {
     /**
      * Start of Payment Forms Submission Flow
      */

--- a/src/app/modules/verification/__tests__/verification.model.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.model.spec.ts
@@ -7,7 +7,7 @@ import { PAYMENT_CONTACT_FIELD_ID } from 'shared/constants'
 
 import { UpdateFieldData } from 'src/types'
 
-import { BasicField } from '../../../../../shared/types'
+import { BasicField, PaymentChannel } from '../../../../../shared/types'
 import getVerificationModel from '../verification.model'
 
 import {
@@ -298,7 +298,11 @@ describe('Verification Model', () => {
                 generateDefaultField(BasicField.Email),
                 generateDefaultField(BasicField.Mobile),
               ],
-              payments_field: { enabled: false },
+              payments_channel: {
+                channel: PaymentChannel.Unconnected,
+                target_account_id: '',
+                publishable_key: '',
+              },
             },
           })
 
@@ -369,7 +373,11 @@ describe('Verification Model', () => {
                 generateDefaultField(BasicField.Email),
                 generateDefaultField(BasicField.Mobile),
               ],
-              payments_field: { enabled: true },
+              payments_channel: {
+                channel: PaymentChannel.Stripe,
+                target_account_id: 'mockAccountId',
+                publishable_key: 'mockPublishableKey',
+              },
             },
           })
 
@@ -399,7 +407,11 @@ describe('Verification Model', () => {
                 generateDefaultField(BasicField.Email),
                 generateDefaultField(BasicField.Mobile),
               ],
-              payments_field: { enabled: true },
+              payments_channel: {
+                channel: PaymentChannel.Stripe,
+                target_account_id: 'mockAccountId',
+                publishable_key: 'mockPublishableKey',
+              },
             },
           })
 

--- a/src/app/modules/verification/verification.model.ts
+++ b/src/app/modules/verification/verification.model.ts
@@ -132,15 +132,17 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
   ): Promise<IVerificationSchema | null> {
     const formFields = getVerifiableFormFields(form.form_fields)
     if (form.responseMode === FormResponseMode.Encrypt) {
-      const { payments_channel } = form as IEncryptedFormSchema
-      const paymentField = getVerifiablePaymentContactField(
-        payments_channel.channel !== PaymentChannel.Unconnected,
+      const { payments_channel, payments_field } = form as IEncryptedFormSchema
+      const paymentContactField = getVerifiablePaymentContactField(
+        payments_channel.channel !== PaymentChannel.Unconnected &&
+          !!payments_field.amount_cents &&
+          !!payments_field.description,
       )
-      if (!formFields && !paymentField) return null
+      if (!formFields && !paymentContactField) return null
       return this.create({
         formId: form._id,
         fields: formFields ?? [],
-        paymentField,
+        paymentField: paymentContactField,
       })
     } else {
       if (!formFields) return null


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Payment enabled toggle is confusing for admins and is an additional step for them when they have already connected to their Stripe accounts.

Closes FRM-760

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes.
    - Existing payment fields have `enabled` field, which will be sent as part of the request when admins are trying to save their edited payment field. This is throw an error as it is an unexpected field.
    - `scripts/20230529_rm_payment_enabled/script.js` should be run in the DB as soon as possible after the new version is deployed.

**Features**:

- Replace references to `payment_field.enabled` with checks of whether `payment_channel.channel` is unconnected or not. 
- Displaying payment preview only if:
   1. Payment Channel is connected
   2. Description is not an empty string
   3. Amount in cents to be collected is not 0

## Screenshots

### Before Stripe account is connected

Form should look like a normal form without payments.

https://github.com/opengovsg/FormSG/assets/37061143/5f624a2e-2f06-4b7e-a64c-392f01a8f107

### After Stripe account is connected, before payment details are populated

Form should look like a normal form without payments.

https://github.com/opengovsg/FormSG/assets/37061143/ea8e5ec9-aeff-43b5-a660-74d0dccdf04c

### After payment details have been populated (and Stripe is connected)

Form should have payment preview and can make payment as usual.

https://github.com/opengovsg/FormSG/assets/37061143/a493237a-d450-4a1d-b515-7a8785f2f992

### When Stripe is disconnected

Form should be look like a normal form without payments. Previously populated description and payment amount should still be visible in the payment input panel.

https://github.com/opengovsg/FormSG/assets/37061143/96d0d98d-7470-4ad3-80bf-e69f9dc56f27

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Before Stripe account is connected, form should look like a normal form without payments.
   - [ ] Builder view:
      - [ ] Should not have the Payment Preview.
   - [ ] Preview view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".
   - [ ] Respondent view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".

- [ ] After Stripe account is connected, before payment details are populated, form should look like a normal form without payments.
   - [ ] Connect the form to a Stripe account.
   - [ ] Builder view:
      - [ ] Should not have the Payment Preview.
      - [ ] Payment input panel should allow admin to key in the description and payment amount. (Note: don't save this first.)
   - [ ] Preview view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".
   - [ ] Respondent view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".

- [ ] After payment details have been populated (and Stripe is connected), form should have payment preview and can make payment as usual.
   - [ ] Go to the payment input panel, input the description and payment amount for the payment. Save it.
   - [ ] Builder view:
      - [ ] Should have the Payment Preview.
   - [ ] Preview view:
      - [ ] Should have the Payment Preview.
      - [ ] Submit button should say "Proceed to pay".
   - [ ] Respondent view:
      - [ ] Should have the Payment Preview.
      - [ ] Submit button should say "Proceed to pay".
      - [ ] Make a payment. The flow should be the same as regular payments before.

- [ ] When Stripe is disconnected, form should be look like a normal form without payments. Previously populated description and payment amount should still be visible in the payment input panel.
   - [ ] Disconnect the form from Stripe.
   - [ ] Builder view:
      - [ ] Should not have the Payment Preview.
      - [ ] Payment input panel should have the details previously saved, but should not allow admin to change the description and payment amount.
   - [ ] Preview view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".
   - [ ] Respondent view:
      - [ ] Should not have the Payment Preview.
      - [ ] Submit button should say "Submit now".

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New scripts**:

- `scripts/20230529_rm_payment_enabled/script.js`: removes `payments_field.enabled` from documents, should be run ASAP after deployment.
