### PR TITLE
chore: return InvalidFileKeyError if file not found

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -1438,9 +1438,7 @@ describe('encrypt-submission.service', () => {
       // Assert
       expect(awsSpy).toHaveBeenCalledOnce()
       expect(actualResult.isErr()).toEqual(true)
-      expect(actualResult._unsafeUnwrapErr()).toEqual(
-        new VirusScanFailedError(),
-      )
+      expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidFileKeyError())
     })
 
     it("should return errAsync if the lambda's errored response is not in the right format", async () => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -771,6 +771,8 @@ export const triggerVirusScanning = (
         })
 
         if (error instanceof ParseVirusScannerLambdaPayloadError) return error
+        else if (error.statusCode === StatusCodes.NOT_FOUND)
+          return new InvalidFileKeyError()
         else if (error.statusCode !== StatusCodes.BAD_REQUEST)
           return new VirusScanFailedError()
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -772,7 +772,9 @@ export const triggerVirusScanning = (
 
         if (error instanceof ParseVirusScannerLambdaPayloadError) return error
         else if (error.statusCode === StatusCodes.NOT_FOUND)
-          return new InvalidFileKeyError()
+          return new InvalidFileKeyError(
+            'Invalid file key. The file must be uploaded first.',
+          )
         else if (error.statusCode !== StatusCodes.BAD_REQUEST)
           return new VirusScanFailedError()
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -773,7 +773,7 @@ export const triggerVirusScanning = (
         if (error instanceof ParseVirusScannerLambdaPayloadError) return error
         else if (error.statusCode === StatusCodes.NOT_FOUND)
           return new InvalidFileKeyError(
-            'Invalid file key. The file must be uploaded first.',
+            'Invalid file key - file key is not found in the quarantine bucket. The file must be uploaded first.',
           )
         else if (error.statusCode !== StatusCodes.BAD_REQUEST)
           return new VirusScanFailedError()


### PR DESCRIPTION
## Problem
- Returns 400 instead of 500 if file key not found in quarantine bucket 