### PR TITLE
fix: remove space from receipt link email

### DIFF
--- a/src/app/views/templates/payment-confirmation.view.html
+++ b/src/app/views/templates/payment-confirmation.view.html
@@ -5,7 +5,7 @@
     <p>
       Your payment on <%= appName %> form: <%= formTitle %> has been received
       successfully. Your response ID is <%= submissionId %> and your proof of
-      payment can be found <a href="<%= invoiceUrl %>">here </a>.
+      payment can be found <a href="<%= invoiceUrl %>">here</a>.
     </p>
     <p>Regards,<br /><%= appName %> team</p>
   </body>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There's an extra space in the payment receipt emails sent to respondents after they make payment.

Closes FRM-1110

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Removes extra space in payment receipt email.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

![image](https://github.com/opengovsg/FormSG/assets/37061143/619d41c8-9127-48e7-bb53-4facdd6c09c3)

**AFTER**:
<!-- [insert screenshot here] -->

<img width="1139" alt="Screenshot 2023-08-17 at 10 39 45 AM" src="https://github.com/opengovsg/FormSG/assets/37061143/7b8ef5d0-fbec-4ead-a589-d72d9c702c93">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Make payment on a form. Check that the email received does not have a space behind the link for "here".
