### PR TITLE
feat(mrf): response link with key

### DIFF
--- a/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
+++ b/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
@@ -12,14 +12,13 @@ import {
 
 import { GUIDE_SECRET_KEY_LOSS } from '~constants/links'
 import { useIsMobile } from '~hooks/useIsMobile'
-import formsgSdk from '~utils/formSdk'
+import { isKeypairValid, SECRET_KEY_REGEX } from '~utils/secretKeyValidation'
 
 import Button from '../Button'
 import FormLabel from '../FormControl/FormLabel'
 import Link from '../Link'
 
 const SECRET_KEY_NAME = 'secretKey'
-const SECRET_KEY_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
 
 export type SecretKeyVerificationInputProps = {
   publicKey: string | null
@@ -63,12 +62,8 @@ export const SecretKeyVerificationInput = ({
         // Should not see this error message.
         if (!publicKey) return 'Unexpected form mode'
 
-        const trimmedSecretKey = secretKey.trim()
-        const isKeypairValid =
-          SECRET_KEY_REGEX.test(trimmedSecretKey) &&
-          formsgSdk.crypto.valid(publicKey, trimmedSecretKey)
-
-        return isKeypairValid || 'The secret key provided is invalid'
+        const isValid = isKeypairValid(publicKey, secretKey)
+        return isValid || 'The secret key provided is invalid'
       },
     }
   }, [publicKey])

--- a/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
+++ b/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
@@ -28,6 +28,7 @@ export type SecretKeyVerificationInputProps = {
   isButtonFullWidth: boolean
   showGuideLink: boolean
   buttonText: string
+  prefillSecretKey?: string
 }
 
 interface SecretKeyFormInputs {
@@ -42,6 +43,7 @@ export const SecretKeyVerificationInput = ({
   isButtonFullWidth,
   showGuideLink,
   buttonText,
+  prefillSecretKey,
 }: SecretKeyVerificationInputProps) => {
   const isMobile = useIsMobile()
 
@@ -51,7 +53,9 @@ export const SecretKeyVerificationInput = ({
     register,
     setValue,
     handleSubmit,
-  } = useForm<SecretKeyFormInputs>()
+  } = useForm<SecretKeyFormInputs>({
+    defaultValues: { secretKey: prefillSecretKey },
+  })
 
   const fileUploadRef = useRef<HTMLInputElement | null>(null)
 

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -50,6 +50,30 @@ const LoadingDecryption = memo(() => {
   )
 })
 
+const StackRow = ({
+  label,
+  value,
+  isLoading,
+  isError,
+}: {
+  label: string
+  value: string
+  isLoading: boolean
+  isError: boolean
+}) => {
+  return (
+    <Stack
+      spacing={{ base: '0', md: '0.5rem' }}
+      direction={{ base: 'column', md: 'row' }}
+    >
+      <Text as="span" textStyle="subhead-1">
+        {label}:
+      </Text>
+      <Skeleton isLoaded={!isLoading && !isError}>{value}</Skeleton>
+    </Stack>
+  )
+}
+
 export const IndividualResponsePage = (): JSX.Element => {
   const { submissionId, formId } = useParams()
   if (!submissionId) throw new Error('Missing submissionId')
@@ -96,6 +120,13 @@ export const IndividualResponsePage = (): JSX.Element => {
       />
     )
 
+  const responseLinkWithKey = `${
+    window.location.origin
+  }/${getMultirespondentSubmissionEditPath(
+    form?._id ?? '',
+    submissionId,
+  )}?key=${encodeURIComponent(data?.submissionSecretKey || '')}`
+
   return (
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
@@ -105,26 +136,18 @@ export const IndividualResponsePage = (): JSX.Element => {
         spacing={{ base: '1.5rem', md: '2.5rem' }}
       >
         <Stack bg="primary.100" p="1.5rem" textStyle="monospace">
-          <Stack
-            spacing={{ base: '0', md: '0.5rem' }}
-            direction={{ base: 'column', md: 'row' }}
-          >
-            <Text as="span" textStyle="subhead-1">
-              Response ID:
-            </Text>
-            <Text>{submissionId}</Text>
-          </Stack>
-          <Stack
-            spacing={{ base: '0', md: '0.5rem' }}
-            direction={{ base: 'column', md: 'row' }}
-          >
-            <Text as="span" textStyle="subhead-1">
-              Timestamp:
-            </Text>
-            <Skeleton isLoaded={!isLoading && !isError}>
-              {data?.submissionTime ?? 'Loading...'}
-            </Skeleton>
-          </Stack>
+          <StackRow
+            label="Response ID"
+            value={submissionId}
+            isLoading={isLoading}
+            isError={isError}
+          />
+          <StackRow
+            label="Timestamp"
+            value={data?.submissionTime ?? 'Loading...'}
+            isLoading={isLoading}
+            isError={isError}
+          />
           {attachmentDownloadUrls.size > 0 && (
             <Stack
               spacing={{ base: '0', md: '0.5rem' }}
@@ -156,36 +179,12 @@ export const IndividualResponsePage = (): JSX.Element => {
             </Stack>
           )}
           {form?.responseMode === FormResponseMode.Multirespondent && (
-            <>
-              <Stack
-                spacing={{ base: '0', md: '0.5rem' }}
-                direction={{ base: 'column', md: 'row' }}
-              >
-                <Text as="span" textStyle="subhead-1">
-                  Response link:
-                </Text>
-                <Skeleton isLoaded={!isLoading && !isError}>
-                  {`${window.location.protocol}//${
-                    window.location.host
-                  }/${getMultirespondentSubmissionEditPath(
-                    form._id,
-                    submissionId,
-                  )}`}
-                </Skeleton>
-              </Stack>
-              <Stack
-                spacing={{ base: '0', md: '0.5rem' }}
-                direction={{ base: 'column', md: 'row' }}
-              >
-                <Text as="span" textStyle="subhead-1">
-                  Submission secret key:
-                </Text>
-                <Skeleton isLoaded={!isLoading && !isError}>
-                  {data?.submissionSecretKey ??
-                    'Failed to obtain submission secret key'}
-                </Skeleton>
-              </Stack>
-            </>
+            <StackRow
+              label="Response link"
+              value={responseLinkWithKey}
+              isLoading={isLoading}
+              isError={isError}
+            />
           )}
         </Stack>
         {isLoading || isError ? (

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -122,10 +122,9 @@ export const IndividualResponsePage = (): JSX.Element => {
 
   const responseLinkWithKey = `${
     window.location.origin
-  }/${getMultirespondentSubmissionEditPath(
-    form?._id ?? '',
-    submissionId,
-  )}?key=${encodeURIComponent(data?.submissionSecretKey || '')}`
+  }/${getMultirespondentSubmissionEditPath(form?._id ?? '', submissionId, {
+    key: data?.submissionSecretKey || '',
+  })}`
 
   return (
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>

--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -15,7 +15,7 @@ import {
 
 import { FormStatus } from '~shared/types/form/form'
 
-import formsgSdk from '~utils/formSdk'
+import { isKeypairValid, SECRET_KEY_REGEX } from '~utils/secretKeyValidation'
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -34,7 +34,6 @@ export interface SecretKeyActivationModalProps
 }
 
 const SECRET_KEY_NAME = 'secretKey'
-const SECRET_KEY_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
 
 interface SecretKeyFormInputs {
   [SECRET_KEY_NAME]: string
@@ -60,10 +59,9 @@ const useSecretKeyActivationModal = ({
   const { mutateFormStatus } = useMutateFormSettings()
 
   const handleVerifyKeypair = handleSubmit(({ secretKey }) => {
-    const trimmedSecretKey = secretKey.trim()
-    const isKeypairValid = formsgSdk.crypto.valid(publicKey, trimmedSecretKey)
+    const isValid = isKeypairValid(publicKey, secretKey)
 
-    if (!isKeypairValid) {
+    if (!isValid) {
       return setError(
         SECRET_KEY_NAME,
         {

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
 import { FormAuthType } from '~shared/types'
+
+import { isKeypairValid } from '~utils/secretKeyValidation'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 import { decryptSubmission } from '~features/public-form/utils/decryptSubmission'
@@ -48,6 +51,29 @@ export const FormFieldsContainer = (): JSX.Element | null => {
 
     // MRF
     if (previousSubmissionId && !previousSubmission) {
+      let submissionSecretKey = ''
+      try {
+        submissionSecretKey = queryParams.key
+          ? decodeURIComponent(queryParams.key || '')
+          : ''
+      } catch (e) {
+        console.log(e)
+      }
+
+      const isValid = isKeypairValid(
+        submissionPublicKey || '',
+        submissionSecretKey,
+      )
+
+      if (isValid) {
+        setPreviousSubmission(
+          decryptSubmission({
+            submission: encryptedPreviousSubmission,
+            secretKey: submissionSecretKey,
+          }),
+        )
+      }
+
       return (
         <SecretKeyVerification
           publicKey={submissionPublicKey}
@@ -60,7 +86,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
             )
           }
           isLoading={isLoading}
-          prefillSecretKey={queryParams.key}
+          prefillSecretKey={submissionSecretKey}
         />
       )
     }
@@ -82,6 +108,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     previousSubmissionId,
     previousSubmission,
     handleSubmitForm,
+    queryParams.key,
     submissionPublicKey,
     encryptedPreviousSubmission,
   ])

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -27,6 +27,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     useState<ReturnType<typeof decryptSubmission>>()
 
   const { submissionPublicKey = null } = encryptedPreviousSubmission ?? {}
+  const [searchParams] = useSearchParams()
+  const queryParams = Object.fromEntries([...searchParams])
 
   const renderFields = useMemo(() => {
     // Render skeleton when no data
@@ -58,6 +60,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
             )
           }
           isLoading={isLoading}
+          prefillSecretKey={queryParams.key}
         />
       )
     }

--- a/frontend/src/utils/secretKeyValidation.ts
+++ b/frontend/src/utils/secretKeyValidation.ts
@@ -1,0 +1,14 @@
+import formsgSdk from '~utils/formSdk'
+
+export const SECRET_KEY_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
+
+export const isKeypairValid = (
+  publicKey: string,
+  secretKey: string,
+): boolean => {
+  const trimmedSecretKey = secretKey.trim()
+  return (
+    SECRET_KEY_REGEX.test(trimmedSecretKey) &&
+    formsgSdk.crypto.valid(publicKey, trimmedSecretKey)
+  )
+}

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -5,9 +5,37 @@ export const getPaymentInvoiceDownloadUrlPath = (
   return `payments/${formId}/${paymentId}/invoice/download` as const
 }
 
+/**
+ * Returns the respondent path for MRF submission edit page
+ *
+ * Supply options.key to obtain the path with a prefilled key
+ *
+ * Usage:
+ * ```
+ * const editPath = getMultirespondentSubmissionEditPath(
+ *   form._id,
+ *   submissionId, {
+ *     key: submissionSecretKey,
+ * })
+ *
+ * const resolvedPath = `${window.location.origin}/${editPath}`
+ * ```
+ * @param formId
+ * @param submissionId
+ * @param options
+ * @returns
+ */
 export const getMultirespondentSubmissionEditPath = (
   formId: string,
   submissionId: string,
+  options?: {
+    key?: string
+  },
 ) => {
-  return `${formId}/edit/${submissionId}`
+  const editPath = `${formId}/edit/${submissionId}`
+  const { key } = options || {}
+  if (key) {
+    return `${editPath}?key=${encodeURIComponent(key)}`
+  }
+  return editPath
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
1. Admins gave feedback on their disdain on manually entering the form "submission level key".
2. Admins would like to send a link to their users without manually passing them two separate sets of information.
3. "Submission level key" should be embedded on the URL and should not require the user to manually enter it

Closes FRM-1604

## Solution
<!-- How did you solve the problem? -->
1. On Admin Response Results Page, the response link is combined with submission level key
2. On public form, the key is prefilled
3. On public form, if the key is valid, the form will be automatically unlocked

Submission level key is stored on search params as `key`

## Before & After Screenshots
| Component | Before | After |
|--------|--------|--------|
| Admin Response Results Page | ![Screenshot 2023-12-19 at 5 45 34 PM](https://github.com/opengovsg/FormSG/assets/12391617/a63ebdf5-d0d1-4f9f-81cd-1cb9a91495a0) | <img width="757" alt="Screenshot 2023-12-19 at 5 42 48 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/05e4abaf-4c94-4b81-8cb6-82d4a8f0a014"> |

**Auto-prefill + Unlock**
1. Unlock with valid key passed in
2. Fall back to "prefill" when key is invalid 

https://github.com/opengovsg/FormSG/assets/12391617/b2f08d9a-3d37-4a27-a98c-0c8dcbe174e4

