### PR TITLE
fix: modified handleStripeEvent to account for missing metadata payload

### DIFF
--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -32,6 +32,7 @@ import * as PaymentService from './payments.service'
 import {
   StripeFetchError,
   StripeMetadataIncorrectEnvError,
+  StripeMetadataInvalidError,
 } from './stripe.errors'
 import * as StripeService from './stripe.service'
 import { mapRouteError } from './stripe.utils'
@@ -314,9 +315,13 @@ export const reconcileAccount: ControllerHandler<
           return okAsync(undefined)
         })
         .orElse((error) => {
-          if (error instanceof StripeMetadataIncorrectEnvError) {
-            // Intercept this as it is not really an error. Ignore it as it was
-            // never meant for this environment anyway.
+          if (
+            error instanceof StripeMetadataIncorrectEnvError ||
+            error instanceof StripeMetadataInvalidError
+          ) {
+            // Intercept this as it is not really an error.
+            // StripeMetadataIncorrectEnvError: the request will be processed by another environment server.
+            // StripeMetadataInvalidError: Agencies are using the Stripe account to process payments outside of FormSG.
             return okAsync(undefined)
           }
           logger.error({

--- a/src/app/modules/payments/stripe.events.controller.ts
+++ b/src/app/modules/payments/stripe.events.controller.ts
@@ -11,7 +11,10 @@ import { createLoggerWithLabel } from '../../config/logger'
 import { stripe } from '../../loaders/stripe'
 import { ControllerHandler } from '../core/core.types'
 
-import { StripeMetadataIncorrectEnvError } from './stripe.errors'
+import {
+  StripeMetadataIncorrectEnvError,
+  StripeMetadataInvalidError,
+} from './stripe.errors'
 import * as StripeService from './stripe.service'
 import { mapRouteError } from './stripe.utils'
 
@@ -91,9 +94,13 @@ const _handleStripeEventUpdates: ControllerHandler<
       .match(
         () => res.sendStatus(StatusCodes.OK),
         (error) => {
-          if (error instanceof StripeMetadataIncorrectEnvError) {
-            // Intercept this error and return 202 Accepted instead, indicating
-            // the request will be processed by another environment server.
+          if (
+            error instanceof StripeMetadataIncorrectEnvError ||
+            error instanceof StripeMetadataInvalidError
+          ) {
+            // Intercept these errors and return 202 Accepted instead.
+            // StripeMetadataIncorrectEnvError: the request will be processed by another environment server.
+            // StripeMetadataInvalidError: Agencies are using the Stripe account to process payments outside of FormSG.
             return res.sendStatus(StatusCodes.ACCEPTED)
           }
           // Additional logging with error details


### PR DESCRIPTION
## Problem
[Elevated 400 errors](https://opengovproducts.slack.com/archives/CLJPA6NDN/p1701930334563029) from `POST api/v3/notifications/stripe` due to empty StripeMetadata.
This could be due to agencies using their Stripe account to process payments outside of FormSG

Closes FRM-1563

## Solution
Updated handlers to return `202` if StripeMetadata does not conform to the shape defined by FormSG

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
- [x] Verify that payment webhooks are returning 200 from stripe dashboard

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
