### PR TITLE
fix: add specific payment descriptions logic for payment types

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
@@ -138,24 +138,25 @@ describe('encrypt-submission.utils', () => {
     })
 
     it('should return product names for Products Payment Type', () => {
-      const expectedValue = 'expectedValue'
+      const expectedItemName1 = 'expectedItemName1'
+      const expectedItemName2 = 'expectedItemName2'
       const formData = {
         payments_field: {
           payment_type: PaymentType.Products,
           description: 'description',
-          name: expectedValue,
+          name: 'name',
         },
       } as unknown as IPopulatedEncryptedForm
 
       const products: any = [
-        { data: { name: 'name1' }, quantity: 1 },
-        { data: { name: 'name2' }, quantity: 2 },
+        { data: { name: expectedItemName1 }, quantity: 1 },
+        { data: { name: expectedItemName2 }, quantity: 2 },
       ]
 
       const result = getPaymentIntentDescription(formData, products)
 
-      expect(result).toContain('name1')
-      expect(result).toContain('name2')
+      expect(result).toContain(expectedItemName1)
+      expect(result).toContain(expectedItemName2)
     })
 
     it('should return form title for Products Payment Type when there are no products', () => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -451,6 +451,22 @@ const _createPaymentSubmission = async ({
     paymentContactEmail: paymentReceiptEmail,
   }
 
+  const getPaymentIntentDescription = () => {
+    switch (form.payments_field.payment_type) {
+      case PaymentType.Fixed:
+        // legacy behaviour to keep fixed payments as it is
+        return form.payments_field.description
+      case PaymentType.Variable:
+        return form.payments_field.name
+      case PaymentType.Products: {
+        if (!paymentProducts) return form.title
+        const productDescriptions = paymentProducts
+          .map((product) => `${product.data.name} x ${product.quantity}`)
+          .join(', ')
+        return productDescriptions
+      }
+    }
+  }
   const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
     amount,
     currency: paymentConfig.defaultCurrency,
@@ -458,7 +474,7 @@ const _createPaymentSubmission = async ({
     automatic_payment_methods: {
       enabled: true,
     },
-    description: form.payments_field.description,
+    description: getPaymentIntentDescription(),
     receipt_email: paymentReceiptEmail,
     metadata,
   }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -73,6 +73,7 @@ import {
 import {
   createEncryptedSubmissionDto,
   getPaymentAmount,
+  getPaymentIntentDescription,
   mapRouteError,
 } from './encrypt-submission.utils'
 import IncomingEncryptSubmission from './IncomingEncryptSubmission.class'
@@ -451,22 +452,6 @@ const _createPaymentSubmission = async ({
     paymentContactEmail: paymentReceiptEmail,
   }
 
-  const getPaymentIntentDescription = () => {
-    switch (form.payments_field.payment_type) {
-      case PaymentType.Fixed:
-        // legacy behaviour to keep fixed payments as it is
-        return form.payments_field.description
-      case PaymentType.Variable:
-        return form.payments_field.name
-      case PaymentType.Products: {
-        if (!paymentProducts) return form.title
-        const productDescriptions = paymentProducts
-          .map((product) => `${product.data.name} x ${product.quantity}`)
-          .join(', ')
-        return productDescriptions
-      }
-    }
-  }
   const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
     amount,
     currency: paymentConfig.defaultCurrency,
@@ -474,7 +459,7 @@ const _createPaymentSubmission = async ({
     automatic_payment_methods: {
       enabled: true,
     },
-    description: getPaymentIntentDescription(),
+    description: getPaymentIntentDescription(form, paymentProducts),
     receipt_email: paymentReceiptEmail,
     metadata,
   }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -318,7 +318,8 @@ export const getPaymentIntentDescription = (
   paymentProducts?: StorageModeSubmissionContentDto['paymentProducts'],
 ) => {
   const formPaymentFields = form.payments_field
-  switch (formPaymentFields.payment_type) {
+  const { payment_type } = formPaymentFields
+  switch (payment_type) {
     case PaymentType.Fixed:
       // legacy behaviour of fixed payments where the product name is referred as description
       return formPaymentFields.description
@@ -330,6 +331,11 @@ export const getPaymentIntentDescription = (
         .map((product) => `${product.data.name} x ${product.quantity}`)
         .join(', ')
       return productDescriptions
+    }
+    default: {
+      // Force TS to emit an error if the cases above are not exhaustive
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const exhaustiveCheck: never = payment_type
     }
   }
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -13,6 +13,7 @@ import {
 import { calculatePrice } from '../../../../../shared/utils/paymentProductPrice'
 import {
   IEncryptedSubmissionSchema,
+  IPopulatedEncryptedForm,
   ISubmissionSchema,
   MapRouteErrors,
   SubmissionData,
@@ -299,6 +300,36 @@ export const getPaymentAmount = (
       // Force TS to emit an error if the cases above are not exhaustive
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const exhaustiveCheck: never = payment_type
+    }
+  }
+}
+
+/**
+ * Retrieves payment description by payment_type
+ *
+ * - `Fixed Payments` references the description to as legacy behaviour
+ * - `Variable Payments` references the name
+ * - `Products` references the product name and quantity separated by a comma
+ * @param form
+ * @param paymentProducts
+ */
+export const getPaymentIntentDescription = (
+  form: IPopulatedEncryptedForm,
+  paymentProducts?: StorageModeSubmissionContentDto['paymentProducts'],
+) => {
+  const formPaymentFields = form.payments_field
+  switch (formPaymentFields.payment_type) {
+    case PaymentType.Fixed:
+      // legacy behaviour to keep fixed payments as it is
+      return formPaymentFields.description
+    case PaymentType.Variable:
+      return formPaymentFields.name
+    case PaymentType.Products: {
+      if (!paymentProducts) return form.title
+      const productDescriptions = paymentProducts
+        .map((product) => `${product.data.name} x ${product.quantity}`)
+        .join(', ')
+      return productDescriptions
     }
   }
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -320,7 +320,7 @@ export const getPaymentIntentDescription = (
   const formPaymentFields = form.payments_field
   switch (formPaymentFields.payment_type) {
     case PaymentType.Fixed:
-      // legacy behaviour to keep fixed payments as it is
+      // legacy behaviour of fixed payments where the product name is referred as description
       return formPaymentFields.description
     case PaymentType.Variable:
       return formPaymentFields.name


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Descriptions sent to Stripe during `stripe.paymentIntents.create` are not properly retrieved after we've released payment by products and variable payments.

Closes FRM-1286

## Solution
<!-- How did you solve the problem? -->

Identified that there are three different categories of payments to retrieve the description field from.
```
Fixed -> payments_field.description // due to legacy reasons, fixed payments uses descriptions instead of name
Variable -> payments_field.name
Products -> selected products
```


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

Due to the sensitivity of the data in the screenshots, please see [comment](https://linear.app/ogp/issue/FRM-1286#comment-d15b41d2) in ticket.

## Tests
<!-- What tests should be run to confirm functionality? -->
Hint: use this url to get the payment item on stripe dashboard quickly `https://dashboard.stripe.com/test/connect/accounts/<acct_id>/payments/<pi_id>`

**Variable Payment Form**
- [ ] Create a variable payment form, set the name as "tis but a variable", and description as "description"
  - [ ] Complete making a payment
  - [ ] Ensure that payment summary displays "tis but a variable"
  - [ ] Ensure that `description` on Stripe Payment item is "tis but a variable"

**Products Payment Form**
- [ ] Create a Products payment form, create two products
  - [ ] Set first item as "item1",  "description1" for name and description, and multiple quantity as "OFF"
  - [ ] Set second item as "item2", "description2"  for name and description, and multiple quantity of 1 to 99
  - [ ] Set payment settings as multiple products
  - [ ] Complete making a payment with two selected items, and 2nd item to be quantity 10
  - [ ] Ensure that payment summary displays "item1 x 1, item2 x 10"
  - [ ] Ensure that `description` on Stripe Payment item is "item1 x 1, item2 x 10"
