### PR TITLE
feat: indicate if GST has been applied to a payment transaction

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -119,6 +119,15 @@ export const updateBusinessInfo: UpdateStorageFormFn<'business'> = async (
   return updateFormSettings(formId, { business: newBusinessField })
 }
 
+export const updateGstEnabledFlag = async (
+  formId: string,
+  gstEnabledFlag: StorageFormSettings['payments_field']['gst_enabled'],
+) => {
+  return updateFormSettings(formId, {
+    payments_field: { gst_enabled: gstEnabledFlag },
+  })
+}
+
 /**
  * Internal function that calls the PATCH API.
  * @param formId the id of the form to update

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -90,12 +90,7 @@ const BusinessInfoBlock = ({
     <>
       {settings.payments_field.gst_enabled ? (
         <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
-          <FormLabel
-            description="Leave blank to use your agency's GST Registration Number"
-            isRequired
-          >
-            GST Registration Number
-          </FormLabel>
+          <FormLabel isRequired>GST Registration Number</FormLabel>
           <BusinessFieldInput
             placeholder={agencyDefaults?.gstRegNo || ''}
             initialValue={settings.business?.gstRegNo || ''}
@@ -104,12 +99,7 @@ const BusinessInfoBlock = ({
         </FormControl>
       ) : null}
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
-        <FormLabel
-          description="Leave blank to use your agency's business address"
-          isRequired
-        >
-          Business Address
-        </FormLabel>
+        <FormLabel isRequired>Business Address</FormLabel>
         <BusinessFieldInput
           placeholder={agencyDefaults?.address || ''}
           initialValue={settings.business?.address || ''}

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -88,19 +88,21 @@ const BusinessInfoBlock = ({
   }
   return (
     <>
-      <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
-        <FormLabel
-          description="Leave blank to use your agency's GST Registration Number"
-          isRequired
-        >
-          GST Registration Number
-        </FormLabel>
-        <BusinessFieldInput
-          placeholder={agencyDefaults?.gstRegNo || ''}
-          initialValue={settings.business?.gstRegNo || ''}
-          handleMutation={handleGstRegNoMutation}
-        />
-      </FormControl>
+      {settings.payments_field.gst_enabled ? (
+        <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
+          <FormLabel
+            description="Leave blank to use your agency's GST Registration Number"
+            isRequired
+          >
+            GST Registration Number
+          </FormLabel>
+          <BusinessFieldInput
+            placeholder={agencyDefaults?.gstRegNo || ''}
+            initialValue={settings.business?.gstRegNo || ''}
+            handleMutation={handleGstRegNoMutation}
+          />
+        </FormControl>
+      ) : null}
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
         <FormLabel
           description="Leave blank to use your agency's business address"

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/EnableGSTSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/EnableGSTSection.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react'
+import { Skeleton } from '@chakra-ui/react'
+
+import { FormResponseMode } from '~shared/types'
+
+import Toggle from '~components/Toggle'
+
+import { useMutateFormSettings } from '../../mutations'
+import { useAdminFormSettings } from '../../queries'
+
+export const FormGSTToggle = (): JSX.Element => {
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  const hasGST = useMemo(
+    () =>
+      settings &&
+      settings.responseMode === FormResponseMode.Encrypt &&
+      settings?.payments_field.gst_enabled,
+    [settings],
+  )
+
+  const { mutateGST } = useMutateFormSettings()
+
+  const handleToggleGST = useCallback(() => {
+    if (
+      !settings ||
+      isLoadingSettings ||
+      mutateGST.isLoading ||
+      settings.responseMode !== FormResponseMode.Encrypt
+    )
+      return
+    const nextHasGst = !settings.payments_field.gst_enabled
+    return mutateGST.mutate(nextHasGst)
+  }, [isLoadingSettings, mutateGST, settings])
+
+  return (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings}>
+      <Toggle
+        mb="2.5rem"
+        isLoading={mutateGST.isLoading}
+        isChecked={hasGST}
+        label="Apply GST"
+        description="Include GST in the transaction amount"
+        onChange={() => handleToggleGST()}
+      />
+    </Skeleton>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/GstToggleSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/GstToggleSection.tsx
@@ -8,7 +8,7 @@ import Toggle from '~components/Toggle'
 import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
-export const FormGSTToggle = (): JSX.Element => {
+export const GstToggleSection = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -28,8 +28,9 @@ export const FormGSTToggle = (): JSX.Element => {
       isLoadingSettings ||
       mutateGST.isLoading ||
       settings.responseMode !== FormResponseMode.Encrypt
-    )
+    ) {
       return
+    }
     const nextHasGst = !settings.payments_field.gst_enabled
     return mutateGST.mutate(nextHasGst)
   }, [isLoadingSettings, mutateGST, settings])
@@ -40,8 +41,8 @@ export const FormGSTToggle = (): JSX.Element => {
         mb="2.5rem"
         isLoading={mutateGST.isLoading}
         isChecked={hasGST}
-        label="Apply GST"
-        description="Include GST in the transaction amount"
+        label="GST applicable"
+        description="GST will be mentioned in proof of payment"
         onChange={() => handleToggleGST()}
       />
     </Skeleton>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -24,7 +24,7 @@ import { useEnv } from '~features/env/queries'
 import { useAdminFormPayments, useAdminFormSettings } from '../../queries'
 
 import { BusinessInfoSection } from './BusinessInfoSection'
-import { FormGSTToggle } from './EnableGSTSection'
+import { GstToggleSection } from './GstToggleSection'
 import { usePaymentGuideLink } from './queries'
 import {
   StripeConnectButton,
@@ -232,7 +232,7 @@ export const PaymentSettingsSection = (): JSX.Element => {
           {hasPaymentCapabilities && (
             <>
               <Divider my="2.5rem" />
-              <FormGSTToggle />
+              <GstToggleSection />
               <BusinessInfoSection />
             </>
           )}

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -24,6 +24,7 @@ import { useEnv } from '~features/env/queries'
 import { useAdminFormPayments, useAdminFormSettings } from '../../queries'
 
 import { BusinessInfoSection } from './BusinessInfoSection'
+import { FormGSTToggle } from './EnableGSTSection'
 import { usePaymentGuideLink } from './queries'
 import {
   StripeConnectButton,
@@ -231,6 +232,7 @@ export const PaymentSettingsSection = (): JSX.Element => {
           {hasPaymentCapabilities && (
             <>
               <Divider my="2.5rem" />
+              <FormGSTToggle />
               <BusinessInfoSection />
             </>
           )}

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -37,6 +37,7 @@ import {
   updateFormTitle,
   updateFormWebhookRetries,
   updateFormWebhookUrl,
+  updateGstEnabledFlag,
   updateTwilioCredentials,
 } from './SettingsService'
 
@@ -303,6 +304,20 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateGST = useMutation(
+    (gstEnabledFlag: StorageFormSettings['payments_field']['gst_enabled']) =>
+      updateGstEnabledFlag(formId, gstEnabledFlag),
+    {
+      onSuccess: (newData) => {
+        handleSuccess({
+          newData,
+          toastDescription: `GST setting has been updated.`,
+        })
+      },
+      onError: handleError,
+    },
+  )
+
   return {
     mutateWebhookRetries,
     mutateFormWebhookUrl,
@@ -315,6 +330,7 @@ export const useMutateFormSettings = () => {
     mutateFormAuthType,
     mutateFormEsrvcId,
     mutateFormBusiness,
+    mutateGST,
   }
 }
 

--- a/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
+++ b/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
@@ -1,8 +1,9 @@
 /* eslint-disable */
 
 /**
- * Add gstEnabled flag to payments and forms collections and set the 
- * gstEnabled flag for all documents to true
+ * This script adds the `gstEnabled` flag to the payments collection and sets the flag for all existing documents to true. 
+ * It also adds the `gst_enabled` flag to the `payments_field` in the form collection, and sets the flag for all existing
+ * documents with a `payments_field` to true. 
  */
 
 // PAYMENTS COLLECTION
@@ -34,7 +35,7 @@ db
   .getCollection('payments')
   .countDocuments({ gstEnabled: { $exists: false } }) === 0
 
-  
+
 // FORM COLLECTION
 // BEFORE
 

--- a/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
+++ b/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
@@ -1,0 +1,72 @@
+/* eslint-disable */
+
+/**
+ * Add gstEnabled flag to payments and forms collections and set the 
+ * gstEnabled flag for all documents to true
+ */
+
+// PAYMENTS COLLECTION
+// BEFORE
+// Count total number of payments with no gstEnabled flag. This should be 0.
+db.getCollection('payments').countDocuments({ gstEnabled: { $size: 0 } }) === 0
+
+// Count total number of payments.
+const totalPayments = db.getCollection('payments').countDocuments({})
+
+// Count total number of payments with no gstEnabled flag value. This should be equal to the total number of payments.
+db
+  .getCollection('payments')
+  .countDocuments({ gstEnabled: { $exists: false } }) === totalPayments
+
+// UPDATE
+db.getCollection('payments').updateMany({}, [
+  { $set: { gstEnabled: true } },
+])
+
+// AFTER
+// Count total number of payments with gstEnabled flag value. This should be equal to the total number of payments.
+db
+  .getCollection('payments')
+  .countDocuments({ gstEnabled: { $exists: true } }) === totalPayments
+
+// Count total number of payments with no gstEnabled flag value. This should be equal to 0
+db
+  .getCollection('payments')
+  .countDocuments({ gstEnabled: { $exists: false } }) === 0
+
+  
+// FORM COLLECTION
+// BEFORE
+
+// Count number of forms that contains the payments_field property
+const totalPaymentForms = db.getCollection("forms").find(
+    {payments_field: {$ne: null }},
+).count()
+
+// Count total number of forms with no gstEnabled flag value. This should be equal to 0.
+db.getCollection('forms')
+  .find({ 'payments_field.gst_enabled': { $exists: true } })
+  .count()
+
+// UPDATE all forms (with payment fields) gst_enabled flag to true
+db.getCollection('forms').updateMany({ payments_field: { $ne: null } },  [
+  { $set: { payments_field: { gst_enabled: true } } },
+])
+
+// AFTER
+// Count total number of forms with gstEnabled flag value. This should be equal to the total number of forms with payments_fields.
+db.getCollection('forms')
+  .find({ 'payments_field.gst_enabled': { $exists: true } })
+  .count()
+
+// Count total number of forms with payments_field property and no gstEnabled flag value. This should be equal to 0
+
+db.getCollection('forms')
+  .find({
+    $and: [
+      { payments_field: { $ne: null } },
+      { payments_field: {gst_enabled: { $ne: null }} },
+    ],
+  })
+  .count()
+

--- a/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
+++ b/scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js
@@ -8,16 +8,13 @@
 
 // PAYMENTS COLLECTION
 // BEFORE
-// Count total number of payments with no gstEnabled flag. This should be 0.
-db.getCollection('payments').countDocuments({ gstEnabled: { $size: 0 } }) === 0
-
 // Count total number of payments.
-const totalPayments = db.getCollection('payments').countDocuments({})
+db.getCollection('payments').countDocuments({})
 
 // Count total number of payments with no gstEnabled flag value. This should be equal to the total number of payments.
 db
   .getCollection('payments')
-  .countDocuments({ gstEnabled: { $exists: false } }) === totalPayments
+  .countDocuments({ gstEnabled: { $exists: false } })
 
 // UPDATE
 db.getCollection('payments').updateMany({}, [
@@ -28,19 +25,19 @@ db.getCollection('payments').updateMany({}, [
 // Count total number of payments with gstEnabled flag value. This should be equal to the total number of payments.
 db
   .getCollection('payments')
-  .countDocuments({ gstEnabled: { $exists: true } }) === totalPayments
+  .countDocuments({ gstEnabled: { $exists: true } })
 
 // Count total number of payments with no gstEnabled flag value. This should be equal to 0
 db
   .getCollection('payments')
-  .countDocuments({ gstEnabled: { $exists: false } }) === 0
+  .countDocuments({ gstEnabled: { $exists: false } })
 
 
 // FORM COLLECTION
 // BEFORE
 
 // Count number of forms that contains the payments_field property
-const totalPaymentForms = db.getCollection("forms").find(
+db.getCollection("forms").find(
     {payments_field: {$ne: null }},
 ).count()
 

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -99,6 +99,7 @@ export type FormPaymentsField =
       enabled: boolean
       description?: string
       name?: string
+      gst_enabled?: boolean
     } & (VariablePaymentsField | FixedPaymentField)
 
 export type FormBusinessField = {

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -43,6 +43,7 @@ export type Payment = {
   email: string
   amount: number
   paymentIntentId: string
+  gstEnabled: boolean
 
   // Payment status tracking
   webhookLog: Stripe.Event[]

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -104,7 +104,7 @@ const PAYMENTS_DEFAULTS = {
     min_amount: 0,
     max_amount: 0,
     payment_type: PaymentType.Fixed,
-    gst_enabled: false,
+    gst_enabled: true,
   },
 }
 

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -104,6 +104,7 @@ const PAYMENTS_DEFAULTS = {
     min_amount: 0,
     max_amount: 0,
     payment_type: PaymentType.Fixed,
+    gst_enabled: false,
   },
 }
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -200,6 +200,10 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       enum: Object.values(PaymentType),
       default: PaymentType.Fixed,
     },
+    gst_enabled: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   business: {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -202,7 +202,7 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
     },
     gst_enabled: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
 

--- a/src/app/models/payment.server.model.ts
+++ b/src/app/models/payment.server.model.ts
@@ -38,6 +38,10 @@ const PaymentSchema = new Schema<IPaymentSchema, IPaymentModel>(
       type: String,
       required: true,
     },
+    gstEnabled: {
+      type: Boolean,
+      required: true,
+    },
     responses: [],
 
     webhookLog: [],

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -32,6 +32,7 @@ export const updateSettingsValidator = celebrate({
       address: Joi.string().allow(''),
       gstRegNo: Joi.string().allow(''),
     }),
+    payments_field: Joi.object({ gst_enabled: Joi.boolean() }),
   })
     .min(1)
     .custom((value, helpers) => verifyValidUnicodeString(value, helpers)),

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -371,6 +371,10 @@ const updatePaymentsValidator = celebrate({
       then: Joi.string().trim().required(),
       otherwise: Joi.string().trim().allow(''),
     }),
+    gst_enabled: Joi.when('enabled', {
+      is: Joi.equal(true),
+      then: Joi.boolean().required(),
+    }),
   },
 })
 

--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -42,6 +42,7 @@ describe('payments.controller', () => {
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
         },
+        gstEnabled: false,
       })
 
       const mockReq = expressHandler.mockRequest({
@@ -72,6 +73,7 @@ describe('payments.controller', () => {
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
         },
+        gstEnabled: false,
       })
 
       const mockReq = expressHandler.mockRequest({
@@ -101,6 +103,7 @@ describe('payments.controller', () => {
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
         },
+        gstEnabled: false,
       })
 
       const mockReq = expressHandler.mockRequest({
@@ -130,6 +133,7 @@ describe('payments.controller', () => {
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
         },
+        gstEnabled: false,
       })
 
       const mockReq = expressHandler.mockRequest({

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -44,6 +44,7 @@ describe('payments.service', () => {
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
         email: 'someone@mail.com',
+        gstEnabled: false,
       })
 
       // Act
@@ -86,6 +87,7 @@ describe('payments.service', () => {
         amount: 314159,
         email: email,
         status: PaymentStatus.Succeeded,
+        gstEnabled: false,
       })
     })
     afterEach(() => jest.clearAllMocks())
@@ -114,6 +116,7 @@ describe('payments.service', () => {
         amount: 314159,
         email: email,
         status: PaymentStatus.Succeeded,
+        gstEnabled: false,
       })
       const result =
         await PaymentsService.findLatestSuccessfulPaymentByEmailAndFormId(
@@ -163,6 +166,7 @@ describe('payments.service', () => {
         amount: 314159,
         email: newEmail,
         status: PaymentStatus.Pending,
+        gstEnabled: false,
       })
       const result =
         await PaymentsService.findLatestSuccessfulPaymentByEmailAndFormId(
@@ -197,6 +201,7 @@ describe('payments.service', () => {
         targetAccountId: 'acct_MOCK_ID',
         formId: new ObjectId(),
         pendingSubmissionId: new ObjectId(),
+        gstEnabled: false,
       }
 
       await Payment.create({

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -76,6 +76,7 @@ describe('stripe.controller', () => {
       ...mockBusinessInfo,
       formTitle: mockFormTitle,
       submissionId: mockSubmissionId,
+      gstEnabled: false,
     }
     const mockForm = {
       _id: MOCK_FORM_ID,
@@ -111,6 +112,7 @@ describe('stripe.controller', () => {
           receiptUrl: 'http://form.gov.sg',
           submissionId: mockSubmissionId,
         },
+        gstEnabled: false,
       })
     })
     it('should generate return a pdf file when receipt url is present', async () => {
@@ -213,6 +215,7 @@ describe('stripe.controller', () => {
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
         },
+        gstEnabled: false,
       })
 
       const mockReq = expressHandler.mockRequest({

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -281,6 +281,7 @@ describe('stripe.service', () => {
         status: PaymentStatus.Pending,
         paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
         email: 'formsg@tech.gov.sg',
+        gstEnabled: false,
       })
       await pendingSubmission.updateOne({
         paymentId: payment._id,

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -999,6 +999,7 @@ export const generatePaymentInvoice = (
       gstRegNo: businessGstRegNo || '',
       formTitle: populatedForm.title,
       submissionId: payment.completedPayment?.submissionId || '',
+      gstEnabled: payment.gstEnabled,
     })
 
     return ResultAsync.fromPromise(

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -409,30 +409,24 @@ export const convertToInvoiceFormat = (
     gstRegNo,
     formTitle,
     submissionId,
+    gstEnabled,
   }: {
     address: string
     gstRegNo: string
     formTitle: string
     submissionId: string
+    gstEnabled: boolean
   },
 ) => {
   // handle special characters in addresses
   const ADDRESS = encode(address)
   const GST_REG_NO = encode(gstRegNo)
 
-  const edited = receiptHtmlSource
+  const commonEdits = receiptHtmlSource
     .replace(/(<title>.*?)receipt(.*?<\/title>)/, '$1invoice$2')
     .replace(/Receipt from /g, 'Invoice from ')
-    .replace(
-      /Receipt (#[0-9-]+)/,
-      `Invoice $1<br /><br />GST Reg No: ${GST_REG_NO}<br />Address: ${ADDRESS}`,
-    )
     .replace(/Date paid/g, 'Invoice Date')
     .replace(/<br>\(This amount is inclusive of GST\)/, '')
-    .replace(
-      '<strong>Amount charged</strong>',
-      '<strong>Amount charged</strong> <i>(includes GST)</i>',
-    )
     .replace(
       /Something wrong with the email\? <a.+a>/,
       `FormSG Form: ${encode(formTitle)}<br />Response ID: ${submissionId}`,
@@ -442,7 +436,22 @@ export const convertToInvoiceFormat = (
       '<td class="st-Spacer st-Spacer--gutter" width="48"></td>',
     )
 
-  const dom = new JSDOM(edited)
+  const gstDependentEdits = gstEnabled
+    ? commonEdits
+        .replace(
+          /Receipt (#[0-9-]+)/,
+          `Invoice $1<br /><br />GST Reg No: ${GST_REG_NO}<br />Address: ${ADDRESS}`,
+        )
+        .replace(
+          '<strong>Amount charged</strong>',
+          `<strong>Amount charged</strong><i>(includes GST)</i>'`,
+        )
+    : commonEdits.replace(
+        /Receipt (#[0-9-]+)/,
+        `Invoice $1<br /><br />Address: ${ADDRESS}`,
+      )
+
+  const dom = new JSDOM(gstDependentEdits)
   const { document } = dom.window
 
   // select last 3 tables to remove, n = last index

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -444,7 +444,7 @@ export const convertToInvoiceFormat = (
         )
         .replace(
           '<strong>Amount charged</strong>',
-          `<strong>Amount charged</strong><i>(includes GST)</i>'`,
+          `<strong>Amount charged</strong> <i>(includes GST)</i>`,
         )
     : commonEdits.replace(
         /Receipt (#[0-9-]+)/,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -429,6 +429,7 @@ const submitEncryptModeForm: ControllerHandler<
       amount,
       email: paymentReceiptEmail,
       responses: incomingSubmission.responses,
+      gstEnabled: form.payments_field.gst_enabled,
     })
     const paymentId = payment.id
 

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.submissions.routes.spec.ts
@@ -1242,6 +1242,7 @@ describe('admin-form.submissions.routes', () => {
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
         email: 'someone@mail.com',
+        gstEnabled: false,
       })
       // Create 3 submissions
       const submissions = await Promise.all(
@@ -1355,6 +1356,7 @@ describe('admin-form.submissions.routes', () => {
         paymentIntentId: 'somePaymentIntentId',
         amount: 314159,
         email: 'someone@mail.com',
+        gstEnabled: false,
       })
       // Create 3 submissions
       const submissions = await Promise.all(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We want to indicate whether payment transactions in a form are GST-applicable.

Closes FRM-1160 and FRM-1161

## Solution
Frontend
- add GST toggle to an admin's form's payment settings. The GST Registration Number field will appear if the toggle is set to `true`. 
  - If the toggle is set to `false`, this does **not** clear the GST Registration Number field in the backend, as I assume that this value is linked to the agency and is hence unlikely to change
- When generating the payment invoice, check if GST has been enabled at the payment transaction level. If yes, make the relevant edits to the invoice (add `(includes GST)` and the `GST Reg No`)

Backend
- add `gst_enabled` flag to `form` model. The default value is `true`
- add `gst_enabled` flag to `payment` model
- When creating a payment document upon form submission, check if GST has been enabled at the form level.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
**Payment settings page**
![chrome-capture-2023-6-18](https://github.com/opengovsg/FormSG/assets/56983748/2d1f974c-4263-4b6b-89a4-6c680565b136)

**Invoice**
![image](https://github.com/opengovsg/FormSG/assets/56983748/ab1f0ce7-85d2-484c-8503-127176408a79)

**AFTER**:
<!-- [insert screenshot here] -->
**Invoice of payment with GST**
![Screenshot 2023-07-17 at 5 49 24 PM](https://github.com/opengovsg/FormSG/assets/56983748/1980f9b3-beb1-4800-9021-343fc4508b48)

**Invoice of payment without GST**
![Screenshot 2023-07-17 at 5 50 16 PM](https://github.com/opengovsg/FormSG/assets/56983748/46c57dc0-6aa3-4d44-a14c-f9008e517500)

## Tests
<!-- What tests should be run to confirm functionality? -->
1. Enable GST
- [ ] Create a new form with payments enabled. In the payment settings page, the GST toggle should already be set to true by default.
- [ ] Submit a form and complete the payment
- [ ] In the BE: 
  - Forms collection: check that the form has payments_fields.gst_enabled = true
  - Payments collection: check that the payment has gstEnabled = true
- [ ] For the generated invoice, check that it contains
  - the GST Reg No
  - _(includes GST)_ beside 'Amount Charged'
2. Disable GST
- [ ] Go to a form with payments enabled. In the payment settings page, set the GST toggle to false.
- [ ] Submit a form and complete the payment
- [ ] In the BE: 
  - Forms collection: check that the form has payments_fields.gst_enabled = false
  - Payments collection: check that the payment has gstEnabled = false
- [ ] For the generated invoice, check that it **does not** contain
  - the GST Reg No
  - _(includes GST)_ beside 'Amount Charged'

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New scripts**:

- `scripts/20230718_set-gst-enabled-flag/set-gst-enabled-flag.js` : This script adds the `gstEnabled` flag to the payments collection and sets the flag for all existing documents to true. It also adds the `gst_enabled` flag to the `payments_field` in the form collection, and sets the flag for all existing documents with a `payments_field` to true. 
