### PR TITLE
fix: add sanitisation function for products

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -123,7 +123,7 @@ const submitEncryptModeForm = async (
   const {
     encryptedContent,
     responseMetadata,
-    paymentProducts: _clientPaymentsProducts,
+    paymentProducts: dirtyPaymentsProducts,
   } = encryptedPayload
 
   // Checks if user is SPCP-authenticated before allowing submission
@@ -312,10 +312,7 @@ const submitEncryptModeForm = async (
     form.payments_field?.enabled &&
     form.payments_channel.channel === PaymentChannel.Stripe
   ) {
-    const paymentProducts = sanitisePaymentProducts(
-      form,
-      _clientPaymentsProducts,
-    )
+    const paymentProducts = sanitisePaymentProducts(form, dirtyPaymentsProducts)
     return _createPaymentSubmission({
       req,
       res,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -66,6 +66,7 @@ import {
   getPaymentAmount,
   getPaymentIntentDescription,
   getStripePaymentMethod,
+  sanitisePaymentProducts,
 } from './encrypt-submission.utils'
 
 const logger = createLoggerWithLabel(module)
@@ -119,8 +120,11 @@ const submitEncryptModeForm = async (
   const encryptedPayload = req.formsg.encryptedPayload
 
   // Create Incoming Submission
-  const { encryptedContent, responseMetadata, paymentProducts } =
-    encryptedPayload
+  const {
+    encryptedContent,
+    responseMetadata,
+    paymentProducts: _clientPaymentsProducts,
+  } = encryptedPayload
 
   // Checks if user is SPCP-authenticated before allowing submission
   let uinFin
@@ -308,6 +312,10 @@ const submitEncryptModeForm = async (
     form.payments_field?.enabled &&
     form.payments_channel.channel === PaymentChannel.Stripe
   ) {
+    const paymentProducts = sanitisePaymentProducts(
+      form,
+      _clientPaymentsProducts,
+    )
     return _createPaymentSubmission({
       req,
       res,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -196,7 +196,7 @@ export const getStripePaymentMethod = (
  * The payment products from incoming submission can be freely altered by the respondent
  * which could result in undesirable data seeded into our database
  * @param form
- * @param uncleanPaymentProducts
+ * @param dirtyPaymentProducts
  */
 export const sanitisePaymentProducts = (
   form: IPopulatedEncryptedForm,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import moment from 'moment-timezone'
+import { Types } from 'mongoose'
 import Stripe from 'stripe'
 
 import {
@@ -201,13 +202,13 @@ export const sanitisePaymentProducts = (
   form: IPopulatedEncryptedForm,
   dirtyPaymentProducts: ProductItem[] | undefined,
 ): ProductItem[] | undefined => {
-  if (!dirtyPaymentProducts) return dirtyPaymentProducts
-  if (!form.payments_field.products) return dirtyPaymentProducts
+  if (!dirtyPaymentProducts) return
+  if (!form.payments_field.products) return
 
   const sanitisedProducts = form.payments_field.products
     .map((cleanProductData): ProductItem | null => {
-      const dirtyProduct = dirtyPaymentProducts.find(
-        ({ data }) => data._id === cleanProductData._id,
+      const dirtyProduct = dirtyPaymentProducts.find(({ data }) =>
+        (cleanProductData._id as unknown as Types.ObjectId).equals(data._id),
       )
       if (!dirtyProduct) return null
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Users can maliciously submit a product from FE to manipulate the product through scripts. This causes the product item evaluated on our BE to be incorrectly referencing the data from FE, instead of from the form payment products. 

## Solution
<!-- How did you solve the problem? -->
Don't trust FE.

Treat the product data from FE as dirty. Extract only the relevant details (quantity + selected) and replace the product data from the one in BE.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
##### Payment by Product form submission should still work**
- [ ] Make a payment on a form with payment by products
  - [ ] Ensure that payment had succeeded
  - [ ] Ensure that payment title on payment summary displays correctly
  - [ ] Ensure that payment title on payment successfully page displays correctly
  - [ ] Ensure that payment title on receipt displays correctly

##### Variable Payment form submission should still work
- [ ] Make a payment on a form with Variable Payment
  - [ ] Ensure that payment had succeeded
  - [ ] Ensure that payment title on payment summary displays correctly
  - [ ] Ensure that payment title on payment successfully page displays correctly
  - [ ] Ensure that payment title on receipt displays correctly