### PR TITLE
chore: update virus scanner node version

### DIFF
--- a/serverless/virus-scanner/Dockerfile
+++ b/serverless/virus-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.20-bullseye-slim
+FROM node:18.18.2-buster-slim
 
 # Install aws-lambda-cpp build dependencies
 RUN apt-get update && \

--- a/serverless/virus-scanner/serverless.yml
+++ b/serverless/virus-scanner/serverless.yml
@@ -37,9 +37,10 @@ functions:
     image:
       name: virus-scanner
     # max timeout per invocation
-    timeout: 300
+    # cloudflare timesout after 60 seconds, so virus scanning cannot take too long
+    timeout: 50
     # allocate more memory as the default 1028 MB size will cause lambda to crash
-    memorySize: 2048
+    memorySize: 4096
     # Provision concurrency so at least one instance always hot
     # https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#provisioned-concurrency
     # 1 for staging, 5 for prod


### PR DESCRIPTION
(WIP)
## Problem
- Upgrades virus scanner node version to v18
- More details in https://opengovproducts.slack.com/archives/CKHLS3W3X/p1698306167536309

## Tests

- [ ] Create storage mode form with attachment. Attachment can be submitted successfully (check network calls to see that virus scanning route is correctly triggered)
- [ ] Malicious attachment is correctly flagged out
[secure.eicar.org_eicar.com.txt](https://github.com/opengovsg/FormSG/files/13176693/secure.eicar.org_eicar.com.txt)

