### PR TITLE
fix: remove MyInfo line from Email Mode during form creation

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -66,7 +66,6 @@ export const FormResponseOptions = forwardRef<
           listItems={[
             'Attachments: up to 7MB per form',
             'Up to Restricted and Sensitive (High) data',
-            'Supports MyInfo fields',
           ]}
         />
       </Tile>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MyInfo is now available on storage-mode and email-mode forms. Previously, it was only available on email-mode forms. We want to update the copy to remove any mention of MyInfo from the features available on email-mode forms.

## Solution
<!-- How did you solve the problem? -->
Remove the line that said `Supports MyInfo fields` from the email-mode form option

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/opengovsg/FormSG/assets/56983748/3bd8af35-f4b6-4fd7-954b-6a04dbb4982c)

**AFTER**:
<img width="693" alt="image" src="https://github.com/opengovsg/FormSG/assets/56983748/6d452cbb-8056-409a-ae65-d50bacc71389">

## Tests
- [ ] On the admin's dashboard, click "Create form"
- [ ] Check that `Supports MyInfo fields` no longer shows up on the copy for email-mode
