### PR TITLE
fix: payout webhooks not returning OK

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -712,7 +712,6 @@ describe('stripe.service', () => {
       it('should return error result when call to stripe.balanceTransactions failed', async () => {
         const processStripeEventSpy = jest
           .spyOn(StripeService, 'processStripeEvent')
-          .mockImplementationOnce(() => errAsync(new PaymentNotFoundError()))
         const balanceTransactionApiSpy = jest
           .spyOn(stripe.balanceTransactions, 'list')
           .mockImplementationOnce(

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -3,7 +3,7 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import { keyBy } from 'lodash'
 import mongoose from 'mongoose'
-import { errAsync, ok, ResultAsync } from 'neverthrow'
+import { err, errAsync, ok, ResultAsync } from 'neverthrow'
 import { PaymentChannel, PaymentStatus, SubmissionType } from 'shared/types'
 import Stripe from 'stripe'
 
@@ -21,6 +21,7 @@ import {
 
 import { PaymentNotFoundError } from '../payments.errors'
 import * as PaymentsService from '../payments.service'
+import { StripeMetadataInvalidError } from '../stripe.errors'
 import * as StripeService from '../stripe.service'
 import * as StripeUtils from '../stripe.utils'
 
@@ -707,11 +708,10 @@ describe('stripe.service', () => {
   })
 
   describe('handleStripeEvent', () => {
-    describe('event.type of payout', () => {
-      beforeEach(() => jest.resetAllMocks())
+    describe('with event.type of payout', () => {
+      beforeEach(() => jest.restoreAllMocks())
+
       it('should return error result when call to stripe.balanceTransactions failed', async () => {
-        const processStripeEventSpy = jest
-          .spyOn(StripeService, 'processStripeEvent')
         const balanceTransactionApiSpy = jest
           .spyOn(stripe.balanceTransactions, 'list')
           .mockImplementationOnce(
@@ -720,6 +720,10 @@ describe('stripe.service', () => {
                 autoPagingEach: () => Promise.reject('boom'),
               } as unknown as Stripe.ApiListPromise<Stripe.BalanceTransaction>),
           )
+        const processStripeEventSpy = jest.spyOn(
+          StripeService,
+          'processStripeEvent',
+        )
 
         const result = await StripeService.handleStripeEvent(
           MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_CREATED'],
@@ -729,11 +733,34 @@ describe('stripe.service', () => {
         expect(result.isErr()).toBeTrue()
       })
 
-      it('should return error result when processStripeEvent failed with event.type', async () => {
-        const processStripeEventSpy = jest
-          .spyOn(StripeService, 'processStripeEvent')
-          .mockImplementationOnce(() => errAsync(new PaymentNotFoundError()))
+      it('should return error result when call to getMetadataPaymentId failed', async () => {
+        const balanceTransactionApiSpy = jest
+          .spyOn(stripe.balanceTransactions, 'list')
+          .mockImplementationOnce(
+            () =>
+              ({
+                autoPagingEach: (fn) => fn({ type: 'charge', source: {} }),
+              } as unknown as Stripe.ApiListPromise<Stripe.BalanceTransaction>),
+          )
+        const getMetadataPaymentIdSpy = jest
+          .spyOn(StripeUtils, 'getMetadataPaymentId')
+          .mockImplementation(() => err(new StripeMetadataInvalidError()))
+        const processStripeEventSpy = jest.spyOn(
+          StripeService,
+          'processStripeEvent',
+        )
 
+        const result = await StripeService.handleStripeEvent(
+          MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_CREATED'],
+        )
+
+        expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
+        expect(getMetadataPaymentIdSpy).toHaveBeenCalledOnce()
+        expect(processStripeEventSpy).not.toHaveBeenCalledOnce()
+        expect(result.isErr()).toBeTrue()
+      })
+
+      it('should return error result when call to processStripeEvent failed', async () => {
         const balanceTransactionApiSpy = jest
           .spyOn(stripe.balanceTransactions, 'list')
           .mockImplementationOnce(
@@ -759,13 +786,7 @@ describe('stripe.service', () => {
         expect(result.isErr()).toBeTrue()
       })
 
-      it('should return non-error result when processStripeEvent succeeds with event.type of payment_intent.created', async () => {
-        const processStripeEventSpy = jest
-          .spyOn(StripeService, 'processStripeEvent')
-          .mockImplementationOnce(jest.fn())
-        const getMetadataPaymentIdSpy = jest
-          .spyOn(StripeUtils, 'getMetadataPaymentId')
-          .mockImplementation(() => ok('still gud'))
+      it('should return ok result when there are no internal errors', async () => {
         const balanceTransactionApiSpy = jest
           .spyOn(stripe.balanceTransactions, 'list')
           .mockImplementationOnce(
@@ -774,6 +795,12 @@ describe('stripe.service', () => {
                 autoPagingEach: (fn) => fn({ type: 'charge', source: {} }),
               } as unknown as Stripe.ApiListPromise<Stripe.BalanceTransaction>),
           )
+        const getMetadataPaymentIdSpy = jest
+          .spyOn(StripeUtils, 'getMetadataPaymentId')
+          .mockImplementation(() => ok('still gud'))
+        const processStripeEventSpy = jest
+          .spyOn(StripeService, 'processStripeEvent')
+          .mockImplementationOnce(jest.fn())
 
         const result = await StripeService.handleStripeEvent(
           MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_CREATED'],

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -3,7 +3,7 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import { keyBy } from 'lodash'
 import mongoose from 'mongoose'
-import { err, errAsync, ok, ResultAsync } from 'neverthrow'
+import { err, errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
 import { PaymentChannel, PaymentStatus, SubmissionType } from 'shared/types'
 import Stripe from 'stripe'
 
@@ -800,7 +800,7 @@ describe('stripe.service', () => {
           .mockImplementation(() => ok('still gud'))
         const processStripeEventSpy = jest
           .spyOn(StripeService, 'processStripeEvent')
-          .mockImplementationOnce(jest.fn())
+          .mockImplementationOnce(() => okAsync(undefined))
 
         const result = await StripeService.handleStripeEvent(
           MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_CREATED'],

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -742,13 +742,20 @@ describe('stripe.service', () => {
                 autoPagingEach: (fn) => fn({ type: 'charge', source: {} }),
               } as unknown as Stripe.ApiListPromise<Stripe.BalanceTransaction>),
           )
+        const getMetadataPaymentIdSpy = jest
+          .spyOn(StripeUtils, 'getMetadataPaymentId')
+          .mockImplementation(() => ok('still gud'))
+        const processStripeEventSpy = jest
+          .spyOn(StripeService, 'processStripeEvent')
+          .mockImplementationOnce(() => errAsync(new PaymentNotFoundError()))
 
         const result = await StripeService.handleStripeEvent(
           MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_CREATED'],
         )
 
         expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
-        expect(processStripeEventSpy).not.toHaveBeenCalledOnce()
+        expect(getMetadataPaymentIdSpy).toHaveBeenCalledOnce()
+        expect(processStripeEventSpy).toHaveBeenCalledOnce()
         expect(result.isErr()).toBeTrue()
       })
 

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -546,6 +546,7 @@ export const handleStripeEvent = (
     case 'payout.reconciliation_completed': {
       // Retrieve the list of balance transactions related to this payout, and
       // associate the payout with the set of charges it pays out for
+      let payoutProcessError: ResultAsync<void, HandleStripeEventResultError>
       result = ResultAsync.fromPromise(
         stripe.balanceTransactions
           .list(
@@ -556,12 +557,15 @@ export const handleStripeEvent = (
             if (balanceTransaction.type !== 'charge') return
 
             const charge = balanceTransaction.source as Stripe.Charge
-            const innerResult = getMetadataPaymentId(
+            const innerResult = await getMetadataPaymentId(
               charge.metadata,
             ).asyncAndThen((paymentId) => processStripeEvent(paymentId, event))
 
             // Reducer to keep errors around
-            result = result.andThen(() => innerResult)
+            if (innerResult && innerResult.isErr()) {
+              payoutProcessError = errAsync(innerResult.error)
+              return
+            }
           }),
         (error) => {
           if (error instanceof Stripe.errors.StripeInvalidRequestError) {
@@ -584,7 +588,7 @@ export const handleStripeEvent = (
           })
           return new StripeFetchError()
         },
-      ).andThen(() => result)
+      ).andThen(() => payoutProcessError)
       break
     }
     default:

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -563,6 +563,12 @@ export const handleStripeEvent = (
 
             // Reducer to keep errors around
             if (innerResult && innerResult.isErr()) {
+              logger.error({
+                message:
+                  'Error when calling processStripeEvent while paging through balanceTransaction',
+                meta: { ...logMeta, chargeId: charge },
+                error: innerResult,
+              })
               payoutProcessError = errAsync(innerResult.error)
               return
             }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Stripe Payout webhooks are not returning with `200 OK` even though they are processed correctly.

Investigation yielded an error with the promise chain to be cyclic, causing the `StripeService.handleStripeEvent` to never end. This results in the the controller `handleStripeEventFromWebhook` to think that the handler is still running and not causing `res.send()` (or its equivalent) to trigger.

TS Playground Sandbox [example](https://www.typescriptlang.org/play?ssl=19&ssc=1&pln=20&pc=1#code/DYUwLgBATiDOCuxIF4IAUoHsC2BLWIAdDLJsAG4gAUA5JgNY0CUAUCwIawCeAdgMYQAZvH5hcmHhGztcPKkwDeLCNDiIU6LHgLE4ZSrQbNlKiITAALEHPkAuCOUy4AJhGQA+CEtOm+E2JCyPCBQGDj4IG6a4Tok+tQ0QSFh2iAAjMY+KiTqUTlI5lY2TG6eSaFaEaxZqmDwUJIA9I0QAO6RfOw8PJiQMHUNEF1clrIA5hBWMEOwQ-BgmGjsY+MAoux8FqoAjvC4JEMOTq799TwmKgC+TIXWVPKlqghIrCang-lgLJcs0rLyt2Kjz8PFIoEIwEwY1ofx4aQgfmwAAdQGAQM5mCVmhBgpQoAicCjwHA2CxUU91AAmKIpCK6MEGOiMVjk8q0ggAJTgSPsww43H4QhEfDEEikMh4lPk3gpSGpqHZRDiFASRmqpkB9yY9kcLkeMp8bMqnO5NONSr0KtoRpiIEpmSy7yaLXaCK6PT64DOQx4Iws40mIUinDmCyWKx4Y3Wmx2ewO7COeqdEAuEGumoeHggNtSXNgSNe2S9HzUcu+vwlUpuljumc8ILBREh0JosOpiKJaIxTCxLQ7qJJQA)


## Solution
<!-- How did you solve the problem? -->
Decouple setting of result of its async function over to another function.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Payout event from stripe should now return a 200 OK
- [ ] Find an trigger a webhook from stripe dashboard