### PR TITLE
feat: add prefills for variable payments

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -4,8 +4,10 @@ import { useSearchParams } from 'react-router-dom'
 import { Box, Stack } from '@chakra-ui/react'
 import { isEmpty, times } from 'lodash'
 
+import { PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID } from '~shared/constants'
 import { BasicField, FormFieldDto } from '~shared/types/field'
 import { FormColorTheme, FormResponseMode, LogicDto } from '~shared/types/form'
+import { centsToDollars } from '~shared/utils/payments'
 
 import InlineMessage from '~components/InlineMessage'
 import { FormFieldValues } from '~templates/Field'
@@ -96,6 +98,18 @@ export const FormFields = ({
       return acc
     }, {})
   }, [augmentedFormFields, fieldPrefillMap])
+
+  // payment prefills - only for variable payments
+  if (searchParams.has(PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID)) {
+    const paymentParamValue = Number.parseInt(
+      searchParams.get(PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID) ?? '',
+      10,
+    )
+    if (Number.isInteger(paymentParamValue)) {
+      const paymentAmount = centsToDollars(Number(paymentParamValue))
+      defaultFormValues[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID] = paymentAmount
+    }
+  }
 
   const formMethods = useForm<FormFieldValues>({
     defaultValues: defaultFormValues,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -105,7 +105,7 @@ export const FormFields = ({
       searchParams.get(PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID) ?? '',
       10,
     )
-    if (Number.isInteger(paymentParamValue)) {
+    if (Number.isInteger(paymentParamValue) && paymentParamValue > 0) {
       const paymentAmount = centsToDollars(Number(paymentParamValue))
       defaultFormValues[PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID] = paymentAmount
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Agencies requires a way to programmatically preset the variable payments field. They don't require a hard-prefill nor a verified prefill (i.e., savvy respondents would be able to change the prefills by updating the URL)

Closes FRM-1514

## Solution
<!-- How did you solve the problem? -->
Expose `PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID` as the `fieldId` for prefills.
Read and populate variable payments field if prefill exists.
Validation of values is not performed until the payer interacts with the field -- similar to how soft-prefill works currently.
There's no toggle required for prefills (no need for field_id)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
##### Ensure that prefill works on non-payment forms
- [ ] On a regular form
- [ ] Toggle on prefill for a Short Text field
- [ ] Append prefilled id + data on the URL
- [ ] Ensure that the Short Text field is prefilled

##### Prefills happy flow
- [ ] Add a payment variable to a form
- [ ] Append `?payment_variable_input_amount_field_id=<amount_in_cents>` to the end of the url
- [ ] Observe that the variable input field is **prefilled**

##### Prefills happy flow with other prefillable fields
- [ ] Add a payment variable to a form
- [ ] Toggle on prefill for a Short Text field
- [ ] Append prefilled id + data on the URL
- [ ] Append `&payment_variable_input_amount_field_id=<amount_in_cents>` to the end of the url (note that we're trying to have two prefills on the URL. 1 for Short Text, another for Variable Payments`
- [ ] Observe that the variable input field is **prefilled**

##### Prefills invalid data flow
- [ ] Create a new payment variable form
- [ ] Append `?payment_variable_input_amount_field_id=THIS_IS_NOT_A_NUMBER` to the end of the url
- [ ] Observe that the variable input field is **not prefilled**