### PR TITLE
chore: drop fallback to encrypt mode entirely

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -632,11 +632,8 @@ export const PublicFormProvider = ({
                   },
                 })
 
-                if (/Network Error/i.test(error.message)) {
-                  axiosDebugFlow()
-                  return submitStorageFormWithFetch()
-                }
-                showErrorToast(error, form)
+                axiosDebugFlow()
+                return submitStorageFormWithFetch()
               })
           )
         }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -11,11 +11,7 @@ import { SubmitHandler } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
-import {
-  useFeatureIsOn,
-  useFeatureValue,
-  useGrowthBook,
-} from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 import { differenceInMilliseconds, isPast } from 'date-fns'
 import get from 'lodash/get'
 import simplur from 'simplur'

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -155,45 +155,6 @@ export const submitEmailModeForm = async ({
   ).then(({ data }) => data)
 }
 
-export const submitStorageModeForm = async ({
-  formFields,
-  formLogics,
-  formInputs,
-  formId,
-  publicKey,
-  captchaResponse = null,
-  captchaType = '',
-  paymentReceiptEmail,
-  responseMetadata,
-  paymentProducts,
-  payments,
-}: SubmitStorageFormArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-    responseMetadata,
-    paymentReceiptEmail,
-    payments,
-    paymentProducts,
-  })
-  return ApiService.post<SubmissionResponseDto>(
-    `${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt`,
-    submissionContent,
-    {
-      params: {
-        captchaResponse: String(captchaResponse),
-        captchaType,
-      },
-    },
-  ).then(({ data }) => data)
-}
-
 export const submitStorageModeClearForm = async ({
   formFields,
   formLogics,
@@ -361,56 +322,6 @@ export const submitEmailModeFormWithFetch = async ({
       method: 'POST',
       body: formData,
       headers: {
-        Accept: 'application/json',
-      },
-    },
-  )
-
-  return processFetchResponse(response)
-}
-
-// TODO (#5826): Fallback mutation using Fetch. Remove once network error is resolved
-export const submitStorageModeFormWithFetch = async ({
-  formFields,
-  formLogics,
-  formInputs,
-  formId,
-  publicKey,
-  captchaResponse = null,
-  captchaType = '',
-  paymentReceiptEmail,
-  responseMetadata,
-  paymentProducts,
-  payments,
-}: SubmitStorageFormArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-    responseMetadata,
-    paymentReceiptEmail,
-    payments,
-    paymentProducts,
-  })
-
-  // Add captcha response to query string
-  const queryString = new URLSearchParams({
-    captchaResponse: String(captchaResponse),
-    captchaType,
-  }).toString()
-
-  const response = await fetch(
-    `${API_BASE_URL}${PUBLIC_FORMS_ENDPOINT}/${formId}/submissions/encrypt?${queryString}`,
-    {
-      method: 'POST',
-      body: JSON.stringify(submissionContent),
-      headers: {
-        'Content-Type': 'application/json',
         Accept: 'application/json',
       },
     },

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -39,7 +39,6 @@ import { FormFieldValues } from '~templates/Field'
 import {
   createClearSubmissionFormData,
   createClearSubmissionWithVirusScanningFormData,
-  createEncryptedSubmissionData,
   getAttachmentsMap,
 } from './utils/createSubmission'
 import { filterHiddenInputs } from './utils/filterHiddenInputs'

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -20,13 +20,10 @@ import {
   submitEmailModeFormWithFetch,
   submitFormFeedback,
   submitFormIssue,
-  SubmitStorageFormArgs,
   SubmitStorageFormClearArgs,
   submitStorageModeClearForm,
   submitStorageModeClearFormWithFetch,
   submitStorageModeClearFormWithVirusScanning,
-  submitStorageModeForm,
-  submitStorageModeFormWithFetch,
   uploadAttachmentToQuarantine,
 } from './PublicFormService'
 
@@ -82,12 +79,6 @@ export const usePublicFormMutations = (
     },
   )
 
-  const submitStorageModeFormMutation = useMutation(
-    (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeForm({ ...args, formId })
-    },
-  )
-
   const submitStorageModeClearFormMutation = useMutation(
     (args: Omit<SubmitStorageFormClearArgs, 'formId'>) => {
       return submitStorageModeClearForm({ ...args, formId })
@@ -98,12 +89,6 @@ export const usePublicFormMutations = (
   const submitEmailModeFormFetchMutation = useMutation(
     (args: Omit<SubmitEmailFormArgs, 'formId'>) => {
       return submitEmailModeFormWithFetch({ ...args, formId })
-    },
-  )
-
-  const submitStorageModeFormFetchMutation = useMutation(
-    (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeFormWithFetch({ ...args, formId })
     },
   )
 
@@ -194,9 +179,7 @@ export const usePublicFormMutations = (
 
   return {
     submitEmailModeFormMutation,
-    submitStorageModeFormMutation,
     submitFormFeedbackMutation,
-    submitStorageModeFormFetchMutation,
     submitEmailModeFormFetchMutation,
     submitStorageModeClearFormMutation,
     submitStorageModeClearFormFetchMutation,


### PR DESCRIPTION
## Problem
- about <0.4% of submissions still going through to /encrypt endpoint, even though growthbook rollout is now 100% and the default value is /storage endpoint
- this PR drops the fallback to encrypt mode entirely
- Thereafter, we should expect 100.00% of submissions to go to /storage endpoint

## Tests
- [ ] Storage mode submission works
- [ ] Storage mode submission with attachment works