### PR TITLE
feat: react router params validator for mongo ids

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -40,6 +40,7 @@ import { FormPaymentPage } from '~features/public-form/components/FormPaymentPag
 import { BillingPage } from '~features/user/billing'
 
 import { HashRouterElement } from './HashRouterElement'
+import { ParamIdValidator } from './ParamIdValidator'
 import { PrivateElement } from './PrivateElement'
 import { PublicElement } from './PublicElement'
 
@@ -109,20 +110,38 @@ export const AppRouter = (): JSX.Element => {
         <Route path={PUBLICFORM_ROUTE}>
           <Route
             index
-            element={<PublicElement element={<PublicFormPage />} />}
+            element={
+              <ParamIdValidator
+                element={<PublicElement element={<PublicFormPage />} />}
+              />
+            }
           />
           <Route
             path={USE_TEMPLATE_REDIRECT_SUBROUTE}
-            element={<PublicElement element={<UseTemplateRedirectPage />} />}
+            element={
+              <ParamIdValidator
+                element={
+                  <PublicElement element={<UseTemplateRedirectPage />} />
+                }
+              />
+            }
           />
           <Route
             path={PAYMENT_PAGE_SUBROUTE}
-            element={<PublicElement element={<FormPaymentPage />} />}
+            element={
+              <ParamIdValidator
+                element={<PublicElement element={<FormPaymentPage />} />}
+              />
+            }
           />
         </Route>
         <Route
           path={`${ADMINFORM_ROUTE}/:formId`}
-          element={<PrivateElement element={<AdminFormLayout />} />}
+          element={
+            <ParamIdValidator
+              element={<PrivateElement element={<AdminFormLayout />} />}
+            />
+          }
         >
           <Route index element={<CreatePage />} />
           <Route path={ADMINFORM_SETTINGS_SUBROUTE} element={<SettingsPage />}>
@@ -147,11 +166,19 @@ export const AppRouter = (): JSX.Element => {
         </Route>
         <Route
           path={`${ADMINFORM_ROUTE}/:formId/${ADMINFORM_PREVIEW_ROUTE}`}
-          element={<PrivateElement element={<PreviewFormPage />} />}
+          element={
+            <ParamIdValidator
+              element={<PrivateElement element={<PreviewFormPage />} />}
+            />
+          }
         />
         <Route
           path={`${ADMINFORM_ROUTE}/:formId/${ADMINFORM_USETEMPLATE_ROUTE}`}
-          element={<PrivateElement element={<TemplateFormPage />} />}
+          element={
+            <ParamIdValidator
+              element={<PrivateElement element={<TemplateFormPage />} />}
+            />
+          }
         />
         <Route path="*" element={<NotFoundErrorPage />} />
       </Routes>

--- a/frontend/src/app/ParamIdValidator.tsx
+++ b/frontend/src/app/ParamIdValidator.tsx
@@ -11,12 +11,14 @@ interface ParamIdValidatorProps {
 export const ParamIdValidator = ({ element }: ParamIdValidatorProps) => {
   const { formId, submissionId, paymentId } = useParams()
 
+  const isInvalidMongoId = (id?: string) => id && !id.match(MONGODB_ID_REGEX)
+
   // Bootstrap route validation as suggested by React Router Docs:
   // https://reactrouter.com/en/main/start/faq#what-happened-to-regexp-routes-paths
   if (
-    (formId && !formId.match(MONGODB_ID_REGEX)) ||
-    (submissionId && !submissionId.match(MONGODB_ID_REGEX)) ||
-    (paymentId && !paymentId.match(MONGODB_ID_REGEX))
+    isInvalidMongoId(formId) ||
+    isInvalidMongoId(submissionId) ||
+    isInvalidMongoId(paymentId)
   )
     return <NotFoundErrorPage />
 

--- a/frontend/src/app/ParamIdValidator.tsx
+++ b/frontend/src/app/ParamIdValidator.tsx
@@ -1,0 +1,24 @@
+import { useParams } from 'react-router-dom'
+
+import { MONGODB_ID_REGEX } from '~constants/routes'
+
+import NotFoundErrorPage from '~pages/NotFoundError'
+
+interface ParamIdValidatorProps {
+  element: React.ReactElement
+}
+
+export const ParamIdValidator = ({ element }: ParamIdValidatorProps) => {
+  const { formId, submissionId, paymentId } = useParams()
+
+  // Bootstrap route validation as suggested by React Router Docs:
+  // https://reactrouter.com/en/main/start/faq#what-happened-to-regexp-routes-paths
+  if (
+    (formId && !formId.match(MONGODB_ID_REGEX)) ||
+    (submissionId && !submissionId.match(MONGODB_ID_REGEX)) ||
+    (paymentId && !paymentId.match(MONGODB_ID_REGEX))
+  )
+    return <NotFoundErrorPage />
+
+  return element
+}

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -13,7 +13,7 @@ export const BILLING_ROUTE = '/billing'
 // the regex in PublicFormPage.
 export const PUBLICFORM_ROUTE = '/:formId'
 export const USE_TEMPLATE_REDIRECT_SUBROUTE = 'use-template'
-export const FORMID_REGEX = /^([a-fA-F0-9]{24})$/
+export const MONGODB_ID_REGEX = /^([a-fA-F0-9]{24})$/
 
 export const ADMINFORM_ROUTE = '/admin/form'
 /** Build tab has no subroute, its the index admin form route. */

--- a/frontend/src/features/admin-form/common/queries.ts
+++ b/frontend/src/features/admin-form/common/queries.ts
@@ -6,7 +6,7 @@ import { AdminFormDto, PreviewFormViewDto } from '~shared/types/form/form'
 
 import { ApiError } from '~typings/core'
 
-import { FORMID_REGEX } from '~constants/routes'
+import { MONGODB_ID_REGEX } from '~constants/routes'
 
 import { useUser } from '~features/user/queries'
 
@@ -134,7 +134,7 @@ export const usePreviewForm = (
     {
       // Treat preview form as static on load.
       staleTime: Infinity,
-      enabled: FORMID_REGEX.test(formId) && enabled,
+      enabled: MONGODB_ID_REGEX.test(formId) && enabled,
     },
   )
 }
@@ -150,7 +150,7 @@ export const useFormTemplate = (
     {
       // Treat preview form as static on load.
       staleTime: Infinity,
-      enabled: FORMID_REGEX.test(formId) && enabled,
+      enabled: MONGODB_ID_REGEX.test(formId) && enabled,
     },
   )
 }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -28,7 +28,7 @@ import {
   PublicFormDto,
 } from '~shared/types/form'
 
-import { FORMID_REGEX } from '~constants/routes'
+import { MONGODB_ID_REGEX } from '~constants/routes'
 import { useBrowserStm } from '~hooks/payments'
 import { useTimeout } from '~hooks/useTimeout'
 import { useToast } from '~hooks/useToast'
@@ -93,7 +93,7 @@ export function useCommonFormProvider(formId: string) {
     return vfnTransaction.transactionId
   }, [createTransactionMutation, vfnTransaction])
 
-  const isNotFormId = useMemo(() => !FORMID_REGEX.test(formId), [formId])
+  const isNotFormId = useMemo(() => !MONGODB_ID_REGEX.test(formId), [formId])
 
   const expiryInMs = useMemo(() => {
     if (!vfnTransaction?.expireAt) return null

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -4,7 +4,7 @@ import { PublicFormViewDto } from '~shared/types/form/form'
 
 import { ApiError } from '~typings/core'
 
-import { FORMID_REGEX } from '~constants/routes'
+import { MONGODB_ID_REGEX } from '~constants/routes'
 
 import { getPublicFormView } from './PublicFormService'
 
@@ -26,7 +26,7 @@ export const usePublicFormView = (
     {
       // Treat form as static on load.
       staleTime: Infinity,
-      enabled: FORMID_REGEX.test(formId) && enabled,
+      enabled: MONGODB_ID_REGEX.test(formId) && enabled,
     },
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

VAPT issue - GTA-10-007 WP1: Client-side path traversal in admin interface. Remediation: Add validation for URL params used in React app router.

Closes FRM-1125

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Features**:

- Implements `ParamIdValidator` component to wrap components where params include IDs. This is to validate the id shape.
- If the id is invalid (i.e. does not look like a mongodb object id), direct users to a Not Found page.

**Improvements**:

- refactor: rename FORMID_REGEX as MONGODB_ID_REGEX

## Tests
<!-- What tests should be run to confirm functionality? -->

Check that the following dynamic routes should work when valid ids are given and redirect to a Not Found page when invalid ids are given:
- [ ] Public routes
   - [ ] go to `/:formId` (public form page)
      - [ ] form should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/:formId/use-template` (use template page)
      - [ ] use template page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/:formId/payment/:paymentId` (payment page)
      - [ ] payment page should render as usual
      - [ ] if `:formId` and/or `:paymentId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/:formId/payment/:paymentId` (payment page)
      - [ ] payment page should render as usual
      - [ ] if `:formId` and/or `:paymentId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
- [ ] Private routes
   - [ ] go to `/admin/form/:formId` (admin form page)
      - [ ] admin form create page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/settings` (admin form settings page)
      - [ ] admin form settings page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/results` (admin form results page)
      - [ ] admin form results page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/results/:submissionId` (admin form results submission page)
      - [ ] admin form results submission page should render as usual
      - [ ] if `:formId` and/or `:submissionId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/results/feedback` (admin form feedback page)
      - [ ] admin form feedback page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/preview` (admin form preview page)
      - [ ] admin form preview page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page
   - [ ] go to `/admin/form/:formId/use-template` (admin form use template page)
      - [ ] admin form use template page should render as usual
      - [ ] if `:formId` param is replaced with something outside of the regex `/^([a-fA-F0-9]{24})$/`, it should redirect to a not found page