### PR TITLE
fix: remove focus from myinfo child field when form is opened

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -75,12 +75,11 @@ export const ChildrenCompoundField = ({
     name: schema._id,
   })
 
-  const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
-    {
+  const { fields, append, update, remove } =
+    useFieldArray<ChildrenCompoundFieldInputs>({
       control: formContext.control,
       name: `${schema._id}.child`,
-    },
-  )
+    })
 
   useEffect(() => {
     if (schema.childrenSubFields) {
@@ -94,9 +93,9 @@ export const ChildrenCompoundField = ({
   // Initialize with a single child section
   useEffect(() => {
     if (!fields || !fields.length) {
-      append([''])
+      update(0, '')
     }
-  }, [fields, append])
+  }, [fields, update])
 
   const ariaChildrenDescription = useMemo(() => {
     let description = simplur`This is a children field. There [is|are] ${fields.length} child[|ren].`
@@ -295,7 +294,8 @@ const ChildrenBody = ({
               items={[childName, ...namesNotSelected()].filter((e) => e !== '')}
               value={childName}
               isDisabled={isSubmitting}
-              initialIsOpen={!!myInfoChildrenBirthRecords?.childname}
+              // initialIsOpen={false}
+              // initialIsOpen={!!myInfoChildrenBirthRecords?.childname}
               onChange={(name) => {
                 // This is bad practice but we have no choice because our
                 // custom Select doesn't forward the event.

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -75,11 +75,12 @@ export const ChildrenCompoundField = ({
     name: schema._id,
   })
 
-  const { fields, append, update, remove } =
-    useFieldArray<ChildrenCompoundFieldInputs>({
+  const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
+    {
       control: formContext.control,
       name: `${schema._id}.child`,
-    })
+    },
+  )
 
   useEffect(() => {
     if (schema.childrenSubFields) {
@@ -93,9 +94,9 @@ export const ChildrenCompoundField = ({
   // Initialize with a single child section
   useEffect(() => {
     if (!fields || !fields.length) {
-      update(0, '')
+      append([''], { shouldFocus: false })
     }
-  }, [fields, update])
+  }, [fields, append])
 
   const ariaChildrenDescription = useMemo(() => {
     let description = simplur`This is a children field. There [is|are] ${fields.length} child[|ren].`

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -295,8 +295,6 @@ const ChildrenBody = ({
               items={[childName, ...namesNotSelected()].filter((e) => e !== '')}
               value={childName}
               isDisabled={isSubmitting}
-              // initialIsOpen={false}
-              // initialIsOpen={!!myInfoChildrenBirthRecords?.childname}
               onChange={(name) => {
                 // This is bad practice but we have no choice because our
                 // custom Select doesn't forward the event.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When a form is opened, the focus immediately goes to the MyInfo child field. The focus should not be on any form field.

Closes FRM-1323

## Solution
<!-- How did you solve the problem? -->
To initialise the MyInfo child field, specify the focusOption `{shouldFocus: false}` in `append`. ([Docs here](https://react-hook-form.com/docs/usefieldarray)).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/56983748/7b6b2811-6319-4638-a630-e76583f0fcfe



**AFTER**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/56983748/c57ced59-cb46-40d8-926b-7d28a5cf792c



## Tests
<!-- What tests should be run to confirm functionality? -->
1. MyInfo child field - 1 child only
- [ ] Open up a MyInfo child form with 1 child field
- [ ] The focus should not be on the child field, unless the field is clicked
- [ ] Select a child
- [ ] Submit the form
- [ ] Check that the email response contains the child's info

2. MyInfo child field - 2 children only (same test as above)
- [ ] Open up a MyInfo child form with 2 children fields
- [ ] The focus should not be on the child field, unless the field is clicked
- [ ] Select a child
- [ ] Submit the form
- [ ] Check that the email response contains the children's info

3. MyInfo child field - 1 child only with option to add children
- [ ] Enable the option "Allow respondent to add multiple children" on a MyInfo child form
- [ ] Open up a MyInfo child form with 1 child field
- [ ] The focus should not be on the child field, unless the field is clicked
- [ ] Select a child
- [ ] Add another child
- [ ] Select the 2nd child
- [ ] Submit the form
- [ ] Check that the email response contains the children's info