### PR TITLE
fix: reinstate MyInfo verified field indicator for MyInfo child DOB

### DIFF
--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -112,7 +112,6 @@ function hashChildrenFieldValues(
       // Hence we format it here
       if (subField === MyInfoChildAttributes.ChildDateOfBirth) {
         myInfoFormattedValue = formatMyinfoDate(value)
-        return
       }
       readOnlyHashPromises[
         getMyInfoChildHashKey(field._id, subField, childIdx, childName)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When doing tests to QA the MyInfo child fields, I realised that there was no `[MyInfo]` prefix (which represents that a field is MyInfo verified) for child Date of Birth fields, even though this data is obtained from MyInfo and should be verified.

## Solution
<!-- How did you solve the problem? -->
Remove a redundant `return` statement, which was preventing the field from being hashed. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - This changes the field name in the email response

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="710" alt="Screenshot 2023-09-26 at 2 19 35 PM" src="https://github.com/opengovsg/FormSG/assets/56983748/f8b74ca4-2ad4-4fa6-9d2c-b84eca06b8c1">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="702" alt="Screenshot 2023-09-26 at 2 19 09 PM" src="https://github.com/opengovsg/FormSG/assets/56983748/0b2f41fd-cdb5-456d-a455-c3593d9f0372">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Fill in a form that contains the MyInfo child DOB field
- [x] Select a child, the child's DOB should be automatically prefilled
- [x] Submit the form
- [x] Check that in the email response, the DOB field name is prefixed with `[MyInfo]`
