### PR TITLE
fix: add check for childname when populating field value

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -246,6 +246,14 @@ const ChildrenBody = ({
     return allChildren.filter((name) => !temp.has(name))
   }, [myInfoChildrenBirthRecords, allChildren, allSelectedNames])
 
+  const childNameValues = useMemo(() => {
+    return [childName, ...namesNotSelected()].filter((name) => {
+      if (name === '' || name === undefined) {
+        return false
+      } else return true
+    })
+  }, [childName, namesNotSelected])
+
   const indexOfChild: number = useMemo(() => {
     return (
       myInfoChildrenBirthRecords?.[MyInfoChildAttributes.ChildName]?.indexOf(
@@ -263,20 +271,22 @@ const ChildrenBody = ({
       if (indexOfChild === undefined || indexOfChild < 0) {
         return ''
       }
+
+      // We use the childname to check if the parent has a child above 21.
+      // If the childname is an empty string, it represents a child above 21.
+      // As our definition of child in FormSG means child below 21, we want to
+      // return empty strings for other child attributes even if their value is populated by myinfo
+      // if there is no childname.
+      if (myInfoChildrenBirthRecords.childname?.[indexOfChild] === '') {
+        return ''
+      }
+
       const result = myInfoChildrenBirthRecords?.[attr]?.[indexOfChild]
       // Unknown basically means no result
       if (
         attr === MyInfoChildAttributes.ChildVaxxStatus &&
         result === MyInfoChildVaxxStatus.Unknown
       ) {
-        return ''
-      }
-      // We use the childname to indicate if there is a child below 21.
-      // If the childname is an empty string, it means there is no child below 21.
-      // As our definition of child in FormSG means child below 21, we want to
-      // return empty strings for other child attributes even if their value is populated by myinfo
-      // if there is no childname.
-      if (myInfoChildrenBirthRecords.childname?.[0] === '') {
         return ''
       }
       return result ?? ''
@@ -300,7 +310,7 @@ const ChildrenBody = ({
               {...selectRest}
               placeholder={"Select your child's name"}
               colorScheme={`theme-${colorTheme}`}
-              items={[childName, ...namesNotSelected()].filter((e) => e !== '')}
+              items={childNameValues}
               value={childName}
               isDisabled={isSubmitting}
               initialIsOpen={!!myInfoChildrenBirthRecords?.childname}

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -271,6 +271,14 @@ const ChildrenBody = ({
       ) {
         return ''
       }
+      // We use the childname to indicate if there is a child below 21.
+      // If the childname is an empty string, it means there is no child below 21.
+      // As our definition of child in FormSG means child below 21, we want to
+      // return empty strings for other child attributes even if their value is populated by myinfo
+      // if there is no childname.
+      if (myInfoChildrenBirthRecords.childname?.[0] === '') {
+        return ''
+      }
       return result ?? ''
     },
     [indexOfChild, myInfoChildrenBirthRecords],

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -22,11 +22,7 @@ import {
 } from '@chakra-ui/react'
 import simplur from 'simplur'
 
-import {
-  ChildrenCompoundFieldInputs,
-  ChildrenCompoundFieldSchema,
-  DATE_DISPLAY_FORMAT,
-} from '~shared/constants/dates'
+import { DATE_DISPLAY_FORMAT } from '~shared/constants/dates'
 import { MYINFO_ATTRIBUTE_MAP } from '~shared/constants/field/myinfo'
 import {
   FormColorTheme,
@@ -45,6 +41,10 @@ import { FormLabel } from '~components/FormControl/FormLabel/FormLabel'
 import { IconButton } from '~components/IconButton/IconButton'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
+import {
+  ChildrenCompoundFieldInputs,
+  ChildrenCompoundFieldSchema,
+} from '../types'
 
 export interface ChildrenCompoundFieldProps extends BaseFieldProps {
   schema: ChildrenCompoundFieldSchema

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -313,7 +313,7 @@ export const types: MyInfoFieldBlock[] = [
     verified: ['SG', 'PR', 'F'],
     source: 'Immigration & Checkpoints Authority / Health Promotion Board',
     description:
-      "The data of the form-filler's children. Vaccination status is verified by HPB. All other data in this field is verified by ICA.",
+      'The data of the form-filler’s children. Only data of children below 21 years old will be available. Vaccination status is verified by HPB. All other data is verified by ICA.',
     fieldType: BasicField.Children,
     previewValue: 'Child 1',
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
MyInfo returns the NRIC for children above the age of 21, and does not return any other field values. We want to define children as below 21 years old.

Closes FRM-1300

## Solution
<!-- How did you solve the problem? -->
- Update the copy in the children field details to reflect that child fields are for children below 21 years old
- Check if `childname` is present in the MyInfo records. If it is not, return an empty string for all other children myinfo field values. (Note: prefilling for MyInfo child fields is done in the frontend)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
![before](https://github.com/opengovsg/FormSG/assets/56983748/d11ab4bb-6c70-4857-928d-ae8d09a922c7)

**AFTER**:
![after](https://github.com/opengovsg/FormSG/assets/56983748/b618cb17-e23b-4f4e-b6d1-188cd736a703)

## Tests
<!-- What tests should be run to confirm functionality? -->
Regression test
- [x] On a MyInfo child form with the property `Birth Certification Number`, log in as a user with at least 1 child below the age of 21. 
- [x] Select that child, and submit the form.
- [x] The form should be submitted successfully
- [x] The form response should submit that single child

Unfortunately we're not able to test this on staging as the existing Mockpass profiles do not have children above 21yo. 
Hence, **please perform this test once it has been deployed to production**:
- [ ] On a MyInfo child form with the property `Birth Certification Number`, log in as a user with at least 1 child above the age of 21. 
- [ ] Click around the MyInfo child fields. Nothing should appear in the Birth Cert Number field.
