### PR TITLE
chore: always fallback to fetch

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -421,12 +421,9 @@ export const PublicFormProvider = ({
                       },
                     },
                   )
-                  if (/Network Error/i.test(error.message)) {
-                    axiosDebugFlow()
-                    return submitEmailFormWithFetch()
-                  } else {
-                    showErrorToast(error, form)
-                  }
+                  // Always fallback to fetch if submission fails
+                  axiosDebugFlow()
+                  return submitEmailFormWithFetch()
                 })
             )
           }
@@ -559,12 +556,9 @@ export const PublicFormProvider = ({
                   },
                 },
               )
-              if (/Network Error/i.test(error.message)) {
-                axiosDebugFlow()
-                // fallback to fetch
-                return submitStorageFormWithFetch()
-              }
-              showErrorToast(error, form)
+              // always fallback to fetch if submission fails
+              axiosDebugFlow()
+              return submitStorageFormWithFetch()
             })
         }
       }


### PR DESCRIPTION
## Problem
- Currently, if submission fails due to axios network error, we trigger fetch fallback
- This is done via string matching of error message
- Fetch fallback does not seem to be triggered after last release

## Solution
- Always fallback to fetch as a retry mechanism