### PR TITLE
feat: soften and fix storage submission validation

### DIFF
--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -4,6 +4,6 @@ export const featureFlags = {
   turnstile: 'turnstile' as const,
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   encryptionBoundaryShift: 'encryption-boundary-shift' as const,
-  encryptionBoundaryShiftValidation:
-    'encryption-boundary-shift-validation' as const,
+  encryptionBoundaryShiftHardValidation:
+    'encryption-boundary-shift-hard-validation' as const,
 }

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -4,4 +4,6 @@ export const featureFlags = {
   turnstile: 'turnstile' as const,
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   encryptionBoundaryShift: 'encryption-boundary-shift' as const,
+  encryptionBoundaryShiftValidation:
+    'encryption-boundary-shift-validation' as const,
 }

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -6398,7 +6398,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_RESPONSES,
         MOCK_ENCRYPTED_CONTENT,
-        true,
       )
       expect(
         MockEncryptSubmissionService.createEncryptSubmissionWithoutSave,
@@ -6801,7 +6800,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_RESPONSES,
         MOCK_ENCRYPTED_CONTENT,
-        true,
       )
       expect(
         MockEncryptSubmissionService.createEncryptSubmissionWithoutSave,
@@ -6855,7 +6853,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_RESPONSES,
         MOCK_ENCRYPTED_CONTENT,
-        true,
       )
       expect(
         MockEncryptSubmissionService.createEncryptSubmissionWithoutSave,
@@ -6909,7 +6906,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_RESPONSES,
         MOCK_ENCRYPTED_CONTENT,
-        true,
       )
       expect(
         MockEncryptSubmissionService.createEncryptSubmissionWithoutSave,
@@ -6963,7 +6959,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_RESPONSES,
         MOCK_ENCRYPTED_CONTENT,
-        true,
       )
       expect(
         MockEncryptSubmissionService.createEncryptSubmissionWithoutSave,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -5420,7 +5420,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).toHaveBeenCalledWith(
         MOCK_FORM.form_fields,
@@ -5955,7 +5954,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).not.toHaveBeenCalled()
       expect(
@@ -6013,7 +6011,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).not.toHaveBeenCalled()
       expect(
@@ -6071,7 +6068,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).not.toHaveBeenCalled()
       expect(
@@ -6129,7 +6125,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).toHaveBeenCalledWith(
         MOCK_FORM.form_fields,
@@ -6196,7 +6191,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).toHaveBeenCalledWith(
         MOCK_FORM.form_fields,
@@ -6263,7 +6257,6 @@ describe('admin-form.controller', () => {
       expect(MockParsedResponsesObject.parseResponses).toHaveBeenCalledWith(
         MOCK_FORM,
         MOCK_RESPONSES,
-        false,
       )
       expect(MockAdminFormService.extractMyInfoFieldIds).toHaveBeenCalledWith(
         MOCK_FORM.form_fields,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1679,7 +1679,7 @@ export const submitEncryptPreview: ControllerHandler<
       }),
     )
     .andThen((form) =>
-      IncomingEncryptSubmission.init(form, responses, encryptedContent, true) // set as true as there's no need to gate anything if the its not a real submission
+      IncomingEncryptSubmission.init(form, responses, encryptedContent)
         .map((incomingSubmission) => ({ incomingSubmission, form }))
         .mapErr((error) => {
           logger.error({

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1779,7 +1779,7 @@ export const submitEmailPreview: ControllerHandler<
   const parsedResponsesResult = await SubmissionService.validateAttachments(
     responses,
     form.responseMode,
-  ).andThen(() => ParsedResponsesObject.parseResponses(form, responses, false)) // email mode submissions (esp previews) does not need to use encryption boundary shift code
+  ).andThen(() => ParsedResponsesObject.parseResponses(form, responses))
   if (parsedResponsesResult.isErr()) {
     logger.error({
       message: 'Error while parsing responses for preview submission',

--- a/src/app/modules/submission/IncomingSubmission.class.ts
+++ b/src/app/modules/submission/IncomingSubmission.class.ts
@@ -21,6 +21,7 @@ import {
   VerifiableResponseIdSet,
   VisibleResponseIdSet,
 } from './submission.types'
+import { isAttachmentResponse } from './submission.utils'
 
 export abstract class IncomingSubmission {
   private readonly visibleFieldIds: Result<FieldIdSet, ProcessingError>
@@ -169,15 +170,20 @@ export abstract class IncomingSubmission {
       return err(new ProcessingError('Submission prevented by form logic'))
     }
 
-    const validationResultList = this.responses.map((response) => {
-      const responseId = String(response._id)
-      const formField = this.fieldMap[responseId]
-      return validateField(
-        this.form._id,
-        formField,
-        this.getLegacyProcessedFieldResponse(response),
-      )
-    })
+    const validationResultList = [] as Result<true, ValidateFieldError>[]
+    for (const response of this.responses) {
+      // Skip over attachment responses as they have been stripped at this point
+      // and fields have been validated in the validateSubmission middleware.
+      if (!isAttachmentResponse(response)) {
+        const responseId = String(response._id)
+        const formField = this.fieldMap[responseId]
+        return validateField(
+          this.form._id,
+          formField,
+          this.getLegacyProcessedFieldResponse(response),
+        )
+      }
+    }
 
     const validationResultCombined =
       Result.combineWithAllErrors(validationResultList)

--- a/src/app/modules/submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/ParsedResponsesObject.class.ts
@@ -84,16 +84,11 @@ export default class ParsedResponsesObject {
   static parseResponses(
     form: IFormDocument,
     responses: FieldResponse[],
-    encryptionBoundaryShiftEnabled: boolean, // true only in validateSubmission middleware, which is used only for new storage submission endpoint
   ): Result<
     ParsedResponsesObject,
     ProcessingError | ConflictError | ValidateFieldError
   > {
-    const filteredResponsesResult = getFilteredResponses(
-      form,
-      responses,
-      encryptionBoundaryShiftEnabled,
-    )
+    const filteredResponsesResult = getFilteredResponses(form, responses, false)
     if (filteredResponsesResult.isErr()) {
       return err(filteredResponsesResult.error)
     }

--- a/src/app/modules/submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/ParsedResponsesObject.class.ts
@@ -84,7 +84,7 @@ export default class ParsedResponsesObject {
   static parseResponses(
     form: IFormDocument,
     responses: FieldResponse[],
-    encryptionBoundaryShiftEnabled: boolean,
+    encryptionBoundaryShiftEnabled: boolean, // true only in validateSubmission middleware, which is used only for new storage submission endpoint
   ): Result<
     ParsedResponsesObject,
     ProcessingError | ConflictError | ValidateFieldError

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -178,11 +178,7 @@ const submitEmailModeForm: ControllerHandler<
           form.responseMode,
         )
           .andThen(() =>
-            ParsedResponsesObject.parseResponses(
-              form,
-              req.body.responses,
-              false, // email mode submissions do not need to use encryption boundary shift code
-            ),
+            ParsedResponsesObject.parseResponses(form, req.body.responses),
           )
           .map((parsedResponses) => ({ parsedResponses, form }))
           .mapErr((error) => {

--- a/src/app/modules/submission/encrypt-submission/IncomingEncryptSubmission.class.ts
+++ b/src/app/modules/submission/encrypt-submission/IncomingEncryptSubmission.class.ts
@@ -1,4 +1,4 @@
-import { ok, Result } from 'neverthrow'
+import { Result } from 'neverthrow'
 
 import { FieldResponse, IPopulatedEncryptedForm } from '../../../../types'
 import { checkIsEncryptedEncoding } from '../../../utils/encryption'
@@ -32,17 +32,12 @@ export default class IncomingEncryptSubmission extends IncomingSubmission {
     form: IPopulatedEncryptedForm,
     responses: FieldResponse[],
     encryptedContent: string,
-    encryptionBoundaryShiftEnabled: boolean,
   ): Result<
     IncomingEncryptSubmission,
     ProcessingError | ConflictError | ValidateFieldError[]
   > {
     return checkIsEncryptedEncoding(encryptedContent)
-      .andThen(() => {
-        if (encryptionBoundaryShiftEnabled)
-          return ok(responses as FilteredResponse[])
-        else return getFilteredResponses(form, responses, false)
-      })
+      .andThen(() => getFilteredResponses(form, responses, false))
       .andThen((filteredResponses) =>
         this.getFieldMap(form, filteredResponses).map((fieldMap) => ({
           responses: filteredResponses,

--- a/src/app/modules/submission/encrypt-submission/IncomingEncryptSubmission.class.ts
+++ b/src/app/modules/submission/encrypt-submission/IncomingEncryptSubmission.class.ts
@@ -37,7 +37,7 @@ export default class IncomingEncryptSubmission extends IncomingSubmission {
     ProcessingError | ConflictError | ValidateFieldError[]
   > {
     return checkIsEncryptedEncoding(encryptedContent)
-      .andThen(() => getFilteredResponses(form, responses, false))
+      .andThen(() => getFilteredResponses(form, responses, true))
       .andThen((filteredResponses) =>
         this.getFieldMap(form, filteredResponses).map((fieldMap) => ({
           responses: filteredResponses,

--- a/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/IncomingEncryptSubmission.class.spec.ts
@@ -74,7 +74,6 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       responses,
       '',
-      false,
     )
     expect(initResult._unsafeUnwrap().responses).toEqual(responses)
   })
@@ -129,58 +128,8 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       responses,
       '',
-      false,
     )
     const filteredResponses = [mobileResponse, emailResponse]
-    expect(initResult._unsafeUnwrap().responses).toEqual(filteredResponses)
-  })
-
-  it('should not filter responses when new encryption boundary flag is on', () => {
-    mockCheckIsEncryptedEncoding.mockReturnValueOnce(ok(true))
-    const mobileField = generateDefaultField(BasicField.Mobile, {
-      isVerifiable: true,
-    })
-    const emailField = generateDefaultField(BasicField.Email, {
-      isVerifiable: true,
-      autoReplyOptions: {
-        hasAutoReply: true,
-        autoReplySubject: 'subject',
-        autoReplySender: 'sender@test.gov.sg',
-        autoReplyMessage: 'message',
-        includeFormSummary: false,
-      },
-    })
-    const yesNoField = generateDefaultField(BasicField.YesNo)
-    const ratingField = generateDefaultField(BasicField.Rating)
-    const basicFormFields = [mobileField, emailField, yesNoField, ratingField]
-    const mobileResponse = generateSingleAnswerResponse(
-      mobileField,
-      '+6587654321',
-      'signature',
-    )
-    const emailResponse = generateSingleAnswerResponse(
-      emailField,
-      'test@example.com',
-      'signature',
-    )
-    const yesNoResponse = generateSingleAnswerResponse(yesNoField, 'Yes')
-    const ratingResponse = generateSingleAnswerResponse(ratingField, '5')
-    const responses = [
-      mobileResponse,
-      emailResponse,
-      yesNoResponse,
-      ratingResponse,
-    ]
-    const filteredResponses = responses
-    const initResult = IncomingEncryptSubmission.init(
-      {
-        responseMode: FormResponseMode.Encrypt,
-        form_fields: basicFormFields,
-      } as unknown as IPopulatedEncryptedForm,
-      responses,
-      '',
-      true,
-    )
     expect(initResult._unsafeUnwrap().responses).toEqual(filteredResponses)
   })
 
@@ -212,7 +161,6 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       responses,
       '',
-      false,
     )
     expect(initResult._unsafeUnwrapErr()).toEqual(
       new ConflictError('Some form fields are missing'),
@@ -260,7 +208,6 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       responses,
       '',
-      false,
     )
 
     expect(result.isOk()).toEqual(true)
@@ -283,7 +230,6 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       [mobileResponse],
       '',
-      false,
     )
 
     expect(result.isErr()).toEqual(true)
@@ -309,7 +255,6 @@ describe('IncomingEncryptSubmission', () => {
       } as unknown as IPopulatedEncryptedForm,
       [],
       '',
-      false,
     )
 
     expect(result.isErr()).toEqual(true)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -23,7 +23,7 @@ import {
   IPopulatedEncryptedForm,
   StripePaymentMetadataDto,
 } from '../../../../types'
-import { FormsgCompleteDto } from '../../../../types/api'
+import { FormCompleteDto } from '../../../../types/api'
 import config from '../../../config/config'
 import { paymentConfig } from '../../../config/features/payment.config'
 import { createLoggerWithLabel } from '../../../config/logger'
@@ -341,7 +341,9 @@ const _createPaymentSubmission = async ({
   responseMetadata,
   paymentProducts,
 }: {
-  req: Parameters<SubmitEncryptModeFormHandlerType>[0] & FormsgCompleteDto
+  req: Parameters<SubmitEncryptModeFormHandlerType>[0] & {
+    formsg: FormCompleteDto
+  }
   res: Parameters<SubmitEncryptModeFormHandlerType>[1]
   form: IPopulatedEncryptedForm
   paymentProducts: StorageModeSubmissionContentDto['paymentProducts']

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -128,7 +128,7 @@ const submitEncryptModeForm = async (
   const encryptedPayload = req.formsg.encryptedPayload
 
   // Create Incoming Submission
-  const { encryptedContent, responses, responseMetadata, paymentProducts } =
+  const { encryptedContent, responseMetadata, paymentProducts } =
     encryptedPayload
 
   // Checks if user is SPCP-authenticated before allowing submission
@@ -295,7 +295,7 @@ const submitEncryptModeForm = async (
       form,
       logMeta,
       formId,
-      responses,
+      responses: req.formsg.filteredResponses,
       paymentProducts,
       responseMetadata,
       submissionContent,
@@ -307,7 +307,7 @@ const submitEncryptModeForm = async (
     res,
     logMeta,
     formId,
-    responses,
+    responses: req.formsg.filteredResponses,
     responseMetadata,
     submissionContent,
   })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -188,11 +188,7 @@ export const validateStorageSubmission = async (
     formDef.responseMode,
   )
     .andThen(() =>
-      ParsedResponsesObject.parseResponses(
-        formDef,
-        req.body.responses,
-        req.formsg.featureFlags.includes(featureFlags.encryptionBoundaryShift),
-      ),
+      ParsedResponsesObject.parseResponses(formDef, req.body.responses),
     )
     .map((parsedResponses) => {
       const responses = [] as EncryptFormFieldResponse[]

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -384,7 +384,6 @@ export const validateEncryptSubmission = async (
     form,
     responses,
     encryptedContent,
-    req.formsg.featureFlags.includes(featureFlags.encryptionBoundaryShift),
   )
   if (incomingSubmissionResult.isErr()) {
     logger.error({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -195,7 +195,7 @@ export const validateSubmission = async (
       // TODO(FRM-1318): Set DB flag to true to harden submission validation after validation has similar error rates as email mode forms.
       if (
         req.formsg.featureFlags.includes(
-          featureFlags.encryptionBoundaryShiftValidation,
+          featureFlags.encryptionBoundaryShiftHardValidation,
         )
       ) {
         const { statusCode, errorMessage } = mapRouteError(error)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -186,23 +186,28 @@ export const validateSubmission = async (
     )
     .map(() => next())
     .mapErr((error) => {
-      logger.error({
-        message:
-          'Error processing responses, but proceeding with submission as submission have been validated client-side',
-        meta: logMeta,
-        error,
-      })
       // TODO(FRM-1318): Set DB flag to true to harden submission validation after validation has similar error rates as email mode forms.
       if (
         req.formsg.featureFlags.includes(
           featureFlags.encryptionBoundaryShiftHardValidation,
         )
       ) {
+        logger.error({
+          message: 'Error processing responses',
+          meta: logMeta,
+          error,
+        })
         const { statusCode, errorMessage } = mapRouteError(error)
         return res.status(statusCode).json({
           message: errorMessage,
         })
       }
+      logger.warn({
+        message:
+          'Error processing responses, but proceeding with submission as submission have been validated client-side',
+        meta: logMeta,
+        error,
+      })
       return next()
     })
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -165,6 +165,10 @@ export const checkNewBoundaryEnabled = async (
   return next()
 }
 
+/**
+ * Validates storage submissions to the new endpoint (/api/v3/forms/:formId/submissions/storage).
+ * This uses the same validators as email mode submissions.
+ */
 export const validateStorageSubmission = async (
   req: ValidateSubmissionMiddlewareHandlerRequest,
   res: Parameters<StorageSubmissionMiddlewareHandlerType>[1],
@@ -362,7 +366,7 @@ export const moveEncryptedPayload = async (
 }
 
 /**
- * Moves encrypted payload present in req.body to req.formsg.encryptedPayload.
+ * Validates mobile and email fields for storage submissions on the old endpoint.
  * Should only be used for the old storage mode submission endpoint (/api/v3/forms/:formId/submissions/encrypt).
  */
 export const validateEncryptSubmission = async (
@@ -409,6 +413,9 @@ export const validateEncryptSubmission = async (
   return next()
 }
 
+/**
+ * Creates formsg namespace in req.body and populates it with featureFlags, formDef and encryptedFormDef.
+ */
 export const createFormsgAndRetrieveForm = async (
   req: CreateFormsgAndRetrieveFormMiddlewareHandlerRequest,
   res: Parameters<CreateFormsgAndRetrieveFormMiddlewareHandlerType>[1],

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -192,11 +192,17 @@ export const validateSubmission = async (
         meta: logMeta,
         error,
       })
-      // TODO(FRM-1318): Uncomment to harden submission validation after validation has similar error rates as email mode forms.
-      // const { statusCode, errorMessage } = mapRouteError(error)
-      // return res.status(statusCode).json({
-      //   message: errorMessage,
-      // })
+      // TODO(FRM-1318): Set DB flag to true to harden submission validation after validation has similar error rates as email mode forms.
+      if (
+        req.formsg.featureFlags.includes(
+          featureFlags.encryptionBoundaryShiftValidation,
+        )
+      ) {
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      }
       return next()
     })
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -333,8 +333,7 @@ export const encryptSubmission = async (
 
   req.formsg.encryptedPayload = {
     attachments: encryptedAttachments,
-    // filteredResponses might not have been loaded due to validation errors, default to req.body.responses
-    responses: req.formsg.filteredResponses ?? req.body.responses,
+    responses: req.formsg.filteredResponses,
     encryptedContent,
     version: req.body.version,
     paymentProducts: req.body.paymentProducts,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -187,14 +187,17 @@ export const validateSubmission = async (
     .map(() => next())
     .mapErr((error) => {
       logger.error({
-        message: 'Error processing responses',
+        message:
+          'Error processing responses, but proceeding with submission as submission have been validated client-side',
         meta: logMeta,
         error,
       })
-      const { statusCode, errorMessage } = mapRouteError(error)
-      return res.status(statusCode).json({
-        message: errorMessage,
-      })
+      // TODO(FRM-1318): Uncomment to harden submission validation after validation has similar error rates as email mode forms.
+      // const { statusCode, errorMessage } = mapRouteError(error)
+      // return res.status(statusCode).json({
+      //   message: errorMessage,
+      // })
+      return next()
     })
 }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -189,9 +189,9 @@ export const validateSubmission = async (
         req.formsg.featureFlags.includes(featureFlags.encryptionBoundaryShift),
       ),
     )
-    .map((payload) => {
+    .map((parsedResponses) => {
       const responses = [] as EncryptFormFieldResponse[]
-      for (const response of payload.getAllResponses()) {
+      for (const response of parsedResponses.getAllResponses()) {
         if (response.isVisible) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { isVisible: _, ...rest } = response

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
@@ -5,8 +5,9 @@ import {
 import { IPopulatedEncryptedForm } from '../../../../types'
 import {
   EncryptSubmissionDto,
+  FormCompleteDto,
+  FormFilteredResponseDto,
   FormLoadedDto,
-  FormsgCompleteDto,
   ParsedStorageModeSubmissionBody,
 } from '../../../../types/api'
 import { ControllerHandler } from '../../core/core.types'
@@ -43,7 +44,12 @@ export type StorageSubmissionMiddlewareHandlerType = ControllerHandler<
 
 export type StorageSubmissionMiddlewareHandlerRequest =
   Parameters<StorageSubmissionMiddlewareHandlerType>[0] & {
-    formsg: FormLoadedDto
+    formsg: FormCompleteDto
+  }
+
+export type ValidateSubmissionMiddlewareHandlerRequest =
+  Parameters<CreateFormsgAndRetrieveFormMiddlewareHandlerType>[0] & {
+    formsg: FormFilteredResponseDto
   }
 
 export type EncryptSubmissionMiddlewareHandlerType = ControllerHandler<
@@ -54,7 +60,9 @@ export type EncryptSubmissionMiddlewareHandlerType = ControllerHandler<
 >
 
 export type EncryptSubmissionMiddlewareHandlerRequest =
-  Parameters<EncryptSubmissionMiddlewareHandlerType>[0] & FormsgCompleteDto
+  Parameters<EncryptSubmissionMiddlewareHandlerType>[0] & {
+    formsg: FormCompleteDto
+  }
 
 export type SubmitEncryptModeFormHandlerType = ControllerHandler<
   { formId: string },
@@ -62,4 +70,4 @@ export type SubmitEncryptModeFormHandlerType = ControllerHandler<
 >
 
 export type SubmitEncryptModeFormHandlerRequest =
-  Parameters<SubmitEncryptModeFormHandlerType>[0] & FormsgCompleteDto
+  Parameters<SubmitEncryptModeFormHandlerType>[0] & { formsg: FormCompleteDto }

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -369,7 +369,6 @@ export const validateAttachments = (
           invalidExtensions,
         },
       })
-      console.log('invalidExtensions', invalidExtensions)
       return errAsync(new InvalidFileExtensionError())
     }
     return okAsync(true as const)

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -149,11 +149,8 @@ export const extractEmailConfirmationData = (
 export const getFilteredResponses = (
   form: IFormDocument,
   responses: FieldResponse[],
-  encryptionBoundaryShiftEnabled: boolean,
+  isEncryptedMode: boolean,
 ): Result<FilteredResponse[], ConflictError> => {
-  const isEncryptedMode =
-    form.responseMode === FormResponseMode.Encrypt &&
-    !encryptionBoundaryShiftEnabled
   const responseModeFilter = getResponseModeFilter(isEncryptedMode)
   const formFieldModeFilter = getFormFieldModeFilter(isEncryptedMode)
 

--- a/src/types/api/encrypt_submission.ts
+++ b/src/types/api/encrypt_submission.ts
@@ -1,5 +1,7 @@
 import type { Merge } from 'type-fest'
 
+import { ProcessedFieldResponse } from 'src/app/modules/submission/submission.types'
+
 import {
   AttachmentResponse,
   FieldResponse,
@@ -13,7 +15,7 @@ import { ParsedEmailModeSubmissionBody } from './email_submission'
 
 export type EncryptSubmissionDto = Merge<
   StorageModeSubmissionContentDto,
-  { responses: EncryptFormFieldResponse[] }
+  { responses: EncryptFormFieldResponse[] | ProcessedFieldResponse[] }
 >
 
 export type EncryptAttachmentResponse = AttachmentResponse & {
@@ -42,14 +44,10 @@ export type FormLoadedDto = {
   encryptedFormDef: IPopulatedEncryptedForm
 }
 
-export type EncryptingPayloadDto = {
-  formsg: FormLoadedDto & {
-    encryptedPayload?: EncryptSubmissionDto
-  }
+export type FormFilteredResponseDto = FormLoadedDto & {
+  filteredResponses: EncryptFormFieldResponse[]
 }
 
-export type FormsgCompleteDto = {
-  formsg: FormLoadedDto & {
-    encryptedPayload: EncryptSubmissionDto
-  }
+export type FormCompleteDto = FormFilteredResponseDto & {
+  encryptedPayload: EncryptSubmissionDto
 }

--- a/src/types/api/encrypt_submission.ts
+++ b/src/types/api/encrypt_submission.ts
@@ -12,6 +12,7 @@ import {
 import { IPopulatedEncryptedForm, IPopulatedForm } from '../form'
 
 import { ParsedEmailModeSubmissionBody } from './email_submission'
+import { ParsedClearFormFieldResponse } from './submission'
 
 export type EncryptSubmissionDto = Merge<
   StorageModeSubmissionContentDto,
@@ -45,7 +46,7 @@ export type FormLoadedDto = {
 }
 
 export type FormFilteredResponseDto = FormLoadedDto & {
-  filteredResponses: EncryptFormFieldResponse[]
+  filteredResponses: ParsedClearFormFieldResponse[]
 }
 
 export type FormCompleteDto = FormFilteredResponseDto & {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Backend storage submission validation is currently hard but might be buggy / risky as it was done in a huge PR (https://github.com/opengovsg/FormSG/pull/6595) of +1,479 / −1,022. As we have frontend validation that is already stable, it is an option to temporarily only perform a soft validation on the backend.

We should harden our backend validation after logged validation error rates are the similar to that of email mode submissions. A ticket has been created for this: FRM-1318.

This PR fixes the [bug that prevented us from rolling out the new storage submission endpoint](https://opengovproducts.slack.com/archives/CLJPA6NDN/p1693885396583929?thread_ts=1693884652.604959&cid=CLJPA6NDN) too, which was caused by the responses being wrongly validated again in the `encryptSubmission` middleware. This should only be done for the old submission endpoint.

Closes FRM-1333

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Create `validateEncryptSubmission` middleware so that validation run in `IncomingEncryptSubmission.init` is only run for the old storage submission endpoint.

**Improvements**:

- Moves on to next middleware even if submission validation throws error.
- Use [EncryptionBoundaryShift-Production cloudwatch dashboard](https://ap-southeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-1#dashboards/dashboard/EncryptionBoundaryShift-Production) to track any errors on the backend storage submission validation middleware.
- Introduction of `req.formsg.filteredResponses` to pass filteredResponses between middlewares (instead of filtering when we need to).

## Tests
<!-- What tests should be run to confirm functionality? -->

Make sure that submission still goes through if server validation doesn't pass, and make sure that the cloudwatch dashboard works:
- [ ] Deploy the app to a staging env.
- [ ] On growthbook, ensure that `encryption-boundary-shift` will be `true` the form you create (ie forced value or 100% rollout).
- [ ] In the `featureflags` DB collection, ensure that`encryption-boundary-shift-hard-validation` is unset or set to `false`.
- [ ] Make an invalid submission to the new storage submission endpoint by cURL. You should be able to submit successfully.
- [ ] The submission should show up in the form's admin results page.
- [ ] Check your logs, there should be error logs with `Error processing responses, but proceeding with submission as submission have been validated client-side`.
- [ ] Go to [EncryptionBoundaryShiftStaging cloudwatch dashboard](https://ap-southeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-1#dashboards/dashboard/EncryptionBoundaryShift-Staging), you should see the recent errored BE validation show up on the graph. The logs might take ~5min to appear.
- [ ] Check that all the instances are still healthy and didn't crash.

Make sure that the `encryption-boundary-shift-hard-validation` feature flag works:
- [ ] On growthbook, ensure that `encryption-boundary-shift` will be `true` the form you create (ie forced value or 100% rollout).
- [ ] In the `featureflags` DB collection, set `encryption-boundary-shift-hard-validation` to `true`.
- [ ] Make an invalid submission to the new storage submission endpoint by cURL. There should be a validation error shown to the respondent, preventing submission.
- [ ] The submission should **not** show up in the form's admin results page.
- [ ] Check that all the instances are still healthy and didn't crash.

Regression:
- [ ] Submit a storage mode form on the old endpoint for the following test cases:
  - [ ] Required table field hidden by logic.
  - [ ] Attachment uploaded submission.
  - [ ] Mobile and email fields:
    - [ ] Verifiable and filled
    - [ ] Required and hidden by logic
  - [ ] Fields with answer array (e.g. checkbox).
- [ ] Submit a storage mode form on the new endpoint for the above test cases.
- [ ] Submit an email mode form for the above test cases.

## Deploy Notes

1. Before deployment, in the DB's `featureflags` collection, ensure that `encryption-boundary-shift-hard-validation` is unset or set as false.
2. After deployment, monitor:
    1. "Submissions" section in the [FormSG DD monitor](https://app.datadoghq.com/dashboard/b3u-egb-apu/form-s-g?refresh_mode=sliding&from_ts=1694393221756&to_ts=1694479621756&live=true) - to ensure that email and old storage submission endpoint is still doing well.
3. Once satisfied that there are no regressions, on growthbook, increase rollout % for new storage submission endpoint to 1%.
4. Monitor:
    1. "Encryption Boundary Shift" in [FormSG Release Dashboard DD monitor](https://app.datadoghq.com/dashboard/fh2-pvk-ncb/formsg-release-dashboard?refresh_mode=sliding&from_ts=1694393504503&to_ts=1694479904503&live=true).
    2. [EncryptionBoundaryShift-Production cloudwatch dashboard](https://ap-southeast-1.console.aws.amazon.com/systems-manager/resource-groups/cloudwatch?region=ap-southeast-1&dashboard=EncryptionBoundaryShift-Production). It's okay if stuff is logged here, because these are warnings logged by the _soft_ validation and email mode still has BE validation errors as well! What we're aiming for is an error rate similar to that of email mode.

**New feature flags**:
- In the `featureflags` collection - `encryption-boundary-shift-hard-validation`: the backend uses this to decide whether hard validation is used for the new submission endpoint.
