### PR TITLE
feat: add a call-to-action for info modals

### DIFF
--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -17,7 +17,7 @@ export const LOCAL_STORAGE_EVENT = 'local-storage'
  * Key to store whether a user has seen the rollout announcements before.
  */
 export const ROLLOUT_ANNOUNCEMENT_KEY_PREFIX =
-  'has-seen-rollout-announcement-20230531-'
+  'has-seen-rollout-announcement-20230531b-'
 
 /**
  * Key to store whether the admin has seen the feature tour in localStorage.

--- a/frontend/src/features/rollout-announcement/Announcements.tsx
+++ b/frontend/src/features/rollout-announcement/Announcements.tsx
@@ -8,6 +8,7 @@ export const NEW_FEATURES = [
     title: 'Collect payments on your form',
     description:
       'Citizens can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include credit card and PayNow.',
+    learnMoreLink: 'https://go.gov.sg/formsg-payment-overview',
     animationData: PaymentsAnnouncementGraphic,
   },
 ]

--- a/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
+++ b/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
@@ -35,7 +35,7 @@ export const NewFeatureContent = (props: {
         <Text textStyle="body-1" color="secondary.500">
           {description}
         </Text>
-        <Text>
+        <Text textStyle="body-1" color="secondary.500">
           Click <Link href={learnMoreLink}>here</Link> to learn more.
         </Text>
       </ModalBody>

--- a/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
+++ b/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
@@ -1,6 +1,7 @@
 import { ModalBody, ModalHeader, Text } from '@chakra-ui/react'
 import { AnimationConfigWithData } from 'lottie-web'
 
+import Link from '~components/Link'
 import { LottieAnimation } from '~templates/LottieAnimation'
 
 import { NewFeatureTag } from './NewFeatureTag'
@@ -8,13 +9,14 @@ import { NewFeatureTag } from './NewFeatureTag'
 interface NewFeatureContentProps {
   title: string
   description: string
+  learnMoreLink: string
   animationData: AnimationConfigWithData['animationData']
 }
 
 export const NewFeatureContent = (props: {
   content: NewFeatureContentProps
 }): JSX.Element => {
-  const { title, description, animationData } = props.content
+  const { title, description, animationData, learnMoreLink } = props.content
 
   return (
     <>
@@ -32,6 +34,9 @@ export const NewFeatureContent = (props: {
       <ModalBody whiteSpace="pre-wrap">
         <Text textStyle="body-1" color="secondary.500">
           {description}
+        </Text>
+        <Text>
+          Click <Link href={learnMoreLink}>here</Link> to learn more.
         </Text>
       </ModalBody>
     </>

--- a/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
+++ b/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
@@ -33,7 +33,10 @@ export const NewFeatureContent = (props: {
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
         <Text textStyle="body-1" color="secondary.500">
-          {description} <Link href={learnMoreLink}>Learn more</Link>
+          {description}{' '}
+          <Link isExternal href={learnMoreLink}>
+            Learn more
+          </Link>
         </Text>
       </ModalBody>
     </>

--- a/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
+++ b/frontend/src/features/rollout-announcement/components/NewFeatureContent.tsx
@@ -33,10 +33,7 @@ export const NewFeatureContent = (props: {
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
         <Text textStyle="body-1" color="secondary.500">
-          {description}
-        </Text>
-        <Text textStyle="body-1" color="secondary.500">
-          Click <Link href={learnMoreLink}>here</Link> to learn more.
+          {description} <Link href={learnMoreLink}>Learn more</Link>
         </Text>
       </ModalBody>
     </>


### PR DESCRIPTION
## Problem

The infobox modal does not have a click to action, so the user journey ends abruptly. 

## Solution
Updating the modal structure to always have a Learn More Link.

Note1: The PR updates the info key, so people who JUST saw the modal will see it again *with the link this time) if we release as-is.

Note2: I'm opening up the PR to get quick feedback and get the build tasks to pass, but I haven't even seen how this looks yet 😰 ...

## Tests

- [x] Open formsg in incognito mode
- [x] Verify you see the new modal with learn more link
- [x] Click the link, verify you get the slide deck via go
