### PR TITLE
feat: ui review changes

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -102,7 +102,7 @@ export const ProductModal = ({
       const validateMin = !!val && dollarsToCents(val) >= minPaymentAmountCents
       // Repeat the check on minPaymentAmountCents for correct typing
       if (!!minPaymentAmountCents && !validateMin) {
-        return `The maximum amount is S${formatCurrency(
+        return `The minimum amount is S${formatCurrency(
           Number(centsToDollars(minPaymentAmountCents)),
         )}`
       }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -89,8 +89,8 @@ export const ProductModal = ({
     typeof DISPLAY_AMOUNT_KEY
   > = {
     validate: (val) => {
-      // // Validate that it is a money value.
-      // // Regex allows leading and trailing spaces, max 2dp
+      // Validate that it is a money value.
+      // Regex allows leading and trailing spaces, max 2dp
       const validateMoney = /^\s*(\d+)(\.\d{0,2})?\s*$/.test(val ?? '')
       if (!validateMoney)
         return `Enter an amount between S${formatCurrency(

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -89,15 +89,20 @@ export const ProductModal = ({
     typeof DISPLAY_AMOUNT_KEY
   > = {
     validate: (val) => {
-      // Validate that it is a money value.
-      // Regex allows leading and trailing spaces, max 2dp
+      // // Validate that it is a money value.
+      // // Regex allows leading and trailing spaces, max 2dp
       const validateMoney = /^\s*(\d+)(\.\d{0,2})?\s*$/.test(val ?? '')
-      if (!validateMoney) return 'Please enter a valid payment amount'
+      if (!validateMoney)
+        return `Enter an amount between S${formatCurrency(
+          Number(centsToDollars(minPaymentAmountCents)),
+        )} and S${formatCurrency(
+          Number(centsToDollars(maxPaymentAmountCents)),
+        )}`
 
       const validateMin = !!val && dollarsToCents(val) >= minPaymentAmountCents
       // Repeat the check on minPaymentAmountCents for correct typing
       if (!!minPaymentAmountCents && !validateMin) {
-        return `The maximum amount is ${formatCurrency(
+        return `The maximum amount is S${formatCurrency(
           Number(centsToDollars(minPaymentAmountCents)),
         )}`
       }
@@ -105,7 +110,7 @@ export const ProductModal = ({
       const validateMax = !!val && dollarsToCents(val) <= maxPaymentAmountCents
       // Repeat the check on maxPaymentAmountCents for correct typing
       if (!!maxPaymentAmountCents && !validateMax) {
-        return `The maximum amount is ${formatCurrency(
+        return `The maximum amount is S${formatCurrency(
           Number(centsToDollars(maxPaymentAmountCents)),
         )}`
       }
@@ -124,10 +129,10 @@ export const ProductModal = ({
     validate: (val) => {
       if (!getValues(MULTI_QTY_KEY)) return true
       if (val <= 0) {
-        return 'Please enter a value greater than 0'
+        return 'Enter a value greater than 0'
       }
       if (val > getValues(MAX_QTY_KEY)) {
-        return 'Please enter a value smaller than the maximum quantity'
+        return 'Enter a value smaller than the maximum quantity'
       }
       return true
     },
@@ -136,17 +141,22 @@ export const ProductModal = ({
     validate: (val) => {
       if (!getValues(MULTI_QTY_KEY)) return true
       if (val <= 0) {
-        return 'Please enter a value greater than 0'
+        return 'Enter a value greater than 0'
       }
 
       const amount = dollarsToCents(getValues(DISPLAY_AMOUNT_KEY) ?? '')
 
       if (val * amount > maxPaymentAmountCents) {
         const maxQty = Math.floor(maxPaymentAmountCents / amount)
-        return `The maximum quantity is ${maxQty}`
+        if (maxQty <= 0) {
+          return `Quantity limit could not be set because amount is above S${formatCurrency(
+            Number(centsToDollars(maxPaymentAmountCents)),
+          )}`
+        }
+        return `The maximum quantity for this amount is ${maxQty}`
       }
       if (val < getValues(MIN_QTY_KEY)) {
-        return 'Please enter a value greater than the minimum quantity'
+        return 'Enter a value greater than the minimum quantity'
       }
       return true
     },
@@ -257,9 +267,12 @@ export const ProductModal = ({
                       render={({ field }) => (
                         <Input
                           {...register(MIN_QTY_KEY, {
-                            required: watchMultiQtyEnabled,
+                            required:
+                              watchMultiQtyEnabled &&
+                              'The minimum quantity is 1',
                           })}
                           isInvalid={!!errors[MIN_QTY_KEY]}
+                          placeholder={'1'}
                           {...field}
                           onChange={(e) => {
                             field.onChange(e)
@@ -285,7 +298,9 @@ export const ProductModal = ({
                       render={({ field }) => (
                         <Input
                           {...register(MAX_QTY_KEY, {
-                            required: watchMultiQtyEnabled,
+                            required:
+                              watchMultiQtyEnabled &&
+                              'Enter a maximum quantity',
                           })}
                           isInvalid={!!errors[MAX_QTY_KEY]}
                           placeholder={'99'}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -1,4 +1,4 @@
-import { BiCheck } from 'react-icons/bi'
+import { BiCheck, BiInfoCircle } from 'react-icons/bi'
 import { IconType } from 'react-icons/lib'
 import { Box, Divider, Flex, Icon, Link, Text } from '@chakra-ui/react'
 import { keyBy } from 'lodash'
@@ -6,6 +6,7 @@ import { keyBy } from 'lodash'
 import { PaymentStatus, SubmissionPaymentDto } from '~shared/types'
 
 import { Tag } from '~components/Tag'
+import Tooltip from '~components/Tooltip'
 
 import { getPaymentDataView } from '../common/utils/getPaymentDataView'
 
@@ -64,7 +65,7 @@ export const PaymentSection = ({
         </Flex>
       </Flex>
       <Flex flexDir="column" gap="1.25rem">
-        <PaymentDataHeader name="Payout" {...payoutTagProps} />
+        <PayoutDataHeader name="Payout to bank account" {...payoutTagProps} />
         <Flex flexDir="column" gap="0.75rem">
           <PaymentDataItem {...paymentDataMap['payoutId']} isMonospace />
           <PaymentDataItem {...paymentDataMap['payoutDate']} />
@@ -81,17 +82,46 @@ type PaymentDataHeaderProps = {
   rightIcon?: IconType
 }
 
+const PayoutDataHeader = ({
+  name,
+  label,
+  colorScheme,
+  rightIcon,
+}: PaymentDataHeaderProps) => (
+  <Flex gap="1rem">
+    <Flex>
+      <Text textStyle="h2" as="h2" color="primary.500">
+        {name}
+      </Text>
+
+      <Tooltip
+        placement="top"
+        label="This is when money collected gets deposited into your bank account.
+        Depending on payment method, payouts happen 1 - 3 working days after a respondent makes payment."
+      >
+        <Flex justify="center" align="center">
+          <Icon as={BiInfoCircle} fontSize="1.5rem" ml="0.5rem" />
+        </Flex>
+      </Tooltip>
+    </Flex>
+    <Tag colorScheme={colorScheme} pointerEvents="none">
+      <Text textStyle="caption-1">{label}</Text>
+      {rightIcon && <Icon as={rightIcon} ml="0.25rem" />}
+    </Tag>
+  </Flex>
+)
+
 const PaymentDataHeader = ({
   name,
   label,
   colorScheme,
   rightIcon,
 }: PaymentDataHeaderProps) => (
-  <Flex gap="1.5rem">
+  <Flex gap="1rem">
     <Text textStyle="h2" as="h2" color="primary.500">
       {name}
     </Text>
-    <Tag colorScheme={colorScheme}>
+    <Tag colorScheme={colorScheme} pointerEvents="none">
       <Text textStyle="caption-1">{label}</Text>
       {rightIcon && <Icon as={rightIcon} ml="0.25rem" />}
     </Tag>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -24,15 +24,15 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: '#',
     accessor: 'number',
-    minWidth: 80, // minWidth is only used as a limit for resizing
-    width: 80, // width is used for both the flex-basis and flex-grow
+    minWidth: 20, // minWidth is only used as a limit for resizing
+    width: 20, // width is used for both the flex-basis and flex-grow
     maxWidth: 100, // maxWidth is only used as a limit for resizing
   },
   {
     Header: 'Response ID',
     accessor: 'refNo',
-    minWidth: 200,
-    width: 300,
+    minWidth: 100,
+    width: 100,
     maxWidth: 240, // maxWidth is only used as a limit for resizing
   },
   {
@@ -57,26 +57,19 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
   },
 
   {
-    Header: 'Paid Amount', //  (amt responder paid)
+    Header: 'Paid Amount (S$)', //  (amt responder paid)
     accessor: ({ payments }) => {
       if (!payments) {
         return ''
       }
-      return `S$${centsToDollars(payments.paymentAmt)}`
+      return `${centsToDollars(payments.paymentAmt)}`
     },
     minWidth: 50,
     width: 75,
   },
 
   {
-    Header: 'Net Amount', //  (amt they receive in bank)
-    accessor: ({ payments }) => getNetAmount(payments),
-    minWidth: 50,
-    width: 75,
-  },
-
-  {
-    Header: 'Fees', //  (paid - net)
+    Header: 'Fees (S$)', //  (paid - net)
     accessor: ({ payments }) => {
       if (!payments?.transactionFee) {
         return ''
@@ -85,11 +78,19 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
         return ''
       }
 
-      return `S$${centsToDollars(payments.transactionFee)}`
+      return `${centsToDollars(payments.transactionFee)}`
     },
     minWidth: 50,
     width: 75,
   },
+
+  {
+    Header: 'Net Amount (S$)', //  (amt they receive in bank)
+    accessor: ({ payments }) => getNetAmount(payments),
+    minWidth: 50,
+    width: 75,
+  },
+
   {
     Header: 'Payout Date',
     accessor: ({ payments }) => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/utils.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/utils.ts
@@ -16,7 +16,7 @@ export const getNetAmount = (
   const grossAmt = centsToDollars(payments.paymentAmt - payments.transactionFee)
   const isFinalTransactionFee = payments.payoutDate
   if (!isFinalTransactionFee) {
-    return `Est. S$${grossAmt}`
+    return `Est. ${grossAmt}`
   }
-  return `S$${grossAmt}`
+  return `${grossAmt}`
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
@@ -1,11 +1,14 @@
 import { Controller, useFormContext } from 'react-hook-form'
-import { Box, FormControl, FormErrorMessage, Text } from '@chakra-ui/react'
+import { Box, FormControl, Text } from '@chakra-ui/react'
 
 import { PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID } from '~shared/constants'
+import { centsToDollars, formatCurrency } from '~shared/utils/payments'
 
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import MoneyInput from '~components/MoneyInput'
 
 import { centsToDollarString } from '~features/admin-form/responses/common/utils/getPaymentDataView'
+import { useEnv } from '~features/env/queries'
 
 import { usePaymentFieldValidation } from '../../../../../hooks/usePaymentFieldValidation'
 
@@ -16,18 +19,26 @@ export const VariablePaymentItemDetailsBlock = ({
   paymentDescription,
   paymentItemName,
   paymentMin,
-  paymentMax,
+  paymentMax: _paymentMax,
 }: VariableItemDetailProps): JSX.Element => {
   const {
     control,
     formState: { errors },
   } = useFormContext()
+
+  const { data: { maxPaymentAmountCents = Number.MAX_SAFE_INTEGER } = {} } =
+    useEnv()
+  const paymentMax = _paymentMax || maxPaymentAmountCents
   const amountValidation = usePaymentFieldValidation<
     {
       [PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]: string
     },
     typeof PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID
   >({ lesserThanCents: paymentMax, greaterThanCents: paymentMin })
+
+  const amountHint = `Enter an amount between ${centsToDollarString(
+    paymentMin,
+  )} and S${formatCurrency(Number(centsToDollars(paymentMax)))}.`
 
   return (
     <Box>
@@ -53,13 +64,14 @@ export const VariablePaymentItemDetailsBlock = ({
             />
           )}
         />
-        <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
-          The minimum amount is {centsToDollarString(paymentMin)} and the
-          maximum amount is {centsToDollarString(paymentMax)}.
-        </Text>
-        <FormErrorMessage>
-          {errors[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]?.message}
-        </FormErrorMessage>
+
+        {errors[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]?.message ? (
+          <FormErrorMessage>{amountHint}</FormErrorMessage>
+        ) : (
+          <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
+            {amountHint}
+          </Text>
+        )}
       </FormControl>
     </Box>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1109

Reviews from design

Admin individual response page
- Update copy for header titles
- Add tooltip to mention payout dates
- Fix badge hover by ignoring pointer events

Admin response table
- update table width, ordering, and copy for response table

Variable payment preview
- Update copy for variable payment preview
- Fix input hint showing between 0 and 0, when paymentMax is not populated, on admin create and build page
- Update input hint to switch to error when payee input invalid values

Product modal Changes
- Updating of error copies
- Addition of new error message to better direct admin to fix `amount` field when `amount max qty` exceeds `maxPaymentAmountCents`
- Fix issue where errors doesn't appear when admins didn't input min / max amount

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->


**AFTER**:
<!-- [insert screenshot here] -->


| Changes | Before | After |
|--------|--------|--------|
| Admin individual response page | <img width="585" alt="Screenshot 2023-08-21 at 4 33 16 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/02280fe6-dfd3-4462-874f-61708f39f486"> | <img width="529" alt="Screenshot 2023-08-21 at 4 33 29 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/1f14a355-2415-4563-bd46-99dee5da9fc5"> |
| Admin response table |  <img width="456" alt="Screenshot 2023-08-21 at 4 30 26 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/6a67a3e8-0cdf-4924-a5b8-9b40bd224767"> | <img width="698" alt="Screenshot 2023-08-21 at 4 29 32 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/9d28baa7-d84f-4f9b-8d6f-1f9101a6f50c"> |
| Variable payment preview | <img width="432" alt="Screenshot 2023-08-21 at 4 34 55 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/533554b2-95fa-4614-805e-60b1ada1c50c"> | <img width="424" alt="Screenshot 2023-08-21 at 4 34 58 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/4a5ea031-7e4a-4dcb-911a-c6da9fe31a35"> |
| Cell | Cell | Cell | 
| Product Modal - Qty x Amt Error prompt | <img width="746" alt="Screenshot 2023-08-21 at 4 18 49 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/7691ed64-2ad7-4ab6-837a-e1274059d4dd"> |  <img width="734" alt="Screenshot 2023-08-21 at 4 19 03 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/a8851d3f-8ec6-445e-b1de-b43481716a34"> | 
| Product Modal - Empty Qty Prompt |  <img width="713" alt="Screenshot 2023-08-21 at 4 19 32 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/5f832a87-45c2-49c0-9c90-d46e003826ef"> | <img width="699" alt="Screenshot 2023-08-21 at 4 19 43 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/52cbb199-ea5a-4ebd-87e9-8e78b0062e56">   | 

## Tests
<!-- What tests should be run to confirm functionality? -->
**Admin individual response page**
- [ ] Observe that mouse-over on badge doesn't trigger any on-hover visual changes
- [ ] Observe that mouse-over tooltip will show payout information **above** the tooltip

**Admin response table**
On payment forms
- [ ] Observe that only headers have currency symbols

On non-payment forms
- [ ] Observe that payment headers are not rendered

**Variable payment preview**
Create and build page
- [ ] Observe that input hint is shown when `paymentMax` is not populated
