### PR TITLE
fix: account for undefined response code when tracking webhook dd stats

### DIFF
--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -223,8 +223,8 @@ export const sendWebhook = (
 }
 
 export const getWebhookType = (webhookUrl: string) => {
-  const isZapier = new RegExp(/^https:\/\/hooks\.zapier\.com\//)
-  const isPlumber = new RegExp(/^https:\/\/plumber\.gov\.sg\/webhooks\//)
+  const isZapier = /^https:\/\/hooks\.zapier\.com\//
+  const isPlumber = /^https:\/\/plumber\.gov\.sg\/webhooks\//
   const webhookType = isZapier.test(webhookUrl)
     ? 'zapier'
     : isPlumber.test(webhookUrl)

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -223,9 +223,13 @@ export const sendWebhook = (
 }
 
 export const getWebhookType = (webhookUrl: string) => {
-  const isZapier = webhookUrl.match(/^https:\/\/hooks\.zapier\.com\//)
-  const isPlumber = webhookUrl.match(/^https:\/\/plumber\.gov\.sg\/webhooks\//)
-  const webhookType = isZapier ? 'zapier' : isPlumber ? 'plumber' : 'generic'
+  const isZapier = new RegExp(/^https:\/\/hooks\.zapier\.com\//)
+  const isPlumber = new RegExp(/^https:\/\/plumber\.gov\.sg\/webhooks\//)
+  const webhookType = isZapier.test(webhookUrl)
+    ? 'zapier'
+    : isPlumber.test(webhookUrl)
+    ? 'plumber'
+    : 'generic'
   return webhookType
 }
 

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -253,8 +253,9 @@ export const createInitialWebhookSender =
     return sendWebhook(submission.getWebhookView(), webhookUrl).andThen(
       (webhookResponse) => {
         webhookStatsdClient.increment('sent', 1, 1, {
-          responseCode: webhookResponse.response.status.toString(),
+          responseCode: `${webhookResponse.response.status || null}`,
           webhookType: getWebhookType(webhookUrl),
+          isRetryEnabled: `${isRetryEnabled}`,
         })
 
         // Save record of sending to database


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

@timotheeg pointed out some ways that the webhook DD metric tracking could be improved in #6469

Related to FRM-1009

## Solution
<!-- How did you solve the problem? -->
- Use `regexp.test(string)` instead of `string.match(rexep)`
- add `isRetryEnabled` as a tag
- Use template literals for tags

## Tests
<!-- What tests should be run to confirm functionality? -->
(Same as those in #6469)
- [ ] Create a storage-mode form. Set the webhook URL as a [Zapier](https://zapier.com/) URL (follow this [guide](https://guide.form.gov.sg/user-guides/advanced-guide/webhooks/zapier-integration) to set up a Zapier integration with your FormSG form to get that URL). Submit a response. A count of the response should be reflected in this [DD-graph](https://app.datadoghq.com/dashboard/f29-urp-an7/wan-lings-dashboard-test?fullscreen_end_ts=1687175566578&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1687171966578&fullscreen_widget=4704661163853978&tpl_var_env%5B0%5D=staging&from_ts=1684583088053&to_ts=1687175088053&live=false) with the tag 'zapier'
- [ ] Repeat the same test, but with a URL from [Plumber](https://plumber.gov.sg/) - you will have to create a new pipe in Plumber with a **prod** FormSG form to get this URL. The associated tag should be 'plumber'
- [ ] Repeat the same test, but with a non-zapier and non-plumber URL. The associated tag should be 'generic'
