### PR TITLE
refactor: Fix backwards compatibility issues with Turnstile integration

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -21,6 +21,7 @@ import {
   PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID,
 } from '~shared/constants'
 import { PaymentType } from '~shared/types'
+import { CaptchaTypes } from '~shared/types/captcha'
 import {
   FormAuthType,
   FormResponseMode,
@@ -143,12 +144,8 @@ export const PublicFormProvider = ({
   // todo: remove after full rollout
   const enableTurnstileFeatureFlag = useIsFeatureEnabled(
     featureFlags.turnstile,
-    false,
+    true,
   )
-  enum CaptchaTypes {
-    Turnstile = 'turnstile',
-    Recaptcha = 'recaptcha',
-  }
 
   let hasLoaded: boolean
   let containerID: string

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -616,6 +616,7 @@ export const PublicFormProvider = ({
       enableTurnstileFeatureFlag,
       getTurnstileResponse,
       getCaptchaResponse,
+      captchaType,
       showErrorToast,
       submitEmailModeFormMutation,
       submitStorageModeFormMutation,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -144,7 +144,7 @@ export const PublicFormProvider = ({
   // todo: remove after full rollout
   const enableTurnstileFeatureFlag = useIsFeatureEnabled(
     featureFlags.turnstile,
-    true,
+    false,
   )
 
   let hasLoaded: boolean

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -145,8 +145,14 @@ export const PublicFormProvider = ({
     featureFlags.turnstile,
     false,
   )
+  enum CaptchaTypes {
+    Turnstile = 'turnstile',
+    Recaptcha = 'recaptcha',
+  }
+
   let hasLoaded: boolean
   let containerID: string
+  let captchaType: CaptchaTypes
 
   const {
     hasLoaded: hasTurnstileLoaded,
@@ -154,6 +160,7 @@ export const PublicFormProvider = ({
     containerID: turnstileContainerID,
   } = useTurnstile({
     sitekey: data?.form.hasCaptcha ? turnstileSiteKey : undefined,
+    enableUsage: enableTurnstileFeatureFlag,
   })
 
   const {
@@ -162,14 +169,17 @@ export const PublicFormProvider = ({
     containerId: recaptchaContainerID,
   } = useRecaptcha({
     sitekey: data?.form.hasCaptcha ? captchaPublicKey : undefined,
+    enableUsage: !enableTurnstileFeatureFlag,
   })
 
   if (enableTurnstileFeatureFlag) {
     hasLoaded = hasTurnstileLoaded
     containerID = turnstileContainerID
+    captchaType = CaptchaTypes.Turnstile
   } else {
     hasLoaded = hasRecaptchaLoaded
     containerID = recaptchaContainerID
+    captchaType = CaptchaTypes.Recaptcha
   }
 
   const { isNotFormId, toast, vfnToastIdRef, expiryInMs, ...commonFormValues } =
@@ -287,6 +297,7 @@ export const PublicFormProvider = ({
         formLogics: form.form_logics,
         formInputs,
         captchaResponse,
+        captchaType,
         responseMetadata: {
           responseTimeMs: differenceInMilliseconds(Date.now(), startTime),
           numVisibleFields: isPaymentEnabled
@@ -406,6 +417,7 @@ export const PublicFormProvider = ({
                   ...formData,
                   publicKey: form.publicKey,
                   captchaResponse,
+                  captchaType,
                   paymentReceiptEmail: paymentReceiptEmailField?.value,
                   ...(form.payments_field.payment_type === PaymentType.Variable
                     ? {
@@ -458,6 +470,74 @@ export const PublicFormProvider = ({
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
             return submitStorageFormWithFetch()
+          } else {
+            datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
+              meta: {
+                ...logMeta,
+                responseMode: 'storage',
+                method: 'axios',
+              },
+            })
+
+            return (
+              submitStorageModeFormMutation
+                .mutateAsync(
+                  {
+                    ...formData,
+                    publicKey: form.publicKey,
+                    captchaResponse,
+                    captchaType,
+                    paymentReceiptEmail: paymentReceiptEmailField?.value,
+                  },
+                  {
+                    onSuccess: ({
+                      submissionId,
+                      timestamp,
+                      // payment forms will have non-empty paymentData field
+                      paymentData,
+                    }) => {
+                      trackSubmitForm(form)
+
+                      if (paymentData) {
+                        navigate(
+                          getPaymentPageUrl(formId, paymentData.paymentId),
+                        )
+                        storePaymentMemory(paymentData.paymentId)
+                        return
+                      }
+                      setSubmissionData({
+                        id: submissionId,
+                        timestamp,
+                      })
+                    },
+                  },
+                )
+                // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
+                .catch(async (error) => {
+                  // TODO(#5826): Remove when we have resolved the Network Error
+                  datadogLogs.logger.warn(
+                    `handleSubmitForm: ${error.message}`,
+                    {
+                      meta: {
+                        ...logMeta,
+                        responseMode: 'storage',
+                        method: 'axios',
+                        error: {
+                          message: error.message,
+                          stack: error.stack,
+                        },
+                      },
+                    },
+                  )
+
+                  if (/Network Error/i.test(error.message)) {
+                    axiosDebugFlow()
+                    return submitStorageFormWithFetch()
+                  } else {
+                    showErrorToast(error, form)
+                  }
+                })
+            )
           }
           datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
             meta: {

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -470,74 +470,6 @@ export const PublicFormProvider = ({
           // TODO (#5826): Toggle to use fetch for submissions instead of axios. If enabled, this is used for testing and to use fetch instead of axios by default if testing shows fetch is more  stable. Remove once network error is resolved
           if (useFetchForSubmissions) {
             return submitStorageFormWithFetch()
-          } else {
-            datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
-              meta: {
-                ...logMeta,
-                responseMode: 'storage',
-                method: 'axios',
-              },
-            })
-
-            return (
-              submitStorageModeFormMutation
-                .mutateAsync(
-                  {
-                    ...formData,
-                    publicKey: form.publicKey,
-                    captchaResponse,
-                    captchaType,
-                    paymentReceiptEmail: paymentReceiptEmailField?.value,
-                  },
-                  {
-                    onSuccess: ({
-                      submissionId,
-                      timestamp,
-                      // payment forms will have non-empty paymentData field
-                      paymentData,
-                    }) => {
-                      trackSubmitForm(form)
-
-                      if (paymentData) {
-                        navigate(
-                          getPaymentPageUrl(formId, paymentData.paymentId),
-                        )
-                        storePaymentMemory(paymentData.paymentId)
-                        return
-                      }
-                      setSubmissionData({
-                        id: submissionId,
-                        timestamp,
-                      })
-                    },
-                  },
-                )
-                // Using catch since we are using mutateAsync and react-hook-form will continue bubbling this up.
-                .catch(async (error) => {
-                  // TODO(#5826): Remove when we have resolved the Network Error
-                  datadogLogs.logger.warn(
-                    `handleSubmitForm: ${error.message}`,
-                    {
-                      meta: {
-                        ...logMeta,
-                        responseMode: 'storage',
-                        method: 'axios',
-                        error: {
-                          message: error.message,
-                          stack: error.stack,
-                        },
-                      },
-                    },
-                  )
-
-                  if (/Network Error/i.test(error.message)) {
-                    axiosDebugFlow()
-                    return submitStorageFormWithFetch()
-                  } else {
-                    showErrorToast(error, form)
-                  }
-                })
-            )
           }
           datadogLogs.logger.info(`handleSubmitForm: submitting via axios`, {
             meta: {
@@ -554,6 +486,7 @@ export const PublicFormProvider = ({
                   ...formData,
                   publicKey: form.publicKey,
                   captchaResponse,
+                  captchaType,
                   paymentReceiptEmail: paymentReceiptEmailField?.value,
                   ...(form.payments_field.payment_type === PaymentType.Variable
                     ? {

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -152,7 +152,7 @@ export const submitStorageModeForm = async ({
     {
       params: {
         captchaResponse: String(captchaResponse),
-        captchaType: captchaType,
+        captchaType,
       },
     },
   ).then(({ data }) => data)

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -182,7 +182,7 @@ export const submitEmailModeFormWithFetch = async ({
   // Add captcha response to query string
   const queryString = new URLSearchParams({
     captchaResponse: String(captchaResponse),
-    captchaType: captchaType,
+    captchaType,
   }).toString()
 
   const response = await fetch(
@@ -229,7 +229,7 @@ export const submitStorageModeFormWithFetch = async ({
   // Add captcha response to query string
   const queryString = new URLSearchParams({
     captchaResponse: String(captchaResponse),
-    captchaType: captchaType,
+    captchaType,
   }).toString()
 
   const response = await fetch(

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -78,6 +78,7 @@ export const logoutPublicForm = async (
 export type SubmitEmailFormArgs = {
   formId: string
   captchaResponse?: string | null
+  captchaType?: string
   formFields: FormFieldDto[]
   formLogics: FormDto['form_logics']
   formInputs: FormFieldValues
@@ -94,6 +95,7 @@ export const submitEmailModeForm = async ({
   formInputs,
   formId,
   captchaResponse = null,
+  captchaType = '',
   responseMetadata,
 }: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
   const filteredInputs = filterHiddenInputs({
@@ -113,6 +115,7 @@ export const submitEmailModeForm = async ({
     {
       params: {
         captchaResponse: String(captchaResponse),
+        captchaType: captchaType,
       },
     },
   ).then(({ data }) => data)
@@ -125,6 +128,7 @@ export const submitStorageModeForm = async ({
   formId,
   publicKey,
   captchaResponse = null,
+  captchaType = '',
   paymentReceiptEmail,
   responseMetadata,
   payments,
@@ -148,6 +152,7 @@ export const submitStorageModeForm = async ({
     {
       params: {
         captchaResponse: String(captchaResponse),
+        captchaType: captchaType,
       },
     },
   ).then(({ data }) => data)
@@ -160,6 +165,7 @@ export const submitEmailModeFormWithFetch = async ({
   formInputs,
   formId,
   captchaResponse = null,
+  captchaType = '',
   responseMetadata,
 }: SubmitEmailFormArgs): Promise<SubmissionResponseDto> => {
   const filteredInputs = filterHiddenInputs({
@@ -176,6 +182,7 @@ export const submitEmailModeFormWithFetch = async ({
   // Add captcha response to query string
   const queryString = new URLSearchParams({
     captchaResponse: String(captchaResponse),
+    captchaType: captchaType,
   }).toString()
 
   const response = await fetch(
@@ -200,6 +207,7 @@ export const submitStorageModeFormWithFetch = async ({
   formId,
   publicKey,
   captchaResponse = null,
+  captchaType = '',
   paymentReceiptEmail,
   responseMetadata,
   payments,
@@ -221,6 +229,7 @@ export const submitStorageModeFormWithFetch = async ({
   // Add captcha response to query string
   const queryString = new URLSearchParams({
     captchaResponse: String(captchaResponse),
+    captchaType: captchaType,
   }).toString()
 
   const response = await fetch(

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -7,11 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import get from 'lodash/get'
 import { useIntervalWhen } from 'rooks'
 
-import { featureFlags } from '~shared/constants'
-
 import { useScript } from '~hooks/useScript'
-
-import { useIsFeatureEnabled } from '~features/feature-flags/queries'
 
 type RecaptchaBaseConfig = {
   sitekey?: string

--- a/frontend/src/features/recaptcha/useRecaptcha.tsx
+++ b/frontend/src/features/recaptcha/useRecaptcha.tsx
@@ -28,6 +28,7 @@ interface UseRecaptchaProps extends RecaptchaBaseConfig {
   id?: string
   useRecaptchaNet?: boolean
   useEnterprise?: boolean
+  enableUsage: boolean
 }
 
 type RecaptchaConfig = RecaptchaBaseConfig & {
@@ -85,6 +86,7 @@ export const useRecaptcha = ({
   badge = 'inline',
   size = 'invisible',
   useRecaptchaNet = true,
+  enableUsage,
 }: UseRecaptchaProps) => {
   useScript(getRecaptchaUrl({ useEnterprise, useRecaptchaNet }))
 
@@ -100,15 +102,6 @@ export const useRecaptcha = ({
   const executionPromise = useRef<GreptchaExecutionCallback>({})
 
   const captchaRef = useRef<HTMLDivElement | null>(null)
-
-  // Feature flag to control turnstile captcha rollout
-  // defaults to false
-  // Cloudflare Turnstile and Google reCaptcha should be mutually exclusive
-  // todo: remove after full rollout
-  const enableTurnstileFeatureFlag = useIsFeatureEnabled(
-    featureFlags.turnstile,
-    false,
-  )
 
   useIntervalWhen(
     () => {
@@ -182,7 +175,7 @@ export const useRecaptcha = ({
         'expired-callback': handleExpiry,
         'error-callback': handleError,
       }
-      if (!enableTurnstileFeatureFlag) {
+      if (enableUsage) {
         const widget = grecaptcha?.render(containerId, renderProps)
         setWidgetId(widget)
       }
@@ -200,7 +193,7 @@ export const useRecaptcha = ({
     handleError,
     useEnterprise,
     grecaptcha,
-    enableTurnstileFeatureFlag,
+    enableUsage,
   ])
 
   /**

--- a/frontend/src/features/turnstile/useTurnstile.tsx
+++ b/frontend/src/features/turnstile/useTurnstile.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIntervalWhen } from 'rooks'
 
-import { featureFlags } from '~shared/constants'
-
 import { useScript } from '~hooks/useScript'
-
-import { useIsFeatureEnabled } from '~features/feature-flags/queries'
 
 type TurnstileBaseConfig = {
   sitekey?: string

--- a/frontend/src/features/turnstile/useTurnstile.tsx
+++ b/frontend/src/features/turnstile/useTurnstile.tsx
@@ -20,6 +20,7 @@ type TurnstileBaseConfig = {
 interface UseTurnstileProps extends TurnstileBaseConfig {
   // id of container to load Turnstile captcha in.
   containerID?: string
+  enableUsage: boolean
 }
 
 type TurnstileConfig = TurnstileBaseConfig & {
@@ -56,6 +57,7 @@ export const useTurnstile = ({
   execution = 'execute',
   theme = 'light',
   appearance = 'interaction-only',
+  enableUsage,
 }: UseTurnstileProps) => {
   useScript(
     'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit',
@@ -66,14 +68,6 @@ export const useTurnstile = ({
 
   const executionPromise = useRef<TurnstileExecutionCallback>({})
 
-  // Feature flag to control turnstile captcha rollout
-  // defaults to false
-  // Cloudflare Turnstile and Google reCaptcha should be mutually exclusive
-  // todo: remove after full rollout
-  const enableTurnstileFeatureFlag = useIsFeatureEnabled(
-    featureFlags.turnstile,
-    false,
-  )
   useIntervalWhen(
     () => {
       if (turnstile?.render) {
@@ -114,7 +108,7 @@ export const useTurnstile = ({
         'expired-callback': handleExpiry,
         'error-callback': handleError,
       }
-      if (enableTurnstileFeatureFlag) {
+      if (enableUsage) {
         const widget = turnstile?.render('#' + containerID, renderProps)
         setWidgetID(widget)
       }
@@ -123,7 +117,7 @@ export const useTurnstile = ({
     hasLoaded,
     widgetID,
     containerID,
-    enableTurnstileFeatureFlag,
+    enableUsage,
     sitekey,
     appearance,
     execution,

--- a/shared/types/captcha.ts
+++ b/shared/types/captcha.ts
@@ -1,5 +1,3 @@
-// Represents the type of captcha providers that
-// the service supports.
 export enum CaptchaTypes {
   Turnstile = 'turnstile',
   Recaptcha = 'recaptcha',

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -1,6 +1,5 @@
 import { ok, okAsync, ResultAsync } from 'neverthrow'
 
-import { featureFlags } from '../../../../../shared/constants'
 import {
   FormAuthType,
   SubmissionErrorDto,
@@ -11,13 +10,13 @@ import { ParsedEmailModeSubmissionBody } from '../../../../types/api'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
+import { CaptchaTypes } from '../../../services/captcha/captcha.types'
 import MailService from '../../../services/mail/mail.service'
 import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.middleware'
 import * as TurnstileService from '../../../services/turnstile/turnstile.service'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { ControllerHandler } from '../../core/core.types'
 import { setFormTags } from '../../datadog/datadog.utils'
-import * as FeatureFlagService from '../../feature-flags/feature-flags.service'
 import * as FormService from '../../form/form.service'
 import {
   MYINFO_LOGIN_COOKIE_NAME,
@@ -51,7 +50,7 @@ const submitEmailModeForm: ControllerHandler<
   { formId: string },
   SubmissionResponseDto | SubmissionErrorDto,
   ParsedEmailModeSubmissionBody,
-  { captchaResponse?: unknown }
+  { captchaResponse?: unknown; captchaType?: unknown }
 > = async (req, res) => {
   const { formId } = req.params
   const attachments = mapAttachmentsFromResponses(req.body.responses)
@@ -72,23 +71,6 @@ const submitEmailModeForm: ControllerHandler<
     action: 'handleEmailSubmission',
     ...createReqMeta(req),
     formId,
-  }
-
-  const featureFlagsListResult = await FeatureFlagService.getEnabledFlags()
-  // Feature flag to control turnstile captcha rollout
-  // defaults to false
-  // todo: remove after full rollout
-  let enableTurnstileFeatureFlag = false
-  if (featureFlagsListResult.isErr()) {
-    logger.error({
-      message: 'Error occurred whilst retrieving enabled feature flags',
-      meta: logMeta,
-      error: featureFlagsListResult.error,
-    })
-  } else {
-    enableTurnstileFeatureFlag = featureFlagsListResult.value.includes(
-      featureFlags.turnstile,
-    )
   }
 
   return (
@@ -133,34 +115,38 @@ const submitEmailModeForm: ControllerHandler<
       .andThen((form) => {
         // Check the captcha
         if (form.hasCaptcha) {
-          if (enableTurnstileFeatureFlag) {
-            return TurnstileService.verifyTurnstileResponse(
-              req.query.captchaResponse,
-              getRequestIp(req),
-            )
-              .map(() => form)
-              .mapErr((error) => {
-                logger.error({
-                  message: 'Error while verifying turnstile captcha',
-                  meta: logMeta,
-                  error,
+          switch (req.query.captchaType) {
+            case CaptchaTypes.Turnstile: {
+              return TurnstileService.verifyTurnstileResponse(
+                req.query.captchaResponse,
+                getRequestIp(req),
+              )
+                .map(() => form)
+                .mapErr((error) => {
+                  logger.error({
+                    message: 'Error while verifying turnstile captcha',
+                    meta: logMeta,
+                    error,
+                  })
+                  return error
                 })
-                return error
-              })
-          } else {
-            return CaptchaService.verifyCaptchaResponse(
-              req.query.captchaResponse,
-              getRequestIp(req),
-            )
-              .map(() => form)
-              .mapErr((error) => {
-                logger.error({
-                  message: 'Error while verifying captcha',
-                  meta: logMeta,
-                  error,
+            }
+            // defaults to recaptcha
+            default: {
+              return CaptchaService.verifyCaptchaResponse(
+                req.query.captchaResponse,
+                getRequestIp(req),
+              )
+                .map(() => form)
+                .mapErr((error) => {
+                  logger.error({
+                    message: 'Error while verifying captcha',
+                    meta: logMeta,
+                    error,
+                  })
+                  return error
                 })
-                return error
-              })
+            }
           }
         }
         return okAsync(form) as ResultAsync<IPopulatedEmailForm, never>
@@ -454,6 +440,7 @@ const submitEmailModeForm: ControllerHandler<
 }
 
 export const handleEmailSubmission = [
+  // todo: remove CaptchaMiddleware after extracting common components in Captcha and Turnstile
   CaptchaMiddleware.validateCaptchaParams,
   TurnstileMiddleware.validateTurnstileParams,
   EmailSubmissionMiddleware.receiveEmailSubmission,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -131,7 +131,7 @@ const submitEmailModeForm: ControllerHandler<
                   return error
                 })
             }
-            // defaults to recaptcha
+            case CaptchaTypes.Recaptcha: // fallthrough, defaults to recaptcha
             default: {
               return CaptchaService.verifyCaptchaResponse(
                 req.query.captchaResponse,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -440,7 +440,7 @@ const submitEmailModeForm: ControllerHandler<
 }
 
 export const handleEmailSubmission = [
-  // todo: remove CaptchaMiddleware after extracting common components in Captcha and Turnstile
+  // TODO: remove CaptchaMiddleware after extracting common components in Captcha and Turnstile
   CaptchaMiddleware.validateCaptchaParams,
   TurnstileMiddleware.validateTurnstileParams,
   EmailSubmissionMiddleware.receiveEmailSubmission,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -5,12 +5,12 @@ import {
   SubmissionErrorDto,
   SubmissionResponseDto,
 } from '../../../../../shared/types'
+import { CaptchaTypes } from '../../../../../shared/types/captcha'
 import { IPopulatedEmailForm } from '../../../../types'
 import { ParsedEmailModeSubmissionBody } from '../../../../types/api'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
-import { CaptchaTypes } from '../../../services/captcha/captcha.types'
 import MailService from '../../../services/mail/mail.service'
 import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.middleware'
 import * as TurnstileService from '../../../services/turnstile/turnstile.service'

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -169,7 +169,7 @@ const submitEncryptModeForm: ControllerHandler<
         }
         break
       }
-      // defaults to recaptcha
+      case CaptchaTypes.Recaptcha: // fallthrough, defaults to reCAPTCHA
       default: {
         const captchaResult = await CaptchaService.verifyCaptchaResponse(
           req.query.captchaResponse,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -19,6 +19,7 @@ import {
   SubmissionErrorDto,
   SubmissionResponseDto,
 } from '../../../../../shared/types'
+import { CaptchaTypes } from '../../../../../shared/types/captcha'
 import { StripePaymentMetadataDto } from '../../../../types'
 import { EncryptSubmissionDto } from '../../../../types/api'
 import config from '../../../config/config'
@@ -30,7 +31,6 @@ import { getEncryptPendingSubmissionModel } from '../../../models/pending_submis
 import { getEncryptSubmissionModel } from '../../../models/submission.server.model'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as CaptchaService from '../../../services/captcha/captcha.service'
-import { CaptchaTypes } from '../../../services/captcha/captcha.types'
 import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.middleware'
 import * as TurnstileService from '../../../services/turnstile/turnstile.service'
 import { createReqMeta, getRequestIp } from '../../../utils/request'

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
@@ -68,7 +68,6 @@ describe('public-form.submissions.routes', () => {
 
   const mockCpClient = jest.mocked(MockCpOidcClient.mock.instances[0])
 
-  beforeAll(async () => await dbHandler.connect())
   beforeEach(async () => {
     request = session(app)
   })
@@ -100,7 +99,7 @@ describe('public-form.submissions.routes', () => {
               responses: [MOCK_TEXTFIELD_RESPONSE],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -132,7 +131,7 @@ describe('public-form.submissions.routes', () => {
               responses: [{ ...MOCK_TEXTFIELD_RESPONSE, answer: '' }],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -167,7 +166,7 @@ describe('public-form.submissions.routes', () => {
               ],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -197,7 +196,7 @@ describe('public-form.submissions.routes', () => {
               responses: [{ ...MOCK_SECTION_RESPONSE, isHeader: true }],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -229,7 +228,7 @@ describe('public-form.submissions.routes', () => {
               ],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -259,7 +258,7 @@ describe('public-form.submissions.routes', () => {
               responses: [MOCK_CHECKBOX_RESPONSE],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(200)
@@ -284,7 +283,7 @@ describe('public-form.submissions.routes', () => {
           .post(`/forms/${form._id}/submissions/email`)
           // Note missing responses
           .field('body', JSON.stringify({}))
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -309,7 +308,7 @@ describe('public-form.submissions.routes', () => {
               responses: [omit(MOCK_TEXTFIELD_RESPONSE, '_id')],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -334,7 +333,7 @@ describe('public-form.submissions.routes', () => {
               responses: [omit(MOCK_TEXTFIELD_RESPONSE, 'fieldType')],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -361,7 +360,7 @@ describe('public-form.submissions.routes', () => {
               ],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -386,7 +385,7 @@ describe('public-form.submissions.routes', () => {
               responses: [omit(MOCK_TEXTFIELD_RESPONSE, 'answer')],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -411,7 +410,7 @@ describe('public-form.submissions.routes', () => {
               responses: [{ ...MOCK_TEXTFIELD_RESPONSE, answerArray: [] }],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -436,7 +435,7 @@ describe('public-form.submissions.routes', () => {
               responses: [omit(MOCK_ATTACHMENT_RESPONSE), 'content'],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -461,7 +460,7 @@ describe('public-form.submissions.routes', () => {
               responses: [omit(MOCK_ATTACHMENT_RESPONSE), 'filename'],
             }),
           )
-          .query({ captchaResponse: 'null' })
+          .query({ captchaResponse: 'null', captchaType: '' })
 
         // Assert
         expect(response.status).toBe(400)
@@ -519,7 +518,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
           // Note cookie is not set
 
           // Assert
@@ -546,7 +545,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             // Note cookie is for CorpPass, not SingPass
             .set('Cookie', ['jwtCp=mockJwt'])
 
@@ -579,7 +578,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           // Assert
@@ -613,7 +612,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           // Assert
@@ -654,7 +653,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', [
               // The j: indicates that the cookie is in JSON
               `${MYINFO_LOGIN_COOKIE_NAME}=j:${encodeURIComponent(
@@ -686,7 +685,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
           // Note cookie is not set
 
           // Assert
@@ -713,7 +712,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             // Note cookie is for SingPass, not MyInfo
             .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -777,7 +776,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', [
               // The j: indicates that the cookie is in JSON
               `${MYINFO_LOGIN_COOKIE_NAME}=j:${MOCK_MYINFO_JWT}`,
@@ -813,7 +812,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           // Assert
@@ -840,7 +839,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
           // Note cookie is not set
 
           // Assert
@@ -867,7 +866,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             // Note cookie is for SingPass, not CorpPass
             .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -897,7 +896,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           // Assert
@@ -928,7 +927,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           // Assert
@@ -973,7 +972,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           expect(response.status).toBe(200)
@@ -997,7 +996,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
           // Note cookie is not set
 
           expect(response.status).toBe(401)
@@ -1021,7 +1020,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
           // Note cookie is for CorpPass, not SingPass
 
@@ -1051,7 +1050,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           expect(response.status).toBe(401)
@@ -1082,7 +1081,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           expect(response.status).toBe(401)
@@ -1112,7 +1111,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           expect(response.status).toBe(200)
@@ -1136,7 +1135,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
           // Note cookie is not set
 
           expect(response.status).toBe(401)
@@ -1160,7 +1159,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             // Note cookie is for SingPass, not CorpPass
             .set('Cookie', ['jwtSp=mockJwt'])
 
@@ -1187,7 +1186,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           expect(response.status).toBe(401)
@@ -1215,7 +1214,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/encrypt`)
             .send(MOCK_SUBMISSION_BODY)
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtCp=mockJwt'])
 
           expect(response.status).toBe(401)

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
@@ -68,6 +68,7 @@ describe('public-form.submissions.routes', () => {
 
   const mockCpClient = jest.mocked(MockCpOidcClient.mock.instances[0])
 
+  beforeAll(async () => await dbHandler.connect())
   beforeEach(async () => {
     request = session(app)
   })
@@ -491,7 +492,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', ['jwtSp=mockJwt'])
 
           // Assert
@@ -744,7 +745,7 @@ describe('public-form.submissions.routes', () => {
           const response = await request
             .post(`/forms/${form._id}/submissions/email`)
             .field('body', JSON.stringify(MOCK_NO_RESPONSES_BODY))
-            .query({ captchaResponse: 'null' })
+            .query({ captchaResponse: 'null', captchaType: '' })
             .set('Cookie', [`${MYINFO_LOGIN_COOKIE_NAME}=${MOCK_MYINFO_JWT}`])
 
           // Assert

--- a/src/app/services/captcha/captcha.middleware.ts
+++ b/src/app/services/captcha/captcha.middleware.ts
@@ -3,5 +3,6 @@ import { celebrate, Joi, Segments } from 'celebrate'
 export const validateCaptchaParams = celebrate({
   [Segments.QUERY]: Joi.object({
     captchaResponse: Joi.string().allow(null).required(),
+    captchaType: Joi.string().allow('').required(),
   }),
 })

--- a/src/app/services/captcha/captcha.middleware.ts
+++ b/src/app/services/captcha/captcha.middleware.ts
@@ -3,6 +3,6 @@ import { celebrate, Joi, Segments } from 'celebrate'
 export const validateCaptchaParams = celebrate({
   [Segments.QUERY]: Joi.object({
     captchaResponse: Joi.string().allow(null).required(),
-    captchaType: Joi.string().allow('').required(),
+    captchaType: Joi.string().allow(''),
   }),
 })

--- a/src/app/services/captcha/captcha.types.ts
+++ b/src/app/services/captcha/captcha.types.ts
@@ -1,0 +1,6 @@
+// Represents the type of captcha providers that
+// the service supports.
+export enum CaptchaTypes {
+  Turnstile = 'turnstile',
+  Recaptcha = 'recaptcha',
+}

--- a/src/app/services/turnstile/turnstile.errors.ts
+++ b/src/app/services/turnstile/turnstile.errors.ts
@@ -4,7 +4,7 @@ import { ApplicationError } from '../../modules/core/core.errors'
  * Error connecting to captcha server
  */
 export class TurnstileConnectionError extends ApplicationError {
-  constructor(message = 'Error while connecting to Turnstile server') {
+  constructor(message = 'Error while connecting to Turnstile server.') {
     super(message)
   }
 }
@@ -13,7 +13,7 @@ export class TurnstileConnectionError extends ApplicationError {
  * Wrong captcha response
  */
 export class VerifyTurnstileError extends ApplicationError {
-  constructor(message = 'Incorrect Turnstile response') {
+  constructor(message = 'Incorrect Turnstile response.') {
     super(message)
   }
 }
@@ -22,7 +22,7 @@ export class VerifyTurnstileError extends ApplicationError {
  * Missing captcha response
  */
 export class MissingTurnstileError extends ApplicationError {
-  constructor(message = 'Missing Turnstile response') {
+  constructor(message = 'Missing Turnstile response.') {
     super(message)
   }
 }

--- a/src/app/services/turnstile/turnstile.middleware.ts
+++ b/src/app/services/turnstile/turnstile.middleware.ts
@@ -3,5 +3,6 @@ import { celebrate, Joi, Segments } from 'celebrate'
 export const validateTurnstileParams = celebrate({
   [Segments.QUERY]: Joi.object({
     captchaResponse: Joi.string().allow(null).required(),
+    captchaType: Joi.string().allow('').required(),
   }),
 })

--- a/src/app/services/turnstile/turnstile.middleware.ts
+++ b/src/app/services/turnstile/turnstile.middleware.ts
@@ -3,6 +3,6 @@ import { celebrate, Joi, Segments } from 'celebrate'
 export const validateTurnstileParams = celebrate({
   [Segments.QUERY]: Joi.object({
     captchaResponse: Joi.string().allow(null).required(),
-    captchaType: Joi.string().allow('').required(),
+    captchaType: Joi.string().allow(''),
   }),
 })


### PR DESCRIPTION
## Problem
Improving backwards compatibility of turnstile integration.

Context: Currently, using the enableTurnstileFeatureFlag in frontend/backend can result in the following edge case. A user visits the site before the flag is switched on (i.e. reCAPTCHA enabled) and receives a reCAPTCHA challenge/response. The user completes the form and clicks 'Submit' after we have switched on the flag (i.e. Turnstile enabled). The challenge-response from reCAPTCHA will be forwarded to our backend and verified against Turnstile, which will fail. Users must either click submit again to receive a new turnstile challenge or refresh the page. I did some investigation and its not possible to differentiate between Turnstile/reCAPTCHA based on the challenge-response alone.

Closes FRM-1107

## Solution
This merge request solves the above problem by having the frontend explicitly tell the backend which captcha provider is being used.

## Tests

- [ ]  Verify that Turnstile captcha works (i.e. able to submit forms) after switching on the enableTurnstileFeatureFlag
- [ ] Verify that Google recaptcha works (i.e. able to submit forms) after switching off the enableTurnstileFeatureFlag

