### PR TITLE
fix: handle and wrap stripe fetches in neverthrow

### DIFF
--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -1,5 +1,6 @@
 // Use 'stripe-event-types' for better type discrimination.
 /// <reference types="stripe-event-types" />
+import axios from 'axios'
 import cuid from 'cuid'
 import mongoose from 'mongoose'
 import { errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
@@ -15,11 +16,13 @@ import {
   IEncryptedFormSchema,
   IPaymentSchema,
   IPopulatedEncryptedForm,
+  IPopulatedForm,
 } from '../../../types'
 import config from '../../config/config'
 import { paymentConfig } from '../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { stripe } from '../../loaders/stripe'
+import { generatePdfFromHtml } from '../../utils/convert-html-to-pdf'
 import {
   getMongoErrorMessage,
   transformMongoError,
@@ -50,6 +53,7 @@ import {
 import {
   computePaymentState,
   computePayoutDetails,
+  convertToInvoiceFormat,
   getChargeIdFromNestedCharge,
   getMetadataPaymentId,
 } from './stripe.utils'
@@ -948,4 +952,58 @@ export const verifyPaymentStatusWithStripe = (
           })
       }
     })
+}
+
+export const generatePaymentInvoice = (
+  payment: IPaymentSchema,
+  populatedForm: IPopulatedEncryptedForm,
+): ResultAsync<Buffer, StripeFetchError> => {
+  if (!payment.completedPayment?.receiptUrl) {
+    return errAsync(new StripeFetchError('Receipt url not ready'))
+  }
+  return ResultAsync.fromPromise(
+    axios.get<string>(payment.completedPayment.receiptUrl),
+    (error) => new StripeFetchError(String(error)),
+  ).andThen((receiptUrlResponse) => {
+    // retrieve receiptURL as html
+    const html = receiptUrlResponse.data
+    const agencyBusinessInfo = (populatedForm as IPopulatedForm).admin.agency
+      .business
+    const formBusinessInfo = populatedForm.business
+
+    const businessAddress = [
+      formBusinessInfo?.address,
+      agencyBusinessInfo?.address,
+    ].find(Boolean)
+
+    const businessGstRegNo = [
+      formBusinessInfo?.gstRegNo,
+      agencyBusinessInfo?.gstRegNo,
+    ].find(Boolean)
+
+    // we will still continute the invoice generation even if there's no address/gstregno
+    if (!businessAddress || !businessGstRegNo)
+      logger.warn({
+        message:
+          'Some business info not available during invoice generation. Expecting either agency or form to have business info',
+        meta: {
+          action: 'downloadPaymentInvoice',
+          payment,
+          agencyName: populatedForm.admin.agency.fullName,
+          agencyBusinessInfo,
+          formBusinessInfo,
+        },
+      })
+    const invoiceHtml = convertToInvoiceFormat(html, {
+      address: businessAddress || '',
+      gstRegNo: businessGstRegNo || '',
+      formTitle: populatedForm.title,
+      submissionId: payment.completedPayment?.submissionId || '',
+    })
+
+    return ResultAsync.fromPromise(
+      generatePdfFromHtml(invoiceHtml),
+      (error) => new StripeFetchError(String(error)),
+    )
+  })
 }


### PR DESCRIPTION
## Problem
When downloading stripe invoice, especially dated invoices (>3months back) the download API would crash and show a cloudflare 502(!!) to the user.

This behaviour is unexpected, and unfriendly as the user does not have any way to redress this situation.

Closes FRM-1074

## Solution

Check if API returns error, and catch the error with `mapErr`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**BEFORE**:
![Screenshot 2023-06-27 at 10 20 23 PM](https://github.com/opengovsg/FormSG/assets/12391617/415b8f5c-0078-4386-8489-f29b3c75ace3)

**AFTER**:
![Screenshot 2023-06-27 at 10 19 59 PM](https://github.com/opengovsg/FormSG/assets/12391617/b9e8b760-6c15-4df3-a43a-8a4c585c8188)

## Tests
**Regressions**
Ensuring that valid invoices downloads are still downloadable
As a form admin
- [ ] invoice is downloadable
As a responder
- [ ] make payment on a payment form
- [ ] invoice is downloadable

**Feature Test** (not strictly required to pass in pre-deployment check)
Ensure that expired invoices download doesn't crash (show cloudflare 502s)
As a form admin
- [ ] download of invalid invoice shows a BE error message of `StripeFetchError` to the browser instead of CF 502
