### PR TITLE
fix: admin feedback capturing wrong local storage value

### DIFF
--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -32,4 +32,4 @@ export const EMERGENCY_CONTACT_KEY_PREFIX = 'has-seen-emergency-contact'
 /**
  * Key to store when was the last time user has seen the admin feedback modal
  */
-export const ADMIN_FEEDBACK_HISTORY_PREFIX = 'last-seen-admin-feedback'
+export const ADMIN_FEEDBACK_HISTORY_PREFIX = 'last-seen-admin-feedback-'

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -31,7 +31,7 @@ export const WorkspacePage = (): JSX.Element => {
       adminFeedbackDisplayFrequency,
     } = {},
   } = useEnv()
-  const { user } = useUser()
+  const { user, isLoading } = useUser()
   const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
   const isMobile = useIsMobile()
 
@@ -64,6 +64,8 @@ export const WorkspacePage = (): JSX.Element => {
   // and has yet to seen feedback beyond our stipulated frequency
   const showAdminFeedback =
     isAdminFeedbackEligible &&
+    // user details is loaded
+    !isLoading &&
     // if feedbackTime has not been seen
     (!lastFeedbackTime ||
       // or if last feedback time seen is more than frequency (frequency env var must be defined)
@@ -86,6 +88,7 @@ export const WorkspacePage = (): JSX.Element => {
       setIsAdminFeedbackEligible(false)
     }
   }, [
+    // isLoading,
     currentTime,
     showAdminFeedback,
     setIsDisplayFeedback,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -1,13 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 import { Flex, useDisclosure } from '@chakra-ui/react'
 
 import { AdminNavBar } from '~/app/AdminNavBar'
 
-import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useIsMobile } from '~hooks/useIsMobile'
-import { useLocalStorage } from '~hooks/useLocalStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 import { fillHeightCss } from '~utils/fillHeightCss'
 import { getBannerProps } from '~utils/getBannerProps'
 import { Banner } from '~components/Banner'
@@ -15,7 +10,7 @@ import { Banner } from '~components/Banner'
 import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 
-import AdminFeedbackBox from './components/AdminFeedbackBox'
+import AdminFeedbackContainer from './components/AdminFeedbackContainer'
 // TODO #4279: Remove after React rollout is complete
 import CreateFormModal from './components/CreateFormModal'
 import { WorkspacePageContent } from './components/WorkspacePageContent'
@@ -60,64 +55,6 @@ export const WorkspacePage = (): JSX.Element => {
         </WorkspaceProvider>
       </Flex>
       {user && <AdminFeedbackContainer userId={user._id} />}
-    </>
-  )
-}
-
-const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
-  const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
-  const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
-  const isMobile = useIsMobile()
-
-  const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
-
-  const [lastFeedbackTime, setLastFeedbackTime] =
-    useLocalStorage<number>(adminFeedbackKey)
-  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
-    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
-
-  // capture current time on page load to prevent re-renders from update to current time
-  const currentTime = useRef(Date.now())
-
-  // check if admin is eligible in current session
-  // and has yet to seen feedback beyond our stipulated frequency
-  const showAdminFeedback =
-    isAdminFeedbackEligible &&
-    // if feedbackTime has not been seen
-    (!lastFeedbackTime ||
-      // or if last feedback time seen is more than frequency (frequency env var must be defined)
-      (!!adminFeedbackDisplayFrequency &&
-        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
-
-  // sets display of feedback box
-  useEffect(() => {
-    if (
-      // TODO: create mobile version of admin feedback
-      !isMobile &&
-      // whether to show admin the feedback box
-      showAdminFeedback
-    ) {
-      setIsDisplayFeedback(true)
-      // reset local storage and admin feedback eligibility when admin feedback is displayed
-      setLastFeedbackTime(currentTime.current)
-      setIsAdminFeedbackEligible(false)
-    }
-  }, [
-    currentTime,
-    showAdminFeedback,
-    setIsDisplayFeedback,
-    setLastFeedbackTime,
-    setIsAdminFeedbackEligible,
-    isMobile,
-  ])
-
-  const closeAdminFeedback = useCallback(
-    () => setIsDisplayFeedback(false),
-    [setIsDisplayFeedback],
-  )
-  return (
-    <>
-      {isDisplayFeedback && <AdminFeedbackBox onClose={closeAdminFeedback} />}
     </>
   )
 }

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -31,7 +31,7 @@ export const WorkspacePage = (): JSX.Element => {
       adminFeedbackDisplayFrequency,
     } = {},
   } = useEnv()
-  const { user, isLoading } = useUser()
+  const { user } = useUser()
   const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
   const isMobile = useIsMobile()
 
@@ -73,8 +73,8 @@ export const WorkspacePage = (): JSX.Element => {
   // sets display of feedback box
   useEffect(() => {
     if (
-      // user details is loaded
-      !isLoading &&
+      // // user details is loaded
+      // !isLoading &&
       // TODO: create mobile version of admin feedback
       !isMobile &&
       // whether to show admin the feedback box
@@ -86,7 +86,6 @@ export const WorkspacePage = (): JSX.Element => {
       setIsAdminFeedbackEligible(false)
     }
   }, [
-    isLoading,
     currentTime,
     showAdminFeedback,
     setIsDisplayFeedback,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -24,28 +24,8 @@ import { WorkspaceProvider } from './WorkspaceProvider'
 export const CONTAINER_MAXW = '69.5rem'
 
 export const WorkspacePage = (): JSX.Element => {
-  const {
-    data: {
-      siteBannerContent,
-      adminBannerContent,
-      adminFeedbackDisplayFrequency,
-    } = {},
-  } = useEnv()
-  const { user, isLoading } = useUser()
-  const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
-  const isMobile = useIsMobile()
-
-  const adminFeedbackKey = useMemo(() => {
-    return ADMIN_FEEDBACK_HISTORY_PREFIX + user?._id
-  }, [user])
-
-  const [lastFeedbackTime, setLastFeedbackTime] =
-    useLocalStorage<number>(adminFeedbackKey)
-  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
-    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
-
-  // capture current time on page load to prevent re-renders from update to current time
-  const currentTime = useRef(Date.now())
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const { user } = useUser()
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
@@ -59,48 +39,6 @@ export const WorkspacePage = (): JSX.Element => {
   )
 
   const createFormModalDisclosure = useDisclosure()
-
-  // check if admin is eligible in current session
-  // and has yet to seen feedback beyond our stipulated frequency
-  const showAdminFeedback =
-    isAdminFeedbackEligible &&
-    // user details is loaded
-    !isLoading &&
-    // if feedbackTime has not been seen
-    (!lastFeedbackTime ||
-      // or if last feedback time seen is more than frequency (frequency env var must be defined)
-      (!!adminFeedbackDisplayFrequency &&
-        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
-
-  // sets display of feedback box
-  useEffect(() => {
-    if (
-      // // user details is loaded
-      // !isLoading &&
-      // TODO: create mobile version of admin feedback
-      !isMobile &&
-      // whether to show admin the feedback box
-      showAdminFeedback
-    ) {
-      setIsDisplayFeedback(true)
-      // reset local storage and admin feedback eligibility when admin feedback is displayed
-      setLastFeedbackTime(currentTime.current)
-      setIsAdminFeedbackEligible(false)
-    }
-  }, [
-    // isLoading,
-    currentTime,
-    showAdminFeedback,
-    setIsDisplayFeedback,
-    setLastFeedbackTime,
-    setIsAdminFeedbackEligible,
-    isMobile,
-  ])
-
-  const closeAdminFeedback = useCallback(
-    () => setIsDisplayFeedback(false),
-    [setIsDisplayFeedback],
-  )
 
   return (
     <>
@@ -121,6 +59,64 @@ export const WorkspacePage = (): JSX.Element => {
           />
         </WorkspaceProvider>
       </Flex>
+      {user && <AdminFeedbackContainer userId={user._id} />}
+    </>
+  )
+}
+
+const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
+  const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
+  const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
+  const isMobile = useIsMobile()
+
+  const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
+
+  const [lastFeedbackTime, setLastFeedbackTime] =
+    useLocalStorage<number>(adminFeedbackKey)
+  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
+    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
+
+  // capture current time on page load to prevent re-renders from update to current time
+  const currentTime = useRef(Date.now())
+
+  // check if admin is eligible in current session
+  // and has yet to seen feedback beyond our stipulated frequency
+  const showAdminFeedback =
+    isAdminFeedbackEligible &&
+    // if feedbackTime has not been seen
+    (!lastFeedbackTime ||
+      // or if last feedback time seen is more than frequency (frequency env var must be defined)
+      (!!adminFeedbackDisplayFrequency &&
+        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
+
+  // sets display of feedback box
+  useEffect(() => {
+    if (
+      // TODO: create mobile version of admin feedback
+      !isMobile &&
+      // whether to show admin the feedback box
+      showAdminFeedback
+    ) {
+      setIsDisplayFeedback(true)
+      // reset local storage and admin feedback eligibility when admin feedback is displayed
+      setLastFeedbackTime(currentTime.current)
+      setIsAdminFeedbackEligible(false)
+    }
+  }, [
+    currentTime,
+    showAdminFeedback,
+    setIsDisplayFeedback,
+    setLastFeedbackTime,
+    setIsAdminFeedbackEligible,
+    isMobile,
+  ])
+
+  const closeAdminFeedback = useCallback(
+    () => setIsDisplayFeedback(false),
+    [setIsDisplayFeedback],
+  )
+  return (
+    <>
       {isDisplayFeedback && <AdminFeedbackBox onClose={closeAdminFeedback} />}
     </>
   )

--- a/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
+++ b/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
@@ -94,8 +94,10 @@ const AdminFeedbackRatingContent = ({
   onRatingClick: (rating: AdminFeedbackRating) => void
 }) => {
   return (
-    <Stack direction="row" alignItems="center" gap="1.5rem">
-      <Text textStyle="h6">How was your form building experience?</Text>
+    <Stack direction="row" alignItems="center" gap="0.75rem">
+      <Text textStyle="h6" mr="0.75rem">
+        How was your form building experience?
+      </Text>
       <IconButton
         variant="clear"
         icon={<GoThumbsup />}

--- a/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
+++ b/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
@@ -94,7 +94,7 @@ const AdminFeedbackRatingContent = ({
   onRatingClick: (rating: AdminFeedbackRating) => void
 }) => {
   return (
-    <Stack direction="row" alignItems="center" gap="2.2rem">
+    <Stack direction="row" alignItems="center" gap="1.5rem">
       <Text textStyle="h6">How was your form building experience?</Text>
       <IconButton
         variant="clear"

--- a/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
+import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
+import { useIsMobile } from '~hooks/useIsMobile'
+import { useLocalStorage } from '~hooks/useLocalStorage'
+import { useSessionStorage } from '~hooks/useSessionStorage'
+
+import { useEnv } from '~features/env/queries'
+
+import AdminFeedbackBox from '../AdminFeedbackBox'
+
+export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
+  const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
+  const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
+  const isMobile = useIsMobile()
+
+  const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
+
+  const [lastFeedbackTime, setLastFeedbackTime] =
+    useLocalStorage<number>(adminFeedbackKey)
+  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
+    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
+
+  // capture current time on page load to prevent re-renders from update to current time
+  const currentTime = useRef(Date.now())
+
+  // check if admin is eligible in current session
+  // and has yet to seen feedback beyond our stipulated frequency
+  const showAdminFeedback =
+    isAdminFeedbackEligible &&
+    // if feedbackTime has not been seen
+    (!lastFeedbackTime ||
+      // or if last feedback time seen is more than frequency (frequency env var must be defined)
+      (!!adminFeedbackDisplayFrequency &&
+        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
+
+  // sets display of feedback box
+  useEffect(() => {
+    if (
+      // TODO: create mobile version of admin feedback
+      !isMobile &&
+      // whether to show admin the feedback box
+      showAdminFeedback
+    ) {
+      setIsDisplayFeedback(true)
+      // reset local storage and admin feedback eligibility when admin feedback is displayed
+      setLastFeedbackTime(currentTime.current)
+      setIsAdminFeedbackEligible(false)
+    }
+  }, [
+    currentTime,
+    showAdminFeedback,
+    setIsDisplayFeedback,
+    setLastFeedbackTime,
+    setIsAdminFeedbackEligible,
+    isMobile,
+  ])
+
+  const closeAdminFeedback = useCallback(
+    () => setIsDisplayFeedback(false),
+    [setIsDisplayFeedback],
+  )
+  return (
+    <>
+      {isDisplayFeedback && <AdminFeedbackBox onClose={closeAdminFeedback} />}
+    </>
+  )
+}

--- a/frontend/src/features/workspace/components/AdminFeedbackContainer/index.ts
+++ b/frontend/src/features/workspace/components/AdminFeedbackContainer/index.ts
@@ -1,0 +1,1 @@
+export { AdminFeedbackContainer as default } from './AdminFeedbackContainer'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

working on #6465 

We are pre-emptively setting `isDisplayAdminFeedback` when `lastFeedbackTime` is `undefined`. This undefine-ness is caused by our implementation of `useLocalStorage` that may return the previous key value. In this case `ADMIN_FEEDBACK_HISTORY_PREFIX + undefined'`. 

Also updated the design of the rating modal from @staceytan1998 's correction!

## Solution
<!-- How did you solve the problem? -->

Abstracted out a new container called `AdminFeedbackContainer` that will only be called if the `useUser` return is defined. hence the above case of `undefined` admin feedback prefix access will not happen. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
    - Not breaking as #6454 has been released 

## Tests
<!-- What tests should be run to confirm functionality? -->

**Ensure the fix is working** 
- [ ] check that admin feedback key is in local storage with a defined time
- [ ] check that admin feedback flag is true
- [ ] refresh the dashboard
- [ ] you should not see the feedback modal

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `ADMIN_FEEDBACK_FIELD_THRESHOLD` : (optional, default:5) threshold of the amount of fields in an active form, to enable eligibility of user for admin feedback
- `ADMIN_FEEDBACK_DISPLAY_FREQUENCY`: (optional, default:28 days in miliseconds) frequency to display the admin feedback to a user
