### PR TITLE
feat: dashboard infobox message for e2ee

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -35,6 +35,8 @@ export const GUIDE_STRIPE_ONBOARDING = 'https://go.gov.sg/formsg-payments'
 export const GUIDE_PAYMENTS_ENTRY = 'https://go.gov.sg/formsg-payment-overview'
 export const GUIDE_PAYMENTS_INVOICE_DIFFERENCES =
   'https://go.gov.sg/formsg-payments-invoice-differences'
+export const GUIDE_ENCRYPTION_BOUNDARY_SHIFT =
+  'https://guide.form.gov.sg/faq/faq/storage-mode-virus-scanning-and-content-validation'
 export const ACCEPTED_FILETYPES_SPREADSHEET = 'https://go.gov.sg/formsg-cwl'
 
 export const APP_FOOTER_LINKS = [

--- a/frontend/src/features/workspace/components/WorkspacePageContent.tsx
+++ b/frontend/src/features/workspace/components/WorkspacePageContent.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Box, Container, Grid } from '@chakra-ui/react'
 
-import { GUIDE_PAYMENTS_ENTRY } from '~constants/links'
+import { GUIDE_ENCRYPTION_BOUNDARY_SHIFT } from '~constants/links'
 import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import InlineMessage from '~components/InlineMessage'
@@ -40,7 +40,7 @@ export const WorkspacePageContent = ({
     [isUserLoading, hasSeenAnnouncement],
   )
 
-  const dashboardMessage = `Introducing payments! Respondents can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
+  const dashboardMessage = `FormSG encryption is changing to make it more secure. This won't affect data/security classifications, and no action is needed from you. [Learn more](${GUIDE_ENCRYPTION_BOUNDARY_SHIFT})`
 
   return totalFormsCount === 0 ? (
     <EmptyWorkspace

--- a/frontend/src/features/workspace/components/WorkspacePageContent.tsx
+++ b/frontend/src/features/workspace/components/WorkspacePageContent.tsx
@@ -40,6 +40,7 @@ export const WorkspacePageContent = ({
     [isUserLoading, hasSeenAnnouncement],
   )
 
+  // TODO: change dashboard message to env var
   const dashboardMessage = `FormSG encryption is changing to make it more secure. This won't affect data/security classifications, and no action is needed from you. [Learn more](${GUIDE_ENCRYPTION_BOUNDARY_SHIFT})`
 
   return totalFormsCount === 0 ? (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Messaging for encryption boundary shift was previously done through the banner. However, the banner is also used for incidents, so it was accidentally cleared after the twilio incident last week.

As such, this PR shifts the messaging to dashboard infobox.

Closes FRM-1214

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Features**:

- Encryption boundary shift messaging in dashboard infobox.

## Before & After Screenshots

**BEFORE**:

<img width="1512" alt="Screenshot 2023-08-22 at 4 51 01 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/3b5d988b-b50f-44d1-98b6-f9d34d7754c8">

**AFTER**:

<img width="1512" alt="Screenshot 2023-08-22 at 4 48 40 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/e3780608-a869-45cd-911e-24b7b738ef08">

## Tests

- [ ] Check that the dashboard infobox has been updated with the right copy.