### PR TITLE
fix: updating csp to fix bypass

### DIFF
--- a/frontend/src/app/AppHelmet.tsx
+++ b/frontend/src/app/AppHelmet.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async'
 export const AppHelmet = (): JSX.Element => {
   const GATrackingID = process.env.REACT_APP_GA_TRACKING_ID
   return (
-    <Helmet titleTemplate="%s | FormSG" defer={false}>
+    <Helmet titleTemplate="%s | FormSG" defer={true}>
       {GATrackingID ? (
         <script
           async

--- a/frontend/src/app/AppHelmet.tsx
+++ b/frontend/src/app/AppHelmet.tsx
@@ -1,8 +1,7 @@
 import { Helmet } from 'react-helmet-async'
 
 export const AppHelmet = (): JSX.Element => {
-  // const GATrackingID = process.env.REACT_APP_GA_TRACKING_ID
-  const GATrackingID = 'UA-130216930-3'
+  const GATrackingID = process.env.REACT_APP_GA_TRACKING_ID
   return (
     <Helmet titleTemplate="%s | FormSG" defer={false}>
       {GATrackingID ? (

--- a/frontend/src/app/AppHelmet.tsx
+++ b/frontend/src/app/AppHelmet.tsx
@@ -1,9 +1,10 @@
 import { Helmet } from 'react-helmet-async'
 
 export const AppHelmet = (): JSX.Element => {
-  const GATrackingID = process.env.REACT_APP_GA_TRACKING_ID
+  // const GATrackingID = process.env.REACT_APP_GA_TRACKING_ID
+  const GATrackingID = 'UA-130216930-3'
   return (
-    <Helmet titleTemplate="%s | FormSG" defer={true}>
+    <Helmet titleTemplate="%s | FormSG" defer={false}>
       {GATrackingID ? (
         <script
           async

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -40,8 +40,8 @@ describe('helmetMiddlewares', () => {
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
       // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      // Commenting out due to CSP bypass issues and we are not using GA4 yet.
-      // 'https://*.googletagmanager.com/',
+      // not actively used yet, loading specific file due to CSP bypass issue
+      'https://*.googletagmanager.com/gtag/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -39,6 +39,7 @@ describe('helmetMiddlewares', () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
+      'https://*.googletagmanager.com/gtag/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -31,7 +31,6 @@ describe('helmetMiddlewares', () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
-      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',
@@ -40,7 +39,7 @@ describe('helmetMiddlewares', () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com',
+      'https://*.googletagmanager.com/gtag/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -39,7 +39,7 @@ describe('helmetMiddlewares', () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com/gtag/',
+      'https://*.googletagmanager.com',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -36,7 +36,7 @@ describe('helmetMiddlewares', () => {
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/releases',
+      'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
     ],

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -31,17 +31,13 @@ describe('helmetMiddlewares', () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
-      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://www.gstatic.cn/',
-      'https://*.googletagmanager.com',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -39,7 +39,9 @@ describe('helmetMiddlewares', () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com/gtag/',
+      // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
+      // Commenting out due to CSP bypass issues and we are not using GA4 yet.
+      // 'https://*.googletagmanager.com/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -31,6 +31,7 @@ describe('helmetMiddlewares', () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
+      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',

--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -36,6 +36,7 @@ describe('helmetMiddlewares', () => {
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
+      'https://www.gstatic.com/recaptcha/releases',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
     ],

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -49,6 +49,7 @@ const helmetMiddlewares = () => {
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
+      'https://www.gstatic.com/recaptcha/releases',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
     ],

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -52,6 +52,7 @@ const helmetMiddlewares = () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
+      'https://*.googletagmanager.com/gtag/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -44,7 +44,6 @@ const helmetMiddlewares = () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
-      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',
@@ -53,7 +52,7 @@ const helmetMiddlewares = () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
+      'https://*.googletagmanager.com/gtag/', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -44,6 +44,7 @@ const helmetMiddlewares = () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
+      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',
@@ -52,8 +53,7 @@ const helmetMiddlewares = () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      // 'https://*.googletagmanager.com/gtag/',
-      'https://*.googletagmanager.com',
+      'https://*.googletagmanager.com', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -49,7 +49,7 @@ const helmetMiddlewares = () => {
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/releases',
+      'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
     ],

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -52,7 +52,9 @@ const helmetMiddlewares = () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com/gtag/', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
+      // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
+      // Commenting out due to CSP bypass issues and we are not using GA4 yet.
+      // 'https://*.googletagmanager.com/',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -52,7 +52,8 @@ const helmetMiddlewares = () => {
       'https://www.gstatic.com/recaptcha/releases/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://*.googletagmanager.com/gtag/',
+      // 'https://*.googletagmanager.com/gtag/',
+      'https://*.googletagmanager.com',
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -44,17 +44,13 @@ const helmetMiddlewares = () => {
     fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
     scriptSrc: [
       "'self'",
-      'https://www.googletagmanager.com/',
       'https://ssl.google-analytics.com/',
       'https://www.google-analytics.com/',
       'https://www.tagmanager.google.com/',
       'https://www.google.com/recaptcha/',
       'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/',
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
-      'https://www.gstatic.cn/',
-      'https://*.googletagmanager.com', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
     ],
     connectSrc: [
       "'self'",

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -53,8 +53,8 @@ const helmetMiddlewares = () => {
       'https://challenges.cloudflare.com',
       'https://js.stripe.com/v3',
       // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      // Commenting out due to CSP bypass issues and we are not using GA4 yet.
-      // 'https://*.googletagmanager.com/',
+      // not actively used yet, loading specific files due to CSP bypass issue
+      'https://*.googletagmanager.com/gtag/',
     ],
     connectSrc: [
       "'self'",


### PR DESCRIPTION
## Problem
Remove googletagmanager and gstatic from CSP configurations to mitigate the following VAPT issues.
1. CSP bypass via AngularJS on Google-managed hosts
2. CSP bypass via open redirect in Google Tag Manager

Closes FRM-1119

## Solution

Background info
[Google Tag manager CSP](https://developers.google.com/tag-platform/tag-manager/csp)
[reCAPTCHA CSP](https://developers.google.com/recaptcha/docs/faq)


1. Remove domains hosting AngularJS library from script-src directive
2. Remove domains deploying the open redirect endpoint from the script-src directive
3. Alternatively, load specific files as opposed to entire domains.


**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Check that scripts from reCAPTCHA can load successfully in form submission page (network tab). 
- [ ] Check that reCAPTCHA can trigger successfully. Ensure that feature flags for turnstile is set to false and use VPN to trigger reCAPTCHA.
- [ ] Check that there are no script failures related to GTM/GA when you navigate the home page and log in. No errors are expected as we are not using GA4 yet.
https://analytics.google.com/analytics/web/#/report-home/a130216930w207559009p200196046



