### PR TITLE
ci: adjust timeouts for playwright pipe

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,7 +6,7 @@ on:
     branches: [develop, release-al2, master]
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,10 +24,13 @@ jobs:
         run: npm run build
       - name: Run Playwright tests (login)
         run: npx playwright test __tests__/e2e/login.spec.ts
+        timeout-minutes: 5
       - name: Run Playwright tests (email-submission)
         run: npx playwright test __tests__/e2e/email-submission.spec.ts
+        timeout-minutes: 15
       - name: Run Playwright tests (encrypt-submission)
         run: npx playwright test __tests__/e2e/encrypt-submission.spec.ts
+        timeout-minutes: 10
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When playwright tests, we need to wait for them to timeout before we can get logs and figure out why they fail.

## Solution
<!-- How did you solve the problem? -->

Playwright tests already use default timeouts, with the exception of the thank you page. As such the timeouts for the playwright tests themselves were not changed.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Adjust playwright pipeline timeouts based on empirical values (~max time + 5 min).

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Playwright tests should succeed when tests pass.
- [ ] Playwright tests should timeout with the timeouts set, and show logs within 40 minutes.