### PR TITLE
feat: remove divider in payments input panel

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-hook-form'
 import { Link as ReactLink } from 'react-router-dom'
 import { useDebounce } from 'react-use'
-import { Box, FormControl, Link, Text, Textarea } from '@chakra-ui/react'
+import { Box, FormControl, Link, Stack, Text, Textarea } from '@chakra-ui/react'
 import { cloneDeep } from 'lodash'
 
 import {
@@ -204,31 +204,33 @@ const PaymentInput = ({
           )}
         />
       </FormControl>
-      <FormControl
-        isReadOnly={paymentsMutation.isLoading}
-        isInvalid={!!errors.name}
-        isDisabled={isDisabled}
-        isRequired
-      >
-        <FormLabel description="This will be reflected on the proof of payment">
-          Product/service name
-        </FormLabel>
-        <Input
-          {...register('name', {
-            required: 'This field is required',
-          })}
-        />
-        <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
-      </FormControl>
-      <FormControl
-        isReadOnly={paymentsMutation.isLoading}
-        isDisabled={isDisabled}
-        isRequired
-      >
-        <FormLabel>Description</FormLabel>
-        <Textarea {...register('description')} />
-        <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
-      </FormControl>
+      <Stack spacing="2rem">
+        <FormControl
+          isReadOnly={paymentsMutation.isLoading}
+          isInvalid={!!errors.name}
+          isDisabled={isDisabled}
+          isRequired
+        >
+          <FormLabel description="This will be reflected on the proof of payment">
+            Product/service name
+          </FormLabel>
+          <Input
+            {...register('name', {
+              required: 'This field is required',
+            })}
+          />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl
+          isReadOnly={paymentsMutation.isLoading}
+          isDisabled={isDisabled}
+          isRequired
+        >
+          <FormLabel>Description</FormLabel>
+          <Textarea {...register('description')} />
+          <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
+        </FormControl>
+      </Stack>
       {paymentsData?.payment_type === PaymentType.Variable ? (
         <VariablePaymentAmountField
           isLoading={paymentsMutation.isLoading}


### PR DESCRIPTION
## Content
<!-- How did you solve the problem? -->
This PR removes the divider between the Product's name and description in the payments inputs panel

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="424" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/c89bc632-090d-4142-ac17-10ba80120a32">


**AFTER**:
<!-- [insert screenshot here] -->
![image (2)](https://github.com/opengovsg/FormSG/assets/56983748/a0848035-92ab-418d-a488-49f711a61b2c)



