### PR TITLE
fix: use secret to sign and verify sgid jwt

### DIFF
--- a/__tests__/setup/.test-env
+++ b/__tests__/setup/.test-env
@@ -28,6 +28,7 @@ SGID_FORM_LOGIN_REDIRECT_URI=http://localhost:5000/sgid/login
 SGID_ADMIN_LOGIN_REDIRECT_URI=http://localhost:5000/api/v3/auth/sgid/login
 SGID_PRIVATE_KEY=./node_modules/@opengovsg/mockpass/static/certs/key.pem
 SGID_PUBLIC_KEY=./node_modules/@opengovsg/mockpass/static/certs/server.crt
+SGID_JWT_SECRET=sgidjwtsecret
 
 IS_SP_MAINTENANCE=Date/Time-SP
 IS_CP_MAINTENANCE=Date/Time-CP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - SGID_HOSTNAME=http://localhost:5156
       - SGID_CLIENT_ID=sgidclientid
       - SGID_CLIENT_SECRET=sgidclientsecret
+      - SGID_JWT_SECRET=sgidjwtsecret
       - SGID_ADMIN_LOGIN_REDIRECT_URI=http://localhost:5001/api/v3/auth/sgid/login
       - SGID_FORM_LOGIN_REDIRECT_URI=http://localhost:5001/sgid/login
       - SGID_PRIVATE_KEY=./node_modules/@opengovsg/mockpass/static/certs/key.pem

--- a/src/app/config/features/sgid.config.ts
+++ b/src/app/config/features/sgid.config.ts
@@ -22,13 +22,13 @@ export const sgidVarsSchema: Schema<ISgidVarsSchema> = {
     env: 'SGID_CLIENT_SECRET',
   },
   privateKeyPath: {
-    doc: 'The path to the private key to decrypt payloads from sgID. Also used for JWT signing',
+    doc: 'The path to the private key to decrypt payloads from sgID.',
     format: String,
     default: null,
     env: 'SGID_PRIVATE_KEY',
   },
   publicKeyPath: {
-    doc: 'The path to the public key given to sgID. Also used to verify JWTs created by FormSG',
+    doc: 'The path to the public key given to sgID.',
     format: String,
     default: null,
     env: 'SGID_PUBLIC_KEY',

--- a/src/app/config/features/sgid.config.ts
+++ b/src/app/config/features/sgid.config.ts
@@ -69,6 +69,12 @@ export const sgidVarsSchema: Schema<ISgidVarsSchema> = {
     default: '',
     env: 'SGID_HOSTNAME',
   },
+  jwtSecret: {
+    doc: 'The secret key used to sign and verify JWT based on userinfo from sgID',
+    format: String,
+    default: '',
+    env: 'SGID_JWT_SECRET',
+  },
 }
 
 // Load and validate sgid configuration values

--- a/src/app/modules/sgid/__tests__/sgid.service.spec.ts
+++ b/src/app/modules/sgid/__tests__/sgid.service.spec.ts
@@ -23,6 +23,7 @@ import {
   MOCK_CODE_VERIFIER,
   MOCK_DESTINATION,
   MOCK_JWT,
+  MOCK_JWT_ALGORITHM,
   MOCK_JWT_PAYLOAD,
   MOCK_NONCE,
   MOCK_OPTIONS,
@@ -264,9 +265,9 @@ describe('sgid.service', () => {
           userName: MOCK_USER_INFO.data['myinfo.nric_number'],
           rememberMe: false,
         },
-        MOCK_OPTIONS.privateKeyPath,
+        MOCK_OPTIONS.jwtSecret,
         {
-          algorithm: 'RS256',
+          algorithm: MOCK_JWT_ALGORITHM,
           expiresIn: MOCK_OPTIONS.cookieMaxAge / 1000,
         },
       )
@@ -289,9 +290,9 @@ describe('sgid.service', () => {
           userName: MOCK_USER_INFO.data[SGID_MYINFO_NRIC_NUMBER_SCOPE],
           rememberMe: true,
         },
-        MOCK_OPTIONS.privateKeyPath,
+        MOCK_OPTIONS.jwtSecret,
         {
-          algorithm: 'RS256',
+          algorithm: MOCK_JWT_ALGORITHM,
           expiresIn: MOCK_OPTIONS.cookieMaxAgePreserved / 1000,
         },
       )
@@ -306,8 +307,8 @@ describe('sgid.service', () => {
       expect(result._unsafeUnwrap()).toStrictEqual(MOCK_JWT_PAYLOAD)
       expect(MockJwt.verify).toHaveBeenCalledWith(
         MOCK_JWT,
-        MOCK_OPTIONS.publicKeyPath,
-        { algorithms: ['RS256'] },
+        MOCK_OPTIONS.jwtSecret,
+        { algorithms: [MOCK_JWT_ALGORITHM] },
       )
     })
 
@@ -327,8 +328,8 @@ describe('sgid.service', () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(SgidInvalidJwtError)
       expect(MockJwt.verify).toHaveBeenCalledWith(
         MOCK_JWT,
-        MOCK_OPTIONS.publicKeyPath,
-        { algorithms: ['RS256'] },
+        MOCK_OPTIONS.jwtSecret,
+        { algorithms: [MOCK_JWT_ALGORITHM] },
       )
     })
     it('should return SgidVerifyJwtError on verify failure', () => {
@@ -340,8 +341,8 @@ describe('sgid.service', () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(SgidVerifyJwtError)
       expect(MockJwt.verify).toHaveBeenCalledWith(
         MOCK_JWT,
-        MOCK_OPTIONS.publicKeyPath,
-        { algorithms: ['RS256'] },
+        MOCK_OPTIONS.jwtSecret,
+        { algorithms: [MOCK_JWT_ALGORITHM] },
       )
     })
   })

--- a/src/app/modules/sgid/__tests__/sgid.test.constants.ts
+++ b/src/app/modules/sgid/__tests__/sgid.test.constants.ts
@@ -80,4 +80,7 @@ export const MOCK_OPTIONS = {
   cookieDomain: MOCK_COOKIE_SETTINGS.domain,
   cookieMaxAge: MOCK_COOKIE_AGE,
   cookieMaxAgePreserved: MOCK_COOKIE_AGE * 2,
+  jwtSecret: 'jwt-secret',
 }
+
+export const MOCK_JWT_ALGORITHM = 'HS256'

--- a/src/app/modules/sgid/sgid.service.ts
+++ b/src/app/modules/sgid/sgid.service.ts
@@ -36,6 +36,7 @@ export class SgidServiceClass {
 
   private publicKey: string | Buffer
   private privateKey: string
+  private jwtSecret: string
 
   private cookieDomain: string
   private cookieMaxAge: number
@@ -51,6 +52,7 @@ export class SgidServiceClass {
     formLoginRedirectUri: redirectUri,
     clientId,
     clientSecret,
+    jwtSecret,
   }: ISgidVarsSchema) {
     this.privateKey = fs.readFileSync(privateKeyPath, { encoding: 'utf8' })
     this.client = new SgidClient({
@@ -65,6 +67,7 @@ export class SgidServiceClass {
     this.cookieDomain = cookieDomain
     this.cookieMaxAge = cookieMaxAge
     this.cookieMaxAgePreserved = cookieMaxAgePreserved
+    this.jwtSecret = jwtSecret
   }
 
   /**
@@ -232,7 +235,7 @@ export class SgidServiceClass {
     const userName = data['myinfo.nric_number']
     const payload: SGIDJwtSingpassPayload = { userName, rememberMe }
     const maxAge = rememberMe ? this.cookieMaxAgePreserved : this.cookieMaxAge
-    const jwt = Jwt.sign(payload, this.privateKey, {
+    const jwt = Jwt.sign(payload, this.jwtSecret, {
       algorithm: JWT_ALGORITHM,
       expiresIn: maxAge / 1000,
     })
@@ -263,7 +266,7 @@ export class SgidServiceClass {
   }): Result<{ jwt: string; maxAge: number; sub: string }, ApplicationError> {
     const payload: SGIDJwtAccessPayload = { accessToken }
     const maxAge = this.cookieMaxAge
-    const jwt = Jwt.sign(payload, this.privateKey, {
+    const jwt = Jwt.sign(payload, this.jwtSecret, {
       algorithm: JWT_ALGORITHM,
       expiresIn: maxAge / 1000,
     })
@@ -333,7 +336,7 @@ export class SgidServiceClass {
         return err(new SgidMissingJwtError())
       }
 
-      const payload = Jwt.verify(jwtSgid, this.privateKey, {
+      const payload = Jwt.verify(jwtSgid, this.jwtSecret, {
         algorithms: [JWT_ALGORITHM],
       })
 

--- a/src/app/modules/sgid/sgid.service.ts
+++ b/src/app/modules/sgid/sgid.service.ts
@@ -29,7 +29,7 @@ import { isSgidJwtAccessPayload, isSgidJwtSingpassPayload } from './sgid.util'
 
 const logger = createLoggerWithLabel(module)
 
-const JWT_ALGORITHM = 'RS256'
+const JWT_ALGORITHM = 'HS256'
 
 export class SgidServiceClass {
   private client: SgidClient
@@ -333,7 +333,7 @@ export class SgidServiceClass {
         return err(new SgidMissingJwtError())
       }
 
-      const payload = Jwt.verify(jwtSgid, this.publicKey, {
+      const payload = Jwt.verify(jwtSgid, this.privateKey, {
         algorithms: [JWT_ALGORITHM],
       })
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -145,6 +145,7 @@ export interface ISgidVarsSchema {
   cookieMaxAgePreserved: number
   cookieDomain: string
   hostname: string
+  jwtSecret: string
 }
 
 export interface IOptionalVarsSchema {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

SGID was not working on staging-alt as our `JWT_ALGORITHM` used to sign and verify the JWT for the profile was incompatible with the private key. We should decouple the private key used by SGID from the private key used to sign and verify the JWT.

Closes FRM-1479

## Solution
<!-- How did you solve the problem? -->
Change the algorithm used to HS256 (symmetric algorithm, only 1 secret is required).
Use a new env var, `SGID_JWT_SECRET`, to sign and verify the JWT

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Submit a form with SGID Singpass auth. You should be able to submit the form successfully.
- [ ] Submit a form with SGID MyInfo auth, that has at least 1 MyInfo field. You should be able to submit the form successfully.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `SGID_JWT_SECRET` : The secret key used to sign and verify JWT based on userinfo from sgID

