### PR TITLE
fix: add cloudflareinsights as allowable csp

### DIFF
--- a/src/app/loaders/express/__tests__/helmet.spec.ts
+++ b/src/app/loaders/express/__tests__/helmet.spec.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet'
 import config from 'src/app/config/config'
 import { sentryConfig } from 'src/app/config/features/sentry.config'
 
+import { CSP_CORE_DIRECTIVES } from '../constants'
 import helmetMiddlewares from '../helmet'
 
 describe('helmetMiddlewares', () => {
@@ -14,70 +15,7 @@ describe('helmetMiddlewares', () => {
   jest.mock('src/app/config/features/sentry.config')
   const mockSentryConfig = jest.mocked(sentryConfig)
 
-  const cspCoreDirectives = {
-    imgSrc: [
-      "'self'",
-      'blob:',
-      'data:',
-      'https://www.googletagmanager.com/',
-      'https://www.google-analytics.com/',
-      `https://s3-${config.aws.region}.amazonaws.com/agency.form.sg/`,
-      config.aws.imageBucketUrl,
-      config.aws.logoBucketUrl,
-      '*',
-      'https://*.google-analytics.com',
-      'https://*.googletagmanager.com',
-    ],
-    fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
-    scriptSrc: [
-      "'self'",
-      'https://ssl.google-analytics.com/',
-      'https://www.google-analytics.com/',
-      'https://www.tagmanager.google.com/',
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/releases/',
-      'https://challenges.cloudflare.com',
-      'https://js.stripe.com/v3',
-      // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      // not actively used yet, loading specific file due to CSP bypass issue
-      'https://*.googletagmanager.com/gtag/',
-    ],
-    connectSrc: [
-      "'self'",
-      'https://www.google-analytics.com/',
-      'https://ssl.google-analytics.com/',
-      'https://*.browser-intake-datadoghq.com',
-      'https://sentry.io/api/',
-      config.aws.attachmentBucketUrl,
-      config.aws.imageBucketUrl,
-      config.aws.logoBucketUrl,
-      config.aws.virusScannerQuarantineS3BucketUrl,
-      'https://*.google-analytics.com',
-      'https://*.analytics.google.com',
-      'https://*.googletagmanager.com',
-    ],
-    frameSrc: [
-      "'self'",
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://challenges.cloudflare.com',
-      'https://js.stripe.com/',
-    ],
-    styleSrc: [
-      "'self'",
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/',
-      'https://www.gstatic.cn/',
-      "'unsafe-inline'",
-    ],
-    workerSrc: [
-      "'self'",
-      'blob:', // DataDog RUM session replay - https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
-    ],
-    frameAncestors: ['*'],
-  }
+  const cspCoreDirectives = CSP_CORE_DIRECTIVES
 
   beforeAll(() => {
     mockHelmet.xssFilter = jest.fn().mockReturnValue('xssFilter')

--- a/src/app/loaders/express/constants.ts
+++ b/src/app/loaders/express/constants.ts
@@ -1,0 +1,67 @@
+import config from '../../config/config'
+
+export const CSP_CORE_DIRECTIVES = {
+  imgSrc: [
+    "'self'",
+    'blob:',
+    'data:',
+    'https://www.googletagmanager.com/',
+    'https://www.google-analytics.com/',
+    `https://s3-${config.aws.region}.amazonaws.com/agency.form.sg/`,
+    config.aws.imageBucketUrl,
+    config.aws.logoBucketUrl,
+    '*',
+    'https://*.google-analytics.com',
+    'https://*.googletagmanager.com',
+  ],
+  fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
+  scriptSrc: [
+    "'self'",
+    'https://ssl.google-analytics.com/',
+    'https://www.google-analytics.com/',
+    'https://www.tagmanager.google.com/',
+    'https://www.google.com/recaptcha/',
+    'https://www.recaptcha.net/recaptcha/',
+    'https://www.gstatic.com/recaptcha/releases/',
+    'https://challenges.cloudflare.com',
+    'https://js.stripe.com/v3',
+    // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
+    // not actively used yet, loading specific files due to CSP bypass issue
+    'https://*.googletagmanager.com/gtag/',
+    'https://*.cloudflareinsights.com/', // Cloudflare web analytics https://developers.cloudflare.com/analytics/types-of-analytics/#web-analytics
+  ],
+  connectSrc: [
+    "'self'",
+    'https://www.google-analytics.com/',
+    'https://ssl.google-analytics.com/',
+    'https://*.browser-intake-datadoghq.com',
+    'https://sentry.io/api/',
+    config.aws.attachmentBucketUrl,
+    config.aws.imageBucketUrl,
+    config.aws.logoBucketUrl,
+    config.aws.virusScannerQuarantineS3BucketUrl,
+    'https://*.google-analytics.com',
+    'https://*.analytics.google.com',
+    'https://*.googletagmanager.com',
+  ],
+  frameSrc: [
+    "'self'",
+    'https://www.google.com/recaptcha/',
+    'https://www.recaptcha.net/recaptcha/',
+    'https://challenges.cloudflare.com',
+    'https://js.stripe.com/',
+  ],
+  styleSrc: [
+    "'self'",
+    'https://www.google.com/recaptcha/',
+    'https://www.recaptcha.net/recaptcha/',
+    'https://www.gstatic.com/recaptcha/',
+    'https://www.gstatic.cn/',
+    "'unsafe-inline'",
+  ],
+  workerSrc: [
+    "'self'",
+    'blob:', // DataDog RUM session replay - https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
+  ],
+  frameAncestors: ['*'],
+}

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -5,6 +5,8 @@ import { ContentSecurityPolicyOptions } from 'helmet/dist/types/middlewares/cont
 import config from '../../config/config'
 import { sentryConfig } from '../../config/features/sentry.config'
 
+import { CSP_CORE_DIRECTIVES } from './constants'
+
 const helmetMiddlewares = () => {
   // Only add the "Strict-Transport-Security" header if request is https.
   const hstsMiddleware: RequestHandler = (req, res, next) => {
@@ -27,71 +29,8 @@ const helmetMiddlewares = () => {
     policy: 'strict-origin-when-cross-origin',
   })
 
-  const cspCoreDirectives: ContentSecurityPolicyOptions['directives'] = {
-    imgSrc: [
-      "'self'",
-      'blob:',
-      'data:',
-      'https://www.googletagmanager.com/', // TODO #4279: This is used for Universal Analytics, so remove after react rollout
-      'https://www.google-analytics.com/',
-      `https://s3-${config.aws.region}.amazonaws.com/agency.form.sg/`, // Agency logos
-      config.aws.imageBucketUrl, // Image field
-      config.aws.logoBucketUrl, // Form logo
-      '*', // TODO: Remove when we host our own images for Image field and Form Logo
-      'https://*.google-analytics.com', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      'https://*.googletagmanager.com',
-    ],
-    fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
-    scriptSrc: [
-      "'self'",
-      'https://ssl.google-analytics.com/',
-      'https://www.google-analytics.com/',
-      'https://www.tagmanager.google.com/',
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/releases/',
-      'https://challenges.cloudflare.com',
-      'https://js.stripe.com/v3',
-      // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      // not actively used yet, loading specific files due to CSP bypass issue
-      'https://*.googletagmanager.com/gtag/',
-      'https://*.cloudflareinsights.com/', // Cloudflare web analytics https://developers.cloudflare.com/analytics/types-of-analytics/#web-analytics
-    ],
-    connectSrc: [
-      "'self'",
-      'https://www.google-analytics.com/',
-      'https://ssl.google-analytics.com/',
-      'https://*.browser-intake-datadoghq.com', // https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
-      'https://sentry.io/api/',
-      config.aws.attachmentBucketUrl, // Attachment downloads
-      config.aws.imageBucketUrl, // Image field
-      config.aws.logoBucketUrl, // Form logo
-      config.aws.virusScannerQuarantineS3BucketUrl, // Virus scanning
-      'https://*.google-analytics.com', // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
-      'https://*.analytics.google.com',
-      'https://*.googletagmanager.com',
-    ],
-    frameSrc: [
-      "'self'",
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://challenges.cloudflare.com',
-      'https://js.stripe.com/',
-    ],
-    styleSrc: [
-      "'self'",
-      'https://www.google.com/recaptcha/',
-      'https://www.recaptcha.net/recaptcha/',
-      'https://www.gstatic.com/recaptcha/',
-      'https://www.gstatic.cn/',
-      "'unsafe-inline'",
-    ],
-    workerSrc: [
-      "'self'",
-      'blob:', // DataDog RUM session replay - https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy/
-    ],
-    frameAncestors: ['*'],
-  }
+  const cspCoreDirectives: ContentSecurityPolicyOptions['directives'] =
+    CSP_CORE_DIRECTIVES
 
   const reportUri = sentryConfig.cspReportUri
 

--- a/src/app/loaders/express/helmet.ts
+++ b/src/app/loaders/express/helmet.ts
@@ -55,6 +55,7 @@ const helmetMiddlewares = () => {
       // GA4 https://developers.google.com/tag-platform/tag-manager/web/csp
       // not actively used yet, loading specific files due to CSP bypass issue
       'https://*.googletagmanager.com/gtag/',
+      'https://*.cloudflareinsights.com/', // Cloudflare web analytics https://developers.cloudflare.com/analytics/types-of-analytics/#web-analytics
     ],
     connectSrc: [
       "'self'",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
`
Refused to load the script 'https://static.cloudflareinsights.com/beacon.min.js/<Truncated for brevity>...' because it violates the following Content Security Policy directive: <Truncated for brevity> ...
`
Closes FRM-1497

## Solution
<!-- How did you solve the problem? -->
Add `https://*.cloudflareinsights.com/` into allowed list

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
