### PR TITLE
fix: payment modal header overlaps

### DIFF
--- a/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
+++ b/frontend/src/features/public-form/components/DuplicatePaymentModal/DuplicatePaymentModal.tsx
@@ -50,7 +50,9 @@ export const DuplicatePaymentModal = ({
         <ModalOverlay />
         <ModalContent>
           <ModalCloseButton />
-          <ModalHeader pb={'2rem'}>Proceed to pay again?</ModalHeader>
+          <ModalHeader pb={'2rem'} w="90%">
+            Proceed to pay again?
+          </ModalHeader>
           <ModalBody flexGrow={0}>
             <Stack>
               <Text>

--- a/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentModal/FormPaymentModal.tsx
@@ -40,7 +40,9 @@ export const FormPaymentModal = ({
         <ModalOverlay />
         <ModalContent>
           <ModalCloseButton />
-          <ModalHeader pb={'2rem'}>You are about to make payment</ModalHeader>
+          <ModalHeader pb={'2rem'} w="90%">
+            You are about to make payment
+          </ModalHeader>
           <ModalBody flexGrow={0}>
             Please ensure that your form information is accurate. You will not
             be able to edit your form after you proceed.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Problem identified for `DuplicatePayModal` and `FormPaymentModal` mobile mode. Where the modal header will overlap with the modal close button

## Solution
<!-- How did you solve the problem? -->

Reduce width size of modal header to prevent overlaps

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Duplicate Payment Modal (mobile)
    - [ ] Ensure header does not overlap
    - [ ] Ensure modal can be closed
    - [ ] Ensure modal can be proceeded 
- [ ] Form Payment Modal (mobile)
    - [ ] Ensure header does not overlap
    - [ ] Ensure modal can be closed
    - [ ] Ensure modal can be proceeded
