### PR TITLE
chore: use responses instead of results

### DIFF
--- a/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
@@ -93,7 +93,8 @@ export const UnlockedChartsContainer = () => {
   }, [decryptedContent])
 
   const prettifiedResponsesCount = useMemo(
-    () => simplur` ${[filteredDecryptedData.length ?? 0]}result[|s] retrieved`,
+    () =>
+      simplur` ${[filteredDecryptedData.length ?? 0]}response[|s] retrieved`,
     [filteredDecryptedData],
   )
 


### PR DESCRIPTION
## Problem
- Copy update for charts: use `X responses retrieved` instead of `X results retrieved`