### PR TITLE
fix: prevent generation of charts if number of responses exceed limit

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -9,7 +9,7 @@ RUN chown 1001:1001 /mongodb_data
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 ENV NODE_ENV=development
 # --openssl-legacy-provider flag
-# A breaking change in the SSL provider was introduced in node 17. This caused 
+# A breaking change in the SSL provider was introduced in node 17. This caused
 # webpack 4 to break. This is an interim solution; we should investigate removing
 # this flag once angular has been removed and we have upgraded to CRA5 (which uses
 # webpack 5).
@@ -28,7 +28,7 @@ RUN apk update && apk upgrade && \
     # that is guaranteed to work. Upgrades must be done in lockstep.
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-    chromium=117.0.5938.62-r0 \
+    chromium=119.0.6045.159-r0	 \
     nss \
     freetype \
     freetype-dev \
@@ -53,7 +53,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 RUN apk add font-wqy-zenhei --repository https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 # Avoid using globs as there seems to be some inconsistency in the way dockerfile handles globs
-# * https://github.com/moby/moby/issues/15858 
+# * https://github.com/moby/moby/issues/15858
 COPY package.json package-lock.json ./
 COPY shared/package.json shared/package-lock.json ./shared/
 COPY frontend/package.json frontend/package-lock.json ./frontend/

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,6 +28,7 @@ RUN apk update && apk upgrade && \
     # that is guaranteed to work. Upgrades must be done in lockstep.
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
+    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
     chromium=119.0.6045.159-r0 \
     nss \
     freetype \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,7 +28,7 @@ RUN apk update && apk upgrade && \
     # that is guaranteed to work. Upgrades must be done in lockstep.
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-    chromium=119.0.6045.159-r0	 \
+    chromium=119.0.6045.159-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -81,7 +81,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-    chromium=119.0.6045.159-r0	 \
+    chromium=119.0.6045.159-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -30,10 +30,10 @@ RUN npm ci --legacy-peer-deps
 COPY . ./
 
 # --openssl-legacy-provider flag
-# A breaking change in the SSL provider was introduced in node 17. This caused 
+# A breaking change in the SSL provider was introduced in node 17. This caused
 # webpack 4 to break. This is an interim solution; we should investigate removing
 # this flag once angular has been removed and we have upgraded to CRA5 (which uses
-# webpack 5). 
+# webpack 5).
 # See also:
 # * https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
 # * https://github.com/webpack/webpack/issues/14532#issuecomment-1304378535
@@ -81,7 +81,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-    chromium=117.0.5938.62-r0 \
+    chromium=119.0.6045.159-r0	 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -81,6 +81,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
+# Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
     chromium=119.0.6045.159-r0 \
     nss \
     freetype \

--- a/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom'
 import { Box, Container, Divider, Stack } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { FormResponseMode } from '~shared/types/form'
 
@@ -21,7 +22,7 @@ export const ChartsPage = (): JSX.Element => {
   const { data: form, isLoading } = useAdminForm()
   const { totalResponsesCount, secretKey } = useStorageResponsesContext()
   const { pathname } = useLocation()
-
+  const chartsMaxResponseCount = useFeatureValue('chartsMaxResponseCount', 100) // limit number of responses to 100 as fallback
   const toast = useToast({ status: 'danger' })
 
   if (isLoading) return <ResponsesPageSkeleton />
@@ -53,11 +54,22 @@ export const ChartsPage = (): JSX.Element => {
     return <></>
   }
 
-  if (totalResponsesCount === 0) {
+  const responseCount = totalResponsesCount || 0
+
+  if (responseCount === 0) {
     return (
       <EmptyChartsContainer
         title="No charts generated yet."
         subtitle="Charts will be generated when you receive responses on your form."
+      />
+    )
+  }
+
+  if (responseCount >= chartsMaxResponseCount) {
+    return (
+      <EmptyChartsContainer
+        title="No charts generated"
+        subtitle={`Charts is in beta and limited to forms with a maximum of ${chartsMaxResponseCount} responses.`}
       />
     )
   }

--- a/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
@@ -2,6 +2,7 @@ import { useLocation } from 'react-router-dom'
 import { Box, Container, Divider, Stack } from '@chakra-ui/react'
 import { useFeatureValue } from '@growthbook/growthbook-react'
 
+import { featureFlags } from '~shared/constants'
 import { FormResponseMode } from '~shared/types/form'
 
 import { ACTIVE_ADMINFORM_RESULTS_ROUTE_REGEX } from '~constants/routes'
@@ -22,7 +23,10 @@ export const ChartsPage = (): JSX.Element => {
   const { data: form, isLoading } = useAdminForm()
   const { totalResponsesCount, secretKey } = useStorageResponsesContext()
   const { pathname } = useLocation()
-  const chartsMaxResponseCount = useFeatureValue('chartsMaxResponseCount', 100) // limit number of responses to 100 as fallback
+  const chartsMaxResponseCount = useFeatureValue(
+    featureFlags.chartsMaxResponseCount,
+    100,
+  ) // limit number of responses to 100 as fallback
   const toast = useToast({ status: 'danger' })
 
   if (isLoading) return <ResponsesPageSkeleton />

--- a/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
@@ -69,7 +69,7 @@ export const ChartsPage = (): JSX.Element => {
     return (
       <EmptyChartsContainer
         title="No charts generated"
-        subtitle={`Charts is in beta and limited to forms with a maximum of ${chartsMaxResponseCount} responses.`}
+        subtitle="The number of form submissions has exceeded the capacity allowed by Charts beta."
       />
     )
   }

--- a/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/ChartsPage.tsx
@@ -65,7 +65,7 @@ export const ChartsPage = (): JSX.Element => {
     )
   }
 
-  if (responseCount >= chartsMaxResponseCount) {
+  if (responseCount > chartsMaxResponseCount) {
     return (
       <EmptyChartsContainer
         title="No charts generated"

--- a/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { Container, Divider, Flex, Stack, Text, VStack } from '@chakra-ui/react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
 import simplur from 'simplur'
 import { removeStopwords } from 'stopword'
 

--- a/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
+++ b/frontend/src/features/admin-form/responses/ChartsPage/UnlockedCharts/UnlockedChartsContainer.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Container, Divider, Flex, Stack, Text, VStack } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 import simplur from 'simplur'
 import { removeStopwords } from 'stopword'
 
@@ -156,11 +157,6 @@ export const UnlockedChartsContainer = () => {
               {filteredDecryptedData.length}
             </Text>
             {prettifiedResponsesCount}
-          </Text>
-          <Text textStyle="body-2" color="secondary.400">
-            {filteredDecryptedData.length > 1000
-              ? 'Charts are generated based on the latest 1,000 responses.'
-              : null}
           </Text>
         </Flex>
         <DateRangePicker

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -9,4 +9,5 @@ export const featureFlags = {
   encryptionBoundaryShiftVirusScanner:
     'encryption-boundary-shift-virus-scanner' as const,
   myinfoSgid: 'myinfo-sgid' as const,
+  chartsMaxResponseCount: 'charts-max-response-count' as const,
 }


### PR DESCRIPTION
## Problem
Charts is lagging for forms with a large number of responses. The current limitation of 1000 responses is limited at the DB query level and although responses will not be computed for charts, they will still be decrypted, which could result in the lagginess.

Fixed another issue where chromium version upgrades are causing deployment to fail.

Closes FRM-1550

## Solution
Show empty charts and prevent decryption if total response count exceeds a configured limit.
[Update] Updating Chromium as the [Chromium version currently available on alpine3.18 is 119.0.6045.159-r0](https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=)



**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="1512" alt="Screenshot 2023-11-30 at 1 28 26 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/804d317f-8386-4700-9136-fb52faf3db3a">

**AFTER**:
<img width="1512" alt="Screenshot 2023-11-30 at 1 28 12 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/812a8fb5-1f4c-4f33-b28b-ff77f2f62c9e">

## Deployment
- [ ]  Add `charts-max-response-count` to Growthbook and set it to 1000

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] No charts will be showed if total response count exceeds limit.
