### PR TITLE
chore: add note to update guide to sync with file exts

### DIFF
--- a/shared/utils/file-validation.ts
+++ b/shared/utils/file-validation.ts
@@ -2,6 +2,8 @@ import JSZip from 'jszip'
 import flattenDeep from 'lodash/flattenDeep'
 import uniq from 'lodash/uniq'
 
+// Note: Guide should be updated if the list of valid extensions is changed.
+// https://guide.form.gov.sg/faq/faq/attachments
 export const VALID_EXTENSIONS = [
   '.asc',
   '.avi',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
- Adds a note to update the guide on accepted file attachments whenever we update list of file extensions
- Closes FRM-1509
