### PR TITLE
feat: Inject response time to DD v2

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../../../shared/types'
 import { IPopulatedEmailForm } from '../../../../types'
 import { ParsedEmailModeSubmissionBody } from '../../../../types/api'
-import { statsdClient } from '../../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
@@ -30,6 +29,7 @@ import {
   extractEmailConfirmationData,
   getNormalisedResponseTime,
 } from '../submission.utils'
+import { submissionsStatsdClient } from '../submissions.statsd-client'
 
 import * as EmailSubmissionService from './email-submission.service'
 import { IPopulatedEmailFormWithResponsesAndHash } from './email-submission.types'
@@ -324,8 +324,8 @@ const submitEmailModeForm: ControllerHandler<
           // TODO 6395 make responseMetadata mandatory
           if (responseMetadata) {
             // response time
-            statsdClient.distribution(
-              'formsg.submissions.responseTime',
+            submissionsStatsdClient.distribution(
+              'responseTime',
               responseMetadata.responseTimeMs,
               1,
               {
@@ -333,8 +333,8 @@ const submitEmailModeForm: ControllerHandler<
               },
             )
             // normalised resposne time
-            statsdClient.distribution(
-              'formsg.submissions.normResponseTime',
+            submissionsStatsdClient.distribution(
+              'normResponseTime',
               getNormalisedResponseTime(
                 responseMetadata.responseTimeMs,
                 responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../../shared/types'
 import { IPopulatedEmailForm } from '../../../../types'
 import { ParsedEmailModeSubmissionBody } from '../../../../types/api'
+import { statsdClient } from '../../../config/datadog-statsd-client'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
@@ -25,7 +26,10 @@ import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import * as EmailSubmissionMiddleware from '../email-submission/email-submission.middleware'
 import * as SubmissionService from '../submission.service'
-import { extractEmailConfirmationData } from '../submission.utils'
+import {
+  extractEmailConfirmationData,
+  getNormalisedResponseTime,
+} from '../submission.utils'
 
 import * as EmailSubmissionService from './email-submission.service'
 import { IPopulatedEmailFormWithResponsesAndHash } from './email-submission.types'
@@ -316,6 +320,20 @@ const submitEmailModeForm: ControllerHandler<
             message: 'Sending admin mail',
             meta: logMetaWithSubmission,
           })
+          if (responseMetadata)
+            statsdClient.distribution(
+              'formsg.submissions.normalisedReponseTime',
+              getNormalisedResponseTime(
+                responseMetadata.responseTimeMs,
+                responseMetadata.numVisibleFields,
+              ),
+              1,
+              {
+                mode: 'email',
+                responseTimeMs: '${responseMetadata.responseTimeMs}',
+                numOfVisibleFields: '${responseMetadata.numVisibleFields}',
+              },
+            )
 
           // Send response to admin
           // NOTE: This should short circuit in the event of an error.

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -322,7 +322,7 @@ const submitEmailModeForm: ControllerHandler<
           })
           if (responseMetadata)
             statsdClient.distribution(
-              'formsg.submissions.normalisedReponseTime',
+              'formsg.submissions.normResponseTimeMetadata',
               getNormalisedResponseTime(
                 responseMetadata.responseTimeMs,
                 responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -325,7 +325,7 @@ const submitEmailModeForm: ControllerHandler<
           if (responseMetadata) {
             // response time
             statsdClient.distribution(
-              'formsg.submissions.responseTimeMetadata',
+              'formsg.submissions.responseTime',
               responseMetadata.responseTimeMs,
               1,
               {
@@ -334,7 +334,7 @@ const submitEmailModeForm: ControllerHandler<
             )
             // normalised resposne time
             statsdClient.distribution(
-              'formsg.submissions.normResponseTimeMetadata',
+              'formsg.submissions.normResponseTime',
               getNormalisedResponseTime(
                 responseMetadata.responseTimeMs,
                 responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -320,6 +320,8 @@ const submitEmailModeForm: ControllerHandler<
             message: 'Sending admin mail',
             meta: logMetaWithSubmission,
           })
+
+          // TODO 6395 make responseMetadata mandatory
           if (responseMetadata)
             statsdClient.distribution(
               'formsg.submissions.normResponseTimeMetadata',

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -322,7 +322,17 @@ const submitEmailModeForm: ControllerHandler<
           })
 
           // TODO 6395 make responseMetadata mandatory
-          if (responseMetadata)
+          if (responseMetadata) {
+            // response time
+            statsdClient.distribution(
+              'formsg.submissions.responseTimeMetadata',
+              responseMetadata.responseTimeMs,
+              1,
+              {
+                mode: 'email',
+              },
+            )
+            // normalised resposne time
             statsdClient.distribution(
               'formsg.submissions.normResponseTimeMetadata',
               getNormalisedResponseTime(
@@ -332,11 +342,9 @@ const submitEmailModeForm: ControllerHandler<
               1,
               {
                 mode: 'email',
-                responseTimeMs: '${responseMetadata.responseTimeMs}',
-                numOfVisibleFields: '${responseMetadata.numVisibleFields}',
               },
             )
-
+          }
           // Send response to admin
           // NOTE: This should short circuit in the event of an error.
           // This is why sendSubmissionToAdmin is separated from sendEmailConfirmations in 2 blocks

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -436,7 +436,7 @@ const submitEncryptModeForm: ControllerHandler<
 
     if (responseMetadata)
       statsdClient.distribution(
-        'formsg.submissions.normalisedReponseTime',
+        'formsg.submissions.normResponseTimeMetadata',
         getNormalisedResponseTime(
           responseMetadata.responseTimeMs,
           responseMetadata.numVisibleFields,
@@ -599,7 +599,7 @@ const submitEncryptModeForm: ControllerHandler<
 
   if (responseMetadata)
     statsdClient.distribution(
-      'formsg.submissions.normalisedReponseTime',
+      'formsg.submissions.normResponseTimeMetadata',
       getNormalisedResponseTime(
         responseMetadata.responseTimeMs,
         responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -42,8 +42,7 @@ import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { getPopulatedUserById } from '../../user/user.service'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
-import { getNormalisedResponseTime } from '../submission.utils'
-import { submissionsStatsdClient } from '../submissions.statsd-client'
+import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import {
   addPaymentDataStream,
@@ -436,29 +435,10 @@ const submitEncryptModeForm: ControllerHandler<
 
     // TODO 6395 make responseMetadata mandatory
     if (responseMetadata) {
-      // response time
-      submissionsStatsdClient.distribution(
-        'responseTime',
-        responseMetadata.responseTimeMs,
-        1,
-        {
-          mode: 'encrypt',
-          payment: false as unknown as string,
-        },
-      )
-      // normalised response time
-      submissionsStatsdClient.distribution(
-        'normResponseTime',
-        getNormalisedResponseTime(
-          responseMetadata.responseTimeMs,
-          responseMetadata.numVisibleFields,
-        ),
-        1,
-        {
-          mode: 'encrypt',
-          payment: true as unknown as string,
-        },
-      )
+      reportSubmissionResponseTime(responseMetadata, {
+        mode: 'encrypt',
+        payment: false as unknown as string,
+      })
     }
     // Step 3: Create the payment intent via API call to stripe.
     // Stripe requires the amount to be an integer in the smallest currency unit (i.e. cents)
@@ -609,29 +589,10 @@ const submitEncryptModeForm: ControllerHandler<
 
   // TODO 6395 make responseMetadata mandatory
   if (responseMetadata) {
-    // response time
-    submissionsStatsdClient.distribution(
-      'responseTime',
-      responseMetadata.responseTimeMs,
-      1,
-      {
-        mode: 'encrypt',
-        payment: false as unknown as string,
-      },
-    )
-    // normalised response time
-    submissionsStatsdClient.distribution(
-      'normResponseTime',
-      getNormalisedResponseTime(
-        responseMetadata.responseTimeMs,
-        responseMetadata.numVisibleFields,
-      ),
-      1,
-      {
-        mode: 'encrypt',
-        payment: false as unknown as string,
-      },
-    )
+    reportSubmissionResponseTime(responseMetadata, {
+      mode: 'encrypt',
+      payment: true as unknown as string,
+    })
   }
 
   // Send success back to client

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -437,7 +437,7 @@ const submitEncryptModeForm: ControllerHandler<
     if (responseMetadata) {
       reportSubmissionResponseTime(responseMetadata, {
         mode: 'encrypt',
-        payment: false as unknown as string,
+        payment: 'false',
       })
     }
     // Step 3: Create the payment intent via API call to stripe.
@@ -591,7 +591,7 @@ const submitEncryptModeForm: ControllerHandler<
   if (responseMetadata) {
     reportSubmissionResponseTime(responseMetadata, {
       mode: 'encrypt',
-      payment: true as unknown as string,
+      payment: 'true',
     })
   }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -435,7 +435,18 @@ const submitEncryptModeForm: ControllerHandler<
     })
 
     // TODO 6395 make responseMetadata mandatory
-    if (responseMetadata)
+    if (responseMetadata) {
+      // response time
+      statsdClient.distribution(
+        'formsg.submissions.responseTimeMetadata',
+        responseMetadata.responseTimeMs,
+        1,
+        {
+          mode: 'encrypt',
+          payment: false as unknown as string,
+        },
+      )
+      // normalised response time
       statsdClient.distribution(
         'formsg.submissions.normResponseTimeMetadata',
         getNormalisedResponseTime(
@@ -446,11 +457,9 @@ const submitEncryptModeForm: ControllerHandler<
         {
           mode: 'encrypt',
           payment: true as unknown as string,
-          responseTimeMs: '${responseMetadata.responseTimeMs}',
-          numOfVisibleFields: '${responseMetadata.numVisibleFields}',
         },
       )
-
+    }
     // Step 3: Create the payment intent via API call to stripe.
     // Stripe requires the amount to be an integer in the smallest currency unit (i.e. cents)
     const metadata: StripePaymentMetadataDto = {
@@ -599,7 +608,18 @@ const submitEncryptModeForm: ControllerHandler<
   })
 
   // TODO 6395 make responseMetadata mandatory
-  if (responseMetadata)
+  if (responseMetadata) {
+    // response time
+    statsdClient.distribution(
+      'formsg.submissions.responseTimeMetadata',
+      responseMetadata.responseTimeMs,
+      1,
+      {
+        mode: 'encrypt',
+        payment: false as unknown as string,
+      },
+    )
+    // normalised response time
     statsdClient.distribution(
       'formsg.submissions.normResponseTimeMetadata',
       getNormalisedResponseTime(
@@ -610,10 +630,9 @@ const submitEncryptModeForm: ControllerHandler<
       {
         mode: 'encrypt',
         payment: false as unknown as string,
-        responseTimeMs: '${responseMetadata.responseTimeMs}',
-        numOfVisibleFields: '${responseMetadata.numVisibleFields}',
       },
     )
+  }
 
   // Send success back to client
   res.json({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -438,7 +438,7 @@ const submitEncryptModeForm: ControllerHandler<
     if (responseMetadata) {
       // response time
       statsdClient.distribution(
-        'formsg.submissions.responseTimeMetadata',
+        'formsg.submissions.responseTime',
         responseMetadata.responseTimeMs,
         1,
         {
@@ -448,7 +448,7 @@ const submitEncryptModeForm: ControllerHandler<
       )
       // normalised response time
       statsdClient.distribution(
-        'formsg.submissions.normResponseTimeMetadata',
+        'formsg.submissions.normResponseTime',
         getNormalisedResponseTime(
           responseMetadata.responseTimeMs,
           responseMetadata.numVisibleFields,
@@ -611,7 +611,7 @@ const submitEncryptModeForm: ControllerHandler<
   if (responseMetadata) {
     // response time
     statsdClient.distribution(
-      'formsg.submissions.responseTimeMetadata',
+      'formsg.submissions.responseTime',
       responseMetadata.responseTimeMs,
       1,
       {
@@ -621,7 +621,7 @@ const submitEncryptModeForm: ControllerHandler<
     )
     // normalised response time
     statsdClient.distribution(
-      'formsg.submissions.normResponseTimeMetadata',
+      'formsg.submissions.normResponseTime',
       getNormalisedResponseTime(
         responseMetadata.responseTimeMs,
         responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -434,6 +434,7 @@ const submitEncryptModeForm: ControllerHandler<
       },
     })
 
+    // TODO 6395 make responseMetadata mandatory
     if (responseMetadata)
       statsdClient.distribution(
         'formsg.submissions.normResponseTimeMetadata',
@@ -444,7 +445,7 @@ const submitEncryptModeForm: ControllerHandler<
         1,
         {
           mode: 'encrypt',
-          payment: 'true',
+          payment: true as unknown as string,
           responseTimeMs: '${responseMetadata.responseTimeMs}',
           numOfVisibleFields: '${responseMetadata.numVisibleFields}',
         },
@@ -597,6 +598,7 @@ const submitEncryptModeForm: ControllerHandler<
     },
   })
 
+  // TODO 6395 make responseMetadata mandatory
   if (responseMetadata)
     statsdClient.distribution(
       'formsg.submissions.normResponseTimeMetadata',
@@ -607,7 +609,7 @@ const submitEncryptModeForm: ControllerHandler<
       1,
       {
         mode: 'encrypt',
-        payment: 'false',
+        payment: false as unknown as string,
         responseTimeMs: '${responseMetadata.responseTimeMs}',
         numOfVisibleFields: '${responseMetadata.numVisibleFields}',
       },

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -22,7 +22,6 @@ import {
 import { StripePaymentMetadataDto } from '../../../../types'
 import { EncryptSubmissionDto } from '../../../../types/api'
 import config from '../../../config/config'
-import { statsdClient } from '../../../config/datadog-statsd-client'
 import { paymentConfig } from '../../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { stripe } from '../../../loaders/stripe'
@@ -44,6 +43,7 @@ import { getPopulatedUserById } from '../../user/user.service'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
 import { getNormalisedResponseTime } from '../submission.utils'
+import { submissionsStatsdClient } from '../submissions.statsd-client'
 
 import {
   addPaymentDataStream,
@@ -437,8 +437,8 @@ const submitEncryptModeForm: ControllerHandler<
     // TODO 6395 make responseMetadata mandatory
     if (responseMetadata) {
       // response time
-      statsdClient.distribution(
-        'formsg.submissions.responseTime',
+      submissionsStatsdClient.distribution(
+        'responseTime',
         responseMetadata.responseTimeMs,
         1,
         {
@@ -447,8 +447,8 @@ const submitEncryptModeForm: ControllerHandler<
         },
       )
       // normalised response time
-      statsdClient.distribution(
-        'formsg.submissions.normResponseTime',
+      submissionsStatsdClient.distribution(
+        'normResponseTime',
         getNormalisedResponseTime(
           responseMetadata.responseTimeMs,
           responseMetadata.numVisibleFields,
@@ -610,8 +610,8 @@ const submitEncryptModeForm: ControllerHandler<
   // TODO 6395 make responseMetadata mandatory
   if (responseMetadata) {
     // response time
-    statsdClient.distribution(
-      'formsg.submissions.responseTime',
+    submissionsStatsdClient.distribution(
+      'responseTime',
       responseMetadata.responseTimeMs,
       1,
       {
@@ -620,8 +620,8 @@ const submitEncryptModeForm: ControllerHandler<
       },
     )
     // normalised response time
-    statsdClient.distribution(
-      'formsg.submissions.normResponseTime',
+    submissionsStatsdClient.distribution(
+      'normResponseTime',
       getNormalisedResponseTime(
         responseMetadata.responseTimeMs,
         responseMetadata.numVisibleFields,

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -148,3 +148,10 @@ export const getFilteredResponses = (
   }
   return ok(results as FilteredResponse[])
 }
+
+export const getNormalisedResponseTime = (
+  responseTimeMs: number,
+  numVisibleFields: number,
+) => {
+  return (10 * responseTimeMs) / numVisibleFields
+}

--- a/src/app/modules/submission/submissions.statsd-client.ts
+++ b/src/app/modules/submission/submissions.statsd-client.ts
@@ -1,5 +1,34 @@
+import { Tags } from 'hot-shots'
+import { ResponseMetadata } from 'shared/types'
+
 import { statsdClient } from '../../config/datadog-statsd-client'
+
+import { getNormalisedResponseTime } from './submission.utils'
 
 export const submissionsStatsdClient = statsdClient.childClient({
   prefix: 'formsg.submissions.',
 })
+
+export const reportSubmissionResponseTime = (
+  responseMetadata: ResponseMetadata,
+  tags: Tags,
+) => {
+  // response Time
+  submissionsStatsdClient.distribution(
+    'responseTime',
+    responseMetadata.responseTimeMs,
+    1,
+    tags,
+  )
+
+  // normalised response Time
+  submissionsStatsdClient.distribution(
+    'normResponseTime',
+    getNormalisedResponseTime(
+      responseMetadata.responseTimeMs,
+      responseMetadata.numVisibleFields,
+    ),
+    1,
+    tags,
+  )
+}

--- a/src/app/modules/submission/submissions.statsd-client.ts
+++ b/src/app/modules/submission/submissions.statsd-client.ts
@@ -1,0 +1,5 @@
+import { statsdClient } from '../../config/datadog-statsd-client'
+
+export const submissionsStatsdClient = statsdClient.childClient({
+  prefix: 'formsg.submissions.',
+})

--- a/src/app/modules/submission/submissions.statsd-client.ts
+++ b/src/app/modules/submission/submissions.statsd-client.ts
@@ -23,7 +23,7 @@ export const reportSubmissionResponseTime = (
 
   // normalised response Time
   submissionsStatsdClient.distribution(
-    'normResponseTime',
+    'responseTime.normalised',
     getNormalisedResponseTime(
       responseMetadata.responseTimeMs,
       responseMetadata.numVisibleFields,

--- a/src/types/api/email_submission.ts
+++ b/src/types/api/email_submission.ts
@@ -27,6 +27,6 @@ export type ParsedEmailModeSubmissionBody = Merge<
   EmailModeSubmissionContentDto,
   {
     responses: ParsedEmailFormFieldResponse[]
-    responseMetadata: ResponseMetadata
+    responseMetadata?: ResponseMetadata
   }
 >


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Now that #6377 injects the `responseMetadata` to DB, we should also compute and provide the normalised response time to datadog as our metrics. 

Closes FRM-499

## Solution
<!-- How did you solve the problem? -->

Following up from #6387 and #6402, have removed cardinal tags to prevent metrics from blowing up. Instead, have included an additional metric for raw response time data.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Make a couple of submissions
- [ ] go to dd metrics explorer
- [ ] look for `formsg.submissions.normResponseTimeMetadata` 
- [ ] look for `formsg.submissions.responseTimeMetadata` 
- [ ] your submissions' response time data should be visible