### PR TITLE
fix: inconsistent modal close buttons

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -8,7 +8,6 @@ import {
   FormControl,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -27,6 +26,7 @@ import {
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
+import { ModalCloseButton } from '~components/Modal'
 import MoneyInput from '~components/MoneyInput'
 import Toggle from '~components/Toggle'
 

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -4,7 +4,6 @@ import {
   Link,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -15,6 +14,7 @@ import {
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import ButtonGroup from '~components/ButtonGroup'
+import { ModalCloseButton } from '~components/Modal'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 

--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -49,7 +49,7 @@ export const DuplicatePaymentModal = ({
       <Modal isOpen onClose={onClose} size={isMobile ? 'full' : undefined}>
         <ModalOverlay />
         <ModalContent>
-          {!isMobile && <ModalCloseButton />}
+          <ModalCloseButton />
           <ModalHeader pb={'2rem'}>Proceed to pay again?</ModalHeader>
           <ModalBody flexGrow={0}>
             <Stack>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -39,7 +39,7 @@ export const FormPaymentModal = ({
       <Modal isOpen onClose={onClose} size={isMobile ? 'full' : undefined}>
         <ModalOverlay />
         <ModalContent>
-          {!isMobile && <ModalCloseButton />}
+          <ModalCloseButton />
           <ModalHeader pb={'2rem'}>You are about to make payment</ModalHeader>
           <ModalBody flexGrow={0}>
             Please ensure that your form information is accurate. You will not

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -2,7 +2,6 @@ import { MouseEvent, MouseEventHandler } from 'react'
 import {
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -12,6 +11,7 @@ import {
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import ButtonGroup from '~components/ButtonGroup'
+import { ModalCloseButton } from '~components/Modal'
 
 type FormPaymentModalProps = {
   onSubmit: MouseEventHandler<HTMLButtonElement> | undefined

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -63,7 +63,9 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
         <ModalOverlay />
         <ModalContent>
           <ModalCloseButton onClick={handleStartOver} />
-          <ModalHeader pb={'2rem'}>Restore previous session?</ModalHeader>
+          <ModalHeader pb={'2rem'} w="90%">
+            Restore previous session?
+          </ModalHeader>
           <ModalBody flexGrow={0}>
             We noticed an incomplete session on this form. You can restore your
             previous session and complete payment.

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -14,6 +14,7 @@ import { useBrowserStm } from '~hooks/payments'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
 import ButtonGroup from '~components/ButtonGroup'
+import { ModalCloseButton } from '~components/Modal'
 
 import { getPaymentPageUrl } from '~features/public-form/utils/urls'
 
@@ -61,6 +62,7 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
       >
         <ModalOverlay />
         <ModalContent>
+          <ModalCloseButton />
           <ModalHeader pb={'2rem'}>Restore previous session?</ModalHeader>
           <ModalBody flexGrow={0}>
             We noticed an incomplete session on this form. You can restore your

--- a/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/FormPaymentResumeModal.tsx
@@ -62,7 +62,7 @@ export const PublicFormPaymentResumeModal = (): JSX.Element => {
       >
         <ModalOverlay />
         <ModalContent>
-          <ModalCloseButton />
+          <ModalCloseButton onClick={handleStartOver} />
           <ModalHeader pb={'2rem'}>Restore previous session?</ModalHeader>
           <ModalBody flexGrow={0}>
             We noticed an incomplete session on this form. You can restore your

--- a/frontend/src/features/rollout-announcement/RolloutAnnouncementModal.tsx
+++ b/frontend/src/features/rollout-announcement/RolloutAnnouncementModal.tsx
@@ -4,7 +4,6 @@ import { useSwipeable } from 'react-swipeable'
 import {
   Flex,
   Modal,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalOverlay,
@@ -13,6 +12,7 @@ import {
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
+import { ModalCloseButton } from '~components/Modal'
 
 import { ProgressIndicator } from '../../components/ProgressIndicator/ProgressIndicator'
 

--- a/frontend/src/templates/NavigationPrompt/UnsavedChangesModal.tsx
+++ b/frontend/src/templates/NavigationPrompt/UnsavedChangesModal.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -13,6 +12,7 @@ import {
 } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
+import { ModalCloseButton } from '~components/Modal'
 
 export interface UnsavedChangesModalProps extends Omit<ModalProps, 'children'> {
   onConfirm: () => void


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1358

Some of our modals are using `chakra-ui/react.ModalCloseButton` instead of `~/components/Modal.ModalCloseButton`

## Solution
<!-- How did you solve the problem? -->

Refactor all modals to use internal `ModalCloseButton`

Also fixed to show close button on mobile for payment modals

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="679" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/0e6671a7-cef1-42f1-9cfd-469ae24c8ca2">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="679" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/d965e5f8-860e-4cae-8b16-d3acfe0998fa">


## Tests
<!-- What tests should be run to confirm functionality? -->

For each below check that:
1. Modal close button has the correct styling, i.e. subtle color + 2rem sized 'X'
2. Modal close button successfully closes the modal

- [x] Payment by product item modal
- [x] Dirty (Unsaved changes) modal
- [x] Rollout announcement modal
- [x] Proceed to pay modal (desktop)
- [x] Duplicate payment modal (desktop)
- [x] Payment resume modal (desktop)
- [x] Proceed to pay modal (mobile)
- [x] Duplicate payment modal (mobile)
- [x] Payment resume modal (mobile)
