### PR TITLE
fix: failed ensures should block submission

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -121,7 +121,8 @@ const submitEncryptModeForm = async (
         new SubmissionFailedError(),
       )
       return res.status(statusCode).json({ message: errorMessage })
-    } else return // required to stop submission processing
+    }
+    return // required to stop submission processing
   }
 
   const encryptedPayload = req.formsg.encryptedPayload

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -115,11 +115,13 @@ const submitEncryptModeForm = async (
     res,
   })
 
-  if (!hasEnsuredAll && !res.headersSent) {
-    const { errorMessage, statusCode } = mapRouteError(
-      new SubmissionFailedError(),
-    )
-    return res.status(statusCode).json({ message: errorMessage })
+  if (!hasEnsuredAll) {
+    if (!res.headersSent) {
+      const { errorMessage, statusCode } = mapRouteError(
+        new SubmissionFailedError(),
+      )
+      return res.status(statusCode).json({ message: errorMessage })
+    } else return // required to stop submission processing
   }
 
   const encryptedPayload = req.formsg.encryptedPayload


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Bug was introduced by #6595 where failing ensures do not return early if a response has already been sent.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Failing ensures should return early.

## Tests
<!-- What tests should be run to confirm functionality? -->

Check that storage mode submissions will be gated by ensures.
   - [ ] ensureIsPublicForm:
      - [ ] Go to a public form.
      - [ ] Close the form on the admin portal.
      - [ ] Make a submission. Submission should not succeed.
         - [ ] Error should be shown to client.
         - [ ] New submission should **_not_** show up on DB
   - [ ] ensureValidCaptcha:
      - [ ] Go to a public form with captcha disabled.
      - [ ] Enable captcha on the admin portal.
      - [ ] Make a submission. Submission should not succeed.
         - [ ] Error should be shown to client.
         - [ ] New submission should **_not_** show up on DB
   - [ ] ensureFormWithinSubmissionLimits:
      - [ ] Go to a public form with a submission limit. The form should still be open at this point.
      - [ ] On the DB, edit the submission limit so that it is less than or equal to the number of existing submissions.
      - [ ] Make a submission. Submission should not succeed.
         - [ ] Error should be shown to client.
         - [ ] New submission should **_not_** show up on DB
