### PR TITLE
fix: skip qty validation when multiqty is disabled

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -40,6 +40,7 @@ type ProductInput = Product & {
 const MIN_QTY_KEY = `min_qty`
 const MAX_QTY_KEY = `max_qty`
 const DISPLAY_AMOUNT_KEY = 'display_amount'
+const MULTI_QTY_KEY = 'multi_qty'
 export const ProductModal = ({
   onClose,
   onSaveProduct,
@@ -64,8 +65,9 @@ export const ProductModal = ({
           display_amount: centsToDollars(product.amount_cents ?? 0),
         }
       : {
-          min_qty: 1,
-          max_qty: 99,
+          [MULTI_QTY_KEY]: false,
+          [MIN_QTY_KEY]: 1,
+          [MAX_QTY_KEY]: 99,
         },
     mode: 'all',
   })
@@ -111,7 +113,7 @@ export const ProductModal = ({
     },
   }
 
-  const watchMultiQtyEnabled = watch('multi_qty', product?.multi_qty ?? false)
+  const watchMultiQtyEnabled = watch(MULTI_QTY_KEY, product?.multi_qty ?? false)
   const handleSaveProduct = handleSubmit((product) => {
     const { display_amount, ...rest } = product
     onSaveProduct({ ...rest, amount_cents: dollarsToCents(display_amount) })
@@ -120,7 +122,7 @@ export const ProductModal = ({
 
   const minQtyValidation: RegisterOptions<ProductInput, typeof MIN_QTY_KEY> = {
     validate: (val) => {
-      if (!getValues('multi_qty')) return true
+      if (!getValues(MULTI_QTY_KEY)) return true
       if (val <= 0) {
         return 'Please enter a value greater than 0'
       }
@@ -132,7 +134,8 @@ export const ProductModal = ({
   }
   const maxQtyValidation: RegisterOptions<ProductInput, typeof MAX_QTY_KEY> = {
     validate: (val) => {
-      if (!getValues('multi_qty')) return true
+      if (!getValues(MULTI_QTY_KEY)) return true
+      if (!getValues(DISPLAY_AMOUNT_KEY)) return true
       if (val <= 0) {
         return 'Please enter a value greater than 0'
       }
@@ -221,7 +224,7 @@ export const ProductModal = ({
             <Box>
               <FormControl>
                 <Controller
-                  name={'multi_qty'}
+                  name={MULTI_QTY_KEY}
                   control={control}
                   render={({ field: { value, onChange, ...rest } }) => (
                     <Toggle

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -95,7 +95,7 @@ export const ProductModal = ({
       const validateMin = !!val && dollarsToCents(val) >= minPaymentAmountCents
       // Repeat the check on minPaymentAmountCents for correct typing
       if (!!minPaymentAmountCents && !validateMin) {
-        return `Please enter a payment amount above ${formatCurrency(
+        return `The maximum amount is ${formatCurrency(
           Number(centsToDollars(minPaymentAmountCents)),
         )}`
       }
@@ -103,7 +103,7 @@ export const ProductModal = ({
       const validateMax = !!val && dollarsToCents(val) <= maxPaymentAmountCents
       // Repeat the check on maxPaymentAmountCents for correct typing
       if (!!maxPaymentAmountCents && !validateMax) {
-        return `Please enter a payment amount below ${formatCurrency(
+        return `The maximum amount is ${formatCurrency(
           Number(centsToDollars(maxPaymentAmountCents)),
         )}`
       }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -135,12 +135,11 @@ export const ProductModal = ({
   const maxQtyValidation: RegisterOptions<ProductInput, typeof MAX_QTY_KEY> = {
     validate: (val) => {
       if (!getValues(MULTI_QTY_KEY)) return true
-      if (!getValues(DISPLAY_AMOUNT_KEY)) return true
       if (val <= 0) {
         return 'Please enter a value greater than 0'
       }
 
-      const amount = dollarsToCents(getValues(DISPLAY_AMOUNT_KEY))
+      const amount = dollarsToCents(getValues(DISPLAY_AMOUNT_KEY) ?? '')
 
       if (val * amount > maxPaymentAmountCents) {
         const maxQty = Math.floor(maxPaymentAmountCents / amount)

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -120,6 +120,7 @@ export const ProductModal = ({
 
   const minQtyValidation: RegisterOptions<ProductInput, typeof MIN_QTY_KEY> = {
     validate: (val) => {
+      if (!getValues('multi_qty')) return true
       if (val <= 0) {
         return 'Please enter a value greater than 0'
       }
@@ -131,6 +132,7 @@ export const ProductModal = ({
   }
   const maxQtyValidation: RegisterOptions<ProductInput, typeof MAX_QTY_KEY> = {
     validate: (val) => {
+      if (!getValues('multi_qty')) return true
       if (val <= 0) {
         return 'Please enter a value greater than 0'
       }
@@ -218,10 +220,21 @@ export const ProductModal = ({
             </FormControl>
             <Box>
               <FormControl>
-                <Toggle
-                  {...register('multi_qty')}
-                  label="Quantity limit"
-                  description="Set the minimum and maximum quantities respondents can select"
+                <Controller
+                  name={'multi_qty'}
+                  control={control}
+                  render={({ field: { value, onChange, ...rest } }) => (
+                    <Toggle
+                      {...rest}
+                      isChecked={value}
+                      onChange={(e) => {
+                        onChange(e)
+                        trigger([MIN_QTY_KEY, MAX_QTY_KEY, DISPLAY_AMOUNT_KEY])
+                      }}
+                      label="Quantity limit"
+                      description="Set the minimum and maximum quantities respondents can select"
+                    />
+                  )}
                 />
               </FormControl>
               <FormControl

--- a/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
@@ -387,7 +387,7 @@ describe('admin-form.payment.service', () => {
         })
         const updatedProducts = [
           {
-            multi_qty: true,
+            multi_qty: false,
             max_qty: 11,
             amount_cents: 10,
           },
@@ -406,7 +406,36 @@ describe('admin-form.payment.service', () => {
             updatedProducts,
           )
 
-        expect(putSpy).not.toHaveBeenCalled()
+        expect(putSpy).toHaveBeenCalledOnce()
+        expect(actualResult.isOk()).toBeTrue()
+      })
+      it('should allow updates when product * max qty is below max amount', async () => {
+        jest.replaceProperty(PaymentConfig, 'paymentConfig', {
+          ...PaymentConfig.paymentConfig,
+          maxPaymentAmountCents: 100,
+        })
+        const updatedProducts = [
+          {
+            multi_qty: false,
+            max_qty: 9,
+            amount_cents: 10,
+          },
+        ] as PaymentsProductUpdateDto
+
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsProductById')
+          .mockResolvedValueOnce({
+            payments_field: {},
+          } as unknown as IEncryptedFormDocument)
+
+        // Act
+        const actualResult =
+          await AdminFormPaymentService.updatePaymentsProduct(
+            mockFormId,
+            updatedProducts,
+          )
+
+        expect(putSpy).toHaveBeenCalledOnce()
         expect(actualResult.isOk()).toBeTrue()
       })
     })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
@@ -1,6 +1,10 @@
 import { ObjectId } from 'bson-ext'
 import mongoose from 'mongoose'
-import { PaymentsUpdateDto, PaymentType } from 'shared/types'
+import {
+  PaymentsProductUpdateDto,
+  PaymentsUpdateDto,
+  PaymentType,
+} from 'shared/types'
 
 import * as PaymentConfig from 'src/app/config/features/payment.config'
 import { getEncryptedFormModel } from 'src/app/models/form.server.model'
@@ -52,7 +56,7 @@ describe('admin-form.payment.service', () => {
         )
 
         // Assert
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
           InvalidPaymentAmountError,
         )
@@ -76,7 +80,7 @@ describe('admin-form.payment.service', () => {
         )
 
         // Assert
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
           InvalidPaymentAmountError,
         )
@@ -99,7 +103,7 @@ describe('admin-form.payment.service', () => {
         // Assert
         expect(putSpy).toHaveBeenCalledWith(mockFormId, updatedPaymentSettings)
 
-        expect(actualResult.isOk()).toEqual(true)
+        expect(actualResult.isOk()).toBeTrue()
         // Should equal updatedPaymentSettings obj
         expect(actualResult._unsafeUnwrap()).toEqual(updatedPaymentSettings)
       })
@@ -118,7 +122,7 @@ describe('admin-form.payment.service', () => {
 
         // Assert
         expect(putSpy).toHaveBeenCalledWith(mockFormId, updatedPaymentSettings)
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
       })
 
@@ -136,7 +140,7 @@ describe('admin-form.payment.service', () => {
 
         // Assert
         expect(putSpy).toHaveBeenCalledWith(mockFormId, updatedPaymentSettings)
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
           FormNotFoundError,
         )
@@ -182,7 +186,7 @@ describe('admin-form.payment.service', () => {
           mockFormId,
           updatedPaymentSettingsMaxAboveMin,
         )
-        expect(actualResult.isOk()).toEqual(true)
+        expect(actualResult.isOk()).toBeTrue()
         expect(actualResult._unsafeUnwrap()).toEqual(
           updatedPaymentSettingsMaxAboveMin,
         )
@@ -215,7 +219,7 @@ describe('admin-form.payment.service', () => {
           mockFormId,
           updatedPaymentSettingsMaxAboveMin,
         )
-        expect(actualResult.isOk()).toEqual(true)
+        expect(actualResult.isOk()).toBeTrue()
         expect(actualResult._unsafeUnwrap()).toEqual(
           updatedPaymentSettingsMaxAboveMin,
         )
@@ -237,7 +241,7 @@ describe('admin-form.payment.service', () => {
 
         // Assert
         expect(putSpy).not.toHaveBeenCalled()
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
           InvalidPaymentAmountError,
         )
@@ -254,18 +258,156 @@ describe('admin-form.payment.service', () => {
           max_amount: 1000,
         } as PaymentsUpdateDto
 
+        const putSpy = jest.spyOn(EncryptFormModel, 'updatePaymentsById')
         // Act
         const actualResult = await AdminFormPaymentService.updatePayments(
           mockFormId,
           updatedPaymentSettingsBelow,
         )
 
-        const putSpy = jest.spyOn(EncryptFormModel, 'updatePaymentsById')
         expect(putSpy).not.toHaveBeenCalled()
-        expect(actualResult.isErr()).toEqual(true)
+        expect(actualResult.isErr()).toBeTrue()
         expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
           InvalidPaymentAmountError,
         )
+      })
+    })
+  })
+
+  describe('updatePaymentsProduct', () => {
+    const mockFormId = new ObjectId().toString()
+
+    describe('with multi qty enabled', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it('should allow updates when product * max qty is below max amount', async () => {
+        jest.replaceProperty(PaymentConfig, 'paymentConfig', {
+          ...PaymentConfig.paymentConfig,
+          maxPaymentAmountCents: 100,
+        })
+        const updatedProducts = [
+          {
+            multi_qty: true,
+            max_qty: 9,
+            amount_cents: 10,
+          },
+        ] as PaymentsProductUpdateDto
+
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsProductById')
+          .mockResolvedValueOnce({
+            payments_field: {},
+          } as unknown as IEncryptedFormDocument)
+
+        // Act
+        const actualResult =
+          await AdminFormPaymentService.updatePaymentsProduct(
+            mockFormId,
+            updatedProducts,
+          )
+
+        expect(putSpy).toHaveBeenCalledOnce()
+        expect(actualResult.isOk()).toBeTrue()
+      })
+
+      it('should allow updates when product * max qty is at max amount', async () => {
+        jest.replaceProperty(PaymentConfig, 'paymentConfig', {
+          ...PaymentConfig.paymentConfig,
+          maxPaymentAmountCents: 100,
+        })
+        const updatedProducts = [
+          {
+            multi_qty: true,
+            max_qty: 10,
+            amount_cents: 10,
+          },
+        ] as PaymentsProductUpdateDto
+
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsProductById')
+          .mockResolvedValueOnce({
+            payments_field: {},
+          } as unknown as IEncryptedFormDocument)
+
+        // Act
+        const actualResult =
+          await AdminFormPaymentService.updatePaymentsProduct(
+            mockFormId,
+            updatedProducts,
+          )
+
+        expect(putSpy).toHaveBeenCalled()
+        expect(actualResult.isOk()).toBeTrue()
+      })
+
+      it('should disallow updates when product * max qty exceeds max amount', async () => {
+        jest.replaceProperty(PaymentConfig, 'paymentConfig', {
+          ...PaymentConfig.paymentConfig,
+          maxPaymentAmountCents: 100,
+        })
+        const updatedProducts = [
+          {
+            multi_qty: true,
+            max_qty: 11,
+            amount_cents: 10,
+          },
+        ] as PaymentsProductUpdateDto
+
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsProductById')
+          .mockResolvedValueOnce({
+            payments_field: {},
+          } as unknown as IEncryptedFormDocument)
+
+        // Act
+        const actualResult =
+          await AdminFormPaymentService.updatePaymentsProduct(
+            mockFormId,
+            updatedProducts,
+          )
+
+        expect(putSpy).not.toHaveBeenCalled()
+        expect(actualResult.isErr()).toBeTrue()
+        expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+          InvalidPaymentAmountError,
+        )
+      })
+    })
+
+    describe('with multi qty disabled', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+      it('should allow updates when product * max qty possibly exceeds max amount', async () => {
+        jest.replaceProperty(PaymentConfig, 'paymentConfig', {
+          ...PaymentConfig.paymentConfig,
+          maxPaymentAmountCents: 100,
+        })
+        const updatedProducts = [
+          {
+            multi_qty: true,
+            max_qty: 11,
+            amount_cents: 10,
+          },
+        ] as PaymentsProductUpdateDto
+
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsProductById')
+          .mockResolvedValueOnce({
+            payments_field: {},
+          } as unknown as IEncryptedFormDocument)
+
+        // Act
+        const actualResult =
+          await AdminFormPaymentService.updatePaymentsProduct(
+            mockFormId,
+            updatedProducts,
+          )
+
+        expect(putSpy).not.toHaveBeenCalled()
+        expect(actualResult.isOk()).toBeTrue()
       })
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.payments.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.service.ts
@@ -103,7 +103,9 @@ export const updatePaymentsProduct = (
   PossibleDatabaseError | FormNotFoundError | InvalidPaymentAmountError
 > => {
   for (const product of newProducts) {
-    const maximumSelectableQtyCost = product.max_qty * product.amount_cents
+    // treat as a single item purchase if multi_qty is false
+    const qtyModifier = product.multi_qty ? product.max_qty : 1
+    const maximumSelectableQtyCost = qtyModifier * product.amount_cents
     if (maximumSelectableQtyCost > paymentConfig.maxPaymentAmountCents) {
       return errAsync(
         new InvalidPaymentAmountError(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. A quantity validation check was performed preventing the field to be saved as the quantity field errors out, but this is not visible to the user.
This should be fixed such that the quantity check is not performed when the quantity limit toggle is off.
2. On the backend,`multi_qty` is always treated to be true even if the toggle is disabled, resulting in validation failure when the user is trying to add only 1 single item.

Closes FRM-1255

## Solution
<!-- How did you solve the problem? -->

1. Quantity validation will do an early return with true when quantity limit toggle is off. 
2. A `trigger` is also added so that we can update the `useForm` errors through a validation.
3. Backend checks if `multi_qty` is enabled and set the qty modifier to be 1 when disabled during calculations.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
https://github.com/opengovsg/FormSG/assets/12391617/f160b752-98ca-4086-80f1-f59d45173476

**AFTER**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/12391617/6695c5bf-6965-45e3-983b-15c54fdd3130


## Tests
<!-- What tests should be run to confirm functionality? -->
Quantity below max payment amount (200k)
- [ ] Save button should be enabled when amount is 20k, and toggle disabled
- [ ] Enable toggle and set max quantity as `9`
- [ ] Save button remains enabled
- [ ] Saving items succeeds and is reflected on payment input panel with amount as `$20000.00`

Quantity at max payment amount (200k)
- [ ] Save button should be enabled when amount is 20k, and toggle disabled
- [ ] Enable toggle and set max quantity as `10`
- [ ] Save button remains enabled
- [ ] Saving items succeeds and is reflected on payment input panel with amount as `$20000.00`

Quantity above max payment amount (200k)
- [ ] Save button should be enabled when amount is 20k, and toggle disabled
- [ ] Enable toggle and set max quantity as `11`
- [ ] Save button is now **disabled**
- [ ] Saving button should not be interactable
- [ ] Disable toggle
- [ ] Saving button is now **enabled**
- [ ] Saving items succeeds and is reflected on payment input panel with amount as `$20000.00`

Regression
- [ ] Add new products
- [ ] Enabling toggle doesn't crash the modal
  - [ ] Shows error `Please enter a valid payment amount`
- [ ] Disabling toggle doesn't crash the modal 
  - [ ] Continue to show error `Please enter a valid payment amount`
