### PR TITLE
feat: rm bot protection for GSIB users

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -135,9 +135,9 @@ export const PublicFormProvider = ({
     }
   }, [submissionData])
 
+  // Only load catpcha if enabled on form and the user is not on GSIB
   const enableCaptcha = data && data.form.hasCaptcha && !data.isIntranetUser
 
-  // Only load catpcha if enabled on form and the user is not on GSIB
   const {
     data: { captchaPublicKey, turnstileSiteKey, useFetchForSubmissions } = {},
   } = useEnv(/* enabled= */ enableCaptcha)

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -135,9 +135,10 @@ export const PublicFormProvider = ({
     }
   }, [submissionData])
 
+  // Only load catpcha if enabled on form and the user is not on GSIB
   const {
     data: { captchaPublicKey, turnstileSiteKey, useFetchForSubmissions } = {},
-  } = useEnv(/* enabled= */ !!data?.form.hasCaptcha)
+  } = useEnv(/* enabled= */ !!data?.form.hasCaptcha && !data?.isIntranetUser)
 
   // Feature flag to control turnstile captcha rollout
   // defaults to false

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -135,7 +135,7 @@ export const PublicFormProvider = ({
     }
   }, [submissionData])
 
-  const enableCaptcha = !!data?.form.hasCaptcha && !data?.isIntranetUser
+  const enableCaptcha = data && data.form.hasCaptcha && !data.isIntranetUser
 
   // Only load catpcha if enabled on form and the user is not on GSIB
   const {

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -135,10 +135,12 @@ export const PublicFormProvider = ({
     }
   }, [submissionData])
 
+  const enableCaptcha = !!data?.form.hasCaptcha && !data?.isIntranetUser
+
   // Only load catpcha if enabled on form and the user is not on GSIB
   const {
     data: { captchaPublicKey, turnstileSiteKey, useFetchForSubmissions } = {},
-  } = useEnv(/* enabled= */ !!data?.form.hasCaptcha && !data?.isIntranetUser)
+  } = useEnv(/* enabled= */ enableCaptcha)
 
   // Feature flag to control turnstile captcha rollout
   // defaults to false
@@ -157,7 +159,7 @@ export const PublicFormProvider = ({
     getTurnstileResponse,
     containerID: turnstileContainerID,
   } = useTurnstile({
-    sitekey: data?.form.hasCaptcha ? turnstileSiteKey : undefined,
+    sitekey: enableCaptcha ? turnstileSiteKey : undefined,
     enableUsage: enableTurnstileFeatureFlag,
   })
 
@@ -166,7 +168,7 @@ export const PublicFormProvider = ({
     getCaptchaResponse,
     containerId: recaptchaContainerID,
   } = useRecaptcha({
-    sitekey: data?.form.hasCaptcha ? captchaPublicKey : undefined,
+    sitekey: enableCaptcha ? captchaPublicKey : undefined,
     enableUsage: !enableTurnstileFeatureFlag,
   })
 
@@ -593,7 +595,7 @@ export const PublicFormProvider = ({
         isAuthRequired,
         captchaContainerId: containerID,
         expiryInMs,
-        isLoading: isLoading || (!!data?.form.hasCaptcha && !hasLoaded),
+        isLoading: isLoading || (!!enableCaptcha && !hasLoaded),
         isPaymentEnabled,
         isPreview: false,
         setNumVisibleFields,

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -113,8 +113,13 @@ const submitEmailModeForm: ControllerHandler<
           }),
       )
       .andThen((form) => {
-        // Check the captcha
-        if (form.hasCaptcha) {
+        // Check if respondent is a GSIB user
+        const isIntranetUser = FormService.checkIsIntranetFormAccess(
+          getRequestIp(req),
+          form,
+        )
+        // Check the captcha, provided user is not on GSIB
+        if (!isIntranetUser && form.hasCaptcha) {
           switch (req.query.captchaType) {
             case CaptchaTypes.Turnstile: {
               return TurnstileService.verifyTurnstileResponse(

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -148,8 +148,13 @@ const submitEncryptModeForm: ControllerHandler<
       })
     }
   }
-  // Check captcha
-  if (form.hasCaptcha) {
+  // Check if respondent is a GSIB user
+  const isIntranetUser = FormService.checkIsIntranetFormAccess(
+    getRequestIp(req),
+    form,
+  )
+  // Check captcha, provided user is not on GSIB
+  if (!isIntranetUser && form.hasCaptcha) {
     switch (req.query.captchaType) {
       case CaptchaTypes.Turnstile: {
         const turnstileResult = await TurnstileService.verifyTurnstileResponse(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Recently, GSIB respondents have been unable to submit forms due to recaptcha being unable to load.

<img width="315" alt="Screenshot 2023-07-26 at 3 46 33 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/1e24f166-49e4-4ed4-899c-f4fbe1208563">

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Features**:

- Check if respondent is an intranet user (ie on GSIB). Only use recaptcha if respondent is not on GSIB and captcha is enabled on the form.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a storage mode form with all fields
   - [ ] Make sure captcha is on
   - [ ] Go to the form on a device not on GSIB
     - [ ] Scroll to the bottom to check that captcha is there
     - [ ] Fill up and submit the form
     - [ ] Check that the response is recorded
   - [ ] Go to the form on a device on GSIB
     - [ ] Scroll to the bottom to check that captcha is there
     - [ ] Fill up and submit the form
     - [ ] Check that the response is recorded
- [ ] Create a email mode form with all fields
   - [ ] Make sure captcha is on
   - [ ] Go to the form on a device not on GSIB
     - [ ] Scroll to the bottom to check that captcha is there
     - [ ] Fill up and submit the form
     - [ ] Check that the response is recorded
   - [ ] Go to the form on a device on GSIB
     - [ ] Scroll to the bottom to check that captcha is there
     - [ ] Fill up and submit the form
     - [ ] Check that the response is recorded
