### PR TITLE
feat: add logging to check for missing Myinfo field values

### DIFF
--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -10,6 +10,16 @@ import DIALECTS from './myinfo-dialects'
 import NATIONALITIES from './myinfo-nationalities'
 import OCCUPATIONS from './myinfo-occupations'
 import RACES from './myinfo-races'
+import HOUSING_TYPES from './myinfo-housing-types'
+import HDB_TYPES from './myinfo-hdb-types'
+
+export * from './myinfo-countries'
+export * from './myinfo-dialects'
+export * from './myinfo-nationalities'
+export * from './myinfo-occupations'
+export * from './myinfo-races'
+export * from './myinfo-hdb-types'
+export * from './myinfo-housing-types'
 
 export type MyInfoVerifiedType = 'SG' | 'PR' | 'F'
 
@@ -131,14 +141,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The type of housing that the form-filler lives in. This information is verified by HDB for public housing, and by URA for private housing.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: [
-      'APARTMENT',
-      'CONDOMINIUM',
-      'DETACHED HOUSE',
-      'EXECUTIVE CONDOMINIUM',
-      'SEMI-DETACHED HOUSE',
-      'TERRACE HOUSE',
-    ],
+    fieldOptions: HOUSING_TYPES,
     previewValue: 'DETACHED HOUSE',
   },
   {
@@ -149,15 +152,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Housing Development Board',
     description: 'The type of HDB flat that the form-filler lives in.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: [
-      '1-ROOM FLAT (HDB)',
-      '2-ROOM FLAT (HDB)',
-      '3-ROOM FLAT (HDB)',
-      '4-ROOM FLAT (HDB)',
-      '5-ROOM FLAT (HDB)',
-      'EXECUTIVE FLAT (HDB)',
-      'STUDIO APARTMENT (HDB)',
-    ],
+    fieldOptions: HDB_TYPES,
     previewValue: 'EXECUTIVE FLAT (HDB)',
   },
   {

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -5,13 +5,13 @@ import {
   MyInfoChildVaxxStatus,
   MyInfoField,
 } from '../../../types/field'
-import COUNTRIES from './myinfo-countries'
-import DIALECTS from './myinfo-dialects'
-import NATIONALITIES from './myinfo-nationalities'
-import OCCUPATIONS from './myinfo-occupations'
-import RACES from './myinfo-races'
-import HOUSING_TYPES from './myinfo-housing-types'
-import HDB_TYPES from './myinfo-hdb-types'
+import { myInfoCountries } from './myinfo-countries'
+import { myInfoDialects } from './myinfo-dialects'
+import { myInfoNationalities } from './myinfo-nationalities'
+import { myInfoOccupations } from './myinfo-occupations'
+import { myInfoRaces } from './myinfo-races'
+import { myInfoHousingTypes } from './myinfo-housing-types'
+import { myInfoHdbTypes } from './myinfo-hdb-types'
 
 export * from './myinfo-countries'
 export * from './myinfo-dialects'
@@ -83,7 +83,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The race of the form-filler. This field is verified by ICA for Singaporean/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: RACES,
+    fieldOptions: myInfoRaces,
     previewValue: 'CHINESE',
   },
   {
@@ -95,7 +95,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The nationality of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: NATIONALITIES,
+    fieldOptions: myInfoNationalities,
     previewValue: 'SINGAPORE CITIZEN',
   },
   {
@@ -107,7 +107,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The birth country of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: COUNTRIES,
+    fieldOptions: myInfoCountries,
     previewValue: 'SINGAPORE',
   },
   {
@@ -129,7 +129,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Immigration and Checkpoints Authority',
     description: 'The dialect group of the form-filler.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: DIALECTS,
+    fieldOptions: myInfoDialects,
     previewValue: 'HOKKIEN',
   },
   {
@@ -141,7 +141,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The type of housing that the form-filler lives in. This information is verified by HDB for public housing, and by URA for private housing.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: HOUSING_TYPES,
+    fieldOptions: myInfoHousingTypes,
     previewValue: 'DETACHED HOUSE',
   },
   {
@@ -152,7 +152,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Housing Development Board',
     description: 'The type of HDB flat that the form-filler lives in.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: HDB_TYPES,
+    fieldOptions: myInfoHdbTypes,
     previewValue: 'EXECUTIVE FLAT (HDB)',
   },
   {
@@ -196,7 +196,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The country of marriage of the form-filler. This field is treated as unverified, as data provided by MSF may be outdated in cases of marriages in a foreign country.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: COUNTRIES,
+    fieldOptions: myInfoCountries,
     previewValue: 'SINGAPORE',
   },
   {
@@ -218,7 +218,7 @@ export const types: MyInfoFieldBlock[] = [
     description:
       'The occupation of the form-filler. Verified for foreigners with Singpass only.',
     fieldType: BasicField.Dropdown,
-    fieldOptions: OCCUPATIONS,
+    fieldOptions: myInfoOccupations,
     previewValue: 'MANAGING DIRECTOR/CHIEF EXECUTIVE OFFICER',
   },
   {
@@ -367,7 +367,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Immigration & Checkpoints Authority',
     description: 'Race',
     fieldType: BasicField.Dropdown,
-    fieldOptions: RACES,
+    fieldOptions: myInfoRaces,
     previewValue: 'CHINESE',
   },
   {
@@ -378,7 +378,7 @@ export const types: MyInfoFieldBlock[] = [
     source: 'Immigration & Checkpoints Authority',
     description: 'Secondary race',
     fieldType: BasicField.Dropdown,
-    fieldOptions: RACES,
+    fieldOptions: myInfoRaces,
     previewValue: 'CHINESE',
   },
 ]

--- a/shared/constants/field/myinfo/myinfo-countries.ts
+++ b/shared/constants/field/myinfo/myinfo-countries.ts
@@ -254,5 +254,3 @@ export const myInfoCountries = [
   'ZAMBIA',
   'ZIMBABWE',
 ]
-
-export default myInfoCountries

--- a/shared/constants/field/myinfo/myinfo-countries.ts
+++ b/shared/constants/field/myinfo/myinfo-countries.ts
@@ -1,4 +1,4 @@
-const myInfoCountries = [
+export const myInfoCountries = [
   'AFGHANISTAN',
   'ALBANIA',
   'ALGERIA',

--- a/shared/constants/field/myinfo/myinfo-dialects.ts
+++ b/shared/constants/field/myinfo/myinfo-dialects.ts
@@ -146,5 +146,3 @@ export const myInfoDialects = [
   'WENCHOW',
   'YIDDISH',
 ]
-
-export default myInfoDialects

--- a/shared/constants/field/myinfo/myinfo-dialects.ts
+++ b/shared/constants/field/myinfo/myinfo-dialects.ts
@@ -1,4 +1,4 @@
-const myInfoDialects = [
+export const myInfoDialects = [
   'AKAN',
   'ALBANIAN',
   'AMHARIC',

--- a/shared/constants/field/myinfo/myinfo-hdb-types.ts
+++ b/shared/constants/field/myinfo/myinfo-hdb-types.ts
@@ -7,5 +7,3 @@ export const myInfoHdbTypes = [
   'EXECUTIVE FLAT (HDB)',
   'STUDIO APARTMENT (HDB)',
 ]
-
-export default myInfoHdbTypes

--- a/shared/constants/field/myinfo/myinfo-hdb-types.ts
+++ b/shared/constants/field/myinfo/myinfo-hdb-types.ts
@@ -1,0 +1,11 @@
+export const myInfoHdbTypes = [
+  '1-ROOM FLAT (HDB)',
+  '2-ROOM FLAT (HDB)',
+  '3-ROOM FLAT (HDB)',
+  '4-ROOM FLAT (HDB)',
+  '5-ROOM FLAT (HDB)',
+  'EXECUTIVE FLAT (HDB)',
+  'STUDIO APARTMENT (HDB)',
+]
+
+export default myInfoHdbTypes

--- a/shared/constants/field/myinfo/myinfo-housing-types.ts
+++ b/shared/constants/field/myinfo/myinfo-housing-types.ts
@@ -6,5 +6,3 @@ export const myInfoHousingTypes = [
   'SEMI-DETACHED HOUSE',
   'TERRACE HOUSE',
 ]
-
-export default myInfoHousingTypes

--- a/shared/constants/field/myinfo/myinfo-housing-types.ts
+++ b/shared/constants/field/myinfo/myinfo-housing-types.ts
@@ -1,0 +1,10 @@
+export const myInfoHousingTypes = [
+  'APARTMENT',
+  'CONDOMINIUM',
+  'DETACHED HOUSE',
+  'EXECUTIVE CONDOMINIUM',
+  'SEMI-DETACHED HOUSE',
+  'TERRACE HOUSE',
+]
+
+export default myInfoHousingTypes

--- a/shared/constants/field/myinfo/myinfo-nationalities.ts
+++ b/shared/constants/field/myinfo/myinfo-nationalities.ts
@@ -206,5 +206,3 @@ export const myInfoNationalities = [
   'ZAMBIAN',
   'ZIMBABWEAN',
 ]
-
-export default myInfoNationalities

--- a/shared/constants/field/myinfo/myinfo-nationalities.ts
+++ b/shared/constants/field/myinfo/myinfo-nationalities.ts
@@ -1,4 +1,4 @@
-const myInfoNationalities = [
+export const myInfoNationalities = [
   'AFGHAN',
   'ALBANIAN',
   'ALGERIAN',

--- a/shared/constants/field/myinfo/myinfo-occupations.ts
+++ b/shared/constants/field/myinfo/myinfo-occupations.ts
@@ -8336,5 +8336,3 @@ export const myInfoOccupations = [
   'YOUTH RESIDENTIAL ASSISTANT',
   'YOUTH WORKER',
 ]
-
-export default myInfoOccupations

--- a/shared/constants/field/myinfo/myinfo-races.ts
+++ b/shared/constants/field/myinfo/myinfo-races.ts
@@ -53,7 +53,7 @@ export const myInfoRaces = [
   'CEYLON MOOR',
   'CEYLONESE',
   'CHAMORRO',
-  // 'CHINESE',
+  'CHINESE',
   'COCOS',
   'CORNISH',
   'CREOLE',

--- a/shared/constants/field/myinfo/myinfo-races.ts
+++ b/shared/constants/field/myinfo/myinfo-races.ts
@@ -53,7 +53,7 @@ export const myInfoRaces = [
   'CEYLON MOOR',
   'CEYLONESE',
   'CHAMORRO',
-  'CHINESE',
+  // 'CHINESE',
   'COCOS',
   'CORNISH',
   'CREOLE',
@@ -226,5 +226,3 @@ export const myInfoRaces = [
   'YUGOSLAV',
   'ZIMBABWEAN',
 ]
-
-export default myInfoRaces

--- a/shared/constants/field/myinfo/myinfo-races.ts
+++ b/shared/constants/field/myinfo/myinfo-races.ts
@@ -1,4 +1,4 @@
-const myInfoRaces = [
+export const myInfoRaces = [
   'ACHEHNESE',
   'AFGHAN',
   'AFRICAN',

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -255,7 +255,6 @@ export class MyInfoServiceClass {
     currFormFields: LeanDocument<IFieldSchema[]>,
   ): ResultAsync<PossiblyPrefilledField[], MyInfoHashingError | DatabaseError> {
     const allChildAttrs: InternalAttr[] = []
-
     const prefilledFields = currFormFields.map((field) => {
       const myInfoAttr = getMyInfoAttr(field)
       // Children field prefilling is handled by the frontend.

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -62,10 +62,10 @@ import {
   getMyInfoAttr,
   getMyInfoAttributeConstantsList,
   hashFieldValues,
-  isFieldValueInMyinfoList,
   isMyInfoChildrenBirthRecords,
   isMyInfoLoginCookie,
   isMyInfoRelayState,
+  logIfFieldValueNotInMyinfoList,
   validateMyInfoForm,
 } from './myinfo.util'
 import getMyInfoHashModel from './myinfo_hash.model'
@@ -277,7 +277,11 @@ export class MyInfoServiceClass {
       if (fieldValue) {
         const myInfoConstantsList = getMyInfoAttributeConstantsList(myInfoAttr)
         if (myInfoConstantsList) {
-          isFieldValueInMyinfoList(fieldValue, myInfoAttr, myInfoConstantsList)
+          logIfFieldValueNotInMyinfoList(
+            fieldValue,
+            myInfoAttr,
+            myInfoConstantsList,
+          )
         }
       }
 

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -281,6 +281,7 @@ export class MyInfoServiceClass {
         myInfoAttr as InternalAttr,
       )
 
+      // Add logging to check if Myinfo field value exists in our constants lists
       const isFieldValueInMyinfoListCheck = (
         fieldValue: string,
         myInfoAttr: string | string[],
@@ -299,6 +300,7 @@ export class MyInfoServiceClass {
         }
       }
 
+      // Check if field value exists in our constants lists
       if (fieldValue) {
         if (myInfoAttr === MyInfoAttribute.Occupation) {
           isFieldValueInMyinfoListCheck(

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -12,7 +12,17 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import CircuitBreaker from 'opossum'
 
 import {
+  myInfoCountries,
+  myInfoDialects,
+  myInfoHdbTypes,
+  myInfoHousingTypes,
+  myInfoNationalities,
+  myInfoOccupations,
+  myInfoRaces,
+} from '../../../../shared/constants/field/myinfo'
+import {
   MyInfoAttribute as InternalAttr,
+  MyInfoAttribute,
   MyInfoChildData,
 } from '../../../../shared/types'
 import {
@@ -270,6 +280,59 @@ export class MyInfoServiceClass {
       const { fieldValue, isReadOnly } = myInfoData.getFieldValueForAttr(
         myInfoAttr as InternalAttr,
       )
+
+      const isFieldValueInMyinfoListCheck = (
+        fieldValue: string,
+        myInfoAttr: string | string[],
+        myInfoList: string[],
+      ) => {
+        const isFieldValueInMyinfoList = myInfoList.includes(fieldValue)
+        if (!isFieldValueInMyinfoList) {
+          logger.error({
+            message: 'Myinfo field value not found in existing list',
+            meta: {
+              action: 'prefillAndSaveMyInfoFields',
+              myInfoFieldValue: fieldValue,
+              myInfoAttr,
+            },
+          })
+        }
+      }
+
+      if (fieldValue) {
+        if (myInfoAttr === MyInfoAttribute.Occupation) {
+          isFieldValueInMyinfoListCheck(
+            fieldValue,
+            myInfoAttr,
+            myInfoOccupations,
+          )
+        } else if (
+          myInfoAttr === MyInfoAttribute.Race ||
+          myInfoAttr === MyInfoAttribute.ChildRace ||
+          myInfoAttr === MyInfoAttribute.ChildSecondaryRace
+        ) {
+          isFieldValueInMyinfoListCheck(fieldValue, myInfoAttr, myInfoRaces)
+        } else if (myInfoAttr === MyInfoAttribute.Nationality) {
+          isFieldValueInMyinfoListCheck(
+            fieldValue,
+            myInfoAttr,
+            myInfoNationalities,
+          )
+        } else if (myInfoAttr === MyInfoAttribute.Dialect) {
+          isFieldValueInMyinfoListCheck(fieldValue, myInfoAttr, myInfoDialects)
+        } else if (myInfoAttr === MyInfoAttribute.BirthCountry) {
+          isFieldValueInMyinfoListCheck(fieldValue, myInfoAttr, myInfoCountries)
+        } else if (myInfoAttr === MyInfoAttribute.HousingType) {
+          isFieldValueInMyinfoListCheck(
+            fieldValue,
+            myInfoAttr,
+            myInfoHousingTypes,
+          )
+        } else if (myInfoAttr === MyInfoAttribute.HdbType) {
+          isFieldValueInMyinfoListCheck(fieldValue, myInfoAttr, myInfoHdbTypes)
+        }
+      }
+
       const prefilledField = cloneDeep(field) as PossiblyPrefilledField
       prefilledField.fieldValue = fieldValue
       // Disable field

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -574,7 +574,7 @@ export const getMyInfoAttributeConstantsList = (
  * @param myInfoList
  */
 
-export const isFieldValueInMyinfoList = (
+export const logIfFieldValueNotInMyinfoList = (
   fieldValue: string,
   myInfoAttr: string | string[],
   myInfoList: string[],

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -6,7 +6,16 @@ import mongoose, { LeanDocument } from 'mongoose'
 import { err, ok, Result } from 'neverthrow'
 import { v4 as uuidv4, validate as validateUUID } from 'uuid'
 
-import { types as myInfoTypes } from '../../../../shared/constants/field/myinfo'
+import {
+  myInfoCountries,
+  myInfoDialects,
+  myInfoHdbTypes,
+  myInfoHousingTypes,
+  myInfoNationalities,
+  myInfoOccupations,
+  myInfoRaces,
+  types as myInfoTypes,
+} from '../../../../shared/constants/field/myinfo'
 import {
   BasicField,
   ChildrenCompoundFieldBase,
@@ -525,4 +534,60 @@ export const handleMyInfoChildHashResponse = (
     })
   })
   return
+}
+
+/**
+ * This function is responsible for mapping a myInfo attribute to
+ * an existing myInfo constants list
+ *
+ * @param myInfoAttr the myInfo attribute
+ */
+export const getMyInfoAttributeConstantsList = (
+  myInfoAttr: string | string[],
+) => {
+  switch (myInfoAttr) {
+    case MyInfoAttribute.Occupation:
+      return myInfoOccupations
+    case MyInfoAttribute.Race:
+    case MyInfoAttribute.ChildRace:
+    case MyInfoAttribute.ChildSecondaryRace:
+      return myInfoRaces
+    case MyInfoAttribute.Nationality:
+      return myInfoNationalities
+    case MyInfoAttribute.Dialect:
+      return myInfoDialects
+    case MyInfoAttribute.BirthCountry:
+      return myInfoCountries
+    case MyInfoAttribute.HousingType:
+      return myInfoHousingTypes
+    case MyInfoAttribute.HdbType:
+      return myInfoHdbTypes
+    default:
+      return
+  }
+}
+
+/**
+ * Add logging to check if myInfo field value exists in a myInfo constants list
+ * @param fieldValue
+ * @param myInfoAttr
+ * @param myInfoList
+ */
+
+export const isFieldValueInMyinfoList = (
+  fieldValue: string,
+  myInfoAttr: string | string[],
+  myInfoList: string[],
+) => {
+  const isFieldValueInMyinfoList = myInfoList.includes(fieldValue)
+  if (!isFieldValueInMyinfoList) {
+    logger.error({
+      message: 'Myinfo field value not found in existing Myinfo constants list',
+      meta: {
+        action: 'prefillAndSaveMyInfoFields',
+        myInfoFieldValue: fieldValue,
+        myInfoAttr,
+      },
+    })
+  }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to track when we receive Myinfo field values (for dropdown fields) that are not in our Myinfo constants lists, as this prevents respondents from submitting their form.

Closes FRM-1306

## Solution
<!-- How did you solve the problem? -->
Add a check in `myinfo.service.ts`, which sends an error message when a field value for `NATIONALITIES`, `OCCUPATIONS`, `RACES`, `HOUSING_TYPES`, `HDB_TYPES` is not found.
- Other Myinfo fields which this check is not carried out for (because it's unlikely that these definitions will change): Sex, Residential status, Marital status, Workpass status, ChildGender, ChildVaxxStatus)

Added a monitor in DD [here](https://app.datadoghq.com/monitors/130812469), which pings the Slack alerts channel

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Move field options into separate constants files (`HOUSING_TYPES`, `HDB_TYPES`)


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Missing Myinfo value is captured in logs. This has already been done on staging, can search for the message "Myinfo field value not found in existing list" on Cloudwatch, under `/aws/elasticbeanstalk/formsg-staging/var/log/eb-docker/containers/eb-current-app/stdouterr.log`

Steps that were taken:
- Delete constants from the current myinfo constants files (`NATIONALITIES`, `OCCUPATIONS`, `RACES`, `HOUSING_TYPES`, `HDB_TYPES`)
- Fill in a form with a profile that has the values of the deleted constants in the previous step
- The myinfo fields should show up as blank, and you should see a "Myinfo field value not found in existing list" message for each missing value in Cloudwatch

Regression test
- [ ] Create a Myinfo form with the fields: Race, Nationality, Occupation, Dialect, Birth country, Housing type, HDB type
- [ ] Fill in the form, submit
- [ ] You should be able to submit the form successfully. The fields should be reflected in the email response

