### PR TITLE
fix: missing errors in error mapper

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -62,8 +62,10 @@ import {
 } from '../../spcp/spcp.errors'
 import { MissingUserError } from '../../user/user.errors'
 import {
+  AttachmentTooLargeError,
   ConflictError,
   InvalidEncodingError,
+  InvalidFileExtensionError,
   ProcessingError,
   ResponseModeError,
   SubmissionNotFoundError,
@@ -205,6 +207,8 @@ const errorMapper: MapRouteError = (
       }
     case ValidateFieldError:
     case DatabaseValidationError:
+    case InvalidFileExtensionError:
+    case AttachmentTooLargeError:
     case ProcessingError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The errors `AttachmentTooLargeError` and `InvalidFileExtensionError` were missing from the error mapper used for storage mode submissions. This caused them to throw 500 unknown route errors. [This is an example trace](https://app.datadoghq.com/apm/traces?query=env%3Aproduction%20AND%20service%3Aformsg%20AND%20resource_name%3A%22POST%20%2Fapi%2Fv3%2Fforms%2F%3AformId%28%5Ba-fA-F0-9%5D%7B24%7D%29%2Fsubmissions%2Fstorage%22%20AND%20%40http.status_code%3A500%20AND%20%2A%20operation_name%3Aexpress.request&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=4289875360716224540&spanType=all&spanViewType=logs&timeHint=1696314762499&trace=AgAAAYr0PSUDEPxAuQAAAAAAAAAYAAAAAEFZcjBQVGtFQUFCWTktdVJNMUtFdllnNwAAACQAAAAAMDE4YWY0NDQtM2ZlMy00NDY0LThlM2YtNjRiNTYxODYwYjQy&traceID=4289875360716224540&start=1696314743000&end=1696314803000&paused=true) of presenting this issue.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- `AttachmentTooLargeError` and `InvalidFileExtensionError` errors added to error mappers to be treated like other form submission errors where validation fails. There should be a 400 status code returned and an error message asking them to try again. These 2 were the missing error mappings identified from possible errors from `src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts` > `validateStorageSubmission`.

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Go to a storage mode form with at least 1 attachment field.
- [ ] Open the network panel.
- [ ] Make a submission with at least 1 attachment.
- [ ] Copy the cURL request of the above submission.
- [ ] In a terminal, paste this request and remove the file extensions in both the answer and the file field at the end. This is to simulate an invalid file extension (since there will be no file extensions).
- [ ] Add the `-I` flag to the cURL request.
- [ ] Enter the request. The status code should be 400 and the message should be "There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page."
