### PR TITLE
fix: learn more link for what's new drawer

### DIFF
--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -34,7 +34,7 @@ export const FEATURE_UPDATE_LIST: FeatureUpdateList = {
       title: 'Collect payments on your form',
       date: new Date('31 May 2023 GMT+8'),
       description:
-        'Citizens can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow.',
+        'Citizens can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow. [Learn more](https://go.gov.sg/formsg-payment-overview)',
       image: {
         animationData: Animation1,
         alt: 'Collect payments on your form',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Learn more link for What's New drawer missing for PR https://github.com/opengovsg/FormSG/pull/6416.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Add learn more link to What's New drawer.

## Screenshots

<img width="1512" alt="Screenshot 2023-06-05 at 2 06 17 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/6c29e78d-ed89-4ac3-bdb3-72b9abb5e88b">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Check that What's New drawer has the "Learn more" copy linked to "https://go.gov.sg/formsg-payment-overview" as seen in screenshot.
