### PR TITLE
fix: remove index from myinfo child question name

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -234,7 +234,7 @@ export const getAnswersForChild = (
         childName,
       ),
       fieldType: response.fieldType,
-      question: `Child-${childIdx + 1}.${subFields[idx]}`,
+      question: `Child.${subFields[idx]}`,
       myInfo: {
         attr: subFields[idx] as unknown as MyInfoAttribute,
       },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

If an email response has more than 1 Myinfo Child field, the index of the child field stays at 1. For example:
<img width="384" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/b1d6c7f3-6f29-4632-9c8e-406a508c808e">


## Solution
<!-- How did you solve the problem? -->
As a quick fix, remove the index.

A longer-term fix where the index is incremented accurately will be opened in a separate PR (FRM-1325)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - Respondents who are already collecting Myinfo responses will have the addition of an extra column (due to the new question name) when they use the data collation tool to generate a CSV. I've checked and the form admins currently using the Myinfo child field are ones that we're already in touch with, and so they are aware of the changes / have not gone live with their forms


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On a Myinfo-enabled form, add a Myinfo child field
- [ ] Submit the form
- [ ] In the form response email, the Myinfo child fields should not contain any number in the field name. They should look like this naming convention `[child] [MyInfo] Child.childname`, where `childname` is the field type
