### PR TITLE
fix: add payment data to virus scanner endpoint

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -559,7 +559,10 @@ export const PublicFormProvider = ({
           // TODO (FRM-1413): Move to main return statement once virus scanner has been fully rolled out
           if (enableEncryptionBoundaryShift && enableVirusScanner) {
             return submitStorageModeClearFormWithVirusScanningMutation.mutateAsync(
-              formData,
+              {
+                ...formData,
+                ...formPaymentData,
+              },
               {
                 onSuccess: ({
                   submissionId,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -679,11 +679,15 @@ export const PublicFormProvider = ({
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
       enableEncryptionBoundaryShift,
+      enableVirusScanner,
+      submitStorageModeClearFormMutation,
+      submitStorageModeFormMutation,
       submitStorageModeClearFormFetchMutation,
       submitStorageModeFormFetchMutation,
       navigate,
       formId,
       storePaymentMemory,
+      submitStorageModeClearFormWithVirusScanningMutation,
     ],
   )
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -5,7 +5,10 @@ import { StatusCodes } from 'http-status-codes'
 import { chain, omit } from 'lodash'
 import { ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
-import { featureFlags } from '../../../../../shared/constants'
+import {
+  featureFlags,
+  VIRUS_SCANNER_SUBMISSION_VERSION,
+} from '../../../../../shared/constants'
 import {
   BasicField,
   StorageModeAttachment,
@@ -317,7 +320,7 @@ export const scanAndRetrieveAttachments = async (
   // should have virus scanning enabled. If not, skip this middleware.
   // Note: Version number is sent by the frontend and should only be >=2.1 if virus scanning is enabled on the frontend.
 
-  if (req.body.version < 2.1) {
+  if (req.body.version < VIRUS_SCANNER_SUBMISSION_VERSION) {
     logger.warn({
       message: 'Virus scanner is not enabled on FE.',
       meta: logMeta,

--- a/src/app/modules/submission/receiver/receiver.service.ts
+++ b/src/app/modules/submission/receiver/receiver.service.ts
@@ -1,9 +1,9 @@
 import Busboy from 'busboy'
 import { IncomingHttpHeaders } from 'http'
 import { err, ok, Result, ResultAsync } from 'neverthrow'
-import { VIRUS_SCANNER_SUBMISSION_VERSION } from 'shared/constants'
 import { FormResponseMode } from 'shared/types'
 
+import { VIRUS_SCANNER_SUBMISSION_VERSION } from '../../../../../shared/constants'
 import { MB } from '../../../../../shared/constants/file'
 import { IAttachmentInfo } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'

--- a/src/app/modules/submission/receiver/receiver.service.ts
+++ b/src/app/modules/submission/receiver/receiver.service.ts
@@ -1,6 +1,7 @@
 import Busboy from 'busboy'
 import { IncomingHttpHeaders } from 'http'
 import { err, ok, Result, ResultAsync } from 'neverthrow'
+import { VIRUS_SCANNER_SUBMISSION_VERSION } from 'shared/constants'
 import { FormResponseMode } from 'shared/types'
 
 import { MB } from '../../../../../shared/constants/file'
@@ -159,7 +160,7 @@ export const configureMultipartReceiver = (
               // TODO (FRM-1413): change to a version existence guardrail when
               // virus scanning has completed rollout, so that virus scanning
               // cannot be bypassed on storage mode submissions.
-              (body.version ?? 0) >= 2.1,
+              (body.version ?? 0) >= VIRUS_SCANNER_SUBMISSION_VERSION,
             )
             return resolve(body)
           } else {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Payment forms will fail on the /submissions/storage v2.1 with 500 as the payment data is not passed to the endpoint. When there is recaptcha, the submission fails entirely as the recaptcha is retried.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Pass `formPaymentData` into the submit with virus scanning mutation.

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a payment form with recaptcha. 
- [ ] Try to submit the payment form. It should succeed.
