### PR TITLE
chore: reduce max payment limit

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -32,23 +32,27 @@ export const VariablePaymentAmountField = ({
       minPaymentAmountCents = Number.MIN_SAFE_INTEGER,
     } = {},
   } = useEnv()
+
+  const minAmountInDollars = `S${formatCurrency(
+    Number(centsToDollars(minPaymentAmountCents)),
+  )}`
+  const maxAmountInDollars = `S${formatCurrency(
+    Number(centsToDollars(maxPaymentAmountCents)),
+  )}`
+
   const minAmountValidation: RegisterOptions<
     FormPaymentsInput,
     typeof MIN_FIELD_KEY
   > = usePaymentFieldValidation<FormPaymentsInput, typeof MIN_FIELD_KEY>({
     lesserThanCents: dollarsToCents(input[MAX_FIELD_KEY] || ''),
-    msgWhenEmpty: `The minimum amount is S${formatCurrency(
-      Number(centsToDollars(minPaymentAmountCents)),
-    )}`,
+    msgWhenEmpty: `The minimum amount is ${minAmountInDollars}`,
   })
   const maxAmountValidation: RegisterOptions<
     FormPaymentsInput,
     typeof MAX_FIELD_KEY
   > = usePaymentFieldValidation<FormPaymentsInput, typeof MAX_FIELD_KEY>({
     greaterThanCents: dollarsToCents(input[MIN_FIELD_KEY] || ''),
-    msgWhenEmpty: `The maximum amount is S${formatCurrency(
-      Number(centsToDollars(maxPaymentAmountCents)),
-    )}`,
+    msgWhenEmpty: `The maximum amount is ${maxAmountInDollars}`,
   })
   return (
     <FormControl
@@ -77,7 +81,7 @@ export const VariablePaymentAmountField = ({
                 flex={1}
                 step={0}
                 inputMode="decimal"
-                placeholder="S$0.50"
+                placeholder={minAmountInDollars}
                 {...field}
               />
             )}
@@ -97,7 +101,7 @@ export const VariablePaymentAmountField = ({
                 flex={1}
                 step={0}
                 inputMode="decimal"
-                placeholder="S$1,000,000"
+                placeholder={maxAmountInDollars}
                 {...field}
               />
             )}

--- a/src/app/config/features/payment.config.ts
+++ b/src/app/config/features/payment.config.ts
@@ -53,7 +53,7 @@ const paymentFeature: Schema<IPaymentFeature> = {
   maxPaymentAmountCents: {
     doc: 'Maximum amount that can be paid for a form',
     format: Number,
-    default: 100000000, // Arbitrary large payment amount we should be concerned about
+    default: 200 * 1000 * 100, // 200k, this is the maximum limit for paynow transactions
     env: 'PAYMENT_MAX_PAYMENT_AMOUNT_CENTS',
   },
   minPaymentAmountCents: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Form admins can set the payment limit up to 1mn which is not supported by paynow (only up to 200k per transaction limit).

Closes FRM-1173

## Solution
<!-- How did you solve the problem? -->
Switching the limits of payment config to 200k down from 1mn

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="355" alt="Screenshot 2023-07-18 at 3 27 27 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/246d8d47-5a07-4c55-baf0-115a8b4ec8b7">
<img width="350" alt="Screenshot 2023-07-18 at 3 27 23 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/6a69ebaa-a670-4da0-a63b-d59685b002e5">


**AFTER**:
<!-- [insert screenshot here] -->

<img width="347" alt="Screenshot 2023-07-18 at 3 23 19 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/fa85a355-b8a5-41d2-b4ba-1c21c8d3b20c">
<img width="346" alt="Screenshot 2023-07-18 at 3 23 15 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/ab28ccab-9a0f-4304-8a21-af29c708e07a">


## Tests
<!-- What tests should be run to confirm functionality? -->
Regression Form payments settings
- [ ] form admins should be able to update their payment amount
- [ ] form admins with previously higher form payment values should be able to update their payment amount (change on db if you don't have any existing forms with high payments)

Feature test
- [ ] form admins cannot set any value above `200000` (try `222333`)
