### PR TITLE
fix: rm growthbook legacy streaming prop

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -77,7 +77,7 @@ export const AppRouter = (): JSX.Element => {
   useEffect(() => {
     if (growthbook) {
       // Load features from the GrowthBook API
-      growthbook.loadFeatures({ autoRefresh: true })
+      growthbook.loadFeatures()
     }
   }, [growthbook])
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`autoRefresh` is legacy (screenshot below) and there is background sync on by default according to the [documentation](https://docs.growthbook.io/lib/react#streaming-updates).

<img width="672" alt="Screenshot 2023-09-22 at 4 02 51 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/2c7d885b-e108-4a69-8325-ec9d10546657">

## Solution
<!-- How did you solve the problem? -->

Remove `autoRefresh` setting in `growthbook.loadFeatures`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

Before tests: Make sure that growthbook is connected.

Regression tests:
- [ ] Create a storage submission form. 
- [ ] Set the `encryption-boundary-shift` flag on growthbook to on.
- [ ] Make a submission on the storage mode form. This should be made to the `/submissions/storage` endpoint.
- [ ] Change the `encryption-boundary-shift` flag on growthbook to off.
- [ ] Make a submission on the storage mode form. This should be made to the `/submissions/encrypt` endpoint.
