### PR TITLE
fix: Find latest successful payment query to sort by completed payment date and constraint query to last 30 days

### DIFF
--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -65,6 +65,7 @@ describe('payments.controller', () => {
     })
     it('should return 200 and the latest payment record id if there are multiple successful payments', async () => {
       const email = 'formsg@tech.gov.sg'
+      const now = moment().utc()
 
       // create 2 payments with different payment dates but same email
       const latestPayment = await Payment.create({
@@ -77,7 +78,7 @@ describe('payments.controller', () => {
         email: email,
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
-          paymentDate: moment().utc().toDate(),
+          paymentDate: now.toDate(),
         },
         gstEnabled: false,
       })
@@ -91,7 +92,7 @@ describe('payments.controller', () => {
         email: email,
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
-          paymentDate: moment().utc().subtract(1, 'hour').toDate(),
+          paymentDate: now.subtract(1, 'hour').toDate(),
         },
         gstEnabled: false,
       })
@@ -124,7 +125,7 @@ describe('payments.controller', () => {
         email: email,
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
-          paymentDate: new Date(moment().subtract(31, 'days').toDate()),
+          paymentDate: moment().subtract(31, 'days').toDate(),
         },
         gstEnabled: false,
       })

--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -2,6 +2,7 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import expressHandler from '__tests__/unit/backend/helpers/jest-express'
 import { ObjectId } from 'bson'
 import { StatusCodes } from 'http-status-codes'
+import moment from 'moment-timezone'
 import mongoose from 'mongoose'
 import { PaymentStatus } from 'shared/types'
 
@@ -41,6 +42,7 @@ describe('payments.controller', () => {
         email: email,
         completedPayment: {
           receiptUrl: 'http://form.gov.sg',
+          paymentDate: new Date(),
         },
         gstEnabled: false,
       })
@@ -60,6 +62,86 @@ describe('payments.controller', () => {
       )
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.send).toHaveBeenCalledOnce()
+    })
+    it('should return 200 and the latest payment record id if there are multiple successful payments', async () => {
+      const email = 'formsg@tech.gov.sg'
+
+      // create 2 payments with different payment dates but same email
+      const latestPayment = await Payment.create({
+        formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: email,
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+          paymentDate: moment().utc().toDate(),
+        },
+        gstEnabled: false,
+      })
+      await Payment.create({
+        formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: email,
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+          paymentDate: moment().utc().subtract(1, 'hour').toDate(),
+        },
+        gstEnabled: false,
+      })
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: MOCK_FORM_ID },
+        body: { email },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+
+      await PaymentsController.handleGetPreviousPaymentId(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.send).toHaveBeenCalledWith(latestPayment._id)
+    })
+    it('should return 404 if there are no successful payments made within the alst 30 days', async () => {
+      const email = 'formsg@tech.gov.sg'
+
+      await Payment.create({
+        formId: MOCK_FORM_ID,
+        targetAccountId: 'acct_MOCK_ACCOUNT_ID',
+        pendingSubmissionId: new ObjectId(),
+        amount: 12345,
+        status: PaymentStatus.Succeeded,
+        paymentIntentId: 'pi_MOCK_PAYMENT_INTENT',
+        email: email,
+        completedPayment: {
+          receiptUrl: 'http://form.gov.sg',
+          paymentDate: new Date(moment().subtract(31, 'days').toDate()),
+        },
+        gstEnabled: false,
+      })
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: MOCK_FORM_ID },
+        body: { email },
+      })
+
+      const mockRes = expressHandler.mockResponse()
+
+      await PaymentsController.handleGetPreviousPaymentId(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      expect(mockRes.sendStatus).toHaveBeenCalledWith(404)
     })
     it('should return 404 if there are no previous payments by the specific email', async () => {
       const payment = await Payment.create({

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -76,6 +76,7 @@ describe('payments.service', () => {
   describe('findLatestSuccessfulPaymentByEmailAndFormId', () => {
     const expectedObjectId = new ObjectId()
     const email = 'someone@mail.com'
+    const now = moment().utc()
 
     beforeEach(async () => {
       await dbHandler.clearCollection(Payment.collection.name)
@@ -90,7 +91,7 @@ describe('payments.service', () => {
         status: PaymentStatus.Succeeded,
         gstEnabled: false,
         completedPayment: {
-          paymentDate: moment().utc().toDate(),
+          paymentDate: now.toDate(),
         },
       })
     })
@@ -120,7 +121,7 @@ describe('payments.service', () => {
         status: PaymentStatus.Succeeded,
         gstEnabled: false,
         completedPayment: {
-          paymentDate: moment().utc().subtract(1, 'days').toDate(),
+          paymentDate: now.subtract(1, 'days').toDate(),
         },
       })
 

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone'
 import { ObjectId } from 'mongodb'
 import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
@@ -312,8 +313,11 @@ export const findLatestSuccessfulPaymentByEmailAndFormId = (
       email: email,
       formId: formId,
       status: PaymentStatus.Succeeded,
+      'completedPayment.paymentDate': {
+        $gt: moment().subtract(30, 'days').utc().toDate(),
+      },
     })
-      .sort({ _id: -1 })
+      .sort({ 'completedPayment.paymentDate': -1 })
       .exec(),
     (error) => {
       logger.error({


### PR DESCRIPTION
## Problem
Closes #6204, closes #6182 
- `findLatestSuccessfulPayment` returns latest created form id and not latest successful payment
- As per #6182, we can constraint the query to only successful payments that occurred within the last 30 days

## Solution
- Sort by `completedPayment.paymentDate`
- Restrict query to only completed payments that occur within the last 30 days

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
- [ ] Multiple completed payments where payment date is not in sequence of payment form creation (Refer to #6204 description)
- Previously successful payment occurring within >30 days 

**New tests added:**
Service level:
- Test for service to return latest successful payment and not latest created payment
- Test for service to return error if there is no existing successful payment within the previous 30 days

Controller level: 
- Test for controller to return 200 and the latest successful payment
- Test for service to return 404 if there is no existing successful payment within the previous 30 days

Side note:
Tests on the controller level might be redundant as logic is already tested on the service level.