### PR TITLE
feat: payments UI/UX clean up

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -31,8 +31,7 @@ export const GUIDE_PREVENT_EMAIL_BOUNCE =
 export const GUIDE_EMAIL_RELIABILITY =
   'https://go.gov.sg/formsg-guide-email-reliability'
 export const GUIDE_PREFILL = 'https://go.gov.sg/formsg-guide-prefills'
-export const GUIDE_STRIPE_ONBOARDING =
-  'https://go.gov.sg/formsg-stripe-onboarding'
+export const GUIDE_STRIPE_ONBOARDING = 'https://go.gov.sg/formsg-payments'
 export const GUIDE_PAYMENTS_ENTRY = 'https://go.gov.sg/formsg-payment-overview'
 export const GUIDE_PAYMENTS_INVOICE_DIFFERENCES =
   'https://go.gov.sg/formsg-payments-invoice-differences'

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/FixedPaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/FixedPaymentAmountField.tsx
@@ -38,7 +38,7 @@ export const FixedPaymentAmountField = ({
       isInvalid={!!errors[DISPLAY_AMOUNT_FIELD_KEY]}
       isRequired
     >
-      <FormLabel isRequired description="Amount should include GST">
+      <FormLabel isRequired description="Including GST">
         Payment amount
       </FormLabel>
       <Controller

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -226,7 +226,7 @@ const PaymentInput = ({
         isRequired
       >
         <FormLabel>Description</FormLabel>
-        <Textarea {...register('description')} />
+        <Input {...register('description')} />
         <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
       </FormControl>
       {paymentsData?.payment_type === PaymentType.Variable ? (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-hook-form'
 import { Link as ReactLink } from 'react-router-dom'
 import { useDebounce } from 'react-use'
-import { Box, FormControl, Link, Text, Textarea } from '@chakra-ui/react'
+import { Box, FormControl, Link, Text } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -210,7 +210,7 @@ const PaymentInput = ({
         isDisabled={isDisabled}
         isRequired
       >
-        <FormLabel description="This will be reflected on the proof of payment">
+        <FormLabel description="This will appear on proof of payment">
           Product/service name
         </FormLabel>
         <Input

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -62,7 +62,7 @@ export const VariablePaymentAmountField = ({
     >
       <FormLabel
         isRequired
-        description="Customise the amount that respondents are allowed to define"
+        description="Set the minimum and maximum amounts respondents can pay"
       >
         Payment amount limit
       </FormLabel>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -59,6 +59,7 @@ export const VariablePaymentAmountField = ({
       isReadOnly={isLoading}
       // these invalid checks are required to trigger FormErrorMessage to display
       isInvalid={!!errors[MIN_FIELD_KEY]?.message || !!errors[MAX_FIELD_KEY]}
+      isDisabled={isDisabled}
     >
       <FormLabel
         isRequired
@@ -71,7 +72,7 @@ export const VariablePaymentAmountField = ({
           isInvalid={!!errors[MIN_FIELD_KEY]}
           isDisabled={isDisabled}
         >
-          <FormLabel isRequired>Minimum Amount</FormLabel>
+          <FormLabel isRequired>Minimum amount</FormLabel>
           <Controller
             name={MIN_FIELD_KEY}
             control={control}
@@ -91,7 +92,7 @@ export const VariablePaymentAmountField = ({
           isInvalid={!!errors[MAX_FIELD_KEY]}
           isDisabled={isDisabled}
         >
-          <FormLabel isRequired>Maximum Amount</FormLabel>
+          <FormLabel isRequired>Maximum amount</FormLabel>
           <Controller
             name={MAX_FIELD_KEY}
             control={control}

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -9,7 +9,8 @@ type PaymentDataViewItem = {
 }
 
 /** Utility functions for prettifying the output of the payment data view. */
-const centsToDollarString = (cents: number) => `S$${(cents / 100).toFixed(2)}`
+export const centsToDollarString = (cents: number) =>
+  `S$${(cents / 100).toFixed(2)}`
 const toSentenceCase = (str: string) =>
   `${str.charAt(0).toUpperCase()}${str.substring(1).toLowerCase()}`
     // replace underscores with a space

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -24,12 +24,10 @@ import { useAdminFormSettings } from '../../queries'
 interface BusinessFieldInputProps {
   initialValue: string
   handleMutation: (newAddress: string) => void
-  placeholder: string
 }
 const BusinessFieldInput = ({
   initialValue,
   handleMutation,
-  placeholder,
 }: BusinessFieldInputProps): JSX.Element => {
   const [value, setValue] = useState(initialValue)
 
@@ -66,8 +64,6 @@ const BusinessFieldInput = ({
       onChange={handleValueChange}
       onKeyDown={handleKeydown}
       onBlur={handleBlur}
-      placeholder={placeholder}
-      _placeholder={{ opacity: 1 }}
     />
   )
 }
@@ -92,8 +88,9 @@ const BusinessInfoBlock = ({
         <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
           <FormLabel isRequired>GST Registration Number</FormLabel>
           <BusinessFieldInput
-            placeholder={agencyDefaults?.gstRegNo || ''}
-            initialValue={settings.business?.gstRegNo || ''}
+            initialValue={
+              settings.business?.gstRegNo || agencyDefaults?.gstRegNo || ''
+            }
             handleMutation={handleGstRegNoMutation}
           />
         </FormControl>
@@ -101,8 +98,9 @@ const BusinessInfoBlock = ({
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
         <FormLabel isRequired>Business Address</FormLabel>
         <BusinessFieldInput
-          placeholder={agencyDefaults?.address || ''}
-          initialValue={settings.business?.address || ''}
+          initialValue={
+            settings.business?.address || agencyDefaults?.address || ''
+          }
           handleMutation={handleAddressMutation}
         />
       </FormControl>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   Skeleton,
   Text,
+  VStack,
 } from '@chakra-ui/react'
 
 import { FormResponseMode, PaymentChannel } from '~shared/types'
@@ -40,30 +41,39 @@ const BeforeConnectionInstructions = ({
   const { data: paymentGuideLink } = usePaymentGuideLink()
   if (isProductionEnv) {
     return (
-      <>
-        <InlineMessage variant="info" my="2rem">
+      <VStack spacing="2.5rem" alignItems="start">
+        <InlineMessage variant="info">
           <Text>
             Read{' '}
             <Link isExternal href={paymentGuideLink}>
               our guide
             </Link>{' '}
-            to learn more about onboarding to Stripe. To enjoy bulk tender
-            transaction rates,{' '}
-            <Link href={GUIDE_STRIPE_ONBOARDING} target="_blank">
-              use this form
-            </Link>{' '}
-            to submit your Stripe account ID and raise a purchase order to
-            Stripe.
+            to set up a Stripe account. If your agency already has a Stripe
+            account, you can connect it to this form.
           </Text>
         </InlineMessage>
+        <Text textStyle="h3" color="secondary.500">
+          Bulk transaction rates
+        </Text>
+        <Text>
+          To request bulk transaction rates for your payments, use{' '}
+          <Link href={GUIDE_STRIPE_ONBOARDING} target="_blank">
+            this form
+          </Link>{' '}
+          to contact us for assistance.{' '}
+          <Text as="b">
+            Without this step, you will be charged default transaction rates.
+          </Text>
+        </Text>
+
         {/* Stripe connect button should only be enabled when checkbox is checked. */}
         <Checkbox
           isChecked={allowConnect}
           mb="2rem"
           onChange={(e) => setAllowConnect(e.target.checked)}
         >
-          I understand that if I do not send my Stripe account ID and raise a
-          purchase order to Stripe, I will be paying default transaction rates.
+          I understand that I will be paying default transaction rates, unless I
+          have requested bulk transaction rates and received confirmation
         </Checkbox>
         <StripeConnectButton
           connectState={
@@ -72,7 +82,7 @@ const BeforeConnectionInstructions = ({
               : StripeConnectButtonStates.DISABLED
           }
         />
-      </>
+      </VStack>
     )
   } else {
     return (

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
@@ -14,7 +14,7 @@ export const PaymentsUnsupportedMsg = (): JSX.Element => {
         Payments are not available in Email mode
       </Text>
       <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-        Citizens can now make payment for fees or services directly on your
+        Respondents can now make payment for fees or services directly on your
         form. This feature is only available in Storage Mode.&nbsp;
         <Link isExternal href={paymentGuideLink}>
           Learn more about payments

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
@@ -41,7 +41,7 @@ export const StripeConnectButton = ({
         onClick={onLinkAccountClick}
         colorScheme="primary"
       >
-        Connect with my Stripe account
+        Connect my Stripe account
       </Button>
     )
   } else {

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentItemNameDescription.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentItemNameDescription.tsx
@@ -15,7 +15,9 @@ const PaymentItemNameDescription = ({
         <Text textStyle="subhead-1">{paymentItemName}</Text>
       ) : null}
       {paymentDescription ? (
-        <Text textStyle="body-2">{paymentDescription}</Text>
+        <Text textStyle="body-2" color="secondary.400">
+          {paymentDescription}
+        </Text>
       ) : null}
     </Box>
   )

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailBlock.tsx
@@ -53,14 +53,14 @@ export const VariablePaymentItemDetailsField = ({
             />
           )}
         />
+        <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
+          The minimum amount is {centsToDollarString(paymentMin)} and the
+          maximum amount is {centsToDollarString(paymentMax)}.
+        </Text>
         <FormErrorMessage>
           {errors[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]?.message}
         </FormErrorMessage>
       </FormControl>
-      <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
-        The minimum amount is {centsToDollarString(paymentMin)} and the maximum
-        amount is {centsToDollarString(paymentMax)}.
-      </Text>
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailBlock.tsx
@@ -1,9 +1,11 @@
 import { Controller, useFormContext } from 'react-hook-form'
-import { Box, FormControl, FormErrorMessage } from '@chakra-ui/react'
+import { Box, FormControl, FormErrorMessage, Text } from '@chakra-ui/react'
 
 import { PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID } from '~shared/constants'
 
 import MoneyInput from '~components/MoneyInput'
+
+import { centsToDollarString } from '~features/admin-form/responses/common/utils/getPaymentDataView'
 
 import { usePaymentFieldValidation } from '../../../../../hooks/usePaymentFieldValidation'
 
@@ -55,6 +57,10 @@ export const VariablePaymentItemDetailsField = ({
           {errors[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]?.message}
         </FormErrorMessage>
       </FormControl>
+      <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
+        The minimum amount is {centsToDollarString(paymentMin)} and the maximum
+        amount is {centsToDollarString(paymentMax)}.
+      </Text>
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
@@ -160,7 +160,7 @@ export const StripePaymentBlock = ({
           <VisuallyHidden aria-live="assertive">
             {submittedAriaText}
           </VisuallyHidden>
-          <Text textStyle="h3" textColor="primary.500" mb="1rem">
+          <Text textStyle="h3" textColor="primary.500" mb="2.25rem">
             Payment
           </Text>
           <PaymentItemDetailsBlock

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
@@ -48,6 +48,7 @@ const StripeCheckoutForm = ({
   const [stripeMessage, setStripeMessage] = useState('')
   const [isStripeProcessing, setIsStripeProcessing] = useState(false)
   const [, , clearPaymentMemory] = useBrowserStm(formId)
+  const [isPaynow, setIsPayNow] = useState(false)
 
   useEffect(() => {
     if (isRetry) {
@@ -100,7 +101,16 @@ const StripeCheckoutForm = ({
   return (
     <form onSubmit={handleSubmit}>
       <FormControl isInvalid={stripeMessage !== ''}>
-        <PaymentElement />
+        <PaymentElement
+          onChange={(e) => {
+            console.log({ e })
+            if (e.value.type === 'paynow') {
+              setIsPayNow(true)
+            } else {
+              setIsPayNow(false)
+            }
+          }}
+        />
         {stripeMessage !== '' ? (
           <FormErrorMessage>
             {`${stripeMessage} No payment has been taken. Please try again.`}
@@ -116,7 +126,7 @@ const StripeCheckoutForm = ({
           isLoading={isStripeProcessing}
           mt="2.5rem"
         >
-          Submit payment
+          {isPaynow ? 'Scan PayNow QR code' : 'Submit payment'}
         </Button>
       </FormControl>
     </form>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/PaymentBlock.tsx
@@ -103,7 +103,6 @@ const StripeCheckoutForm = ({
       <FormControl isInvalid={stripeMessage !== ''}>
         <PaymentElement
           onChange={(e) => {
-            console.log({ e })
             if (e.value.type === 'paynow') {
               setIsPayNow(true)
             } else {

--- a/frontend/src/features/rollout-announcement/Announcements.tsx
+++ b/frontend/src/features/rollout-announcement/Announcements.tsx
@@ -9,7 +9,7 @@ export const NEW_FEATURES = [
     // Announcement date: 2023-05-31
     title: 'Collect payments on your form',
     description:
-      'Citizens can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow.',
+      'Respondents can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow.',
     learnMoreLink: GUIDE_PAYMENTS_ENTRY,
     animationData: PaymentsAnnouncementGraphic,
   },

--- a/frontend/src/features/whats-new/FeatureUpdateList.ts
+++ b/frontend/src/features/whats-new/FeatureUpdateList.ts
@@ -35,7 +35,7 @@ export const FEATURE_UPDATE_LIST: FeatureUpdateList = {
     {
       title: 'Collect payments on your form',
       date: new Date('31 May 2023 GMT+8'),
-      description: `Citizens can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow. [Learn more](${GUIDE_PAYMENTS_ENTRY})`,
+      description: `Respondents can now pay for fees and services directly on your form! We integrate with Stripe to provide reliable payments and hassle-free reconciliations. Payment methods we support include debit / credit cards and PayNow. [Learn more](${GUIDE_PAYMENTS_ENTRY})`,
       image: {
         animationData: Animation1,
         alt: 'Collect payments on your form',

--- a/frontend/src/features/workspace/components/WorkspacePageContent.tsx
+++ b/frontend/src/features/workspace/components/WorkspacePageContent.tsx
@@ -40,7 +40,7 @@ export const WorkspacePageContent = ({
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const dashboardMessage = `Introducing payments! Citizens can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
+  const dashboardMessage = `Introducing payments! Respondents can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
 
   return totalFormsCount === 0 ? (
     <EmptyWorkspace

--- a/frontend/src/pages/Landing/Home/LandingPage.tsx
+++ b/frontend/src/pages/Landing/Home/LandingPage.tsx
@@ -93,7 +93,7 @@ export const LandingPage = (): JSX.Element => {
     <>
       <FeatureBanner
         title="Introducing Payments"
-        body="Citizens can now pay for fees and services directly on your form!"
+        body="Respondents can now pay for fees and services directly on your form!"
         learnMoreLink={LANDING_PAYMENTS_ROUTE}
       />
       <AppPublicHeader />
@@ -447,7 +447,7 @@ export const LandingPage = (): JSX.Element => {
                 </ListItem>
                 <ListItem textStyle="body-2">
                   <OrderedListIcon index={3} />
-                  Build and share form link with citizens
+                  Build and share form link with respondents
                 </ListItem>
                 <ListItem textStyle="body-2">
                   <OrderedListIcon index={4} />

--- a/frontend/src/pages/Landing/Payments/LandingPaymentsPage.tsx
+++ b/frontend/src/pages/Landing/Payments/LandingPaymentsPage.tsx
@@ -137,7 +137,7 @@ export const LandingPaymentsPage = (): JSX.Element => {
         <FeatureGridItem
           image={featureReconImg}
           title="Simple reconciliation"
-          description="Associate a payment reference ID with every form submission ID. Track payments and payouts in one dashboard."
+          description="Associate a payment reference ID with every form response ID. Track payments and payouts in one dashboard."
         />
         <FeatureGridItem
           image={featureTrustedImg}
@@ -205,7 +205,7 @@ export const LandingPaymentsPage = (): JSX.Element => {
           </HelpAccordionItem>
           <HelpAccordionItem title="How does reconciliation work?">
             <Text>
-              Each payment reference ID is associated with a form submission ID.
+              Each payment reference ID is associated with a form response ID.
               Payment and payout status can be viewed in your form response page
               as well as on the Stripe dashboard.
             </Text>
@@ -248,9 +248,9 @@ export const LandingPaymentsPage = (): JSX.Element => {
               Collect payments on your form
             </Text>
             <SectionBodyText color={mainSectionTextColour}>
-              Citizens can now pay for fees and services directly on your form.
-              Enter your agency email to receive our guide on how to get started
-              with payments.
+              Respondents can now pay for fees and services directly on your
+              form. Enter your agency email to receive our guide on how to get
+              started with payments.
             </SectionBodyText>
             <FormProvider {...formMethods}>
               <Flex alignItems="start" mt="2rem">

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -45,7 +45,7 @@ export const PaymentPreview = ({
 
   return (
     <>
-      <Box as="h2" mb="1rem" textStyle="h2" color={sectionColor}>
+      <Box as="h2" mb="2.25rem" textStyle="h2" color={sectionColor}>
         Payment
       </Box>
       <Box mb="2rem">

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -292,12 +292,12 @@ export const generatePaymentOnboardingHtml = ({
   appName: string
 }): string => {
   return dedent`
-  <p>Dear Sir or Madam,</p>
-  <p>Thank you for your interest in our payments feature! <a href="${paymentConfig.landingGuideLink}">Download the file</a> to learn how to get started with payments today!</p>
+  <p>Dear Form admin,</p>
+  <p>Thank you for your interest in our payments feature! <a href="${paymentConfig.landingGuideLink}">Download our payments guide</a> to learn how to start collecting payments on your form today!</p>
   <p>If you have any questions regarding payments, feel free to reach out to support@form.gov.sg.</p>
   <p>Regards,
   <br/>
-  ${appName} team</p>
+  ${appName}</p>
   `
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1196

## Solution
<!-- How did you solve the problem? -->
- Various copy changes


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On a payment form's Stripe element, select PayNow. The button at the bottom of the form should say 'Scan PayNow QR code. Otherwise, it should say 'Submit payment'
