### PR TITLE
fix: invalid mixed digit input

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -43,8 +43,8 @@ const DISPLAY_AMOUNT_KEY = 'display_amount'
 const MULTI_QTY_KEY = 'multi_qty'
 
 const parseIntElseNull = (val: string) => {
-  const parsed = parseInt(val, 10)
-  return Number.isNaN(parsed) ? null : parsed
+  const parsedInt = parseInt(val, 10)
+  return Number.isNaN(parsedInt) ? null : parsedInt
 }
 
 export const ProductModal = ({

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -41,6 +41,12 @@ const MIN_QTY_KEY = `min_qty`
 const MAX_QTY_KEY = `max_qty`
 const DISPLAY_AMOUNT_KEY = 'display_amount'
 const MULTI_QTY_KEY = 'multi_qty'
+
+const parseIntElseNull = (val: string) => {
+  const parsed = parseInt(val, 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
 export const ProductModal = ({
   onClose,
   onSaveProduct,
@@ -129,14 +135,16 @@ export const ProductModal = ({
     validate: (valStr: string) => {
       if (!getValues(MULTI_QTY_KEY)) return true
 
-      const valNumber = parseInt(valStr, 10)
-      if (Number.isNaN(valNumber)) {
+      const valNumber = parseIntElseNull(valStr)
+      if (!valNumber || valNumber <= 0) {
         return 'Enter a value greater than 0'
       }
-      if (valNumber <= 0) {
-        return 'Enter a value greater than 0'
-      }
-      if (valNumber > getValues(MAX_QTY_KEY)) {
+
+      const maxNumber =
+        parseIntElseNull(getValues(MAX_QTY_KEY) as unknown as string) ||
+        Number.MAX_SAFE_INTEGER
+
+      if (valNumber > maxNumber) {
         return 'Enter a value smaller than the maximum quantity'
       }
       return true
@@ -145,11 +153,9 @@ export const ProductModal = ({
   const maxQtyValidation: RegisterOptions = {
     validate: (valStr: string) => {
       if (!getValues(MULTI_QTY_KEY)) return true
-      const valNumber = parseInt(valStr, 10)
-      if (Number.isNaN(valNumber)) {
-        return 'Enter a value greater than 0'
-      }
-      if (valNumber <= 0) {
+
+      const valNumber = parseIntElseNull(valStr)
+      if (!valNumber || valNumber <= 0) {
         return 'Enter a value greater than 0'
       }
 
@@ -164,7 +170,11 @@ export const ProductModal = ({
         }
         return `The maximum quantity for this amount is ${maxQty}`
       }
-      if (valNumber < getValues(MIN_QTY_KEY)) {
+      const minNumber =
+        parseIntElseNull(getValues(MIN_QTY_KEY) as unknown as string) ||
+        Number.MIN_SAFE_INTEGER
+
+      if (valNumber < minNumber) {
         return 'Enter a value greater than the minimum quantity'
       }
       return true

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -181,7 +181,6 @@ export const ProductModal = ({
     },
   }
 
-  console.log(getValues([MULTI_QTY_KEY, MIN_QTY_KEY, MAX_QTY_KEY]))
   return (
     <Modal isOpen onClose={onClose}>
       <ModalOverlay />

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -125,28 +125,37 @@ export const ProductModal = ({
     onClose()
   })
 
-  const minQtyValidation: RegisterOptions<ProductInput, typeof MIN_QTY_KEY> = {
-    validate: (val) => {
+  const minQtyValidation: RegisterOptions = {
+    validate: (valStr: string) => {
       if (!getValues(MULTI_QTY_KEY)) return true
-      if (val <= 0) {
+
+      const valNumber = parseInt(valStr, 10)
+      if (Number.isNaN(valNumber)) {
         return 'Enter a value greater than 0'
       }
-      if (val > getValues(MAX_QTY_KEY)) {
+      if (valNumber <= 0) {
+        return 'Enter a value greater than 0'
+      }
+      if (valNumber > getValues(MAX_QTY_KEY)) {
         return 'Enter a value smaller than the maximum quantity'
       }
       return true
     },
   }
-  const maxQtyValidation: RegisterOptions<ProductInput, typeof MAX_QTY_KEY> = {
-    validate: (val) => {
+  const maxQtyValidation: RegisterOptions = {
+    validate: (valStr: string) => {
       if (!getValues(MULTI_QTY_KEY)) return true
-      if (val <= 0) {
+      const valNumber = parseInt(valStr, 10)
+      if (Number.isNaN(valNumber)) {
+        return 'Enter a value greater than 0'
+      }
+      if (valNumber <= 0) {
         return 'Enter a value greater than 0'
       }
 
       const amount = dollarsToCents(getValues(DISPLAY_AMOUNT_KEY) ?? '')
 
-      if (val * amount > maxPaymentAmountCents) {
+      if (valNumber * amount > maxPaymentAmountCents) {
         const maxQty = Math.floor(maxPaymentAmountCents / amount)
         if (maxQty <= 0) {
           return `Quantity limit could not be set because amount is above S${formatCurrency(
@@ -155,13 +164,14 @@ export const ProductModal = ({
         }
         return `The maximum quantity for this amount is ${maxQty}`
       }
-      if (val < getValues(MIN_QTY_KEY)) {
+      if (valNumber < getValues(MIN_QTY_KEY)) {
         return 'Enter a value greater than the minimum quantity'
       }
       return true
     },
   }
 
+  console.log(getValues([MULTI_QTY_KEY, MIN_QTY_KEY, MAX_QTY_KEY]))
   return (
     <Modal isOpen onClose={onClose}>
       <ModalOverlay />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Two digit inputs are incorrect

Closes FRM-1331

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
<!-- [insert screenshot here] -->
| Before | After |
|--------|--------|
| <img width="718" alt="Screenshot 2023-09-07 at 9 44 28 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/fa74f8dc-21b3-4a67-bf54-e9b9bf9f2016"> |  <img width="721" alt="Screenshot 2023-09-07 at 9 44 21 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/3ea40a7a-eaa0-4adf-909c-b702b1b623a2">|
| <img width="721" alt="Screenshot 2023-09-07 at 9 46 05 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/2e96ba7a-6724-4aa2-bf49-32b85de6f59b"> |  <img width="715" alt="Screenshot 2023-09-07 at 9 45 48 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/f2125beb-1fb4-40e2-9e5b-ed323f30eed1"> |

## Tests
<!-- What tests should be run to confirm functionality? -->
Note for all the tests:
1. Manually change the input values in order to have them stored as `string`
2. Both min and max **needs to be changed**
3. String comparison will only occur **if both operands** are `string`

Regression
On the product modal
- [ ] Ensure that `min: 1, max: 10` passes
- [ ] Ensure that `min: 10, max: 1` fails

Cases from reported example
- [ ] Ensure that `min: 59, max: 100` passes
- [ ] Ensure that `min: 10, max: 9` fails

Mixed digit strings (values should be compared as numbers instead of string)
- [ ] Ensure that `min: 2, max: 10` passes // strcmp would have failed as "2" is smaller than "1"
- [ ] Ensure that `min: 10, max: 2` fails // strcmp would have passed as "1" is smaller than "2"
- [ ] Ensure that `min: 111, max: 20` fails // strcmp would have passed as "11" is larger than "20"
- [ ] Ensure that `min: 123, max: 1200` passes // strcmp would have failed as "123" is larger than "120"