### PR TITLE
chore: increase hot lambda to 10

### DIFF
--- a/.github/workflows/deploy-virus-scanner-production.yml
+++ b/.github/workflows/deploy-virus-scanner-production.yml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/aws-deploy-scanner.yml
     with:
       environment: 'production'
-      provisionedConcurrency: 5
+      provisionedConcurrency: 10
       checkoutBranch: 'release-al2'
     secrets: inherit


### PR DESCRIPTION
## Problem
- Increase provisioned lambda to 10 to reduce the need for invoking new lambdas for virus scan, hence reducing wait time for users