### PR TITLE
chore: lint and update commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ npm run test:frontend
 #### End-to-end tests
 
 ```bash
-npm run test-e2e
+npm run test:e2e-v2
 ```
 
 will build both the frontend and backend then run our end-to-end tests. The tests are located at [`__tests__/e2e`](./__tests__/e2e). You will need to stop the Docker dev container to be able to run the end-to-end tests.
@@ -205,7 +205,7 @@ will build both the frontend and backend then run our end-to-end tests. The test
 If you do not need to rebuild the frontend and backend, you can run
 
 ```bash
-npm run test-e2e-ci
+npx playwright test
 ```
 
 #### Cross-browser testing

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -13,7 +13,6 @@ import {
 import { DateString } from '../generic'
 import { FormLogic, LogicDto } from './form_logic'
 import { PaymentChannel, PaymentType } from '../payment'
-import { MyInfoChildrenBirthRecords } from '@opengovsg/myinfo-gov-client'
 
 export type FormId = Opaque<string, 'FormId'>
 
@@ -180,7 +179,7 @@ export type PublicStorageFormDto = Merge<
     StorageFormDto,
     // Arrays like typeof list have numeric index signatures, so their number key
     // yields the union of all numerically-indexed properties.
-    (typeof STORAGE_PUBLIC_FORM_FIELDS)[number]
+    typeof STORAGE_PUBLIC_FORM_FIELDS[number]
   >,
   PublicFormBase
 >
@@ -190,7 +189,7 @@ export type PublicEmailFormDto = Merge<
     EmailFormDto,
     // Arrays like typeof list have numeric index signatures, so their number key
     // yields the union of all numerically-indexed properties.
-    (typeof EMAIL_PUBLIC_FORM_FIELDS)[number]
+    typeof EMAIL_PUBLIC_FORM_FIELDS[number]
   >,
   PublicFormBase
 >
@@ -199,11 +198,11 @@ export type PublicFormDto = PublicStorageFormDto | PublicEmailFormDto
 
 export type EmailFormSettings = Pick<
   EmailFormDto,
-  (typeof EMAIL_FORM_SETTINGS_FIELDS)[number]
+  typeof EMAIL_FORM_SETTINGS_FIELDS[number]
 >
 export type StorageFormSettings = Pick<
   StorageFormDto,
-  (typeof STORAGE_FORM_SETTINGS_FIELDS)[number]
+  typeof STORAGE_FORM_SETTINGS_FIELDS[number]
 >
 
 export type FormSettings = EmailFormSettings | StorageFormSettings
@@ -241,7 +240,7 @@ export type AdminFormViewDto = {
 
 export type AdminDashboardFormMetaDto = Pick<
   AdminFormDto,
-  (typeof ADMIN_FORM_META_FIELDS)[number]
+  typeof ADMIN_FORM_META_FIELDS[number]
 >
 
 export type DuplicateFormBodyDto = {

--- a/shared/types/response.ts
+++ b/shared/types/response.ts
@@ -1,6 +1,6 @@
 import type { Opaque } from 'type-fest'
 import { z } from 'zod'
-import { BasicField, MyInfoAttribute, MyInfoChildAttributes } from './field'
+import { BasicField, MyInfoAttribute } from './field'
 
 const ResponseBase = z.object({
   myInfo: z.never().optional(),

--- a/src/types/field/childrenCompoundField.ts
+++ b/src/types/field/childrenCompoundField.ts
@@ -1,4 +1,3 @@
-// prettier-ignore
 import {
   BasicField,
   ChildrenCompoundFieldBase,

--- a/src/types/field/childrenCompoundField.ts
+++ b/src/types/field/childrenCompoundField.ts
@@ -1,3 +1,4 @@
+// prettier-ignore
 import {
   BasicField,
   ChildrenCompoundFieldBase,


### PR DESCRIPTION
## Problem
Backend lint fails on dev branch. Plus README has out of date commands for e2e tests dating back to Angular days.

## Solution
Lint and update README.

**Breaking Changes** 
- [X] No - this PR is backwards compatible  
