### PR TITLE
fix: changed z index of workspacesearchbar

### DIFF
--- a/frontend/src/features/workspace/components/WorkspaceSearchbar/WorkspaceSearchbar.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceSearchbar/WorkspaceSearchbar.tsx
@@ -135,7 +135,7 @@ export const WorkspaceSearchbar = forwardRef<WorkspaceSearchbarProps, 'input'>(
           onChange={(e) => setInternalValue(e.target.value)}
           pr={filterElemWidth}
         />
-        <InputRightElement width="auto" ref={filterRef}>
+        <InputRightElement width="auto" ref={filterRef} zIndex={0}>
           <Divider height="calc(100% - 1.5rem)" orientation="vertical" />
           <Menu placement="bottom-end">
             <MenuButton

--- a/frontend/src/templates/AvatarMenu/AvatarMenu.tsx
+++ b/frontend/src/templates/AvatarMenu/AvatarMenu.tsx
@@ -92,7 +92,7 @@ export const AvatarMenu = ({
   return (
     <Menu autoSelect={false} defaultIsOpen={defaultIsOpen}>
       {({ isOpen }) => (
-        <>
+        <div style={{ zIndex: 1000 }}>
           <AvatarMenuButton isActive={isOpen} isOpen={isOpen}>
             <Avatar
               name={name}
@@ -107,7 +107,7 @@ export const AvatarMenu = ({
             <AvatarMenuDivider />
             {children}
           </Menu.List>
-        </>
+        </div>
       )}
     </Menu>
   )

--- a/frontend/src/templates/AvatarMenu/AvatarMenu.tsx
+++ b/frontend/src/templates/AvatarMenu/AvatarMenu.tsx
@@ -92,7 +92,7 @@ export const AvatarMenu = ({
   return (
     <Menu autoSelect={false} defaultIsOpen={defaultIsOpen}>
       {({ isOpen }) => (
-        <div style={{ zIndex: 1000 }}>
+        <>
           <AvatarMenuButton isActive={isOpen} isOpen={isOpen}>
             <Avatar
               name={name}
@@ -107,7 +107,7 @@ export const AvatarMenu = ({
             <AvatarMenuDivider />
             {children}
           </Menu.List>
-        </div>
+        </>
       )}
     </Menu>
   )


### PR DESCRIPTION
## Problem
Avatar Menu does not cover filter button

Closes FRM-1544

## Solution
Set z index of avatar menu

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

- Details ...

## Before & After Screenshots

**BEFORE**:
<img width="908" alt="Screenshot 2023-11-28 at 12 33 24 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/ad42e16d-c49a-42b0-aab6-295796f80d42">

**AFTER**:
<img width="687" alt="Screenshot 2023-11-28 at 12 44 00 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/a1c43eb3-c556-45ed-b70b-2b49ff7ed5b8">


## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ]  Check that filter does not cover Avatar menu when expanding avatar menu




