### PR TITLE
chore: rm redundant type assertion in url validation

### DIFF
--- a/frontend/src/features/logic/utils/typeguards.ts
+++ b/frontend/src/features/logic/utils/typeguards.ts
@@ -45,6 +45,6 @@ export const isLogicableField = (args: {
 export const isValueStringArray = (
   value: FormCondition['value'],
 ): value is string[] => {
-  // use .some because of limitation of typecript in calling .every() on union of array types: https://github.com/microsoft/TypeScript/issues/44373
+  // use .some because of limitation of typescript in calling .every() on union of array types: https://github.com/microsoft/TypeScript/issues/44373
   return Array.isArray(value) && !value.some((v) => typeof v === 'number')
 }

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -11,7 +11,7 @@ export const useLocalStorage = <T>(
   // Get from local storage then
   // parse stored json or return initialValue
   const readValue = useCallback(() => {
-    // Prevent build error "window is undefined" but keep keep working
+    // Prevent build error "window is undefined" and keep it working
     if (typeof window === 'undefined') {
       return initialValue
     }

--- a/frontend/src/hooks/useMdComponents.tsx
+++ b/frontend/src/hooks/useMdComponents.tsx
@@ -84,7 +84,7 @@ export const useMdComponents = ({
       a: ({ node, ...props }) => {
         const { href } = props
         const isExternal =
-          typeof href === 'string' && !href.startsWith(window.location.origin)
+          (href && !href.startsWith(window.location.origin)) || false
 
         return <Link {...props} isExternal={isExternal} {...linkStyles} />
       },

--- a/shared/types/field/childrenCompoundField.ts
+++ b/shared/types/field/childrenCompoundField.ts
@@ -1,8 +1,4 @@
-import {
-  BasicField,
-  MyInfoChildAttributes,
-  MyInfoableFieldBase,
-} from './base'
+import { BasicField, MyInfoChildAttributes, MyInfoableFieldBase } from './base'
 
 export interface ChildrenCompoundFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Children

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -13,7 +13,6 @@ import {
 import { DateString } from '../generic'
 import { FormLogic, LogicDto } from './form_logic'
 import { PaymentChannel, PaymentType } from '../payment'
-import { MyInfoChildrenBirthRecords } from '@opengovsg/myinfo-gov-client'
 
 export type FormId = Opaque<string, 'FormId'>
 

--- a/shared/utils/url-validation.ts
+++ b/shared/utils/url-validation.ts
@@ -4,28 +4,8 @@ import validator from 'validator'
  * Checks that string is a valid URL over HTTPS.
  * @param url
  */
-export const isValidHttpsUrl = (url: string): boolean => {
-  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
-  if (typeof url !== 'string') {
-    return false
-  }
-  return validator.isURL(url, {
+export const isValidHttpsUrl = (url: string): boolean =>
+  validator.isURL(url, {
     protocols: ['https'],
     require_protocol: true,
   })
-}
-
-/**
- * Checks that string is a valid HTTP or HTTPS URL.
- * @param url the url to check
- * @returns true if valid, false otherwise
- */
-export const isValidUrl = (url: string): boolean => {
-  // TODO(#1788): Remove redundant type assertions once frontend is fully in Typescript.
-  if (typeof url !== 'string') {
-    return false
-  }
-  return validator.isURL(url, {
-    protocols: ['https', 'http'],
-  })
-}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Type assertions were required in angular days as files might be called by JS files which don't care about typing. This is no longer the case as we now use a codebase completely migrated to TS.

Closes #1788

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- removes redundant type assertion for url validation
- chore: remove unused isValidUrl function

## Tests
<!-- What tests should be run to confirm functionality? -->

Regression test for webhook:
- [ ] Create a storage mode form
- [ ] Add a webhook to the form
- [ ] Make a submission, it should successfully post a webhook as well.
