### PR TITLE
fix: subtle bugs in MyInfo Child and UI copyedits

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
@@ -97,9 +97,7 @@ export const EditMyInfoChildren = ({
         </HStack>
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">
-          Collect the following child information
-        </Text>
+        <Text textStyle="subhead-1">Collect the following child data</Text>
         <Box alignSelf="stretch">
           <Controller
             control={control}

--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -141,6 +141,9 @@ export const CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS: {
   label: string
 }[] = Object.values(MyInfoChildAttributes)
   .filter((e) => e !== MyInfoChildAttributes.ChildName)
+  // TODO awaiting approval from MyInfo to get child vaccination status.
+  // Disabling in the frontend for now.
+  .filter((e) => e !== MyInfoChildAttributes.ChildVaxxStatus)
   .map((value) => {
     return {
       value,

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -124,24 +124,27 @@ export const ChildrenCompoundField = ({
         aria-describedby={`children-desc-${schema._id}`}
         aria-labelledby={`${schema._id}-label`}
       >
-        <VStack align="stretch" role="list">
-          {fields.map((field, currChildBodyIdx) => (
-            <ChildrenBody
-              key={`body-${currChildBodyIdx}`}
-              {...{
-                currChildBodyIdx,
-                schema,
-                fields,
-                field,
-                colorTheme,
-                remove,
-                myInfoChildrenBirthRecords,
-                isSubmitting,
-                formContext,
-              }}
-            />
-          ))}
-        </VStack>
+        <>
+          <Spacer h="8px" />
+          <VStack align="stretch" role="list">
+            {fields.map((field, currChildBodyIdx) => (
+              <ChildrenBody
+                key={`body-${currChildBodyIdx}`}
+                {...{
+                  currChildBodyIdx,
+                  schema,
+                  fields,
+                  field,
+                  colorTheme,
+                  remove,
+                  myInfoChildrenBirthRecords,
+                  isSubmitting,
+                  formContext,
+                }}
+              />
+            ))}
+          </VStack>
+        </>
         {schema.allowMultiple ? (
           <HStack>
             <Button
@@ -376,7 +379,9 @@ const ChildrenBody = ({
                   </FormLabel>
                   <DatePicker
                     {...rest}
-                    inputValue={value}
+                    dateFormat="yyyy/MM/dd"
+                    // Convert MyInfo YYYY-MM-DD to YYYY/MM/DD
+                    inputValue={value?.replaceAll('-', '/')}
                     onInputValueChange={(date) => {
                       setValue(fieldPath, date)
                     }}

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -318,7 +318,7 @@ export const types: MyInfoFieldBlock[] = [
     verified: ['SG', 'PR', 'F'],
     source: 'Immigration & Checkpoints Authority / Health Promotion Board',
     description:
-      "The data of the form-filler's children. This field is verified by ICA and HPB for vaccination status.",
+      "The data of the form-filler's children. Vaccination status is verified by HPB. All other data in this field is verified by ICA.",
     fieldType: BasicField.Children,
     previewValue: 'Child 1',
   },

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -92,6 +92,9 @@ function hashChildrenFieldValues(
       ) {
         return
       }
+      if (!value) {
+        return
+      }
       readOnlyHashPromises[
         getMyInfoChildHashKey(field._id, subField, childIdx, childName)
       ] = bcrypt.hash(value, HASH_SALT_ROUNDS)


### PR DESCRIPTION
## Problem
Some small UI inconsistencies with Figma, also some subtle bugs in the date of birth field and empty strings being hashed.

## Solution
UI:
* Changed description to something clearer: Vaccination status is verified by HPB. All other data in this field is verified by ICA.
* Field wording child information -> child data
* child records label and first input spacing increase to 16px

Bugs:
* Fixed date formatting
* Skip hashing of empty string fields

**Breaking Changes** 
- [X] No - this PR is backwards compatible  The public is not using this feature as of now.

**BEFORE SCREENSHOTS**
![image](https://github.com/opengovsg/FormSG/assets/119096102/e868ab1f-4193-42ed-a9b5-2193a3bf1077)

**AFTER SCREENSHOTS**
![image](https://github.com/opengovsg/FormSG/assets/119096102/b56cddc5-2f6c-4b31-8424-29325673b2a1)

Tests
NOTE: CANNOT BE TESTED ON STAGING BECAUSE OUR CHILD PROFILES DO NOT HAVE NAMES.

- [ ] Create a child MyInfo field in email mode form.
- [ ] Add "secondary race" subfield.
- [ ] Share form and login to form with MyInfo allowed.
- [ ] "secondary race" subfield should be empty
- [ ] Select any "secondary race" from dropdown
- [ ] Submit the form.
- [ ] Check email received. Child name should have `[Myinfo]` tag, while child's secondary race should not have the tag.