### PR TITLE
fix: set decompress to false

### DIFF
--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -122,6 +122,8 @@ describe('webhook.service', () => {
       headers: {
         'X-FormSG-Signature': mockWebhookHeader,
       },
+      decompress: false,
+      maxContentLength: 10000,
       maxRedirects: 0,
       timeout: 10000,
     }

--- a/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -13,6 +13,7 @@ import { IEncryptedSubmissionSchema, WebhookView } from 'src/types'
 
 import { WebhookResponse } from '../../../../../shared/types'
 import { SubmissionNotFoundError } from '../../submission/submission.errors'
+import { WEBHOOK_MAX_CONTENT_LENGTH } from '../webhook.constants'
 import { WebhookQueueMessage } from '../webhook.message'
 import { WebhookProducer } from '../webhook.producer'
 import * as WebhookService from '../webhook.service'
@@ -123,7 +124,7 @@ describe('webhook.service', () => {
         'X-FormSG-Signature': mockWebhookHeader,
       },
       decompress: false,
-      maxContentLength: 10000,
+      maxContentLength: WEBHOOK_MAX_CONTENT_LENGTH,
       maxRedirects: 0,
       timeout: 10000,
     }

--- a/src/app/modules/webhook/webhook.constants.ts
+++ b/src/app/modules/webhook/webhook.constants.ts
@@ -50,3 +50,11 @@ export const MAX_DELAY_SECONDS = minutes(15)
  * number of seconds in the future, it will be sent.
  */
 export const DUE_TIME_TOLERANCE_SECONDS = minutes(1)
+
+/**
+ * WEBHOOK_MAX_CONTENT_LENGTH defined the max size of the http response content in bytes
+ * allowed by the webhook call. Given that the response of the webhook call is not used and does not
+ * impact our partner's processing of the call, we set this to 1MB, which should accommodate webhook responses.
+ *
+ */
+export const WEBHOOK_MAX_CONTENT_LENGTH = 1000000

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -156,6 +156,8 @@ export const sendWebhook = (
                 signature,
               }),
             },
+            decompress: false,
+            maxContentLength: 10000,
             maxRedirects: 0,
             // Timeout after 10 seconds to allow for cold starts in receiver,
             // e.g. Lambdas

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -18,6 +18,7 @@ import { transformMongoError } from '../../utils/handle-mongo-error'
 import { PossibleDatabaseError } from '../core/core.errors'
 import { SubmissionNotFoundError } from '../submission/submission.errors'
 
+import { WEBHOOK_MAX_CONTENT_LENGTH } from './webhook.constants'
 import {
   WebhookFailedWithAxiosError,
   WebhookFailedWithPresignedUrlGenerationError,
@@ -157,7 +158,7 @@ export const sendWebhook = (
               }),
             },
             decompress: false,
-            maxContentLength: 10000,
+            maxContentLength: WEBHOOK_MAX_CONTENT_LENGTH,
             maxRedirects: 0,
             // Timeout after 10 seconds to allow for cold starts in receiver,
             // e.g. Lambdas


### PR DESCRIPTION
## Problem
[GTA-10-009 WP1](https://docs.google.com/document/d/1G33977oPLMzGH78hrzxivRF5Wtrgfs-3sLaBlxFUFR0/edit)
Decompress defaults to true although we are not using the response from webhook requests

Closes FRM-1116, FRM-1117

## Solution
Set decompress to false and maxContentLength to 10 kb which should be sufficient for typical requests. This is in consideration that we do not require the response from webhook requests apart from storing it for archiving purposes.

## Test plan

- [ ] Successful webhook call
