### PR TITLE
fix: mobile view of unsaved modal

### DIFF
--- a/frontend/src/templates/NavigationPrompt/UnsavedChangesModal.tsx
+++ b/frontend/src/templates/NavigationPrompt/UnsavedChangesModal.tsx
@@ -9,6 +9,7 @@ import {
   ModalOverlay,
   ModalProps,
   Stack,
+  useBreakpointValue,
 } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -41,6 +42,11 @@ export const UnsavedChangesModal = ({
   cancelButtonText = 'No, stay on page',
   ...modalProps
 }: UnsavedChangesModalProps): JSX.Element => {
+  const modalSize = useBreakpointValue({
+    base: 'mobile',
+    xs: 'mobile',
+    md: 'md',
+  })
   const isMobile = useIsMobile()
 
   return (
@@ -48,6 +54,7 @@ export const UnsavedChangesModal = ({
       isOpen={isOpen}
       onClose={onClose}
       returnFocusOnClose={returnFocusOnClose}
+      size={modalSize}
       {...modalProps}
     >
       <ModalOverlay />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

@staceytan1998 found that our dirty modal `UnsavedChangesModal.tsx` has incorrect sizing in mobile view

## Solution
<!-- How did you solve the problem? -->
Similar to other modals, use `chakra-ui/react.useBreakpointValue`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="434" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/529e8ae6-3fb6-4055-9c77-0dcbe76b06e1">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="434" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/92110209-5188-4dcf-9084-5f22c8a55d4f">


## Tests
<!-- What tests should be run to confirm functionality? -->
On mobile mode
- [ ] build a form
- [ ] make some changes to a field
- [ ] try to navigate away without saving or canceling
- [ ] the modal should fill the entire window
- [ ] return to edit and save
- [ ] form field should be updated

On desktop mode (regression)
- [ ] build a form
- [ ] make some changes to a field
- [ ] try to navigate away without saving or canceling
- [ ] dirty modal should pop up
- [ ] do not make the changes
- [ ] form should be as before