### PR TITLE
chore: reduce toast duration to 4s

### DIFF
--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -44,7 +44,7 @@ export const useToast = ({
 
   const customToastImpl = useMemo(() => {
     const impl = ({
-      duration = 6000,
+      duration = 4000,
       position = 'top',
       render,
       status,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Discussed with @staceytan1998 and we think that the current toast duration is too long. From quick research, it seems the best duration is between 2-5s, with a preference for 3s duration. However, decided to keep it at 4s as we have some decently long toasts.

## Solution
<!-- How did you solve the problem? -->

Change `useToast` duration to `4000`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] do any action that results in a toast (Create/delete form, create/update/delete fields)
- [ ] check that the toast duration is ~4s