### PR TITLE
feat(sgid-myinfo): add even more sgid myinfo fields

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -267,9 +267,6 @@ const MyInfoText = ({
 
   return (
     <Text>
-      {authType === FormAuthType.SGID_MyInfo
-        ? 'Some MyInfo fields are not yet supported in your selected authentication type. '
-        : null}
       {`Only 30 MyInfo fields are allowed in Email mode (${numMyInfoFields}/30). `}
       <Link isExternal href={GUIDE_EMAIL_MODE}>
         Learn more

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -61,6 +61,8 @@ const SGID_SUPPORTED_V2 = [
   MyInfoAttribute.WorkpassStatus,
   MyInfoAttribute.Marital,
   MyInfoAttribute.MobileNo,
+  MyInfoAttribute.WorkpassExpiryDate,
+  MyInfoAttribute.ResidentialStatus,
 ]
 
 export const MyInfoFieldPanel = () => {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -63,6 +63,12 @@ const SGID_SUPPORTED_V2 = [
   MyInfoAttribute.MobileNo,
   MyInfoAttribute.WorkpassExpiryDate,
   MyInfoAttribute.ResidentialStatus,
+  MyInfoAttribute.Dialect,
+  MyInfoAttribute.Occupation,
+  MyInfoAttribute.CountryOfMarriage,
+  MyInfoAttribute.MarriageCertNo,
+  MyInfoAttribute.MarriageDate,
+  MyInfoAttribute.DivorceDate,
 ]
 
 export const MyInfoFieldPanel = () => {

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -49,6 +49,8 @@ export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
       return ExternalAttr.MaritalStatus
     case InternalAttr.MobileNo:
       return ExternalAttr.MobileNoWithCountryCode
+    case InternalAttr.ResidentialStatus:
+      return ExternalAttr.ResidentialStatus
     default:
       // This should be removed once sgID reaches parity with MyInfo.
       // For now, the returned value will be automatically filtered
@@ -92,6 +94,8 @@ const internalAttrToSGIDExternal = (
       return ExternalAttr.RegisteredAddress
     case InternalAttr.BirthCountry:
       return ExternalAttr.BirthCountry
+    case InternalAttr.ResidentialStatus:
+      return ExternalAttr.ResidentialStatus
     case InternalAttr.VehicleNo:
       return ExternalAttr.VehicleNo
     case InternalAttr.Employment:
@@ -172,6 +176,7 @@ export class SGIDMyInfoData
       case ExternalAttr.Name:
       case ExternalAttr.PassportNumber:
       case ExternalAttr.DateOfBirth:
+      case ExternalAttr.ResidentialStatus:
       case ExternalAttr.PassportExpiryDate:
       case ExternalAttr.Sex:
       case ExternalAttr.Race:

--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -51,6 +51,18 @@ export const internalAttrToScope = (attr: InternalAttr): ExternalAttr => {
       return ExternalAttr.MobileNoWithCountryCode
     case InternalAttr.ResidentialStatus:
       return ExternalAttr.ResidentialStatus
+    case InternalAttr.Dialect:
+      return ExternalAttr.Dialect
+    case InternalAttr.Occupation:
+      return ExternalAttr.Occupation
+    case InternalAttr.CountryOfMarriage:
+      return ExternalAttr.CountryOfMarriage
+    case InternalAttr.MarriageCertNo:
+      return ExternalAttr.MarriageCertNo
+    case InternalAttr.MarriageDate:
+      return ExternalAttr.MarriageDate
+    case InternalAttr.DivorceDate:
+      return ExternalAttr.DivorceDate
     default:
       // This should be removed once sgID reaches parity with MyInfo.
       // For now, the returned value will be automatically filtered
@@ -106,6 +118,18 @@ const internalAttrToSGIDExternal = (
       return ExternalAttr.WorkpassExpiryDate
     case InternalAttr.Marital:
       return ExternalAttr.MaritalStatus
+    case InternalAttr.Dialect:
+      return ExternalAttr.Dialect
+    case InternalAttr.Occupation:
+      return ExternalAttr.Occupation
+    case InternalAttr.CountryOfMarriage:
+      return ExternalAttr.CountryOfMarriage
+    case InternalAttr.MarriageCertNo:
+      return ExternalAttr.MarriageCertNo
+    case InternalAttr.MarriageDate:
+      return ExternalAttr.MarriageDate
+    case InternalAttr.DivorceDate:
+      return ExternalAttr.DivorceDate
     default:
       return undefined
   }
@@ -188,9 +212,15 @@ export class SGIDMyInfoData
       case ExternalAttr.Employment:
       case ExternalAttr.WorkpassStatus:
       case ExternalAttr.WorkpassExpiryDate:
+      case ExternalAttr.Dialect:
+      case ExternalAttr.Occupation:
         return !!data
       // Fields required to always be editable according to MyInfo docs
       case ExternalAttr.MaritalStatus:
+      case ExternalAttr.CountryOfMarriage:
+      case ExternalAttr.MarriageCertNo:
+      case ExternalAttr.MarriageDate:
+      case ExternalAttr.DivorceDate:
         return false
       // Fall back to leaving field editable as data shape is unknown.
       default:

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -50,10 +50,10 @@ export enum SGIDScope {
   // SGID also has another myinfo.mobile_number field that does not contain the country code prefix.
   // We use the one that contains prefix, as this matches our mobile number form field.
   MobileNoWithCountryCode = 'myinfo.mobile_number_with_country_code',
-  Dialect = 'dialect',
-  Occupation = 'occupation',
-  CountryOfMarriage = 'countryofmarriage',
-  MarriageCertNo = 'marriagecertno',
-  MarriageDate = 'marriagedate',
-  DivorceDate = 'divorcedate',
+  Dialect = 'myinfo.dialect',
+  Occupation = 'myinfo.occupation',
+  CountryOfMarriage = 'myinfo.country_of_marriage',
+  MarriageCertNo = 'myinfo.marriage_certificate_number',
+  MarriageDate = 'myinfo.marriage_date',
+  DivorceDate = 'myinfo.divorce_date',
 }

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -41,6 +41,7 @@ export enum SGIDScope {
   HousingType = 'myinfo.housingtype',
   HdbType = 'myinfo.hdbtype',
   BirthCountry = 'myinfo.birth_country',
+  ResidentialStatus = 'myinfo.residentialstatus',
   VehicleNo = 'myinfo.vehicles',
   Employment = 'myinfo.name_of_employer',
   WorkpassStatus = 'myinfo.workpass_status',

--- a/src/app/modules/sgid/sgid.constants.ts
+++ b/src/app/modules/sgid/sgid.constants.ts
@@ -50,4 +50,10 @@ export enum SGIDScope {
   // SGID also has another myinfo.mobile_number field that does not contain the country code prefix.
   // We use the one that contains prefix, as this matches our mobile number form field.
   MobileNoWithCountryCode = 'myinfo.mobile_number_with_country_code',
+  Dialect = 'dialect',
+  Occupation = 'occupation',
+  CountryOfMarriage = 'countryofmarriage',
+  MarriageCertNo = 'marriagecertno',
+  MarriageDate = 'marriagedate',
+  DivorceDate = 'divorcedate',
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
SGID has enabled more fields. We want to enable these MyInfo fields on FormSG as an extension of #6766 

Closes FRM-1191

## Solution
<!-- How did you solve the problem? -->
Enable the following MyInfo fields for SGID login:
- Workpass Expiry Date 
- Residential Status
- Dialect
- Occupation
- Country of Marriage
- Marriage cert number
- Marriage date
- Divorce date

This brings SGID Myinfo to parity with Singpass myinfo fields, apart from Child Records (which is still behind a beta flag).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] On an email-mode form, select 'Singpass app-only with myInfo' as the authentication method
- [ ] Add the following MyInfo fields to the form:
- Workpass Expiry Date 
- Residential Status
- Dialect
- Occupation
- Country of Marriage
- Marriage cert number
- Marriage date
- Divorce date
- [ ] Submit a test form using the [SGID chrome extension](https://www.notion.so/opengov/SGID-MyInfo-Testing-Packet-8734d52d69484419a1e7ad5f337f3f55). The fields related to marriage/divorce should be editable.



## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
- Ensure that these SGID scopes have been added to the SGID Developer Portal FormSG app (done, thanks to @PrawiraGenestonlia): 
    - Workpass Expiry Date 
    - Residential Status
    - Dialect
    - Occupation
    - Country of Marriage
    - Marriage cert number
    - Marriage date
    - Divorce date
