### PR TITLE
fix: redirect to frontend app after myinfo log in (for local dev environment)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - DB_HOST=mongodb://database:27017/formsg
       - APP_NAME=FormSG
       - APP_URL=http://localhost:5001
+      - FE_APP_URL=http://localhost:3000
       - ATTACHMENT_S3_BUCKET=local-attachment-bucket
       - IMAGE_S3_BUCKET=local-image-bucket
       - LOGO_S3_BUCKET=local-logo-bucket

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -150,6 +150,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 'https://form.gov.sg',
       env: 'APP_URL',
     },
+    feAppUrl: {
+      doc: 'For local dev use only - frontend app url',
+      format: 'url',
+      default: 'https://form.gov.sg',
+      env: 'FE_APP_URL',
+    },
     keywords: {
       doc: 'Application keywords in meta tag',
       format: String,

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -1,6 +1,8 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 
+import { Environment } from '../../../types'
+import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
@@ -139,11 +141,17 @@ export const loginToMyInfo: ControllerHandler<
   }
   const { formId, encodedQuery } = parseStateResult.value
 
-  let redirectDestination = `/${formId}`
+  // For local dev, we need to specify the frontend app URL as this is different from the backend's app URL
+  const redirectDestinationRaw =
+    process.env.NODE_ENV === Environment.Dev
+      ? `${config.app.feAppUrl}/${formId}`
+      : `/${formId}`
+
+  let redirectDestination = redirectDestinationRaw
 
   if (encodedQuery) {
     try {
-      redirectDestination = `/${formId}?${Buffer.from(
+      redirectDestination = `${redirectDestinationRaw}?${Buffer.from(
         encodedQuery,
         'base64',
       ).toString('utf8')}`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -16,6 +16,7 @@ export type AppConfig = {
   title: string
   description: string
   appUrl: string
+  feAppUrl: string
   keywords: string
   images: string[]
   twitterImage: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

**On local dev only**: After logging in on a myinfo form, the user gets redirected to `localhost:5001` (our backend server) instead of `localhost:3000` (our frontend server). This makes it difficult to debug errors on the frontend.

## Solution
<!-- How did you solve the problem? -->
When creating the redirect URL from myinfo back to FormSG, check if it's a `development` environment. If yes, use an absolute path with the frontend app URL instead of a relative path.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Staging/Prod
- [ ] Log into a MyInfo form
- [ ] Upon logging in successfully, you should be redirected back to FormSG

Local dev
- [ ] Log into a MyInfo form
- [ ] Upon logging in successfully, you should be redirected back to FormSG on `localhost:3000`

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `FE_APP_URL` : Frontend application URL (for local development use only)
