### PR TITLE
fix(workspaces): remove form from workspace upon collaborator removal

### DIFF
--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -56,7 +56,7 @@ export const WorkspacePage = (): JSX.Element => {
     return {
       _id: '',
       title: 'All forms',
-      formIds: dashboardForms?.map(({ _id }) => _id),
+      formIds: dashboardForms ? dashboardForms.map(({ _id }) => _id) : [],
       admin: user?._id,
     }
   }, [dashboardForms, user]) as Workspace

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -67,6 +67,7 @@ import { MissingUserError } from '../../user/user.errors'
 import * as UserService from '../../user/user.service'
 import { SmsLimitExceededError } from '../../verification/verification.errors'
 import { hasAdminExceededFreeSmsLimit } from '../../verification/verification.util'
+import { removeFormFromAllWorkspaces } from '../../workspace/workspace.service'
 import {
   FormNotFoundError,
   LogicNotFoundError,
@@ -790,46 +791,70 @@ export const updateFormCollaborators = (
     )
     .map((collaborator) => collaborator.email)
 
-  return ResultAsync.fromPromise(
-    // Check that all updated collaborator domains exist in the Agency collection.
-    Promise.all(
-      updatedCollaboratorEmails.map(async (email) => {
-        const emailDomain = email.split('@').pop()
-        const result = await AgencyModel.findOne({ emailDomain })
-        return !!result
-      }),
+  // find removed collaborators (i.e. collaborators in the original list)
+  // but has been removed in the updated list
+  const removedCollaboratorEmails = form.permissionList.filter((collaborator) =>
+    updatedCollaborators.every(
+      (newCollaborator) => collaborator.email !== newCollaborator.email,
     ),
-    (error) => {
-      logger.error({
-        message: 'Error encountered while validating new form collaborators',
-        meta: logMeta,
-        error,
-      })
-      return transformMongoError(error)
-    },
   )
-    .andThen((doNewCollaboratorsExist) => {
-      const falseIdx = doNewCollaboratorsExist.findIndex((exists) => !exists)
-      return falseIdx < 0
-        ? okAsync(undefined)
-        : errAsync(
-            new InvalidCollaboratorError(updatedCollaboratorEmails[falseIdx]),
-          )
-    })
-    .andThen(() =>
-      ResultAsync.fromPromise(
-        form.updateFormCollaborators(updatedCollaborators),
-        (error) => {
-          logger.error({
-            message: 'Error encountered while updating form collaborators',
-            meta: logMeta,
-            error,
-          })
-          return transformMongoError(error)
-        },
+
+  return (
+    ResultAsync.fromPromise(
+      // Check that all updated collaborator domains exist in the Agency collection.
+      Promise.all(
+        updatedCollaboratorEmails.map(async (email) => {
+          const emailDomain = email.split('@').pop()
+          const result = await AgencyModel.findOne({ emailDomain })
+          return !!result
+        }),
       ),
+      (error) => {
+        logger.error({
+          message: 'Error encountered while validating new form collaborators',
+          meta: logMeta,
+          error,
+        })
+        return transformMongoError(error)
+      },
     )
-    .andThen(({ permissionList }) => okAsync(permissionList))
+      .andThen((doNewCollaboratorsExist) => {
+        const falseIdx = doNewCollaboratorsExist.findIndex((exists) => !exists)
+        return falseIdx < 0
+          ? okAsync(undefined)
+          : errAsync(
+              new InvalidCollaboratorError(updatedCollaboratorEmails[falseIdx]),
+            )
+      })
+      // after checking that collaborator exists
+      // remove forms from workspaces for collaborators that were removed
+      .andThen(() => {
+        removedCollaboratorEmails.map(async (collaborator) => {
+          await UserService.findUserByEmail(collaborator.email).map(
+            async (user) =>
+              await removeFormFromAllWorkspaces({
+                formId: form._id,
+                userId: user._id,
+              }),
+          )
+        })
+        return okAsync(undefined)
+      })
+      .andThen(() =>
+        ResultAsync.fromPromise(
+          form.updateFormCollaborators(updatedCollaborators),
+          (error) => {
+            logger.error({
+              message: 'Error encountered while updating form collaborators',
+              meta: logMeta,
+              error,
+            })
+            return transformMongoError(error)
+          },
+        ),
+      )
+      .andThen(({ permissionList }) => okAsync(permissionList))
+  )
 }
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, upon removal of an admin as a collaborator of a form, we do not remove the form from the workspaces of the admin. Leaving the admin with a workspace that indicates that it has more forms than actuality.

This PR fixes that

Closes FRM-144
Closes #4073 

Thanks @kennethchangOPENGOV for identifying the bug

## Solution
<!-- How did you solve the problem? -->

Upon update of collaborator, will check if there are any removed emails. 

If there are, will iterate through it, and remove formId from each user email's workspaces.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a form
- [ ] Add another email as collaborator

Here on out is the other email
- [ ] Log in as the other email
- [ ] Create a workspace 
- [ ] Move the form above to the workspace
- [ ] Remove yourself as collaborator
- [ ] Form should be removed from workspace and workspace tab should show the correct number of forms in it