### PR TITLE
chore: update issue feedback mail html

### DIFF
--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -319,11 +319,11 @@ export const generateIssueReportedNotificationHtml = ({
   return dedent`
   <p>Dear Form admin,</p>
   <p>Respondents are facing issues on your form: ${formTitle}.<p>
-  <p>These issues are reported by respondents via the ‘Report an issue’ button 
+  <p>These issues are reported by respondents via the 'Report an issue' button 
   on public forms. We encourage you to view these reports as respondents might 
-  be facing urgent issues relating to form submission. </p>
-  <p><a href="${formResultUrl}">Login to Forms</a> and view issues reported in your 
-  ‘Results’ page.</p>
-  <p>Thank you,</br>${appName}</p>
+  be facing urgent issues relating to form submission.</p>
+  <p><a href="${formResultUrl}">Login to Forms</a> and view issues reported in 
+  your results page.</p>
+  <p>Thank you,<br/>${appName}</p>
   `
 }


### PR DESCRIPTION
Update form issue feedback mail html content according to latest update on [figma](https://www.figma.com/file/CMq0CJtawn7NGM7Zdpi8Ti/Form-Design-Master?type=design&node-id=18487-191297&mode=design&t=wfhBJQcPVLhfoelV-0)

A few points happen [PR](https://github.com/opengovsg/FormSG/pull/6473). The breakdowns are listed below:
1. On inverted comma: Apparently Stacey's laptop automatically convert the inverted comma to the fat version `‘Report an issue’`. To standardise the view, we will stick to using the skinny inverted comma `'`

2. On <br/> tag: Apparently this is the incorrect html tag, and most browsers try to be immuned to invalid tag like this. Will update to use the correct tag.
