### PR TITLE
fix: change instances of invoice to proof of payment

### DIFF
--- a/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
@@ -80,7 +80,7 @@ export const EndPageInput = ({
   const paymentDefaults = {
     title: 'Your payment has been made successfully.',
     paragraph: 'Your form has been submitted and payment has been made.',
-    buttonLink: 'Default invoice link',
+    buttonLink: 'Default proof of payment link',
     buttonText: 'Save proof of payment',
   }
 

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -55,7 +55,7 @@ export const StripeReceiptContainer = ({
       <PaymentStack>
         <GenericMessageBlock
           title="Your payment has been received."
-          subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your invoice later."
+          subtitle="We are waiting to get your proof of payment from our payment provider. You may come back to the same link to download your proof of payment later."
           submissionId={submissionId}
         />
       </PaymentStack>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -32,7 +32,7 @@ export const DownloadReceiptBlock = ({
 
   const handleInvoiceClick = () => {
     toast({
-      description: 'Invoice download started',
+      description: 'Proof of payment download started',
     })
     window.location.href = getPaymentInvoiceDownloadUrl(formId, paymentId)
   }


### PR DESCRIPTION
## Context

This PR changes more instances of 'invoice' to 'proof of payment', continuing on the fixes done in #6549

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
