### PR TITLE
fix: paynow payout being ignored

### DIFF
--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -240,6 +240,40 @@ const MOCK_STRIPE_EVENTS = [
     },
     type: 'payout.canceled',
   },
+  {
+    id: 'evt_PAYOUT_PAID',
+    object: 'event',
+    created: 1688972601,
+    account: 'acct_MOCK_ACCOUNT_ID',
+    data: {
+      object: {
+        id: 'po_1NS4j4CJpScV6kYOpH4bAqkr',
+        object: 'payout',
+        amount: 161,
+        arrival_date: 1688947200,
+        automatic: true,
+        balance_transaction: 'txn_1NS4j4CJpScV6kYO6tdVcHWj',
+        created: 1688936462,
+        currency: 'sgd',
+        description: 'STRIPE PAYOUT',
+        destination: 'ba_1MogcfCJpScV6kYOtuuO39wX',
+        failure_balance_transaction: null,
+        failure_code: null,
+        failure_message: null,
+        livemode: true,
+        metadata: {},
+        method: 'standard',
+        original_payout: null,
+        reconciliation_status: 'completed',
+        reversed_by: null,
+        source_type: 'card',
+        statement_descriptor: null,
+        status: 'paid',
+        type: 'bank_account',
+      },
+    },
+    type: 'payout.paid',
+  },
 ] as unknown as Stripe.DiscriminatedEvent[]
 
 const MOCK_STRIPE_EVENTS_MAP = keyBy(MOCK_STRIPE_EVENTS, 'id')
@@ -811,6 +845,201 @@ describe('stripe.service', () => {
         expect(getMetadataPaymentIdSpy).toHaveBeenCalledOnce()
         expect(processStripeEventSpy).toHaveBeenCalledOnce()
         expect(result.isOk()).toBeTrue()
+      })
+
+      describe('with event.type of payout.paid', () => {
+        const chargesResponseType = {
+          type: 'charge',
+          amount: 53,
+          status: 'succeeded',
+          source: {
+            object: 'charge',
+            amount: 53,
+            amount_captured: 53,
+            payment_method_details: {
+              card: {
+                brand: 'visa',
+                checks: {
+                  address_line1_check: null,
+                  address_postal_code_check: null,
+                  cvc_check: 'pass',
+                },
+                country: 'SG',
+                exp_month: 12,
+                exp_year: 2024,
+                fingerprint: 'fingerprint',
+                funding: 'prepaid',
+                installments: null,
+                last4: '1234',
+                mandate: null,
+                network: 'visa',
+                network_token: {
+                  used: false,
+                },
+                three_d_secure: null,
+                wallet: null,
+              },
+              type: 'card',
+            },
+          },
+        } as Stripe.BalanceTransaction
+
+        const paymentResponseType = {
+          type: 'payment',
+          amount: 110,
+          status: 'succeeded',
+          source: {
+            id: 'py_3NR4JHCJpScV6kYO1UnwVvkM',
+            object: 'charge',
+            amount: 110,
+            amount_captured: 110,
+            payment_method_details: {
+              paynow: {
+                reference: '3NR4JHCJpScV6kYO1IZnPfoW',
+              },
+              type: 'paynow',
+            },
+          },
+        } as Stripe.BalanceTransaction
+
+        const payoutResponseType = {
+          type: 'payout',
+          amount: -161,
+          status: 'available',
+          source: {
+            id: 'po_1NS4j4CJpScV6kYOpH4bAqkr',
+            object: 'payout',
+            amount: 161,
+            arrival_date: 1688947200,
+            automatic: true,
+            balance_transaction: 'txn_1NS4j4CJpScV6kYO6tdVcHWj',
+            created: 1688936462,
+            currency: 'sgd',
+            description: 'STRIPE PAYOUT',
+            destination: 'ba_DESTINATION',
+            failure_balance_transaction: null,
+            failure_code: null,
+            failure_message: null,
+            livemode: true,
+            metadata: {},
+            method: 'standard',
+            original_payout: null,
+            reconciliation_status: 'completed',
+            reversed_by: null,
+            source_type: 'card',
+            statement_descriptor: null,
+            status: 'paid',
+            type: 'bank_account',
+          },
+        } as Stripe.BalanceTransaction
+
+        let createBalanceTransactionApiSpy: (
+          balanceTransactions: Array<Stripe.BalanceTransaction>,
+        ) => jest.SpyInstance<Stripe.ApiListPromise<Stripe.BalanceTransaction>>
+        let getMetadataPaymentIdSpy: jest.SpyInstance
+        let processStripeEventSpy: jest.SpyInstance
+
+        beforeEach(() => {
+          createBalanceTransactionApiSpy = (
+            balanceTransactionResponses: Array<Stripe.BalanceTransaction>,
+          ) =>
+            jest
+              .spyOn(stripe.balanceTransactions, 'list')
+              .mockImplementationOnce(
+                () =>
+                  ({
+                    autoPagingEach: (fn) => {
+                      balanceTransactionResponses.forEach((resp) => {
+                        if (!fn(resp)) return Promise.reject('fail case')
+                      })
+                      return Promise.resolve('pass')
+                    },
+                  } as unknown as Stripe.ApiListPromise<Stripe.BalanceTransaction>),
+              )
+          getMetadataPaymentIdSpy = jest
+            .spyOn(StripeUtils, 'getMetadataPaymentId')
+            .mockImplementation(() => ok('still gud'))
+          processStripeEventSpy = jest
+            .spyOn(StripeService, 'processStripeEvent')
+            .mockImplementationOnce(() => okAsync(undefined))
+        })
+
+        it('should not process payout transactions', async () => {
+          // Arrange
+          const balanceTransactionResponses = [
+            payoutResponseType,
+            payoutResponseType,
+          ]
+          const balanceTransactionApiSpy = createBalanceTransactionApiSpy(
+            balanceTransactionResponses,
+          )
+
+          // Act
+          const result = await StripeService.handleStripeEvent(
+            MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_PAID'],
+          )
+
+          // Assert
+          expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
+          expect(getMetadataPaymentIdSpy).toHaveBeenCalledTimes(0)
+          expect(processStripeEventSpy).toHaveBeenCalledTimes(0)
+          expect(result.isOk()).toBeTrue()
+        })
+
+        it('should ignore only payout transactions', async () => {
+          // Arrange
+          const balanceTransactionResponses = [
+            payoutResponseType,
+            chargesResponseType,
+            paymentResponseType,
+          ]
+          const balanceTransactionApiSpy = createBalanceTransactionApiSpy(
+            balanceTransactionResponses,
+          )
+          // excluding payout type
+          const expectedCallCount = balanceTransactionResponses.filter(
+            (resp) => resp.type !== 'payout',
+          ).length
+
+          // Act
+          const result = await StripeService.handleStripeEvent(
+            MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_PAID'],
+          )
+
+          // Assert
+          expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
+          expect(getMetadataPaymentIdSpy).toHaveBeenCalledTimes(
+            expectedCallCount,
+          )
+          expect(processStripeEventSpy).toHaveBeenCalledTimes(expectedCallCount)
+          expect(result.isOk()).toBeTrue()
+        })
+
+        it('should process all bank cards and paynow transactions', async () => {
+          // Arrange
+          const balanceTransactionResponses = [
+            chargesResponseType,
+            paymentResponseType,
+          ]
+          const balanceTransactionApiSpy = createBalanceTransactionApiSpy(
+            balanceTransactionResponses,
+          )
+
+          // Act
+          const result = await StripeService.handleStripeEvent(
+            MOCK_STRIPE_EVENTS_MAP['evt_PAYOUT_PAID'],
+          )
+
+          // Assert
+          expect(balanceTransactionApiSpy).toHaveBeenCalledOnce()
+          expect(getMetadataPaymentIdSpy).toHaveBeenCalledTimes(
+            balanceTransactionResponses.length,
+          )
+          expect(processStripeEventSpy).toHaveBeenCalledTimes(
+            balanceTransactionResponses.length,
+          )
+          expect(result.isOk()).toBeTrue()
+        })
       })
     })
   })

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -559,7 +559,7 @@ export const handleStripeEvent = (
             { stripeAccount: event.account },
           )
           .autoPagingEach(async (balanceTransaction) => {
-            if (balanceTransaction.type !== 'charge') return
+            if (!['charge', 'payment'].includes(balanceTransaction.type)) return
 
             const charge = balanceTransaction.source as Stripe.Charge
             await getMetadataPaymentId(charge.metadata)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Several payouts are found to be not confirmed.

See [investigation details](https://www.notion.so/opengov/Missing-Payout-Investigation-00dd0a4e67c24e78bf08d23d8e12029e?pvs=4)

## Solution
<!-- How did you solve the problem? -->
Payouts that were not confirmed were all from `paynow` as payout source from stripe are reported with type `payment` instead of `charge`. 

Fix to this is a single LOC which is to also include `payment` type as a valid transaction source to process.

To fully capture all the payouts, we will need to:
- collect through all `succeeded` payments that have not successfully obtained a `payout`
- retrigger the webhook payout event

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [X] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
Payout webhook should not fail
- [ ] Refire existing payout webhook from stripe dashboard
  - [ ] Observe that event returns `200 OK` on stripe
- [ ] Datadog should not report errors from BE

