### PR TITLE
feat: decouple otp validation and restrict email domain

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -81,7 +81,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     },
   })
 
-  const watchedIsVerifiable = watch('isVerifiable')
   const watchedHasAllowedEmailDomains = watch('hasAllowedEmailDomains')
   const watchedHasAutoReply = watch('autoReplyOptions.hasAutoReply')
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import { RegisterOptions } from 'react-hook-form'
 import { Box, FormControl, useMergeRefs } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -85,15 +85,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
   const watchedHasAllowedEmailDomains = watch('hasAllowedEmailDomains')
   const watchedHasAutoReply = watch('autoReplyOptions.hasAutoReply')
 
-  // Use separate state for whether toggle is enabled so we can disable
-  // the toggle only after it is set to false. Otherwise, we get the
-  // following bug:
-  // 1. Enable both OTP verification and email domain validation
-  // 2. Disable OTP verification
-  // 3. Now hasAllowedEmailDomains is true but the toggle is disabled
-  const [isDomainToggleEnabled, setIsDomainToggleEnabled] =
-    useState(watchedIsVerifiable)
-
   const requiredValidationRule = useMemo(
     () => createBaseValidationRules({ required: true }),
     [],
@@ -108,15 +99,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     hasAllowedEmailDomainsRef,
     allowedEmailDomainsRegister.ref,
   )
-  useEffect(() => {
-    // Verification must be enabled for domain validation
-    // We cannot simply use setValue as it does not update
-    // the UI
-    if (!watchedIsVerifiable && watchedHasAllowedEmailDomains) {
-      hasAllowedEmailDomainsRef.current?.click()
-    }
-    setIsDomainToggleEnabled(watchedIsVerifiable)
-  }, [watchedIsVerifiable, watchedHasAllowedEmailDomains])
 
   const emailDomainsValidation = useMemo<
     RegisterOptions<EditEmailInputs, 'allowedEmailDomains'>
@@ -186,8 +168,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
             {...allowedEmailDomainsRegister}
             ref={mergedAllowedEmailDomainsRef}
             label="Restrict email domains"
-            description="OTP verification needs to be enabled first"
-            isDisabled={!isDomainToggleEnabled}
           />
         </FormControl>
         {watchedHasAllowedEmailDomains && (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -484,9 +484,7 @@ export const baseEmailValidationFn =
     if (!validator.isEmail(trimmedInputValue)) return INVALID_EMAIL_ERROR
 
     // Valid domain check
-    const allowedDomains = schema.isVerifiable
-      ? new Set(schema.allowedEmailDomains)
-      : new Set()
+    const allowedDomains = new Set(schema.allowedEmailDomains)
     if (allowedDomains.size !== 0) {
       const domainInValue = trimmedInputValue.split('@')[1].toLowerCase()
       if (domainInValue && !allowedDomains.has(`@${domainInValue}`)) {

--- a/scripts/20230703_email-domain-cleanup/script.js
+++ b/scripts/20230703_email-domain-cleanup/script.js
@@ -1,0 +1,60 @@
+/* eslint-disable */
+
+// This script cleans up form_fields with hasAllowedEmailDomains = true but allowedEmailDomains is empty
+
+// BEFORE
+// count number of forms with form_fields where hasAllowedEmailDomains = true and allowedEmailDomains is empty
+
+db.getCollection('forms').find({
+  form_fields: {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: { $in: [true], $exists: true },
+      allowedEmailDomains: { $eq: [], $exists: true },
+    },
+  },
+})
+
+// UPDATE
+// Number of documents updated should match the count in BEFORE
+
+db.getCollection('forms').updateMany(
+  {
+    form_fields: {
+      $elemMatch: {
+        fieldType: 'email',
+        hasAllowedEmailDomains: { $in: [true], $exists: true },
+        allowedEmailDomains: { $eq: [], $exists: true },
+      },
+    },
+  },
+  {
+    $set: {
+      'form_fields.$[elem].hasAllowedEmailDomains': false,
+    },
+  },
+  {
+    arrayFilters: [
+      {
+        'elem.fieldType': 'email',
+        'elem.hasAllowedEmailDomains': { $in: [true], $exists: true },
+        'elem.allowedEmailDomains': { $eq: [], $exists: true },
+      },
+    ],
+    multi: true,
+  },
+)
+
+// AFTER
+// count number of forms with form_fields where hasAllowedEmailDomains = true and allowedEmailDomains is empty
+// Expect 0
+
+db.getCollection('forms').find({
+  form_fields: {
+    $elemMatch: {
+      fieldType: 'email',
+      hasAllowedEmailDomains: { $in: [true], $exists: true },
+      allowedEmailDomains: { $eq: [], $exists: true },
+    },
+  },
+})

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -35,82 +35,169 @@ describe('Form Field Schema', () => {
   afterEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  describe('Short Text Field', () => {
-    describe('prefill', () => {
-      it('should allow creation of short text field with no prefill setting and populate prefill settings with default', async () => {
+  describe('Email Field', () => {
+    describe('restrict email domains', () => {
+      it('should allow email field with isVerifiable true and hasAllowedEmailDomains false with empty allowedEmailDomains', async () => {
         // Arrange
         const field = await createAndReturnFormField({
-          fieldType: BasicField.ShortText,
+          fieldType: BasicField.Email,
+          isVerifiable: true,
+          hasAllowedEmailDomains: false,
+          allowedEmailDomains: [],
         })
 
         // Assert
         const fieldObj = field.toObject()
-        expect(fieldObj).toHaveProperty('allowPrefill', false)
-        expect(fieldObj).toHaveProperty('lockPrefill', false)
+        expect(fieldObj).toHaveProperty('isVerifiable', true)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', false)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', [])
       })
 
-      it('should allow creation of short text field with allowPrefill = false setting and populate lockPrefill settings with default', async () => {
+      it('should allow email field with isVerifiable true and hasAllowedEmailDomains true with non-empty allowedEmailDomains', async () => {
         // Arrange
         const field = await createAndReturnFormField({
-          fieldType: BasicField.ShortText,
-          allowPrefill: false,
+          fieldType: BasicField.Email,
+          isVerifiable: true,
+          hasAllowedEmailDomains: true,
+          allowedEmailDomains: ['@example.com'],
         })
 
         // Assert
         const fieldObj = field.toObject()
-        expect(fieldObj).toHaveProperty('allowPrefill', false)
-        expect(fieldObj).toHaveProperty('lockPrefill', false)
+        expect(fieldObj).toHaveProperty('isVerifiable', true)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', true)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', ['@example.com'])
       })
 
-      it('should allow creation of short text field with allowPrefill = true setting and populate lockPrefill settings with default', async () => {
+      it('should allow email field with isVerifiable false and hasAllowedEmailDomains false with empty allowedEmailDomains', async () => {
         // Arrange
         const field = await createAndReturnFormField({
-          fieldType: BasicField.ShortText,
-          allowPrefill: true,
+          fieldType: BasicField.Email,
+          isVerifiable: false,
+          hasAllowedEmailDomains: false,
+          allowedEmailDomains: [],
         })
 
         // Assert
         const fieldObj = field.toObject()
-        expect(fieldObj).toHaveProperty('allowPrefill', true)
-        expect(fieldObj).toHaveProperty('lockPrefill', false)
+        expect(fieldObj).toHaveProperty('isVerifiable', false)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', false)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', [])
       })
 
-      it('should allow creation of short text field with allowPrefill = true and lockPrefill = true settings', async () => {
-        // Arrange
-        const field = await createAndReturnFormField({
-          fieldType: BasicField.ShortText,
-          allowPrefill: true,
-          lockPrefill: true,
-        })
-
-        // Assert
-        const fieldObj = field.toObject()
-        expect(fieldObj).toHaveProperty('allowPrefill', true)
-        expect(fieldObj).toHaveProperty('lockPrefill', true)
-      })
-
-      it('should not allow creation of short text field with allowPrefill = false and lockPrefill = true settings', async () => {
+      it('should throw an error for email field with isVerifiable true and hasAllowedEmailDomains false with non-empty allowedEmailDomains', async () => {
         // Arrange
         const createField = async () => {
           const field = await createAndReturnFormField({
-            fieldType: BasicField.ShortText,
-            allowPrefill: false,
-            lockPrefill: true,
+            fieldType: BasicField.Email,
+            isVerifiable: true,
+            hasAllowedEmailDomains: false,
+            allowedEmailDomains: ['@example.com'],
           })
-
           return field
         }
 
-        // Act
-        const createFieldPromise = createField()
+        // Assert
+        await expect(createField).rejects.toThrow(
+          'List of allowed email domains should be empty if restrict email domains is disabled',
+        )
+      })
+
+      it('should throw an error for email field with isVerifiable false and hasAllowedEmailDomains false with non-empty allowedEmailDomains', async () => {
+        // Arrange
+        const createField = async () => {
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.Email,
+            isVerifiable: false,
+            hasAllowedEmailDomains: false,
+            allowedEmailDomains: ['@example.com'],
+          })
+          return field
+        }
 
         // Assert
-        await expect(createFieldPromise).rejects.toThrow(
-          'Cannot lock prefill if prefill is not enabled',
+        await expect(createField).rejects.toThrow(
+          'List of allowed email domains should be empty if restrict email domains is disabled',
         )
       })
     })
   }),
+    describe('Short Text Field', () => {
+      describe('prefill', () => {
+        it('should allow creation of short text field with no prefill setting and populate prefill settings with default', async () => {
+          // Arrange
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.ShortText,
+          })
+
+          // Assert
+          const fieldObj = field.toObject()
+          expect(fieldObj).toHaveProperty('allowPrefill', false)
+          expect(fieldObj).toHaveProperty('lockPrefill', false)
+        })
+
+        it('should allow creation of short text field with allowPrefill = false setting and populate lockPrefill settings with default', async () => {
+          // Arrange
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.ShortText,
+            allowPrefill: false,
+          })
+
+          // Assert
+          const fieldObj = field.toObject()
+          expect(fieldObj).toHaveProperty('allowPrefill', false)
+          expect(fieldObj).toHaveProperty('lockPrefill', false)
+        })
+
+        it('should allow creation of short text field with allowPrefill = true setting and populate lockPrefill settings with default', async () => {
+          // Arrange
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.ShortText,
+            allowPrefill: true,
+          })
+
+          // Assert
+          const fieldObj = field.toObject()
+          expect(fieldObj).toHaveProperty('allowPrefill', true)
+          expect(fieldObj).toHaveProperty('lockPrefill', false)
+        })
+
+        it('should allow creation of short text field with allowPrefill = true and lockPrefill = true settings', async () => {
+          // Arrange
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.ShortText,
+            allowPrefill: true,
+            lockPrefill: true,
+          })
+
+          // Assert
+          const fieldObj = field.toObject()
+          expect(fieldObj).toHaveProperty('allowPrefill', true)
+          expect(fieldObj).toHaveProperty('lockPrefill', true)
+        })
+
+        it('should not allow creation of short text field with allowPrefill = false and lockPrefill = true settings', async () => {
+          // Arrange
+          const createField = async () => {
+            const field = await createAndReturnFormField({
+              fieldType: BasicField.ShortText,
+              allowPrefill: false,
+              lockPrefill: true,
+            })
+
+            return field
+          }
+
+          // Act
+          const createFieldPromise = createField()
+
+          // Assert
+          await expect(createFieldPromise).rejects.toThrow(
+            'Cannot lock prefill if prefill is not enabled',
+          )
+        })
+      })
+    }),
     describe('Methods', () => {
       describe('getQuestion', () => {
         it('should return field title when field type is not a table field', async () => {

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -69,22 +69,6 @@ describe('Form Field Schema', () => {
         expect(fieldObj).toHaveProperty('allowedEmailDomains', ['@example.com'])
       })
 
-      it('should allow email field with isVerifiable false and hasAllowedEmailDomains false with empty allowedEmailDomains', async () => {
-        // Arrange
-        const field = await createAndReturnFormField({
-          fieldType: BasicField.Email,
-          isVerifiable: false,
-          hasAllowedEmailDomains: false,
-          allowedEmailDomains: [],
-        })
-
-        // Assert
-        const fieldObj = field.toObject()
-        expect(fieldObj).toHaveProperty('isVerifiable', false)
-        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', false)
-        expect(fieldObj).toHaveProperty('allowedEmailDomains', [])
-      })
-
       it('should throw an error for email field with isVerifiable true and hasAllowedEmailDomains false with non-empty allowedEmailDomains', async () => {
         // Arrange
         const createField = async () => {
@@ -103,6 +87,40 @@ describe('Form Field Schema', () => {
         )
       })
 
+      it('should throw an error for email field with isVerifiable true and hasAllowedEmailDomains true with empty allowedEmailDomains', async () => {
+        // Arrange
+        const createField = async () => {
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.Email,
+            isVerifiable: true,
+            hasAllowedEmailDomains: true,
+            allowedEmailDomains: [],
+          })
+          return field
+        }
+
+        // Assert
+        await expect(createField).rejects.toThrow(
+          'List of allowed email domains should not be empty if restrict email domains is enabled',
+        )
+      })
+
+      it('should allow email field with isVerifiable false and hasAllowedEmailDomains false with empty allowedEmailDomains', async () => {
+        // Arrange
+        const field = await createAndReturnFormField({
+          fieldType: BasicField.Email,
+          isVerifiable: false,
+          hasAllowedEmailDomains: false,
+          allowedEmailDomains: [],
+        })
+
+        // Assert
+        const fieldObj = field.toObject()
+        expect(fieldObj).toHaveProperty('isVerifiable', false)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', false)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', [])
+      })
+
       it('should throw an error for email field with isVerifiable false and hasAllowedEmailDomains false with non-empty allowedEmailDomains', async () => {
         // Arrange
         const createField = async () => {
@@ -119,6 +137,40 @@ describe('Form Field Schema', () => {
         await expect(createField).rejects.toThrow(
           'List of allowed email domains should be empty if restrict email domains is disabled',
         )
+      })
+
+      it('should throw an error for email field with isVerifiable false and hasAllowedEmailDomains true with empty allowedEmailDomains', async () => {
+        // Arrange
+        const createField = async () => {
+          const field = await createAndReturnFormField({
+            fieldType: BasicField.Email,
+            isVerifiable: false,
+            hasAllowedEmailDomains: true,
+            allowedEmailDomains: [],
+          })
+          return field
+        }
+
+        // Assert
+        await expect(createField).rejects.toThrow(
+          'List of allowed email domains should not be empty if restrict email domains is enabled',
+        )
+      })
+
+      it('should allow email field with isVerifiable false and hasAllowedEmailDomains true with non-empty allowedEmailDomains', async () => {
+        // Arrange
+        const field = await createAndReturnFormField({
+          fieldType: BasicField.Email,
+          isVerifiable: false,
+          hasAllowedEmailDomains: true,
+          allowedEmailDomains: ['@example.com'],
+        })
+
+        // Assert
+        const fieldObj = field.toObject()
+        expect(fieldObj).toHaveProperty('isVerifiable', false)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', true)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', ['@example.com'])
       })
     })
   }),

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -79,6 +79,20 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
           message:
             'List of allowed email domains should be empty if restrict email domains is disabled',
         },
+        // Check that allowedEmailDomains is not empty if hasAllowedEmailDomains is true
+        {
+          validator: function (this: IEmailFieldSchema): boolean {
+            if (
+              this.hasAllowedEmailDomains &&
+              this.allowedEmailDomains.length === 0
+            ) {
+              return false
+            }
+            return true
+          },
+          message:
+            'List of allowed email domains should not be empty if restrict email domains is enabled',
+        },
       ],
     },
   })

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -57,12 +57,29 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
       ],
       // If allowedEmailDomains is empty, then all email domains should be allowed.
       default: [],
-      validate: {
-        validator: (emailDomains: string[]): boolean => {
-          return validateEmailDomains(emailDomains)
+      validate: [
+        // Check for duplicate or invalid email domains
+        {
+          validator: (emailDomains: string[]): boolean => {
+            return validateEmailDomains(emailDomains)
+          },
+          message: 'There are one or more duplicate or invalid email domains.',
         },
-        message: 'There are one or more duplicate or invalid email domains.',
-      },
+        // Check that allowedEmailDomains is empty if hasAllowedEmailDomains is false
+        {
+          validator: function (this: IEmailFieldSchema): boolean {
+            if (
+              !this.hasAllowedEmailDomains &&
+              this.allowedEmailDomains.length !== 0
+            ) {
+              return false
+            }
+            return true
+          },
+          message:
+            'List of allowed email domains should be empty if restrict email domains is disabled',
+        },
+      ],
     },
   })
 

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -267,7 +267,7 @@ describe('Email field validation', () => {
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
-  it('should allow any valid email address when isVerifiable is true and hasAllowedEmailDomains is false, regardless of the cardinality of allowedEmailDomains', () => {
+  it('should allow any valid email address not in allowedEmailDomains when isVerifiable is true and hasAllowedEmailDomains is false, regardless of the cardinality of allowedEmailDomains', () => {
     const formField = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -295,7 +295,35 @@ describe('Email field validation', () => {
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
-  it('should allow any valid email address when isVerifiable is false and hasAllowedEmailDomains is true, regardless of the cardinality of allowedEmailDomains', () => {
+  it('should allow any email address with a domain in allowedEmailDomains when isVerifiable is true and hasAllowedEmailDomains is false, and allowedEmailDomains is not empty', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: true,
+      hasAllowedEmailDomains: false,
+      allowedEmailDomains: ['@example.com', '@test.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'volunteer-testing@test.gov.sg',
+      signature: 'some signature',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should not allow email address which are not in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is true, if allowedEmailDomains is not empty', () => {
     const formField = {
       _id: 'abc123',
       fieldType: BasicField.Email,
@@ -318,10 +346,119 @@ describe('Email field validation', () => {
       formField,
       response as ProcessedFieldResponse,
     )
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
+  it('should allow email address which are in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is true, if allowedEmailDomains is not empty', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@example.com', '@test.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'volunteer-testing@test.gov.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
+  it('should allow any valid email address when isVerifiable is false and hasAllowedEmailDomains is true if allowedEmailDomains is empty', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: [],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'volunteer-testing@test.gov.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow any valid email address not in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is false and  allowedEmailDomains is not empty', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: false,
+      allowedEmailDomains: ['@example.com'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'volunteer-testing@test.gov.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow any valid email address  in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is false and  allowedEmailDomains is not empty', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: false,
+      allowedEmailDomains: ['@example.com', '@test.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'volunteer-testing@test.gov.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
   it('should disallow responses submitted for hidden fields', () => {
     const formField = {
       _id: 'abc123',

--- a/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/src/app/utils/field-validation/validators/emailValidator.ts
@@ -32,11 +32,10 @@ const emailFormatValidator: EmailValidator = (response) => {
  */
 const makeEmailDomainValidator: EmailValidatorConstructor =
   (emailField) => (response) => {
-    const { isVerifiable, hasAllowedEmailDomains, allowedEmailDomains } =
-      emailField
+    const { hasAllowedEmailDomains, allowedEmailDomains } = emailField
     const { answer } = response
     const emailAddress = String(answer).trim()
-    if (!(isVerifiable && hasAllowedEmailDomains && allowedEmailDomains.length))
+    if (!(hasAllowedEmailDomains && allowedEmailDomains.length))
       return right(response)
     const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
 


### PR DESCRIPTION
## Problem
Closes FRM-1064


## Solution
- Removed coupling between OTP validation and restrict email domain
- Updated validators
- Added unit tests
- Added model level checks for consistency in the state of `hasAllowedEmailDomains` and `allowedEmailDomains`

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

- **If the PR is rolled-back**, we may have forms with restrict email domain enabled and _without_ OTP validation. In such a case, email domain restriction will not apply, as the previous code disregards email domain restriction if OTP validation is disabled.


## Before & After Screenshots

**BEFORE**:
<img width="324" alt="Screenshot 2023-06-29 at 10 19 33 PM" src="https://github.com/opengovsg/FormSG/assets/63710093/182c4d49-68bd-4457-aaae-27327c8815b0">

**AFTER**:

<img width="325" alt="Screenshot 2023-06-29 at 10 17 19 PM" src="https://github.com/opengovsg/FormSG/assets/63710093/78dd3cda-43db-4b5e-889f-f29391e20f19">

## Tests
- [ ] Can create email field without otp verification and without restrict email domain and submit form
- [ ] Can create email field with otp verification and without restrict email domain and submit form
- [ ] Can create email field without otp verification and with restrict email domain and submit form
  - [ ] Whitelisted domains submit successfully
  - [ ] Non-whitelisted domains blocked by frontend
  - [ ] Non-whitelisted domains blocked by backend
- [ ] (via network call) attempting to create email field with `hasAllowedEmailDomains` true and `allowedEmailDomains` nonEmpty will result in error with message `List of allowed email domains should be empty if restrict email domains is disabled`

## Scripts

There are 23 documents with invalid state for `hasAllowedEmailDomains = true` but `allowedEmailDomains = []`. Will have to run a DB migration script [f437212](https://github.com/opengovsg/FormSG/pull/6497/commits/f437212bcfb9fdc46d593cbaa857ee18c6ebf41c)