### PR TITLE
fix: fix attachment file size check differences between FE and BE

### DIFF
--- a/shared/constants/file.ts
+++ b/shared/constants/file.ts
@@ -3,8 +3,8 @@
 /** File types that can be uploaded for form image/logo */
 export const VALID_UPLOAD_FILE_TYPES = ['image/jpeg', 'image/png', 'image/gif']
 
-export const KB = 1024
-export const MB = 1024 * KB
+export const KB = 1000
+export const MB = 1000 * KB
 
 // Define max file size as 2MB
 export const MAX_UPLOAD_FILE_SIZE = 2 * MB // 2 Million/Mega Bytes, or 2 MB

--- a/shared/constants/file.ts
+++ b/shared/constants/file.ts
@@ -3,8 +3,8 @@
 /** File types that can be uploaded for form image/logo */
 export const VALID_UPLOAD_FILE_TYPES = ['image/jpeg', 'image/png', 'image/gif']
 
-export const KB = 1000
-export const MB = 1000 * KB
+export const KB = 1024
+export const MB = 1024 * KB
 
 // Define max file size as 2MB
 export const MAX_UPLOAD_FILE_SIZE = 2 * MB // 2 Million/Mega Bytes, or 2 MB

--- a/src/app/utils/field-validation/validators/attachmentValidator.ts
+++ b/src/app/utils/field-validation/validators/attachmentValidator.ts
@@ -44,7 +44,7 @@ const makeAttachmentSizeValidator: AttachmentValidatorConstructor =
   (attachmentField) => (response) => {
     const { attachmentSize } = attachmentField
     const byteSizeLimit = parseInt(attachmentSize) * MB
-    return response.content.byteLength < byteSizeLimit
+    return response.content.byteLength > byteSizeLimit
       ? right(response)
       : left(`AttachmentValidator:\t File size more than limit`)
   }

--- a/src/app/utils/field-validation/validators/attachmentValidator.ts
+++ b/src/app/utils/field-validation/validators/attachmentValidator.ts
@@ -44,7 +44,7 @@ const makeAttachmentSizeValidator: AttachmentValidatorConstructor =
   (attachmentField) => (response) => {
     const { attachmentSize } = attachmentField
     const byteSizeLimit = parseInt(attachmentSize) * MB
-    return response.content.byteLength > byteSizeLimit
+    return response.content.byteLength <= byteSizeLimit
       ? right(response)
       : left(`AttachmentValidator:\t File size more than limit`)
   }


### PR DESCRIPTION
## Problem
We received `Invalid answer: AttachmentValidator:	 File size more than limit` on the backend. Given that attachment size is checked on the frontend, this shouldn't happen in normal cases.

The validation condition on frontend and backend is different.

Frontend
```
       if (
          !IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type) &&
          maxSize &&
          file.size > maxSize
        ) {
          return {
            code: 'file-too-large',
            message: `You have exceeded the limit, please upload a file below ${readableMaxSize}`,
          }
        }
```
backend
```
const makeAttachmentSizeValidator: AttachmentValidatorConstructor =
  (attachmentField) => (response) => {
    const { attachmentSize } = attachmentField
    const byteSizeLimit = parseInt(attachmentSize) * MB
    return response.content.byteLength < byteSizeLimit
      ? right(response)
      : left(`AttachmentValidator:\t File size more than limit`)
  }
```
Given that limit = 1MB and uploaded file size = 1MB, frontend will allow the upload to go true while backend will reject the upload, resulting in users experiencing 400 errors.


Closes FRM-1571

## Solution
Standardised validation conditions across frontend and backend


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
- [ ] create email mode form with attachment field of 1mb limit
- [ ] run mkfile 1000000 test.txt to create a 1mb file (note that formsg uses 1mb = 1000000 instead of 1024*1024)
- [ ] upload attachment, you should not encounter any errors


## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
