### PR TITLE
feat(workspaces): create and duplicate form into active workspace

### DIFF
--- a/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
+++ b/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
@@ -25,7 +25,7 @@ import {
 import { ModalCloseButton } from '~components/Modal'
 
 import { useUserMutations } from '~features/user/mutations'
-import { useWorkspace } from '~features/workspace/queries'
+import { useDashboard } from '~features/workspace/queries'
 
 import { useUser } from '../queries'
 
@@ -39,7 +39,7 @@ type TransferOwnershipInputs = {
 }
 
 const useModalState = ({ onClose, reset, trigger }) => {
-  const { refetch } = useWorkspace()
+  const { refetch } = useDashboard()
 
   const [page, setPage] = useState(0)
   const [email, setEmail] = useState('')

--- a/frontend/src/features/workspace/WorkspaceService.ts
+++ b/frontend/src/features/workspace/WorkspaceService.ts
@@ -3,6 +3,7 @@ import {
   AdminDashboardFormMetaDto,
   CreateEmailFormBodyDto,
   CreateStorageFormBodyDto,
+  DuplicateFormBodyDto,
   FormDto,
 } from '~shared/types/form/form'
 import { WorkspaceDto } from '~shared/types/workspace'
@@ -95,7 +96,7 @@ export const createStorageModeForm = async (
 
 export const dupeEmailModeForm = async (
   formId: string,
-  body: CreateEmailFormBodyDto,
+  body: DuplicateFormBodyDto,
 ): Promise<FormDto> => {
   return ApiService.post<FormDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/duplicate`,
@@ -105,7 +106,7 @@ export const dupeEmailModeForm = async (
 
 export const dupeStorageModeForm = async (
   formId: string,
-  body: CreateStorageFormBodyDto,
+  body: DuplicateFormBodyDto,
 ): Promise<FormDto> => {
   return ApiService.post<FormDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/duplicate`,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -62,7 +62,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
   const { createEmailModeFormMutation, createStorageModeFormMutation } =
     useCreateFormMutations()
 
-  const { activeWorkspace } = useWorkspaceContext()
+  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
 
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
@@ -72,7 +72,8 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
-        workspaceId: activeWorkspace._id,
+        // do not mutate with workspaceId if it is 'All Forms'
+        workspaceId: isDefaultWorkspace ? undefined : activeWorkspace._id,
       })
     },
   )

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -6,6 +6,7 @@ import { FormResponseMode } from '~shared/types'
 import formsgSdk from '~utils/formSdk'
 
 import { useCreateFormMutations } from '~features/workspace/mutations'
+import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import {
   CreateFormFlowStates,
@@ -61,6 +62,8 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
   const { createEmailModeFormMutation, createStorageModeFormMutation } =
     useCreateFormMutations()
 
+  const { activeWorkspace } = useWorkspaceContext()
+
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
       if (responseMode !== FormResponseMode.Encrypt) return
@@ -69,6 +72,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
+        workspaceId: activeWorkspace._id,
       })
     },
   )
@@ -79,6 +83,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: inputs.responseMode,
+        workspaceId: activeWorkspace._id,
       })
     }
     setCurrentStep([CreateFormFlowStates.Landing, 1])

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -64,6 +64,10 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
 
+  // do not mutate with workspaceId if it is 'All Forms' (default workspace)
+  // as the default workspace contains an empty string as workspaceId
+  const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
+
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
       if (responseMode !== FormResponseMode.Encrypt) return
@@ -72,8 +76,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
-        // do not mutate with workspaceId if it is 'All Forms'
-        workspaceId: isDefaultWorkspace ? undefined : activeWorkspace._id,
+        workspaceId,
       })
     },
   )
@@ -84,7 +87,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: inputs.responseMode,
-        workspaceId: activeWorkspace._id,
+        workspaceId,
       })
     }
     setCurrentStep([CreateFormFlowStates.Landing, 1])

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -70,7 +70,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   const { dupeEmailModeFormMutation, dupeStorageModeFormMutation } =
     useDuplicateFormMutations()
 
-  const { activeWorkspace } = useWorkspaceContext()
+  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
 
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
@@ -82,7 +82,8 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
-        workspaceId: activeWorkspace._id,
+        // do not mutate with workspaceId if it is 'All Forms'
+        workspaceId: isDefaultWorkspace ? undefined : activeWorkspace._id,
       })
     },
   )

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -72,6 +72,10 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
 
+  // do not mutate with workspaceId if it is 'All Forms' (default workspace)
+  // as the default workspace contains an empty string as workspaceId
+  const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
+
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
       if (responseMode !== FormResponseMode.Encrypt || !activeFormMeta?._id)
@@ -82,8 +86,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
-        // do not mutate with workspaceId if it is 'All Forms'
-        workspaceId: isDefaultWorkspace ? undefined : activeWorkspace._id,
+        workspaceId,
       })
     },
   )
@@ -96,7 +99,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: inputs.responseMode,
-        workspaceId: activeWorkspace._id,
+        workspaceId,
       })
     }
     setCurrentStep([CreateFormFlowStates.Landing, 1])

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -5,8 +5,9 @@ import { FormResponseMode } from '~shared/types'
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { isMyInfo } from '~features/myinfo/utils'
 import { useDuplicateFormMutations } from '~features/workspace/mutations'
-import { useWorkspace } from '~features/workspace/queries'
+import { useDashboard } from '~features/workspace/queries'
 import { makeDuplicateFormTitle } from '~features/workspace/utils/createDuplicateFormTitle'
+import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import {
   CreateFormFlowStates,
@@ -17,7 +18,7 @@ import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizard
 import { useWorkspaceRowsContext } from '../WorkspaceFormRow/WorkspaceRowsContext'
 
 export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
-  const { data: dashboardForms, isLoading: isWorkspaceLoading } = useWorkspace()
+  const { data: dashboardForms, isLoading: isWorkspaceLoading } = useDashboard()
   const { activeFormMeta } = useWorkspaceRowsContext()
   const { data: previewFormData, isLoading: isPreviewFormLoading } =
     usePreviewForm(
@@ -69,6 +70,8 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   const { dupeEmailModeFormMutation, dupeStorageModeFormMutation } =
     useDuplicateFormMutations()
 
+  const { activeWorkspace } = useWorkspaceContext()
+
   const handleCreateStorageModeForm = handleSubmit(
     ({ title, responseMode }) => {
       if (responseMode !== FormResponseMode.Encrypt || !activeFormMeta?._id)
@@ -79,6 +82,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
         title,
         responseMode,
         publicKey: keypair.publicKey,
+        workspaceId: activeWorkspace._id,
       })
     },
   )
@@ -91,6 +95,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: inputs.responseMode,
+        workspaceId: activeWorkspace._id,
       })
     }
     setCurrentStep([CreateFormFlowStates.Landing, 1])

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -6,6 +6,7 @@ import { AdminFeedbackRating } from '~shared/types'
 import {
   CreateEmailFormBodyDto,
   CreateStorageFormBodyDto,
+  DuplicateFormBodyDto,
   FormDto,
 } from '~shared/types/form/form'
 
@@ -95,7 +96,7 @@ export const useDuplicateFormMutations = () => {
   const dupeEmailModeFormMutation = useMutation<
     FormDto,
     ApiError,
-    CreateEmailFormBodyDto & { formIdToDuplicate: string }
+    DuplicateFormBodyDto & { formIdToDuplicate: string }
   >(
     ({ formIdToDuplicate, ...params }) =>
       dupeEmailModeForm(formIdToDuplicate, params),
@@ -108,7 +109,7 @@ export const useDuplicateFormMutations = () => {
   const dupeStorageModeFormMutation = useMutation<
     FormDto,
     ApiError,
-    CreateStorageFormBodyDto & { formIdToDuplicate: string }
+    DuplicateFormBodyDto & { formIdToDuplicate: string }
   >(
     ({ formIdToDuplicate, ...params }) =>
       dupeStorageModeForm(formIdToDuplicate, params),

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -40,6 +40,7 @@ const useCommonHooks = () => {
   const handleSuccess = useCallback(
     (data: Pick<FormDto, '_id'>) => {
       queryClient.invalidateQueries(workspaceKeys.dashboard)
+      queryClient.invalidateQueries(workspaceKeys.workspaces)
       navigate(`${ADMINFORM_ROUTE}/${data._id}`)
     },
     [navigate, queryClient],

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -269,7 +269,7 @@ export type AdminDashboardFormMetaDto = Pick<
   typeof ADMIN_FORM_META_FIELDS[number]
 >
 
-export type DuplicateFormBodyDto = {
+export type DuplicateFormOverwriteDto = {
   title: string
 } & (
   | {
@@ -281,6 +281,10 @@ export type DuplicateFormBodyDto = {
       publicKey: string
     }
 )
+
+export type DuplicateFormBodyDto = DuplicateFormOverwriteDto & {
+  workspaceId?: string
+}
 
 export type CreateEmailFormBodyDto = Pick<
   EmailFormDto,

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -285,11 +285,12 @@ export type DuplicateFormBodyDto = {
 export type CreateEmailFormBodyDto = Pick<
   EmailFormDto,
   'emails' | 'responseMode' | 'title'
->
+> & { workspaceId?: string }
+
 export type CreateStorageFormBodyDto = Pick<
   StorageFormDto,
   'publicKey' | 'responseMode' | 'title'
->
+> & { workspaceId?: string }
 
 export type CreateFormBodyDto =
   | CreateEmailFormBodyDto

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -465,10 +465,13 @@ describe('admin-form.controller', () => {
       expect(MockUserService.findUserById).toHaveBeenCalledWith(
         MOCK_REQ.session?.user?._id,
       )
-      expect(MockAdminFormService.createForm).toHaveBeenCalledWith({
-        ...MOCK_FORM_PARAMS,
-        admin: MOCK_USER._id,
-      })
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        undefined,
+      )
     })
 
     it('should return 409 on DatabaseConflictError', async () => {
@@ -489,10 +492,13 @@ describe('admin-form.controller', () => {
       expect(MockUserService.findUserById).toHaveBeenCalledWith(
         MOCK_REQ.session?.user?._id,
       )
-      expect(MockAdminFormService.createForm).toHaveBeenCalledWith({
-        ...MOCK_FORM_PARAMS,
-        admin: MOCK_USER._id,
-      })
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        undefined,
+      )
     })
 
     it('should return 413 on DatabasePayloadSizeError', async () => {
@@ -513,10 +519,13 @@ describe('admin-form.controller', () => {
       expect(MockUserService.findUserById).toHaveBeenCalledWith(
         MOCK_REQ.session?.user?._id,
       )
-      expect(MockAdminFormService.createForm).toHaveBeenCalledWith({
-        ...MOCK_FORM_PARAMS,
-        admin: MOCK_USER._id,
-      })
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        undefined,
+      )
     })
 
     it('should return 422 on DatabaseValidationError', async () => {
@@ -537,10 +546,13 @@ describe('admin-form.controller', () => {
       expect(MockUserService.findUserById).toHaveBeenCalledWith(
         MOCK_REQ.session?.user?._id,
       )
-      expect(MockAdminFormService.createForm).toHaveBeenCalledWith({
-        ...MOCK_FORM_PARAMS,
-        admin: MOCK_USER._id,
-      })
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        undefined,
+      )
     })
 
     it('should return 422 on MissingUserError', async () => {
@@ -580,31 +592,38 @@ describe('admin-form.controller', () => {
       expect(MockUserService.findUserById).toHaveBeenCalledWith(
         MOCK_REQ.session?.user?._id,
       )
-      expect(MockAdminFormService.createForm).toHaveBeenCalledWith({
-        ...MOCK_FORM_PARAMS,
-        admin: MOCK_USER._id,
-      })
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        undefined,
+      )
     })
 
-    it('should return 500 when database error occurs during user retrieval', async () => {
-      // Arrange
-      const mockErrorString = 'db ded'
-      const mockRes = expressHandler.mockResponse()
-      MockUserService.findUserById.mockReturnValueOnce(
-        errAsync(new DatabaseError(mockErrorString)),
-      )
+    it(
+      'should return 500 when database error occurs during user retrieval',
+      async () => {
+        // Arrange
+        const mockErrorString = 'db ded'
+        const mockRes = expressHandler.mockResponse()
+        MockUserService.findUserById.mockReturnValueOnce(
+          errAsync(new DatabaseError(mockErrorString)),
+        )
 
-      // Act
-      await AdminFormController.createForm(MOCK_REQ, mockRes, jest.fn())
+        // Act
+        await AdminFormController.createForm(MOCK_REQ, mockRes, jest.fn())
 
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(500)
-      expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
-      expect(MockUserService.findUserById).toHaveBeenCalledWith(
-        MOCK_REQ.session?.user?._id,
-      )
-      expect(MockAdminFormService.createForm).not.toHaveBeenCalled()
-    })
+        // Assert
+        expect(mockRes.status).toHaveBeenCalledWith(500)
+        expect(mockRes.json).toHaveBeenCalledWith({ message: mockErrorString })
+        expect(MockUserService.findUserById).toHaveBeenCalledWith(
+          MOCK_REQ.session?.user?._id,
+        )
+        expect(MockAdminFormService.createForm).not.toHaveBeenCalled()
+      },
+      undefined,
+    )
   })
 
   describe('handleGetAdminForm', () => {
@@ -3233,7 +3252,7 @@ describe('admin-form.controller', () => {
           _id: MOCK_USER_ID,
         },
       },
-      body: {} as DuplicateFormBodyDto,
+      body: {} as CreateFormBodyDto,
     })
 
     it('should return duplicated form view on duplicate success', async () => {
@@ -3282,6 +3301,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
       )
     })
 
@@ -3350,6 +3370,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
       )
     })
 
@@ -3484,6 +3505,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -474,6 +474,44 @@ describe('admin-form.controller', () => {
       )
     })
 
+    it('should return 200 with created form into a workspace', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const mockReqWithWorkspaceId = expressHandler.mockRequest({
+        session: {
+          user: {
+            _id: MOCK_USER_ID,
+          },
+        },
+        body: {
+          form: { ...MOCK_FORM_PARAMS, workspaceId: mockWorkspaceId },
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      MockUserService.findUserById.mockReturnValueOnce(okAsync(MOCK_USER))
+      MockAdminFormService.createForm.mockReturnValueOnce(okAsync(MOCK_FORM))
+
+      // Act
+      await AdminFormController.createForm(
+        mockReqWithWorkspaceId,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_FORM)
+      expect(MockUserService.findUserById).toHaveBeenCalledWith(
+        MOCK_REQ.session?.user?._id,
+      )
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_FORM_PARAMS,
+          admin: MOCK_USER._id,
+        },
+        mockWorkspaceId,
+      )
+    })
+
     it('should return 409 on DatabaseConflictError', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()
@@ -3302,6 +3340,57 @@ describe('admin-form.controller', () => {
         MOCK_USER_ID,
         expectedParams,
         undefined,
+      )
+    })
+
+    it('should return duplicated form view on duplicate success into a workspace', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const expectedParams: DuplicateFormBodyDto = {
+        responseMode: FormResponseMode.Encrypt,
+        publicKey: 'some public key',
+        title: 'mock title',
+      }
+      const mockDupedFormView = {
+        title: 'mock view',
+      } as AdminDashboardFormMetaDto
+      const mockDupedForm = merge({}, MOCK_FORM, {
+        title: 'duped form with new title',
+        _id: new ObjectId(),
+        getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+      })
+      const mockRes = expressHandler.mockResponse()
+      const mockReqWithParams = merge({}, MOCK_REQ, {
+        body: { workspaceId: mockWorkspaceId, ...expectedParams },
+      })
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+      MockAdminFormService.duplicateForm.mockReturnValueOnce(
+        okAsync(mockDupedForm),
+      )
+
+      // Act
+      await AdminFormController.duplicateAdminForm(
+        mockReqWithParams,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_USER_ID,
+        expectedParams,
+        mockWorkspaceId,
       )
     })
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -3,8 +3,9 @@ import { generateDefaultField } from '__tests__/unit/backend/helpers/generate-fo
 import { PresignedPost } from 'aws-sdk/clients/s3'
 import { ObjectId } from 'bson-ext'
 import { assignIn, cloneDeep, merge, omit, pick } from 'lodash'
-import mongoose from 'mongoose'
+import mongoose, { ClientSession } from 'mongoose'
 import { err, errAsync, ok, okAsync } from 'neverthrow'
+import { Workspace } from 'shared/types/workspace'
 
 import config, { aws } from 'src/app/config/config'
 import getAgencyModel from 'src/app/models/agency.server.model'
@@ -12,6 +13,7 @@ import getFormModel, {
   getEmailFormModel,
   getEncryptedFormModel,
 } from 'src/app/models/form.server.model'
+import { getWorkspaceModel } from 'src/app/models/workspace.server.model'
 import {
   ApplicationError,
   DatabaseConflictError,
@@ -80,6 +82,7 @@ const FormModel = getFormModel(mongoose)
 const EmailFormModel = getEmailFormModel(mongoose)
 const EncryptFormModel = getEncryptedFormModel(mongoose)
 const AgencyModel = getAgencyModel(mongoose)
+const WorkspaceModel = getWorkspaceModel(mongoose)
 
 jest.mock('src/app/modules/user/user.service')
 const MockUserService = jest.mocked(UserService)
@@ -461,6 +464,53 @@ describe('admin-form.service', () => {
       expect(actualResult.isOk()).toEqual(true)
       expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
       expect(createSpy).toHaveBeenCalledWith(expectedParams)
+      expect(mockForm.getDuplicateParams).toHaveBeenCalledWith({
+        ...expectedOverrideProps,
+        // Should now have start page set to default
+        startPage: {
+          logo: {
+            state: FormLogoState.Default,
+          },
+        },
+      })
+    })
+
+    // primary functionality of workspace transaction is tested in 'createForm'
+    it('should use form to workspace transaction if duplicating form to workspace', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const mockNewAdminId = new ObjectId().toHexString()
+      const expectedParams: PickDuplicateForm & OverrideProps = {
+        admin: MOCK_NEW_ADMIN_ID,
+        ...MOCK_ENCRYPT_OVERRIDE_PARAMS,
+      }
+      const mockForm = createMockForm(expectedParams)
+
+      // Mock util return
+      const expectedOverrideProps = { title: 'new title' } as OverrideProps
+      jest
+        .spyOn(AdminFormUtils, 'processDuplicateOverrideProps')
+        .mockReturnValueOnce(expectedOverrideProps)
+      const expectedForm = createMockForm(expectedOverrideProps)
+      const createFormInWorkspaceTransactionSpy = jest
+        .spyOn(AdminFormService, 'createFormInWorkspaceTransaction')
+        .mockResolvedValueOnce(expectedForm as never)
+
+      // Act
+      const actualResult = await AdminFormService.duplicateForm(
+        mockForm,
+        mockNewAdminId,
+        MOCK_EMAIL_OVERRIDE_PARAMS,
+        mockWorkspaceId,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
+      expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
+        expectedParams,
+        mockWorkspaceId,
+      )
       expect(mockForm.getDuplicateParams).toHaveBeenCalledWith({
         ...expectedOverrideProps,
         // Should now have start page set to default
@@ -926,6 +976,153 @@ describe('admin-form.service', () => {
         new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
       )
       expect(createSpy).toHaveBeenCalledWith(formParams)
+    })
+
+    // Creating into Workspace tests
+    it('should use form to workspace transaction if workspaceId is given', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const formParams: Parameters<typeof AdminFormService.createForm>[0] = {
+        title: 'create form title',
+        admin: new ObjectId().toHexString(),
+        responseMode: FormResponseMode.Email,
+        emails: 'example@example.com',
+      }
+      const expectedForm = {
+        _id: new ObjectId(),
+        ...formParams,
+      } as IFormSchema
+
+      // We directly test the processing of form creation into a workspace
+      // circumventing .withTransaction() in createFormInWorkspaceTransaction which is untestable
+      const createFormInWorkspaceTransactionSpy = jest
+        .spyOn(AdminFormService, 'createFormInWorkspaceTransaction')
+        .mockImplementationOnce((formParams, workspaceId) =>
+          AdminFormService.processCreateFormInWorkspace(
+            formParams,
+            workspaceId,
+            null as unknown as ClientSession,
+          ),
+        )
+
+      const createSpy = jest
+        .spyOn(FormModel, 'create')
+        .mockResolvedValueOnce([expectedForm] as never)
+      const addFormIdsToWorkspaceSpy = jest
+        .spyOn(WorkspaceModel, 'addFormIdsToWorkspace')
+        .mockResolvedValueOnce(null as unknown as Workspace)
+
+      // Act
+      const actualResult = await AdminFormService.createForm(
+        formParams,
+        mockWorkspaceId,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
+      expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
+        formParams,
+        mockWorkspaceId,
+      )
+      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+      expect(addFormIdsToWorkspaceSpy).toHaveBeenCalledWith({
+        workspaceId: mockWorkspaceId,
+        formIds: [expectedForm._id],
+        session: null,
+      })
+    })
+
+    it('should return DatabaseError on database error whilst creating form in a workspace', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const formParams: Parameters<typeof AdminFormService.createForm>[0] = {
+        title: 'create form title',
+        admin: new ObjectId().toHexString(),
+        responseMode: FormResponseMode.Email,
+        emails: 'example@example.com',
+      }
+      const createFormInWorkspaceTransactionSpy = jest
+        .spyOn(AdminFormService, 'createFormInWorkspaceTransaction')
+        .mockImplementationOnce((formParams, workspaceId) =>
+          AdminFormService.processCreateFormInWorkspace(
+            formParams,
+            workspaceId,
+            null as unknown as ClientSession,
+          ),
+        )
+      const mockErrorString = 'no'
+      const createSpy = jest
+        .spyOn(FormModel, 'create')
+        .mockRejectedValueOnce(new Error(mockErrorString) as never)
+
+      // Act
+      const actualResult = await AdminFormService.createForm(
+        formParams,
+        mockWorkspaceId,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
+      )
+      expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
+        formParams,
+        mockWorkspaceId,
+      )
+      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+    })
+
+    it('should return DatabaseError on database error whilst moving form into a workspace', async () => {
+      // Arrange
+      const mockWorkspaceId = new ObjectId().toHexString()
+      const formParams: Parameters<typeof AdminFormService.createForm>[0] = {
+        title: 'create form title',
+        admin: new ObjectId().toHexString(),
+        responseMode: FormResponseMode.Email,
+        emails: 'example@example.com',
+      }
+      const expectedForm = {
+        _id: new ObjectId(),
+        ...formParams,
+      } as IFormSchema
+      const createFormInWorkspaceTransactionSpy = jest
+        .spyOn(AdminFormService, 'createFormInWorkspaceTransaction')
+        .mockImplementationOnce((formParams, workspaceId) =>
+          AdminFormService.processCreateFormInWorkspace(
+            formParams,
+            workspaceId,
+            null as unknown as ClientSession,
+          ),
+        )
+
+      const createSpy = jest
+        .spyOn(FormModel, 'create')
+        .mockResolvedValueOnce([expectedForm] as never)
+      const mockErrorString = 'no'
+      const addFormIdsToWorkspaceSpy = jest
+        .spyOn(WorkspaceModel, 'addFormIdsToWorkspace')
+        .mockRejectedValueOnce(new Error(mockErrorString) as never)
+
+      // Act
+      const actualResult = await AdminFormService.createForm(
+        formParams,
+        mockWorkspaceId,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
+      )
+      expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
+        formParams,
+        mockWorkspaceId,
+      )
+      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+      expect(addFormIdsToWorkspaceSpy).toHaveBeenCalledWith({
+        workspaceId: mockWorkspaceId,
+        formIds: [expectedForm._id],
+        session: null,
+      })
     })
   })
 

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -45,7 +45,7 @@ import {
   SubmissionCountQueryDto,
   WebhookSettingsUpdateDto,
 } from '../../../../../shared/types'
-import { IForm, IFormDocument, IPopulatedForm } from '../../../../types'
+import { IFormDocument, IPopulatedForm } from '../../../../types'
 import {
   EncryptSubmissionDto,
   FormUpdateParams,
@@ -116,7 +116,7 @@ const logger = createLoggerWithLabel(module)
 // Validators
 const createFormValidator = celebrate({
   [Segments.BODY]: {
-    form: BaseJoi.object<Omit<IForm, 'admin'>>()
+    form: BaseJoi.object<CreateFormBodyDto>()
       .keys({
         // Require valid responsesMode field.
         responseMode: Joi.string()

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -155,7 +155,8 @@ const createFormValidator = celebrate({
 })
 
 const duplicateFormValidator = celebrate({
-  [Segments.BODY]: BaseJoi.object<DuplicateFormBodyDto>({
+  // uses CreateFormBodyDto as that is the shape of the data used in client's WorkspaceService
+  [Segments.BODY]: BaseJoi.object<CreateFormBodyDto>({
     // Require valid responsesMode field.
     responseMode: Joi.string()
       .valid(...Object.values(FormResponseMode))
@@ -181,6 +182,7 @@ const duplicateFormValidator = celebrate({
         is: FormResponseMode.Encrypt,
         then: Joi.string().required().disallow(''),
       }),
+    workspaceId: Joi.string().allow(''),
   }),
 })
 
@@ -858,11 +860,11 @@ export const handleArchiveForm: ControllerHandler<{ formId: string }> = async (
 export const duplicateAdminForm: ControllerHandler<
   { formId: string },
   unknown,
-  DuplicateFormBodyDto
+  CreateFormBodyDto
 > = (req, res) => {
   const { formId } = req.params
   const userId = (req.session as AuthedSessionData).user._id
-  const overrideParams = req.body
+  const { workspaceId, ...overrideParams } = req.body
 
   return (
     // Step 1: Retrieve currently logged in user.
@@ -880,6 +882,7 @@ export const duplicateAdminForm: ControllerHandler<
               originalForm,
               userId,
               overrideParams,
+              workspaceId,
             ),
           )
           // Step 4: Retrieve dashboard view of duplicated form.

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1157,7 +1157,9 @@ export const createForm: ControllerHandler<
   DeserializeTransform<FormDto> | ErrorDto,
   { form: CreateFormBodyDto }
 > = async (req, res) => {
-  const { form: formParams } = req.body
+  const {
+    form: { workspaceId, ...formParams },
+  } = req.body
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
   return (
@@ -1165,7 +1167,13 @@ export const createForm: ControllerHandler<
     UserService.findUserById(sessionUserId)
       // Step 2: Create form with given params and set admin to logged in user.
       .andThen((user) =>
-        AdminFormService.createForm({ ...formParams, admin: user._id }),
+        AdminFormService.createForm(
+          {
+            ...formParams,
+            admin: user._id,
+          },
+          workspaceId,
+        ),
       )
       .map((createdForm) => {
         return res

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -146,6 +146,7 @@ const createFormValidator = celebrate({
             is: FormResponseMode.Encrypt,
             then: Joi.string().required().disallow(''),
           }),
+        workspaceId: Joi.string(),
       })
       .required()
       // Allow other form schema keys to be passed for form creation.
@@ -156,7 +157,7 @@ const createFormValidator = celebrate({
 
 const duplicateFormValidator = celebrate({
   // uses CreateFormBodyDto as that is the shape of the data used in client's WorkspaceService
-  [Segments.BODY]: BaseJoi.object<CreateFormBodyDto>({
+  [Segments.BODY]: BaseJoi.object<DuplicateFormBodyDto>({
     // Require valid responsesMode field.
     responseMode: Joi.string()
       .valid(...Object.values(FormResponseMode))
@@ -182,7 +183,7 @@ const duplicateFormValidator = celebrate({
         is: FormResponseMode.Encrypt,
         then: Joi.string().required().disallow(''),
       }),
-    workspaceId: Joi.string().allow(''),
+    workspaceId: Joi.string(),
   }),
 })
 
@@ -860,7 +861,7 @@ export const handleArchiveForm: ControllerHandler<{ formId: string }> = async (
 export const duplicateAdminForm: ControllerHandler<
   { formId: string },
   unknown,
-  CreateFormBodyDto
+  DuplicateFormBodyDto
 > = (req, res) => {
   const { formId } = req.params
   const userId = (req.session as AuthedSessionData).user._id

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -18,7 +18,7 @@ import { MYINFO_ATTRIBUTE_MAP } from '../../../../../shared/constants/field/myin
 import {
   AdminDashboardFormMetaDto,
   BasicField,
-  DuplicateFormBodyDto,
+  DuplicateFormOverwriteDto,
   EndPageUpdateDto,
   FieldCreateDto,
   FieldUpdateDto,
@@ -579,7 +579,7 @@ export const processCreateFormInWorkspace = async (
 export const duplicateForm = (
   originalForm: IFormDocument,
   newAdminId: string,
-  overrideParams: DuplicateFormBodyDto,
+  overrideParams: DuplicateFormOverwriteDto,
   workspaceId?: string,
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1427

## Solution
<!-- How did you solve the problem? -->
Include `workspaceId` as an optional parameter into `createAdminForm` and `duplicateAdminForm` controllers. 

Created a new `admin-form.service.ts` helper method `createFormInWorkspaceTransaction` using mongo transaction to create and shift the new form into a workspace if the workspaceId is provided. Else it will default to the current status quo to allow for backwards compatibility.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

Functionality test
- [ ] create a storage mode form in a workspace
- [ ] the form should be added to the workspace
- [ ] create an email mode form in a workspace
- [ ] the form should be added to the workspace
- [ ] duplicate a storage mode form in a workspace
- [ ] the form should be added to the workspace
- [ ] duplicate an email mode form in a workspace
- [ ] the form should be added to the workspace
- [ ] duplicate a form belonging to a workspace, whilst being on `All Forms`
- [ ] the form should not be added to any workspace and remain only on `All Forms`

Regression test (to be done in  in `All Forms` tab)
- [ ] create a storage mode form
- [ ] create an email mode form
- [ ] duplicate a storage mode form
- [ ] duplicate an email mode form
