### PR TITLE
feat: check new owner email domain before transferring form ownership

### DIFF
--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -10,6 +10,7 @@ import {
   IUserSchema,
   PublicUser,
 } from '../../types'
+import { getEmailDomainFromEmail } from '../utils/email-domain'
 
 import getAgencyModel, { AGENCY_SCHEMA_ID } from './agency.server.model'
 
@@ -36,7 +37,7 @@ const compileUserModel = (db: Mongoose) => {
               return false
             }
 
-            const emailDomain = value.split('@').pop()
+            const emailDomain = getEmailDomainFromEmail(value)
             try {
               const agency = await Agency.findOne({ emailDomain })
               return !!agency

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -4,6 +4,8 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync, Result, ResultAsync } from 'neverthrow'
 import validator from 'validator'
 
+import { getEmailDomainFromEmail } from 'src/app/utils/email-domain'
+
 import { SUPPORT_FORM_LINK } from '../../../../shared/constants/links'
 import {
   AgencyDocument,
@@ -62,7 +64,7 @@ export const validateEmailDomain = (
     return errAsync(new InvalidDomainError())
   }
 
-  const emailDomain = email.split('@').pop()
+  const emailDomain = getEmailDomainFromEmail(email)
   return ResultAsync.fromPromise(
     AgencyModel.findOne({ emailDomain }).exec(),
     (error) => {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -579,6 +579,13 @@ describe('admin-form.service', () => {
       email: MOCK_NEW_OWNER_EMAIL,
     } as IUserSchema
 
+    beforeEach(() => {
+      const findAgencySpy = jest.spyOn(AgencyModel, 'findOne')
+      // Return a truthy value to ensure that the find is successful
+      // @ts-ignore
+      findAgencySpy.mockResolvedValueOnce({})
+    })
+
     it('should return updated form with new owner successfully', async () => {
       // Arrange
       const expectedPopulateResult = {

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1048,7 +1048,19 @@ export const transferFormOwnership: ControllerHandler<
         AdminFormService.transferFormOwnership(retrievedForm, newOwnerEmail),
       )
       // Success, return updated form.
-      .map((updatedPopulatedForm) => res.json({ form: updatedPopulatedForm }))
+      .map((updatedPopulatedForm) => {
+        logger.info({
+          message: 'Form ownership transferred',
+          meta: {
+            action: 'transferFormOwnership',
+            ...createReqMeta(req),
+            userId: sessionUserId,
+            formId,
+            newOwnerEmail,
+          },
+        })
+        return res.json({ form: updatedPopulatedForm })
+      })
       // Some error occurred earlier in the chain.
       .mapErr((error) => {
         logger.error({

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -10,6 +10,8 @@ import mongoose, { ClientSession } from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import type { Except, Merge } from 'type-fest'
 
+import { getEmailDomainFromEmail } from 'src/app/utils/email-domain'
+
 import {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
@@ -328,7 +330,7 @@ export const transferFormOwnership = (
     newOwnerEmail,
   }
 
-  const emailDomain = newOwnerEmail.split('@').pop()
+  const emailDomain = getEmailDomainFromEmail(newOwnerEmail)
   return ResultAsync.fromPromise(
     AgencyModel.findOne({ emailDomain }),
     (error) => {
@@ -830,7 +832,7 @@ export const updateFormCollaborators = (
     // Check that all updated collaborator domains exist in the Agency collection.
     Promise.all(
       updatedCollaboratorEmails.map(async (email) => {
-        const emailDomain = email.split('@').pop()
+        const emailDomain = getEmailDomainFromEmail(email)
         const result = await AgencyModel.findOne({ emailDomain })
         return !!result
       }),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -328,75 +328,104 @@ export const transferFormOwnership = (
     newOwnerEmail,
   }
 
-  return (
-    // Step 1: Retrieve current owner of form to transfer.
-    UserService.findUserById(String(currentForm.admin._id))
-      .andThen((currentOwner) => {
-        // No need to transfer form ownership if new and current owners are
-        // the same.
-        if (newOwnerEmail.toLowerCase() === currentOwner.email.toLowerCase()) {
-          return errAsync(
-            new TransferOwnershipError(
-              'You are already the owner of this form',
-            ),
-          )
-        }
-        return okAsync(currentOwner)
+  const emailDomain = newOwnerEmail.split('@').pop()
+  return ResultAsync.fromPromise(
+    AgencyModel.findOne({ emailDomain }),
+    (error) => {
+      logger.error({
+        message: 'Error encountered while validating new form owner',
+        meta: logMeta,
+        error,
       })
-      .andThen((currentOwner) =>
-        // Step 2: Retrieve user document for new owner.
-        UserService.findUserByEmail(newOwnerEmail)
-          .mapErr((error) => {
-            logger.error({
-              message:
-                'Error occurred whilst finding new owner email to transfer ownership to',
-              meta: logMeta,
-              error,
-            })
-
-            // Override MissingUserError with more specific message if new owner
-            // cannot be found.
-            if (error instanceof MissingUserError) {
-              return new TransferOwnershipError(
-                `${newOwnerEmail} must have logged in once before being added as Owner`,
-              )
-            }
-            return error
-          })
-          // Step 3: Perform form ownership transfer.
-          .andThen((newOwner) =>
-            ResultAsync.fromPromise(
-              currentForm.transferOwner<IPopulatedForm>(currentOwner, newOwner),
-              (error) => {
-                logger.error({
-                  message: 'Error occurred whilst transferring form ownership',
-                  meta: logMeta,
-                  error,
-                })
-
-                return new DatabaseError(getMongoErrorMessage(error))
-              },
-            ),
-          ),
-      )
-      // Step 4: Populate updated form.
-      .andThen((updatedForm) =>
-        ResultAsync.fromPromise(
-          updatedForm
-            .populate({ path: 'admin', populate: { path: 'agency' } })
-            .execPopulate(),
-          (error) => {
-            logger.error({
-              message: 'Error occurred whilst populating form with admin',
-              meta: logMeta,
-              error,
-            })
-
-            return new DatabaseError(getMongoErrorMessage(error))
-          },
-        ),
-      )
+      return transformMongoError(error)
+    },
   )
+    .andThen((result) => {
+      if (!result) {
+        return errAsync(
+          new TransferOwnershipError(
+            `The new owner email (${newOwnerEmail}) is not from a whitelisted domain`,
+          ),
+        )
+      }
+      return okAsync(undefined)
+    })
+
+    .andThen(() =>
+      // Step 1: Retrieve current owner of form to transfer.
+      UserService.findUserById(String(currentForm.admin._id))
+        .andThen((currentOwner) => {
+          // No need to transfer form ownership if new and current owners are
+          // the same.
+          if (
+            newOwnerEmail.toLowerCase() === currentOwner.email.toLowerCase()
+          ) {
+            return errAsync(
+              new TransferOwnershipError(
+                'You are already the owner of this form',
+              ),
+            )
+          }
+          return okAsync(currentOwner)
+        })
+        .andThen((currentOwner) =>
+          // Step 2: Retrieve user document for new owner.
+          UserService.findUserByEmail(newOwnerEmail)
+            .mapErr((error) => {
+              logger.error({
+                message:
+                  'Error occurred whilst finding new owner email to transfer ownership to',
+                meta: logMeta,
+                error,
+              })
+
+              // Override MissingUserError with more specific message if new owner
+              // cannot be found.
+              if (error instanceof MissingUserError) {
+                return new TransferOwnershipError(
+                  `${newOwnerEmail} must have logged in once before being added as Owner`,
+                )
+              }
+              return error
+            })
+            // Step 3: Perform form ownership transfer.
+            .andThen((newOwner) =>
+              ResultAsync.fromPromise(
+                currentForm.transferOwner<IPopulatedForm>(
+                  currentOwner,
+                  newOwner,
+                ),
+                (error) => {
+                  logger.error({
+                    message:
+                      'Error occurred whilst transferring form ownership',
+                    meta: logMeta,
+                    error,
+                  })
+
+                  return new DatabaseError(getMongoErrorMessage(error))
+                },
+              ),
+            ),
+        )
+        // Step 4: Populate updated form.
+        .andThen((updatedForm) =>
+          ResultAsync.fromPromise(
+            updatedForm
+              .populate({ path: 'admin', populate: { path: 'agency' } })
+              .execPopulate(),
+            (error) => {
+              logger.error({
+                message: 'Error occurred whilst populating form with admin',
+                meta: logMeta,
+                error,
+              })
+
+              return new DatabaseError(getMongoErrorMessage(error))
+            },
+          ),
+        ),
+    )
 }
 
 /**

--- a/src/app/utils/email-domain.ts
+++ b/src/app/utils/email-domain.ts
@@ -1,0 +1,3 @@
+export const getEmailDomainFromEmail = (email: string) => {
+  return email.split('@').pop()
+}

--- a/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/src/app/utils/field-validation/validators/emailValidator.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../types/field'
 import { ResponseValidator } from '../../../../types/field/utils/validation'
 import { ProcessedSingleAnswerResponse } from '../../../modules/submission/submission.types'
+import { getEmailDomainFromEmail } from '../../email-domain'
 
 import { makeSignatureValidator, notEmptySingleAnswerResponse } from './common'
 
@@ -38,7 +39,9 @@ const makeEmailDomainValidator: EmailValidatorConstructor =
     const emailAddress = String(answer).trim()
     if (!(isVerifiable && hasAllowedEmailDomains && allowedEmailDomains.length))
       return right(response)
-    const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
+    const emailDomain = (
+      '@' + getEmailDomainFromEmail(emailAddress)
+    ).toLowerCase()
 
     return allowedEmailDomains.some(
       (domain) => domain.toLowerCase() === emailDomain,


### PR DESCRIPTION
## Problem

(Don't know if this issue has been worked on, but I've been working on a related feature (#34) which might have expected this issue to be part of the scope at first.)

Problem description: Unlike `updateFormCollaborators`, in `transferFormOwnership`, the new owner's email domain is not checked against the `AgencyModel`. We should check.

Might resolve #5971

## Solution

Copy the email domain check from `updateFormCollaborators` but do it at the start of `transferFormOwnership`.

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:

- Consolidated all `.split('@').pop()` with the same intent into a utility function `getEmailDomainFromEmail`.

## Tests

TBC
