### PR TITLE
fix: rm fallback from submit v2.1 mutation

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -579,25 +579,6 @@ export const PublicFormProvider = ({
                     timestamp,
                   })
                 },
-                onError: (error) => {
-                  // TODO(#5826): Remove when we have resolved the Network Error
-                  datadogLogs.logger.warn(
-                    `handleSubmitForm: submit with virus scan`,
-                    {
-                      meta: {
-                        ...logMeta,
-                        responseMode: 'storage',
-                        method: 'axios',
-                        error,
-                      },
-                    },
-                  )
-
-                  // defaults to the safest option of storage submission without virus scanning
-                  return submitStorageFormWithFetch(
-                    enableEncryptionBoundaryShift,
-                  )
-                },
               },
             )
           }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Fallback for virus can mutation catches all errors. This is an issue as when malicious files are scanned, the fallback is triggered as well. This bug was identified by @KenLSM in https://github.com/opengovsg/FormSG/pull/6777.

## Solution
<!-- How did you solve the problem? -->

There are many points of failure for the mutation to fail. The original intention of the fallback mechanism is to try the submission again if there are any unexpected errors related to the virus scan itself (e.g. if lambda is down, if s3 uploads can't be done, etc). However, these block submissions anyway - the response to this should be to rollback using the growthbook flag.

As such, we want to remove the `onError` block.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Malicious file scan triggering retry on submit fetch on storage mode form.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Go to a storage form with attachments.
- [ ] Submit a malicious file (get a test one from https://www.eicar.org/download-anti-malware-testfile/). An error message should be thrown and submission should be blocked.
