### PR TITLE
fix: supply empty object when snapshot script has not completely migrated

### DIFF
--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -258,7 +258,9 @@ export const getPaymentInfo: ControllerHandler<
               submissionId: payment.pendingSubmissionId,
               products: payment.products,
               amount: payment.amount,
-              payment_fields_snapshot: payment.payment_fields_snapshot,
+              // Empty {} is returned for backwards compatibility during migration.
+              // Can be removed after set-payment-fields-snapshot.js script has been completely executed
+              payment_fields_snapshot: payment.payment_fields_snapshot || {},
             })
           })
         })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`payment.payment_fields_snapshot` is referenced on the `<PaymentSummary />` component on the dedicated payment page. This field will not be populated if the user starts a payment during our deployment. 

We have a datafix script to retroactively supply this information, but in the event that the user starts a payment during our deployment, they will be met with a white page after payment (FE crash)

## Solution
<!-- How did you solve the problem? -->
The crash was due to accessing property of `null`. The crash can be mitigated by returning an empty `{}` instead of null.



**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  


## Before & After Screenshots

**AFTER**:
<!-- [insert screenshot here] -->
<img width="704" alt="Screenshot 2023-08-15 at 2 59 52 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/d7e585d7-2096-4149-912b-42eac84d9d08">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Make a payment
- [ ] Find your payment document in the DB, rename `payment.payment_fields_snapshot` to something else
- [ ] On the Dedicated Payment Page and observe that the page doesn't crash (product/service will be empty)
