### PR TITLE
fix: initialize payoutProcessError with default value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "FormSG",
-  "version": "6.61.0",
+  "version": "6.61.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "FormSG",
-      "version": "6.61.0",
+      "version": "6.61.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.347.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
-  "version": "6.61.0",
+  "version": "6.61.1",
   "homepage": "https://form.gov.sg",
   "authors": [
     "FormSG <formsg@data.gov.sg>"

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -809,7 +809,7 @@ describe('stripe.service', () => {
         expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
         expect(getMetadataPaymentIdSpy).toHaveBeenCalledOnce()
         expect(processStripeEventSpy).toHaveBeenCalledOnce()
-        expect(result).toBeUndefined()
+        expect(result.isOk()).toBeTrue()
       })
     })
   })

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -546,7 +546,8 @@ export const handleStripeEvent = (
     case 'payout.reconciliation_completed': {
       // Retrieve the list of balance transactions related to this payout, and
       // associate the payout with the set of charges it pays out for
-      let payoutProcessError: ResultAsync<void, HandleStripeEventResultError>
+      let payoutProcessError: ResultAsync<void, HandleStripeEventResultError> =
+        okAsync(undefined)
       result = ResultAsync.fromPromise(
         stripe.balanceTransactions
           .list(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. Payout hooks from stripe are returning `502`
2. Cloudwatch was receiving `... undefined (reading match) ...`

Introduced in #6436

**Sequence of events**

1. `payoutProcessError` is not initialized to be anything.
Suppose there’s no error when running `ResultAsync`. 
2. `result` will be set with payoutProcessError := null, as it was not set to be anything.
3. Then returned back to it’s caller with `return result // null`. Caller was expecting a type ResultAsync
4. Caller freaks out


## Solution
<!-- How did you solve the problem? -->

Initialize `payoutProcessError` with `okAsync`, assuming that it will be replaced when errors occurs inside `processStripeEvent`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  