### PR TITLE
fix: use payment intent data for preview

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentPage.tsx
@@ -21,7 +21,7 @@ export const FormPaymentPage = () => {
   if (!paymentId) throw new Error('No paymentId provided')
 
   return (
-    <PublicFormProvider formId={formId}>
+    <PublicFormProvider startTime={Date.now()} formId={formId}>
       <FormSectionsProvider>
         <Flex direction="column" css={fillMinHeightCss}>
           <FormBanner />

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -107,6 +107,8 @@ const StripePaymentContainer = ({
               <StripePaymentBlock
                 submissionId={paymentInfoData.submissionId}
                 triggerPaymentStatusRefetch={() => setRefetchKey(Date.now())}
+                paymentAmount={data?.paymentIntent?.amount}
+                paymentItemName={data?.paymentIntent?.description}
               />
             </PaymentStack>
           </>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
@@ -24,6 +24,9 @@ interface PaymentPageBlockProps {
   isRetry?: boolean
   focusOnMount?: boolean
   triggerPaymentStatusRefetch: () => void
+  paymentAmount?: number
+  // null here due to payment_intent.description from stripe
+  paymentItemName?: string | null
 }
 
 interface StripeCheckoutFormProps {
@@ -124,6 +127,8 @@ export const StripePaymentBlock = ({
   focusOnMount,
   isRetry,
   triggerPaymentStatusRefetch,
+  paymentAmount,
+  paymentItemName,
 }: PaymentPageBlockProps): JSX.Element => {
   const { form } = usePublicFormContext()
 
@@ -158,9 +163,15 @@ export const StripePaymentBlock = ({
             Payment
           </Text>
           <PaymentItemDetailsBlock
-            paymentItemName={form.payments_field?.description}
+            paymentItemName={
+              paymentItemName
+                ? paymentItemName
+                : form.payments_field.description
+            }
             colorTheme={colorTheme}
-            paymentAmount={form.payments_field?.amount_cents}
+            paymentAmount={
+              paymentAmount ? paymentAmount : form.payments_field.amount_cents
+            }
           />
         </Box>
         <StripeCheckoutForm


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We currently use form payment fields to display payment item preview, which may not be the amount the payee is paying (if admin changes form payment field between payee filling the from -> payment page)

Closes FRM-983

## Solution
<!-- How did you solve the problem? -->

Use payment intent information to display the payment item preview on payment page instead

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] go to a payment public form
- [ ] make a submission + payment intent (make sure to keep track of the current field price)
- [ ] (at this point you should be at the payment page)
- [ ] on admin side, change the payment field amount and description 
- [ ] the payment preview amount and description should be the same as when you have made the submission (not the updated version)
- [ ] complete the payment