### PR TITLE
build(deps): bump winston-cloudwatch to v6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "web-streams-polyfill": "^3.2.1",
         "whatwg-fetch": "^3.6.2",
         "winston": "^3.8.2",
-        "winston-cloudwatch": "^6.2.0",
+        "winston-cloudwatch": "^6.1.1",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -5983,6 +5983,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -10610,6 +10617,13 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -10853,6 +10867,44 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/degenerator": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/degenerator/node_modules/ast-types": {
+      "version": "0.13.4",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/degenerator/node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/degenerator/node_modules/tslib": {
+      "version": "2.3.1",
+      "license": "0BSD"
     },
     "node_modules/del": {
       "version": "3.0.0",
@@ -11531,6 +11583,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.14.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -13002,7 +13093,6 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -14191,6 +14281,18 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
@@ -14226,6 +14328,34 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/ftp": {
+      "version": "0.3.10",
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ftp/node_modules/isarray": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "node_modules/ftp/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/ftp/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -14555,6 +14685,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/get-uri/node_modules/debug": {
+      "version": "4.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-uri/node_modules/file-uri-to-path": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/get-value": {
@@ -15251,6 +15418,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -15542,7 +15736,6 @@
     },
     "node_modules/ip": {
       "version": "1.1.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {
@@ -18868,6 +19061,13 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "engines": [
@@ -21147,6 +21347,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -21932,6 +22139,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^5.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "5"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^3.0.2",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/pako": {
@@ -22765,6 +23017,45 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.0",
+        "debug": "4",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lru-cache": "^5.1.1",
+        "pac-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/proxy-from-env": {
@@ -24199,6 +24490,14 @@
         "jquery": ">=1.8.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -24428,6 +24727,49 @@
           "optional": true
         }
       }
+    },
+    "node_modules/socks": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks/node_modules/ip": {
+      "version": "2.0.0",
+      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "1.4.1",
@@ -27068,7 +27410,6 @@
     },
     "node_modules/universalify": {
       "version": "0.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -27424,6 +27765,38 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vm2": {
+      "version": "3.9.18",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
+      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/vm2/node_modules/acorn": {
+      "version": "8.8.0",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/vm2/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -28294,9 +28667,9 @@
       }
     },
     "node_modules/winston-cloudwatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
-      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
+      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
       "dependencies": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -28304,7 +28677,8 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1"
+        "lodash.iserror": "^3.1.1",
+        "proxy-agent": "^5.0.0"
       },
       "peerDependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
@@ -28614,6 +28988,10 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/xregexp": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -28629,7 +29007,6 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -33154,6 +33531,9 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2"
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true
@@ -36393,6 +36773,9 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1"
+    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -36558,6 +36941,29 @@
     "defined": {
       "version": "1.0.1",
       "dev": true
+    },
+    "degenerator": {
+      "version": "3.0.2",
+      "requires": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.8"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.13.4",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1"
+        },
+        "tslib": {
+          "version": "2.3.1"
+        }
+      }
     },
     "del": {
       "version": "3.0.0",
@@ -36998,6 +37404,25 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5"
+    },
+    "escodegen": {
+      "version": "1.14.2",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1"
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "optional": true
+        }
+      }
     },
     "eslint": {
       "version": "8.30.0",
@@ -37969,8 +38394,7 @@
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "dev": true
+      "version": "4.3.0"
     },
     "esutils": {
       "version": "2.0.3"
@@ -38811,6 +39235,14 @@
     "fs-constants": {
       "version": "1.0.0"
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "requires": {
@@ -38833,6 +39265,30 @@
     "fsevents": {
       "version": "2.3.2",
       "optional": true
+    },
+    "ftp": {
+      "version": "0.3.10",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31"
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1"
@@ -39033,6 +39489,28 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "get-uri": {
+      "version": "3.0.2",
+      "requires": {
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "file-uri-to-path": {
+          "version": "2.0.0"
+        }
       }
     },
     "get-value": {
@@ -39504,6 +39982,22 @@
         "toidentifier": "1.0.1"
       }
     },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -39691,8 +40185,7 @@
       "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA=="
     },
     "ip": {
-      "version": "1.1.5",
-      "dev": true
+      "version": "1.1.5"
     },
     "ipaddr.js": {
       "version": "1.9.1"
@@ -42016,6 +42509,12 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonparse": {
       "version": "1.3.1"
     },
@@ -43537,6 +44036,9 @@
       "version": "2.6.1",
       "dev": true
     },
+    "netmask": {
+      "version": "2.0.2"
+    },
     "neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -44072,6 +44574,36 @@
     },
     "p-try": {
       "version": "2.2.0"
+    },
+    "pac-proxy-agent": {
+      "version": "5.0.0",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^5.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "pac-resolver": {
+      "version": "5.0.1",
+      "requires": {
+        "degenerator": "^3.0.2",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.2"
+      }
     },
     "pako": {
       "version": "1.0.11"
@@ -44639,6 +45171,33 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
+      }
+    },
+    "proxy-agent": {
+      "version": "5.0.0",
+      "requires": {
+        "agent-base": "^6.0.0",
+        "debug": "4",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lru-cache": "^5.1.1",
+        "pac-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        }
       }
     },
     "proxy-from-env": {
@@ -45635,6 +46194,9 @@
     "slick-carousel": {
       "version": "1.8.1"
     },
+    "smart-buffer": {
+      "version": "4.2.0"
+    },
     "smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -45792,6 +46354,34 @@
         "debug": {
           "version": "4.3.4",
           "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "2.7.0",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "5.0.1",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
           "requires": {
             "ms": "2.1.2"
           }
@@ -47581,8 +48171,7 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "unix-dgram": {
       "version": "2.0.4",
@@ -47826,6 +48415,23 @@
     "vm-browserify": {
       "version": "1.1.2",
       "dev": true
+    },
+    "vm2": {
+      "version": "3.9.18",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
+      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0"
+        },
+        "acorn-walk": {
+          "version": "8.2.0"
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -48475,9 +49081,9 @@
       }
     },
     "winston-cloudwatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
-      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
+      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
       "requires": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -48485,7 +49091,8 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1"
+        "lodash.iserror": "^3.1.1",
+        "proxy-agent": "^5.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -48673,6 +49280,9 @@
       "version": "0.0.32",
       "dev": true
     },
+    "xregexp": {
+      "version": "2.0.0"
+    },
     "xtend": {
       "version": "4.0.2",
       "dev": true
@@ -48682,8 +49292,7 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "yaml": {
       "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "http-errors": "^2.0.0",
         "http-status-codes": "^2.2.0",
         "intl-tel-input": "~12.4.0",
+        "ip": "^1.1.8",
         "jose": "^4.13.1",
         "jsdom": "^21.1.1",
         "json-stringify-safe": "^5.0.1",
@@ -130,7 +131,7 @@
         "web-streams-polyfill": "^3.2.1",
         "whatwg-fetch": "^3.6.2",
         "winston": "^3.8.2",
-        "winston-cloudwatch": "^6.1.1",
+        "winston-cloudwatch": "^6.2.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -5983,13 +5984,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -10617,13 +10611,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -10867,44 +10854,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/degenerator": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.8"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/degenerator/node_modules/ast-types": {
-      "version": "0.13.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
     },
     "node_modules/del": {
       "version": "3.0.0",
@@ -11583,45 +11532,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.14.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -13093,6 +13003,7 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -14281,18 +14192,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
@@ -14328,34 +14227,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/ftp": {
-      "version": "0.3.10",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ftp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/ftp/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/ftp/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -14685,43 +14556,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/get-uri/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/get-uri/node_modules/file-uri-to-path": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/get-value": {
@@ -15418,33 +15252,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -15735,8 +15542,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.5",
-      "license": "MIT"
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -19061,13 +18869,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "engines": [
@@ -21347,13 +21148,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -22139,51 +21933,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/pako": {
@@ -23017,45 +22766,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/proxy-from-env": {
@@ -24490,14 +24200,6 @@
         "jquery": ">=1.8.0"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -24727,49 +24429,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/socks": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks/node_modules/ip": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "1.4.1",
@@ -27410,6 +27069,7 @@
     },
     "node_modules/universalify": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -27765,38 +27425,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vm2": {
-      "version": "3.9.18",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
-      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn": {
-      "version": "8.8.0",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -28667,9 +28295,9 @@
       }
     },
     "node_modules/winston-cloudwatch": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
-      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
+      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
       "dependencies": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -28677,8 +28305,7 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1",
-        "proxy-agent": "^5.0.0"
+        "lodash.iserror": "^3.1.1"
       },
       "peerDependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
@@ -28988,10 +28615,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/xregexp": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -29007,6 +28630,7 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -33531,9 +33155,6 @@
         "defer-to-connect": "^2.0.0"
       }
     },
-    "@tootallnate/once": {
-      "version": "1.1.2"
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true
@@ -36773,9 +36394,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "3.0.1"
-    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -36941,29 +36559,6 @@
     "defined": {
       "version": "1.0.1",
       "dev": true
-    },
-    "degenerator": {
-      "version": "3.0.2",
-      "requires": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.8"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.13.4",
-          "requires": {
-            "tslib": "^2.0.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1"
-        },
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
     },
     "del": {
       "version": "3.0.0",
@@ -37404,25 +36999,6 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5"
-    },
-    "escodegen": {
-      "version": "1.14.2",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1"
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "optional": true
-        }
-      }
     },
     "eslint": {
       "version": "8.30.0",
@@ -38394,7 +37970,8 @@
       }
     },
     "estraverse": {
-      "version": "4.3.0"
+      "version": "4.3.0",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3"
@@ -39235,14 +38812,6 @@
     "fs-constants": {
       "version": "1.0.0"
     },
-    "fs-extra": {
-      "version": "8.1.0",
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "fs-minipass": {
       "version": "2.1.0",
       "requires": {
@@ -39265,30 +38834,6 @@
     "fsevents": {
       "version": "2.3.2",
       "optional": true
-    },
-    "ftp": {
-      "version": "0.3.10",
-      "requires": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1"
@@ -39489,28 +39034,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "get-uri": {
-      "version": "3.0.2",
-      "requires": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "file-uri-to-path": {
-          "version": "2.0.0"
-        }
       }
     },
     "get-value": {
@@ -39982,22 +39505,6 @@
         "toidentifier": "1.0.1"
       }
     },
-    "http-proxy-agent": {
-      "version": "4.0.1",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
     "http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
@@ -40185,7 +39692,9 @@
       "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA=="
     },
     "ip": {
-      "version": "1.1.5"
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
     "ipaddr.js": {
       "version": "1.9.1"
@@ -42509,12 +42018,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
-    "jsonfile": {
-      "version": "4.0.0",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsonparse": {
       "version": "1.3.1"
     },
@@ -44036,9 +43539,6 @@
       "version": "2.6.1",
       "dev": true
     },
-    "netmask": {
-      "version": "2.0.2"
-    },
     "neverthrow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.0.0.tgz",
@@ -44574,36 +44074,6 @@
     },
     "p-try": {
       "version": "2.2.0"
-    },
-    "pac-proxy-agent": {
-      "version": "5.0.0",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "pac-resolver": {
-      "version": "5.0.1",
-      "requires": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
-        "netmask": "^2.0.2"
-      }
     },
     "pako": {
       "version": "1.0.11"
@@ -45171,33 +44641,6 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
-      }
-    },
-    "proxy-agent": {
-      "version": "5.0.0",
-      "requires": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        }
       }
     },
     "proxy-from-env": {
@@ -46194,9 +45637,6 @@
     "slick-carousel": {
       "version": "1.8.1"
     },
-    "smart-buffer": {
-      "version": "4.2.0"
-    },
     "smtp-server": {
       "version": "3.11.0",
       "dev": true,
@@ -46354,34 +45794,6 @@
         "debug": {
           "version": "4.3.4",
           "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "socks": {
-      "version": "2.7.0",
-      "requires": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "2.0.0"
-        }
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "5.0.1",
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
           "requires": {
             "ms": "2.1.2"
           }
@@ -48171,7 +47583,8 @@
       }
     },
     "universalify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "unix-dgram": {
       "version": "2.0.4",
@@ -48415,23 +47828,6 @@
     "vm-browserify": {
       "version": "1.1.2",
       "dev": true
-    },
-    "vm2": {
-      "version": "3.9.18",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
-      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.8.0"
-        },
-        "acorn-walk": {
-          "version": "8.2.0"
-        }
-      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -49081,9 +48477,9 @@
       }
     },
     "winston-cloudwatch": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
-      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.2.0.tgz",
+      "integrity": "sha512-FcJ3x+rcAKGKr4Y9tbPjXkt39I6aiAMD//ElDYcWGMFp4GjMeXP6JYrfl1yNqvH65fzehqLD71MQMlt/5/9ZIQ==",
       "requires": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -49091,8 +48487,7 @@
         "lodash.assign": "^4.2.0",
         "lodash.find": "^4.6.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.iserror": "^3.1.1",
-        "proxy-agent": "^5.0.0"
+        "lodash.iserror": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -49280,9 +48675,6 @@
       "version": "0.0.32",
       "dev": true
     },
-    "xregexp": {
-      "version": "2.0.0"
-    },
     "xtend": {
       "version": "4.0.2",
       "dev": true
@@ -49292,7 +48684,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "web-streams-polyfill": "^3.2.1",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.8.2",
-    "winston-cloudwatch": "^6.2.0",
+    "winston-cloudwatch": "^6.1.1",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "http-errors": "^2.0.0",
     "http-status-codes": "^2.2.0",
     "intl-tel-input": "~12.4.0",
+    "ip": "^1.1.8",
     "jose": "^4.13.1",
     "jsdom": "^21.1.1",
     "json-stringify-safe": "^5.0.1",
@@ -173,7 +174,7 @@
     "web-streams-polyfill": "^3.2.1",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.8.2",
-    "winston-cloudwatch": "^6.1.1",
+    "winston-cloudwatch": "^6.2.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Updating `winston-cloudwatch` was attempted in https://github.com/opengovsg/FormSG/pull/6542, but caused release to not be able to build on our staging env due to the missing package `ip`, which was only available as a dev dependency. 

`ip` was a dependency installed as part of `proxy-agent` previously used by `winston-cloudwatch`. With the `winston-cloudwatch` update to 6.22.0, it was then removed, causing the production app to fail to build as `ip` is used in our webhook validation code.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? 
- [ ] Yes - this PR contains breaking changes
    - Details ...-->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Add `ip` dependency.

## Tests
<!-- What tests should be run to confirm functionality? -->

Regression tests
- [ ] Log in to FormSG.
- [ ] Create and submit a form with email and mobile OTP verification.
- [ ] Duplicate the form using the template function, using another mode.
- [ ] Submit the new form.
- [ ] Log out of FormSG.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `ip`: used for webhook validation code to check for private IP addresses
