### PR TITLE
feat: gate mrf form creation on frontend and backend by beta-flags

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -6,6 +6,8 @@ import { FormResponseMode } from '~shared/types/form/form'
 import Badge from '~components/Badge'
 import Tile from '~components/Tile'
 
+import { useUser } from '~features/user/queries'
+
 export interface FormResponseOptionsProps {
   onChange: (option: FormResponseMode) => void
   value: FormResponseMode
@@ -29,6 +31,7 @@ export const FormResponseOptions = forwardRef<
   FormResponseOptionsProps,
   'button'
 >(({ value, onChange }, ref) => {
+  const { user } = useUser()
   return (
     <Stack spacing="1rem" w="100%" direction={{ base: 'column', md: 'row' }}>
       <Tile
@@ -69,28 +72,30 @@ export const FormResponseOptions = forwardRef<
           ]}
         />
       </Tile>
-      <Tile
-        ref={ref}
-        variant="complex"
-        //TODO(MRF/FRM-1599): Fix this icon.
-        icon={BiGroup}
-        badge={<Badge colorScheme="success">New</Badge>}
-        isActive={value === FormResponseMode.Multirespondent}
-        onClick={() => onChange(FormResponseMode.Multirespondent)}
-        isFullWidth
-        flex={1}
-      >
-        <Tile.Title>Multi-respondent form</Tile.Title>
-        <Tile.Subtitle>
-          Create a workflow to collect responses from multiple respondents
-        </Tile.Subtitle>
-        <OptionDescription
-          listItems={[
-            'Route form to respondents according to a sequence',
-            'Specify up to two respondents to route form to for filling',
-          ]}
-        />
-      </Tile>
+      {user?.betaFlags?.mrf && (
+        <Tile
+          ref={ref}
+          variant="complex"
+          //TODO(MRF/FRM-1599): Fix this icon.
+          icon={BiGroup}
+          badge={<Badge colorScheme="success">New</Badge>}
+          isActive={value === FormResponseMode.Multirespondent}
+          onClick={() => onChange(FormResponseMode.Multirespondent)}
+          isFullWidth
+          flex={1}
+        >
+          <Tile.Title>Multi-respondent form</Tile.Title>
+          <Tile.Subtitle>
+            Create a workflow to collect responses from multiple respondents
+          </Tile.Subtitle>
+          <OptionDescription
+            listItems={[
+              'Route form to respondents according to a sequence',
+              'Specify up to two respondents to route form to for filling',
+            ]}
+          />
+        </Tile>
+      )}
     </Stack>
   )
 })

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -15,6 +15,7 @@ export const UserBase = z.object({
     .object({
       payment: z.boolean().optional(),
       children: z.boolean().optional(),
+      mrf: z.boolean().optional(),
     })
     .optional(),
   flags: z

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -73,6 +73,7 @@ const compileUserModel = (db: Mongoose) => {
       betaFlags: {
         payment: Boolean,
         children: Boolean,
+        mrf: Boolean,
       },
       flags: {
         lastSeenFeatureUpdateVersion: Number,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -5,7 +5,7 @@ import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
-import { ResultAsync } from 'neverthrow'
+import { okAsync, ResultAsync } from 'neverthrow'
 
 import {
   MAX_UPLOAD_FILE_SIZE,
@@ -105,6 +105,7 @@ import { PermissionLevel } from './admin-form.types'
 import {
   mapGoGovErrors,
   mapRouteError,
+  verifyUserBetaflag,
   verifyValidUnicodeString,
 } from './admin-form.utils'
 
@@ -1183,6 +1184,11 @@ export const createForm: ControllerHandler<
   return (
     // Step 1: Retrieve currently logged in user.
     UserService.findUserById(sessionUserId)
+      .andThen((user) =>
+        formParams.responseMode === FormResponseMode.Multirespondent
+          ? verifyUserBetaflag(user, 'mrf')
+          : okAsync(user),
+      )
       // Step 2: Create form with given params and set admin to logged in user.
       .andThen((user) =>
         AdminFormService.createForm(


### PR DESCRIPTION
## Problem



Closes FRM-1578

## Solution

Add `mrf` betaflag to user beta flags schema. Only allow mrf creation for users on the frontend and backend if they have the betaflag.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [ ] When a user does not have the `mrf` beta flag, the multi-respondent form response mode tile should not be shown on the form creation modal.
- [ ] When a user does not have the `mrf` beta flag, send a `POST api/v3/admin/forms` in multirespondent mode. This should return a 403 Forbidden.
- [ ] When a user has the `mrf` beta flag, the multi-respondent form response mode tile should be shown on the form creation modal. Form creation should succeed.