### PR TITLE
feat: add datafix script to convert payment_fields_snapshot from an array to an object

### DIFF
--- a/scripts/20230816_convert-payment-fields-snapshot-to-object/convert-payment-fields-snapshot-to-object.js
+++ b/scripts/20230816_convert-payment-fields-snapshot-to-object/convert-payment-fields-snapshot-to-object.js
@@ -1,0 +1,62 @@
+/* eslint-disable */
+/**
+ * This script converts the all instances where the `payment_fields_snapshot` field is an array to an object
+ */
+
+// PAYMENTS COLLECTION
+// BEFORE
+// Count total number of payments.
+db.getCollection('payments').countDocuments({})
+
+// Count total number of payments where the payment_fields_snapshot is an array
+db.getCollection('payments').countDocuments({
+  payment_fields_snapshot: { $type: 'array' },
+})
+
+
+// UPDATE
+db.getCollection('payments').aggregate([
+  {
+    $match: {
+      payment_fields_snapshot: { $type: 'array' },
+    },
+  },
+  {
+    $lookup: {
+      from: 'forms',
+      localField: 'formId',
+      foreignField: '_id',
+      as: 'form',
+    },
+  },
+  {
+    $set: {
+      payment_fields_snapshot: {
+        $reduce: {
+          input: '$form.payments_field',
+          initialValue: {},
+          in: { $mergeObjects: ['$$value', '$$this'] },
+        },
+      },
+    },
+  },
+  { $project: { form: 0 } },
+  {
+    $merge: {
+      into: 'payments',
+      on: '_id',
+      whenMatched: 'replace',
+    },
+  },
+])
+
+// AFTER
+// Count total number of payments where the payment_fields_snapshot is an array. This should be equal to 0
+db.getCollection('payments').countDocuments({
+  payment_fields_snapshot: { $type: 'array' },
+})
+
+// Count total number of payments with payment_fields_snapshot value. This should be equal to the total number of payments.
+db.getCollection('payments').countDocuments({
+  payment_fields_snapshot: { $exists: true },
+})


### PR DESCRIPTION
## Context
<!-- What problem are you trying to solve? What issue does this close? -->
When the `set-payment-fields-snapshot.js` database script was run, this set `payment_fields_snapshot` as an array instead of an object. 

As the shape of `payment_fields_snapshot` is supposed to be that of an object, we want to convert instances where `payment_fields_snapshot` is an array into an object. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
Before running the DB script:
- [ ] Load the payment summary page of a payment where its `payment_fields_snapshot` is an array. The product/service name should be missing.
After running the DB script:
- [ ] Load the payment summary page of the same payment. The product/service name should now be populated with the same name that's in the proof of payment.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New scripts**:

- `convert-payment-fields-snapshot-to-object.js` : This script adds the `payment_fields_snapshot` field to the payments collection and sets the field as the form document's `payment_field` for all existing documents.
