### PR TITLE
fix(workspaces): remove form from collab workspace

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -377,7 +377,7 @@ describe('admin-form.service', () => {
 
       // Assert
       expect(actual.isOk()).toEqual(true)
-      expect(actual._unsafeUnwrap()).toEqual(true)
+      expect(actual._unsafeUnwrap()).toEqual(mockArchivedForm)
     })
 
     it('should return DatabaseError if any database errors occur', async () => {

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -271,7 +271,7 @@ export const extractMyInfoFieldIds = (
 export const archiveForm = (
   form: IPopulatedForm,
 ): ResultAsync<
-  true,
+  IFormSchema,
   | DatabaseError
   | DatabaseValidationError
   | DatabaseConflictError
@@ -288,8 +288,8 @@ export const archiveForm = (
     })
 
     return transformMongoError(error)
-    // On success, return true
-  }).map(() => true)
+    // On success, return form
+  }).map((form) => form)
 }
 
 /**

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -265,7 +265,7 @@ export const extractMyInfoFieldIds = (
 /**
  * Archives given form.
  * @param form the form to archive
- * @returns ok(true) if successful
+ * @returns ok(IFormSchema) if successful
  * @returns err(DatabaseError) if any database errors occur
  */
 export const archiveForm = (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1478

## Solution
<!-- How did you solve the problem? -->

Iterate thru the list of permissions, retrieve the user from the email, then remove the formId from all the workspaces under the user.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] As a collaborator of the form, move the form into a workspace
- [ ] As the owner of the same form, delete the form
- [ ] The form should be removed from the collaborator's workspace, check that the total form number tally is correct.
