### PR TITLE
fix: add payment field to numVisibleFields

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -135,6 +135,10 @@ export const PublicFormProvider = ({
   const { isNotFormId, toast, vfnToastIdRef, expiryInMs, ...commonFormValues } =
     useCommonFormProvider(formId)
 
+  const isPaymentEnabled =
+    data?.form.responseMode === FormResponseMode.Encrypt &&
+    data.form.payments_field.enabled
+
   useEffect(() => {
     if (data?.myInfoError) {
       toast({
@@ -231,7 +235,9 @@ export const PublicFormProvider = ({
         captchaResponse,
         responseMetadata: {
           responseTimeMs: differenceInMilliseconds(Date.now(), startTime),
-          numVisibleFields,
+          numVisibleFields: isPaymentEnabled
+            ? numVisibleFields + 1
+            : numVisibleFields,
         },
       }
 
@@ -474,6 +480,7 @@ export const PublicFormProvider = ({
       useFetchForSubmissions,
       numVisibleFields,
       startTime,
+      isPaymentEnabled,
     ],
   )
 
@@ -491,10 +498,6 @@ export const PublicFormProvider = ({
       !data.spcpSession,
     [data?.form, data?.spcpSession],
   )
-
-  const isPaymentEnabled =
-    data?.form.responseMode === FormResponseMode.Encrypt &&
-    data.form.payments_field.enabled
 
   if (isNotFormId) {
     return <NotFoundErrorPage />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, we do not include payment field in our computation for `responseMetadata.numVisibleFields`.

## Solution
<!-- How did you solve the problem? -->

If payment is enabled on the form, `handleSubmitForm` will increment the number of visible fields by 1. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] make a payment on a form
- [ ] check the payload, the body should contain the correct number of visible fields including payments
- [ ] check the db is updated with the correct number of visible fields
- [ ] ensure that response time metrics are still visible in DD