### PR TITLE
feat: set secret key input to password type on activation modal

### DIFF
--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -196,6 +196,7 @@ export const SecretKeyActivationModal = ({
                 <FormLabel>Enter or upload Secret Key</FormLabel>
                 <Stack direction="row" spacing="0.5rem">
                   <Input
+                    type="password"
                     {...register('secretKey', {
                       required: "Please enter the form's secret key",
                       pattern: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Similar to #6930 but for activation modal

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
-  No - this PR is backwards compatible  

## Before & After Screenshots
<img width="936" alt="Screenshot 2023-11-28 at 1 45 44 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/a4a6e02e-a59d-48f3-b453-69d9df327a86">
