### PR TITLE
fix(markdown): handle newlines after indentation groups

### DIFF
--- a/frontend/src/components/MarkdownText/MarkdownText.tsx
+++ b/frontend/src/components/MarkdownText/MarkdownText.tsx
@@ -42,8 +42,8 @@ export const MarkdownText = ({
          *   \n: new line character
          */
         children
-          .replace(/\n/gi, '&nbsp; \n')
-          .replace(/(\n(-|\d+\.|\*)\s.*\n)(&nbsp; \n)/gi, '$1 \n')
+          .replace(/\n/g, '&nbsp; \n')
+          .replace(/(\n(-|\d+\.|\*)\s.*\n)(&nbsp; \n)/g, '$1 \n')
       )
     }
     return children

--- a/frontend/src/components/MarkdownText/MarkdownText.tsx
+++ b/frontend/src/components/MarkdownText/MarkdownText.tsx
@@ -23,7 +23,28 @@ export const MarkdownText = ({
   const processedRawString = useMemo(() => {
     // Create new line nodes for every new line in raw string so new lines gets rendered.
     if (multilineBreaks) {
-      return children.replace(/\n/gi, '&nbsp; \n')
+      return (
+        /**
+         * For lines that are contain a token that indents,
+         * we want to remove the whitespace before the newline
+         * so that new lines that come after these tokens
+         * can break out of the indentation group
+         *
+         *  (-|\d+\.|\*): matching character tokens that indents
+         *     -: "-"
+         *     *: "*",
+         *     \d+ : "1.", "2.", etc.
+         *
+         *   \s: whitespace following the token, indentation groups must start with token followed by a whitespace character
+         *
+         *   .*: any character, any number of times, this is the actual text content of the line
+         *
+         *   \n: new line character
+         */
+        children
+          .replace(/\n/gi, '&nbsp; \n')
+          .replace(/(\n(-|\d+\.|\*)\s.*\n)(&nbsp; \n)/gi, '$1 \n')
+      )
     }
     return children
   }, [children, multilineBreaks])


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->


Given
```
title 1
- item 1
- item 2

title 2
```
Title 2 will be rendered under the same indentation as `item 2` as it did not break out of the `<li>` group.
```
title 1
- item 1
- item 2

  title 2
```

Replacing `\n` with an empty space prevents markdown from detecting `\n\n` that signifies a break from the list item.

The previous PR which tackled this issue #6917 was reverted as older versions of Safari [could not handle Lookbehind in regular expressions](https://caniuse.com/js-regexp-lookbehind)

## Solution
<!-- How did you solve the problem? -->
Replace `&nbsp; \n` that comes after a list item with `\n`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<img width="1506" alt="Screenshot 2023-12-03 at 9 41 11 PM" src="https://github.com/opengovsg/FormSG/assets/56983748/d8ca50c3-8145-4890-b8d1-d7d75922bb68">

**AFTER**:
<img width="1488" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/17ce08d6-1e8a-407a-91ed-4d2c1ca1cf6b">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] In the form builder page, create a new Paragraph question 
- [ ] For the Paragraph's content, insert the following (like the screenshot)
```
title 1
- item 1
- item 2
- item 3


title 2
```
- [ ] In the form builder, `title 2` should not be indented
- [ ] In the public form page, `title 2` should not be indented

