### PR TITLE
chore: remove customMin and customMax virtuals

### DIFF
--- a/src/app/models/field/common/textValidationOptionsSchema.ts
+++ b/src/app/models/field/common/textValidationOptionsSchema.ts
@@ -4,38 +4,13 @@ import {
   TextSelectedValidation,
   TextValidationOptions,
 } from '../../../../../shared/types'
-import { WithCustomMinMax } from '../../../../types/field/utils/virtuals'
 
-export const TextValidationOptionsSchema = new Schema<
-  WithCustomMinMax<TextValidationOptions>
->(
-  {
-    customVal: {
-      type: Number,
-    },
-    selectedValidation: {
-      type: String,
-      enum: [...Object.values(TextSelectedValidation), null],
-    },
+export const TextValidationOptionsSchema = new Schema<TextValidationOptions>({
+  customVal: {
+    type: Number,
   },
-  {
-    // TODO: Remove virtuals (#2039)
-    toJSON: {
-      virtuals: true,
-    },
+  selectedValidation: {
+    type: String,
+    enum: [...Object.values(TextSelectedValidation), null],
   },
-)
-
-// Virtuals to allow for backwards compatibility after customMin and customMax were removed as part of #408
-// TODO: Remove virtuals (#2039)
-TextValidationOptionsSchema.virtual('customMin').get(function (
-  this: TextValidationOptions,
-) {
-  return this.customVal
-})
-
-TextValidationOptionsSchema.virtual('customMax').get(function (
-  this: TextValidationOptions,
-) {
-  return this.customVal
 })

--- a/src/app/models/field/numberField.ts
+++ b/src/app/models/field/numberField.ts
@@ -5,43 +5,18 @@ import {
   NumberValidationOptions,
 } from '../../../../shared/types'
 import { INumberFieldSchema } from '../../../types'
-import { WithCustomMinMax } from '../../../types/field/utils/virtuals'
 
 import { MyInfoSchema } from './baseField'
 
 const createNumberFieldSchema = () => {
-  const ValidationOptionsSchema = new Schema<
-    WithCustomMinMax<NumberValidationOptions>
-  >(
-    {
-      customVal: {
-        type: Number,
-      },
-      selectedValidation: {
-        type: String,
-        enum: [...Object.values(NumberSelectedValidation), null],
-      },
+  const ValidationOptionsSchema = new Schema<NumberValidationOptions>({
+    customVal: {
+      type: Number,
     },
-    {
-      // TODO: Remove virtuals (#2039)
-      toJSON: {
-        virtuals: true,
-      },
+    selectedValidation: {
+      type: String,
+      enum: [...Object.values(NumberSelectedValidation), null],
     },
-  )
-
-  // Virtuals to allow for backwards compatibility after customMin and customMax were removed as part of #408
-  // TODO: Remove virtuals (#2039)
-  ValidationOptionsSchema.virtual('customMin').get(function (
-    this: NumberValidationOptions,
-  ) {
-    return this.customVal
-  })
-
-  ValidationOptionsSchema.virtual('customMax').get(function (
-    this: NumberValidationOptions,
-  ) {
-    return this.customVal
   })
 
   const NumberFieldSchema = new Schema<INumberFieldSchema>({

--- a/src/types/field/utils/virtuals.ts
+++ b/src/types/field/utils/virtuals.ts
@@ -1,9 +1,0 @@
-import { Document } from 'mongoose'
-
-// Types for virtuals for backwards compatibility after customMin and customMax were removed as part of #408
-// TODO: Remove virtual type (#2039)
-export type WithCustomMinMax<T> = T &
-  Document & {
-    customMin: number | null
-    customMax: number | null
-  }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2039 

## Solution
<!-- How did you solve the problem? -->

1. Removed `WithCustomMinMax` schema type
2. Removed `customMin` and `customMax` virtuals set in the shared text schema and number field schema 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ x ] No - I believe the changes should be compatible since we are only removing virtuals from the schema (?)

## Tests
<!-- What tests should be run to confirm functionality? -->
- For each combination of (min/max/exact) for (number / short text / long text) field:
  - [ ] Create a field with the validation. This should work.
  - [ ] Modify the validation options. This should work.
  - [ ] Attempt to submit a form with a response not satisfying the validation option. This should trigger an error on the frontend.
  - [ ] Attempt to submit a form with a response satisfying the validation option. This should work.