### PR TITLE
feat(payments): add paynow payment method

### DIFF
--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -12,7 +12,7 @@ import {
 } from '../../constants/form'
 import { DateString } from '../generic'
 import { FormLogic, LogicDto } from './form_logic'
-import { PaymentChannel, PaymentType } from '../payment'
+import { PaymentChannel, PaymentMethodType, PaymentType } from '../payment'
 import { Product } from './product'
 
 export type FormId = Opaque<string, 'FormId'>
@@ -72,6 +72,7 @@ export enum FormResponseMode {
 }
 
 export type FormPaymentsChannel = {
+  payment_methods?: [PaymentMethodType]
   channel: PaymentChannel
   target_account_id: string
   publishable_key: string

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -72,7 +72,7 @@ export enum FormResponseMode {
 }
 
 export type FormPaymentsChannel = {
-  payment_methods?: [PaymentMethodType]
+  payment_methods?: PaymentMethodType[]
   channel: PaymentChannel
   target_account_id: string
   publishable_key: string

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -20,7 +20,6 @@ export enum PaymentChannel {
 }
 
 export enum PaymentMethodType {
-  Unset = '',
   Paynow = 'Paynow',
 }
 

--- a/shared/types/payment.ts
+++ b/shared/types/payment.ts
@@ -18,6 +18,12 @@ export enum PaymentChannel {
   Stripe = 'Stripe',
   // for extensibility to future payment options
 }
+
+export enum PaymentMethodType {
+  Unset = '',
+  Paynow = 'Paynow',
+}
+
 export enum PaymentType {
   Fixed = 'Fixed',
   Variable = 'Variable',

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -96,6 +96,7 @@ const PAYMENTS_DEFAULTS = {
     channel: PaymentChannel.Unconnected,
     target_account_id: '',
     publishable_key: '',
+    payment_methods: [],
   },
   payments_field: {
     enabled: false,

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -43,7 +43,6 @@ import {
   LogicDto,
   LogicType,
   PaymentChannel,
-  PaymentMethodType,
   PaymentType,
   StorageFormSettings,
 } from '../../../shared/types'
@@ -219,7 +218,7 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
     },
     payment_methods: {
       type: [String],
-      default: [PaymentMethodType.Unset],
+      default: [],
     },
   },
 
@@ -249,7 +248,7 @@ EncryptedFormDocumentSchema.methods.addPaymentAccountId = async function ({
       channel: PaymentChannel.Stripe,
       target_account_id: accountId,
       publishable_key: publishableKey,
-      payment_methods: [PaymentMethodType.Unset],
+      payment_methods: [],
     }
   }
   return this.save()
@@ -260,7 +259,7 @@ EncryptedFormDocumentSchema.methods.removePaymentAccount = async function () {
     channel: PaymentChannel.Unconnected,
     target_account_id: '',
     publishable_key: '',
-    payment_methods: [PaymentMethodType.Unset],
+    payment_methods: [],
   }
   if (this.payments_field) {
     this.payments_field.enabled = false

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -43,6 +43,7 @@ import {
   LogicDto,
   LogicType,
   PaymentChannel,
+  PaymentMethodType,
   PaymentType,
   StorageFormSettings,
 } from '../../../shared/types'
@@ -216,6 +217,10 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       default: '',
       validate: [/^\S*$/i, 'publishable_key must not contain whitespace.'],
     },
+    payment_methods: {
+      type: [String],
+      default: [PaymentMethodType.Unset],
+    },
   },
 
   payments_field: formPaymentsFieldSchema,
@@ -244,6 +249,7 @@ EncryptedFormDocumentSchema.methods.addPaymentAccountId = async function ({
       channel: PaymentChannel.Stripe,
       target_account_id: accountId,
       publishable_key: publishableKey,
+      payment_methods: [PaymentMethodType.Unset],
     }
   }
   return this.save()
@@ -254,6 +260,7 @@ EncryptedFormDocumentSchema.methods.removePaymentAccount = async function () {
     channel: PaymentChannel.Unconnected,
     target_account_id: '',
     publishable_key: '',
+    payment_methods: [PaymentMethodType.Unset],
   }
   if (this.payments_field) {
     this.payments_field.enabled = false

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -85,6 +85,7 @@ import {
   createEncryptedSubmissionDto,
   getPaymentAmount,
   getPaymentIntentDescription,
+  getStripePaymentMethod,
   mapRouteError,
 } from './encrypt-submission.utils'
 
@@ -484,10 +485,7 @@ const _createPaymentSubmission = async ({
   const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
     amount,
     currency: paymentConfig.defaultCurrency,
-    // determine payment methods available based on stripe settings
-    automatic_payment_methods: {
-      enabled: true,
-    },
+    ...getStripePaymentMethod(form),
     description: getPaymentIntentDescription(form, paymentProducts),
     receipt_email: paymentReceiptEmail,
     metadata,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -1,9 +1,12 @@
 import { StatusCodes } from 'http-status-codes'
 import moment from 'moment-timezone'
+import Stripe from 'stripe'
 
 import {
   FormPaymentsField,
+  PaymentChannel,
   PaymentFieldsDto,
+  PaymentMethodType,
   PaymentType,
   StorageModeSubmissionContentDto,
   StorageModeSubmissionDto,
@@ -385,5 +388,26 @@ export const formatMyInfoStorageResponseData = (
         return response
       }
     })
+  }
+}
+
+export const getStripePaymentMethod = (
+  form: IPopulatedEncryptedForm,
+): Omit<Stripe.PaymentIntentCreateParams, 'amount' | 'currency'> => {
+  const isPaynowOnly =
+    form.payments_channel.payment_methods?.includes(PaymentMethodType.Paynow) &&
+    form.payments_channel.payment_methods?.length === 1
+  const stripePaynowOnly =
+    form.payments_channel.channel === PaymentChannel.Stripe && isPaynowOnly
+
+  if (stripePaynowOnly) {
+    return {
+      payment_method_types: ['paynow'],
+    }
+  }
+  return {
+    automatic_payment_methods: {
+      enabled: true,
+    },
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Admins want to only support certain forms to only provide payment through paynow (and disallowing other payment methods).

Closes FRM-1515

## Solution
<!-- How did you solve the problem? -->
Added a `payment_methods: string[]` that can contain allowed payment methods
- Currently, only `Paynow: 'Paynow'` is supported

Backwards compatibility is supported through marking the new field as optional, and populated with `[]` when `form.payments_channel` is updated (during remove or add payment channel)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

**Features**:

- Supports `Paynow` only through backend configuration by adding `form.payments_channel.payment_methods: ["Paynow"]`

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="1028" alt="Screenshot 2023-11-15 at 11 32 54 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/f97828ed-b755-4373-ac1b-c51a31a540f4">


**AFTER**:
<!-- [insert screenshot here] -->
<img width="1141" alt="Screenshot 2023-11-15 at 11 32 17 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/576ea70e-06b4-4bae-a560-f537fa6d832e">

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
- [ ] Find an existing payment form
- [ ] Make a payment
- [ ] Ensure that both payment methods "Cards", and "Paynow" are available to be selected

**New features**
##### Newly created forms should have both "Cards" and "Paynow" payment methods
- [ ] Create a new payment form
- [ ] Make a payment
- [ ] Ensure that both payment methods "Cards", and "Paynow" are available to be selected

##### Forms with enabled toggle should only allow "Paynow" payment method
- [ ] Create a new payment form
- [ ] Upsert `form.payments_channel.payment_methods: ["Paynow"]` to the form on DB

```
  "payments_channel": {
    "channel": "Stripe",
    "target_account_id": "acct_****",
    "publishable_key": "pk_test_****",
    "payment_methods": [
      "Paynow"
    ]
  },
```
- [ ] Make a payment
- [ ] Ensure that only payment method "Paynow" is available to be selected
