### PR TITLE
style: Use S$ instead of SGD

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
@@ -26,9 +26,9 @@ export const PaymentItemDetailsBlock = ({
       <Text textStyle="body-1" mb="0.75rem">
         {paymentItemName}
       </Text>
-      <Box as="h2" textStyle="h2">{`S$${centsToDollars(
-        paymentAmount ?? 0,
-      )}`}</Box>
+      <Box as="h2" textStyle="h2">
+        S${centsToDollars(paymentAmount ?? 0)}
+      </Box>
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
@@ -26,7 +26,7 @@ export const PaymentItemDetailsBlock = ({
       <Text textStyle="body-1" mb="0.75rem">
         {paymentItemName}
       </Text>
-      <Box as="h2" textStyle="h2">{`S$ ${centsToDollars(
+      <Box as="h2" textStyle="h2">{`S$${centsToDollars(
         paymentAmount ?? 0,
       )}`}</Box>
     </Box>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentItemDetailsBlock.tsx
@@ -26,9 +26,9 @@ export const PaymentItemDetailsBlock = ({
       <Text textStyle="body-1" mb="0.75rem">
         {paymentItemName}
       </Text>
-      <Box as="h2" textStyle="h2">{`${centsToDollars(
+      <Box as="h2" textStyle="h2">{`S$ ${centsToDollars(
         paymentAmount ?? 0,
-      )} SGD`}</Box>
+      )}`}</Box>
     </Box>
   )
 }


### PR DESCRIPTION
## Problem
Use S$ sign instead of SGD for public form view

Closes [FRM-970](https://linear.app/ogp/issue/FRM-970/use-sdollar-instead-of-sgd-for-more-conventional-representation-of)

## Solution
Update SGD with S$

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="965" alt="Screenshot 2023-06-01 at 5 23 55 PM" src="https://github.com/opengovsg/FormSG/assets/10881671/5cfd6633-a1e3-43e8-bc48-095d808d38d9">

**AFTER**:
<img width="928" alt="Screenshot 2023-06-01 at 6 28 46 PM" src="https://github.com/opengovsg/FormSG/assets/10881671/faab4bc0-7265-49c6-83e0-8248504767de">

## Tests
Ensure the 'S$' changes are reflected in:
- [ ] Form builder payment preview
- [ ] Public form 
- [ ] Public form payment page
