### PR TITLE
feat: payment dashboard

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -80,7 +80,7 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     Header: 'Payout Date',
     accessor: ({ payments }) => {
       if (!payments) {
-        return ''
+        return 'Pending'
       }
       return payments.payoutDate
     },

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -11,6 +11,8 @@ import { Flex, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
 
 import { StorageModeSubmissionMetadata } from '~shared/types'
 
+import { centsToDollars } from '~utils/payments'
+
 import { useUnlockedResponses } from './UnlockedResponsesProvider'
 
 type ResponseColumnData = StorageModeSubmissionMetadata
@@ -34,7 +36,56 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     Header: 'Timestamp',
     accessor: 'submissionTime',
     minWidth: 200,
-    width: 300,
+    width: 250,
+    disableResizing: true,
+  },
+
+  {
+    Header: 'Paid Amount', //  (amt responder paid)
+    accessor: ({ payments }) => {
+      if (!payments) {
+        return ''
+      }
+      return `S$${centsToDollars(payments.paymentAmt)}`
+    },
+    minWidth: 50,
+    width: 150,
+    disableResizing: true,
+  },
+
+  {
+    Header: 'Gross Amount', //  (amt they receive in bank)
+    accessor: ({ payments }) => {
+      if (!payments?.transactionFee) {
+        return ''
+      }
+      if (payments.transactionFee < 0) {
+        return ''
+      }
+
+      const grossAmt = centsToDollars(
+        payments.paymentAmt - payments.transactionFee,
+      )
+      const isFinalTransactionFee = payments.payoutDate
+      if (!isFinalTransactionFee) {
+        return `Est. S$${grossAmt}`
+      }
+      return `S$${grossAmt}`
+    },
+    minWidth: 50,
+    width: 150,
+    disableResizing: true,
+  },
+  {
+    Header: 'Payout Date',
+    accessor: ({ payments }) => {
+      if (!payments) {
+        return ''
+      }
+      return payments.payoutDate
+    },
+    minWidth: 50,
+    width: 150,
     disableResizing: true,
   },
 ]

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable.tsx
@@ -41,6 +41,20 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
 
   {
+    Header: 'Email', //  (paid - net)
+    accessor: ({ payments }) => {
+      if (!payments?.email) {
+        return ''
+      }
+
+      return payments.email
+    },
+    minWidth: 50,
+    width: 150,
+    disableResizing: true,
+  },
+
+  {
     Header: 'Paid Amount', //  (amt responder paid)
     accessor: ({ payments }) => {
       if (!payments) {
@@ -54,7 +68,7 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
 
   {
-    Header: 'Gross Amount', //  (amt they receive in bank)
+    Header: 'Net Amount', //  (amt they receive in bank)
     accessor: ({ payments }) => {
       if (!payments?.transactionFee) {
         return ''
@@ -71,6 +85,23 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
         return `Est. S$${grossAmt}`
       }
       return `S$${grossAmt}`
+    },
+    minWidth: 50,
+    width: 150,
+    disableResizing: true,
+  },
+
+  {
+    Header: 'Fees', //  (paid - net)
+    accessor: ({ payments }) => {
+      if (!payments?.transactionFee) {
+        return ''
+      }
+      if (payments.transactionFee < 0) {
+        return ''
+      }
+
+      return `S$${centsToDollars(payments.transactionFee)}`
     },
     minWidth: 50,
     width: 150,
@@ -159,6 +190,7 @@ export const ResponsesTable = () => {
       as="div"
       variant="solid"
       colorScheme="secondary"
+      width="100vw"
       {...getTableProps()}
     >
       <Thead as="div" pos="sticky" top={0}>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -15,7 +15,9 @@ import { centsToDollars } from '~utils/payments'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
-import { useUnlockedResponses } from './UnlockedResponsesProvider'
+import { useUnlockedResponses } from '../UnlockedResponsesProvider'
+
+import { getNetAmount } from './utils'
 
 type ResponseColumnData = StorageModeSubmissionMetadata
 
@@ -42,9 +44,9 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     disableResizing: true,
   },
 ]
-const PAYMENT_COLUMNS = [
+const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
   {
-    Header: 'Email', //  (paid - net)
+    Header: 'Email',
     accessor: ({ payments }) => {
       if (!payments?.email) {
         return ''
@@ -69,22 +71,7 @@ const PAYMENT_COLUMNS = [
 
   {
     Header: 'Net Amount', //  (amt they receive in bank)
-    accessor: ({ payments }) => {
-      if (!payments?.transactionFee) {
-        return ''
-      }
-      if (payments.transactionFee < 0) {
-        return ''
-      }
-      const grossAmt = centsToDollars(
-        payments.paymentAmt - payments.transactionFee,
-      )
-      const isFinalTransactionFee = payments.payoutDate
-      if (!isFinalTransactionFee) {
-        return `Est. S$${grossAmt}`
-      }
-      return `S$${grossAmt}`
-    },
+    accessor: ({ payments }) => getNetAmount(payments),
     minWidth: 50,
     width: 75,
   },

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/__tests__/utils.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/__tests__/utils.test.ts
@@ -1,3 +1,7 @@
+import { StorageModeSubmissionMetadata } from '~shared/types'
+
+import { centsToDollars } from '~utils/payments'
+
 import { getNetAmount } from '../utils'
 
 describe('getNetAmount', () => {
@@ -12,19 +16,61 @@ describe('getNetAmount', () => {
 
   it('should return empty string when no there is no transaction fees', () => {
     // Arrange
-    const emptyObjectInput = {}
+    const emptyObjectInput = {} as StorageModeSubmissionMetadata['payments']
     // Act
     const result = getNetAmount(emptyObjectInput)
     // Assert
     expect(result).toBe('')
   })
 
-  it('should return 0 when traansaction fee is 0', () => {
+  it('should return 0 when traansaction fee is < 0', () => {
     // Arrange
-    const zeroTransactionFee = { transactionFee: 0 }
+    const zeroTransactionFee = {
+      transactionFee: -1,
+    } as StorageModeSubmissionMetadata['payments']
     // Act
     const result = getNetAmount(zeroTransactionFee)
     // Assert
     expect(result).toBe('')
+  })
+
+  it('should display as estimates when payment is not final', () => {
+    // Arrange
+    const zeroTransactionFee = {
+      transactionFee: 0,
+      paymentAmt: 100,
+      payoutDate: null,
+    } as StorageModeSubmissionMetadata['payments']
+    // Act
+    const result = getNetAmount(zeroTransactionFee)
+    // Assert
+    expect(result).toContain('Est')
+  })
+
+  it('should not display as estimate when payout is provided', () => {
+    // Arrange
+    const zeroTransactionFee = {
+      transactionFee: 0,
+      paymentAmt: 100,
+      payoutDate: Date(),
+    } as StorageModeSubmissionMetadata['payments']
+    // Act
+    const result = getNetAmount(zeroTransactionFee)
+    // Assert
+    expect(result).not.toContain('Est')
+  })
+
+  it('should return gross amount if transaction fee is 0', () => {
+    // Arrange
+    const EXPECTED_PAYMENT_AMOUNT = 123
+    const zeroTransactionFee = {
+      transactionFee: 0,
+      paymentAmt: EXPECTED_PAYMENT_AMOUNT,
+      payoutDate: Date(),
+    } as StorageModeSubmissionMetadata['payments']
+    // Act
+    const result = getNetAmount(zeroTransactionFee)
+    // Assert
+    expect(result).toContain(centsToDollars(EXPECTED_PAYMENT_AMOUNT))
   })
 })

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/__tests__/utils.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/__tests__/utils.test.ts
@@ -1,0 +1,30 @@
+import { getNetAmount } from '../utils'
+
+describe('getNetAmount', () => {
+  it('should return empty string when no payments are provided', () => {
+    // Arrange
+    const nullInput = null
+    // Act
+    const result = getNetAmount(nullInput)
+    // Assert
+    expect(result).toBe('')
+  })
+
+  it('should return empty string when no there is no transaction fees', () => {
+    // Arrange
+    const emptyObjectInput = {}
+    // Act
+    const result = getNetAmount(emptyObjectInput)
+    // Assert
+    expect(result).toBe('')
+  })
+
+  it('should return 0 when traansaction fee is 0', () => {
+    // Arrange
+    const zeroTransactionFee = { transactionFee: 0 }
+    // Act
+    const result = getNetAmount(zeroTransactionFee)
+    // Assert
+    expect(result).toBe('')
+  })
+})

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/index.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/index.ts
@@ -1,0 +1,1 @@
+export * from './ResponsesTable'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/utils.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/utils.ts
@@ -1,0 +1,23 @@
+import { StorageModeSubmissionMetadata } from '~shared/types'
+
+import { centsToDollars } from '~utils/payments'
+
+export const getNetAmount = (
+  payments: StorageModeSubmissionMetadata['payments'],
+) => {
+  if (!payments) {
+    return ''
+  }
+  if (payments.transactionFee == null) {
+    return ''
+  }
+  if (payments.transactionFee < 0) {
+    return ''
+  }
+  const grossAmt = centsToDollars(payments.paymentAmt - payments.transactionFee)
+  const isFinalTransactionFee = payments.payoutDate
+  if (!isFinalTransactionFee) {
+    return `Est. S$${grossAmt}`
+  }
+  return `S$${grossAmt}`
+}

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -112,17 +112,19 @@ export type StorageModeSubmissionStreamDto = z.infer<
   typeof StorageModeSubmissionStreamDto
 >
 
+export type SubmissionPaymentMetadata = {
+  payoutDate: string | null
+  paymentAmt: number
+  transactionFee: number | null
+  email: string
+} | null
+
 export type StorageModeSubmissionMetadata = {
   number: number
   refNo: SubmissionId
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
-  payments: {
-    payoutDate: string | null
-    paymentAmt: number
-    transactionFee: number | null
-    email: string
-  } | null
+  payments: SubmissionPaymentMetadata
 }
 
 export type StorageModeSubmissionMetadataList = {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -121,6 +121,7 @@ export type StorageModeSubmissionMetadata = {
     payoutDate: string | null
     paymentAmt: number
     transactionFee: number | null
+    email: string
   } | null
 }
 

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -118,7 +118,7 @@ export type StorageModeSubmissionMetadata = {
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
   payments: {
-    payoutDate: string
+    payoutDate: string | null
     paymentAmt: number
     transactionFee: number | null
   } | null

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -117,6 +117,11 @@ export type StorageModeSubmissionMetadata = {
   refNo: SubmissionId
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
+  payments: {
+    payoutDate: string
+    paymentAmt: number
+    transactionFee: number | null
+  } | null
 }
 
 export type StorageModeSubmissionMetadataList = {

--- a/src/app/models/__tests__/encrypt-submission.server.model.spec.ts
+++ b/src/app/models/__tests__/encrypt-submission.server.model.spec.ts
@@ -47,6 +47,7 @@ describe('Encrypt Submission Model', () => {
         // Assert
         const expected: StorageModeSubmissionMetadata = {
           number: 1,
+          payments: null,
           refNo: validSubmission._id,
           submissionTime: moment(createdDate)
             .tz('Asia/Singapore')
@@ -129,6 +130,7 @@ describe('Encrypt Submission Model', () => {
           metadata: validSubmissions
             .map((data, idx) => ({
               number: idx + 1,
+              payments: null,
               refNo: data._id,
               submissionTime: moment(data.created)
                 .tz('Asia/Singapore')
@@ -171,6 +173,7 @@ describe('Encrypt Submission Model', () => {
           metadata: [
             {
               number: 2,
+              payments: null,
               refNo: secondSubmission._id,
               submissionTime: moment(secondSubmission.created)
                 .tz('Asia/Singapore')
@@ -213,6 +216,7 @@ describe('Encrypt Submission Model', () => {
           metadata: [
             {
               number: 3,
+              payments: null,
               refNo: latestSubmission._id,
               submissionTime: moment(latestSubmission.created)
                 .tz('Asia/Singapore')

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -291,6 +291,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
     }
 
     const result = results[0]
+    const paymentMeta = result.payments?.[0]
 
     // Build submissionMetadata object.
     const metadata: StorageModeSubmissionMetadata = {
@@ -299,15 +300,17 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
       submissionTime: moment(result.created)
         .tz('Asia/Singapore')
         .format('Do MMM YYYY, h:mm:ss a'),
-      payments: result.payments[0]?.payout
+      payments: paymentMeta
         ? {
-            payoutDate: moment(result.payments[0].payout.payoutDate)
-              .tz('Asia/Singapore')
-              .format('ddd, D MMM YYYY'),
+            payoutDate: paymentMeta.payout
+              ? moment(paymentMeta.payout.payoutDate)
+                  .tz('Asia/Singapore')
+                  .format('ddd, D MMM YYYY')
+              : null,
 
-            paymentAmt: result.payments[0].amount,
+            paymentAmt: paymentMeta.amount,
             transactionFee:
-              result.payments[0].completedPayment?.transactionFee ?? null,
+              paymentMeta.completedPayment?.transactionFee ?? null,
           }
         : null,
     }
@@ -321,7 +324,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
  * now.
  */
 type MetadataAggregateResult = Pick<ISubmissionSchema, '_id' | 'created'> & {
-  payments: PaymentAggregates[]
+  payments?: PaymentAggregates[]
 }
 type PaymentAggregates = Pick<
   IPaymentSchema,
@@ -383,21 +386,24 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
     let currentNumber = count - numToSkip
 
     const metadata = result.map((data) => {
+      const paymentMeta = data.payments?.[0]
       const metadataEntry: StorageModeSubmissionMetadata = {
         number: currentNumber,
         refNo: data._id,
         submissionTime: moment(data.created)
           .tz('Asia/Singapore')
           .format('Do MMM YYYY, h:mm:ss a'),
-        payments: data.payments[0]?.payout
+        payments: paymentMeta
           ? {
-              payoutDate: moment(data.payments[0].payout.payoutDate)
-                .tz('Asia/Singapore')
-                .format('ddd, D MMM YYYY'),
+              payoutDate: paymentMeta.payout
+                ? moment(paymentMeta.payout.payoutDate)
+                    .tz('Asia/Singapore')
+                    .format('ddd, D MMM YYYY')
+                : null,
 
-              paymentAmt: data.payments[0].amount,
+              paymentAmt: paymentMeta.amount,
               transactionFee:
-                data.payments[0].completedPayment?.transactionFee ?? null,
+                paymentMeta.completedPayment?.transactionFee ?? null,
             }
           : null,
       }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -259,8 +259,8 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
   const pageResults: Promise<MetadataAggregateResult[]> = this.aggregate([
     {
       $match: {
-        form: formId,
-        _id: submissionId,
+        form: mongoose.Types.ObjectId(formId),
+        _id: mongoose.Types.ObjectId(submissionId),
         submissionType: SubmissionType.Encrypt,
       },
     },

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -279,6 +279,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
         'payments.payout': 1,
         'payments.completedPayment': 1,
         'payments.amount': 1,
+        'payments.email': 1,
       },
     },
   ])
@@ -311,6 +312,7 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
             paymentAmt: paymentMeta.amount,
             transactionFee:
               paymentMeta.completedPayment?.transactionFee ?? null,
+            email: paymentMeta.email,
           }
         : null,
     }
@@ -328,7 +330,7 @@ type MetadataAggregateResult = Pick<ISubmissionSchema, '_id' | 'created'> & {
 }
 type PaymentAggregates = Pick<
   IPaymentSchema,
-  'amount' | 'payout' | 'completedPayment'
+  'amount' | 'payout' | 'completedPayment' | 'email'
 >
 
 EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
@@ -368,6 +370,7 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
         'payments.payout': 1,
         'payments.completedPayment': 1,
         'payments.amount': 1,
+        'payments.email': 1,
       },
     },
   ])
@@ -404,6 +407,7 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
               paymentAmt: paymentMeta.amount,
               transactionFee:
                 paymentMeta.completedPayment?.transactionFee ?? null,
+              email: paymentMeta.email,
             }
           : null,
       }

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -1254,6 +1254,7 @@ describe('admin-form.submissions.routes', () => {
         number: 11 - index,
         // Loosen refNo checks due to non-deterministic aggregation query.
         // Just expect refNo is one of the possible ones.
+        payments: null,
         refNo: expect.toBeOneOf(createdSubmissionIds),
         submissionTime: expect.any(String),
       }))
@@ -1319,6 +1320,7 @@ describe('admin-form.submissions.routes', () => {
         metadata: [
           {
             number: 1,
+            payments: null,
             refNo: String(submissions[1]._id),
             submissionTime: expect.any(String),
           },

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -1344,7 +1344,7 @@ describe('admin-form.submissions.routes', () => {
       })
     })
 
-    it('should return 200 with metadata of single submissionId when query.submissionId is provided for non-payment fields', async () => {
+    it('should return 200 with metadata of single submissionId when query.submissionId is provided for submissions with payments', async () => {
       // Arrange
       const createdPayment = await Payment.create({
         _id: new ObjectId(),
@@ -1419,7 +1419,7 @@ describe('admin-form.submissions.routes', () => {
         metadata: [
           {
             number: 1,
-            payments: expect.any(String),
+            payments: null,
             refNo: String(submissions[1]._id),
             submissionTime: expect.any(String),
           },

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -18,6 +18,7 @@ import {
   getEmailFormModel,
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
+import getPaymentModel from 'src/app/models/payment.server.model'
 import getSubmissionModel, {
   getEncryptSubmissionModel,
 } from 'src/app/models/submission.server.model'
@@ -34,6 +35,7 @@ import {
 import {
   FormResponseMode,
   FormStatus,
+  PaymentStatus,
   SubmissionType,
 } from '../../../../../../../../shared/types'
 import { AdminFormsRouter } from '../admin-forms.routes'
@@ -54,6 +56,7 @@ const EmailFormModel = getEmailFormModel(mongoose)
 const EncryptFormModel = getEncryptedFormModel(mongoose)
 const SubmissionModel = getSubmissionModel(mongoose)
 const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
+const Payment = getPaymentModel(mongoose)
 
 const ADMIN_FORMS_PREFIX = '/admin/forms'
 
@@ -1228,6 +1231,55 @@ describe('admin-form.submissions.routes', () => {
       expect(response.body).toEqual({ count: 0, metadata: [] })
     })
 
+    it('should return 200 with requested page of metadata with payments when payment exists', async () => {
+      // Arrange
+      const createdPayment = await Payment.create({
+        _id: new ObjectId(),
+        formId: defaultForm._id,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'somePaymentIntentId',
+        amount: 314159,
+        email: 'someone@mail.com',
+      })
+      // Create 3 submissions
+      const submissions = await Promise.all(
+        times(3, (count) =>
+          createEncryptSubmission({
+            form: defaultForm,
+            encryptedContent: `any encrypted content ${count}`,
+            verifiedContent: `any verified content ${count}`,
+            paymentId: createdPayment._id,
+          }),
+        ),
+      )
+
+      const createdSubmissionIds = submissions.map((s) => String(s._id))
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          page: 1,
+        })
+
+      // Assert
+      const expected = times(3, (index) => ({
+        number: 3 - index,
+        payments: expect.any(Object),
+        // Loosen refNo checks due to non-deterministic aggregation query.
+        // Just expect refNo is one of the possible ones.
+        refNo: expect.toBeOneOf(createdSubmissionIds),
+        submissionTime: expect.any(String),
+      }))
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({
+        count: 3,
+        metadata: expected,
+      })
+    })
+
     it('should return 200 with requested page of metadata when metadata exists', async () => {
       // Arrange
       // Create 11 submissions
@@ -1292,6 +1344,53 @@ describe('admin-form.submissions.routes', () => {
       })
     })
 
+    it('should return 200 with metadata of single submissionId when query.submissionId is provided for non-payment fields', async () => {
+      // Arrange
+      const createdPayment = await Payment.create({
+        _id: new ObjectId(),
+        formId: defaultForm._id,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'somePaymentIntentId',
+        amount: 314159,
+        email: 'someone@mail.com',
+      })
+      // Create 3 submissions
+      const submissions = await Promise.all(
+        times(3, (count) =>
+          createEncryptSubmission({
+            form: defaultForm,
+            encryptedContent: `any encrypted content ${count}`,
+            verifiedContent: `any verified content ${count}`,
+            paymentId: createdPayment._id,
+          }),
+        ),
+      )
+
+      // Act
+      const response = await request
+        .get(`/admin/forms/${defaultForm._id}/submissions/metadata`)
+        .query({
+          submissionId: String(submissions[1]._id),
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Only return the single submission id's metadata
+      expect(response.body).toEqual({
+        count: 1,
+        metadata: [
+          {
+            number: 1,
+            payments: expect.any(Object),
+            refNo: String(submissions[1]._id),
+            submissionTime: expect.any(String),
+          },
+        ],
+      })
+    })
+
     it('should return 200 with metadata of single submissionId when query.submissionId is provided', async () => {
       // Arrange
       // Create 3 submissions
@@ -1320,7 +1419,7 @@ describe('admin-form.submissions.routes', () => {
         metadata: [
           {
             number: 1,
-            payments: null,
+            payments: expect.any(String),
             refNo: String(submissions[1]._id),
             submissionTime: expect.any(String),
           },
@@ -1481,12 +1580,14 @@ const createEncryptSubmission = ({
   verifiedContent,
   attachmentMetadata,
   created,
+  paymentId,
 }: {
   form: IFormDocument
   encryptedContent: string
   attachmentMetadata?: Map<string, string>
   verifiedContent?: string
   created?: Date
+  paymentId?: string
 }) => {
   return EncryptSubmissionModel.create({
     submissionType: SubmissionType.Encrypt,
@@ -1498,5 +1599,6 @@ const createEncryptSubmission = ({
     verifiedContent,
     created,
     version: 1,
+    paymentId,
   })
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Most admins wants to quickly have a quick snapshot view of the payment information, namely:
- email
- paid amount
- net amount
- fees
- payout date

Closes FRM-1096

## Solution
<!-- How did you solve the problem? -->
- Obtain additional from the payments with projection through `paymentId`
- Detect if form is a payment form and return payment information on dashboard


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

![Screenshot 2023-07-07 at 4 03 04 PM](https://github.com/opengovsg/FormSG/assets/12391617/6e898ac4-cbcf-49da-8f9f-e10659db53c0)

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
Viewing of results for non-payment forms
As an admin
- [ ] enable to view form results response table without new fields (email, paid amount, net amount, fees, payout date)

**Features**
Viewing of results for payment forms
As an admin
- [ ] enable to view form results response table with new fields (email, paid amount, net amount, fees, payout date)