### PR TITLE
feat(FE): set secret key input to password type

### DIFF
--- a/frontend/src/features/admin-form/responses/components/SecretKeyVerification/SecretKeyVerification.tsx
+++ b/frontend/src/features/admin-form/responses/components/SecretKeyVerification/SecretKeyVerification.tsx
@@ -165,6 +165,7 @@ export const SecretKeyVerification = ({
             <Stack direction="row" spacing="0.5rem">
               <Skeleton isLoaded={!isLoading} w="100%">
                 <Input
+                  type="password"
                   isDisabled={isLoading}
                   {...register(SECRET_KEY_NAME, secretKeyValidationRules)}
                 />


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Secret keys should be hidden

## Solution
<!-- How did you solve the problem? -->

Set `input="password"` on `<Input />`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

<img width="732" alt="Screenshot 2023-11-28 at 11 32 28 AM" src="https://github.com/opengovsg/FormSG/assets/12391617/874a7a4a-e986-42fc-9952-e8ad45efb5fb">

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
- [ ] Ensure secret key on storage mode form is shown as a password field (`*`)
