### PR TITLE
feat: add index to myinfo child email response

### DIFF
--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -318,6 +318,16 @@ export const types: MyInfoFieldBlock[] = [
     previewValue: 'Child 1',
   },
   {
+    name: MyInfoAttribute.ChildName,
+    value: "Child's name",
+    category: 'children',
+    verified: ['SG', 'PR', 'F'],
+    source: 'Immigration & Checkpoints Authority / Health Promotion Board',
+    description: 'Name',
+    fieldType: BasicField.Children,
+    previewValue: 'PHUA CHU KING',
+  },
+  {
     name: MyInfoAttribute.ChildBirthCertNo,
     value: "Child's birth certificte number",
     category: 'children',

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -23,9 +23,9 @@ export interface IMyInfoRedirectURLArgs {
 // Field ID or a special key for a Child
 export type MyInfoKey = string | MyInfoChildKey
 
-// Field type, field ID, child attribute type, child name
+// Field type, field ID, child attribute type, child index, child name
 export type MyInfoChildKey =
-  `${MyInfoAttribute.ChildrenBirthRecords}.${string}.${MyInfoChildAttributes}.${string}`
+  `${MyInfoAttribute.ChildrenBirthRecords}.${string}.${MyInfoChildAttributes}.${number}.${string}`
 
 export type MyInfoHashPromises = Partial<
   Record<MyInfoAttribute | MyInfoChildKey, Promise<string>>

--- a/src/app/modules/myinfo/myinfo.types.ts
+++ b/src/app/modules/myinfo/myinfo.types.ts
@@ -23,9 +23,9 @@ export interface IMyInfoRedirectURLArgs {
 // Field ID or a special key for a Child
 export type MyInfoKey = string | MyInfoChildKey
 
-// Field type, field ID, child attribute type, child index, child name
+// Field type, field ID, child attribute type, child name
 export type MyInfoChildKey =
-  `${MyInfoAttribute.ChildrenBirthRecords}.${string}.${MyInfoChildAttributes}.${number}.${string}`
+  `${MyInfoAttribute.ChildrenBirthRecords}.${string}.${MyInfoChildAttributes}.${string}`
 
 export type MyInfoHashPromises = Partial<
   Record<MyInfoAttribute | MyInfoChildKey, Promise<string>>

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -114,7 +114,7 @@ function hashChildrenFieldValues(
         myInfoFormattedValue = formatMyinfoDate(value)
       }
       readOnlyHashPromises[
-        getMyInfoChildHashKey(field._id, subField, childIdx, childName)
+        getMyInfoChildHashKey(field._id, subField, childName)
       ] = bcrypt.hash(myInfoFormattedValue, HASH_SALT_ROUNDS)
     })
   })
@@ -481,16 +481,14 @@ export const getMyInfoAttr = (
  * Helper function to get a MyInfo child's hash key inside an IHashes.
  *
  * @param fieldId The ID of the field the Child response belongs to.
- * @param childIdx The nth child to look for.
  * @returns An IHashes-compatible key.
  */
 export const getMyInfoChildHashKey = (
   fieldId: string,
   childAttr: MyInfoChildAttributes,
-  childIdx: number,
   childName: string,
 ): MyInfoChildKey => {
-  return `${MyInfoAttribute.ChildrenBirthRecords}.${fieldId}.${childAttr}.${childIdx}.${childName}`
+  return `${MyInfoAttribute.ChildrenBirthRecords}.${fieldId}.${childAttr}.${childName}`
 }
 
 /**
@@ -514,7 +512,7 @@ export const handleMyInfoChildHashResponse = (
   if (!subFields) {
     return
   }
-  childField.answerArray.forEach((childAnswer, childIndex) => {
+  childField.answerArray.forEach((childAnswer) => {
     // Name should be first field for child answers
     const childName = childAnswer[0]
     // Validate each answer (child)
@@ -522,7 +520,6 @@ export const handleMyInfoChildHashResponse = (
       const key = getMyInfoChildHashKey(
         field._id as string,
         subFields[subFieldIndex],
-        childIndex,
         childName,
       )
       const hash = hashes[key]

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -114,7 +114,7 @@ function hashChildrenFieldValues(
         myInfoFormattedValue = formatMyinfoDate(value)
       }
       readOnlyHashPromises[
-        getMyInfoChildHashKey(field._id, subField, childName)
+        getMyInfoChildHashKey(field._id, subField, childIdx, childName)
       ] = bcrypt.hash(myInfoFormattedValue, HASH_SALT_ROUNDS)
     })
   })
@@ -486,9 +486,10 @@ export const getMyInfoAttr = (
 export const getMyInfoChildHashKey = (
   fieldId: string,
   childAttr: MyInfoChildAttributes,
+  childIdx: number,
   childName: string,
 ): MyInfoChildKey => {
-  return `${MyInfoAttribute.ChildrenBirthRecords}.${fieldId}.${childAttr}.${childName}`
+  return `${MyInfoAttribute.ChildrenBirthRecords}.${fieldId}.${childAttr}.${childIdx}.${childName}`
 }
 
 /**
@@ -512,7 +513,7 @@ export const handleMyInfoChildHashResponse = (
   if (!subFields) {
     return
   }
-  childField.answerArray.forEach((childAnswer) => {
+  childField.answerArray.forEach((childAnswer, childIndex) => {
     // Name should be first field for child answers
     const childName = childAnswer[0]
     // Validate each answer (child)
@@ -520,6 +521,7 @@ export const handleMyInfoChildHashResponse = (
       const key = getMyInfoChildHashKey(
         field._id as string,
         subFields[subFieldIndex],
+        childIndex,
         childName,
       )
       const hash = hashes[key]

--- a/src/app/modules/submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/ParsedResponsesObject.class.ts
@@ -130,6 +130,7 @@ export default class ParsedResponsesObject {
 
     // Validate each field in the form and inject metadata into the responses.
     const processedResponses = []
+    let childIdx = 0
     for (const response of filteredResponses) {
       const responseId = response._id
       const formField = fieldMap[responseId]
@@ -159,6 +160,15 @@ export default class ParsedResponsesObject {
             processingResponse as ProcessedChildrenResponse
           ).childSubFieldsArray =
             (formField as ChildrenCompoundFieldBase).childrenSubFields ?? []
+          ;(processingResponse as ProcessedChildrenResponse).childIdx = childIdx
+          // 1 MyInfo child field might contain more than 1 child, represented by the length of the answerArray
+          // This happens when the button "Add another child" is used to add >= 1 child
+          const noOfChildrenInQn =
+            (processingResponse as ProcessedChildrenResponse).answerArray
+              ?.length ?? 0
+          // We increment the childIdx by the number of children in the qn, instead of just 1
+          // to account for the case where the MyInfo child field contains more than 1 child
+          childIdx += noOfChildrenInQn
         }
       }
 

--- a/src/app/modules/submission/email-submission/email-submission.constants.ts
+++ b/src/app/modules/submission/email-submission/email-submission.constants.ts
@@ -3,7 +3,6 @@ export const MYINFO_PREFIX = '[MyInfo] '
 export const VERIFIED_PREFIX = '[verified] '
 export const TABLE_PREFIX = '[table] '
 export const ATTACHMENT_PREFIX = '[attachment] '
-export const CHILD_PREFIX = '[child] '
 
 // Parameters for hashing submissions
 export const SALT_LENGTH = 32

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -228,7 +228,12 @@ export const getAnswersForChild = (
     return arr.map((answer, idx) => {
       const subfield = subFields[idx]
       return {
-        _id: getMyInfoChildHashKey(response._id, subFields[idx], childName),
+        _id: getMyInfoChildHashKey(
+          response._id,
+          subFields[idx],
+          childIdx,
+          childName,
+        ),
         fieldType: response.fieldType,
         // qnChildIdx represents the index of the MyInfo field
         // childIdx represents the index of the child in this MyInfo field

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -225,7 +225,6 @@ export const getAnswersForChild = (
     return []
   }
   return response.answerArray.flatMap((arr) => {
-    console.log('arr: ', arr)
     // First array element is always child name
     const childName = arr[0]
     return arr.map((answer, idx) => ({
@@ -494,8 +493,6 @@ const createFormattedDataForOneField = <T extends EmailDataFields | undefined>(
     const checkbox = getAnswerForCheckbox(response)
     return { fieldResponse: [getFormattedFunction(checkbox, hashedFields)] }
   } else if (isProcessedChildResponse(response)) {
-    console.log('childresponse: ', response)
-    console.log('childIdx: ', childIdx)
     return {
       isChild: true,
       fieldResponse: getAnswersForChild(response, childIdx).map((childField) =>
@@ -695,7 +692,6 @@ export class SubmissionEmailObj {
       }
       return fieldResponse
     })
-    console.log('childIdx: ', childIdx)
     return responses
   }
 }

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -86,7 +86,6 @@ import {
 
 import {
   ATTACHMENT_PREFIX,
-  CHILD_PREFIX,
   MYINFO_PREFIX,
   TABLE_PREFIX,
   VERIFIED_PREFIX,
@@ -137,8 +136,6 @@ const getFieldTypePrefix = (response: ResponseFormattedForEmail): string => {
       return TABLE_PREFIX
     case BasicField.Attachment:
       return ATTACHMENT_PREFIX
-    case BasicField.Children:
-      return CHILD_PREFIX
     default:
       return ''
   }

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -229,12 +229,7 @@ export const getAnswersForChild = (
     // First array element is always child name
     const childName = arr[0]
     return arr.map((answer, idx) => ({
-      _id: getMyInfoChildHashKey(
-        response._id,
-        subFields[idx],
-        childIdx,
-        childName,
-      ),
+      _id: getMyInfoChildHashKey(response._id, subFields[idx], childName),
       fieldType: response.fieldType,
       question: `Child-${childIdx + 1}.${subFields[idx]}`,
       myInfo: {

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -230,7 +230,6 @@ export const getAnswersForChild = (
       return {
         _id: getMyInfoChildHashKey(response._id, subFields[idx], childName),
         fieldType: response.fieldType,
-        // question: `Child-${childIdx + 1}.${subFields[idx]}`,
         question: `Child ${childIdx + 1} ${
           MYINFO_ATTRIBUTE_MAP[subfield].description
         }`,

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import { compact } from 'lodash'
 
+import { MYINFO_ATTRIBUTE_MAP } from '../../../../../shared/constants/field/myinfo'
 import {
   BasicField,
   FormAuthType,
@@ -224,17 +225,23 @@ export const getAnswersForChild = (
   return response.answerArray.flatMap((arr) => {
     // First array element is always child name
     const childName = arr[0]
-    return arr.map((answer, idx) => ({
-      _id: getMyInfoChildHashKey(response._id, subFields[idx], childName),
-      fieldType: response.fieldType,
-      question: `Child-${childIdx + 1}.${subFields[idx]}`,
-      myInfo: {
-        attr: subFields[idx] as unknown as MyInfoAttribute,
-      },
-      isVisible: response.isVisible,
-      isUserVerified: response.isUserVerified,
-      answer,
-    }))
+    return arr.map((answer, idx) => {
+      const subfield = subFields[idx]
+      return {
+        _id: getMyInfoChildHashKey(response._id, subFields[idx], childName),
+        fieldType: response.fieldType,
+        // question: `Child-${childIdx + 1}.${subFields[idx]}`,
+        question: `Child ${childIdx + 1} ${
+          MYINFO_ATTRIBUTE_MAP[subfield].description
+        }`,
+        myInfo: {
+          attr: subFields[idx] as unknown as MyInfoAttribute,
+        },
+        isVisible: response.isVisible,
+        isUserVerified: response.isUserVerified,
+        answer,
+      }
+    })
   })
 }
 

--- a/src/app/modules/submission/submission.types.ts
+++ b/src/app/modules/submission/submission.types.ts
@@ -59,7 +59,10 @@ export type ProcessedSingleAnswerResponse<
 export type ProcessedCheckboxResponse = CheckboxResponse & ProcessedResponse
 export type ProcessedTableResponse = TableResponse & ProcessedResponse
 export type ProcessedChildrenResponse = ChildBirthRecordsResponse &
-  ProcessedResponse & { childSubFieldsArray?: MyInfoChildAttributes[] }
+  ProcessedResponse & {
+    childSubFieldsArray?: MyInfoChildAttributes[]
+    childIdx?: number
+  }
 /**
  * Can be either email or storage mode attachment response.
  * Email mode attachment response in the server will have extra metadata injected


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MyInfo child responses are not numbered in the email response.

Closes FRM-1325

## Solution
<!-- How did you solve the problem? -->
There are 2 cases which would affect the numbering of the child

1. When there is >1 MyInfo child field
2. When there is >1 child per MyInfo child field (this happens when the respondent chooses to "Add another child")

The index of the child is represented by `ProcessedChildrenResponse.childIdx`, which is updated in `parseResponses`.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - This will change the response field name in the email response. This incoming change has already been communicated to the current users.


## Before & After Screenshots

**BEFORE**:
<img width="1065" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/ba5ab191-a25f-44f6-b0bb-34a50f1d1262">


**AFTER**:
<img width="767" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/ec195fdb-a27b-41c7-ab30-7b07ee42c2ee">


## Tests
<!-- What tests should be run to confirm functionality? -->
**Test for index** - this can't be performed on Staging as the mockpass profiles only have 1 child, but can be tested locally
- [ ] On a MyInfo form, add 2 child fields. Enable multiple children for the first child field
- [ ] Open the form
- [ ] For the first child field, add another child
- [ ] Fill in the form (there should be 3 children entries in total) and submit it
- [ ] The child fields in the email response should be numbered according to the child's index, e.g. `[MyInfo] Child 1 Name`

**Regression test**
- [ ] Add all MyInfo fields to a form
- [ ] Fill in the form and submit it
- [ ] There should be no change in the format of the MyInfo field names, other than the child field. The child field (assuming there's just 1) should be named in this format [MyInfo] Child <index> <field name> e.g. `[MyInfo] Child 1 Name`

