### PR TITLE
fix: updated payment view to follow colour theme

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/PaymentView.tsx
@@ -11,6 +11,7 @@ import Tooltip from '~components/Tooltip'
 import { PaymentPreview } from '~templates/Field/PaymentPreview/PaymentPreview'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useDesignColorTheme } from '~features/admin-form/create/builder-and-design/utils/useDesignColorTheme'
 
 import {
   CreatePageSidebarContextProps,
@@ -59,6 +60,7 @@ export const PaymentView = () => {
   })
 
   const paymentRef = useRef<HTMLDivElement | null>(null)
+  const colourTheme = useDesignColorTheme()
 
   useEffect(() => {
     if (paymentState === PaymentState.EditingPayment) {
@@ -113,7 +115,7 @@ export const PaymentView = () => {
           >
             <Box p={{ base: '0.75rem', md: '1.5rem' }}>
               <PaymentPreview
-                colorTheme={form?.startPage.colorTheme}
+                colorTheme={colourTheme}
                 paymentDetails={paymentDetailsWithPlaceholderPreview}
                 isBuilder
               />

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -67,7 +67,10 @@ export const PaymentPreview = ({
         )}
       </Box>
       {isBuilder ? (
-        <VerifiableFieldBuilderContainer schema={emailFieldSchema}>
+        <VerifiableFieldBuilderContainer
+          schema={emailFieldSchema}
+          colorTheme={colorTheme}
+        >
           <EmailFieldInput schema={emailFieldSchema} />
         </VerifiableFieldBuilderContainer>
       ) : (

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -74,7 +74,10 @@ export const PaymentPreview = ({
           <EmailFieldInput schema={emailFieldSchema} />
         </VerifiableFieldBuilderContainer>
       ) : (
-        <VerifiableEmailField schema={emailFieldSchema} />
+        <VerifiableEmailField
+          schema={emailFieldSchema}
+          colorTheme={colorTheme}
+        />
       )}
     </>
   )


### PR DESCRIPTION
## Problem
Payment fields does not follow colour theme selected by admin.

Closes FRM-946

## Solution
Passing colour theme to PaymentPreview and VerifiableFieldBuilderContainer components

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="1509" alt="Screenshot 2023-08-06 at 6 22 00 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/d3155f30-0f49-4b33-9aa8-b825954effee">


**AFTER**:
<img width="1510" alt="Screenshot 2023-08-06 at 6 24 49 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/e5ba1926-cf8b-477b-a854-4c03958d412c">


## Tests

- [ ]  Create a payment field
- [ ] Select any colour theme aside from the default colour theme
- [ ] Verify that colour theme changes accordingly in preview and actual form
