### PR TITLE
fix(markdown): refine regex to handle newlines after indentation groups

### DIFF
--- a/frontend/src/components/MarkdownText/MarkdownText.tsx
+++ b/frontend/src/components/MarkdownText/MarkdownText.tsx
@@ -23,7 +23,25 @@ export const MarkdownText = ({
   const processedRawString = useMemo(() => {
     // Create new line nodes for every new line in raw string so new lines gets rendered.
     if (multilineBreaks) {
-      return children.replace(/\n/gi, '&nbsp; \n')
+      /**
+       * Matching new lines that are not preceded by a token that indents.
+       *
+       * (?<!{regex}): negative lookbehind to ensure that the following regex does not match
+       *
+       *   (-|\d+\.|\*): matching character tokens that indents
+       *     -: "-"
+       *     *: "*",
+       *     \d+ : "1.", "2.", etc.
+       *
+       *   \s: whitespace following the token, indentation groups must start with token followed by a whitespace character
+       *
+       *   .*: any character, any number of times, this is the actual text content of the line
+       *
+       *   \n: new line character
+       *
+       * \n: the new line character that we will want markdown to render as a new line
+       */
+      return children.replace(/(?<!(-|\d+\.|\*)\s.*\n)\n/gi, '&nbsp; \n')
     }
     return children
   }, [children, multilineBreaks])


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Given
```
title 1
- item 1
- item 2

title 2
```
Title 2 will be rendered under the same indentation as `item 2` as it did not break out of the `<li>` group.
```
title 1
- item 1
- item 2

  title 2
```

Replacing `\n` with an empty space prevents markdown from detecting `\n\n` that signifies a break from the list item.

## Solution
<!-- How did you solve the problem? -->

Refining replacement of `\n` to exclude cases that are trying to break out of indentation groups.

There were two solutions considered.
1.  Provide options of having true markdown syntax for admins
2. Better qualification of regex

We've chosen to go with 2 as this qualification is not adding additional edgecase on top of what we already have. Providing true markdown will require additional learning curve for the admins.