### PR TITLE
chore(dockerfile): update mocktwilio to start asap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,8 +187,6 @@ services:
   mocktwilio:
     image: stoplight/prism:4
     container_name: formsg-mocktwilio
-    depends_on:
-      - backend
     network_mode: 'service:backend' # reuse backend service's network stack so that it can resolve localhost:4010 to prismtwilio:4010
     command: mock https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_api_v2010.json
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
`mocktwilio` starts late on dev as it waits for `backend` to be first started (note: not completed). However, there's no need for `mocktwilio` to start late.

## Solution
<!-- How did you solve the problem? -->
Removed `depends_on: backend` for `mocktwilio`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  