### PR TITLE
fix(gogov): reset GoGov states in share modal

### DIFF
--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -193,8 +193,9 @@ export const ShareFormModal = ({
       setGoLinkSaved(true)
       setGoLinkSuffixInput(goLinkSuffixData?.goLinkSuffix ?? '')
       setGoLinkHelperText(goLinkClaimSuccessHelperText)
-    } else {
-      // if go link data do not exist for current form, reset the states
+    }
+    return () => {
+      // before unmount or after any changes to goLinkSuffix, will reset the states first
       setGoLinkSaved(false)
       setGoLinkSuffixInput('')
       setGoLinkHelperText(undefined)

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -189,12 +189,17 @@ export const ShareFormModal = ({
   const [claimGoLoading, setClaimGoLoading] = useState(false)
 
   useEffect(() => {
-    if (goLinkSuffixData?.goLinkSuffix) {
+    if (goLinkSuffixData?.goLinkSuffix && formId) {
       setGoLinkSaved(true)
       setGoLinkSuffixInput(goLinkSuffixData?.goLinkSuffix ?? '')
       setGoLinkHelperText(goLinkClaimSuccessHelperText)
+    } else {
+      // if go link data do not exist for current form, reset the states
+      setGoLinkSaved(false)
+      setGoLinkSuffixInput('')
+      setGoLinkHelperText(undefined)
     }
-  }, [goLinkSuffixData?.goLinkSuffix])
+  }, [goLinkSuffixData?.goLinkSuffix, formId])
 
   const { claimGoLinkMutation } = useListShortenerMutations()
 

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -240,7 +240,7 @@ export const ShareFormModal = ({
       setGoLinkHelperText(getGoLinkClaimFailureHelperText(errMessage))
       return
     }
-  }, [user, claimGoLinkMutation, goLinkSuffixInput, formId])
+  }, [user, claimGoLinkMutation, goLinkSuffixInput])
 
   const FormLinkSection = () => (
     <FormControl isReadOnly>

--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -189,7 +189,7 @@ export const ShareFormModal = ({
   const [claimGoLoading, setClaimGoLoading] = useState(false)
 
   useEffect(() => {
-    if (goLinkSuffixData?.goLinkSuffix && formId) {
+    if (goLinkSuffixData?.goLinkSuffix) {
       setGoLinkSaved(true)
       setGoLinkSuffixInput(goLinkSuffixData?.goLinkSuffix ?? '')
       setGoLinkHelperText(goLinkClaimSuccessHelperText)
@@ -199,9 +199,9 @@ export const ShareFormModal = ({
       setGoLinkSuffixInput('')
       setGoLinkHelperText(undefined)
     }
-  }, [goLinkSuffixData?.goLinkSuffix, formId])
+  }, [goLinkSuffixData?.goLinkSuffix])
 
-  const { claimGoLinkMutation } = useListShortenerMutations()
+  const { claimGoLinkMutation } = useListShortenerMutations(formId ?? '')
 
   const [goLinkHelperText, setGoLinkHelperText] = useState<
     goLinkHelperTextType | undefined
@@ -214,7 +214,6 @@ export const ShareFormModal = ({
       setClaimGoLoading(true)
       await claimGoLinkMutation.mutateAsync({
         linkSuffix: goLinkSuffixInput,
-        formId: formId ?? '',
         adminEmail: user.email,
       })
       setClaimGoLoading(false)

--- a/frontend/src/features/link-shortener/mutations.ts
+++ b/frontend/src/features/link-shortener/mutations.ts
@@ -3,20 +3,13 @@ import { useMutation, useQueryClient } from 'react-query'
 import { claimGoLink } from './GoGovService'
 import { goGovKeys } from './queries'
 
-export const useListShortenerMutations = () => {
+export const useListShortenerMutations = (formId: string) => {
   const queryClient = useQueryClient()
 
   const claimGoLinkMutation = useMutation(
-    ({
-      linkSuffix,
-      formId,
-      adminEmail,
-    }: {
-      linkSuffix: string
-      formId: string
-      adminEmail: string
-    }) => claimGoLink(linkSuffix, formId, adminEmail),
-    { onSuccess: () => queryClient.invalidateQueries(goGovKeys.all) },
+    ({ linkSuffix, adminEmail }: { linkSuffix: string; adminEmail: string }) =>
+      claimGoLink(linkSuffix, formId, adminEmail),
+    { onSuccess: () => queryClient.invalidateQueries(goGovKeys.id(formId)) },
   )
 
   return { claimGoLinkMutation }

--- a/frontend/src/features/link-shortener/mutations.ts
+++ b/frontend/src/features/link-shortener/mutations.ts
@@ -1,8 +1,11 @@
-import { useMutation } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
 
 import { claimGoLink } from './GoGovService'
+import { goGovKeys } from './queries'
 
 export const useListShortenerMutations = () => {
+  const queryClient = useQueryClient()
+
   const claimGoLinkMutation = useMutation(
     ({
       linkSuffix,
@@ -13,6 +16,7 @@ export const useListShortenerMutations = () => {
       formId: string
       adminEmail: string
     }) => claimGoLink(linkSuffix, formId, adminEmail),
+    { onSuccess: () => queryClient.invalidateQueries(goGovKeys.all) },
   )
 
   return { claimGoLinkMutation }

--- a/frontend/src/features/link-shortener/queries.ts
+++ b/frontend/src/features/link-shortener/queries.ts
@@ -3,7 +3,6 @@ import { useQuery, UseQueryResult } from 'react-query'
 import { getGoLinkSuffix } from './GoGovService'
 
 export const goGovKeys = {
-  all: ['gogov'] as const,
   id: (id: string) => ['gogov', id] as const,
 }
 

--- a/frontend/src/features/link-shortener/queries.ts
+++ b/frontend/src/features/link-shortener/queries.ts
@@ -2,10 +2,15 @@ import { useQuery, UseQueryResult } from 'react-query'
 
 import { getGoLinkSuffix } from './GoGovService'
 
+export const goGovKeys = {
+  all: ['gogov'] as const,
+  id: (id: string) => ['gogov', id] as const,
+}
+
 export const useGoLink = (
   formId: string,
 ): UseQueryResult<{ goLinkSuffix: string }> => {
-  return useQuery(formId, () => getGoLinkSuffix(formId), {
+  return useQuery(goGovKeys.id(formId), () => getGoLinkSuffix(formId), {
     enabled: !!formId,
   })
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There is currently a FE bug when accessing GoGov links in `ShareFormModal`

See Before Screenshot video 1
To replicate:
1. Go to a dashboard with multiple forms (without gogov links)
2. Verify that the forms do not have a gogov link
3. Create a new gogov link in one of the forms
4. Go to other forms, it will have the gogov link from step 3 in its form share modal

This occurs as we use the same `ShareFormModal` in the entire dashboard for various forms. And once we successfully queried for a GoGov suffix, we will set it as the modal's states, without ever reverting it.

Additionally, there is another bug as we do not invalidate our `useQuery` for fetching `GoLinkSuffix`. Hence, if you exit to another page, then try to access the share modal, you will not find your suffix.

See Before Screenshot video 2
To replicate:
1. Go to a form in the form page
2. Create a go link
3. Go back to dashboard page, and click on share modal in the form 
4. Go link is missing
5. Go back to the form page 
6. Go to share modal
7. Go link is missing
8. Refresh page
9. Go to share modal
10. Go link is present

## Solution
<!-- How did you solve the problem? -->

Reset the gogov useStates when we switch between forms and when the suffix data is undefined.

Fix the query keys for go link query, and will invalidate go queries for the specific formId upon successful gogov link claim. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/59867455/2a293e6e-cd93-48dd-b265-d3fc90d38d49


https://github.com/opengovsg/FormSG/assets/59867455/d765b86a-fff8-4867-85dd-83a5a5b0beb8


**AFTER**:
<!-- [insert screenshot here] -->

https://github.com/opengovsg/FormSG/assets/59867455/3812c673-0f2f-43e6-8075-46675d777b98


https://github.com/opengovsg/FormSG/assets/59867455/c06c2833-3135-475a-b096-fee78a368f19


## Tests
<!-- What tests should be run to confirm functionality? -->

Testing Share Form Modal on dashboard
- [ ] Go to dashboard page
- [ ] Fetch a gogov link
- [ ] Ensure that other forms without gogov link do not replicate the same suffix as the created link
- [ ] Refresh page
- [ ] Go to any form with a gogov link
- [ ] Go to any other form without a gogov link
- [ ] The gogov link suffix should be empty

Testing invalidating gogov queries
- [ ] Go to form page of a form without gogov link
- [ ] Create a go gov link
- [ ] Go back to dashboard page
- [ ] Open share form modal of the form above
- [ ] Gogov link should be present
- [ ] Go back to form page of the form above
- [ ] Open share form modal
- [ ] Gogov link should be present

Regression test
- [ ] Go to FormPage of a form with gogov link
- [ ] Open share modal
- [ ] Ensure gogov link is correct
- [ ] Go to FormPage of a form without gogov link
- [ ] Open share modal
- [ ] Ensure no gogov link
