### PR TITLE
feat: display payment products on individual response page and csv download

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -56,6 +56,7 @@ export const PaymentSection = ({
           </Box>
           <PaymentDataItem {...paymentDataMap['paymentIntentId']} isMonospace />
           <PaymentDataItem {...paymentDataMap['amount']} />
+          <PaymentDataItem {...paymentDataMap['products']} />
           <PaymentDataItem {...paymentDataMap['paymentDate']} />
           <Box py="0.75rem">
             <Divider />

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
@@ -92,6 +92,8 @@ export class CsvRecord {
         return '000000000000000000000009'
       case 'payoutDate':
         return '00000000000000000000000a'
+      case 'products':
+        return '00000000000000000000000b'
     }
   }
 

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -70,6 +70,14 @@ export const getPaymentDataView = (
       value: centsToDollarString(payment.amount),
     },
     {
+      key: 'products',
+      name: 'Product/service',
+      value:
+        payment.products
+          ?.map(({ name, quantity }) => `${name} x ${quantity}`)
+          .join(', ') || '-',
+    },
+    {
       key: 'paymentDate',
       name: 'Payment date and time',
       value: payment.paymentDate,

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -48,7 +48,7 @@ const PaymentSummaryRow = ({
 const getProductNames = (products: ProductItem[]): string => {
   return products
     .filter((product) => product.selected)
-    .map((product) => `${product.quantity}x ${product.data.name}`)
+    .map((product) => `${product.data.name} x ${product.quantity}`)
     .join(', ')
 }
 

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -76,6 +76,14 @@ export const SubmissionPaymentDto = z.object({
   id: z.string(),
   paymentIntentId: z.string(),
   email: z.string(),
+  products: z
+    .array(
+      z.object({
+        name: z.string(),
+        quantity: z.number(),
+      }),
+    )
+    .optional(),
   amount: z.number(),
   status: z.nativeEnum(PaymentStatus),
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -317,6 +317,12 @@ export const getSubmissionPaymentDto = (
       id: payment._id,
       paymentIntentId: payment.paymentIntentId,
       email: payment.email,
+      products: payment.products
+        ?.filter((product) => product.selected)
+        .map((product) => ({
+          name: product.data.name,
+          quantity: product.quantity,
+        })),
       amount: payment.amount,
       status: payment.status,
 


### PR DESCRIPTION
## Problem
Admins can now key in multiple products per form, but they need to know exactly what products have been selected by respondents.

Closes FRM-1248

## Solution
Add the products field to the payment section in the individual response page and downloaded CSV. Additionally, update the syntax for products on the form payment page which was originally incorrect.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Screenshots

Individual response page
<img width="1512" alt="image" src="https://github.com/opengovsg/FormSG/assets/25571626/e9d3f557-548f-490c-8088-8f8619f8395e">

CSV download
<img width="986" alt="image" src="https://github.com/opengovsg/FormSG/assets/25571626/ec440a6b-8fad-4b31-9e44-6d1514221eaa">

## Tests
- [ ] Submit a payment with payment by products (radio version). Once submitted, ensure that the product can be seen on the individual response page and CSV download.
- [ ] Submit a payment with payment by products (checkbox version). Once submitted, ensure that the product can be seen on the individual response page and CSV download.
- [ ] Submit a payment with payment by products (checkbox version with multiple quantity). Once submitted, ensure that the product can be seen on the individual response page and CSV download.
- [ ] Regression: ensure that the product listing is `-` for older fixed payments on both of the individual response page and CSV download.