### PR TITLE
chore: use non-testing branch for font-wqy-zenhei

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -95,7 +95,8 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN apk add font-wqy-zenhei --repository https://dl-cdn.alpinelinux.org/alpine/edge/community --allow-untrusted
+RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/latest-stable/main -u alpine-keys
+RUN apk add font-wqy-zenhei --repository https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -95,7 +95,8 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && apk add font-wqy-zenhei@edge
+RUN apk add font-wqy-zenhei --repository https://dl-cdn.alpinelinux.org/alpine/edge/community --allow-untrusted
+
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 
 # Run as non-privileged user

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -95,7 +95,6 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # This package is needed to render Chinese characters in autoreply PDFs
-RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/latest-stable/main -u alpine-keys
 RUN apk add font-wqy-zenhei --repository https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`font-wqyt-zenhei` is [no longer on testing](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/54760) and has been promoted to the `community` stream.

Closes FRM-1504

## Solution
<!-- How did you solve the problem? -->

1. Reference `edge/community` instead of `edge/testing`
2. Switched to in-line repository flag to avoid tag for single-use installations
