### PR TITLE
fix(payments): payments response page frontend ui issues

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -5,7 +5,7 @@ import { keyBy } from 'lodash'
 
 import { PaymentStatus, SubmissionPaymentDto } from '~shared/types'
 
-import { Tag } from '~components/Tag'
+import Badge from '~components/Badge'
 import Tooltip from '~components/Tooltip'
 
 import { getPaymentDataView } from '../common/utils/getPaymentDataView'
@@ -89,7 +89,7 @@ const PayoutDataHeader = ({
   colorScheme,
   rightIcon,
 }: PaymentDataHeaderProps) => (
-  <Flex gap="1rem">
+  <Flex gap="1rem" align="center">
     <Flex>
       <Text textStyle="h2" as="h2" color="primary.500">
         {name}
@@ -105,10 +105,15 @@ const PayoutDataHeader = ({
         </Flex>
       </Tooltip>
     </Flex>
-    <Tag colorScheme={colorScheme} pointerEvents="none">
-      <Text textStyle="caption-1">{label}</Text>
+    <Badge
+      colorScheme={colorScheme}
+      display="flex"
+      variant="subtle"
+      alignItems="center"
+    >
+      {label}
       {rightIcon && <Icon as={rightIcon} ml="0.25rem" />}
-    </Tag>
+    </Badge>
   </Flex>
 )
 
@@ -118,14 +123,19 @@ const PaymentDataHeader = ({
   colorScheme,
   rightIcon,
 }: PaymentDataHeaderProps) => (
-  <Flex gap="1rem">
+  <Flex gap="1rem" align="center">
     <Text textStyle="h2" as="h2" color="primary.500">
       {name}
     </Text>
-    <Tag colorScheme={colorScheme} pointerEvents="none">
-      <Text textStyle="caption-1">{label}</Text>
+    <Badge
+      colorScheme={colorScheme}
+      display="flex"
+      variant="subtle"
+      alignItems="center"
+    >
+      {label}
       {rightIcon && <Icon as={rightIcon} ml="0.25rem" />}
-    </Tag>
+    </Badge>
   </Flex>
 )
 

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -101,7 +101,7 @@ const PayoutDataHeader = ({
         Depending on payment method, payouts happen 1 - 3 working days after a respondent makes payment."
       >
         <Flex justify="center" align="center">
-          <Icon as={BiInfoCircle} fontSize="1.5rem" ml="0.5rem" />
+          <Icon as={BiInfoCircle} fontSize="1.25rem" ml="0.5rem" />
         </Flex>
       </Tooltip>
     </Flex>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -99,8 +99,8 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       }
       return payments.payoutDate
     },
-    minWidth: 150,
-    width: 150,
+    minWidth: 200,
+    width: 200,
     disableResizing: true,
   },
 ]

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -24,21 +24,21 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: '#',
     accessor: 'number',
-    minWidth: 20, // minWidth is only used as a limit for resizing
-    width: 20, // width is used for both the flex-basis and flex-grow
+    minWidth: 80, // minWidth is only used as a limit for resizing
+    width: 80, // width is used for both the flex-basis and flex-grow
     maxWidth: 100, // maxWidth is only used as a limit for resizing
   },
   {
     Header: 'Response ID',
     accessor: 'refNo',
-    minWidth: 100,
-    width: 100,
+    minWidth: 300,
+    width: 300,
     maxWidth: 240, // maxWidth is only used as a limit for resizing
   },
   {
     Header: 'Timestamp',
     accessor: 'submissionTime',
-    minWidth: 200,
+    minWidth: 250,
     width: 250,
     disableResizing: true,
   },
@@ -50,10 +50,10 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       if (!payments?.email) {
         return ''
       }
-      return payments.email
+      return payments.email + payments.email
     },
-    minWidth: 50,
-    width: 150,
+    minWidth: 250,
+    width: 250,
   },
 
   {
@@ -64,8 +64,8 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       }
       return `${centsToDollars(payments.paymentAmt)}`
     },
-    minWidth: 50,
-    width: 75,
+    minWidth: 150,
+    width: 150,
   },
 
   {
@@ -80,15 +80,15 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
 
       return `${centsToDollars(payments.transactionFee)}`
     },
-    minWidth: 50,
-    width: 75,
+    minWidth: 150,
+    width: 150,
   },
 
   {
     Header: 'Net Amount (S$)', //  (amt they receive in bank)
     accessor: ({ payments }) => getNetAmount(payments),
-    minWidth: 50,
-    width: 75,
+    minWidth: 150,
+    width: 150,
   },
 
   {
@@ -99,8 +99,9 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       }
       return payments.payoutDate
     },
-    minWidth: 50,
+    minWidth: 150,
     width: 150,
+    disableResizing: true,
   },
 ]
 
@@ -184,7 +185,6 @@ export const ResponsesTable = () => {
       as="div"
       variant="solid"
       colorScheme="secondary"
-      width={isPaymentsForm ? '100vw' : undefined}
       {...getTableProps()}
     >
       <Thead as="div" pos="sticky" top={0}>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -50,7 +50,7 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       if (!payments?.email) {
         return ''
       }
-      return payments.email + payments.email
+      return payments.email
     },
     minWidth: 250,
     width: 250,

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -55,7 +55,7 @@ export const getPaymentDataView = (
     { key: 'email', name: 'Payer', value: payment.email },
     {
       key: 'receiptUrl',
-      name: 'Invoice',
+      name: 'Proof of Payment',
       value: getFullInvoiceDownloadUrl(hostOrigin, formId, payment.id),
     },
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1316, closes FRM-1313, closes FRM-1315, closes FRM-1314

## Solution
<!-- How did you solve the problem? -->

1. Resized tooltip icon to `1.25rem` (20px)
2. Increased column minWidth to width values to prevent column shrinkage
3. Added `disableResizing: true,` to the last element as it should not be resized as the UX will be weird
4. Updated proof of payment label for individual response + csv response
5. Swapped `<Tag />` with `<Badge />`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots


| Subject | Before | After |
|--------|--------|--------|
| Tooltip | <img width="460" alt="Screenshot 2023-09-18 at 8 08 59 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/50aaa01e-5f47-440b-8e0b-1f157077d690"> | <img width="476" alt="Screenshot 2023-09-18 at 8 08 53 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/cb003f7d-2b35-46bc-8cfd-9c2df69cd93f"> |
| Proof of Payment Label | <img width="281" alt="Screenshot 2023-09-18 at 8 10 06 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/a9d27751-ce8f-4f38-9ce9-c10181c93521"> |  <img width="295" alt="Screenshot 2023-09-18 at 8 10 11 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/9a417406-9a3d-4220-bda9-2bb446e6e83e"> |
| Proof of Payment Label (`.csv`) | <img width="338" alt="Screenshot 2023-09-18 at 8 11 05 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/e00a5858-a32a-4e96-8c51-c9452f0d8f65"> | <img width="416" alt="Screenshot 2023-09-18 at 8 11 00 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/35cae480-819d-4fe4-bf2f-f0bf12c2de26"> |
| Table Resize | <img width="1149" alt="Screenshot 2023-09-18 at 8 13 16 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/6780a2d2-3588-41b2-bda6-aefc209328e6"> | <img width="1256" alt="Screenshot 2023-09-18 at 8 12 55 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/d4e745e1-677a-4d4d-866d-7c6008ca6f14">  | 
| Table Resize (small screen) | <img width="485" alt="Screenshot 2023-09-18 at 8 16 22 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/2abcab4c-59c9-4a6f-89d5-43539787474b"> |<img width="482" alt="Screenshot 2023-09-18 at 8 16 31 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/6f2cff3d-6f2a-4edf-9f3e-ce10ff998a28">|
| Badge Component | <img width="439" alt="Screenshot 2023-09-19 at 11 15 48 AM" src="https://github.com/opengovsg/FormSG/assets/12391617/7de07052-837a-44cc-acaa-e56c257fa08e">| <img width="474" alt="Screenshot 2023-09-19 at 11 14 41 AM" src="https://github.com/opengovsg/FormSG/assets/12391617/db93a99a-f656-41f5-b858-82f305032e4a">|


## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
Admin CSV Header change
- [x] Ensure that download csv of a payment form should still have proof of payment populated in the results
- [x] Ensure that header should now be label `proof of payment` instead of `invoice`

**New features**
Admin Response Table (with Payments)
- [x] Find a form with multiple completed payments
- [x] Ensure that `#` column can sufficiently render at least 4 digits without spilling to the next line. (edit HTML text to simulate a large number)
- [x] Ensure that the table scrolls when the screen width is smaller than ~600px
- [x] ensure payout date does not wrap (edit html: Tue, 19 Sep 2023)

Admin Response Table (without Payments)
- [x] Find a form without payments
- [x] Ensure that `#` column can sufficiently render at least 4 digits without spilling to the next line. (edit HTML text to simulate a large number)
- [x] Ensure that the table scrolls when the screen width is smaller than ~600px

