### PR TITLE
fix: add case for SGID MyInfo when field value is missing

### DIFF
--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -583,10 +583,24 @@ export const logIfFieldValueNotInMyinfoList = (
   const isFieldValueInMyinfoList = myInfoList.includes(fieldValue)
   const myInfoSource =
     myInfoData instanceof MyInfoData ? 'Singpass MyInfo' : 'SGID MyInfo'
-  // SGID returns NA instead of empty field values, we don't need this to be logged
-  // as this is expected behaviour
-  const isNAFromSgid = myInfoAttr === 'SGID MyInfo' && fieldValue === 'NA'
-  if (!isNAFromSgid || !isFieldValueInMyinfoList) {
+
+  if (myInfoSource === 'Singpass MyInfo' && !isFieldValueInMyinfoList) {
+    logger.error({
+      message: 'Myinfo field value not found in existing Myinfo constants list',
+      meta: {
+        action: 'prefillAndSaveMyInfoFields',
+        myInfoFieldValue: fieldValue,
+        myInfoAttr,
+        myInfoSource,
+      },
+    })
+  } else if (
+    // SGID returns NA instead of empty field values, we don't need this to be logged
+    // as this is expected behaviour
+    myInfoSource === 'SGID MyInfo' &&
+    fieldValue !== 'NA' &&
+    !isFieldValueInMyinfoList
+  ) {
     logger.error({
       message: 'Myinfo field value not found in existing Myinfo constants list',
       meta: {

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -584,7 +584,9 @@ export const logIfFieldValueNotInMyinfoList = (
   const myInfoSource =
     myInfoData instanceof MyInfoData ? 'Singpass MyInfo' : 'SGID MyInfo'
 
-  if (myInfoSource === 'Singpass MyInfo' && !isFieldValueInMyinfoList) {
+  if (isFieldValueInMyinfoList) return
+
+  if (myInfoSource === 'Singpass MyInfo') {
     logger.error({
       message: 'Myinfo field value not found in existing Myinfo constants list',
       meta: {
@@ -598,8 +600,7 @@ export const logIfFieldValueNotInMyinfoList = (
     // SGID returns NA instead of empty field values, we don't need this to be logged
     // as this is expected behaviour
     myInfoSource === 'SGID MyInfo' &&
-    fieldValue !== 'NA' &&
-    !isFieldValueInMyinfoList
+    fieldValue !== 'NA'
   ) {
     logger.error({
       message: 'Myinfo field value not found in existing Myinfo constants list',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

False positives (field values that were **not** missing from the constants lists) were being logged because of an erroneous SGID check. As a result, a [monitor](https://ogp.datadoghq.com/monitors/130812469) was being falsely triggered

## Solution
<!-- How did you solve the problem? -->
Add separate conditionals for Singpass and SGID MyInfo values

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
Singpass MyInfo
- [ ] Submit a Singpass MyInfo form that contains the MyInfo nationality field
- [ ] Check that the field is not logged in error logs (search for meta.action like '`prefillAndSaveMyInfoFields`')

SGID MyInfo
- [ ] Submit a SGID MyInfo form that contains the MyInfo nationality field
- [ ] Check that the field is not logged in error logs (search for meta.action like '`prefillAndSaveMyInfoFields`')
