### PR TITLE
fix: add FE validation rule that email domains must be non empty

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -112,6 +112,10 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
             'Please remove duplicate email domains'
           )
         },
+        noEmpty: (value) => {
+          const split = SPLIT_TEXTAREA_TRANSFORM.output(value)
+          return split.length > 0 || 'Please enter at least one email domain'
+        },
         validEmailDomains: (value) => {
           const split = SPLIT_TEXTAREA_TRANSFORM.output(value)
           return (


### PR DESCRIPTION
## Problem

- #6497 added backend validation that email domains must be non empty if restrict email domains is enabled
- This PR also adds frontend validation for more graceful error presentation

## Screenshots
<img width="379" alt="Screenshot 2023-07-11 at 11 42 50 PM" src="https://github.com/opengovsg/FormSG/assets/63710093/67dedec1-53ee-4013-8ef9-c8b9efa86e84">
