### PR TITLE
feat: enable myinfo child vax field

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -142,9 +142,6 @@ export const CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS: {
   label: string
 }[] = Object.values(MyInfoChildAttributes)
   .filter((e) => e !== MyInfoChildAttributes.ChildName)
-  // TODO awaiting approval from MyInfo to get child vaccination status.
-  // Disabling in the frontend for now.
-  .filter((e) => e !== MyInfoChildAttributes.ChildVaxxStatus)
   .map((value) => {
     return {
       value,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Serving Child Vaccination Requirements has been approved by MyInfo since https://github.com/opengovsg/FormSG/pull/6523, so we should be enabling it.

Thanks @kenjin-work for all the prior work to make this so easy! :)

Closes FRM-1195

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Removed filter for vaccination requirements.

## Before & After Screenshots

**BEFORE**:

Vaccination Requirements not available as one of the options:

<img width="1512" alt="Screenshot 2023-08-23 at 2 23 40 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/87a535fd-2ffd-4193-bcbd-026b6451e183">

**AFTER**:

Vaccination Requirements available as one of the options and can be added:

<img width="1512" alt="Screenshot 2023-08-23 at 2 22 06 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/98e546be-7cf6-4164-9d2c-f95eecd342ab">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Add the `children` beta flag to your admin user.
- [ ] On an email mode form, add a children field and check that "Vaccination Requirements" is one of the options and can be added to the field.
