### PR TITLE
fix: use balance transaction fees from stripe

### DIFF
--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -118,21 +118,13 @@ const confirmStripePaymentPendingSubmission = (
           return new StripeFetchError()
         },
       )
-        .andThen((balanceTransaction) =>
-          okAsync(
-            balanceTransaction.fee_details
-              .filter((feeDetail) => feeDetail.type === 'stripe_fee')
-              .map((feeDetail) => feeDetail.amount)
-              .reduce((a, b) => a + b),
-          ),
-        )
         // Step 2: Update the payment object with the new completed payment metadata
-        .andThen((transactionFee) =>
+        .andThen((balanceTransaction) =>
           PaymentsService.confirmPaymentPendingSubmission(
             payment,
             new Date(event.created * 1000), // Convert to miliseconds from epoch
             receiptUrl,
-            transactionFee,
+            balanceTransaction.fee,
             session,
           ),
         )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

One of our agencies reported that there was a discrepancy between our reported transaction fee and the fees reported by Stripe. This is due to our calculation only including stripe fees, but there could be other fees such as tax (in the case of Paynow).

Closes FRM-955

## Solution
<!-- How did you solve the problem? -->

Take all fees without looking at the type. If admins want to check out the breakdown for fee types, the Stripe dashboard can be used.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Enable both Card and Paynow as payment methods on a Stripe account.
- [ ] Create a storage-mode form on a payment-enabled admin account. Connect the form to the Stripe account above.
- [ ] Perform a form submission and payment with the Card payment method.
   - [ ] Check that the transaction fees on FormSG matches the one on Stripe.
- [ ] Perform a form submission and payment with the Paynow payment method.
   - [ ] Check that the transaction fees on FormSG matches the one on Stripe.
