### PR TITLE
feat: add well-known domain

### DIFF
--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -119,14 +119,16 @@ const loadExpressApp = async (connection: Connection) => {
   // API routes
   app.use('/api', ApiRouter)
 
-  app.get('/.well-known', catchNonExistentStaticRoutesMiddleware)
   // serve static assets. `dist/frontend` contains the root files as well as a `/static` folder
   // express.static calls next() if the file is not found
   app.use(express.static(path.resolve('dist/frontend'), { index: false }))
 
   // If requests for known static asset patterns were not served by
   // the static handlers above, middleware should try to fetch from s3 static bucket or else return 404s
-  app.get(/^\/(public|static)\//, catchNonExistentStaticRoutesMiddleware)
+  app.get(
+    /^\/(public|static|\.well-known)\//,
+    catchNonExistentStaticRoutesMiddleware,
+  )
 
   // Requests for root files (e.g. /robots.txt or /favicon.ico) that were
   // not served statically above will also return 404

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -119,7 +119,7 @@ const loadExpressApp = async (connection: Connection) => {
   // API routes
   app.use('/api', ApiRouter)
 
-  app.get(/^\/.well-known\//, catchNonExistentStaticRoutesMiddleware)
+  app.get('/.well-known', catchNonExistentStaticRoutesMiddleware)
   // serve static assets. `dist/frontend` contains the root files as well as a `/static` folder
   // express.static calls next() if the file is not found
   app.use(express.static(path.resolve('dist/frontend'), { index: false }))

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -119,6 +119,7 @@ const loadExpressApp = async (connection: Connection) => {
   // API routes
   app.use('/api', ApiRouter)
 
+  app.get(/^\/.well-known\//, catchNonExistentStaticRoutesMiddleware)
   // serve static assets. `dist/frontend` contains the root files as well as a `/static` folder
   // express.static calls next() if the file is not found
   app.use(express.static(path.resolve('dist/frontend'), { index: false }))


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

To support applepay, we needed to host some files in some specific urls to verify that we own the domain.

Closes FRM-1441

## Solution
<!-- How did you solve the problem? -->

Have the files be served from s3 through adding `/.well-known` as a known static asset url.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests

Regression
##### Existing well-known routes are not affected
- [ ] Ensure that [/singpass/.well-known/jwts.json](https://form.gov.sg/singpass/.well-known/jwks.json) does not return 4xx

##### Existing static and public routes are not affected
- [ ] Ensure that form.gov.sg is loaded with images and js running

#### Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New aasa file in `.well-known`**:
- [ ] Upload `apple-developer-merchantid-domain-association` file into s3 static bucket
- [ ] Make sure that the [/.well-known/apple-developer-merchantid-domain-association](https://form.gov.sg/.well-known/apple-developer-merchantid-domain-association) does not return 404