### PR TITLE
fix: add myinfo errors to error map for storage-mode submissions

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -56,6 +56,14 @@ import {
   FormNotFoundError,
   PrivateFormError,
 } from '../../form/form.errors'
+import {
+  MyInfoCookieStateError,
+  MyInfoHashDidNotMatchError,
+  MyInfoHashingError,
+  MyInfoInvalidLoginCookieError,
+  MyInfoMissingHashError,
+  MyInfoMissingLoginCookieError,
+} from '../../myinfo/myinfo.errors'
 import { MyInfoKey } from '../../myinfo/myinfo.types'
 import { PaymentNotFoundError } from '../../payments/payments.errors'
 import {
@@ -123,11 +131,31 @@ const errorMapper: MapRouteError = (
     case MissingJwtError:
     case VerifyJwtError:
     case InvalidJwtError:
+    case MyInfoMissingLoginCookieError:
+    case MyInfoCookieStateError:
+    case MyInfoInvalidLoginCookieError:
     case MalformedVerifiedContentError:
       return {
         statusCode: StatusCodes.UNAUTHORIZED,
         errorMessage:
           'Something went wrong with your login. Please try logging in and submitting again.',
+      }
+    case MyInfoMissingHashError:
+      return {
+        statusCode: StatusCodes.GONE,
+        errorMessage:
+          'MyInfo verification expired, please refresh and try again.',
+      }
+    case MyInfoHashDidNotMatchError:
+      return {
+        statusCode: StatusCodes.UNAUTHORIZED,
+        errorMessage: 'MyInfo verification failed.',
+      }
+    case MyInfoHashingError:
+      return {
+        statusCode: StatusCodes.SERVICE_UNAVAILABLE,
+        errorMessage:
+          'MyInfo verification unavailable, please try again later.',
       }
     case MissingUserError:
       return {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MyInfo errors were not captured in the error mapping for storage-mode submissions

## Solution
<!-- How did you solve the problem? -->
Add the MyInfo errors, referencing `email-submission.util.ts`

