### PR TITLE
feat: migrate banners on React to non-'React'-suffixed env vars

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -24,13 +24,12 @@ export const AdminFormLayout = (): JSX.Element => {
   if (!formId) throw new Error('No formId provided')
 
   // TODO (#4279): Revert back to non-react banners post-migration.
-  const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
-    useEnv()
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContentReact || adminBannerContentReact,
-    [adminBannerContentReact, siteBannerContentReact],
+    () => siteBannerContent || adminBannerContent,
+    [adminBannerContent, siteBannerContent],
   )
 
   const bannerProps = useMemo(

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -23,7 +23,6 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  // TODO (#4279): Revert back to non-react banners post-migration.
   const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
   const bannerContent = useMemo(

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -102,7 +102,6 @@ export const LoginPage = (): JSX.Element => {
   const [otpPrefix, setOtpPrefix] = useState<string>('')
   const { t } = useTranslation()
 
-  // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContent || isLoginBanner,

--- a/frontend/src/features/login/LoginPage.tsx
+++ b/frontend/src/features/login/LoginPage.tsx
@@ -96,7 +96,7 @@ const NonMobileSidebarGridArea: FC = ({ children }) => (
 )
 
 export const LoginPage = (): JSX.Element => {
-  const { data: { siteBannerContentReact, isLoginBannerReact } = {} } = useEnv()
+  const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
   const [, setIsAuthenticated] = useLocalStorage<boolean>(LOGGED_IN_KEY)
   const [email, setEmail] = useState<string>()
   const [otpPrefix, setOtpPrefix] = useState<string>('')
@@ -105,8 +105,8 @@ export const LoginPage = (): JSX.Element => {
   // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContentReact || isLoginBannerReact,
-    [siteBannerContentReact, isLoginBannerReact],
+    () => siteBannerContent || isLoginBanner,
+    [siteBannerContent, isLoginBanner],
   )
 
   const bannerProps = useMemo(

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -12,8 +12,8 @@ import { usePublicFormContext } from '../PublicFormContext'
 export const FormBanner = (): JSX.Element | null => {
   const {
     data: {
-      siteBannerContentReact,
-      isGeneralMaintenanceReact,
+      siteBannerContent,
+      isGeneralMaintenance,
       isSPMaintenance,
       isCPMaintenance,
       myInfoBannerContent,
@@ -26,8 +26,8 @@ export const FormBanner = (): JSX.Element | null => {
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () =>
-      siteBannerContentReact ||
-      isGeneralMaintenanceReact ||
+      siteBannerContent ||
+      isGeneralMaintenance ||
       (form?.authType === FormAuthType.SP && isSPMaintenance) ||
       (form?.authType === FormAuthType.CP && isCPMaintenance) ||
       (form?.authType === FormAuthType.MyInfo && myInfoBannerContent) ||
@@ -35,10 +35,10 @@ export const FormBanner = (): JSX.Element | null => {
     [
       form?.authType,
       isCPMaintenance,
-      isGeneralMaintenanceReact,
+      isGeneralMaintenance,
       isSPMaintenance,
       myInfoBannerContent,
-      siteBannerContentReact,
+      siteBannerContent,
     ],
   )
 

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -21,8 +21,6 @@ export const FormBanner = (): JSX.Element | null => {
   } = useEnv()
   const { form } = usePublicFormContext()
 
-  // TODO (#4279): Revert back to non-react banners post-migration.
-
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () =>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -19,7 +19,6 @@ export const CONTAINER_MAXW = '69.5rem'
 export const WorkspacePage = (): JSX.Element => {
   const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
-  // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
     () => siteBannerContent || adminBannerContent,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -17,14 +17,13 @@ import { WorkspaceProvider } from './WorkspaceProvider'
 export const CONTAINER_MAXW = '69.5rem'
 
 export const WorkspacePage = (): JSX.Element => {
-  const { data: { siteBannerContentReact, adminBannerContentReact } = {} } =
-    useEnv()
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
 
   // TODO (#4279): Revert back to non-react banners post-migration.
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
-    () => siteBannerContentReact || adminBannerContentReact,
-    [adminBannerContentReact, siteBannerContentReact],
+    () => siteBannerContent || adminBannerContent,
+    [adminBannerContent, siteBannerContent],
   )
 
   const bannerProps = useMemo(

--- a/shared/types/core.ts
+++ b/shared/types/core.ts
@@ -24,12 +24,8 @@ export type ClientEnvVars = {
   isSPMaintenance: string // Singpass maintenance message
   isCPMaintenance: string // Corppass maintenance message
   myInfoBannerContent: string // MyInfo maintenance message
-  // TODO: remove after React rollout #4786, #4279
+  // TODO: remove after React rollout #4786
   GATrackingID: string | null
-  isGeneralMaintenanceReact: string
-  isLoginBannerReact: string
-  siteBannerContentReact: string
-  adminBannerContentReact: string
 
   spcpCookieDomain: string // Cookie domain used for removing spcp cookies
   stripePublishableKey: string

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -233,11 +233,6 @@ const config: Config = {
   isLoginBanner: basicVars.banner.isLoginBanner,
   siteBannerContent: basicVars.banner.siteBannerContent,
   adminBannerContent: basicVars.banner.adminBannerContent,
-  // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
-  isGeneralMaintenanceReact: basicVars.banner.isGeneralMaintenanceReact,
-  isLoginBannerReact: basicVars.banner.isLoginBannerReact,
-  siteBannerContentReact: basicVars.banner.siteBannerContentReact,
-  adminBannerContentReact: basicVars.banner.adminBannerContentReact,
   rateLimitConfig: basicVars.rateLimit,
   reactMigration: basicVars.reactMigration,
   configureAws,

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -185,31 +185,6 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: '',
       env: 'ADMIN_BANNER_CONTENT',
     },
-    // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
-    isGeneralMaintenanceReact: {
-      doc: 'Load env variable with General Maintenance banner text. For React only.',
-      format: String,
-      default: '',
-      env: 'IS_GENERAL_MAINTENANCE_REACT',
-    },
-    isLoginBannerReact: {
-      doc: 'The banner message on login page. Allows for HTML. For React only.',
-      format: String,
-      default: '',
-      env: 'IS_LOGIN_BANNER_REACT',
-    },
-    siteBannerContentReact: {
-      doc: 'The banner message to show on all pages. Allows for HTML. Will supersede all other banner content if it exists. For React only.',
-      format: String,
-      default: '',
-      env: 'SITE_BANNER_CONTENT_REACT',
-    },
-    adminBannerContentReact: {
-      doc: 'The banner message to show on on admin pages. Allows for HTML. For React only.',
-      format: String,
-      default: '',
-      env: 'ADMIN_BANNER_CONTENT_REACT',
-    },
   },
   formsgSdkMode: {
     doc: 'Inform SDK which public keys are to be used to sign, encrypt, or decrypt data that is passed to it',

--- a/src/app/modules/frontend/frontend.service.ts
+++ b/src/app/modules/frontend/frontend.service.ts
@@ -20,12 +20,8 @@ export const getClientEnvVars = (): ClientEnvVars => {
     isSPMaintenance: spcpMyInfoConfig.isSPMaintenance, // Singpass maintenance message
     isCPMaintenance: spcpMyInfoConfig.isCPMaintenance, // Corppass maintenance message
     myInfoBannerContent: spcpMyInfoConfig.myInfoBannerContent, // MyInfo maintenance message
-    // TODO: remove after React rollout #4786, #4279
+    // TODO: remove after React rollout #4786
     GATrackingID: googleAnalyticsConfig.GATrackingID,
-    isGeneralMaintenanceReact: config.isGeneralMaintenanceReact,
-    isLoginBannerReact: config.isLoginBannerReact,
-    siteBannerContentReact: config.siteBannerContentReact,
-    adminBannerContentReact: config.adminBannerContentReact,
 
     spcpCookieDomain: spcpMyInfoConfig.spcpCookieDomain, // Cookie domain used for removing spcp cookies
     stripePublishableKey: paymentConfig.stripePublishableKey,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -87,13 +87,6 @@ export type Config = {
   isLoginBanner: string
   siteBannerContent: string
   adminBannerContent: string
-
-  // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
-  isGeneralMaintenanceReact: string
-  isLoginBannerReact: string
-  siteBannerContentReact: string
-  adminBannerContentReact: string
-
   rateLimitConfig: RateLimitConfig
   reactMigration: ReactMigrationConfig
   secretEnv: string
@@ -154,11 +147,6 @@ export interface IOptionalVarsSchema {
     isLoginBanner: string
     siteBannerContent: string
     adminBannerContent: string
-    // TODO (#4279): Delete these when react migration is over. Revert back to original banner variables in react frontend.
-    isGeneralMaintenanceReact: string
-    isLoginBannerReact: string
-    siteBannerContentReact: string
-    adminBannerContentReact: string
   }
   awsConfig: {
     region: string


### PR DESCRIPTION
## Problem
Continuation of #6190. We split our banners for angular and react, and this PR switches react back onto the original env vars.

Closes FRM-990

## Solution

Basically a reversion of #5148 .

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Deploy Notes

**Deleted environment variables**:

- `IS_GENERAL_MAINTENANCE_REACT`
- `IS_LOGIN_BANNER_REACT`
- `SITE_BANNER_CONTENT_REACT`
- `ADMIN_BANNER_CONTENT_REACT`