### PR TITLE
chore(ci): backend jest config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,9 @@ jobs:
       - run: npm ci --prefix serverless/virus-scanner
       - run: npm run test:backend:ci
         env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
+          # https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
+          # Recommends to be 3/4 of available memory, our runner has 7GB of memory and 0.75 * 1024 maps to 5376MB
+          NODE_OPTIONS: '--max-old-space-size=5376'
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci --prefix serverless/virus-scanner
-      - run: npm run test:backend
+      - run: npm run test:backend:ci
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
       - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,7 @@ jobs:
       - run: npm ci --prefix serverless/virus-scanner
       - run: npm run test:backend:ci
         env:
-          # https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
-          # Recommends to be 3/4 of available memory, our runner has 7GB of memory and 0.75 * 1024 maps to 5376MB
-          NODE_OPTIONS: '--max-old-space-size=5376'
+          NODE_OPTIONS: '--max-old-space-size=4096'
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env jest",
+    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --runInBand",
     "test:backend:watch": "env-cmd -f __tests__/setup/.test-env jest --watch",
     "test:frontend": "npm --prefix frontend test",
     "test:e2e-v2": "npm run build && npx playwright test",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env jest",
-    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage",
+    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.4",
     "test:backend:watch": "env-cmd -f __tests__/setup/.test-env jest --watch",
     "test:frontend": "npm --prefix frontend test",
     "test:e2e-v2": "npm run build && npx playwright test",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env jest",
-    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --runInBand",
+    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage",
     "test:backend:watch": "env-cmd -f __tests__/setup/.test-env jest --watch",
     "test:frontend": "npm --prefix frontend test",
     "test:e2e-v2": "npm run build && npx playwright test",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env jest",
-    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.4",
+    "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.2",
     "test:backend:watch": "env-cmd -f __tests__/setup/.test-env jest --watch",
     "test:frontend": "npm --prefix frontend test",
     "test:e2e-v2": "npm run build && npx playwright test",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

CI is too damn slow

## Solution
<!-- How did you solve the problem? -->

This probably requires us to tweak the numbers around, but seems like the number's I've set here is good enough for now.

[`--maxWorkers=2`](https://jestjs.io/docs/cli#--maxworkersnumstring):  this is now set to 2, which reflects the [number of CPUs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) that we are provisioned by github runner. This was previously set to 4 in `jest.config.js`. The intention is to reduce the amount of context switches that's required when the CPU switches between threads. 

~`--max-old-space-size=5376`: increased this to [75% of the amount](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) of [RAM we're provisioned](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) by github's runner. Increasing this config defers when the JS Engine does its gc. Theoretically, this should shotern the time taken to test as it spends less time doing deep GCs.~

[`--workerIdleMemoryLimit=0.2`](https://jestjs.io/docs/configuration/#workeridlememorylimit-numberstring): setting this to 0.2 which seemed to be working. Identified that the CI crashes due to OOM, due to memory leaks after workers completes every test case, evident by the increase in memory consumption report from `--logHeapUsage`. 
Note: 0.2 was chosen as 0.4 still hits OOM.

Also, there's a new command `test:backend:ci` that's carved out specifically for `ci`-only configs. 

## Alternatives

I did some quick experiment with using [swc](https://swc.rs/docs/usage/jest) to transpile ts. It is indeed faster, and consumes less memory, but unfortunately it is not a drop-in replacement. There were tests failures (didn't do full run, but about 25% of the tests failed, issues were relating to import syntax) which requires us to make code changes. 