### PR TITLE
chore: remove placeholder stripe keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,11 +103,11 @@ services:
       - REACT_MIGRATION_REMOVE_INFOBOX_THRESHOLD_RESPONDENT=101
       - REACT_MIGRATION_USE_FETCH_FOR_SUBMISSIONS=false
       # env vars for stripe payment integration
-      - PAYMENT_STRIPE_PUBLISHABLE_KEY=publishableKey
+      - PAYMENT_STRIPE_PUBLISHABLE_KEY
       # duplicate PAYMENT_STRIPE_SECRET_KEY to STRIPE_API_KEY in stripe-webhook-listener container
-      - PAYMENT_STRIPE_SECRET_KEY=secretKey
-      - PAYMENT_STRIPE_CLIENT_ID=clientId
-      - PAYMENT_STRIPE_WEBHOOK_SECRET=webhookSecret
+      - PAYMENT_STRIPE_SECRET_KEY
+      - PAYMENT_STRIPE_CLIENT_ID
+      - PAYMENT_STRIPE_WEBHOOK_SECRET
       - PAYMENT_MAX_PAYMENT_AMOUNT_CENTS
       - PAYMENT_MIN_PAYMENT_AMOUNT_CENTS=50
       - SSM_ENV_SITE_NAME=development
@@ -170,7 +170,7 @@ services:
     container_name: stripe-webhook-listener
     command: 'listen --api-key ${STRIPE_API_KEY} --device-name ${STRIPE_DEVICE_NAME} --forward-to host.docker.internal:5001/api/v3/notifications/stripe'
     environment:
-      - STRIPE_API_KEY=secretKey
+      - STRIPE_API_KEY
       - STRIPE_DEVICE_NAME=StripeWebhookListener
 
   mocktwilio:


### PR DESCRIPTION
## Problem
In order to test Stripe payment locally, dev will need to manually update the keys in docker-compose file.

## Solution
With the removal of placeholder keys in docker-compose file, docker run will pick up the environment key from either [environment variable configured locally](https://phoenixnap.com/kb/set-environment-variable-mac) or from `.env`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
