### PR TITLE
fix: remove myinfo child from storage mode

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -5,7 +5,12 @@ import { Box, Text } from '@chakra-ui/react'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
-import { AdminFormDto, FormAuthType, MyInfoAttribute } from '~shared/types'
+import {
+  AdminFormDto,
+  FormAuthType,
+  FormResponseMode,
+  MyInfoAttribute,
+} from '~shared/types'
 
 import { GUIDE_EMAIL_MODE } from '~constants/links'
 import { ADMINFORM_SETTINGS_SINGPASS_SUBROUTE } from '~constants/routes'
@@ -200,7 +205,8 @@ export const MyInfoFieldPanel = () => {
           </Box>
         )}
       </Droppable>
-      {user?.betaFlags?.children ? (
+      {user?.betaFlags?.children &&
+      form?.responseMode === FormResponseMode.Email ? (
         <Droppable isDropDisabled droppableId={CREATE_MYINFO_CHILDREN_DROP_ID}>
           {(provided) => (
             <Box ref={provided.innerRef} {...provided.droppableProps}>

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -11,7 +11,6 @@ import {
   SubmissionType,
 } from '../../../../../shared/types'
 import { calculatePrice } from '../../../../../shared/utils/paymentProductPrice'
-import { isProcessedChildResponse } from '../../../../app/utils/field-validation/field-validation.guards'
 import {
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
@@ -74,7 +73,7 @@ import {
   ValidateFieldError,
 } from '../submission.errors'
 import { ProcessedFieldResponse } from '../submission.types'
-import { getAnswersForChild, getMyInfoPrefix } from '../submission.utils'
+import { getMyInfoPrefix } from '../submission.utils'
 
 import {
   AttachmentSizeLimitExceededError,
@@ -372,18 +371,10 @@ export const formatMyInfoStorageResponseData = (
     return parsedResponses
   } else {
     return parsedResponses.flatMap((response) => {
-      if (isProcessedChildResponse(response)) {
-        return getAnswersForChild(response).map((childField) => {
-          const myInfoPrefix = getMyInfoPrefix(childField, hashedFields)
-          childField.question = `${myInfoPrefix}${childField.question}`
-          return childField
-        })
-      } else {
-        // Obtain prefix for question based on whether it is verified by MyInfo.
-        const myInfoPrefix = getMyInfoPrefix(response, hashedFields)
-        response.question = `${myInfoPrefix}${response.question}`
-        return response
-      }
+      // Obtain prefix for question based on whether it is verified by MyInfo.
+      const myInfoPrefix = getMyInfoPrefix(response, hashedFields)
+      response.question = `${myInfoPrefix}${response.question}`
+      return response
     })
   }
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -11,6 +11,7 @@ import {
   SubmissionType,
 } from '../../../../../shared/types'
 import { calculatePrice } from '../../../../../shared/utils/paymentProductPrice'
+import { isProcessedChildResponse } from '../../../../app/utils/field-validation/field-validation.guards'
 import {
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
@@ -73,7 +74,7 @@ import {
   ValidateFieldError,
 } from '../submission.errors'
 import { ProcessedFieldResponse } from '../submission.types'
-import { getMyInfoPrefix } from '../submission.utils'
+import { getAnswersForChild, getMyInfoPrefix } from '../submission.utils'
 
 import {
   AttachmentSizeLimitExceededError,
@@ -371,10 +372,18 @@ export const formatMyInfoStorageResponseData = (
     return parsedResponses
   } else {
     return parsedResponses.flatMap((response) => {
-      // Obtain prefix for question based on whether it is verified by MyInfo.
-      const myInfoPrefix = getMyInfoPrefix(response, hashedFields)
-      response.question = `${myInfoPrefix}${response.question}`
-      return response
+      if (isProcessedChildResponse(response)) {
+        return getAnswersForChild(response).map((childField) => {
+          const myInfoPrefix = getMyInfoPrefix(childField, hashedFields)
+          childField.question = `${myInfoPrefix}${childField.question}`
+          return childField
+        })
+      } else {
+        // Obtain prefix for question based on whether it is verified by MyInfo.
+        const myInfoPrefix = getMyInfoPrefix(response, hashedFields)
+        response.question = `${myInfoPrefix}${response.question}`
+        return response
+      }
     })
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We're removing the myinfo child field from storage mode forms (which was originally implemented in #6870). This will be released when the webhook response has been properly formatted (FRM-1520)

## Solution
<!-- How did you solve the problem? -->
- Only display the child field option in the MyInfo Panel if the user has the betaflag for children, and if it's an email-mode form


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
- On a storage-mode form that's Myinfo authenticated, go to the form builder's MyInfo panel. You should not see Child records