### PR TITLE
fix: payments params in new storage submission endpoint

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -119,6 +119,21 @@ export const validateEncryptSubmissionParams = celebrate({
 export const validateStorageSubmissionParams = celebrate({
   [Segments.BODY]: Joi.object({
     ...sharedSubmissionParams,
+    paymentProducts: Joi.array().items(
+      Joi.object().keys({
+        data: JoiPaymentProduct.required(),
+        selected: Joi.boolean(),
+        quantity: JoiInt.positive().required(),
+      }),
+    ),
+    paymentReceiptEmail: Joi.string(),
+    payments: Joi.object({
+      amount_cents: Joi.number()
+        .integer()
+        .positive()
+        .min(paymentConfig.minPaymentAmountCents)
+        .max(paymentConfig.maxPaymentAmountCents),
+    }),
     version: Joi.number().required(),
   }),
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -322,6 +322,9 @@ export const encryptSubmission = async (
     responses: filteredResponses.value as EncryptFormFieldResponse[],
     encryptedContent,
     version: req.body.version,
+    paymentProducts: req.body.paymentProducts,
+    paymentReceiptEmail: req.body.paymentReceiptEmail,
+    payments: req.body.payments,
   }
 
   return next()

--- a/src/app/modules/submission/submission.constants.ts
+++ b/src/app/modules/submission/submission.constants.ts
@@ -1,7 +1,6 @@
 import { Joi } from 'celebrate'
 
 import { BasicField } from '../../../../shared/types'
-import { paymentConfig } from '../../config/features/payment.config'
 
 export const sharedSubmissionParams = {
   responses: Joi.array()
@@ -25,14 +24,6 @@ export const sharedSubmissionParams = {
         .with('filename', 'content'), // if filename is present, content must be present
     )
     .required(),
-  paymentReceiptEmail: Joi.string(),
-  payments: Joi.object({
-    amount_cents: Joi.number()
-      .integer()
-      .positive()
-      .min(paymentConfig.minPaymentAmountCents)
-      .max(paymentConfig.maxPaymentAmountCents),
-  }),
   responseMetadata: Joi.object({
     responseTimeMs: Joi.number(),
     numVisibleFields: Joi.number(),

--- a/src/types/api/encrypt_submission.ts
+++ b/src/types/api/encrypt_submission.ts
@@ -3,6 +3,8 @@ import type { Merge } from 'type-fest'
 import {
   AttachmentResponse,
   FieldResponse,
+  PaymentFieldsDto,
+  ProductItem,
   StorageModeSubmissionContentDto,
 } from '../../../shared/types'
 import { IPopulatedEncryptedForm, IPopulatedForm } from '../form'
@@ -28,6 +30,9 @@ export type EncryptFormFieldResponse =
  * ReceiverMiddleware.receiveStorageSubmission middleware.
  */
 export type ParsedStorageModeSubmissionBody = ParsedEmailModeSubmissionBody & {
+  paymentProducts?: Array<ProductItem>
+  paymentReceiptEmail?: string
+  payments?: PaymentFieldsDto
   version: number
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There were 2 bugs with the implementation of the new storage endpoint:

1. Joi validation was not set up properly to optionally accept payment params (`paymentProducts`, `paymentReceiptEmail` and `payments`)
2. These same params were not passed on in the `encryptSubmission` middleware.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Joi validation for payments params should only be for storage submissions, and should include `paymentProducts`.
- `encryptSubmission` middleware should pass payment params on from `req.body` to `formsg.encryptedPayload`.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Submit a payment form with payment by products.
- [ ] Submit a payment form with variable payments.
