### PR TITLE
chore(deps): update libphonenumber-js package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "inter-ui": "^3.19.3",
         "intl-messageformat": "^9.13.0",
         "jszip": "^3.10.0",
-        "libphonenumber-js": "^1.9.44",
+        "libphonenumber-js": "^1.10.48",
         "lodash": "^4.17.21",
         "lottie-web": "^5.9.4",
         "p-queue": "^7.2.0",
@@ -32000,9 +32000,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.9.44",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
-      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
+      "version": "1.10.49",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
+      "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -72435,9 +72435,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.9.44",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
-      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
+      "version": "1.10.49",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
+      "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
     },
     "lie": {
       "version": "3.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "inter-ui": "^3.19.3",
     "intl-messageformat": "^9.13.0",
     "jszip": "^3.10.0",
-    "libphonenumber-js": "^1.9.44",
+    "libphonenumber-js": "^1.10.48",
     "lodash": "^4.17.21",
     "lottie-web": "^5.9.4",
     "p-queue": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "jszip": "^3.10.1",
         "jwk-to-pem": "^2.0.5",
         "jwt-decode": "^3.1.2",
-        "libphonenumber-js": "^1.10.24",
+        "libphonenumber-js": "^1.10.48",
         "lodash": "^4.17.21",
         "moment-timezone": "0.5.41",
         "mongodb-memory-server-core": "^6.9.6",
@@ -21215,9 +21215,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.24.tgz",
-      "integrity": "sha512-3Dk8f5AmrcWqg+oHhmm9hwSTqpWHBdSqsHmjCJGroULFubi0+x7JEIGmRZCuL3TI8Tx39xaKqfnhsDQ4ALa/Nw=="
+      "version": "1.10.49",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
+      "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
     },
     "node_modules/lie": {
       "version": "3.1.1",
@@ -46861,9 +46861,9 @@
       "dev": true
     },
     "libphonenumber-js": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.24.tgz",
-      "integrity": "sha512-3Dk8f5AmrcWqg+oHhmm9hwSTqpWHBdSqsHmjCJGroULFubi0+x7JEIGmRZCuL3TI8Tx39xaKqfnhsDQ4ALa/Nw=="
+      "version": "1.10.49",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
+      "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jszip": "^3.10.1",
     "jwk-to-pem": "^2.0.5",
     "jwt-decode": "^3.1.2",
-    "libphonenumber-js": "^1.10.24",
+    "libphonenumber-js": "^1.10.48",
     "lodash": "^4.17.21",
     "moment-timezone": "0.5.41",
     "mongodb-memory-server-core": "^6.9.6",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -11,7 +11,7 @@
         "date-fns": "^2.26.0",
         "json-stringify-safe": "^5.0.1",
         "jszip": "^3.7.1",
-        "libphonenumber-js": "^1.9.43",
+        "libphonenumber-js": "^1.10.48",
         "lodash": "^4.17.21",
         "type-fest": "^4.1.0",
         "validator": "^13.7.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,7 +6,7 @@
     "date-fns": "^2.26.0",
     "json-stringify-safe": "^5.0.1",
     "jszip": "^3.7.1",
-    "libphonenumber-js": "^1.9.43",
+    "libphonenumber-js": "^1.10.48",
     "lodash": "^4.17.21",
     "type-fest": "^4.1.0",
     "validator": "^13.7.0",


### PR DESCRIPTION
This addresses the various PRs that were opened by dependabot / synk such as #6829, #6891

Also synchronises all the different versions of libphonenumber in our package to minor version `^1.10.x`
