### PR TITLE
fix: use proof-of-payment for payment receipt/invoice

### DIFF
--- a/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
@@ -81,7 +81,7 @@ export const EndPageInput = ({
     title: 'Your payment has been made successfully.',
     paragraph: 'Your form has been submitted and payment has been made.',
     buttonLink: 'Default invoice link',
-    buttonText: 'Save payment invoice',
+    buttonText: 'Save proof of payment',
   }
 
   const {

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -57,7 +57,7 @@ export const DownloadReceiptBlock = ({
           leftIcon={<BiDownload fontSize="1.5rem" />}
           onClick={handleInvoiceClick}
         >
-          Save payment invoice
+          Save proof of payment
         </Button>
       </>
     </GenericMessageBlock>

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -129,7 +129,7 @@ describe('stripe.controller', () => {
         .mockResolvedValueOnce({ data: '<html>some html</html>' })
 
       const convertInvoiceSpy = jest
-        .spyOn(StripeUtils, 'convertToInvoiceFormat')
+        .spyOn(StripeUtils, 'convertToProofOfPaymentFormat')
         .mockReturnValueOnce('<html>some converted html</html>')
 
       const generatePdfFromHtmlSpy = jest
@@ -169,7 +169,7 @@ describe('stripe.controller', () => {
 
       const convertInvoiceSpy = jest.spyOn(
         StripeUtils,
-        'convertToInvoiceFormat',
+        'convertToProofOfPaymentFormat',
       )
 
       const generatePdfFromHtmlSpy = jest.spyOn(

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -112,7 +112,7 @@ describe('stripe.controller', () => {
           receiptUrl: 'http://form.gov.sg',
           submissionId: mockSubmissionId,
         },
-        gstApplicable: false,
+        gstEnabled: false,
       })
     })
     it('should generate return a pdf file when receipt url is present', async () => {

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -76,7 +76,7 @@ describe('stripe.controller', () => {
       ...mockBusinessInfo,
       formTitle: mockFormTitle,
       submissionId: mockSubmissionId,
-      gstEnabled: false,
+      gstApplicable: false,
     }
     const mockForm = {
       _id: MOCK_FORM_ID,
@@ -112,7 +112,7 @@ describe('stripe.controller', () => {
           receiptUrl: 'http://form.gov.sg',
           submissionId: mockSubmissionId,
         },
-        gstEnabled: false,
+        gstApplicable: false,
       })
     })
     it('should generate return a pdf file when receipt url is present', async () => {

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -203,7 +203,7 @@ export const downloadPaymentInvoice: ControllerHandler<{
     .map((pdfBuffer) => {
       res.set({
         'Content-Type': 'application/pdf',
-        'Content-Disposition': `attachment; filename=${paymentId}-invoice.pdf`,
+        'Content-Disposition': `attachment; filename=${paymentId}-proofofpayment.pdf`,
       })
       return res.status(StatusCodes.OK).send(pdfBuffer)
     })

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -53,7 +53,7 @@ import {
 import {
   computePaymentState,
   computePayoutDetails,
-  convertToInvoiceFormat,
+  convertToProofOfPaymentFormat,
   getChargeIdFromNestedCharge,
   getMetadataPaymentId,
 } from './stripe.utils'
@@ -994,7 +994,7 @@ export const generatePaymentInvoice = (
           formBusinessInfo,
         },
       })
-    const invoiceHtml = convertToInvoiceFormat(html, {
+    const invoiceHtml = convertToProofOfPaymentFormat(html, {
       address: businessAddress || '',
       gstRegNo: businessGstRegNo || '',
       formTitle: populatedForm.title,

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -999,7 +999,7 @@ export const generatePaymentInvoice = (
       gstRegNo: businessGstRegNo || '',
       formTitle: populatedForm.title,
       submissionId: payment.completedPayment?.submissionId || '',
-      gstEnabled: payment.gstEnabled,
+      gstApplicable: payment.gstEnabled,
     })
 
     return ResultAsync.fromPromise(

--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -399,10 +399,12 @@ export const computePayoutDetails = (
 }
 
 /**
- * Converts receipt sourced from Stripe into an invoice format
+ * Converts receipt sourced from Stripe into a proof of payment format
+ * If GST is applicable, 'Invoice' is used and the GST Reg No is reflected.
+ * If GST is not applicable, 'Receipt' is used.
  * @param receiptHtmlSource
  */
-export const convertToInvoiceFormat = (
+export const convertToProofOfPaymentFormat = (
   receiptHtmlSource: string,
   {
     address,

--- a/src/app/views/templates/payment-confirmation.view.html
+++ b/src/app/views/templates/payment-confirmation.view.html
@@ -4,8 +4,8 @@
     <p>Hello there,</p>
     <p>
       Your payment on <%= appName %> form: <%= formTitle %> has been received
-      successfully. Your response ID is <%= submissionId %> and your payment
-      invoice can be found <a href="<%= invoiceUrl %>">here </a>.
+      successfully. Your response ID is <%= submissionId %> and your proof of
+      payment can be found <a href="<%= invoiceUrl %>">here </a>.
     </p>
     <p>Regards,<br /><%= appName %> team</p>
   </body>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1170, FRM-1171

## Solution
<!-- How did you solve the problem? -->
- In the proof-of-payment PDF, use the term 'receipt' instead of 'invoice' when GST is not applicable
- Use 'proof of payment' as a general term to refer to payment receipt/invoice
- Rename proof of payment PDF filename to `paymentId-proofofpayment.pdf`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
Refer to issues in Linear

**AFTER**:
<img width="1624" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/07f25a54-2e40-411c-8e1e-2065ed02494d">

<img width="1604" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/7bfa6ec5-956e-4f4a-999c-fbf68cb32c91">

<img width="529" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/4c5481f5-376a-4ca3-9f39-b0a324be6a3c">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Disable the GST-applicable toggle on the payments settings page. Submit a payment. The downloadable proof of payment should contain the keyword 'receipt' instead of 'invoice'
