### PR TITLE
fix: allow submission when Myinfo child field is hidden by logic

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -50,7 +50,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Chinese fonts
-RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
+RUN echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add wqy-zenhei@edge
 
 # Avoid using globs as there seems to be some inconsistency in the way dockerfile handles globs
 # * https://github.com/moby/moby/issues/15858 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -95,7 +95,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add font-wqy-zenhei@edge
+RUN echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add font-wqy-zenhei@edge
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 
 # Run as non-privileged user

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -189,8 +189,6 @@ const transformToChildOutput = (
   schema: ChildrenCompoundFieldSchema,
   input?: ChildrenCompoundFieldValues,
 ): ChildBirthRecordsResponse => {
-  console.log('transformToChildOutput: ', input)
-  console.log('transformToChildOutput schema: ', schema)
   const noOfChildrenSubFields = schema.childrenSubFields?.length ?? 1
   let answerArray: string[][]
   if (input !== undefined && input.child) {
@@ -198,7 +196,6 @@ const transformToChildOutput = (
   } else {
     answerArray = [Array(noOfChildrenSubFields).fill('')]
   }
-  console.log('transformToChildOutput answerArray: ', answerArray)
   return {
     ...pickBaseOutputFromSchema(schema),
     answerArray,

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -191,7 +191,7 @@ const transformToChildOutput = (
 ): ChildBirthRecordsResponse => {
   const noOfChildrenSubFields = schema.childrenSubFields?.length ?? 1
   let answerArray: string[][]
-  if (input !== undefined && input.child) {
+  if (input?.child) {
     answerArray = input.child
   } else {
     answerArray = [Array(noOfChildrenSubFields).fill('')]

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -187,11 +187,21 @@ const transformToSectionOutput = (
 
 const transformToChildOutput = (
   schema: ChildrenCompoundFieldSchema,
-  input: ChildrenCompoundFieldValues,
+  input?: ChildrenCompoundFieldValues,
 ): ChildBirthRecordsResponse => {
+  console.log('transformToChildOutput: ', input)
+  console.log('transformToChildOutput schema: ', schema)
+  const noOfChildrenSubFields = schema.childrenSubFields?.length ?? 1
+  let answerArray: string[][]
+  if (input !== undefined && input.child) {
+    answerArray = input.child
+  } else {
+    answerArray = [Array(noOfChildrenSubFields).fill('')]
+  }
+  console.log('transformToChildOutput answerArray: ', answerArray)
   return {
     ...pickBaseOutputFromSchema(schema),
-    answerArray: input.child,
+    answerArray,
   }
 }
 

--- a/src/app/utils/field-validation/validators/childrenValidator.ts
+++ b/src/app/utils/field-validation/validators/childrenValidator.ts
@@ -24,7 +24,9 @@ const childrenAnswerValidator: ChildrenValidator = (response) => {
   const { answerArray } = response
 
   return answerArray.length === 0
-    ? left(`ChildrenValidator:\t Answer is empty array`)
+    ? left(
+        `ChildrenValidator (childrenAnswerValidator):\t Answer is empty array`,
+      )
     : right(response)
 }
 
@@ -32,13 +34,13 @@ const childrenAnswerValidator: ChildrenValidator = (response) => {
  * Returns a validation function to check if the
  * that the first answer subarray has length > 0.
  */
-const validChildAnswerFirstArray: ChildrenValidator = (response) => {
-  const { answerArray } = response
-  const first = answerArray[0]
-  return Array.isArray(first) && first.length > 0
-    ? right(response)
-    : left(`ChildrenValidator:\t first subarray length is invalid`)
-}
+// const validChildAnswerFirstArray: ChildrenValidator = (response) => {
+//   const { answerArray } = response
+//   const first = answerArray[0]
+//   return Array.isArray(first) && first.length > 0
+//     ? right(response)
+//     : left(`ChildrenValidator:\t first subarray length is invalid`)
+// }
 
 /**
  * Returns a validation function to check if the
@@ -47,23 +49,27 @@ const validChildAnswerFirstArray: ChildrenValidator = (response) => {
 const validChildAnswerConsistency: ChildrenValidator = (response) => {
   const { answerArray } = response
   const len = answerArray[0].length
+
   return answerArray.every((subArr) => subArr.length === len)
     ? right(response)
-    : left(`ChildrenValidator:\t inconsistent answer array subarrays`)
+    : left(
+        `ChildrenValidator (validChildAnswerConsistency):\t inconsistent answer array subarrays`,
+      )
 }
 
 /**
  * Returns a validation function to check if
- * all the answers are non-empty.
+ * all the answers are non-empty if first answer subarray has length > 0
  */
-const validChildAnswersNonEmpty: ChildrenValidator = (response) => {
-  const { answerArray } = response
-  return answerArray.every((subArr) =>
-    subArr.every((val) => typeof val === 'string' && !!val.trim()),
-  )
-    ? right(response)
-    : left(`ChildrenValidator:\t inconsistent answer array subarrays`)
-}
+// const validChildAnswersNonEmpty: ChildrenValidator = (response) => {
+//   const { answerArray } = response
+//   const first = answerArray[0]
+//   return answerArray.every((subArr) =>
+//     subArr.every((val) => typeof val === 'string' && !!val.trim()),
+//   )
+//     ? right(response)
+//     : left(`ChildrenValidator:\t inconsistent answer array subarrays`)
+// }
 
 /**
  * Returns a validation function to check if the
@@ -75,7 +81,7 @@ const validChildAnswerAndSubFields: ChildrenValidator = (response) => {
   return childSubFieldsArray?.length === answerArray[0].length
     ? right(response)
     : left(
-        `ChildrenValidator:\t inconsistent child subfield and answer array length`,
+        `ChildrenValidator (validChildAnswerAndSubFields):\t inconsistent child subfield and answer array length`,
       )
 }
 
@@ -90,7 +96,9 @@ const validChildSubFieldsValidator: ChildrenValidatorConstructor =
     const attrs = new Set(Object.values(MyInfoChildAttributes))
     return childrenSubFields.every((subfield) => attrs.has(subfield))
       ? right(response)
-      : left(`ChildrenValidator:\t one or more subfields are invalid`)
+      : left(
+          `ChildrenValidator (validChildSubFieldsValidator):\t one or more subfields are invalid`,
+        )
   }
 
 /**
@@ -103,7 +111,9 @@ const validChildSubFieldsResponseValidator: ChildrenValidator = (response) => {
   const attrs = new Set(Object.values(MyInfoChildAttributes))
   return childSubFieldsArray?.every((subfield) => attrs.has(subfield))
     ? right(response)
-    : left(`ChildrenValidator:\t one or more subfields responses are invalid`)
+    : left(
+        `ChildrenValidator (validChildSubFieldsResponseValidator):\t one or more subfields responses are invalid`,
+      )
 }
 
 /**
@@ -120,7 +130,7 @@ const validChildSubFieldsAndResponseSubFieldsMatch: ChildrenValidatorConstructor
     )
       ? right(response)
       : left(
-          `ChildrenValidator:\t one or more subfields responses do not match the field's`,
+          `ChildrenValidator (validChildSubFieldsAndResponseSubFieldsMatch):\t one or more subfields responses do not match the field's`,
         )
   }
 
@@ -132,9 +142,9 @@ export const constructChildrenValidator: ChildrenValidatorConstructor = (
 ) =>
   flow(
     childrenAnswerValidator,
-    chain(validChildAnswerFirstArray),
+    // chain(validChildAnswerFirstArray),
     chain(validChildAnswerConsistency),
-    chain(validChildAnswersNonEmpty),
+    // chain(validChildAnswersNonEmpty),
     chain(validChildAnswerAndSubFields),
     chain(validChildSubFieldsValidator(childrenField)),
     chain(validChildSubFieldsAndResponseSubFieldsMatch(childrenField)),

--- a/src/app/utils/field-validation/validators/childrenValidator.ts
+++ b/src/app/utils/field-validation/validators/childrenValidator.ts
@@ -65,12 +65,18 @@ const validChildAnswerConsistency: ChildrenValidator = (response) => {
  */
 const validChildAnswersNonEmpty: ChildrenValidator = (response) => {
   const { childSubFieldsArray, answerArray } = response
+  const first = answerArray[0]
+
+  // Account for the case where no child is selected
   const noOfChildrenSubFields = childSubFieldsArray?.length ?? 1
   const noChildSelectedAnswerArray = Array(noOfChildrenSubFields).fill('')
-  const first = answerArray[0]
+  // Similar to transformToChildOutput in inputTransformation, this is a string of empty strings (which represents number of children subfields).
+  const noChildSelectedAnswer = noChildSelectedAnswerArray[0]
+
   return Array.isArray(first) &&
     first.length > 0 &&
-    first[0] !== noChildSelectedAnswerArray[0]
+    // Check that at least 1 child is selected
+    first[0] !== noChildSelectedAnswer
     ? answerArray.every((subArr) =>
         subArr.every((val) => typeof val === 'string' && !!val.trim()),
       )

--- a/src/app/utils/field-validation/validators/childrenValidator.ts
+++ b/src/app/utils/field-validation/validators/childrenValidator.ts
@@ -34,13 +34,15 @@ const childrenAnswerValidator: ChildrenValidator = (response) => {
  * Returns a validation function to check if the
  * that the first answer subarray has length > 0.
  */
-// const validChildAnswerFirstArray: ChildrenValidator = (response) => {
-//   const { answerArray } = response
-//   const first = answerArray[0]
-//   return Array.isArray(first) && first.length > 0
-//     ? right(response)
-//     : left(`ChildrenValidator:\t first subarray length is invalid`)
-// }
+const validChildAnswerFirstArray: ChildrenValidator = (response) => {
+  const { answerArray } = response
+  const first = answerArray[0]
+  return Array.isArray(first) && first.length > 0
+    ? right(response)
+    : left(
+        `ChildrenValidator (validChildAnswerFirstArray):\t first subarray length is invalid`,
+      )
+}
 
 /**
  * Returns a validation function to check if the
@@ -59,17 +61,25 @@ const validChildAnswerConsistency: ChildrenValidator = (response) => {
 
 /**
  * Returns a validation function to check if
- * all the answers are non-empty if first answer subarray has length > 0
+ * all the answers are non-empty if first answer subarray has length > 0 and a child is selected
  */
-// const validChildAnswersNonEmpty: ChildrenValidator = (response) => {
-//   const { answerArray } = response
-//   const first = answerArray[0]
-//   return answerArray.every((subArr) =>
-//     subArr.every((val) => typeof val === 'string' && !!val.trim()),
-//   )
-//     ? right(response)
-//     : left(`ChildrenValidator:\t inconsistent answer array subarrays`)
-// }
+const validChildAnswersNonEmpty: ChildrenValidator = (response) => {
+  const { childSubFieldsArray, answerArray } = response
+  const noOfChildrenSubFields = childSubFieldsArray?.length ?? 1
+  const noChildSelectedAnswerArray = Array(noOfChildrenSubFields).fill('')
+  const first = answerArray[0]
+  return Array.isArray(first) &&
+    first.length > 0 &&
+    first[0] !== noChildSelectedAnswerArray[0]
+    ? answerArray.every((subArr) =>
+        subArr.every((val) => typeof val === 'string' && !!val.trim()),
+      )
+      ? right(response)
+      : left(
+          `ChildrenValidator (validChildAnswersNonEmpty):\t inconsistent answer array subarrays`,
+        )
+    : right(response)
+}
 
 /**
  * Returns a validation function to check if the
@@ -142,9 +152,9 @@ export const constructChildrenValidator: ChildrenValidatorConstructor = (
 ) =>
   flow(
     childrenAnswerValidator,
-    // chain(validChildAnswerFirstArray),
+    chain(validChildAnswerFirstArray),
     chain(validChildAnswerConsistency),
-    // chain(validChildAnswersNonEmpty),
+    chain(validChildAnswersNonEmpty),
     chain(validChildAnswerAndSubFields),
     chain(validChildSubFieldsValidator(childrenField)),
     chain(validChildSubFieldsAndResponseSubFieldsMatch(childrenField)),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When a Myinfo child field is hidden due to logic, the user is unable to submit the form. Instead, the user sees a `cannot read properties of undefined` error.

Closes FRM-1299

## Solution
<!-- How did you solve the problem? -->
The problem was because the user needed to populate the child field, even if the field was hidden by logic. To fix this, return an array of array of strings if `input` is undefined in `transformToChildOutput`, which transforms form inputs to their desire output shapes for sending to the server. This is similar to other field transformations, where an empty string is the default return output.

Also, add a check for a child in the `validChildAnswersNonEmpty` validator. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<img width="1604" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/70c111ed-0986-46a7-a530-ae8d4d02f9b2">




## Tests
<!-- What tests should be run to confirm functionality? -->
For staging, [these](https://www.notion.so/opengov/MyInfo-Children-Fields-on-Staging-54587512c140404c91a0dde54becb277) are the NRICs of profiles with children.
- [ ] Submit a form with a hidden Myinfo child field. The child's name should be the only Myinfo child field. The email submission should have a blank beside the Myinfo child field.
- [ ] Repeat the above, but with more child fields (BC number, DOB). The email submission should have a blank beside the Myinfo child fields.
- [ ] Submit a form where the Myinfo child field is unhidden. The child's name should be the only Myinfo child field. The email submission's Myinfo child field should be populated.
- [ ] Repeat the above, but with more child fields (BC number, DOB). The email submission's Myinfo child fields should be populated.
- [ ] Repeat the above, but do not select the child's name. Try to submit. A red border should appear around the Myinfo child field, and you should not be able to submit the form.

Regression test:
- [ ] Submit a Myinfo form without any Myinfo child fields
