### PR TITLE
fix: replace "whitelist" wording with "allowlist"

### DIFF
--- a/__tests__/e2e/login.spec.ts
+++ b/__tests__/e2e/login.spec.ts
@@ -24,7 +24,7 @@ test.describe('login', () => {
 
     // Ensure error message is seen
     await expect(
-      page.getByText('This is not a whitelisted public service email domain.'),
+      page.getByText('This is not an allowlisted public service email domain.'),
     ).toBeVisible()
   })
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ to security on FormSG.
 
 - Management of forms is restricted to form creators. In storage mode, form creators
   can add other public servants as form editors. In email mode, form creators can
-  specify a whitelist of email addresses which will receive all form responses.
+  specify an allowlist of email addresses which will receive all form responses.
 
 #### Notable Points
 

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -29,7 +29,7 @@ DevOps
 Network
 
 - AWS VPC (with peering preferred) for managed database hosted by MongoDB Atlas
-- AWS NAT Gateway (for static IP whitelisting with SingPass)
+- AWS NAT Gateway (for static IP allowlisting with SingPass)
 
 Database
 

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -160,7 +160,7 @@ export const useMutateCollaborators = () => {
         switch (error.code) {
           case 422:
             errorMessage = requestEmail
-              ? `${requestEmail} is not part of a whitelisted agency`
+              ? `${requestEmail} is not part of a allowlisted agency`
               : `An unexpected error 422 happened`
             break
           case 400:

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -105,11 +105,11 @@ export const ShareFormModal = ({
   const { data: flags } = useFeatureFlags()
   const displayGoLink = flags?.has(featureFlags.goLinks)
 
-  // Hard-coded .gov.sg whitelist for GoGov integration
-  const gogovWhiteListed = '.gov.sg'
+  // Hard-coded .gov.sg allowlist for GoGov integration
+  const gogovAllowListed = '.gov.sg'
   const { user } = useUser()
-  const whitelisted = useMemo(
-    () => user?.email.endsWith(gogovWhiteListed),
+  const allowlisted = useMemo(
+    () => user?.email.endsWith(gogovAllowListed),
     [user?.email],
   )
 
@@ -327,7 +327,7 @@ export const ShareFormModal = ({
               <TabPanel>
                 <FormLinkSection />
                 {/* GoLinkSection */}
-                {(displayGoLink && whitelisted) ||
+                {(displayGoLink && allowlisted) ||
                 goLinkSuffixData?.goLinkSuffix ? (
                   <FormControl mt="1rem">
                     <FormLabel

--- a/frontend/src/features/login/SgidLoginPage.tsx
+++ b/frontend/src/features/login/SgidLoginPage.tsx
@@ -24,7 +24,7 @@ export const SgidLoginPage = (): JSX.Element => {
       case '200':
         return
       case '401':
-        return 'Your SGID-linked work email does not belong to a whitelisted public service email domain. Please use OTP login instead.'
+        return 'Your SGID-linked work email does not belong to an allowlisted public service email domain. Please use OTP login instead.'
       default:
         return 'Something went wrong. Please try again later.'
     }

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -10,7 +10,7 @@ export const enSG: Translation = {
         components: {
           LoginForm: {
             onlyAvailableForPublicOfficers:
-              'Log in with a .gov.sg or other whitelisted email address',
+              'Log in with a .gov.sg or other allowlisted email address',
             emailEmptyErrorMsg: 'Please enter an email address',
             login: 'Log in',
             haveAQuestion: 'Have a question?',

--- a/frontend/src/mocks/msw/handlers/auth.ts
+++ b/frontend/src/mocks/msw/handlers/auth.ts
@@ -11,7 +11,7 @@ export const otpGenerationResponse = ({
         ctx.status(isInvalid ? 401 : 200),
         ctx.json(
           isInvalid
-            ? 'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.'
+            ? 'This is not an allowlisted public service email domain. Please log in with your official government or government-linked email address.'
             : `OTP sent to ${req.body.email}`,
         ),
       )

--- a/frontend/src/pages/Landing/Payments/LandingPaymentsPage.tsx
+++ b/frontend/src/pages/Landing/Payments/LandingPaymentsPage.tsx
@@ -97,7 +97,7 @@ export const LandingPaymentsPage = (): JSX.Element => {
         if (error.message === 'Forbidden') {
           formMethods.setError(fieldId, {
             message:
-              'We are unable to send you our guide because your email is not whitelisted on FormSG.',
+              'We are unable to send you our guide because your email is not allowlisted on FormSG.',
           })
         } else {
           formMethods.setError(fieldId, {

--- a/src/app/modules/auth/auth.errors.ts
+++ b/src/app/modules/auth/auth.errors.ts
@@ -2,7 +2,7 @@ import { ApplicationError } from '../core/core.errors'
 
 export class InvalidDomainError extends ApplicationError {
   constructor(
-    message = 'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
+    message = 'This is not an allowlisted public service email domain. Please log in with your official government or government-linked email address.',
   ) {
     super(message)
   }

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1778,7 +1778,7 @@ describe('admin-form.service', () => {
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(ApplicationError)
     })
 
-    it('should return InvalidCollaboratorError when the new collaborator has a non-whitelisted email', async () => {
+    it('should return InvalidCollaboratorError when the new collaborator has a non-allowlisted email', async () => {
       // Arrange
       const findAgencySpy = jest.spyOn(AgencyModel, 'findOne')
       findAgencySpy.mockResolvedValueOnce(null)

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -765,7 +765,7 @@ export const updateForm = (
  *
  * @returns ok(collaborators) if form updates successfully
  * @returns err(PossibleDatabaseError) if any database errors occurs
- * @returns err(InvalidCollaboratorError) if a newly-added collaborator email is not whitelisted
+ * @returns err(InvalidCollaboratorError) if a newly-added collaborator email is not allowlisted
  */
 export const updateFormCollaborators = (
   form: IPopulatedForm,

--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -183,7 +183,7 @@ describe('payments.controller', () => {
       expect(mockRes.sendStatus).toHaveBeenCalledWith(StatusCodes.OK)
     })
 
-    it('should return 403 if email domain is not whitelisted', async () => {
+    it('should return 403 if email domain is not allowlisted', async () => {
       // Arrange
       const mockReq = expressHandler.mockRequest({
         body: { email: 'jest-always-mocks@me.sad' },

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -306,7 +306,7 @@ describe('payments.service', () => {
       expect(databaseErr).toBeInstanceOf(InvalidDomainError)
     })
 
-    it('should return a InvalidDomainError if email domain is not whitelisted', async () => {
+    it('should return a InvalidDomainError if email domain is not allowlisted', async () => {
       // Act
       const result = await PaymentsService.sendOnboardingEmailIfEligible(
         'hello@world.com',

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -89,10 +89,10 @@ export const handleSendOnboardingEmail: ControllerHandler<
     .mapErr((error) => {
       if (error instanceof InvalidDomainError) {
         logger.info({
-          message: 'Email domain is not whitelisted for onboarding email',
+          message: 'Email domain is not allowlisted for onboarding email',
           meta: logMeta,
         })
-        // If email domain is not whitelisted, return 403
+        // If email domain is not allowlisted, return 403
         return res.sendStatus(StatusCodes.FORBIDDEN)
       } else if (error instanceof MailSendError) {
         // Mail send error

--- a/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
+++ b/src/app/routes/api/v3/auth/__tests__/auth.routes.spec.ts
@@ -74,7 +74,7 @@ describe('auth.routes', () => {
       // Assert
       expect(response.status).toEqual(401)
       expect(response.body).toEqual(
-        'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
+        'This is not an allowlisted public service email domain. Please log in with your official government or government-linked email address.',
       )
     })
 
@@ -187,7 +187,7 @@ describe('auth.routes', () => {
       expect(response.status).toEqual(401)
       expect(response.body).toEqual({
         message:
-          'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
+          'This is not an allowlisted public service email domain. Please log in with your official government or government-linked email address.',
       })
     })
 
@@ -398,7 +398,7 @@ describe('auth.routes', () => {
       // Assert
       expect(response.status).toEqual(401)
       expect(response.body).toEqual(
-        'This is not a whitelisted public service email domain. Please log in with your official government or government-linked email address.',
+        'This is not an allowlisted public service email domain. Please log in with your official government or government-linked email address.',
       )
     })
 

--- a/src/app/routes/api/v3/payments/payments.routes.ts
+++ b/src/app/routes/api/v3/payments/payments.routes.ts
@@ -111,7 +111,7 @@ PaymentsRouter.use('/reconcile', ProtectedPaymentsRouter)
  * @route POST /payments/onboarding
  *
  * @returns 200 if onboarding email sent
- * @returns 403 if email domain is not whitelisted
+ * @returns 403 if email domain is not allowlisted
  * @returns 400 if email sending fails
  * @returns 500 when database error occurs
  */


### PR DESCRIPTION
## Problem
The use of the terms "whitelist" and "blacklist" can be considered harmful, so "allowlist" and "blocklist" should be used as much as possible.

## Solution
Updated UI, code and docs to say "allowlist" instead of "whitelist"

**Breaking Changes** 
- [x] No - this PR is backwards compatible  