### PR TITLE
chore: variable payments UI review changes

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -95,7 +95,6 @@ export const PaymentView = () => {
   const paymentDetailsWithPlaceholderPreview: typeof paymentDetails = {
     ...paymentDetails,
     name: paymentDetails.name || 'Product/service name',
-    description: paymentDetails.description || 'Description',
   }
   return (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -92,6 +92,11 @@ export const PaymentView = () => {
   if (!paymentDetails.enabled && paymentState !== PaymentState.EditingPayment)
     return null
 
+  const paymentDetailsWithPlaceholderPreview: typeof paymentDetails = {
+    ...paymentDetails,
+    name: paymentDetails.name || 'Product/service name',
+    description: paymentDetails.description || 'Description',
+  }
   return (
     <Box w="100%" maxW="57rem" alignSelf="center" ref={paymentRef}>
       <FormProvider {...formMethods}>
@@ -110,7 +115,7 @@ export const PaymentView = () => {
             <Box p={{ base: '0.75rem', md: '1.5rem' }}>
               <PaymentPreview
                 colorTheme={form?.startPage.colorTheme}
-                paymentDetails={paymentDetails}
+                paymentDetails={paymentDetailsWithPlaceholderPreview}
                 isBuilder
               />
             </Box>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/FixedPaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/FixedPaymentAmountField.tsx
@@ -60,8 +60,7 @@ export const FixedPaymentAmountField = ({
       </FormErrorMessage>
       {Number(input[DISPLAY_AMOUNT_FIELD_KEY]) > 1000 ? (
         <InlineMessage variant="warning" mt="2rem" useMarkdown>
-          You would need to issue your own invoice for amounts above S$1000.
-          [Learn more about this]({GUIDE_PAYMENTS_INVOICE_DIFFERENCES})
+          {`You would need to issue your own invoice for amounts above S$1000. [Learn more about this](${GUIDE_PAYMENTS_INVOICE_DIFFERENCES})`}
         </InlineMessage>
       ) : null}
     </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -165,11 +165,7 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
 
   return (
     <CreatePageDrawerContentContainer>
-      <FormControl
-        isRequired
-        isDisabled={isDisabled}
-        isReadOnly={paymentsMutation.isLoading}
-      >
+      <FormControl isRequired isReadOnly={paymentsMutation.isLoading}>
         <FormLabel>Payment type</FormLabel>
         <Controller
           name={'payment_type'}
@@ -208,7 +204,6 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
           Product/service name
         </FormLabel>
         <Input
-          placeholder="Product/service name"
           {...register('name', {
             required: 'This field is required',
           })}
@@ -217,17 +212,11 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
       </FormControl>
       <FormControl
         isReadOnly={paymentsMutation.isLoading}
-        isInvalid={!!errors.description}
         isDisabled={isDisabled}
         isRequired
       >
         <FormLabel>Description</FormLabel>
-        <Textarea
-          placeholder="Product/service name"
-          {...register('description', {
-            required: 'This field is required',
-          })}
-        />
+        <Textarea {...register('description')} />
         <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
       </FormControl>
       {paymentsData?.payment_type === PaymentType.Variable ? (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -204,13 +204,13 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
         isDisabled={isDisabled}
         isRequired
       >
-        <FormLabel description="This will be reflected on the payment invoice">
+        <FormLabel description="This will be reflected on the proof of payment">
           Product/service name
         </FormLabel>
         <Input
           placeholder="Product/service name"
           {...register('name', {
-            required: 'Please enter a payment description',
+            required: 'This field is required',
           })}
         />
         <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
@@ -221,13 +221,11 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
         isDisabled={isDisabled}
         isRequired
       >
-        <FormLabel description="This will be reflected on the payment invoice">
-          Description
-        </FormLabel>
+        <FormLabel>Description</FormLabel>
         <Textarea
           placeholder="Product/service name"
           {...register('description', {
-            required: 'Please enter a payment description',
+            required: 'This field is required',
           })}
         />
         <FormErrorMessage>{errors.description?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -61,7 +61,13 @@ export type FormPaymentsInput = Omit<
   display_max_amount: string
 }
 
-const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
+const PaymentInput = ({
+  isDisabled,
+  isEncryptMode,
+}: {
+  isDisabled: boolean
+  isEncryptMode: boolean
+}) => {
   const { paymentsMutation } = useMutateFormPage()
 
   const setIsDirty = useDirtyFieldStore(setIsDirtySelector)
@@ -165,7 +171,11 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
 
   return (
     <CreatePageDrawerContentContainer>
-      <FormControl isRequired isReadOnly={paymentsMutation.isLoading}>
+      <FormControl
+        isRequired
+        isDisabled={!isEncryptMode} // only encrypt mode forms can be payment forms
+        isReadOnly={paymentsMutation.isLoading}
+      >
         <FormLabel>Payment type</FormLabel>
         <Controller
           name={'payment_type'}
@@ -302,7 +312,10 @@ export const PaymentsInputPanel = (): JSX.Element | null => {
           <InlineMessage variant="info">{paymentDisabledMessage}</InlineMessage>
         </Box>
       )}
-      <PaymentInput isDisabled={isPaymentDisabled} />
+      <PaymentInput
+        isDisabled={isPaymentDisabled}
+        isEncryptMode={isEncryptMode}
+      />
     </>
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -200,7 +200,7 @@ const PaymentInput = ({ isDisabled }: { isDisabled: boolean }) => {
       </FormControl>
       <FormControl
         isReadOnly={paymentsMutation.isLoading}
-        isInvalid={!!errors.description}
+        isInvalid={!!errors.name}
         isDisabled={isDisabled}
         isRequired
       >

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -50,34 +50,40 @@ export const VariablePaymentAmountField = ({
         Payment amount limit
       </FormLabel>
       <HStack>
-        <Controller
-          name={MIN_FIELD_KEY}
-          control={control}
-          rules={minAmountValidation}
-          render={({ field }) => (
-            <Input
-              flex={1}
-              step={0}
-              inputMode="decimal"
-              placeholder="Minimum amount"
-              {...field}
-            />
-          )}
-        />
-        <Controller
-          name={MAX_FIELD_KEY}
-          control={control}
-          rules={maxAmountValidation}
-          render={({ field }) => (
-            <Input
-              flex={1}
-              step={0}
-              inputMode="decimal"
-              placeholder="Maximum amount"
-              {...field}
-            />
-          )}
-        />
+        <FormControl>
+          <FormLabel isRequired>Minimum Amount</FormLabel>
+          <Controller
+            name={MIN_FIELD_KEY}
+            control={control}
+            rules={minAmountValidation}
+            render={({ field }) => (
+              <Input
+                flex={1}
+                step={0}
+                inputMode="decimal"
+                placeholder="At least S$0.50"
+                {...field}
+              />
+            )}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel isRequired>Maximum Amount</FormLabel>
+          <Controller
+            name={MAX_FIELD_KEY}
+            control={control}
+            rules={maxAmountValidation}
+            render={({ field }) => (
+              <Input
+                flex={1}
+                step={0}
+                inputMode="decimal"
+                placeholder="Below S$1,000,000"
+                {...field}
+              />
+            )}
+          />
+        </FormControl>
       </HStack>
       <FormErrorMessage>{errors[MIN_FIELD_KEY]?.message}</FormErrorMessage>
       <FormErrorMessage>{errors[MAX_FIELD_KEY]?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -2,10 +2,12 @@ import { Controller, RegisterOptions, UseFormReturn } from 'react-hook-form'
 import { FormControl, HStack } from '@chakra-ui/react'
 
 import { usePaymentFieldValidation } from '~hooks/usePaymentFieldValidation'
-import { dollarsToCents } from '~utils/payments'
+import { centsToDollars, dollarsToCents, formatCurrency } from '~utils/payments'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
+
+import { useEnv } from '~features/env/queries'
 
 import { FormPaymentsInput } from './PaymentsInputPanel'
 
@@ -24,17 +26,29 @@ export const VariablePaymentAmountField = ({
   control: UseFormReturn<FormPaymentsInput>['control']
   input: FormPaymentsInput
 }) => {
+  const {
+    data: {
+      maxPaymentAmountCents = Number.MAX_SAFE_INTEGER,
+      minPaymentAmountCents = Number.MIN_SAFE_INTEGER,
+    } = {},
+  } = useEnv()
   const minAmountValidation: RegisterOptions<
     FormPaymentsInput,
     typeof MIN_FIELD_KEY
   > = usePaymentFieldValidation<FormPaymentsInput, typeof MIN_FIELD_KEY>({
     lesserThanCents: dollarsToCents(input[MAX_FIELD_KEY] || ''),
+    msgWhenEmpty: `The minimum amount is S${formatCurrency(
+      Number(centsToDollars(minPaymentAmountCents)),
+    )}`,
   })
   const maxAmountValidation: RegisterOptions<
     FormPaymentsInput,
     typeof MAX_FIELD_KEY
   > = usePaymentFieldValidation<FormPaymentsInput, typeof MAX_FIELD_KEY>({
     greaterThanCents: dollarsToCents(input[MIN_FIELD_KEY] || ''),
+    msgWhenEmpty: `The maximum amount is S${formatCurrency(
+      Number(centsToDollars(maxPaymentAmountCents)),
+    )}`,
   })
   return (
     <FormControl
@@ -63,7 +77,7 @@ export const VariablePaymentAmountField = ({
                 flex={1}
                 step={0}
                 inputMode="decimal"
-                placeholder="At least S$0.50"
+                placeholder="S$0.50"
                 {...field}
               />
             )}
@@ -83,7 +97,7 @@ export const VariablePaymentAmountField = ({
                 flex={1}
                 step={0}
                 inputMode="decimal"
-                placeholder="Below S$1,000,000"
+                placeholder="S$1,000,000"
                 {...field}
               />
             )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -39,9 +39,8 @@ export const VariablePaymentAmountField = ({
   return (
     <FormControl
       isReadOnly={isLoading}
-      isDisabled={isDisabled}
-      isInvalid={!!errors[MIN_FIELD_KEY] || !!errors[MAX_FIELD_KEY]}
-      isRequired
+      // these invalid checks are required to trigger FormErrorMessage to display
+      isInvalid={!!errors[MIN_FIELD_KEY]?.message || !!errors[MAX_FIELD_KEY]}
     >
       <FormLabel
         isRequired
@@ -50,7 +49,10 @@ export const VariablePaymentAmountField = ({
         Payment amount limit
       </FormLabel>
       <HStack>
-        <FormControl>
+        <FormControl
+          isInvalid={!!errors[MIN_FIELD_KEY]}
+          isDisabled={isDisabled}
+        >
           <FormLabel isRequired>Minimum Amount</FormLabel>
           <Controller
             name={MIN_FIELD_KEY}
@@ -67,7 +69,10 @@ export const VariablePaymentAmountField = ({
             )}
           />
         </FormControl>
-        <FormControl>
+        <FormControl
+          isInvalid={!!errors[MAX_FIELD_KEY]}
+          isDisabled={isDisabled}
+        >
           <FormLabel isRequired>Maximum Amount</FormLabel>
           <Controller
             name={MAX_FIELD_KEY}

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentItemNameDescription.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentItemNameDescription.tsx
@@ -5,15 +5,19 @@ import { PaymentItemNameDescriptionProps } from './types'
 const PaymentItemNameDescription = ({
   paymentItemName,
   paymentDescription,
-}: PaymentItemNameDescriptionProps) => (
-  <Box mb="0.75rem">
-    {paymentItemName ? (
-      <Text textStyle="subhead-1">{paymentItemName}</Text>
-    ) : null}
-    {paymentDescription ? (
-      <Text textStyle="body-2">{paymentDescription}</Text>
-    ) : null}
-  </Box>
-)
-
+}: PaymentItemNameDescriptionProps) => {
+  if (!paymentItemName && !paymentDescription) {
+    return null
+  }
+  return (
+    <Box mb="0.75rem">
+      {paymentItemName ? (
+        <Text textStyle="subhead-1">{paymentItemName}</Text>
+      ) : null}
+      {paymentDescription ? (
+        <Text textStyle="body-2">{paymentDescription}</Text>
+      ) : null}
+    </Box>
+  )
+}
 export default PaymentItemNameDescription

--- a/frontend/src/hooks/usePaymentFieldValidation.ts
+++ b/frontend/src/hooks/usePaymentFieldValidation.ts
@@ -45,7 +45,7 @@ export const usePaymentFieldValidation = <
         !!maxCentsLimit && !!val && dollarsToCents(val) <= maxCentsLimit
       // Repeat the check on maxCentsLimit for correct typing
       if (!!maxCentsLimit && !validateMax) {
-        return `The maximum amount is ${formatCurrency(
+        return `Enter a maximum amount that is not more than ${formatCurrency(
           Number(centsToDollars(maxCentsLimit)),
         )}`
       }

--- a/frontend/src/hooks/usePaymentFieldValidation.ts
+++ b/frontend/src/hooks/usePaymentFieldValidation.ts
@@ -29,9 +29,10 @@ export const usePaymentFieldValidation = <
 
   const amountValidation: RegisterOptions<T, V> = {
     validate: (val) => {
-      if (val === '' && msgWhenEmpty) {
+      if (!val && msgWhenEmpty) {
         return msgWhenEmpty
       }
+
       // Validate that it is a money value.
       // Regex allows leading and trailing spaces, max 2dp
       const validateMoney = /^\s*(\d+)(\.\d{0,2})?\s*$/.test(val ?? '')

--- a/frontend/src/hooks/usePaymentFieldValidation.ts
+++ b/frontend/src/hooks/usePaymentFieldValidation.ts
@@ -10,6 +10,7 @@ export const usePaymentFieldValidation = <
 >(options?: {
   greaterThanCents?: number
   lesserThanCents?: number
+  msgWhenEmpty?: string
 }) => {
   const {
     data: {
@@ -21,12 +22,16 @@ export const usePaymentFieldValidation = <
   const {
     lesserThanCents: maxCents = Number.MAX_SAFE_INTEGER,
     greaterThanCents: minCents = Number.MIN_SAFE_INTEGER,
+    msgWhenEmpty = '',
   } = options || {}
   const maxCentsLimit = Math.min(maxCents, maxPaymentAmountCents)
   const minCentsLimit = Math.max(minCents, minPaymentAmountCents)
 
   const amountValidation: RegisterOptions<T, V> = {
     validate: (val) => {
+      if (val === '' && msgWhenEmpty) {
+        return msgWhenEmpty
+      }
       // Validate that it is a money value.
       // Regex allows leading and trailing spaces, max 2dp
       const validateMoney = /^\s*(\d+)(\.\d{0,2})?\s*$/.test(val ?? '')
@@ -36,7 +41,7 @@ export const usePaymentFieldValidation = <
         !!minCentsLimit && !!val && dollarsToCents(val) >= minCentsLimit
       // Repeat the check on minCentsLimit for correct typing
       if (!!minCentsLimit && !validateMin) {
-        return `The minimum amount is ${formatCurrency(
+        return `The minimum amount is S${formatCurrency(
           Number(centsToDollars(minCentsLimit)),
         )}`
       }
@@ -45,7 +50,7 @@ export const usePaymentFieldValidation = <
         !!maxCentsLimit && !!val && dollarsToCents(val) <= maxCentsLimit
       // Repeat the check on maxCentsLimit for correct typing
       if (!!maxCentsLimit && !validateMax) {
-        return `Enter a maximum amount that is not more than ${formatCurrency(
+        return `The maximum amount is S${formatCurrency(
           Number(centsToDollars(maxCentsLimit)),
         )}`
       }

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -363,7 +363,7 @@ const updatePaymentsValidator = celebrate({
 
     description: Joi.when('enabled', {
       is: Joi.equal(true),
-      then: Joi.string().trim().required(),
+      then: Joi.string().trim().allow(''),
       otherwise: Joi.string().trim().allow(''),
     }),
     name: Joi.when('enabled', {


### PR DESCRIPTION
## Changes
Below are done together with design.

* markdown text for payment invoice guide (the one where you saw `[something](link)`

Payment Product/Server + Description
* remove placeholders for `Product/Service` + `Description`
* update copy for `This will be reflected on the payment invoice` -> `This will be reflected on the proof of payment`
* remove description `This will be reflected on the payment invoice` for `Description` label
* update copy for missing fields `Please enter a payment description` -> `This field is required`

Payment Type Variable :: Minmax fields
* add min / max labels for min max field in payment type variable
* update placeholders `Minimum amount` -> `S$0.50`
* update placeholder `Maximum amount` -> `S$1,000,000`
* error copy when min is empty “The minimum amount is S$XX”,
* error copy when max is empty “The maximum amount is S$YY”, 

Payment Type
- selectable even when payment is disabled

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
| Description | Before | After |
|--------|--------|--------|
| Invoice Guide Markdown Text | <img width="512" alt="Screenshot 2023-07-10 at 2 09 23 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/d2dfb4c6-40dc-42c6-8b3e-9a033c5bf38a"> | <img width="506" alt="Screenshot 2023-07-10 at 2 09 09 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/66dcd9d2-f787-405d-87c1-f7026aa7560d"> |
| Payment Amount Limit | <img width="522" alt="Screenshot 2023-07-10 at 5 51 10 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/fff6bad8-7984-4ab1-b8dd-f5db3aa5dbc9"> | <img width="387" alt="Screenshot 2023-07-10 at 5 45 46 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/85154d45-851b-4f6a-af4e-5eb4e59251c4"> |
| Payment Amount Placeholder | <img width="528" alt="Screenshot 2023-07-10 at 5 51 03 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/c0fdc97c-9294-4404-a4c3-1b1819869d4a"> | <img width="386" alt="Screenshot 2023-07-10 at 5 45 29 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/b9a33fe2-eb09-49cc-bdd3-511b52e426c7"> | 
| Payment Panel Fields | <img width="528" alt="Screenshot 2023-07-10 at 5 51 19 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/7cb88710-ce25-47b3-932c-41e26cf1752f"> | <img width="509" alt="Screenshot 2023-07-10 at 5 57 07 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/d395da29-9079-4b5e-9aad-4f520e1e9a00">|
| Payment Type |<img width="401" alt="Screenshot 2023-07-10 at 6 01 39 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/c791bfe2-53c8-4ad0-a38f-a1e5dcac031d"> | <img width="419" alt="Screenshot 2023-07-10 at 6 01 00 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/5ecd95ea-dad5-40d9-aea7-83d894e84872">|

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new storage mode form 
- [ ] Go to Create Tab -> Payment, you should be able to toggle `Payment Type`
- [ ] Connect to stripe account
- [ ] Go to Create Tab -> Payment
- [ ] Ensure that there isn't any placeholders for `Product/service name` and `Description`
- [ ] Go to `Product/service name` and enter without adding any value, you should see an error that it is required
- [ ] Go to `Description` and enter without adding any value, there should be no error
- [ ] Select `Fixed Payment`, go to 'Payment Amount' and input >$1000, you should see the warning message for invoices and be able to click the link
- [ ] Select `Variable payment` you should see the max and min placeholders. 
- [ ] Upon entering empty values for both max and min -> you should see warning messages that tells you the max and min values expected
- [ ] Go to an email mode form
- [ ] Go to Create Tab -> Payment, you should not be able to select any fields in email mode 