### PR TITLE
fix: default payment type to products

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/mutations/useDeleteFormField.ts
@@ -38,8 +38,8 @@ export const useDeleteFormField = () => {
 
   const paymentDeleteDefault: PaymentsUpdateDto = {
     enabled: false,
-    payment_type: PaymentType.Fixed,
-    amount_cents: 0,
+    payment_type: PaymentType.Products,
+    products: [],
   }
 
   const { stateData, setToInactive } = useFieldBuilderStore(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1257

## Solution
<!-- How did you solve the problem? -->
Change `paymentDeleteDefault` to `PaymentType.Products`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new payment field
- [ ] Delete the payment field
- [ ] Go to create tab payment, the default payment type should be products (and you should not see the fixed payment option)
