### PR TITLE
fix(datepicker): webkit-related stylings

### DIFF
--- a/frontend/src/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.stories.tsx
@@ -29,3 +29,14 @@ DatePickerDisallowManualInput.args = {
 
 export const Mobile = Template.bind({})
 Mobile.parameters = getMobileViewParameters()
+
+export const Prefilled = Template.bind({})
+Prefilled.args = {
+  defaultValue: new Date('2021-09-13'),
+  isDisabled: true,
+}
+
+export const Error = Template.bind({})
+Error.args = {
+  isInvalid: true,
+}

--- a/frontend/src/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from '@chakra-ui/react'
 
 import { CalendarProps } from '~components/Calendar'
 
-import { CalendarButton } from './components/CalendarButton'
 import { DatePickerCalendar } from './components/DatePickerCalendar'
 import { DatePickerContent } from './components/DatePickerContent'
 import { DatePickerWrapper } from './components/DatePickerWrapper'
@@ -25,7 +24,6 @@ export const DatePicker = forwardRef<DatePickerProps, 'input'>((props, ref) => {
   return (
     <DatePickerProvider {...props}>
       <DatePickerWrapper ref={ref}>
-        <CalendarButton />
         <DatePickerContent>
           <DatePickerCalendar />
         </DatePickerContent>

--- a/frontend/src/components/DatePicker/components/CalendarButton.tsx
+++ b/frontend/src/components/DatePicker/components/CalendarButton.tsx
@@ -7,13 +7,12 @@ export const CalendarButton = (): JSX.Element => {
   const {
     disclosureProps: { onOpen, isOpen },
     calendarButtonAria,
-    fcProps: { isDisabled, isReadOnly, isInvalid },
+    fcProps: { isDisabled, isReadOnly },
   } = useDatePicker()
   return (
     <IconButton
       onClick={onOpen}
       aria-label={calendarButtonAria}
-      aria-invalid={isInvalid}
       icon={<BxCalendar />}
       variant="inputAttached"
       borderLeftColor={'transparent'}

--- a/frontend/src/components/DatePicker/components/CalendarButton.tsx
+++ b/frontend/src/components/DatePicker/components/CalendarButton.tsx
@@ -6,18 +6,18 @@ import { useDatePicker } from '../DatePickerContext'
 export const CalendarButton = (): JSX.Element => {
   const {
     disclosureProps: { onOpen, isOpen },
-    colorScheme,
     calendarButtonAria,
-    fcProps: { isDisabled, isReadOnly },
+    fcProps: { isDisabled, isReadOnly, isInvalid },
   } = useDatePicker()
   return (
     <IconButton
       onClick={onOpen}
-      colorScheme={colorScheme}
       aria-label={calendarButtonAria}
+      aria-invalid={isInvalid}
       icon={<BxCalendar />}
       variant="inputAttached"
-      borderRadius={0}
+      borderLeftColor={'transparent'}
+      borderLeftRadius={0}
       isActive={isOpen}
       isDisabled={isDisabled || isReadOnly}
     />

--- a/frontend/src/components/DatePicker/components/DatePickerInput.tsx
+++ b/frontend/src/components/DatePicker/components/DatePickerInput.tsx
@@ -1,9 +1,16 @@
 import { useMemo } from 'react'
 import ReactInputMask from 'react-input-mask'
-import { forwardRef, useMergeRefs, VisuallyHidden } from '@chakra-ui/react'
+import {
+  forwardRef,
+  InputGroup,
+  InputRightAddon,
+  useMergeRefs,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 
 import Input from '~components/Input'
 
+import { CalendarButton } from '../components/CalendarButton'
 import { useDatePicker } from '../DatePickerContext'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -36,24 +43,27 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
       <VisuallyHidden aria-live="assertive">
         {selectedDateAriaLiveText}
       </VisuallyHidden>
-      <Input
-        variant="unstyled"
-        inputMode="numeric" // Nudge Android mobile keyboard to be numeric
-        pattern="\d*" // Nudge numeric keyboard on iOS Safari.
-        sx={styles.field}
-        as={ReactInputMask}
-        mask="99/99/9999"
-        value={internalInputValue}
-        onChange={handleInputChange}
-        placeholder={placeholder}
-        maskPlaceholder={placeholder}
-        ref={mergedInputRef}
-        {...fcProps}
-        borderRightRadius={0}
-        onBlur={handleInputBlur}
-        onClick={handleInputClick}
-        isReadOnly={fcProps.isReadOnly || !allowManualInput}
-      />
+      <InputGroup>
+        <Input
+          inputMode="numeric" // Nudge Android mobile keyboard to be numeric
+          pattern="\d*" // Nudge numeric keyboard on iOS Safari.
+          as={ReactInputMask}
+          mask="99/99/9999"
+          value={internalInputValue}
+          onChange={handleInputChange}
+          placeholder={placeholder}
+          maskPlaceholder={placeholder}
+          ref={mergedInputRef}
+          {...fcProps}
+          borderRightRadius={0}
+          onBlur={handleInputBlur}
+          onClick={handleInputClick}
+          isReadOnly={fcProps.isReadOnly || !allowManualInput}
+        />
+        <InputRightAddon p={0} border="none" bg="none">
+          <CalendarButton />
+        </InputRightAddon>
+      </InputGroup>
     </>
   )
 })

--- a/frontend/src/components/DatePicker/components/DatePickerInput.tsx
+++ b/frontend/src/components/DatePicker/components/DatePickerInput.tsx
@@ -16,7 +16,6 @@ import { useDatePicker } from '../DatePickerContext'
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
   const {
-    styles,
     internalInputValue,
     handleInputChange,
     handleInputBlur,

--- a/frontend/src/components/DatePicker/components/DatePickerInput.tsx
+++ b/frontend/src/components/DatePicker/components/DatePickerInput.tsx
@@ -59,7 +59,7 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
           onClick={handleInputClick}
           isReadOnly={fcProps.isReadOnly || !allowManualInput}
         />
-        <InputRightAddon p={0} border="none" bg="none">
+        <InputRightAddon p={0} bg="none">
           <CalendarButton />
         </InputRightAddon>
       </InputGroup>

--- a/frontend/src/components/DatePicker/components/DatePickerWrapper.tsx
+++ b/frontend/src/components/DatePicker/components/DatePickerWrapper.tsx
@@ -13,18 +13,12 @@ export const DatePickerWrapper = forwardRef<{}, 'input'>(
       initialFocusRef,
       closeCalendarOnChange,
       isMobile,
-      fcProps: { isDisabled, isInvalid, isReadOnly },
     } = useDatePicker()
 
     if (isMobile) {
       return (
         <Flex>
-          <Flex
-            sx={styles.fieldwrapper}
-            aria-disabled={isDisabled}
-            aria-invalid={isInvalid}
-            aria-readonly={isReadOnly}
-          >
+          <Flex sx={styles.fieldwrapper}>
             <DatePickerInput ref={ref} />
           </Flex>
           {children}
@@ -43,12 +37,7 @@ export const DatePickerWrapper = forwardRef<{}, 'input'>(
           {...disclosureProps}
         >
           <PopoverAnchor>
-            <Flex
-              sx={styles.fieldwrapper}
-              aria-disabled={isDisabled}
-              aria-invalid={isInvalid}
-              aria-readonly={isReadOnly}
-            >
+            <Flex sx={styles.fieldwrapper}>
               <DatePickerInput ref={ref} />
             </Flex>
           </PopoverAnchor>

--- a/frontend/src/components/DatePicker/components/DatePickerWrapper.tsx
+++ b/frontend/src/components/DatePicker/components/DatePickerWrapper.tsx
@@ -8,7 +8,6 @@ import { DatePickerInput } from './DatePickerInput'
 export const DatePickerWrapper = forwardRef<{}, 'input'>(
   ({ children }, ref) => {
     const {
-      styles,
       disclosureProps,
       initialFocusRef,
       closeCalendarOnChange,
@@ -18,9 +17,7 @@ export const DatePickerWrapper = forwardRef<{}, 'input'>(
     if (isMobile) {
       return (
         <Flex>
-          <Flex sx={styles.fieldwrapper}>
-            <DatePickerInput ref={ref} />
-          </Flex>
+          <DatePickerInput ref={ref} />
           {children}
         </Flex>
       )
@@ -37,9 +34,7 @@ export const DatePickerWrapper = forwardRef<{}, 'input'>(
           {...disclosureProps}
         >
           <PopoverAnchor>
-            <Flex sx={styles.fieldwrapper}>
-              <DatePickerInput ref={ref} />
-            </Flex>
+            <DatePickerInput ref={ref} />
           </PopoverAnchor>
           {children}
         </Popover>

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -242,7 +242,7 @@ const variantInputAttached: SystemStyleFunction = (props) => {
   return {
     fontSize: '1.25rem',
     color: 'secondary.500',
-    ml: '-1px',
+    ml: '1px',
     borderColor: 'neutral.400',
     borderRadius: 0,
     _hover: {

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -242,11 +242,13 @@ const variantInputAttached: SystemStyleFunction = (props) => {
   return {
     fontSize: '1.25rem',
     color: 'secondary.500',
-    ml: '1px',
+    ml: '-1px',
     borderColor: 'neutral.400',
     borderRadius: 0,
+    borderLeftColor: 'transparent',
     _hover: {
       bg: 'neutral.100',
+      borderLeftColor: `neutral.400`,
     },
     _active: {
       borderColor: getColor(theme, fc),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

On mobile phones and safari, the text input for `DatePicker` 
- affects only `<DatePicker />`, other `<Input />`-related fields are not affected
- affects specifically when component is `disabled`

![Screenshot 2023-11-07 at 5 18 56 PM](https://github.com/opengovsg/FormSG/assets/12391617/599f47e6-133a-472f-99ec-1e28ba5609ac)
- text is set to gray but appears to be whitish-grey on chrome mobile, and safari browsers

Closes FRM-1473

## Solution
<!-- How did you solve the problem? -->

- Took reference from design-system and extracted aria fields and moved them down into the child components. 
- Fixed missing `borderRightRadius` on `<CalendarButton />`

Ideally, we should migrate to use design-system so that we don't have to patch issues like this. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Location/Modifier | Before | After |
|--------|--------|--------|
| Active | ![uat_active](https://github.com/opengovsg/FormSG/assets/12391617/1248351e-4bac-4198-8db5-1b5a9211492c) | ![local_active](https://github.com/opengovsg/FormSG/assets/12391617/7bb85751-895f-46fa-a42d-687ce7e6f491)  |
| Filled | ![uat_filled](https://github.com/opengovsg/FormSG/assets/12391617/d5461fb1-5f44-464f-8dc8-f6b50605fce2) | ![local_filled](https://github.com/opengovsg/FormSG/assets/12391617/fe94db64-9566-462a-832e-fd2f865cbd62) | 
| Error |  ![uat_error](https://github.com/opengovsg/FormSG/assets/12391617/443b5db1-2435-4444-a361-5f8a95b49434) | ![local_error](https://github.com/opengovsg/FormSG/assets/12391617/f75006f1-0669-441d-9780-f719a6df9c82)  | 
| Disabled | ![uat_disabled](https://github.com/opengovsg/FormSG/assets/12391617/6344111f-d63d-47b1-bcf5-8ec1dd6a7079) | ![local_disabled](https://github.com/opengovsg/FormSG/assets/12391617/c0e99f7f-f05d-451f-9a69-183759453058)  |
| Admin | ![uat-admin](https://github.com/opengovsg/FormSG/assets/12391617/ede1d8a7-cb8b-4b69-8c55-8386651b628f) | ![local-admin](https://github.com/opengovsg/FormSG/assets/12391617/40181699-c8b8-4a52-9767-4f6414250a52) |
| Admin Active | ![uat-admin_active](https://github.com/opengovsg/FormSG/assets/12391617/aa0bda33-8c71-4eae-bcba-44c941376c4a) | ![local-admin_active](https://github.com/opengovsg/FormSG/assets/12391617/6ab7c626-07d9-44bb-9a62-e3018d19f081)  |
| Admin Hover | ![uat-admin_hover](https://github.com/opengovsg/FormSG/assets/12391617/fb2ef6a7-b98b-4671-b810-dabba4109842) | ![local-admin_hover](https://github.com/opengovsg/FormSG/assets/12391617/531300a3-b17d-48a4-aa1a-b3262eed6433)  |
| Admin Error | ![uat-admin_error](https://github.com/opengovsg/FormSG/assets/12391617/7b1a00d5-2c1e-47d4-8298-0587c0c55074)  | ![local-admin_error](https://github.com/opengovsg/FormSG/assets/12391617/f3154670-bf15-453e-bafc-760e270d5c3a) | 


## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression Tests**
- [ ] Ensure that DatePicker fields cannot be interacted when field is disabled 
- [ ] Ensure that DatePicker fields cannot be selected with `Tab` when field is disabled
- [ ] Ensure that DatePicker input field is visible when viewed from Safari browser when field is disabled