### PR TITLE
feat(virus-scanner): happy path logging

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -305,7 +305,7 @@ export const scanAndRetrieveAttachments = async (
 
   if (!virusScannerEnabled) {
     logger.warn({
-      message: 'Virus scanner is not enabled.',
+      message: 'Virus scanner is not enabled on BE.',
       meta: logMeta,
     })
 
@@ -317,7 +317,18 @@ export const scanAndRetrieveAttachments = async (
   // should have virus scanning enabled. If not, skip this middleware.
   // Note: Version number is sent by the frontend and should only be >=2.1 if virus scanning is enabled on the frontend.
 
-  if (req.body.version < 2.1) return next()
+  if (req.body.version < 2.1) {
+    logger.warn({
+      message: 'Virus scanner is not enabled on FE.',
+      meta: logMeta,
+    })
+    return next()
+  }
+
+  logger.info({
+    message: 'Virus scanner is enabled on both BE and FE.',
+    meta: logMeta,
+  })
 
   // At this point, virus scanner is enabled and storage submission v2.1+. This means that both the FE and BE
   // have virus scanning enabled.

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -353,6 +353,11 @@ export const scanAndRetrieveAttachments = async (
     })
   }
 
+  logger.info({
+    message: 'Successfully scanned and downloaded clean attachments',
+    meta: logMeta,
+  })
+
   // Step 5: Replace req.body.responses with the new responses with populated attachments.
   req.body.responses = scanAndRetrieveFilesResult.value
 

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -42,5 +42,7 @@ export const createReqMeta = <R extends LooseRequest>(req: R): ReqMeta => {
     url: req.baseUrl + req.path,
     urlWithQueryParams: req.originalUrl,
     headers: req.headers,
+    // endpointVersion is only present in requests to storage submission endpoints
+    ...(req.body.version && { endpointVersion: req.body.version }),
   }
 }

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -42,7 +42,5 @@ export const createReqMeta = <R extends LooseRequest>(req: R): ReqMeta => {
     url: req.baseUrl + req.path,
     urlWithQueryParams: req.originalUrl,
     headers: req.headers,
-    // endpointVersion is only present in requests to storage submission endpoints
-    ...(req.body.version && { endpointVersion: req.body.version }),
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Logging was primarily focused on errors, which are good to ensure that our app doesn't fail silently, but in the case of an incident, we will not be able to access the impact accurately as there is no relative total number to compare to. Furthermore, happy path logs will help us better pinpoint exactly where the code failed. 🤞 

Closes FRM-1215

## Solution
<!-- How did you solve the problem? -->

Add happy path logging!

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Logging for feature flags.
- Logging for successful scanning and retrieval.
- Logging for version in `req.body`.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Ensure that you have a form that has virus scanner enabled (i.e. on staging, enable virus scanner for all forms, or on prod, use the form with the forced rule to enable it).
- [ ] Go to a form that has virus scanner enabled. Open the network panel.
  - [ ] Submit a response with a non-malicious file.
  - [ ] Check the network panel - the payload should have version 2.1.
  - [ ] Go to datadog Logs and search for `service:formsg source:cloudwatch @dd.env:staging-alt2 `. You should see the following logs, in order:
    - [ ] Virus scanner is enabled on both BE and FE.
    - [ ] Successfully parsed success payload from virus scanning lambda
    - [ ] Successfully scanned and downloaded clean attachments
    - [ ] Saved submission to MongoDB
    - [ ] POST /api/v3/forms/651ad8aec300f7001132c2d2/submissions/storage
- [ ] Go to a form that has virus scanner enabled again. Open the network panel.
  - [ ] Submit a response with a test malicious file. (Get one from https://www.eicar.org/download-anti-malware-testfile/)
  - [ ] Check the network panel - there should be 1 with version 2.1 in the payload and another with version 2 in the payload.
  - [ ] Go to datadog Logs and search for `service:formsg source:cloudwatch @dd.env:staging-alt2 `. You should see the following logs, in order:
    - [ ] The first API call to the virus scan enabled endpoint:
      - [ ] Virus scanner is enabled on both BE and FE.
      - [ ] Successfully parsed success payload from virus scanning lambda
      - [ ] Error returned from virus scanning lambda or parsing lambda output
      - [ ] Error scanning and downloading clean attachments (opening this, you should see an error message specifying which file failed the scan)
      - [ ] POST /api/v3/forms/651ad8aec300f7001132c2d2/submissions/storage
    - [ ] The second API call to the virus scan disabled endpoint:
      - [ ] Virus scanner is not enabled on FE.
      - [ ] Saved submission to MongoDB
      - [ ] POST /api/v3/forms/651ad8aec300f7001132c2d2/submissions/storage