### PR TITLE
fix: platform api v1 - return appropriate status code for MissingUserError

### DIFF
--- a/src/app/modules/auth/auth.utils.ts
+++ b/src/app/modules/auth/auth.utils.ts
@@ -8,6 +8,7 @@ import { createLoggerWithLabel } from '../../config/logger'
 import * as MailErrors from '../../services/mail/mail.errors'
 import { HashingError } from '../../utils/hash'
 import * as CoreErrors from '../core/core.errors'
+import * as UserErrors from '../user/user.errors'
 
 import * as AuthErrors from './auth.errors'
 
@@ -26,6 +27,7 @@ export const mapRouteError: MapRouteError = (error, coreErrorMessage) => {
         statusCode: StatusCodes.UNAUTHORIZED,
         errorMessage: error.message,
       }
+    case UserErrors.MissingUserError:
     case AuthErrors.InvalidOtpError:
       return {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When an external API request is made with a user email that doesn't exist in our database, we return a 500 error instead of a 422 error. This is because the `MissingUserError` is not captured in `mapRouteError` for auth.

## Solution
<!-- How did you solve the problem? -->
- Add `MissingUserError` to in `mapRouteError` in `auth.utils.ts`, it returns a `422` status code

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Before carrying out the tests below, add  `"isPlatform" : true` to your user's `apiToken` property in the DB.

`POST /api/public/v1/admin/forms/:formId/webhooksettings` to retrieve webhook settings
```
curl --request POST \
  --url https://staging.form.gov.sg/api/public/v1/admin/forms/:formId/settings \
  --header 'Authorization: Bearer test_v1_APITOKENHERE' \
  --header 'Content-Type: application/json' \
  --data '{"userEmail": "adminOfFormId"}'
```
- [ ] Use a user email that is not a FormSG user. You should get a 422 "User not found" message


`PATCH /api/public/v1/admin/forms/:formId/webhooksettings` to update webhook settings
```
curl --request PATCH \
  --url https://staging.form.gov.sg/api/public/v1/admin/forms/:formId/settings \
  --header 'Authorization: Bearer test_v1_APITOKENHERE' \
  --header 'Content-Type: application/json' \
  --data '{"userEmail": "adminOfFormId",
"webhook": {
		"url":"https://www.webhookUrl.com",
	"isRetryEnabled": true
}}'
```
- [ ] Use a user email that is not a FormSG user. You should get a 422 "User not found" message

