### PR TITLE
feat: capture paths with (accidental) trailing slashes

### DIFF
--- a/frontend/src/app/HashRouterElement.tsx
+++ b/frontend/src/app/HashRouterElement.tsx
@@ -27,29 +27,29 @@ type FormRegExpMatchArray = RegExpMatchArray & {
 
 const pathMapper = [
   {
-    regex: /^\/(?<formid>[0-9a-fA-F]{24})$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/?$/,
     getTarget: (m: FormRegExpMatchArray) => `/${m.groups.formid}`,
   },
   {
-    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/admin$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/admin\/?$/,
     getTarget: (m: FormRegExpMatchArray) => `/admin/form/${m.groups.formid}`,
   },
   {
-    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/preview$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/preview\/?$/,
     getTarget: (m: FormRegExpMatchArray) =>
       `/admin/form/${m.groups.formid}/preview`,
   },
   {
-    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/use-template$/,
+    regex: /^\/(?<formid>[0-9a-fA-F]{24})\/use-template\/?$/,
     getTarget: (m: FormRegExpMatchArray) =>
       `/admin/form/${m.groups.formid}/${ADMINFORM_USETEMPLATE_ROUTE}`,
   },
   {
-    regex: /^\/forms$/,
+    regex: /^\/forms\/?$/,
     getTarget: (m: FormRegExpMatchArray) => `${DASHBOARD_ROUTE}`,
   },
   {
-    regex: /^\/examples$/,
+    regex: /^\/examples\/?$/,
     getTarget: (m: FormRegExpMatchArray) => `/examples`,
   },
 ]


### PR DESCRIPTION
## Problem
Old angular URLs that contain trailing slashes are not being redirected to the corresponding **correct** React URL.

So for example, this redirect works:
 https://form.gov.sg/#!/5b88b36bdcac67000fec0403

but this one doesn’t:
https://form.gov.sg/#!/5b88b36bdcac67000fec0403/

[Slack thread for reference](https://opengovproducts.slack.com/archives/CKHLS3W3X/p1685342345688299)

## Solution
Update the HashRouter to capture source urls when they contain trailing slashes

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

**Bug Fixes**:

- Allows more angular URLs (even somewhat incorrect ones) to redirect


## Tests
- [ ] Verify the following hash-bang urls redirect to the correct react urls:
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/admin
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/admin/
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/preview
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/preview/
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/use-template
    - https://form.gov.sg/#!/5b88b36bdcac67000fec0403/use-template/
    - https://form.gov.sg/#!/forms
    - https://form.gov.sg/#!/forms/
    - https://form.gov.sg/#!/examples
    - https://form.gov.sg/#!/examples/
