### PR TITLE
fix: prevent saving empty product items

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/FormFieldDrawerActions.tsx
@@ -20,7 +20,6 @@ export const FormFieldDrawerActions = ({
   isDisabled,
 }: FormFieldDrawerActionsProps): JSX.Element => {
   const isMobile = useIsMobile()
-  const isSavingDisabled = isDisabled || isLoading
 
   return (
     <Stack
@@ -31,7 +30,7 @@ export const FormFieldDrawerActions = ({
     >
       <Button
         isFullWidth={isMobile}
-        isDisabled={isSavingDisabled}
+        isDisabled={isDisabled}
         isLoading={isLoading}
         onClick={handleClick}
       >

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -324,7 +324,8 @@ const PaymentInputFields = ({
 
   const isProducts = paymentsData?.payment_type === PaymentType.Products
   const isFixed = paymentsData?.payment_type === PaymentType.Fixed
-
+  const isSavingDisabled =
+    isDisabled || (isProducts && paymentsData.products.length <= 0)
   return (
     <PaymentContainer>
       <PaymentTypeSelector
@@ -362,7 +363,7 @@ const PaymentInputFields = ({
           handleClick={handleUpdatePayments}
           handleCancel={handleClose}
           buttonText="Save field"
-          isDisabled={isDisabled}
+          isDisabled={isSavingDisabled}
         />
       </PaymentInnerContainer>
     </PaymentContainer>

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -442,7 +442,7 @@ const updatePaymentsValidator = celebrate({
       is: Joi.equal(true),
       then: Joi.when('payment_type', {
         is: Joi.equal(PaymentType.Products),
-        then: Joi.array().items(JoiPaymentProduct).required(),
+        then: Joi.array().items(JoiPaymentProduct).required().min(1),
         otherwise: Joi.any(),
       }),
       otherwise: Joi.any(),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Admins are able to save when there are no products. This results in open forms with payments that has no items to select.

Closes FRM-1256

## Solution
<!-- How did you solve the problem? -->

- Saving of product items with 0 items will be blocked.
- Deleting of the final item will be disabled.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->
Regression
- [ ] On admin view, deleting product items removes the deleted product
- [ ] On admin view, deleting payment component removes the payment component 
  - [ ] On responder view, the form should not have payment component

Feature Test
- [ ] On admin view, `SaveButton` is not interactive if there are no `ProductItems`
- [ ] On admin view, the final `ProductItem` cannot be deleted