### PR TITLE
fix: github warning about unused import

### DIFF
--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -48,7 +48,6 @@ import {
 import { DATE_PARSE_FORMAT } from '~templates/Field/Date/DateField'
 import {
   CheckboxFieldValues,
-  ChildrenCompoundFieldValues,
   SingleAnswerValue,
   VerifiableFieldValues,
 } from '~templates/Field/types'


### PR DESCRIPTION
## Problem
GH warning about unused import.

## Solution
Remove the unused import.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
