### PR TITLE
feat: show error message if no products are selected

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -124,7 +124,7 @@ export const ProductPaymentItemDetailsBlock = ({
     validate: (value) => {
       const totalPrice = calculatePrice(value || [])
       if (totalPrice === 0) {
-        return 'Please select at least 1 product/service'
+        return 'Please select at least 1 option'
       }
     },
   })

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -107,6 +107,17 @@ const PaymentItem = ({
   )
 }
 
+const isProductSelected = (productItems: Array<ProductItem>) => {
+  let isProductSelected = false
+  for (let i = 0; i < productItems.length; i++) {
+    if (productItems[i].selected) {
+      isProductSelected = true
+      break
+    }
+  }
+  return isProductSelected
+}
+
 export const ProductPaymentItemDetailsBlock = ({
   paymentDetails,
   colorTheme,
@@ -121,8 +132,9 @@ export const ProductPaymentItemDetailsBlock = ({
   } = useFormContext()
   register(PAYMENT_PRODUCT_FIELD_ID, {
     validate: (value) => {
-      const totalPrice = calculatePrice(value || [])
-      if (totalPrice === 0) {
+      // Check if at least 1 product is selected
+      const selected = isProductSelected(value || [])
+      if (!selected) {
         return 'Please select at least 1 option'
       }
     },

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
-import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+import { Box, Divider, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
 
 import { PAYMENT_PRODUCT_FIELD_ID } from '~shared/constants'
 import {
@@ -13,6 +13,7 @@ import { centsToDollars, formatCurrency } from '~shared/utils/payments'
 
 import Checkbox from '~components/Checkbox'
 import { SingleSelect } from '~components/Dropdown/SingleSelect/SingleSelect'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Radio from '~components/Radio'
 
 import { generateIntRange } from './utils'
@@ -114,8 +115,19 @@ export const ProductPaymentItemDetailsBlock = ({
   paymentDetails: ProductsPaymentField
   colorTheme: FormColorTheme
 }) => {
-  const { register, setValue } = useFormContext()
-  register(PAYMENT_PRODUCT_FIELD_ID)
+  const {
+    register,
+    setValue,
+    formState: { errors },
+  } = useFormContext()
+  register(PAYMENT_PRODUCT_FIELD_ID, {
+    validate: (value) => {
+      const totalPrice = calculatePrice(value || [])
+      if (totalPrice === 0) {
+        return 'Please select at least 1 product/service'
+      }
+    },
+  })
 
   const [productItems, updateProductItems] = useState<Array<ProductItem>>(
     () => {
@@ -169,16 +181,21 @@ export const ProductPaymentItemDetailsBlock = ({
 
   return (
     <Stack spacing="2rem">
-      {productItems.map((product, idx) => (
-        <PaymentItem
-          key={product.data._id || idx}
-          product={product}
-          colorTheme={colorTheme}
-          onItemChange={handleItemChange}
-          isMultiSelect={productsMeta.multi_product}
-        />
-      ))}
-      <hr />
+      <FormControl isInvalid={!!errors.payment_products}>
+        <Stack spacing="2rem">
+          {productItems.map((product, idx) => (
+            <PaymentItem
+              key={product.data._id || idx}
+              product={product}
+              colorTheme={colorTheme}
+              onItemChange={handleItemChange}
+              isMultiSelect={productsMeta.multi_product}
+            />
+          ))}
+        </Stack>
+        <FormErrorMessage>{errors?.payment_products?.message}</FormErrorMessage>
+        <Divider />
+      </FormControl>
       <Flex justifyContent={'end'}>
         <Text textAlign={'right'} mr={'1rem'}>
           Total price

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -37,11 +37,10 @@ const ItemQuantity = ({
     value: String(quantity),
   }))
   return (
-    <Box width="8rem">
+    <Box width="6rem">
       <SingleSelect
         isClearable={false}
         items={qtyOptions}
-        placeholder="Quantity"
         onChange={(val) => onChange(Number(val))}
         value={String(product.quantity)}
         name={'Quantity'}
@@ -145,7 +144,7 @@ export const ProductPaymentItemDetailsBlock = ({
       paymentDetails.products.map((product) => ({
         data: product,
         selected: false,
-        quantity: product.multi_qty ? 0 : 1,
+        quantity: product.multi_qty ? product.min_qty : 1,
       })),
     )
   }, [paymentDetails.products])

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -108,14 +108,8 @@ const PaymentItem = ({
 }
 
 const isProductSelected = (productItems: Array<ProductItem>) => {
-  let isProductSelected = false
-  for (let i = 0; i < productItems.length; i++) {
-    if (productItems[i].selected) {
-      isProductSelected = true
-      break
-    }
-  }
-  return isProductSelected
+  const isSelected = productItems.some((item) => item.selected)
+  return isSelected
 }
 
 export const ProductPaymentItemDetailsBlock = ({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Payment by Products: No frontend error message appears when 0 products are selected. The user should be prompted to select at least 1 product.

## Solution
<!-- How did you solve the problem? -->
Add validation to the payment product field, by checking if the total price is equal to 0.
Also, set the default value (for multi_qty products) to be the min quantity

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Screenshots
<img width="1624" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/4a5937b8-db29-4643-9b98-076ec2b1c6be">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On a form with multiple products, don't select any product. Click proceed to pay. The error message should appear.
- [ ] On a form with where you can choose the quantity of products, select a product but don't select a quantity. Click proceed to pay. The error message should appear.
