### PR TITLE
fix: gogov error handling

### DIFF
--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -27,7 +27,11 @@ import {
 import dedent from 'dedent'
 import { StatusCodes } from 'http-status-codes'
 
-import { featureFlags, GO_VALIDATION_ERROR_MESSAGE } from '~shared/constants'
+import {
+  featureFlags,
+  GO_ALREADY_EXIST_ERROR_MESSAGE,
+  GO_VALIDATION_ERROR_MESSAGE,
+} from '~shared/constants'
 
 import { BxsCheckCircle, BxsErrorCircle } from '~/assets/icons'
 
@@ -72,6 +76,12 @@ const goLinkClaimSuccessHelperText: goLinkHelperTextType = {
     </Text>
   ),
 }
+
+const GO_VALIDATION_FAILED_HELPER_TEXT =
+  'Short links should only consist of lowercase letters, numbers and hyphens.'
+const GO_ALREADY_EXIST_HELPER_TEXT = 'Short link is already in use.'
+const GO_UNEXPECTED_ERROR_HELPER_TEXT =
+  'Something went wrong. Try refreshing this page. If this issue persists, contact support@form.gov.sg.'
 
 const getGoLinkClaimFailureHelperText = (
   text: string,
@@ -209,14 +219,19 @@ export const ShareFormModal = ({
     } catch (err) {
       setClaimGoLoading(false)
 
-      let errMessage =
-        'Something went wrong. Try refreshing this page. If this issue persists, contact support@form.gov.sg.'
+      let errMessage = GO_UNEXPECTED_ERROR_HELPER_TEXT
 
       if (err instanceof HttpError && err.code === StatusCodes.BAD_REQUEST)
-        errMessage =
-          err.message === GO_VALIDATION_ERROR_MESSAGE
-            ? 'Short links should only consist of lowercase letters, numbers and hyphens.'
-            : 'Short link is already in use.'
+        switch (err.message) {
+          case GO_VALIDATION_ERROR_MESSAGE:
+            errMessage = GO_VALIDATION_FAILED_HELPER_TEXT
+            break
+          case GO_ALREADY_EXIST_ERROR_MESSAGE:
+            errMessage = GO_ALREADY_EXIST_HELPER_TEXT
+            break
+          default:
+          // will use unexpected error text
+        }
 
       setGoLinkHelperText(getGoLinkClaimFailureHelperText(errMessage))
       return

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -6,6 +6,7 @@ import {
   Divider,
   FormControl,
   FormHelperText,
+  HStack,
   InputGroup,
   InputLeftAddon,
   InputRightElement,
@@ -61,7 +62,7 @@ type goLinkHelperTextType = {
 
 const goLinkClaimSuccessHelperText: goLinkHelperTextType = {
   color: 'success.700',
-  icon: <BxsCheckCircle />,
+  icon: <BxsCheckCircle fontSize="1rem" />,
   text: (
     <Text>
       You have successfully claimed this link. This link will appear in your{' '}
@@ -77,7 +78,7 @@ const getGoLinkClaimFailureHelperText = (
 ): goLinkHelperTextType => {
   return {
     color: 'danger.500',
-    icon: <BxsErrorCircle />,
+    icon: <BxsErrorCircle fontSize="1rem" />,
     text: <Text>{text}</Text>,
   }
 }
@@ -209,7 +210,7 @@ export const ShareFormModal = ({
       setClaimGoLoading(false)
 
       let errMessage =
-        'Something went wrong, please refresh the page. If this issue persists, contact us at support@form.gov.sg.'
+        'Something went wrong. Try refreshing this page. If this issue persists, contact support@form.gov.sg.'
 
       if (err instanceof HttpError && err.code === StatusCodes.BAD_REQUEST)
         errMessage =
@@ -386,11 +387,12 @@ export const ShareFormModal = ({
                         )}
                       </Stack>
                       {goLinkHelperText && (
+                        // padding on icon box to emulate padding form <Text>
                         <FormHelperText color={goLinkHelperText.color}>
-                          <Stack direction="row" align="center">
-                            <Box>{goLinkHelperText.icon}</Box>
+                          <HStack alignItems="flex-start">
+                            <Box py="2px">{goLinkHelperText.icon}</Box>
                             <Box>{goLinkHelperText.text}</Box>
-                          </Stack>
+                          </HStack>
                         </FormHelperText>
                       )}
                     </Skeleton>

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -387,7 +387,7 @@ export const ShareFormModal = ({
                         )}
                       </Stack>
                       {goLinkHelperText && (
-                        // padding on icon box to emulate padding form <Text>
+                        // padding on icon box to emulate padding from <Text>
                         <FormHelperText color={goLinkHelperText.color}>
                           <HStack alignItems="flex-start">
                             <Box py="2px">{goLinkHelperText.icon}</Box>

--- a/frontend/src/features/link-shortener/GoGovService.ts
+++ b/frontend/src/features/link-shortener/GoGovService.ts
@@ -14,7 +14,7 @@ export const claimGoLink = async (
   linkSuffix: string,
   formId: string,
   adminEmail: string,
-): Promise<unknown> => {
+): Promise<void> => {
   return ApiService.post(`${ADMIN_FORM_ENDPOINT}/${formId}/${GOGOV_ENDPOINT}`, {
     linkSuffix,
     adminEmail,

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -2,3 +2,9 @@ export const ERROR_QUERY_PARAM_KEY = 'error_type'
 
 // Payment errors namespace (100xxx)
 export const DISALLOW_CONNECT_NON_WHITELIST_STRIPE_ACCOUNT = '100001'
+
+// GoGov Bad Request error messages
+export const GO_VALIDATION_ERROR_MESSAGE =
+  'Validation error when claiming GoGov link'
+
+export const GO_ALREADY_EXIST_ERROR_MESSAGE = 'GoGov link already exists'

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -2980,8 +2980,7 @@ export const handleSetGoLinkSuffix: ControllerHandler<
           axios.post(
             `${goGovBaseUrl}/api/v1/admin/urls`,
             {
-              //longUrl: `${process.env.APP_URL}/${formId}`,
-              longUrl: 'https://staging.form.gov.sg/64ddae6917df8a001264f1a7',
+              longUrl: `${process.env.APP_URL}/${formId}`,
               shortUrl: linkSuffix,
               email: adminEmail,
             },
@@ -3005,7 +3004,7 @@ export const handleSetGoLinkSuffix: ControllerHandler<
       })
       // Step 3: After obtaining GoGov link, save it to the form
       .andThen(() => AdminFormService.setGoLinkSuffix(formId, linkSuffix))
-      .map((data) => res.status(StatusCodes.OK).json(data))
+      .map(() => res.sendStatus(StatusCodes.OK))
       .mapErr((error) => {
         logger.error({
           message: 'Error occurred when setting GoGov link suffix',

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -1,3 +1,7 @@
+import {
+  GO_ALREADY_EXIST_ERROR_MESSAGE,
+  GO_VALIDATION_ERROR_MESSAGE,
+} from '../../../../../shared/constants'
 import { ApplicationError } from '../../core/core.errors'
 
 export class InvalidFileTypeError extends ApplicationError {
@@ -38,8 +42,39 @@ export class PaymentChannelNotFoundError extends ApplicationError {
   }
 }
 
+// Family of GoGov Errors from GoGov Integration
 export class GoGovError extends ApplicationError {
   constructor(message = 'Error occurred when claiming GoGov link') {
+    super(message)
+  }
+}
+
+export class GoGovValidationError extends GoGovError {
+  constructor(message = GO_VALIDATION_ERROR_MESSAGE) {
+    super(message)
+  }
+}
+
+export class GoGovAlreadyExistError extends GoGovError {
+  constructor(message = GO_ALREADY_EXIST_ERROR_MESSAGE) {
+    super(message)
+  }
+}
+
+export class GoGovRequestLimitError extends GoGovError {
+  constructor(message = 'GoGov request limit exceeded') {
+    super(message)
+  }
+}
+
+export class GoGovBadGatewayError extends GoGovError {
+  constructor(message = 'GoGov request failed') {
+    super(message)
+  }
+}
+
+export class GoGovServerError extends GoGovError {
+  constructor(message = 'Unexpected error occured when claiming GoGov link') {
     super(message)
   }
 }

--- a/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -74,6 +74,7 @@ export class GoGovBadGatewayError extends GoGovError {
 }
 
 export class GoGovServerError extends GoGovError {
+  // Default error message will be shown if not AxiosError
   constructor(message = 'Unexpected error occured when claiming GoGov link') {
     super(message)
   }

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -563,14 +563,14 @@ export const mapGoGovErrors = (error: AxiosError): GoGovError => {
       // Short link already exists, which returns type=ShortUrlError
       // Or validation error, which does not contain type
       // Or if url is not https (like localhost), however, this should not happen as we prepend the app url in admin-form-controller
-      // TODO: Verify with GoGov team on response data shape
+      // TODO: Update the conditional when GoGov upgrades their return type shape
       return responseData.type
         ? new GoGovAlreadyExistError()
-        : responseData.message.includes(urlFormatError)
-        ? new GoGovServerError(
+        : !responseData.message.includes(urlFormatError)
+        ? new GoGovValidationError()
+        : new GoGovServerError(
             'GoGov server returned 400 for URL formatting error',
           )
-        : new GoGovValidationError()
     case StatusCodes.TOO_MANY_REQUESTS:
       return new GoGovRequestLimitError()
     // For gogov API this is equivalent to Request Failed

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -529,9 +529,10 @@ export const mapGoGovErrors = (error: AxiosError): GoGovError => {
 
   switch (error.response?.status) {
     case StatusCodes.BAD_REQUEST:
-      // There can be two types of Bad Request from GoGov
+      // There can be three types of Bad Request from GoGov
       // Short link already exists, which returns type=ShortUrlError
       // Or validation error, which does not contain type
+      // Or if url is not https (like localhost), however, this should not happen as we prepend the app url in admin-form-controller
       // TODO: Verify with GoGov team on response data shape
       return (error.response.data as GoGovReturnedData).type
         ? new GoGovAlreadyExistError()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-901

## Solution
<!-- How did you solve the problem? -->

Broke down the GoGov errors based on the discussion in the linear link and from #6455 

Additionally have also identified an edge case of `BAD_REQUEST` that should be handled as a 500 error. Wherein if there was a HTTPS link error, which means that our `process.env.APP_URL` is configured incorrectly.

Lastly, have checked with GoGov Team on error shapes, seems that there was an intention to expand the error type but it wasn't prioritised, will try and make the changes for them instead and then update our error handling in `admin-form.utils.ts`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->
Success
<img width="685" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/c4ae5299-45df-4f9f-b219-e4ccf0327123">


Short link taken
<img width="685" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/0cef90a4-737e-4556-8780-5cd3f7dd2589">

Validation error
<img width="685" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/0ece6f11-7c5f-4f37-a94f-2a719ea8678b">

Any other unexpected issues (429, 5xx)
<img width="685" alt="image" src="https://github.com/opengovsg/FormSG/assets/59867455/66d7b93a-9c89-4055-a6dd-76b3f6c303bc">



## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Try to create a GoGov link with an existing short link
- [ ] It should fail and return 400
- [ ] FE modal should show short link is taken
- [ ] Try to create a GoGov link with invalid characters like underscore or capital letters
- [ ] It should fail and return 400
- [ ] FE modal should show validation error
- [ ] Go to Param store and delete GoGov API key
- [ ] Try to create a GoGov link with a unique string
- [ ] It should fail and return 500
- [ ] FE modal should show an unexpected error
- [ ] Restore the API key

Regression
- [ ] Try to create a GoGov link with a unique string
- [ ] The link should be successfully created