### PR TITLE
fix: use 400 instead of 500 for gogov err status code

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -56,7 +56,6 @@ import * as SmsService from '../../../services/sms/sms.service'
 import { createReqMeta } from '../../../utils/request'
 import * as AuthService from '../../auth/auth.service'
 import {
-  ApplicationError,
   DatabaseConflictError,
   DatabaseError,
   DatabasePayloadSizeError,
@@ -88,7 +87,7 @@ import {
   PREVIEW_CORPPASS_UINFIN,
   PREVIEW_SINGPASS_UINFIN,
 } from './admin-form.constants'
-import { EditFieldError } from './admin-form.errors'
+import { EditFieldError, GoGovError } from './admin-form.errors'
 import { updateSettingsValidator } from './admin-form.middlewares'
 import * as AdminFormService from './admin-form.service'
 import { PermissionLevel } from './admin-form.types'
@@ -2775,7 +2774,7 @@ export const handleSetGoLinkSuffix: ControllerHandler<
             },
           ),
           // TODO: fix error handling (https://linear.app/ogp/issue/FRM-901/improve-error-handling-when-calling-gogov-api)
-          () => new ApplicationError('Error occurred when claiming GoGov link'),
+          () => new GoGovError(),
         )
       })
       // Step 3: After obtaining GoGov link, save it to the form

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -37,3 +37,9 @@ export class PaymentChannelNotFoundError extends ApplicationError {
     super(message)
   }
 }
+
+export class GoGovError extends ApplicationError {
+  constructor(message = 'Error occurred when claiming GoGov link') {
+    super(message)
+  }
+}

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -49,6 +49,7 @@ import {
   CreatePresignedUrlError,
   EditFieldError,
   FieldNotFoundError,
+  GoGovError,
   InvalidCollaboratorError,
   InvalidFileTypeError,
   PaymentChannelNotFoundError,
@@ -173,6 +174,11 @@ export const mapRouteError = (
     case PaymentChannelNotFoundError:
       return {
         statusCode: StatusCodes.FORBIDDEN,
+        errorMessage: error.message,
+      }
+    case GoGovError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,
       }
     default:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

500s thrown are causing false alarms :'(

Works towards FRM-901

## Solution
<!-- How did you solve the problem? -->

Create a general custom error for GoGov integration related errors and use 400 for that.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Go to a form that has not been attached to a GoGov Link yet and open the share form modal.
- [ ] Open the network panel to see the network calls made.
- [ ] Try to claim a GoGov link that you know is already taken on this form.
- [ ] The `/gogov` endpoint should return a `400` status rather than a `500` status code

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

Not sure where to park these:
- [ ] remove exclusion of `/gogov` endpoint from [Server Errors (Overall) >= 1](https://app.datadoghq.com/monitors/79404515) DD monitor
- [ ] remove exclusion of `/gogov` endpoint from [Server Errors (Overall) >= 10](https://app.datadoghq.com/monitors/100352488) DD monitor