### PR TITLE
fix: mobileno is always editable

### DIFF
--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -195,7 +195,6 @@ export class SGIDMyInfoData
     if (!data || !fieldValue) return false
 
     switch (attr) {
-      case ExternalAttr.MobileNoWithCountryCode:
       case ExternalAttr.RegisteredAddress:
       case ExternalAttr.Name:
       case ExternalAttr.PassportNumber:
@@ -216,6 +215,7 @@ export class SGIDMyInfoData
       case ExternalAttr.Occupation:
         return !!data
       // Fields required to always be editable according to MyInfo docs
+      case ExternalAttr.MobileNoWithCountryCode:
       case ExternalAttr.MaritalStatus:
       case ExternalAttr.CountryOfMarriage:
       case ExternalAttr.MarriageCertNo:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The [Singpass data catalog](https://api.singpass.gov.sg/library/myinfo/business/implementation-myinfo-data) states that the mobile number field should always be editable. However, it's currently uneditable for SGID MyInfo.

## Solution
<!-- How did you solve the problem? -->
Move `MobileNoWithCountryCode` to the editable case

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="705" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/7b78f0ab-2a8d-4203-833c-db4ab907999d">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="702" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/3884b7f3-7945-45ae-ac99-70f9ac070ece">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] As an admin, create a form with the auth method "Singpass App-only with MyInfo" and add the "Mobile Number" MyInfo field
- [ ] Open the form and log in using a profile that has a mobile number, using the SGID Chrome extension (first profile Singaporean)
- [ ] The mobile number field should **not** be disabled
- [ ] Submit the form, the mobile number field should be reflected in the response