### PR TITLE
chore: use correct branch for scanner cron job

### DIFF
--- a/.github/workflows/aws-deploy-scanner.yml
+++ b/.github/workflows/aws-deploy-scanner.yml
@@ -11,6 +11,10 @@ on:
         description: 'Provisioned concurrency'
         required: true
         type: number
+      checkoutBranch:
+        description: 'Branch to checkout code from'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -22,15 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source code from specified branch if it is a scheduled run
+      - name: Checkout source code from specified checkout branch
         uses: actions/checkout@v3
-        if: ${{ github.event_name == 'schedule' }}
         with:
-          ref: ${{ inputs.environment }}
-
-      - name: Checkout source code
-        uses: actions/checkout@v3
-        if: ${{ github.event_name != 'schedule' }}
+          ref: ${{ inputs.checkoutBranch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-virus-scanner-production.yml
+++ b/.github/workflows/deploy-virus-scanner-production.yml
@@ -19,4 +19,5 @@ jobs:
     with:
       environment: 'production'
       provisionedConcurrency: 5
+      checkoutBranch: 'release-al2'
     secrets: inherit

--- a/.github/workflows/deploy-virus-scanner-staging.yml
+++ b/.github/workflows/deploy-virus-scanner-staging.yml
@@ -23,4 +23,5 @@ jobs:
     with:
       environment: 'staging'
       provisionedConcurrency: 1
+      checkoutBranch: 'staging'
     secrets: inherit

--- a/.github/workflows/deploy-virus-scanner-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-uat.yml
@@ -19,4 +19,5 @@ jobs:
     with:
       environment: 'uat'
       provisionedConcurrency: 1
+      checkoutBranch: 'uat'
     secrets: inherit


### PR DESCRIPTION
## Problem
- virus scanner CI currently checks out the develop branch for scheduled pushes, and the $environment branch for cron job
- updates the config for daily cron job for virus scanner to specify the checkout branch and use it both for cron job as well as pushes