### PR TITLE
feat: add description to form issue modal

### DIFF
--- a/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
+++ b/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
@@ -114,7 +114,7 @@ export const FormIssueFeedbackModal = ({
             <Stack>
               <FormControl isInvalid={!!errors.issue}>
                 <FormLabel isRequired={true}>
-                  Please describe the issue you encountered.
+                  Please describe the issue you encountered
                 </FormLabel>
                 <Textarea
                   {...register('issue', {

--- a/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
+++ b/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
@@ -98,10 +98,19 @@ export const FormIssueFeedbackModal = ({
             pr="4rem"
           >
             <Text textStyle={{ base: '1.25rem', md: '1.5rem' }}>
-              Have trouble filling out this form?
+              Report an issue
             </Text>
           </ModalHeader>
           <ModalBody>
+            <Text pb="1.5rem" textStyle="body-2" color="secondary.400" mt="0">
+              Fill this in only{' '}
+              <span style={{ fontWeight: 'bold' }}>
+                if you are experiencing issues and are unable to submit this
+                form
+              </span>
+              . If you would like to provide feedback, you can do so after
+              submitting the form.
+            </Text>
             <Stack>
               <FormControl isInvalid={!!errors.issue}>
                 <FormLabel

--- a/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
+++ b/frontend/src/features/public-form/components/FormIssueFeedback/FormIssueFeedbackModal.tsx
@@ -102,7 +102,7 @@ export const FormIssueFeedbackModal = ({
             </Text>
           </ModalHeader>
           <ModalBody>
-            <Text pb="1.5rem" textStyle="body-2" color="secondary.400" mt="0">
+            <Text pb="1.5rem" textStyle="body-2" mt="0">
               Fill this in only{' '}
               <span style={{ fontWeight: 'bold' }}>
                 if you are experiencing issues and are unable to submit this
@@ -113,10 +113,7 @@ export const FormIssueFeedbackModal = ({
             </Text>
             <Stack>
               <FormControl isInvalid={!!errors.issue}>
-                <FormLabel
-                  isRequired={true}
-                  description={'This will be sent to the form creator.'}
-                >
+                <FormLabel isRequired={true}>
                   Please describe the issue you encountered.
                 </FormLabel>
                 <Textarea
@@ -130,12 +127,7 @@ export const FormIssueFeedbackModal = ({
               </FormControl>
 
               <FormControl isInvalid={!!errors.email}>
-                <FormLabel
-                  pt="1rem"
-                  description="Leave your email so the form creator can reach out to you if needed."
-                >
-                  Contact
-                </FormLabel>
+                <FormLabel pt="1rem">Contact</FormLabel>
                 <Input
                   type={BasicField.Email}
                   placeholder="me@example.com"


### PR DESCRIPTION
## Problem
Some of the public users seem to be using the form issue message to submit non-issue matter.

Closes FRM-1164

## Solution
Update description of the modal to explicitly call out that the feature is used only for issue reporting.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="718" alt="image" src="https://github.com/opengovsg/FormSG/assets/10881671/505db23c-a703-4f2e-b689-b0e7ffb8f3ed">

**AFTER**:
![Uploading image.png…]()


## Tests
- [ ] Open a form as public user, and click on the question mark icon at the bottom right corner.
- [ ] Ensure that the form issue modal is describing what this issue is for. Specifically, it should say `Fill this in only if you are experiencing issues and are unable to submit this form. If you would like to provide feedback, you can do so after submitting the form.