### PR TITLE
fix: payment date race condition

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -140,7 +140,6 @@ const StripePaymentContainer = ({
               amount={paymentInfoData.amount}
               products={paymentInfoData.products || []}
               paymentFieldsSnapshot={paymentInfoData.payment_fields_snapshot}
-              paymentDate={paymentInfoData.paymentDate}
             />
           </>
         )

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -21,7 +21,6 @@ export const StripeReceiptContainer = ({
   amount,
   products,
   paymentFieldsSnapshot,
-  paymentDate,
 }: {
   formId: string
   submissionId: string
@@ -29,12 +28,12 @@ export const StripeReceiptContainer = ({
   amount: number
   products: ProductItem[]
   paymentFieldsSnapshot: FormPaymentsField
-  paymentDate?: Date
 }) => {
-  const { data, isLoading, error } = useGetPaymentReceiptStatus(
-    formId,
-    paymentId,
-  )
+  const {
+    data: paymentReceiptStatus,
+    isLoading,
+    error,
+  } = useGetPaymentReceiptStatus(formId, paymentId)
 
   const toast = useToast()
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState(false)
@@ -60,7 +59,7 @@ export const StripeReceiptContainer = ({
     [submitFormFeedbackMutation, toast],
   )
 
-  if (isLoading || error || !data) {
+  if (isLoading || error || !paymentReceiptStatus?.isReady) {
     return (
       <PaymentStack>
         <GenericMessageBlock
@@ -85,7 +84,7 @@ export const StripeReceiptContainer = ({
           products={products}
           paymentType={paymentFieldsSnapshot.payment_type}
           name={paymentFieldsSnapshot.name || ''}
-          paymentDate={paymentDate}
+          paymentDate={paymentReceiptStatus.paymentDate}
         />
       </PaymentStack>
       <PaymentStack>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -19,7 +19,7 @@ type DownloadReceiptBlockProps = {
   products: ProductItem[]
   paymentType?: PaymentType
   name: string
-  paymentDate?: Date
+  paymentDate: Date | null
 }
 
 const PaymentSummaryRow = ({

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -71,6 +71,7 @@ export type PaymentDto = Payment & { _id: string }
 
 export type PaymentReceiptStatusDto = {
   isReady: boolean
+  paymentDate: Date | null
 }
 
 export type GetPaymentInfoDto = {
@@ -81,7 +82,6 @@ export type GetPaymentInfoDto = {
   products: Payment['products']
   amount: Payment['amount']
   payment_fields_snapshot: Payment['payment_fields_snapshot']
-  paymentDate?: Date
 }
 
 export type IncompletePaymentsDto = {

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -57,9 +57,14 @@ export const checkPaymentReceiptStatus: ControllerHandler<{
       })
 
       if (!payment.completedPayment?.receiptUrl) {
-        return res.status(StatusCodes.NOT_FOUND).json({ isReady: false })
+        return res
+          .status(StatusCodes.NOT_FOUND)
+          .json({ isReady: false, paymentDate: null })
       }
-      return res.status(StatusCodes.OK).json({ isReady: true })
+      return res.status(StatusCodes.OK).json({
+        isReady: true,
+        paymentDate: payment.completedPayment?.paymentDate,
+      })
     })
     .mapErr((error) => {
       return res.status(StatusCodes.NOT_FOUND).json({ message: error })
@@ -254,7 +259,6 @@ export const getPaymentInfo: ControllerHandler<
               products: payment.products,
               amount: payment.amount,
               payment_fields_snapshot: payment.payment_fields_snapshot,
-              paymentDate: payment.completedPayment?.paymentDate,
             })
           })
         })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After a responder completes a payment, they would be shown a Payment summary which contains details such as payment products, and payment completion date.

However, the payment completion date has a race condition resulting in the completion date to be empty. 
![image](https://github.com/opengovsg/FormSG/assets/12391617/c706b471-7f5f-470e-8fb8-eccd2b63adb8)


## Solution
<!-- How did you solve the problem? -->

Move payment completion data over to `api/v3/payments/:formId/:paymentId/receipt/status`.

This works because:
1.  the whole `completedPayment` object is populated at once, this includes `receiptUrl` and `paymentDate`
2. Payment summary is not rendered until `completedPayment.receiptUrl` is populated

With the above two facts, we can be sure that `paymentDate` will be available when `<PaymentSummary >` is rendered .

https://github.com/opengovsg/FormSG/assets/12391617/f3004419-2d25-42aa-b1e7-4a8aafacfbd3




**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
