### PR TITLE
fix: escape form title in payment invoice's html content

### DIFF
--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -436,7 +436,7 @@ export const convertToInvoiceFormat = (
     )
     .replace(
       /Something wrong with the email\? <a.+a>/,
-      `FormSG Form: ${escape(formTitle)}<br>Response ID: ${submissionId}`,
+      `FormSG Form: ${escape(formTitle)}<br />Response ID: ${submissionId}`,
     )
     .replace(
       /<td class="Spacer Spacer--gutter" width="64" .+<\/td>/,

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -3,6 +3,7 @@
 import { encode } from 'html-entities'
 import { StatusCodes } from 'http-status-codes'
 import { JSDOM } from 'jsdom'
+import escape from 'lodash/escape'
 import mongoose from 'mongoose'
 import { err, Ok, ok, Result } from 'neverthrow'
 import Stripe from 'stripe'
@@ -435,7 +436,7 @@ export const convertToInvoiceFormat = (
     )
     .replace(
       /Something wrong with the email\? <a.+a>/,
-      `FormSG Form: ${formTitle}<br>Response ID: ${submissionId}`,
+      `FormSG Form: ${escape(formTitle)}<br>Response ID: ${submissionId}`,
     )
     .replace(
       /<td class="Spacer Spacer--gutter" width="64" .+<\/td>/,

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -3,7 +3,6 @@
 import { encode } from 'html-entities'
 import { StatusCodes } from 'http-status-codes'
 import { JSDOM } from 'jsdom'
-import escape from 'lodash/escape'
 import mongoose from 'mongoose'
 import { err, Ok, ok, Result } from 'neverthrow'
 import Stripe from 'stripe'
@@ -436,7 +435,7 @@ export const convertToInvoiceFormat = (
     )
     .replace(
       /Something wrong with the email\? <a.+a>/,
-      `FormSG Form: ${escape(formTitle)}<br />Response ID: ${submissionId}`,
+      `FormSG Form: ${encode(formTitle)}<br />Response ID: ${submissionId}`,
     )
     .replace(
       /<td class="Spacer Spacer--gutter" width="64" .+<\/td>/,


### PR DESCRIPTION
## Problem
The Form Title is not escaped when generating the markup for the invoice.

Reported during VAPT as [GTA-10-012 WP1](https://github.com/opengovsg/formsg-private/issues/162)

## Solution
Escape the form title using [html-entities.encode()](https://github.com/mdevils/html-entities#encodetext-options)

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
- [X] No - this PR is backwards compatible  

## Tests
- [ ] Create a form with payment, add some markup in the form title
- [ ] Complete a payment
- [ ] Retrieve the invoice, verify that the markup is displayed correctly (i.e. is encoded)
