### PR TITLE
build(deps): bump winston-cloudwatch version to "6.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "web-streams-polyfill": "^3.2.1",
         "whatwg-fetch": "^3.6.2",
         "winston": "^3.8.2",
-        "winston-cloudwatch": "^6.1.1",
+        "winston-cloudwatch": "^6.2.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -5983,13 +5983,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -10617,13 +10610,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -10867,44 +10853,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/degenerator": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.8"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/degenerator/node_modules/ast-types": {
-      "version": "0.13.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
     },
     "node_modules/del": {
       "version": "3.0.0",
@@ -11583,45 +11531,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.14.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -13093,6 +13002,7 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -14281,18 +14191,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
@@ -14328,34 +14226,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/ftp": {
-      "version": "0.3.10",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ftp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/ftp/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/ftp/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -14685,43 +14555,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/get-uri/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/get-uri/node_modules/file-uri-to-path": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/get-value": {
@@ -15418,33 +15251,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -15736,6 +15542,7 @@
     },
     "node_modules/ip": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {
@@ -19061,13 +18868,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "engines": [
@@ -21345,13 +21145,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -22137,51 +21930,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/pako": {
@@ -23015,45 +22763,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/proxy-from-env": {
@@ -24488,14 +24197,6 @@
         "jquery": ">=1.8.0"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -24725,49 +24426,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/socks": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks/node_modules/ip": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "1.4.1",
@@ -27408,6 +27066,7 @@
     },
     "node_modules/universalify": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -27763,38 +27422,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vm2": {
-      "version": "3.9.18",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
-      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn": {
-      "version": "8.8.0",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -28665,9 +28292,9 @@
       }
     },
     "node_modules/winston-cloudwatch": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
-      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
+      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
       "dependencies": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -28675,8 +28302,7 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1",
-        "proxy-agent": "^5.0.0"
+        "lodash.iserror": "^3.1.1"
       },
       "peerDependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
@@ -28986,10 +28612,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/xregexp": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -29005,6 +28627,7 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -33529,9 +33152,6 @@
         "defer-to-connect": "^2.0.0"
       }
     },
-    "@tootallnate/once": {
-      "version": "1.1.2"
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true
@@ -36771,9 +36391,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "3.0.1"
-    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -36939,29 +36556,6 @@
     "defined": {
       "version": "1.0.1",
       "dev": true
-    },
-    "degenerator": {
-      "version": "3.0.2",
-      "requires": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.8"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.13.4",
-          "requires": {
-            "tslib": "^2.0.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1"
-        },
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
     },
     "del": {
       "version": "3.0.0",
@@ -37402,25 +36996,6 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5"
-    },
-    "escodegen": {
-      "version": "1.14.2",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1"
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "optional": true
-        }
-      }
     },
     "eslint": {
       "version": "8.30.0",
@@ -38392,7 +37967,8 @@
       }
     },
     "estraverse": {
-      "version": "4.3.0"
+      "version": "4.3.0",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3"
@@ -39233,14 +38809,6 @@
     "fs-constants": {
       "version": "1.0.0"
     },
-    "fs-extra": {
-      "version": "8.1.0",
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "fs-minipass": {
       "version": "2.1.0",
       "requires": {
@@ -39263,30 +38831,6 @@
     "fsevents": {
       "version": "2.3.2",
       "optional": true
-    },
-    "ftp": {
-      "version": "0.3.10",
-      "requires": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1"
@@ -39487,28 +39031,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "get-uri": {
-      "version": "3.0.2",
-      "requires": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "file-uri-to-path": {
-          "version": "2.0.0"
-        }
       }
     },
     "get-value": {
@@ -39980,22 +39502,6 @@
         "toidentifier": "1.0.1"
       }
     },
-    "http-proxy-agent": {
-      "version": "4.0.1",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
     "http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -40183,7 +39689,8 @@
       "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA=="
     },
     "ip": {
-      "version": "1.1.5"
+      "version": "1.1.5",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.1"
@@ -42507,12 +42014,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
-    "jsonfile": {
-      "version": "4.0.0",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsonparse": {
       "version": "1.3.1"
     },
@@ -44030,9 +43531,6 @@
       "version": "2.6.1",
       "dev": true
     },
-    "netmask": {
-      "version": "2.0.2"
-    },
     "neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -44568,36 +44066,6 @@
     },
     "p-try": {
       "version": "2.2.0"
-    },
-    "pac-proxy-agent": {
-      "version": "5.0.0",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "pac-resolver": {
-      "version": "5.0.1",
-      "requires": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
-        "netmask": "^2.0.2"
-      }
     },
     "pako": {
       "version": "1.0.11"
@@ -45165,33 +44633,6 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
-      }
-    },
-    "proxy-agent": {
-      "version": "5.0.0",
-      "requires": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        }
       }
     },
     "proxy-from-env": {
@@ -46188,9 +45629,6 @@
     "slick-carousel": {
       "version": "1.8.1"
     },
-    "smart-buffer": {
-      "version": "4.2.0"
-    },
     "smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -46348,34 +45786,6 @@
         "debug": {
           "version": "4.3.4",
           "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "socks": {
-      "version": "2.7.0",
-      "requires": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "2.0.0"
-        }
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "5.0.1",
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
           "requires": {
             "ms": "2.1.2"
           }
@@ -48165,7 +47575,8 @@
       }
     },
     "universalify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "unix-dgram": {
       "version": "2.0.4",
@@ -48409,23 +47820,6 @@
     "vm-browserify": {
       "version": "1.1.2",
       "dev": true
-    },
-    "vm2": {
-      "version": "3.9.18",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
-      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.8.0"
-        },
-        "acorn-walk": {
-          "version": "8.2.0"
-        }
-      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -49075,9 +48469,9 @@
       }
     },
     "winston-cloudwatch": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
-      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
+      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
       "requires": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -49085,8 +48479,7 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1",
-        "proxy-agent": "^5.0.0"
+        "lodash.iserror": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -49274,9 +48667,6 @@
       "version": "0.0.32",
       "dev": true
     },
-    "xregexp": {
-      "version": "2.0.0"
-    },
     "xtend": {
       "version": "4.0.2",
       "dev": true
@@ -49286,7 +48676,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "web-streams-polyfill": "^3.2.1",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.8.2",
-    "winston-cloudwatch": "^6.1.1",
+    "winston-cloudwatch": "^6.2.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`vm2` package has major security vulnerabilities and is no longer being maintained. This package originates from `winston-cloudwatch` used in our repository for cloudwatch logs.

## Solution
<!-- How did you solve the problem? -->

After triaging ([doc](https://www.notion.so/opengov/20230714-Critical-vm2-vulnerability-0a64afcb2a454ebd96006240ff18645e), credits to @KenLSM for leading it!), it was concluded that `vm2` was a dangling package in `winston-cloudwatch` though it was no longer required after https://github.com/lazywithclass/winston-cloudwatch/pull/172 which was released in winston-cloudwatch@3.2.0.

The PR fixing this issue (https://github.com/lazywithclass/winston-cloudwatch/pull/219) was merged and released in winston-cloudwatch@6.2.0.

Hence, the snyk warnings can be silenced by updating `winston-cloudwatch` to 6.2.0 so that `vm2` is no longer used.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? 
- [ ] Yes - this PR contains breaking changes
    - Details ...-->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Upgrade `winston-cloudwatch` to v6.2.0

## Tests
<!-- What tests should be run to confirm functionality? -->

Regression tests
- [ ] Log in to FormSG.
- [ ] Create and submit a form with email and mobile OTP verification.
- [ ] Duplicate the form using the template function, using another mode.
- [ ] Submit the new form.
- [ ] Log out of FormSG.
