### PR TITLE
chore: remove unused toastr dependency for snyk

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2229,36 +2229,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301 USA
 
 
-## Project
-toastr
-
-### Source
-https://github.com/CodeSeven/toastr
-
-### License
-MIT License
-
-Copyright (c) 2017 Toastr Maintainers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 -------------------------------------------------------------------------------
 
 ## Project

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,6 @@
         "sqs-producer": "^2.1.0",
         "stripe": "^12.5.0",
         "text-encoding": "^0.7.0",
-        "toastr": "^2.1.4",
         "triple-beam": "^1.3.0",
         "ts-essentials": "^9.3.1",
         "tweetnacl": "^1.0.1",
@@ -26347,12 +26346,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toastr": {
-      "version": "2.1.4",
-      "dependencies": {
-        "jquery": ">=1.12.0"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "license": "MIT",
@@ -47143,12 +47136,6 @@
       "version": "5.0.1",
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "toastr": {
-      "version": "2.1.4",
-      "requires": {
-        "jquery": ">=1.12.0"
       }
     },
     "toidentifier": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "sqs-producer": "^2.1.0",
     "stripe": "^12.5.0",
     "text-encoding": "^0.7.0",
-    "toastr": "^2.1.4",
     "triple-beam": "^1.3.0",
     "ts-essentials": "^9.3.1",
     "tweetnacl": "^1.0.1",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Snyk flagged a XXS vulnerability with high severity ([here](https://security.snyk.io/vuln/SNYK-JS-TOASTR-2396430)). As the offending package `toastr` is no longer being used, we should just remove it.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [ ] No - this PR is backwards compatible  

**Improvements**:

- Remove `toastr` dependency from `package.json`.
- Remove credits to `toastr` in `CREDITS.md`.

## Tests
<!-- What tests should be run to confirm functionality? -->

Regression tests:
- [ ] Login as form admin.
- [ ] Create a storage mode form.
   - [ ] Make a submission.
   - [ ] Check that submission recorded correctly.
- [ ] Create an email mode form.
   - [ ] Make a submission.
   - [ ] Check that submission recorded correctly.
