### PR TITLE
fix: mishandling stripe callback when user clicks return to form

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -63,9 +63,7 @@ const MockStripeService = jest.mocked(StripeService)
 describe('stripe.controller', () => {
   beforeAll(async () => await dbHandler.connect())
   afterAll(async () => await dbHandler.closeDatabase())
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
+  beforeEach(() => jest.clearAllMocks())
 
   describe('downloadPaymentInvoice', () => {
     const mockBusinessInfo = {

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -2,9 +2,12 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import expressHandler from '__tests__/unit/backend/helpers/jest-express'
 import axios from 'axios'
 import { ObjectId } from 'bson'
+import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
-import { ok, okAsync } from 'neverthrow'
+import { errAsync, ok, okAsync } from 'neverthrow'
 import { PaymentStatus, SubmissionType } from 'shared/types'
+import Stripe from 'stripe'
+import { MarkRequired } from 'ts-essentials'
 
 import getPaymentModel from 'src/app/models/payment.server.model'
 import { getEncryptPendingSubmissionModel } from 'src/app/models/pending_submission.server.model'
@@ -15,9 +18,12 @@ import {
   IPopulatedForm,
 } from 'src/types'
 
+import config from '../../../config/config'
+import { FormNotFoundError } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
 import * as EncryptSubmissionService from '../../submission/encrypt-submission/encrypt-submission.service'
 import * as StripeController from '../stripe.controller'
+import * as StripeService from '../stripe.service'
 import * as StripeUtils from '../stripe.utils'
 
 const Payment = getPaymentModel(mongoose)
@@ -36,6 +42,9 @@ const MockEncryptSubmissionService = jest.mocked(EncryptSubmissionService)
 
 jest.mock('../../form/form.service')
 const MockFormService = jest.mocked(FormService)
+
+jest.mock('src/app/modules/payments/stripe.service')
+const MockStripeService = jest.mocked(StripeService)
 
 describe('stripe.controller', () => {
   beforeAll(async () => await dbHandler.connect())
@@ -207,6 +216,143 @@ describe('stripe.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.send).toHaveBeenCalledOnce()
       expect(axiosSpy).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('_handleConnectOauthCallback', () => {
+    beforeEach(async () => {
+      await dbHandler.clearCollection(Payment.collection.name)
+      await dbHandler.clearCollection(EncryptPendingSubmission.collection.name)
+    })
+    const mockForm = {
+      _id: MOCK_FORM_ID,
+    } as IPopulatedForm
+    it('should return UNPROCESSABLE_ENTITY when state mismatch', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        query: { state: 'otherState', code: 'someCode' },
+        others: { signedCookies: { stripeState: 'anotherState' } },
+      })
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await StripeController._handleConnectOauthCallbackForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Invalid state parameter',
+      })
+    })
+
+    it('should redirect back to settings/payment page when code is undefined', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        query: { state: 'otherState' },
+        others: { signedCookies: { stripeState: 'otherState' } },
+      })
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await StripeController._handleConnectOauthCallbackForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        `${config.app.appUrl}/admin/form/otherState/settings/payments`,
+      )
+    })
+
+    it('should redirect back to settings/payment page when stripe account linking is successful', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        query: { state: MOCK_FORM_ID + '.otherState', code: 'someCode' },
+        others: {
+          signedCookies: { stripeState: MOCK_FORM_ID + '.otherState' },
+        },
+      })
+      MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
+      const mockStripeToken = {
+        stripe_user_id: 'user_id',
+        stripe_publishable_key: 'publishable_key',
+      } as MarkRequired<
+        Stripe.OAuthToken,
+        'stripe_user_id' | 'stripe_publishable_key'
+      >
+      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValue(
+        ok(mockForm as IPopulatedEncryptedForm),
+      )
+      MockStripeService.exchangeCodeForAccessToken.mockReturnValue(
+        okAsync(mockStripeToken),
+      )
+      MockStripeService.linkStripeAccountToForm.mockReturnValue(
+        okAsync('someId'),
+      )
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await StripeController._handleConnectOauthCallbackForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        `${config.app.appUrl}/admin/form/${MOCK_FORM_ID}/settings/payments`,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledOnceWith(
+        MOCK_FORM_ID,
+      )
+      expect(
+        MockStripeService.exchangeCodeForAccessToken,
+      ).toHaveBeenCalledOnceWith('someCode')
+      expect(
+        MockStripeService.linkStripeAccountToForm,
+      ).toHaveBeenCalledOnceWith(mockForm, {
+        accountId: mockStripeToken.stripe_user_id,
+        publishableKey: mockStripeToken.stripe_publishable_key,
+      })
+    })
+
+    it('should redirect back to settings/payment page when DatabaseError occurs', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        query: { state: 'formId.otherState', code: 'someCode' },
+        others: {
+          signedCookies: { stripeState: 'formId.otherState' },
+        },
+      })
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        errAsync(new FormNotFoundError()),
+      )
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await StripeController._handleConnectOauthCallbackForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        `${config.app.appUrl}/admin/form/formId/settings/payments`,
+      )
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledOnceWith(
+        'formId',
+      )
+      expect(
+        MockStripeService.exchangeCodeForAccessToken,
+      ).not.toHaveBeenCalledWith()
+      expect(
+        MockStripeService.linkStripeAccountToForm,
+      ).not.toHaveBeenCalledWith()
     })
   })
 })

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -295,7 +295,7 @@ const _handleConnectOauthCallback: ControllerHandler<
   unknown,
   unknown,
   unknown,
-  { code?: string | undefined; state: string }
+  { code?: string; state: string }
 > = async (req, res) => {
   const { code, state } = req.query
   // Step 0: Extract state parameter previously signed and stored in cookies.

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -295,10 +295,9 @@ const _handleConnectOauthCallback: ControllerHandler<
   unknown,
   unknown,
   unknown,
-  { code: string; state: string }
+  { code?: string | undefined; state: string }
 > = async (req, res) => {
   const { code, state } = req.query
-
   // Step 0: Extract state parameter previously signed and stored in cookies.
   // Compare state values to ensure that no tampering has occurred.
   const { stripeState } = req.signedCookies
@@ -309,9 +308,14 @@ const _handleConnectOauthCallback: ControllerHandler<
   }
 
   // Step 1: Retrieve formId from state.
+  // Redirect user back to payments page if code is undefined
   const formId = state.split('.')[0]
   const redirectUrl = `${config.app.appUrl}/admin/form/${formId}/settings/payments`
-  // Step 2: Retrieve currently logged in user.
+  if (!code) {
+    return res.redirect(redirectUrl)
+  }
+
+  // Step 2: Retrieve currently logged-in user.
   return (
     FormService.retrieveFullFormById(formId)
       .andThen(checkFormIsEncryptMode)
@@ -343,10 +347,12 @@ const _handleConnectOauthCallback: ControllerHandler<
   )
 }
 
+export const _handleConnectOauthCallbackForTest = _handleConnectOauthCallback
+
 export const handleConnectOauthCallback = [
   celebrate({
     [Segments.QUERY]: Joi.object({
-      code: Joi.string().required(),
+      code: Joi.string(),
       state: Joi.string().required(),
     }).unknown(true),
   }),


### PR DESCRIPTION
## Problem
Currently when user clicks return to form, they will see 400 bad request error with json message body on browser

Closes FRM-1137

## Solution
When code is not found, redirect back to `.../payments/settings` page

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

- Details ...

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/opengovsg/FormSG/assets/10881671/d1169853-c9e3-4615-9f90-2017bc506063)

**AFTER**:
https://github.com/opengovsg/FormSG/assets/10881671/31d8a5ac-335a-4f9d-943e-16674614e372


## Tests
- [ ] Go to any form that has yet to configured payment
- [ ] Go to Settings > Payments, click `Connect with my stripe account`
- [ ] Click Return to FormSG instead of continuing with connection
- [ ] Observe that page is redirected back to Settings > Payments page