### PR TITLE
fix(transferownershipmodal): remove linting errors

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -676,11 +676,15 @@ export const PublicFormProvider = ({
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
       enableEncryptionBoundaryShift,
+      enableVirusScanner,
+      submitStorageModeClearFormMutation,
+      submitStorageModeFormMutation,
       submitStorageModeClearFormFetchMutation,
       submitStorageModeFormFetchMutation,
       navigate,
       formId,
       storePaymentMemory,
+      submitStorageModeClearFormWithVirusScanningMutation,
     ],
   )
 

--- a/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
+++ b/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
@@ -51,6 +51,7 @@ type UseModalStateReturn = {
   onNext: SubmitHandler<TransferOwnershipInputs>
   onConfirm: () => void
 }
+
 const useModalState = ({
   onClose,
   reset,
@@ -101,8 +102,7 @@ const useModalState = ({
         },
       },
     )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, transferOwnershipMutation, email])
+  }, [user, transferOwnershipMutation, email, resetModal, refetch])
 
   useEffect(() => {
     trigger()

--- a/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
+++ b/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
@@ -59,14 +59,14 @@ const useModalState = ({ onClose, reset, trigger }) => {
     reset()
     trigger()
     onClose()
-  }, [page, email])
+  }, [reset, trigger, onClose])
 
   const onNext: SubmitHandler<TransferOwnershipInputs> = useCallback(
     ({ email }) => {
       setEmail(email)
       setPage(1)
     },
-    [page, email],
+    [],
   )
 
   const onConfirm = useCallback(() => {
@@ -80,7 +80,7 @@ const useModalState = ({ onClose, reset, trigger }) => {
         },
       },
     )
-  }, [page, email, user])
+  }, [user, transferOwnershipMutation, email, resetModal, refetch])
 
   useEffect(() => {
     trigger()

--- a/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
+++ b/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
@@ -43,6 +43,14 @@ type TransferOwnershipInputs = {
   email: string
 }
 
+type UseModalStateReturn = {
+  page: number
+  email: string
+  isOwnEmail: (value: string) => boolean
+  resetModal: () => void
+  onNext: SubmitHandler<TransferOwnershipInputs>
+  onConfirm: () => void
+}
 const useModalState = ({
   onClose,
   reset,
@@ -51,14 +59,7 @@ const useModalState = ({
   onClose: () => void
   reset: UseFormReset<TransferOwnershipInputs>
   trigger: UseFormTrigger<TransferOwnershipInputs>
-}): {
-  page: number
-  email: string
-  isOwnEmail: (value: string) => boolean
-  resetModal: () => void
-  onNext: SubmitHandler<TransferOwnershipInputs>
-  onConfirm: () => void
-} => {
+}): UseModalStateReturn => {
   const { refetch } = useWorkspace()
 
   const [page, setPage] = useState(0)

--- a/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
+++ b/frontend/src/features/user/transfer-ownership/TransferOwnershipModal.tsx
@@ -80,7 +80,8 @@ const useModalState = ({ onClose, reset, trigger }) => {
         },
       },
     )
-  }, [user, transferOwnershipMutation, email, resetModal, refetch])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, transferOwnershipMutation, email])
 
   useEffect(() => {
     trigger()

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -88,6 +88,7 @@ export const processFetchResponse = async (response: Response) => {
       const data = await response.json()
       return data
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     // No guarantee that error is an Error object
     datadogLogs.logger.warn(`Fetch error: ${error.message}`, {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The linting warnings for TransferOwnershipModal are annoying and should be fixed.

## Solution
<!-- How did you solve the problem? -->
Fixed the warnings by adding the missing dependencies and removing forbidden non-null assertions

## Tests
<!-- What tests should be run to confirm functionality? -->
**1. Regression test for transferring ownership of all forms**
- [x] Log into the FormSG dashboard
- [x] Transfer all forms to another admin
- [x] Sign in as the other admin and check that all forms from the previous admin have been transferred over
