### PR TITLE
chore: remove eb shift frontend feature flags

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -11,7 +11,6 @@ import { SubmitHandler } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
-import { useGrowthBook } from '@growthbook/growthbook-react'
 import { differenceInMilliseconds, isPast } from 'date-fns'
 import get from 'lodash/get'
 import simplur from 'simplur'
@@ -130,18 +129,6 @@ export const PublicFormProvider = ({
     // Stop querying once submissionData is present.
     /* enabled= */ !submissionData,
   )
-
-  const growthbook = useGrowthBook()
-
-  useEffect(() => {
-    if (growthbook) {
-      growthbook.setAttributes({
-        // Only update the `formId` attribute, keep the rest the same
-        ...growthbook.getAttributes(),
-        formId,
-      })
-    }
-  }, [growthbook, formId])
 
   // Scroll to top of page when user has finished their submission.
   useLayoutEffect(() => {

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -520,49 +520,50 @@ export const PublicFormProvider = ({
             },
           })
 
-          return submitStorageModeClearFormWithVirusScanningMutation.mutateAsync(
-            {
-              ...formData,
-              ...formPaymentData,
-            },
-            {
-              onSuccess: ({
-                submissionId,
-                timestamp,
-                // payment forms will have non-empty paymentData field
-                paymentData,
-              }) => {
-                trackSubmitForm(form)
-
-                if (paymentData) {
-                  navigate(getPaymentPageUrl(formId, paymentData.paymentId))
-                  storePaymentMemory(paymentData.paymentId)
-                  return
-                }
-                setSubmissionData({
-                  id: submissionId,
+          return submitStorageModeClearFormWithVirusScanningMutation
+            .mutateAsync(
+              {
+                ...formData,
+                ...formPaymentData,
+              },
+              {
+                onSuccess: ({
+                  submissionId,
                   timestamp,
-                })
-              },
-              onError: (error) => {
-                // TODO(#5826): Remove when we have resolved the Network Error
-                datadogLogs.logger.warn(
-                  `handleSubmitForm: submit with virus scan`,
-                  {
-                    meta: {
-                      ...logMeta,
-                      responseMode: 'storage',
-                      method: 'axios',
-                      error,
-                    },
-                  },
-                )
+                  // payment forms will have non-empty paymentData field
+                  paymentData,
+                }) => {
+                  trackSubmitForm(form)
 
-                // defaults to the safest option of storage submission without virus scanning
-                return submitStorageFormWithFetch()
+                  if (paymentData) {
+                    navigate(getPaymentPageUrl(formId, paymentData.paymentId))
+                    storePaymentMemory(paymentData.paymentId)
+                    return
+                  }
+                  setSubmissionData({
+                    id: submissionId,
+                    timestamp,
+                  })
+                },
               },
-            },
-          )
+            )
+            .catch(async (error) => {
+              datadogLogs.logger.warn(
+                `handleSubmitForm: submit with virus scan`,
+                {
+                  meta: {
+                    ...logMeta,
+                    responseMode: 'storage',
+                    method: 'axios',
+                    error,
+                  },
+                },
+              )
+              showErrorToast(error, form)
+
+              // fallback to fetch
+              return submitStorageFormWithFetch()
+            })
         }
       }
     },

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -11,11 +11,7 @@ import { SubmitHandler } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
-import {
-  useFeatureIsOn,
-  useFeatureValue,
-  useGrowthBook,
-} from '@growthbook/growthbook-react'
+import { useFeatureValue, useGrowthBook } from '@growthbook/growthbook-react'
 import { differenceInMilliseconds, isPast } from 'date-fns'
 import get from 'lodash/get'
 import simplur from 'simplur'
@@ -268,10 +264,6 @@ export const PublicFormProvider = ({
       })
     }
   }, [data?.form.form_fields, toast, vfnToastIdRef])
-
-  const enableVirusScanner = useFeatureIsOn(
-    featureFlags.encryptionBoundaryShiftVirusScanner,
-  )
 
   const {
     submitEmailModeFormMutation,
@@ -557,7 +549,7 @@ export const PublicFormProvider = ({
           })
 
           // TODO (FRM-1413): Move to main return statement once virus scanner has been fully rolled out
-          if (enableEncryptionBoundaryShift && enableVirusScanner) {
+          if (enableEncryptionBoundaryShift) {
             return submitStorageModeClearFormWithVirusScanningMutation.mutateAsync(
               {
                 ...formData,
@@ -679,7 +671,6 @@ export const PublicFormProvider = ({
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
       enableEncryptionBoundaryShift,
-      enableVirusScanner,
       submitStorageModeClearFormMutation,
       submitStorageModeFormMutation,
       submitStorageModeClearFormFetchMutation,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -559,10 +559,12 @@ export const PublicFormProvider = ({
                   },
                 },
               )
+              if (/Network Error/i.test(error.message)) {
+                axiosDebugFlow()
+                // fallback to fetch
+                return submitStorageFormWithFetch()
+              }
               showErrorToast(error, form)
-
-              // fallback to fetch
-              return submitStorageFormWithFetch()
             })
         }
       }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -249,10 +249,7 @@ export const PublicFormProvider = ({
 
   const {
     submitEmailModeFormMutation,
-    submitStorageModeFormMutation,
     submitEmailModeFormFetchMutation,
-    submitStorageModeFormFetchMutation,
-    submitStorageModeClearFormMutation,
     submitStorageModeClearFormFetchMutation,
     submitStorageModeClearFormWithVirusScanningMutation,
   } = usePublicFormMutations(formId, submissionData?.id ?? '')
@@ -582,10 +579,7 @@ export const PublicFormProvider = ({
       getCaptchaResponse,
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
-      submitStorageModeClearFormMutation,
-      submitStorageModeFormMutation,
       submitStorageModeClearFormFetchMutation,
-      submitStorageModeFormFetchMutation,
       navigate,
       formId,
       storePaymentMemory,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -250,7 +250,7 @@ export const PublicFormProvider = ({
   const {
     submitEmailModeFormMutation,
     submitEmailModeFormFetchMutation,
-    submitStorageModeClearFormFetchMutation,
+    submitStorageModeClearFormWithVirusScanningFetchMutation,
     submitStorageModeClearFormWithVirusScanningMutation,
   } = usePublicFormMutations(formId, submissionData?.id ?? '')
 
@@ -464,7 +464,7 @@ export const PublicFormProvider = ({
               },
             })
 
-            return submitStorageModeClearFormFetchMutation
+            return submitStorageModeClearFormWithVirusScanningFetchMutation
               .mutateAsync(
                 {
                   ...formData,
@@ -579,11 +579,11 @@ export const PublicFormProvider = ({
       getCaptchaResponse,
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
-      submitStorageModeClearFormFetchMutation,
+      submitStorageModeClearFormWithVirusScanningMutation,
+      submitStorageModeClearFormWithVirusScanningFetchMutation,
       navigate,
       formId,
       storePaymentMemory,
-      submitStorageModeClearFormWithVirusScanningMutation,
     ],
   )
 

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -250,8 +250,8 @@ export const PublicFormProvider = ({
   const {
     submitEmailModeFormMutation,
     submitEmailModeFormFetchMutation,
-    submitStorageModeClearFormWithVirusScanningFetchMutation,
-    submitStorageModeClearFormWithVirusScanningMutation,
+    submitStorageModeFormWithVirusScanningFetchMutation,
+    submitStorageModeFormWithVirusScanningMutation,
   } = usePublicFormMutations(formId, submissionData?.id ?? '')
 
   const { handleLogoutMutation } = usePublicAuthMutations(formId)
@@ -464,7 +464,7 @@ export const PublicFormProvider = ({
               },
             })
 
-            return submitStorageModeClearFormWithVirusScanningFetchMutation
+            return submitStorageModeFormWithVirusScanningFetchMutation
               .mutateAsync(
                 {
                   ...formData,
@@ -520,7 +520,7 @@ export const PublicFormProvider = ({
             },
           })
 
-          return submitStorageModeClearFormWithVirusScanningMutation
+          return submitStorageModeFormWithVirusScanningMutation
             .mutateAsync(
               {
                 ...formData,
@@ -582,8 +582,8 @@ export const PublicFormProvider = ({
       getCaptchaResponse,
       submitEmailModeFormFetchMutation,
       submitEmailModeFormMutation,
-      submitStorageModeClearFormWithVirusScanningMutation,
-      submitStorageModeClearFormWithVirusScanningFetchMutation,
+      submitStorageModeFormWithVirusScanningMutation,
+      submitStorageModeFormWithVirusScanningFetchMutation,
       navigate,
       formId,
       storePaymentMemory,

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -39,7 +39,6 @@ import { FormFieldValues } from '~templates/Field'
 import {
   createClearSubmissionFormData,
   createClearSubmissionWithVirusScanningFormData,
-  createEncryptedSubmissionData,
   getAttachmentsMap,
 } from './utils/createSubmission'
 import { filterHiddenInputs } from './utils/filterHiddenInputs'
@@ -145,85 +144,6 @@ export const submitEmailModeForm = async ({
 
   return ApiService.post<SubmissionResponseDto>(
     `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/email`,
-    formData,
-    {
-      params: {
-        captchaResponse: String(captchaResponse),
-        captchaType: captchaType,
-      },
-    },
-  ).then(({ data }) => data)
-}
-
-export const submitStorageModeForm = async ({
-  formFields,
-  formLogics,
-  formInputs,
-  formId,
-  publicKey,
-  captchaResponse = null,
-  captchaType = '',
-  paymentReceiptEmail,
-  responseMetadata,
-  paymentProducts,
-  payments,
-}: SubmitStorageFormArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-    responseMetadata,
-    paymentReceiptEmail,
-    payments,
-    paymentProducts,
-  })
-  return ApiService.post<SubmissionResponseDto>(
-    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt`,
-    submissionContent,
-    {
-      params: {
-        captchaResponse: String(captchaResponse),
-        captchaType,
-      },
-    },
-  ).then(({ data }) => data)
-}
-
-export const submitStorageModeClearForm = async ({
-  formFields,
-  formLogics,
-  formInputs,
-  formId,
-  captchaResponse = null,
-  captchaType = '',
-  paymentReceiptEmail,
-  responseMetadata,
-  paymentProducts,
-  payments,
-}: SubmitStorageFormClearArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-
-  const formData = createClearSubmissionFormData({
-    formFields,
-    formInputs: filteredInputs,
-    responseMetadata,
-    paymentReceiptEmail,
-    paymentProducts,
-    payments,
-    version: ENCRYPTION_BOUNDARY_SHIFT_SUBMISSION_VERSION,
-  })
-
-  return ApiService.post<SubmissionResponseDto>(
-    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/storage`,
     formData,
     {
       params: {
@@ -361,56 +281,6 @@ export const submitEmailModeFormWithFetch = async ({
       method: 'POST',
       body: formData,
       headers: {
-        Accept: 'application/json',
-      },
-    },
-  )
-
-  return processFetchResponse(response)
-}
-
-// TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
-export const submitStorageModeFormWithFetch = async ({
-  formFields,
-  formLogics,
-  formInputs,
-  formId,
-  publicKey,
-  captchaResponse = null,
-  captchaType = '',
-  paymentReceiptEmail,
-  responseMetadata,
-  paymentProducts,
-  payments,
-}: SubmitStorageFormArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-    responseMetadata,
-    paymentReceiptEmail,
-    payments,
-    paymentProducts,
-  })
-
-  // Add captcha response to query string
-  const queryString = new URLSearchParams({
-    captchaResponse: String(captchaResponse),
-    captchaType,
-  }).toString()
-
-  const response = await fetch(
-    `${API_BASE_URL}${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt?${queryString}`,
-    {
-      method: 'POST',
-      body: JSON.stringify(submissionContent),
-      headers: {
-        'Content-Type': 'application/json',
         Accept: 'application/json',
       },
     },

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -155,7 +155,8 @@ export const submitEmailModeForm = async ({
 }
 
 // TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
-export const submitStorageModeClearFormWithFetch = async ({
+// Submit storage mode form with virus scanning (storage v2.1+)
+export const submitStorageModeClearFormWithVirusScanningWithFetch = async ({
   formFields,
   formLogics,
   formInputs,
@@ -166,22 +167,26 @@ export const submitStorageModeClearFormWithFetch = async ({
   responseMetadata,
   paymentProducts,
   payments,
-}: SubmitStorageFormClearArgs) => {
+  fieldIdToQuarantineKeyMap,
+}: SubmitStorageFormWithVirusScanningArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
     formInputs,
     formLogics,
   })
 
-  const formData = createClearSubmissionFormData({
-    formFields,
-    formInputs: filteredInputs,
-    responseMetadata,
-    paymentReceiptEmail,
-    paymentProducts,
-    payments,
-    version: ENCRYPTION_BOUNDARY_SHIFT_SUBMISSION_VERSION,
-  })
+  const formData = createClearSubmissionWithVirusScanningFormData(
+    {
+      formFields,
+      formInputs: filteredInputs,
+      responseMetadata,
+      paymentReceiptEmail,
+      paymentProducts,
+      payments,
+      version: VIRUS_SCANNER_SUBMISSION_VERSION,
+    },
+    fieldIdToQuarantineKeyMap,
+  )
 
   // Add captcha response to query string
   const queryString = new URLSearchParams({

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -153,7 +153,7 @@ export const submitEmailModeForm = async ({
 
 // TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
 // Submit storage mode form with virus scanning (storage v2.1+)
-export const submitStorageModeClearFormWithVirusScanningWithFetch = async ({
+export const submitStorageModeFormWithVirusScanningWithFetch = async ({
   formFields,
   formLogics,
   formInputs,
@@ -206,7 +206,7 @@ export const submitStorageModeClearFormWithVirusScanningWithFetch = async ({
 }
 
 // Submit storage mode form with virus scanning (storage v2.1+)
-export const submitStorageModeClearFormWithVirusScanning = async ({
+export const submitStorageModeFormWithVirusScanning = async ({
   formFields,
   formLogics,
   formInputs,

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -1,10 +1,7 @@
 import { PresignedPost } from 'aws-sdk/clients/s3'
 import axios from 'axios'
 
-import {
-  ENCRYPTION_BOUNDARY_SHIFT_SUBMISSION_VERSION,
-  VIRUS_SCANNER_SUBMISSION_VERSION,
-} from '~shared/constants'
+import { VIRUS_SCANNER_SUBMISSION_VERSION } from '~shared/constants'
 import { SubmitFormIssueBodyDto, SuccessMessageDto } from '~shared/types'
 import {
   AttachmentPresignedPostDataMapType,

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -20,13 +20,9 @@ import {
   submitEmailModeFormWithFetch,
   submitFormFeedback,
   submitFormIssue,
-  SubmitStorageFormArgs,
   SubmitStorageFormClearArgs,
-  submitStorageModeClearForm,
   submitStorageModeClearFormWithFetch,
   submitStorageModeClearFormWithVirusScanning,
-  submitStorageModeForm,
-  submitStorageModeFormWithFetch,
   uploadAttachmentToQuarantine,
 } from './PublicFormService'
 
@@ -82,28 +78,10 @@ export const usePublicFormMutations = (
     },
   )
 
-  const submitStorageModeFormMutation = useMutation(
-    (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeForm({ ...args, formId })
-    },
-  )
-
-  const submitStorageModeClearFormMutation = useMutation(
-    (args: Omit<SubmitStorageFormClearArgs, 'formId'>) => {
-      return submitStorageModeClearForm({ ...args, formId })
-    },
-  )
-
   // TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
   const submitEmailModeFormFetchMutation = useMutation(
     (args: Omit<SubmitEmailFormArgs, 'formId'>) => {
       return submitEmailModeFormWithFetch({ ...args, formId })
-    },
-  )
-
-  const submitStorageModeFormFetchMutation = useMutation(
-    (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeFormWithFetch({ ...args, formId })
     },
   )
 
@@ -194,11 +172,8 @@ export const usePublicFormMutations = (
 
   return {
     submitEmailModeFormMutation,
-    submitStorageModeFormMutation,
     submitFormFeedbackMutation,
-    submitStorageModeFormFetchMutation,
     submitEmailModeFormFetchMutation,
-    submitStorageModeClearFormMutation,
     submitStorageModeClearFormFetchMutation,
     submitStorageModeClearFormWithVirusScanningMutation,
   }

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -21,8 +21,8 @@ import {
   submitFormFeedback,
   submitFormIssue,
   SubmitStorageFormClearArgs,
-  submitStorageModeClearFormWithVirusScanning,
-  submitStorageModeClearFormWithVirusScanningWithFetch,
+  submitStorageModeFormWithVirusScanning,
+  submitStorageModeFormWithVirusScanningWithFetch,
   uploadAttachmentToQuarantine,
 } from './PublicFormService'
 
@@ -85,12 +85,12 @@ export const usePublicFormMutations = (
     },
   )
 
-  const submitStorageModeClearFormWithVirusScanningFetchMutation = useMutation(
+  const submitStorageModeFormWithVirusScanningFetchMutation = useMutation(
     async (args: Omit<SubmitStorageFormClearArgs, 'formId'>) => {
       const attachmentSizes = await getAttachmentSizes(args)
       // If there are no attachments, submit form without virus scanning by passing in empty list
       if (attachmentSizes.length === 0) {
-        return submitStorageModeClearFormWithVirusScanningWithFetch({
+        return submitStorageModeFormWithVirusScanningWithFetch({
           ...args,
           fieldIdToQuarantineKeyMap: [],
           formId,
@@ -145,7 +145,7 @@ export const usePublicFormMutations = (
           )
           // Step 3: Submit form with keys to quarantine bucket attachments
           .then((fieldIdToQuarantineKeyMap) => {
-            return submitStorageModeClearFormWithVirusScanningWithFetch({
+            return submitStorageModeFormWithVirusScanningWithFetch({
               ...args,
               fieldIdToQuarantineKeyMap,
               formId,
@@ -165,12 +165,12 @@ export const usePublicFormMutations = (
     },
   )
 
-  const submitStorageModeClearFormWithVirusScanningMutation = useMutation(
+  const submitStorageModeFormWithVirusScanningMutation = useMutation(
     async (args: Omit<SubmitStorageFormClearArgs, 'formId'>) => {
       const attachmentSizes = await getAttachmentSizes(args)
       // If there are no attachments, submit form without virus scanning by passing in empty list
       if (attachmentSizes.length === 0) {
-        return submitStorageModeClearFormWithVirusScanning({
+        return submitStorageModeFormWithVirusScanning({
           ...args,
           fieldIdToQuarantineKeyMap: [],
           formId,
@@ -224,7 +224,7 @@ export const usePublicFormMutations = (
           )
           // Step 3: Submit form with keys to quarantine bucket attachments
           .then((fieldIdToQuarantineKeyMap) => {
-            return submitStorageModeClearFormWithVirusScanning({
+            return submitStorageModeFormWithVirusScanning({
               ...args,
               fieldIdToQuarantineKeyMap,
               formId,
@@ -238,8 +238,8 @@ export const usePublicFormMutations = (
     submitEmailModeFormMutation,
     submitFormFeedbackMutation,
     submitEmailModeFormFetchMutation,
-    submitStorageModeClearFormWithVirusScanningFetchMutation,
-    submitStorageModeClearFormWithVirusScanningMutation,
+    submitStorageModeFormWithVirusScanningFetchMutation,
+    submitStorageModeFormWithVirusScanningMutation,
   }
 }
 

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -68,5 +68,4 @@ export const PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID =
 export const E2EE_SUBMISSION_VERSION = 1
 // Encryption boundary shift RFC: https://docs.google.com/document/d/1VmNXS_xYY2Yg30AwVqzdndBp5yRJGSDsyjBnH51ktyc/edit?usp=sharing
 // Encryption boundary shift implementation PR: https://github.com/opengovsg/FormSG/pull/6587
-export const ENCRYPTION_BOUNDARY_SHIFT_SUBMISSION_VERSION = 2
 export const VIRUS_SCANNER_SUBMISSION_VERSION = 2.1


### PR DESCRIPTION
## Problem
Works towards FRM-1232 and FRM-1413

- This PR removes the frontend feature flags for (i) encryption boundary shift and (ii) virus scanner. Henceforth, all frontend traffic will be routed through the new storage mode endpoint and virus scanner.
- This is in preparation for myinfo storage mode feature.

## Tests
- [ ] Create storage mode form. Open in public form view.
- [ ] Submission with attachment works
- [ ] Attachment is uploaded to s3
- [ ] Malicious attachment is blocked
[secure.eicar.org_eicar.com.txt](https://github.com/opengovsg/FormSG/files/13176693/secure.eicar.org_eicar.com.txt)
