### PR TITLE
fix: payment quantity modal input inconsistencies

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentQuantityModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentQuantityModal.tsx
@@ -76,9 +76,9 @@ const PaymentQuantityModal = ({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={() => {
-        onClose()
-        resetField('quantity')
+      onClose={onClose}
+      onCloseComplete={() => {
+        resetField('quantity', { defaultValue: initialQty })
       }}
       size="selector"
       variant={isMobile ? 'bottom' : 'default'}

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentQuantityModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentQuantityModal.tsx
@@ -1,7 +1,6 @@
 import { Controller, useForm } from 'react-hook-form'
 import { BiMinus, BiPlus } from 'react-icons/bi'
 import {
-  Box,
   Button,
   FormControl,
   HStack,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
- input value not restoring to default on cancel press
- animation flickers when discarding input (either through backdrop, cancel button, close button)

## Solution
<!-- How did you solve the problem? -->
**Input value not restoring to default**
1. cancel press is not captured under `Modal::onClose()` which is where the reset is triggered

Fixed by resetting on modal post-animation, as it captures all onClose events, even if it's triggered manually.

**Animation flickers**
1. `onClose()` triggers the animation
3. subsequently a `resetField` was called, which updates the value **while** the close animation is still being played

Fixed by updating the fields on modal post-animation instead of together with `onClose()`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
