### PR TITLE
feat(virus-scanner): download clean file

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -60,7 +60,7 @@ RUN --mount=type=secret,id=dd_api_key \
 RUN npm prune --production --legacy-peer-deps
 
 # This stage builds the final container
-FROM node:hydrogen-alpine3.18
+FROM node:hydrogen-alpine3.16
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 WORKDIR /opt/formsg
 
@@ -81,7 +81,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-    chromium=115.0.5790.170-r0 \
+    chromium=102.0.5005.182-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.errors.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.errors.ts
@@ -50,10 +50,8 @@ export class FeatureDisabledError extends ApplicationError {
   }
 }
 
-export class InvalidQuarantineFileKeyError extends ApplicationError {
-  constructor(
-    message = 'Invalid quarantine file key. Quarantine file key should be a valid UUID.',
-  ) {
+export class InvalidFileKeyError extends ApplicationError {
+  constructor(message = 'Invalid file key. File keys should be valid UUIDs.') {
     super(message)
   }
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.errors.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.errors.ts
@@ -69,3 +69,11 @@ export class JsonParseFailedError extends ApplicationError {
     super(message)
   }
 }
+
+export class DownloadCleanFileFailedError extends ApplicationError {
+  constructor(
+    message = 'Attempt to download clean file failed. Please try again.',
+  ) {
+    super(message)
+  }
+}

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -268,29 +268,6 @@ export const scanAndRetrieveAttachments = async (
     })
   }
 
-  // const getBody = (response: GetObjectCommandOutput) => {
-  //   return response.Body && (response.Body as Readable);
-  // }
-
-  // const bodyToBuffer = (body: S3.Body) => {
-  //   let buffer: Buffer
-  //   if (body instanceof Uint8Array || body instanceof Blob) {
-  //     buffer = Buffer.from(body)
-  //   } else if (
-  //     typeof body === 'string' ||
-  //     body instanceof Readable ||
-  //     body instanceof ReadableStream
-  //   ) {
-  //     const chunks: Uint8Array[] = []
-  //     for await (const chunk of body) {
-  //       chunks.push(chunk instanceof Buffer ? chunk : Buffer.from(chunk))
-  //     }
-  //     buffer = Buffer.concat(chunks)
-  //   } else {
-  //     throw new Error('Invalid type for S3 object Body')
-  //   }
-  // }
-
   // Step 4: Retrieve attachments from the clean bucket.
   const downloadCleanFilesResult = await ResultAsync.combine(
     triggerLambdaResult.value.map((isAttachment) => {
@@ -300,11 +277,13 @@ export const scanAndRetrieveAttachments = async (
           isAttachment.cleanFile.cleanFileKey,
           isAttachment.cleanFile.destinationVersionId,
         ).map((result) => {
+          // Replace content with file retreived from clean bucket.
           isAttachment.response.content = result
-          return true
-        })
+          return true // Return true to indicate that the download was successful.
+        }) // If any downloads error out, it will short circuit and return the first error.
       }
 
+      // If response is not an attachment, return okAsync(false).
       return okAsync(false as const)
     }),
   )
@@ -580,8 +559,6 @@ export const createFormsgAndRetrieveForm = async (
   next: NextFunction,
 ) => {
   const { formId } = req.params
-
-  console.log('createFormsgAndRetrieveForm req.body.version', req.body.version)
 
   const logMeta = {
     action: 'createFormsgAndRetrieveForm',

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -241,7 +241,7 @@ export const scanAndRetrieveAttachments = async (
   > = await ResultAsync.combine(
     req.body.responses.map((response) => {
       if (isQuarantinedAttachmentResponse(response)) {
-        return triggerVirusScanning(response.filename).map((result) => ({
+        return triggerVirusScanning(response.answer).map((result) => ({
           response,
           cleanFile: result.body,
         }))
@@ -279,6 +279,8 @@ export const scanAndRetrieveAttachments = async (
         ).map((result) => {
           // Replace content with file retreived from clean bucket.
           isAttachment.response.content = result
+          // Replace answer with filename.
+          isAttachment.response.answer = isAttachment.response.filename
           return true // Return true to indicate that the download was successful.
         }) // If any downloads error out, it will short circuit and return the first error.
       }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -804,7 +804,7 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
 
   if (!validate(cleanFileKey)) {
     logger.error({
-      message: 'Invalid file key - not a valid uuid',
+      message: 'Invalid clean file key - not a valid uuid',
       meta: logMeta,
     })
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -65,7 +65,7 @@ import {
   AttachmentSizeLimitExceededError,
   DownloadCleanFileFailedError,
   InvalidFieldIdError,
-  InvalidQuarantineFileKeyError,
+  InvalidFileKeyError,
   JsonParseFailedError,
   VirusScanFailedError,
 } from './encrypt-submission.errors'
@@ -744,7 +744,7 @@ export const triggerVirusScanning = (
       meta: logMeta,
     })
 
-    return errAsync(new InvalidQuarantineFileKeyError())
+    return errAsync(new InvalidFileKeyError())
   }
 
   return ResultAsync.fromPromise(
@@ -800,6 +800,15 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
     action: 'downloadCleanFile',
     cleanFileKey,
     versionId,
+  }
+
+  if (!validate(cleanFileKey)) {
+    logger.error({
+      message: 'Invalid file key - not a valid uuid',
+      meta: logMeta,
+    })
+
+    return errAsync(new InvalidFileKeyError())
   }
 
   let buffer = Buffer.alloc(0)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -814,7 +814,7 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
   let buffer = Buffer.alloc(0)
 
   const writeStream = new Writable({
-    write(chunk, encoding, callback) {
+    write(chunk, _encoding, callback) {
       buffer = Buffer.concat([buffer, chunk])
       callback()
     },

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -788,6 +788,13 @@ export const triggerVirusScanning = (
   })
 }
 
+/**
+ * Downloads file from clean bucket
+ * @param cleanFileKey object key of the file in the clean bucket
+ * @param versionId id for versioning of the file in the clean bucket
+ * @returns okAsync(buffer) if file has been successfully downloaded from the clean bucket
+ * @returns errAsync(DownloadCleanFileFailedError) if file download failed
+ */
 export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
   const logMeta = {
     action: 'downloadCleanFile',
@@ -834,23 +841,4 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
       return new DownloadCleanFileFailedError()
     },
   )
-
-  // return ResultAsync.fromPromise(
-  //   AwsConfig.s3
-  //     .getObject({
-  //       Bucket: AwsConfig.virusScannerCleanS3Bucket,
-  //       Key: cleanFileKey,
-  //       VersionId: versionId,
-  //     })
-  //     .promise(),
-  //   (error) => {
-  //     logger.error({
-  //       message: 'Error encountered when invoking virus scanning lambda',
-  //       meta: logMeta,
-  //       error,
-  //     })
-
-  //     return new DownloadCleanFileFailedError()
-  //   },
-  // )
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -72,6 +72,7 @@ import {
 
 import {
   AttachmentSizeLimitExceededError,
+  DownloadCleanFileFailedError,
   FeatureDisabledError,
   InvalidFieldIdError,
   InvalidQuarantineFileKeyError,
@@ -222,6 +223,7 @@ const errorMapper: MapRouteError = (
     case DatabaseError:
     case EmptyErrorFieldError:
     case VirusScanFailedError:
+    case DownloadCleanFileFailedError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: error.message,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -75,7 +75,7 @@ import {
   DownloadCleanFileFailedError,
   FeatureDisabledError,
   InvalidFieldIdError,
-  InvalidQuarantineFileKeyError,
+  InvalidFileKeyError,
   SubmissionFailedError,
   VirusScanFailedError,
 } from './encrypt-submission.errors'
@@ -231,7 +231,7 @@ const errorMapper: MapRouteError = (
     case SubmissionFailedError:
     case InvalidFieldIdError:
     case AttachmentSizeLimitExceededError:
-    case InvalidQuarantineFileKeyError:
+    case InvalidFileKeyError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,

--- a/src/app/modules/submission/receiver/receiver.service.ts
+++ b/src/app/modules/submission/receiver/receiver.service.ts
@@ -152,7 +152,11 @@ export const configureMultipartReceiver = (
         .on('close', () => {
           if (body) {
             handleDuplicatesInAttachments(attachments)
-            addAttachmentToResponses(body.responses, attachments)
+            addAttachmentToResponses(
+              body.responses,
+              attachments,
+              (body.version ?? 0) >= 2.1,
+            )
             return resolve(body)
           } else {
             // if body is not defined, the Promise would have been rejected elsewhere.

--- a/src/app/modules/submission/receiver/receiver.service.ts
+++ b/src/app/modules/submission/receiver/receiver.service.ts
@@ -155,6 +155,10 @@ export const configureMultipartReceiver = (
             addAttachmentToResponses(
               body.responses,
               attachments,
+              // default to 0 for email mode forms where version is undefined
+              // TODO (FRM-1413): change to a version existence guardrail when
+              // virus scanning has completed rollout, so that virus scanning
+              // cannot be bypassed on storage mode submissions.
               (body.version ?? 0) >= 2.1,
             )
             return resolve(body)

--- a/src/app/modules/submission/receiver/receiver.types.ts
+++ b/src/app/modules/submission/receiver/receiver.types.ts
@@ -4,4 +4,5 @@ import { FieldResponse } from '../../../../types'
 export interface ParsedMultipartForm {
   responses: FieldResponse[]
   responseMetadata: ResponseMetadata
+  version?: number
 }

--- a/src/app/modules/submission/receiver/receiver.utils.ts
+++ b/src/app/modules/submission/receiver/receiver.utils.ts
@@ -66,6 +66,7 @@ const isAttachmentResponseFromMap = (
 export const addAttachmentToResponses = (
   responses: ParsedClearFormFieldResponse[],
   attachments: IAttachmentInfo[],
+  isVirusScannerEnabled: boolean,
 ): void => {
   // Create a map of the attachments with fieldId as keys
   const attachmentMap: Record<IAttachmentInfo['fieldId'], IAttachmentInfo> =
@@ -79,9 +80,11 @@ export const addAttachmentToResponses = (
     responses.forEach((response) => {
       if (isAttachmentResponseFromMap(attachmentMap, response)) {
         const file = attachmentMap[response._id]
-        response.answer = file.filename
         response.filename = file.filename
         response.content = file.content
+        if (!isVirusScannerEnabled) {
+          response.answer = file.filename
+        }
       }
     })
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This is the 3rd step of a 4-step effort to integrate the virus scanner into storage submission workflow after the encryption boundary shift (FRM-1292). Specifically, this PR sets up part of the middleware to scan attachments - getting the attachments from the clean bucket after they have been scanned.

- [Design docs](https://www.notion.so/opengov/Virus-Scanner-Design-Doc-5464ffd2af88420495209baa6a55e1bf?pvs=4)
- [Overarching Linear ticket](https://linear.app/ogp/issue/FRM-1292/set-up-frontend-backend-integration-for-virus-scanner)

Closes FRM-1302

## Solution
<!-- How did you solve the problem? -->

In the middleware `scanAndRetrieveAttachments`, code is implemented to download the file from the clean bucket.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Features**:

- `downloadCleanFile` is implemented at the service level to download attachments given clean file keys and version ids.

## Tests
<!-- What tests should be run to confirm functionality? -->

### Make sure clean files can be downloaded from clean bucket

#### Preparations:

**Get the storage submission request:**

- [ ] Ensure that your app:
    1. Is connected to growthbook - ensure that the client key is loaded.
    2. Will direct storage submission requests to `/storage`.
- [ ] Create a storage submission form with 2 attachment fields (at least 1 of them optional) and open it.
- [ ] Go to the respondent page and open the network panel.
- [ ] Make a submission including an attachment. To make your life easier with the tests below, attach a small file (e.g. text file with a few bytes).
  - Hint: Content-Types:
    - `text/plain`
    - `application/pdf`
    - `image/png`
    - `image/gif`
- [ ] Copy the cURL request `A` for the submission. It should be to the endpoint that shows up as `storage?recaptcha...`. 
- [ ] Modify `A` to change the version to 2.1. Save this as request `B`.

**Put a valid file in the quarantine bucket:**

- [ ] Create a file with a valid uuid (e.g. `1b90195b-ce8a-4590-810b-04ebaef8e4dd`).
- [ ] Upload the file to the quarantine bucket.
  - If you are on local:
    1. Go to `formsg-backend-1`'s terminal.
    3. Create a text file with something like `echo "testing 123" > 1b90195b-ce8a-4590-810b-04ebaef8e4dd`.
    4. Copy the file over to the quarantine bucket with `aws --endpoint=http://localhost:4566 s3 cp 1b90195b-ce8a-4590-810b-04ebaef8e4dd s3://local-virus-scanner-quarantine-bucket`
    5. Make sure that the file has been successfully copied over with `aws --endpoint=http://localhost:4566 s3 ls s3://local-virus-scanner-quarantine-bucket`
  - If you are not on local, in S3, look for `[staging|prod|uat].virus.scanner.quarantine`.

**Allow virus scanner to be used on BE:**

- [ ] In the DB's `featureflags` collection, add the flag `encryption-boundary-shift-virus-scanner` and set enabled to `true`.

#### Make sure that virus scanner runs and clean file is downloaded when feature flag is on and version number is 2.1+:

- [ ] Modify cURL request `B` by changing the attachment field's answer to the file that you've added to the quarantine bucket. The file you've added should have a key that's a valid uuid. Save this as request `C`.
- [ ] Run request `C`.
  - [ ] The storage submission should succeed.
  - [ ] Go to the admin results page of the form. The latest response should have the attachment that you previously uploaded to the quarantine bucket, NOT the file that you used to create the cURL response.
- [ ] Rerun request `C`. This should now fail with a virus scan failure message since the quarantine bucket file has poofed.

### Regression

#### Make sure that `encryption-boundary-shift-virus-scanner` feature flag works

- [ ] Unset the `encryption-boundary-shift-virus-scanner` feature flag or disable it.
- [ ] Restore the file in the quarantine bucket.
- [ ] Run cURL request `C`. The file in the quarantine bucket should remain.

#### Make sure that versioning works

- [ ] Enable the `encryption-boundary-shift-virus-scanner` feature flag.
- [ ] Ensure that the file is in the quarantine bucket.
- [ ] Run modified request `C` by changing the version number to 2. The file in the quarantine bucket should remain.

#### Make sure that only uuid file keys are accepted

- [ ] Run modified request `C`, where the filename is not a valid UUID. An error should be thrown flagging that the file key is not a valid UUID.

#### Normal E2E flows

- [ ] Submit a email mode form with multiple attachments.
- [ ]  With `encryption-boundary-shift-virus-scanner` flag disabled, submit a storage mode form (/storage endpoint) with multiple attachments.
- [ ] Try this with some of the attachment fields empty.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**Modified AWS policies**:

- `formsg-staging-virus-scanner-s3-lambda` policy modified (for `formsg-staging-ec2-role-1`), in the Statement for `Sid` "GetFileFromClean", `GetObject` is replaced by `GetObjectVersion`. As such, the statement should look like the following:

```json
{
  "Sid": "GetFileFromClean",
  "Effect": "Allow",
  "Action": "s3:GetObjectVersion",
  "Resource": "arn:aws:s3:::staging.virus.scanner.clean/*"
}
```
- Corresponding policies have been added to uat and prod too.