### PR TITLE
ref: remove download receipt URL

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -3,10 +3,7 @@ import { BiDownload } from 'react-icons/bi'
 import { useToast } from '~hooks/useToast'
 import Button from '~components/Button'
 
-import {
-  getPaymentInvoiceDownloadUrl,
-  getPaymentReceiptDownloadUrl,
-} from '~features/public-form/utils/urls'
+import { getPaymentInvoiceDownloadUrl } from '~features/public-form/utils/urls'
 
 import { GenericMessageBlock } from './GenericMessageBlock'
 
@@ -23,13 +20,6 @@ export const DownloadReceiptBlock = ({
 }: DownloadReceiptBlockProps) => {
   const toast = useToast({ status: 'success', isClosable: true })
 
-  const handleReceiptClick = () => {
-    toast({
-      description: 'Receipt download started',
-    })
-    window.location.href = getPaymentReceiptDownloadUrl(formId, paymentId)
-  }
-
   const handleInvoiceClick = () => {
     toast({
       description: 'Invoice download started',
@@ -43,15 +33,6 @@ export const DownloadReceiptBlock = ({
       submissionId={submissionId}
     >
       <>
-        <Button
-          hidden // Currently hidden for JTC
-          mt="2.25rem"
-          mr="2.25rem"
-          leftIcon={<BiDownload fontSize="1.5rem" />}
-          onClick={handleReceiptClick}
-        >
-          Save payment receipt
-        </Button>
         <Button
           mt="2.25rem"
           leftIcon={<BiDownload fontSize="1.5rem" />}

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -6,13 +6,6 @@ export const getPaymentPageUrl = (formId: string, paymentId: string) => {
   return `/${formId}/payment/${paymentId}` as const
 }
 
-export const getPaymentReceiptDownloadUrl = (
-  formId: string,
-  paymentId: string,
-) => {
-  return `${API_BASE_URL}/payments/${formId}/${paymentId}/receipt/download` as const
-}
-
 export const getPaymentInvoiceDownloadUrl = (
   formId: string,
   paymentId: string,

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -192,50 +192,6 @@ describe('stripe.controller', () => {
     })
   })
 
-  describe('downloadReceiptInvoice', () => {
-    beforeEach(async () => {
-      await dbHandler.clearCollection(Payment.collection.name)
-      await dbHandler.clearCollection(EncryptPendingSubmission.collection.name)
-    })
-    it('should generate return a pdf file when receipt url is present', async () => {
-      const pendingSubmission = await EncryptPendingSubmission.create({
-        submissionType: SubmissionType.Encrypt,
-        form: MOCK_FORM_ID,
-        encryptedContent: 'some random encrypted content',
-        version: 1,
-      })
-      const payment = await Payment.create({
-        formId: MOCK_FORM_ID,
-        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
-        pendingSubmissionId: pendingSubmission._id,
-        amount: 12345,
-        status: PaymentStatus.Succeeded,
-        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
-        email: 'formsg@tech.gov.sg',
-        completedPayment: {
-          receiptUrl: 'http://form.gov.sg',
-        },
-        gstEnabled: false,
-      })
-
-      const mockReq = expressHandler.mockRequest({
-        params: { formId: 'test@example.com', paymentId: payment._id },
-      })
-      const mockRes = expressHandler.mockResponse()
-      const axiosSpy = jest
-        .spyOn(axios, 'get')
-        .mockResolvedValueOnce({ data: '<html>>some html</html>' })
-
-      // Act
-      await StripeController.downloadPaymentReceipt(mockReq, mockRes, jest.fn())
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(200)
-      expect(mockRes.send).toHaveBeenCalledOnce()
-      expect(axiosSpy).toHaveBeenCalledOnce()
-    })
-  })
-
   describe('_handleConnectOauthCallback', () => {
     beforeEach(async () => {
       await dbHandler.clearCollection(Payment.collection.name)

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -1,6 +1,5 @@
 // Use 'stripe-event-types' for better type discrimination.
 /// <reference types="stripe-event-types" />
-import axios from 'axios'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import get from 'lodash/get'
@@ -18,7 +17,6 @@ import config from '../../config/config'
 import { paymentConfig } from '../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { stripe } from '../../loaders/stripe'
-import { generatePdfFromHtml } from '../../utils/convert-html-to-pdf'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
@@ -212,76 +210,6 @@ export const downloadPaymentInvoice: ControllerHandler<{
         message: 'Error retrieving invoice',
         meta: {
           action: 'downloadPaymentInvoice',
-          formId,
-          paymentId,
-        },
-        error,
-      })
-      return res.status(StatusCodes.NOT_FOUND).json({ message: error })
-    })
-}
-
-/**
- * Handler for GET /api/v3/payments/:formId/:paymentId/invoice/download
- * Receives Stripe webhooks and updates the database with transaction details.
- *
- * @returns 200 if webhook is successfully processed
- * @returns 404 if the PaymentId is not found
- * @returns 404 if the FormId is not found
- * @returns 404 if payment.completedPayment?.receiptUrl is not found
- */
-export const downloadPaymentReceipt: ControllerHandler<{
-  formId: string
-  paymentId: string
-}> = (req, res) => {
-  const { formId, paymentId } = req.params
-  logger.info({
-    message: 'downloadPaymentReceipt endpoint called',
-    meta: {
-      action: 'downloadPaymentReceipt',
-      formId,
-      paymentId,
-    },
-  })
-
-  return PaymentService.findPaymentById(paymentId)
-    .map((payment) => {
-      logger.info({
-        message: 'Found paymentId in payment document',
-        meta: {
-          action: 'downloadPaymentReceipt',
-          payment,
-        },
-      })
-      if (!payment.completedPayment?.receiptUrl) {
-        return res
-          .status(StatusCodes.NOT_FOUND)
-          .send({ message: 'Receipt url not ready' })
-      }
-      // retrieve receiptURL as html
-      return (
-        axios
-          .get<string>(payment.completedPayment.receiptUrl)
-          // convert to pdf and return
-          .then((receiptUrlResponse) => {
-            const html = receiptUrlResponse.data
-            const pdfBufferPromise = generatePdfFromHtml(html)
-            return pdfBufferPromise
-          })
-          .then((pdfBuffer) => {
-            res.set({
-              'Content-Type': 'application/pdf',
-              'Content-Disposition': `attachment; filename=${paymentId}-receipt.pdf`,
-            })
-            return res.status(StatusCodes.OK).send(pdfBuffer)
-          })
-      )
-    })
-    .mapErr((error) => {
-      logger.error({
-        message: 'Error retrieving receipt',
-        meta: {
-          action: 'downloadPaymentReceipt',
           formId,
           paymentId,
         },

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -21,23 +21,10 @@ PaymentsRouter.get(
 )
 
 /**
- * Downloads the receipt pdf
- * @route GET /payments/:formId/:paymentId/receipt/download
- *
- * @returns 200 with receipt attatchment as content in PDF
- * @returns 404 if receipt url doesn't exist or payment does not exist
- */
-PaymentsRouter.get(
-  '/:formId([a-fA-F0-9]{24})/:paymentId([a-fA-F0-9]{24})/receipt/download',
-  limitRate({ max: rateLimitConfig.downloadPaymentReceipt }),
-  StripeController.downloadPaymentReceipt,
-)
-
-/**
  * Downloads the invoice pdf
  * @route GET /payments/:formId/:paymentId/invoice/download
  *
- * @returns 200 with receipt attatchment as content in PDF
+ * @returns 200 with receipt attachment as content in PDF
  * @returns 404 if receipt url doesn't exist or payment does not exist
  */
 PaymentsRouter.get(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Remove unused `/payments/:formId/:paymentId/receipt/download` endpoint. This leaves `/payments/:formId/:paymentId/invoice/download` as the only endpoint to download proof of payment.

A check on cloudwatch logs shows that 0 requests have been made to `/payments/:formId/:paymentId/receipt/download` for at least the past 1 month.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

