### PR TITLE
fix: disallow path traversal when proxying static assets

### DIFF
--- a/src/app/loaders/express/error-handler.ts
+++ b/src/app/loaders/express/error-handler.ts
@@ -35,7 +35,7 @@ export const catchNonExistentStaticRoutesMiddleware: RequestHandler = async (
   try {
     const path = req.originalUrl.split(/[?#]/)[0] // drop (potential) query and hash, since they're not involved in traversal
 
-    if (/(^|\/)\.\.(\/|$)/.test(path)) {
+    if (/\.\.[/\\]/.test(path)) {
       // Path contains traversal token(s), we do not expect or allow that
       // Should we return a 400?
       throw new Error('Non-redirectable URL')

--- a/src/app/loaders/express/error-handler.ts
+++ b/src/app/loaders/express/error-handler.ts
@@ -33,6 +33,14 @@ export const catchNonExistentStaticRoutesMiddleware: RequestHandler = async (
   // Attempt to fetch from s3 bucket
 
   try {
+    const path = req.originalUrl.split(/[?#]/)[0] // drop (potential) query and hash, since they're not involved in traversal
+
+    if (/(^|\/)\.\.(\/|$)/.test(path)) {
+      // Path contains traversal token(s), we do not expect or allow that
+      // Should we return a 400?
+      throw new Error('Non-redirectable URL')
+    }
+
     const { data, status, headers } = await axios.get(
       `${config.aws.staticAssetsBucketUrl}${req.originalUrl}`,
       {


### PR DESCRIPTION
## Problem
The proxy system we have in place (used to guarantee old/new servers can find static assets on release when requested by old/new clients does not guard against traversal tokens.

Closes FRM-1114

## Solution
Disallow path with traversal tokens.

Notes for potential discussion:
* path tokens are not necessarily bad, so we could try resolving the final paths rather than blanket rejecting them
* If we do decide to blanket block or compute invalid path, should we return a 400 rather than 404?

## Tests
(update the domain based on he environment being tested)
-  [ ]  run the following curl command the the CLI:
```
curl 'https://form.gov.sg/static/..\../cureredirbucket/test.html'
```
It should **NOT** return
```
<!DOCTYPE html>
<body>
<h2>hello</h2>
<script>alert(123)</sript>
</body>
```
instead it should return the usual FormSG start page
```
<!doctype html><html lang="en"><head><meta charset="utf-8"/><base href="/"/><link rel="icon" href="./favicon.ico"/><link rel="icon" type="image/svg+xml" href="./favicon.svg"/><link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png"/><link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="theme-color" content="#ffffff"/><meta name="description" content="Trusted form manager of the Singapore Government"/><link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png"/><link rel="manifest" href="./manifest.json"/><title>FormSG</title><meta property="og:site_name" content="FormSG"/><meta property="og:title" content="FormSG"/><meta property="og:description" content="Trusted form manager of the Singapore Government"/><meta property="og:image" content="./static/images/og-img-metatag-nonpublicform.png"/><meta property="og:type" content="website"/><meta name="twitter:card" content="summary"/><meta name="twitter:title" content="FormSG"/><meta name="twitter:description" content="Trusted form manager of the Singapore Government"/><meta name="twitter:image" content="./static/images/og-img-metatag-nonpublicform.png"/><script src="../static/js/datadog-chunk.6d7096ea607353a4280f.js"></script><link href="./static/css/6.7aaaf388.chunk.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div><script src="./static/js/runtime-main.e84c65d3.js"></script><script src="./static/js/6.cf2ed09b.chunk.js"></script><script src="./static/js/main.0e279f22.chunk.js"></script></body></html>
```
