### PR TITLE
fix: presub remove additional underscore

### DIFF
--- a/src/app/views/templates/issue-reported-notification.view.html
+++ b/src/app/views/templates/issue-reported-notification.view.html
@@ -9,8 +9,8 @@
       might be facing urgent issues relating to form submission.
     </p>
     <p>
-      <a href="<%= formResultUrl %>">Login to Forms </a> and view issues
-      reported in your results page.
+      <a href="<%= formResultUrl %>">Login to Forms</a> and view issues reported
+      in your results page.
     </p>
     <p>Regards,<br /><%= appName %> team</p>
   </body>


### PR DESCRIPTION
Remove additional underscore at white space. Credits to @LinHuiqing for noticing it.

## Before & After Screenshots

**BEFORE**:
<img width="1109" alt="image" src="https://github.com/opengovsg/FormSG/assets/10881671/5f9752de-f3d5-4717-b7f0-cd05605758ad">

**AFTER**:
<img width="1155" alt="image" src="https://github.com/opengovsg/FormSG/assets/10881671/717f285a-4dd0-49ef-8b0d-f548fefcecea">

## Tests

- [ ] Report an issue in any public form (make sure this is the first issue reported for the day), notice the underscore is only for the word `Login to forms`