### PR TITLE
feat: add more myinfo sgid fields

### DIFF
--- a/.ebextensions/env-file-creation.config
+++ b/.ebextensions/env-file-creation.config
@@ -44,9 +44,9 @@ files:
         aws ssm get-parameter --name "${ENV_TYPE}-sentry" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-sms" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-ndi" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_TYPE}-sgid" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-verified-fields" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_TYPE}-webhook-verified-content" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}-sgid" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_SITE_NAME}-payment" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
         aws ssm get-parameter --name "${ENV_SITE_NAME}-cron-payment" --with-decryption --region $AWS_REGION | jq -r '.Parameter.Value' >> $TARGET_DIR/.env
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -48,6 +48,7 @@ const SGID_SUPPORTED_V1 = [
   // MyInfoAttribute.MobileNo,
 ]
 const SGID_SUPPORTED_V2 = [
+  ...SGID_SUPPORTED_V1,
   MyInfoAttribute.Sex,
   MyInfoAttribute.Race,
   MyInfoAttribute.Nationality,
@@ -81,13 +82,11 @@ export const MyInfoFieldPanel = () => {
     }
   }, [growthbook, user])
 
-  const showNewSgidMyInfoFields = useFeatureIsOn(featureFlags.myinfoSgid)
+  const showSgidMyInfoV2 = useFeatureIsOn(featureFlags.myinfoSgid)
 
-  const SGID_SUPPORTED_FINAL = useMemo(() => {
-    return showNewSgidMyInfoFields
-      ? SGID_SUPPORTED_V1.concat(SGID_SUPPORTED_V2)
-      : SGID_SUPPORTED_V1
-  }, [showNewSgidMyInfoFields])
+  const sgidSupportedFinal = useMemo(() => {
+    return showSgidMyInfoV2 ? SGID_SUPPORTED_V2 : SGID_SUPPORTED_V1
+  }, [showSgidMyInfoV2])
 
   /**
    * If sgID is used, checks if the corresponding
@@ -95,14 +94,14 @@ export const MyInfoFieldPanel = () => {
    */
   const sgIDUnSupported = useCallback(
     (form: AdminFormDto | undefined, fieldType: MyInfoAttribute): boolean => {
-      const SGID_SUPPORTED: Set<MyInfoAttribute> = new Set(SGID_SUPPORTED_FINAL)
+      const sgidSupported: Set<MyInfoAttribute> = new Set(sgidSupportedFinal)
 
       return (
         form?.authType === FormAuthType.SGID_MyInfo &&
-        !SGID_SUPPORTED.has(fieldType)
+        !sgidSupported.has(fieldType)
       )
     },
-    [SGID_SUPPORTED_FINAL],
+    [sgidSupportedFinal],
   )
 
   // myInfo should be disabled if

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -49,12 +49,7 @@ const SGID_SUPPORTED: Set<MyInfoAttribute> = new Set([
   // phone number formats.
   // MyInfo phone numbers support country code, while sgID-MyInfo does not.
   // MyInfoAttribute.MobileNo,
-
-  // FRM-1189: This is disabled due to slight different formatting.
-  // We format the Myinfo response by separates lines in addresses with comma
-  // Whereas sgID separates each line with newline.
-  // This should be enabled in future work
-  // MyInfoAttribute.RegisteredAddress,
+  MyInfoAttribute.RegisteredAddress,
 ])
 
 /**

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -76,7 +76,7 @@ export const MyInfoFieldPanel = () => {
         // Only update the `adminEmail` and `adminAgency` attributes, keep the rest the same
         ...growthbook.getAttributes(),
         adminEmail: user?.email,
-        adminAgency: user?.agency,
+        adminAgency: user?.agency.shortName,
       })
     }
   }, [growthbook, user])

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -73,7 +73,7 @@ export const MyInfoFieldPanel = () => {
   useEffect(() => {
     if (growthbook) {
       growthbook.setAttributes({
-        // Only update the `adminEmail` attribute, keep the rest the same
+        // Only update the `adminEmail` and `adminAgency` attributes, keep the rest the same
         ...growthbook.getAttributes(),
         adminEmail: user?.email,
         adminAgency: user?.agency,
@@ -89,18 +89,21 @@ export const MyInfoFieldPanel = () => {
       : SGID_SUPPORTED_V1
   }, [showNewSgidMyInfoFields])
 
-  const SGID_SUPPORTED: Set<MyInfoAttribute> = new Set(SGID_SUPPORTED_FINAL)
-
   /**
    * If sgID is used, checks if the corresponding
    * MyInfo field is supported by sgID.
    */
-  const sgIDUnSupported = (
-    form: AdminFormDto | undefined,
-    fieldType: MyInfoAttribute,
-  ): boolean =>
-    form?.authType === FormAuthType.SGID_MyInfo &&
-    !SGID_SUPPORTED.has(fieldType)
+  const sgIDUnSupported = useCallback(
+    (form: AdminFormDto | undefined, fieldType: MyInfoAttribute): boolean => {
+      const SGID_SUPPORTED: Set<MyInfoAttribute> = new Set(SGID_SUPPORTED_FINAL)
+
+      return (
+        form?.authType === FormAuthType.SGID_MyInfo &&
+        !SGID_SUPPORTED.has(fieldType)
+      )
+    },
+    [SGID_SUPPORTED_FINAL],
+  )
 
   // myInfo should be disabled if
   // 1. form response mode is not email mode
@@ -121,7 +124,7 @@ export const MyInfoFieldPanel = () => {
     (fieldType: MyInfoAttribute): boolean => {
       return isDisabled || sgIDUnSupported(form, fieldType)
     },
-    [form, isDisabled],
+    [form, isDisabled, sgIDUnSupported],
   )
 
   return (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -54,6 +54,12 @@ const SGID_SUPPORTED_V2 = [
   MyInfoAttribute.HousingType,
   MyInfoAttribute.HdbType,
   MyInfoAttribute.RegisteredAddress,
+  MyInfoAttribute.BirthCountry,
+  MyInfoAttribute.VehicleNo,
+  MyInfoAttribute.Employment,
+  MyInfoAttribute.WorkpassStatus,
+  MyInfoAttribute.Marital,
+  MyInfoAttribute.MobileNo,
 ]
 
 export const MyInfoFieldPanel = () => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -37,7 +37,12 @@ import { FieldSection } from './FieldSection'
 
 const SGID_SUPPORTED: Set<MyInfoAttribute> = new Set([
   MyInfoAttribute.Name,
+  MyInfoAttribute.Sex,
   MyInfoAttribute.DateOfBirth,
+  MyInfoAttribute.Race,
+  MyInfoAttribute.Nationality,
+  MyInfoAttribute.HousingType,
+  MyInfoAttribute.HdbType,
   MyInfoAttribute.PassportNumber,
   MyInfoAttribute.PassportExpiryDate,
   // This is disabled due to MyInfo and sgID-MyInfo not using the same

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -8,4 +8,5 @@ export const featureFlags = {
     'encryption-boundary-shift-hard-validation' as const,
   encryptionBoundaryShiftVirusScanner:
     'encryption-boundary-shift-virus-scanner' as const,
+  myinfoSgid: 'myinfo-sgid' as const,
 }

--- a/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/src/app/modules/myinfo/myinfo.adapter.ts
@@ -14,6 +14,7 @@ import {
   MyInfoChildVaxxStatus,
   MyInfoDataTransformer,
 } from '../../../../shared/types'
+import { createLoggerWithLabel } from '../../config/logger'
 
 import {
   formatAddress,
@@ -25,6 +26,8 @@ import {
   formatWorkpassStatus,
 } from './myinfo.format'
 import { isMyInfoChildrenBirthRecords } from './myinfo.util'
+
+const logger = createLoggerWithLabel(module)
 
 /**
  * Converts an internal MyInfo attribute used in FormSG to a scope
@@ -422,6 +425,14 @@ export class MyInfoData
       // Above cases should be exhaustive for all attributes supported by Form.
       // Fall back to leaving field editable as data shape is unknown.
       default:
+        logger.error({
+          message: 'Unknown attribute found in Singpass MyInfo field',
+          meta: {
+            action: '_isDataReadOnly',
+            myInfoValue,
+            attr,
+          },
+        })
         return false
     }
   }

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -281,6 +281,7 @@ export class MyInfoServiceClass {
             fieldValue,
             myInfoAttr,
             myInfoConstantsList,
+            myInfoData,
           )
         }
       }

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -44,12 +44,14 @@ import {
   FormAuthNoEsrvcIdError,
   FormNotFoundError,
 } from '../form/form.errors'
+import { SGIDMyInfoData } from '../sgid/sgid.adapter'
 import { SGID_MYINFO_LOGIN_COOKIE_NAME } from '../sgid/sgid.constants'
 import {
   ProcessedChildrenResponse,
   ProcessedFieldResponse,
 } from '../submission/submission.types'
 
+import { MyInfoData } from './myinfo.adapter'
 import { MYINFO_LOGIN_COOKIE_NAME } from './myinfo.constants'
 import {
   MyInfoCookieStateError,
@@ -542,7 +544,7 @@ export const handleMyInfoChildHashResponse = (
  */
 export const getMyInfoAttributeConstantsList = (
   myInfoAttr: string | string[],
-) => {
+): string[] | undefined => {
   switch (myInfoAttr) {
     case MyInfoAttribute.Occupation:
       return myInfoOccupations
@@ -576,8 +578,11 @@ export const logIfFieldValueNotInMyinfoList = (
   fieldValue: string,
   myInfoAttr: string | string[],
   myInfoList: string[],
+  myInfoData: MyInfoData | SGIDMyInfoData,
 ) => {
   const isFieldValueInMyinfoList = myInfoList.includes(fieldValue)
+  const myInfoSouce =
+    myInfoData instanceof MyInfoData ? 'Singpass MyInfo' : 'SGID MyInfo'
   if (!isFieldValueInMyinfoList) {
     logger.error({
       message: 'Myinfo field value not found in existing Myinfo constants list',
@@ -585,6 +590,7 @@ export const logIfFieldValueNotInMyinfoList = (
         action: 'prefillAndSaveMyInfoFields',
         myInfoFieldValue: fieldValue,
         myInfoAttr,
+        myInfoSouce,
       },
     })
   }

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -581,16 +581,19 @@ export const logIfFieldValueNotInMyinfoList = (
   myInfoData: MyInfoData | SGIDMyInfoData,
 ) => {
   const isFieldValueInMyinfoList = myInfoList.includes(fieldValue)
-  const myInfoSouce =
+  const myInfoSource =
     myInfoData instanceof MyInfoData ? 'Singpass MyInfo' : 'SGID MyInfo'
-  if (!isFieldValueInMyinfoList) {
+  // SGID returns NA instead of empty field values, we don't need this to be logged
+  // as this is expected behaviour
+  const isNAFromSgid = myInfoAttr === 'SGID MyInfo' && fieldValue === 'NA'
+  if (!isNAFromSgid || !isFieldValueInMyinfoList) {
     logger.error({
       message: 'Myinfo field value not found in existing Myinfo constants list',
       meta: {
         action: 'prefillAndSaveMyInfoFields',
         myInfoFieldValue: fieldValue,
         myInfoAttr,
-        myInfoSouce,
+        myInfoSource,
       },
     })
   }

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -114,8 +114,18 @@ export class SGIDMyInfoData
   }
 
   /**
-   * Refer to the myInfo data catalogue to see which fields should be read-only
-   * and which fields should be editable by the user.
+   * SGID only returns verified MyInfo fields, unless the field contains marriage-related information
+   * (decision by SNDGO & MSF due to overseas unregistered marriages).
+   * An empty myInfo field will always evaluate
+   * to false so that the field can be filled by form-filler.
+   *
+   * The affected marriage fields are:
+   * - marital
+   * - marriagedate
+   * - divorcedate
+   * - countryofmarriage
+   * - marriagecertno
+   *
    * @param attr sgID MyInfo OAuth scope.
    * @param fieldValue FormSG field value.
    * @returns Whether the data/field should be readonly.
@@ -137,6 +147,8 @@ export class SGIDMyInfoData
       case ExternalAttr.HousingType:
       case ExternalAttr.HdbType:
         return !!data
+      // Fields required to always be editable according to MyInfo docs
+      // case ExternalAttr.MaritalStatus:
       // Fall back to leaving field editable as data shape is unknown.
       default:
         return false
@@ -161,7 +173,7 @@ export class SGIDMyInfoData
     const fieldValue = this._formatFieldValue(externalAttr)
     return {
       fieldValue,
-      isReadOnly: true,
+      isReadOnly: this._isDataReadOnly(externalAttr, fieldValue),
     }
   }
 }

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -2,6 +2,7 @@ import {
   MyInfoAttribute as InternalAttr,
   MyInfoDataTransformer,
 } from '../../../../shared/types'
+import { createLoggerWithLabel } from '../../config/logger'
 
 import {
   SGID_MYINFO_NRIC_NUMBER_SCOPE,
@@ -9,6 +10,8 @@ import {
 } from './sgid.constants'
 import { formatAddress, formatVehicles } from './sgid.format'
 import { SGIDScopeToValue } from './sgid.types'
+
+const logger = createLoggerWithLabel(module)
 
 export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
   switch (attr) {
@@ -203,6 +206,15 @@ export class SGIDMyInfoData
       }
     }
     const fieldValue = this._formatFieldValue(externalAttr)
+    console.log('fieldValue: ', fieldValue, externalAttr)
+    logger.info({
+      message: 'get field value',
+      meta: {
+        action: 'getFieldValueForAttr',
+        fieldValue,
+        externalAttr,
+      },
+    })
     return {
       fieldValue,
       isReadOnly: this._isDataReadOnly(externalAttr, fieldValue),

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -48,7 +48,7 @@ export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
     case InternalAttr.Marital:
       return ExternalAttr.MaritalStatus
     case InternalAttr.MobileNo:
-      return ExternalAttr.MobileNoWithPrefix
+      return ExternalAttr.MobileNoWithCountryCode
     default:
       // This should be removed once sgID reaches parity with MyInfo.
       // For now, the returned value will be automatically filtered
@@ -87,7 +87,7 @@ const internalAttrToSGIDExternal = (
     case InternalAttr.PassportExpiryDate:
       return ExternalAttr.PassportExpiryDate
     case InternalAttr.MobileNo:
-      return ExternalAttr.MobileNoWithPrefix
+      return ExternalAttr.MobileNoWithCountryCode
     case InternalAttr.RegisteredAddress:
       return ExternalAttr.RegisteredAddress
     case InternalAttr.BirthCountry:
@@ -165,7 +165,7 @@ export class SGIDMyInfoData
       return false
 
     switch (attr) {
-      case ExternalAttr.MobileNoWithPrefix:
+      case ExternalAttr.MobileNoWithCountryCode:
       case ExternalAttr.RegisteredAddress:
       case ExternalAttr.Name:
       case ExternalAttr.PassportNumber:

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -2,13 +2,12 @@ import {
   MyInfoAttribute as InternalAttr,
   MyInfoDataTransformer,
 } from '../../../../shared/types'
-import { formatVehicleNumbers } from '../myinfo/myinfo.format'
 
 import {
   SGID_MYINFO_NRIC_NUMBER_SCOPE,
   SGIDScope as ExternalAttr,
 } from './sgid.constants'
-import { formatAddress } from './sgid.format'
+import { formatAddress, formatVehicles } from './sgid.format'
 import { SGIDScopeToValue } from './sgid.types'
 
 export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
@@ -134,7 +133,7 @@ export class SGIDMyInfoData
       case ExternalAttr.RegisteredAddress:
         return formatAddress(this.#payload[attr])
       case ExternalAttr.VehicleNo:
-        return formatVehicleNumbers(this.#payload[attr])
+        return formatVehicles(this.#payload[attr])
       default:
         return this.#payload[attr]
     }

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -2,6 +2,7 @@ import {
   MyInfoAttribute as InternalAttr,
   MyInfoDataTransformer,
 } from '../../../../shared/types'
+import { formatVehicleNumbers } from '../myinfo/myinfo.format'
 
 import {
   SGID_MYINFO_NRIC_NUMBER_SCOPE,
@@ -30,10 +31,22 @@ export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
       return ExternalAttr.PassportNumber
     case InternalAttr.PassportExpiryDate:
       return ExternalAttr.PassportExpiryDate
-    case InternalAttr.MobileNo:
-      return ExternalAttr.MobileNumber
     case InternalAttr.RegisteredAddress:
       return ExternalAttr.RegisteredAddress
+    case InternalAttr.BirthCountry:
+      return ExternalAttr.BirthCountry
+    case InternalAttr.VehicleNo:
+      return ExternalAttr.VehicleNo
+    case InternalAttr.Employment:
+      return ExternalAttr.Employment
+    case InternalAttr.WorkpassStatus:
+      return ExternalAttr.WorkpassStatus
+    case InternalAttr.WorkpassExpiryDate:
+      return ExternalAttr.WorkpassExpiryDate
+    case InternalAttr.Marital:
+      return ExternalAttr.MaritalStatus
+    case InternalAttr.MobileNo:
+      return ExternalAttr.MobileNoWithPrefix
     default:
       // This should be removed once sgID reaches parity with MyInfo.
       // For now, the returned value will be automatically filtered
@@ -72,9 +85,21 @@ const internalAttrToSGIDExternal = (
     case InternalAttr.PassportExpiryDate:
       return ExternalAttr.PassportExpiryDate
     case InternalAttr.MobileNo:
-      return ExternalAttr.MobileNumber
+      return ExternalAttr.MobileNoWithPrefix
     case InternalAttr.RegisteredAddress:
       return ExternalAttr.RegisteredAddress
+    case InternalAttr.BirthCountry:
+      return ExternalAttr.BirthCountry
+    case InternalAttr.VehicleNo:
+      return ExternalAttr.VehicleNo
+    case InternalAttr.Employment:
+      return ExternalAttr.Employment
+    case InternalAttr.WorkpassStatus:
+      return ExternalAttr.WorkpassStatus
+    case InternalAttr.WorkpassExpiryDate:
+      return ExternalAttr.WorkpassExpiryDate
+    case InternalAttr.Marital:
+      return ExternalAttr.MaritalStatus
     default:
       return undefined
   }
@@ -108,6 +133,8 @@ export class SGIDMyInfoData
     switch (attr) {
       case ExternalAttr.RegisteredAddress:
         return formatAddress(this.#payload[attr])
+      case ExternalAttr.VehicleNo:
+        return formatVehicleNumbers(this.#payload[attr])
       default:
         return this.#payload[attr]
     }
@@ -135,7 +162,7 @@ export class SGIDMyInfoData
     if (!data || !fieldValue) return false
 
     switch (attr) {
-      case ExternalAttr.MobileNumber:
+      case ExternalAttr.MobileNoWithPrefix:
       case ExternalAttr.RegisteredAddress:
       case ExternalAttr.Name:
       case ExternalAttr.PassportNumber:
@@ -146,9 +173,15 @@ export class SGIDMyInfoData
       case ExternalAttr.Nationality:
       case ExternalAttr.HousingType:
       case ExternalAttr.HdbType:
+      case ExternalAttr.BirthCountry:
+      case ExternalAttr.VehicleNo:
+      case ExternalAttr.Employment:
+      case ExternalAttr.WorkpassStatus:
+      case ExternalAttr.WorkpassExpiryDate:
         return !!data
       // Fields required to always be editable according to MyInfo docs
-      // case ExternalAttr.MaritalStatus:
+      case ExternalAttr.MaritalStatus:
+        return false
       // Fall back to leaving field editable as data shape is unknown.
       default:
         return false

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -13,8 +13,18 @@ export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
   switch (attr) {
     case InternalAttr.Name:
       return ExternalAttr.Name
+    case InternalAttr.Sex:
+      return ExternalAttr.Sex
     case InternalAttr.DateOfBirth:
       return ExternalAttr.DateOfBirth
+    case InternalAttr.Race:
+      return ExternalAttr.Race
+    case InternalAttr.Nationality:
+      return ExternalAttr.Nationality
+    case InternalAttr.HousingType:
+      return ExternalAttr.HousingType
+    case InternalAttr.HdbType:
+      return ExternalAttr.HdbType
     case InternalAttr.PassportNumber:
       return ExternalAttr.PassportNumber
     case InternalAttr.PassportExpiryDate:
@@ -44,8 +54,18 @@ const internalAttrToSGIDExternal = (
   switch (attr) {
     case InternalAttr.Name:
       return ExternalAttr.Name
+    case InternalAttr.Sex:
+      return ExternalAttr.Sex
     case InternalAttr.DateOfBirth:
       return ExternalAttr.DateOfBirth
+    case InternalAttr.Race:
+      return ExternalAttr.Race
+    case InternalAttr.Nationality:
+      return ExternalAttr.Nationality
+    case InternalAttr.HousingType:
+      return ExternalAttr.HousingType
+    case InternalAttr.HdbType:
+      return ExternalAttr.HdbType
     case InternalAttr.PassportNumber:
       return ExternalAttr.PassportNumber
     case InternalAttr.PassportExpiryDate:
@@ -83,6 +103,7 @@ export class SGIDMyInfoData
    * @returns the formatted field.
    */
   _formatFieldValue(attr: ExternalAttr): string | undefined {
+    console.log('sgid payload: ', this.#payload)
     return this.#payload[attr]
   }
 
@@ -104,6 +125,11 @@ export class SGIDMyInfoData
       case ExternalAttr.PassportNumber:
       case ExternalAttr.DateOfBirth:
       case ExternalAttr.PassportExpiryDate:
+      case ExternalAttr.Sex:
+      case ExternalAttr.Race:
+      case ExternalAttr.Nationality:
+      case ExternalAttr.HousingType:
+      case ExternalAttr.HdbType:
         return !!data
       // Fall back to leaving field editable as data shape is unknown.
       default:

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -7,6 +7,7 @@ import {
   SGID_MYINFO_NRIC_NUMBER_SCOPE,
   SGIDScope as ExternalAttr,
 } from './sgid.constants'
+import { formatAddress } from './sgid.format'
 import { SGIDScopeToValue } from './sgid.types'
 
 export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
@@ -103,8 +104,13 @@ export class SGIDMyInfoData
    * @returns the formatted field.
    */
   _formatFieldValue(attr: ExternalAttr): string | undefined {
-    console.log('sgid payload: ', this.#payload)
-    return this.#payload[attr]
+    console.log('sgid payload attr: ', this.#payload[attr])
+    switch (attr) {
+      case ExternalAttr.RegisteredAddress:
+        return formatAddress(this.#payload[attr])
+      default:
+        return this.#payload[attr]
+    }
   }
 
   /**

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -161,7 +161,8 @@ export class SGIDMyInfoData
    */
   _isDataReadOnly(attr: ExternalAttr, fieldValue: string | undefined): boolean {
     const data = this.#payload[attr]
-    if (!data || !fieldValue) return false
+    if (!data || !fieldValue || fieldValue === 'NA' || data === 'NA')
+      return false
 
     switch (attr) {
       case ExternalAttr.MobileNoWithPrefix:

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -147,6 +147,7 @@ export class SGIDMyInfoData
    * (decision by SNDGO & MSF due to overseas unregistered marriages).
    * An empty myInfo field will always evaluate
    * to false so that the field can be filled by form-filler.
+   * SGID returns 'NA' for field values that do not exist (vs empty string returned by Singpass MyInfo)
    *
    * The affected marriage fields are:
    * - marital
@@ -207,7 +208,6 @@ export class SGIDMyInfoData
       }
     }
     const fieldValue = this._formatFieldValue(externalAttr)
-    console.log('fieldValue: ', fieldValue, externalAttr)
     logger.info({
       message: 'get field value',
       meta: {

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -188,6 +188,14 @@ export class SGIDMyInfoData
         return false
       // Fall back to leaving field editable as data shape is unknown.
       default:
+        logger.error({
+          message: 'Unknown attribute found in SGID MyInfo field',
+          meta: {
+            action: '_isDataReadOnly',
+            fieldValue,
+            attr,
+          },
+        })
         return false
     }
   }

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -131,7 +131,6 @@ export class SGIDMyInfoData
    * @returns the formatted field.
    */
   _formatFieldValue(attr: ExternalAttr): string | undefined {
-    console.log('sgid payload attr: ', this.#payload[attr])
     switch (attr) {
       case ExternalAttr.RegisteredAddress:
         return formatAddress(this.#payload[attr])

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -46,5 +46,7 @@ export enum SGIDScope {
   WorkpassStatus = 'myinfo.workpass_status',
   WorkpassExpiryDate = 'myinfo.workpass_expiry_date',
   MaritalStatus = 'myinfo.marital_status',
-  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix', // SGID also has another myinfo.mobile_number field that does not contain the country code prefix
+  // SGID also has another myinfo.mobile_number field that does not contain the country code prefix.
+  // We use the one that contains prefix, as this matches our mobile number form field.
+  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix',
 }

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -46,5 +46,5 @@ export enum SGIDScope {
   WorkpassStatus = 'myinfo.workpass_status',
   WorkpassExpiryDate = 'myinfo.workpass_expiry_date',
   MaritalStatus = 'myinfo.marital_status',
-  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix', // SGID also has another myinfo.mobile_number field, but this is without the country code prefix
+  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix', // SGID also has another myinfo.mobile_number field that does not contain the country code prefix
 }

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -48,5 +48,5 @@ export enum SGIDScope {
   MaritalStatus = 'myinfo.marital_status',
   // SGID also has another myinfo.mobile_number field that does not contain the country code prefix.
   // We use the one that contains prefix, as this matches our mobile number form field.
-  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix',
+  MobileNoWithCountryCode = 'myinfo.mobile_number_with_country_code',
 }

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -33,7 +33,6 @@ export enum SGIDScope {
   DateOfBirth = 'myinfo.date_of_birth',
   PassportNumber = 'myinfo.passport_number',
   PassportExpiryDate = 'myinfo.passport_expiry_date',
-  MobileNumber = 'myinfo.mobile_number',
   Email = 'myinfo.email',
   RegisteredAddress = 'myinfo.registered_address',
   Sex = 'myinfo.sex',
@@ -41,4 +40,11 @@ export enum SGIDScope {
   Nationality = 'myinfo.nationality',
   HousingType = 'myinfo.housingtype',
   HdbType = 'myinfo.hdbtype',
+  BirthCountry = 'myinfo.birth_country',
+  VehicleNo = 'myinfo.vehicles',
+  Employment = 'myinfo.name_of_employer',
+  WorkpassStatus = 'myinfo.workpass_status',
+  WorkpassExpiryDate = 'myinfo.workpass_expiry_date',
+  MaritalStatus = 'myinfo.marital_status',
+  MobileNoWithPrefix = 'myinfo.mobile_number_with_prefix', // SGID also has another myinfo.mobile_number field, but this is without the country code prefix
 }

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -36,4 +36,9 @@ export enum SGIDScope {
   MobileNumber = 'myinfo.mobile_number',
   Email = 'myinfo.email',
   RegisteredAddress = 'myinfo.registered_address',
+  Sex = 'myinfo.sex',
+  Race = 'myinfo.race',
+  Nationality = 'myinfo.nationality',
+  HousingType = 'myinfo.housingtype',
+  HdbType = 'myinfo.hdbtype',
 }

--- a/src/app/modules/sgid/sgid.controller.ts
+++ b/src/app/modules/sgid/sgid.controller.ts
@@ -2,6 +2,7 @@ import { ParamsDictionary } from 'express-serve-static-core'
 import { StatusCodes } from 'http-status-codes'
 
 import { FormAuthType } from '../../../../shared/types'
+import { Environment } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
@@ -38,7 +39,15 @@ export const handleLogin: ControllerHandler<
   }
 
   const { formId, rememberMe, decodedQuery } = parsedState.value
-  const target = decodedQuery ? `/${formId}${decodedQuery}` : `/${formId}`
+
+  // For local dev, we need to specify the frontend app URL as this is different from the backend's app URL
+  const redirectTargetRaw =
+    process.env.NODE_ENV === Environment.Dev
+      ? `${config.app.feAppUrl}/${formId}`
+      : `/${formId}`
+  const target = decodedQuery
+    ? `${redirectTargetRaw}${decodedQuery}`
+    : `${redirectTargetRaw}`
 
   const formResult = await FormService.retrieveFullFormById(formId)
   if (formResult.isErr()) {

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -22,7 +22,7 @@ export const formatAddress = (addr: string): string => {
  * @returns Formatted address is comma separated, same as the output of formatAddress in myinfo.format.ts
  */
 export const formatVehicles = (vehicles: string): string => {
-  if (vehicles) {
+  if (vehicles && vehicles !== '[]') {
     try {
       const vehiclesObject = JSON.parse(vehicles)
       const vehicleNos = vehiclesObject

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -27,7 +27,7 @@ export const formatVehicles = (vehicles: string): string => {
       const vehiclesObject = JSON.parse(vehicles)
       const vehicleNos = vehiclesObject
         //TODO: obtain vehicle type from SGID
-        .map((vehicle: any) => vehicle['vehicle_number'])
+        .map((vehicle: { vehicle_number: string }) => vehicle['vehicle_number'])
         .join(', ')
       return vehicleNos
     } catch (error) {

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -9,3 +9,22 @@ export const formatAddress = (addr: string): string => {
   const formattedAddress = addr.replace(/(\n)+/g, ', ')
   return formattedAddress
 }
+
+/**
+ * Formats SGID vehicle types.
+ * SGID vehicles are a strintified array of objects, we want to output this as a string
+ * @param vehicles The vehicles to format.
+ * @example '[{"vehicle_number":"CB6171D"},{"vehicle_number":"SJQ7247B"}]'
+ * @returns Formatted address is comma separated, same as the output of formatAddress in myinfo.format.ts
+ */
+export const formatVehicles = (vehicles: string): string => {
+  // vehicles is a stringified array of objects for now, but this will change to an object in the future
+  const vehiclesObject =
+    typeof vehicles === 'string' ? JSON.parse(vehicles) : vehicles
+  return (
+    vehiclesObject
+      //TODO: obtain vehicle type from SGID
+      .map((vehicle: any) => vehicle['vehicle_number'])
+      .join(', ')
+  )
+}

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -12,15 +12,13 @@ export const formatAddress = (addr: string): string => {
 
 /**
  * Formats SGID vehicle types.
- * SGID vehicles are a strintified array of objects, we want to output this as a string
+ * SGID vehicles are a stringified array of objects, we want to output this as a string
  * @param vehicles The vehicles to format.
  * @example '[{"vehicle_number":"CB6171D"},{"vehicle_number":"SJQ7247B"}]'
  * @returns Formatted address is comma separated, same as the output of formatAddress in myinfo.format.ts
  */
 export const formatVehicles = (vehicles: string): string => {
-  // vehicles is a stringified array of objects for now, but this will change to an object in the future
-  const vehiclesObject =
-    typeof vehicles === 'string' ? JSON.parse(vehicles) : vehicles
+  const vehiclesObject = JSON.parse(vehicles)
   return (
     vehiclesObject
       //TODO: obtain vehicle type from SGID

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -26,7 +26,6 @@ export const formatVehicles = (vehicles: string): string => {
     try {
       const vehiclesObject = JSON.parse(vehicles)
       const vehicleNos = vehiclesObject
-        //TODO: obtain vehicle type from SGID
         .map((vehicle: { vehicle_number: string }) => vehicle['vehicle_number'])
         .join(', ')
       return vehicleNos

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -1,3 +1,7 @@
+import { createLoggerWithLabel } from '../../config/logger'
+
+const logger = createLoggerWithLabel(module)
+
 /**
  * Formats SGID MyInfo attribute as address.
  * SGID MyInfo multi-line address are newline-separated, while MyInfo multi-line addresses are comma-separated
@@ -18,11 +22,23 @@ export const formatAddress = (addr: string): string => {
  * @returns Formatted address is comma separated, same as the output of formatAddress in myinfo.format.ts
  */
 export const formatVehicles = (vehicles: string): string => {
-  const vehiclesObject = JSON.parse(vehicles)
-  return (
-    vehiclesObject
-      //TODO: obtain vehicle type from SGID
-      .map((vehicle: any) => vehicle['vehicle_number'])
-      .join(', ')
-  )
+  if (vehicles) {
+    try {
+      const vehiclesObject = JSON.parse(vehicles)
+      const vehicleNos = vehiclesObject
+        //TODO: obtain vehicle type from SGID
+        .map((vehicle: any) => vehicle['vehicle_number'])
+        .join(', ')
+      return vehicleNos
+    } catch (error) {
+      logger.error({
+        message: 'Failed to parse vehicles',
+        meta: { action: 'formatVehicles', vehicles },
+        error,
+      })
+      return ''
+    }
+  } else {
+    return ''
+  }
 }

--- a/src/app/modules/sgid/sgid.format.ts
+++ b/src/app/modules/sgid/sgid.format.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats SGID MyInfo attribute as address.
+ * SGID MyInfo multi-line address are newline-separated, while MyInfo multi-line addresses are comma-separated
+ * @param addr The address to format.
+ * @example '29 ROCHDALE ROAD\n\nSINGAPORE 535842'
+ * @returns Formatted address is comma separated, same as the output of formatAddress in myinfo.format.ts
+ */
+export const formatAddress = (addr: string): string => {
+  const formattedAddress = addr.replace(/(\n)+/g, ', ')
+  return formattedAddress
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to add more MyInfo fields when authentication is done via SGID.

Closes FRM-1191, FRM-1189

## Solution
<!-- How did you solve the problem? -->
Enable the following MyInfo fields for SGID login:
-   Sex,
-   Race,
-   Nationality,
-   HousingType,
-   HdbType,
-  RegisteredAddress,
-   BirthCountry,
-   VehicleNo,
-   Employment,
-   WorkpassStatus,
-   Marital,
-  MobileNo

Use Growthbook for percentage rollout.

**Details**
- The format for `RegisteredAddress` and `VehicleNo` returned by SGID are slightly different from that of Singpass MyInfo. We reformat them them `sgid.format.ts` to maintain parity with Singpass MyInfo fields.
`RegisteredAddress`: multi-line addresses are newline-separated, instead of comma-separated
`VehicleNo`: vehicles returned are a stringified array of objects
- Remove `NA` from the missing field values check, if the source is SGID
- If SGID returns 'NA', set the fieldValue as an empty string. This is to match how we process Singpass MyInfo fields, and also ensures that our frontend can process the field correctly (e.g. in `extractPreviewValue`)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->
![image](https://github.com/opengovsg/FormSG/assets/56983748/cecdf82f-15f7-43c8-8c36-a453a78ea7aa)

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] On an email-mode form, select 'Singpass app-only with myInfo' as the authentication method
- [x] Add all the available MyInfo fields to the form. These are:
  -   Sex,
  -   Race,
  -   Nationality,
  -   HousingType,
  -   HdbType,
  -  RegisteredAddress,
  -   BirthCountry,
  -   VehicleNo,
  -   Employment,
  -   WorkpassStatus,
  -   Marital,
  -  MobileNo
- [x] Submit a test form using the [SGID chrome extension](https://www.notion.so/opengov/SGID-MyInfo-Testing-Packet-8734d52d69484419a1e7ad5f337f3f55)


Regression Test
- [x] On an email-mode form, select 'Singpass with MyInfo' as the authentication method
- [x] Select the same fields as above
- [x] Submit the form


## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
- Ensure that all the SGID scopes have been added to the SGID Developer Portal FormSG app (done)
- Turn on the Growthbook feature flag (set as `true` for OGP, default is set to `false`), adjust the growthbook rollout percentage accordingly
