### PR TITLE
fix: misc UI changes on Payment Summary page

### DIFF
--- a/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
@@ -42,7 +42,7 @@ export const FeedbackBlock = ({
     <Flex justify="center">
       <chakra.form w="100%" maxW="100%" noValidate onSubmit={handleFormSubmit}>
         <FormControl isInvalid={!!errors.rating} id="rating">
-          <FormLabel isRequired>
+          <FormLabel isRequired color="content.strong">
             How was your form filling experience today?
           </FormLabel>
           <Controller

--- a/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/features/public-form/components/FormFooter/FormFooter.tsx
@@ -28,7 +28,7 @@ export const FormFooter = (): JSX.Element => {
           mx={{ lg: 0 }}
           mb={{ lg: '2rem' }}
         >
-          <Box id={captchaContainerId} sx={noPrintCss} />
+          <Box id={captchaContainerId} sx={noPrintCss} mt="2rem" />
           <Box w="100%">
             <AppFooter
               variant="compact"

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -106,6 +106,7 @@ export const DownloadReceiptBlock = ({
 
       <Button
         mt="2.75rem"
+        width={{ base: '100%', md: 'auto' }}
         leftIcon={<BiDownload fontSize="1.5rem" />}
         onClick={handleInvoiceClick}
       >

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -34,10 +34,10 @@ const PaymentSummaryRow = ({
       direction={{ base: 'column', md: 'row' }}
       spacing={{ base: 0, md: '1.5rem' }}
     >
-      <Text textStyle="body-2" width="6.5rem" color="#848484">
+      <Text textStyle="body-2" width="6.5rem" color="content.medium">
         {title}
       </Text>
-      <Text textStyle="body-2" color="#474747">
+      <Text textStyle="body-2" color="content.default">
         {input}
       </Text>
     </Stack>
@@ -84,15 +84,17 @@ export const DownloadReceiptBlock = ({
   return (
     <Box>
       <Stack spacing="2rem">
-        <Stack tabIndex={-1} spacing="1rem">
-          <Text textStyle="h2">Your payment has been made successfully.</Text>
-          <Text textStyle="subhead-1">
+        <Stack tabIndex={-1} spacing="0.75rem">
+          <Text textStyle="h2" color="content.strong">
+            Your payment has been made successfully.
+          </Text>
+          <Text textStyle="subhead-1" color="content.strong">
             Your form has been submitted and payment has been made.
           </Text>
         </Stack>
         <Divider />
         <Stack>
-          <Text textStyle="h2" mb="0.5rem">
+          <Text textStyle="h2" mb="0.5rem" color="content.strong">
             Payment summary
           </Text>
           <PaymentSummaryRow title="Product/service" input={productName} />

--- a/frontend/src/theme/foundations/colours.ts
+++ b/frontend/src/theme/foundations/colours.ts
@@ -16,6 +16,7 @@ export type ThemeColorScheme =
   | 'theme-brown'
   | 'white'
   | 'subtle'
+  | 'content'
 
 /**
  * Available color schemes to use for form field colors
@@ -193,5 +194,11 @@ export const colours: { [k in ThemeColorScheme]: Record<string, string> } = {
     600: primaryColourPalette[200],
     700: primaryColourPalette[300],
     800: primaryColourPalette[500],
+  },
+  // TODO FRM-1251: Remove when we have the full colour mapping to OGP DS
+  content: {
+    strong: '#2E2E2E',
+    medium: '#848484',
+    default: '#474747',
   },
 }


### PR DESCRIPTION
## Solution
<!-- How did you solve the problem? -->

- Spacing between title and description for thank you page is 12px
- Font colours follow OGP base design system
- Increase spacing from feedback section to recaptcha button - 24px
- Proof of payment button stretches to the width of the screen for mobile

**Improvements**:
- Added some `content` colour mappings from OGP DS as an interim solution, while we wait for the full colour tokens (FRM-1251)

