### PR TITLE
fix: dropdown menu rendering above headers

### DIFF
--- a/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
+++ b/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
@@ -4,6 +4,7 @@ import {
   autoUpdate,
   flip,
   hide,
+  Middleware,
   offset,
   size,
   useFloating,
@@ -18,35 +19,61 @@ export const SelectPopoverProvider: FC = ({ children }): JSX.Element => {
 
   const wrapperRef = useRef<HTMLDivElement | null>(null)
 
-  const { x, y, refs, reference, floating, strategy, update } = useFloating({
-    placement: 'bottom-start',
-    strategy: 'absolute',
-    open: isOpen,
-    middleware: [
-      // offset middleware should be the first middleware
-      offset(1),
-      flip(),
-      hide(),
-      // Set width to be the same as the reference element.
-      size({
-        apply({ rects, elements }) {
-          Object.assign(elements.floating.style, {
-            width: `${rects.reference.width}px`,
-          })
+  // Custom hide middleware that ensures dropdown options are hidden correctly
+  // by the sliding MiniHeader in public form pages.
+  const hideWhenCoveredByHeader: Middleware = {
+    name: 'hideWhenCoveredByHeader',
+    fn(state) {
+      const { reference } = state.elements
+      const { ownerDocument } = reference as Element
+      const { x, y, height } = reference.getBoundingClientRect()
+      // Get className of all elements that cover the bottom-left corner of the combobox
+      const elementsClassName = ownerDocument
+        .elementsFromPoint(x, y + height)
+        .map((e: Element) => e.className)
+      return {
+        data: {
+          isCovered: elementsClassName.includes('chakra-slide'),
         },
-      }),
-    ],
-  })
+      }
+    },
+  }
+
+  const { x, y, refs, reference, floating, strategy, update, middlewareData } =
+    useFloating({
+      placement: 'bottom-start',
+      strategy: 'absolute',
+      open: isOpen,
+      middleware: [
+        // offset middleware should be the first middleware
+        offset(1),
+        flip(),
+        hide(),
+        hideWhenCoveredByHeader,
+        // Set width to be the same as the reference element.
+        size({
+          apply({ rects, elements }) {
+            Object.assign(elements.floating.style, {
+              width: `${rects.reference.width}px`,
+            })
+          },
+        }),
+      ],
+    })
 
   const mergedReferenceRefs = useMergeRefs(reference, wrapperRef)
 
+  const { referenceHidden } = middlewareData.hide || {}
+  const { isCovered } = middlewareData.hideWhenCoveredByHeader || {}
+
   const floatingStyles = useMemo(
     () => ({
+      visibility: referenceHidden || isCovered ? 'hidden' : 'visible',
       position: strategy,
       top: y ?? 0,
       left: x ?? 0,
     }),
-    [strategy, x, y],
+    [referenceHidden, isCovered, strategy, x, y],
   )
 
   // Allows


### PR DESCRIPTION
## Problem
Currently, dropdown menus are being rendered above sticky headers when scrolling. This behaviour can be seen during form creation and in public forms.

This was caused by `FloatingPortal` in `SelectMenu.tsx` which portals the dropdown menu into the document body, making it render above everything else in the app.

Closes #6026 

## Solution
<!-- How did you solve the problem? -->

Remove `FloatingPortal`, then assign the `dropdown` z-index value from Chakra UI to the menu, ensuring it still renders above other elements appropriately.

Side-notes:

- Suppression of ref error is removed since a portal is no longer used.
- I believe the current public form header uses the wrong z-index value, currently it is 1000 which corresponds to `dropdown` in Chakra UI instead of 1100 for `sticky`.

 
**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x]  No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/opengovsg/FormSG/assets/11293086/5e06757f-5eef-4c8d-8398-4f4dcb909c85)

**AFTER**:
![image](https://github.com/opengovsg/FormSG/assets/11293086/f09a92c4-557c-42fc-9fe0-2cfbc817ec39)

## Tests
- [ ] Create a form with a dropdown field, ensure dropdown field does not render above sticky headers