### PR TITLE
feat: change infobox back to payments

### DIFF
--- a/frontend/src/features/workspace/components/WorkspacePageContent.tsx
+++ b/frontend/src/features/workspace/components/WorkspacePageContent.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Box, Container, Grid } from '@chakra-ui/react'
 
-import { GUIDE_ENCRYPTION_BOUNDARY_SHIFT } from '~constants/links'
+import { GUIDE_PAYMENTS_ENTRY } from '~constants/links'
 import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import InlineMessage from '~components/InlineMessage'
@@ -41,7 +41,7 @@ export const WorkspacePageContent = ({
   )
 
   // TODO: change dashboard message to env var
-  const dashboardMessage = `FormSG encryption is changing to make it more secure. This won't affect data/security classifications, and no action is needed from you. [Learn more](${GUIDE_ENCRYPTION_BOUNDARY_SHIFT})`
+  const dashboardMessage = `Introducing payments! Respondents can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
 
   return totalFormsCount === 0 ? (
     <EmptyWorkspace


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Encryption boundary shift is donezo so we can put up the banner to market _FormPay_ again.

## Solution
<!-- How did you solve the problem? -->

Replace dashboard infobox content with payment marketing content.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release?
- [ ] Yes - this PR contains breaking changes
    - Details ... -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

<img width="1512" alt="Screenshot 2023-10-13 at 7 19 55 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/c56aa86f-a479-4c91-962b-1e76a12fa293">

**AFTER**:

<img width="1512" alt="Screenshot 2023-10-13 at 7 18 51 PM" src="https://github.com/opengovsg/FormSG/assets/37061143/cecc6167-3c2b-4675-9449-2858813fe000">

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Ensure that the infobox on the dashboard reflects the payments marketing content.
- [ ] Link on infobox should go to payment slide deck.
