### PR TITLE
fix: display error message when myinfo child fields are not filled in

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import {
   FieldArrayWithId,
+  FieldError,
   useFieldArray,
   UseFieldArrayRemove,
   useFormContext,
@@ -20,6 +21,7 @@ import {
   VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
+import { get } from 'lodash'
 import simplur from 'simplur'
 
 import { DATE_DISPLAY_FORMAT } from '~shared/constants/dates'
@@ -37,6 +39,7 @@ import { createChildrenValidationRules } from '~utils/fieldValidation'
 import { Button } from '~components/Button/Button'
 import { DatePicker } from '~components/DatePicker'
 import { SingleSelect } from '~components/Dropdown/SingleSelect'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import { FormLabel } from '~components/FormControl/FormLabel/FormLabel'
 import { IconButton } from '~components/IconButton/IconButton'
 
@@ -71,9 +74,12 @@ export const ChildrenCompoundField = ({
   )
 
   const formContext = useFormContext<ChildrenCompoundFieldInputs>()
-  const { isSubmitting } = useFormState<ChildrenCompoundFieldInputs>({
+  const { isSubmitting, errors } = useFormState<ChildrenCompoundFieldInputs>({
     name: schema._id,
   })
+  const error: FieldError[][] | undefined =
+    get(errors, schema._id)?.child ?? undefined
+  const childError: FieldError[] | undefined = error ? error[0] : undefined
 
   const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
     {
@@ -142,6 +148,7 @@ export const ChildrenCompoundField = ({
                   myInfoChildrenBirthRecords,
                   isSubmitting,
                   formContext,
+                  error: childError,
                 }}
               />
             ))}
@@ -188,6 +195,7 @@ interface ChildrenBodyProps {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formContext: UseFormReturn<ChildrenCompoundFieldInputs, any>
+  error: FieldError[] | undefined
 }
 
 const ChildrenBody = ({
@@ -200,8 +208,12 @@ const ChildrenBody = ({
   myInfoChildrenBirthRecords,
   isSubmitting,
   formContext,
+  error,
 }: ChildrenBodyProps): JSX.Element => {
   const { register, getValues, setValue, watch } = formContext
+
+  // Child name error will always be the first element of the error array
+  const childNameError = error ? error[0] : undefined
 
   const childNamePath = useMemo(
     () => `${schema._id}.child.${currChildBodyIdx}.0`,
@@ -305,20 +317,23 @@ const ChildrenBody = ({
         <FormLabel gridArea="formlabel">Child</FormLabel>
         <Flex align="stretch" alignItems="stretch" justify="space-between">
           <Box flexGrow={10}>
-            <SingleSelect
-              isRequired
-              {...selectRest}
-              placeholder={"Select your child's name"}
-              colorScheme={`theme-${colorTheme}`}
-              items={childNameValues}
-              value={childName}
-              isDisabled={isSubmitting}
-              onChange={(name) => {
-                // This is bad practice but we have no choice because our
-                // custom Select doesn't forward the event.
-                setValue(childNamePath, name)
-              }}
-            />
+            <FormControl key={field.id} isRequired isInvalid={!!childNameError}>
+              <SingleSelect
+                isRequired
+                {...selectRest}
+                placeholder={"Select your child's name"}
+                colorScheme={`theme-${colorTheme}`}
+                items={childNameValues}
+                value={childName}
+                isDisabled={isSubmitting}
+                onChange={(name) => {
+                  // This is bad practice but we have no choice because our
+                  // custom Select doesn't forward the event.
+                  setValue(childNamePath, name)
+                }}
+              />
+              <FormErrorMessage>{childNameError?.message}</FormErrorMessage>
+            </FormControl>
           </Box>
           <IconButton
             variant="clear"
@@ -343,6 +358,7 @@ const ChildrenBody = ({
           const key = `${field.id}+${index}`
           const fieldPath = `${schema._id}.child.${currChildBodyIdx}.${index}`
           const myInfoValue = getChildAttr(subField)
+          const childrenSubFieldError = error ? error[index] : undefined
 
           // We want to format the date by converting the value from a myinfo format to
           // a format used by our date fields
@@ -362,7 +378,12 @@ const ChildrenBody = ({
           switch (subField) {
             case MyInfoChildAttributes.ChildBirthCertNo: {
               return (
-                <FormControl key={key} isDisabled={isDisabled} isRequired>
+                <FormControl
+                  key={key}
+                  isDisabled={isDisabled}
+                  isRequired
+                  isInvalid={!!childrenSubFieldError}
+                >
                   <FormLabel useMarkdownForDescription gridArea="formlabel">
                     {MYINFO_ATTRIBUTE_MAP[subField].description}
                   </FormLabel>
@@ -370,6 +391,9 @@ const ChildrenBody = ({
                     {...register(fieldPath, validationRules)}
                     value={value}
                   />
+                  <FormErrorMessage>
+                    {childrenSubFieldError?.message}
+                  </FormErrorMessage>
                 </FormControl>
               )
             }
@@ -378,7 +402,12 @@ const ChildrenBody = ({
             case MyInfoChildAttributes.ChildRace:
             case MyInfoChildAttributes.ChildSecondaryRace: {
               return (
-                <FormControl key={key} isDisabled={isDisabled} isRequired>
+                <FormControl
+                  key={key}
+                  isDisabled={isDisabled}
+                  isRequired
+                  isInvalid={!!childrenSubFieldError}
+                >
                   <FormLabel useMarkdownForDescription gridArea="formlabel">
                     {MYINFO_ATTRIBUTE_MAP[subField].description}
                   </FormLabel>
@@ -394,13 +423,21 @@ const ChildrenBody = ({
                       setValue(fieldPath, option)
                     }
                   />
+                  <FormErrorMessage>
+                    {childrenSubFieldError?.message}
+                  </FormErrorMessage>
                 </FormControl>
               )
             }
             case MyInfoChildAttributes.ChildDateOfBirth: {
               const { onChange, ...rest } = register(fieldPath, validationRules)
               return (
-                <FormControl key={key} isDisabled={isDisabled} isRequired>
+                <FormControl
+                  key={key}
+                  isDisabled={isDisabled}
+                  isRequired
+                  isInvalid={!!childrenSubFieldError}
+                >
                   <FormLabel useMarkdownForDescription gridArea="formlabel">
                     {MYINFO_ATTRIBUTE_MAP[subField].description}
                   </FormLabel>
@@ -413,6 +450,9 @@ const ChildrenBody = ({
                     }}
                     colorScheme={`theme-${colorTheme}`}
                   />
+                  <FormErrorMessage>
+                    {childrenSubFieldError?.message}
+                  </FormErrorMessage>
                 </FormControl>
               )
             }

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -77,8 +77,7 @@ export const ChildrenCompoundField = ({
   const { isSubmitting, errors } = useFormState<ChildrenCompoundFieldInputs>({
     name: schema._id,
   })
-  const error: FieldError[][] | undefined =
-    get(errors, schema._id)?.child ?? undefined
+  const error: FieldError[][] | undefined = get(errors, schema._id)?.child
   const childError: FieldError[] | undefined = error ? error[0] : undefined
 
   const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
@@ -329,7 +328,7 @@ const ChildrenBody = ({
                 onChange={(name) => {
                   // This is bad practice but we have no choice because our
                   // custom Select doesn't forward the event.
-                  setValue(childNamePath, name)
+                  setValue(childNamePath, name, { shouldValidate: true })
                 }}
               />
               <FormErrorMessage>{childNameError?.message}</FormErrorMessage>
@@ -372,7 +371,7 @@ const ChildrenBody = ({
             // We need to do this as the underlying data is not updated
             // by the field's value, but rather by onChange, which we did
             // not trigger via prefill.
-            setValue(fieldPath, myInfoFormattedValue)
+            setValue(fieldPath, myInfoFormattedValue, { shouldValidate: true })
           }
           const isDisabled = isSubmitting || !!myInfoValue
           switch (subField) {
@@ -420,7 +419,7 @@ const ChildrenBody = ({
                     onChange={(option) =>
                       // This is bad practice but we have no choice because our
                       // custom Select doesn't forward the event.
-                      setValue(fieldPath, option)
+                      setValue(fieldPath, option, { shouldValidate: true })
                     }
                   />
                   <FormErrorMessage>
@@ -446,7 +445,7 @@ const ChildrenBody = ({
                     displayFormat={DATE_DISPLAY_FORMAT}
                     inputValue={value}
                     onInputValueChange={(date) => {
-                      setValue(fieldPath, date)
+                      setValue(fieldPath, date, { shouldValidate: true })
                     }}
                     colorScheme={`theme-${colorTheme}`}
                   />

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -211,9 +211,6 @@ const ChildrenBody = ({
 }: ChildrenBodyProps): JSX.Element => {
   const { register, getValues, setValue, watch } = formContext
 
-  // Child name error will always be the first element of the error array
-  // const childNameError = error ? error[0] : undefined
-
   const childNamePath = useMemo(
     () => `${schema._id}.child.${currChildBodyIdx}.0`,
     [schema._id, currChildBodyIdx],

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -231,12 +231,18 @@ const ChildrenBody = ({
     onChange: selectOnChange,
     ...selectRest
   } = register(childNamePath, validationRules)
-  console.log('childNameRegisterRef: ', childNameRegisterRef)
+  console.log(
+    'childNameRegisterRef: ',
+    error?.map((e) => e.ref?.id),
+  )
 
   const childNameRef = useRef<HTMLInputElement | null>(null)
-  console.log('childNameRef', childNameRef.current)
+  console.log('>>>>>>>>>33333')
+  console.log('childNameRef', childNameRef.current?.id)
   const childNameError = error
-    ? error.filter((e) => e.ref === childNameRef.current)
+    ? error.find(
+        (e) => (e.ref as HTMLInputElement)?.id === childNameRef.current?.id,
+      )
     : undefined
 
   const childName = watch(childNamePath) as unknown as string

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -78,9 +78,7 @@ export const ChildrenCompoundField = ({
     name: schema._id,
   })
   const error: FieldError[][] | undefined = get(errors, schema._id)?.child
-  console.log('error: ', error)
   const childError: FieldError[] | undefined = error ? error[0] : undefined
-  console.log('childError: ', childError)
 
   const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
     {
@@ -231,17 +229,12 @@ const ChildrenBody = ({
     onChange: selectOnChange,
     ...selectRest
   } = register(childNamePath, validationRules)
-  console.log(
-    'childNameRegisterRef: ',
-    error?.map((e) => e.ref?.id),
-  )
 
   const childNameRef = useRef<HTMLInputElement | null>(null)
-  console.log('>>>>>>>>>33333')
-  console.log('childNameRef', childNameRef.current?.id)
+
   const childNameError = error
     ? error.find(
-        (e) => (e.ref as HTMLInputElement)?.id === childNameRef.current?.id,
+        (e) => (e?.ref as HTMLInputElement)?.id === childNameRef.current?.id,
       )
     : undefined
 

--- a/frontend/src/templates/Field/types.ts
+++ b/frontend/src/templates/Field/types.ts
@@ -136,7 +136,7 @@ export type ChildrenCompoundFieldValues = {
   // Each subarray represents one child value
   // e.g.
   // child : [['NAME', 'T12345678Z', 'VACCINATED'], ... ]
-  // cildFields: [name, bc number, vaxx status]
+  // childFields: [name, bc number, vaxx status]
   child: string[][]
   // Array of attribute names
   childFields: MyInfoChildAttributes[]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Form fillers are not prompted to fill in the myinfo child fields when they are left blank. 
Ideal behaviour (same across all form fields): an error message prompts the user to fill in blanks for required fields.

Closes FRM-1206

## Solution
<!-- How did you solve the problem? -->
- Add `isInvalid` state and `FormErrorMessage` to each child subfield
- To track the error message upon input change, add `{ shouldValidate: true }` to `setValue` ([docs](https://react-hook-form.com/docs/useform/setvalue))

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:

https://github.com/opengovsg/FormSG/assets/56983748/4b957538-e674-46a6-8a17-2c6712fa1203


**AFTER**:

https://github.com/opengovsg/FormSG/assets/56983748/b1d7a2b4-ef43-46d2-95b6-21ab0ef94b35


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On a MyInfo form, add a child field. Choose to collect **all** types of child data
- [ ] Open up the form
- [ ] Sign in as a user that has a child (Staging NRICs [here](https://www.notion.so/Staging-MyInfo-Children-Fields-Testing-Packet-54587512c140404c91a0dde54becb277))
- [ ] Submit the form without populating any child fields (do not select a child)
- [ ] An error message should appear for each MyInfo child field
- [ ] Select a child and populate any myinfo child fields are still blank
- [ ] The error messages should disappear once the fields are populated
- [ ] Submit the form
- [ ] The form response should reflect the child's information
