### PR TITLE
fix(mrf): form duplication with MRF

### DIFF
--- a/frontend/src/features/admin-form/template/TemplateFormService.ts
+++ b/frontend/src/features/admin-form/template/TemplateFormService.ts
@@ -1,5 +1,6 @@
 import {
   CreateEmailFormBodyDto,
+  CreateMultirespondentFormBodyDto,
   CreateStorageFormBodyDto,
   FormDto,
 } from '~shared/types'
@@ -18,9 +19,9 @@ export const createEmailModeTemplateForm = async (
   ).then(({ data }) => data)
 }
 
-export const createStorageModeTemplateForm = async (
+export const createStorageModeOrMultirespondentTemplateForm = async (
   formId: string,
-  body: CreateStorageFormBodyDto,
+  body: CreateStorageFormBodyDto | CreateMultirespondentFormBodyDto,
 ): Promise<FormDto> => {
   return ApiService.post<FormDto>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/use-template`,

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -43,14 +43,22 @@ export const useUseTemplateWizardContext = (
 
   const {
     useEmailModeFormTemplateMutation,
-    useStorageModeFormTemplateMutation,
+    useStorageModeOrMultirespondentFormTemplateMutation,
   } = useUseTemplateMutations()
 
-  const handleCreateStorageModeForm = handleSubmit(
+  const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
     ({ title, responseMode }) => {
-      if (responseMode !== FormResponseMode.Encrypt || !formId) return
+      if (
+        !(
+          responseMode === FormResponseMode.Encrypt ||
+          responseMode === FormResponseMode.Multirespondent
+        ) ||
+        !formId
+      ) {
+        return
+      }
 
-      return useStorageModeFormTemplateMutation.mutate({
+      return useStorageModeOrMultirespondentFormTemplateMutation.mutate({
         formIdToDuplicate: formId,
         title,
         responseMode,
@@ -76,13 +84,13 @@ export const useUseTemplateWizardContext = (
     isFetching: isTemplateFormLoading,
     isLoading:
       useEmailModeFormTemplateMutation.isLoading ||
-      useStorageModeFormTemplateMutation.isLoading,
+      useStorageModeOrMultirespondentFormTemplateMutation.isLoading,
     keypair,
     currentStep,
     direction,
     formMethods,
     handleDetailsSubmit,
-    handleCreateStorageModeForm,
+    handleCreateStorageModeOrMultirespondentForm,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/admin-form/template/mutation.ts
+++ b/frontend/src/features/admin-form/template/mutation.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 
 import {
   CreateEmailFormBodyDto,
+  CreateMultirespondentFormBodyDto,
   CreateStorageFormBodyDto,
   FormDto,
 } from '~shared/types'
@@ -18,7 +19,7 @@ import { workspaceKeys } from '~features/workspace/queries'
 
 import {
   createEmailModeTemplateForm,
-  createStorageModeTemplateForm,
+  createStorageModeOrMultirespondentTemplateForm,
 } from './TemplateFormService'
 
 const useCommonHooks = () => {
@@ -67,13 +68,15 @@ export const useUseTemplateMutations = () => {
     },
   )
 
-  const useStorageModeFormTemplateMutation = useMutation<
+  const useStorageModeOrMultirespondentFormTemplateMutation = useMutation<
     FormDto,
     ApiError,
-    CreateStorageFormBodyDto & { formIdToDuplicate: string }
+    (CreateStorageFormBodyDto | CreateMultirespondentFormBodyDto) & {
+      formIdToDuplicate: string
+    }
   >(
     ({ formIdToDuplicate, ...params }) =>
-      createStorageModeTemplateForm(formIdToDuplicate, params),
+      createStorageModeOrMultirespondentTemplateForm(formIdToDuplicate, params),
     {
       onSuccess: handleSuccess,
       onError: handleError,
@@ -82,6 +85,6 @@ export const useUseTemplateMutations = () => {
 
   return {
     useEmailModeFormTemplateMutation,
-    useStorageModeFormTemplateMutation,
+    useStorageModeOrMultirespondentFormTemplateMutation,
   }
 }

--- a/frontend/src/features/workspace/WorkspaceService.ts
+++ b/frontend/src/features/workspace/WorkspaceService.ts
@@ -113,7 +113,7 @@ export const dupeEmailModeForm = async (
   ).then(({ data }) => data)
 }
 
-export const dupeStorageModeForm = async (
+export const dupeStorageModeOrMultirespondentForm = async (
   formId: string,
   body: DuplicateFormBodyDto,
 ): Promise<FormDto> => {

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -77,8 +77,9 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
           responseMode === FormResponseMode.Encrypt ||
           responseMode === FormResponseMode.Multirespondent
         )
-      )
+      ) {
         return
+      }
 
       return createStorageModeOrMultirespondentFormMutation.mutate({
         title,

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -57,8 +57,10 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { handleSubmit } = formMethods
 
-  const { dupeEmailModeFormMutation, dupeStorageModeFormMutation } =
-    useDuplicateFormMutations()
+  const {
+    dupeEmailModeFormMutation,
+    dupeStorageModeOrMultirespondentFormMutation,
+  } = useDuplicateFormMutations()
 
   const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
 
@@ -66,12 +68,19 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   // as the default workspace contains an empty string as workspaceId
   const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
-  const handleCreateStorageModeForm = handleSubmit(
+  const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
     ({ title, responseMode }) => {
-      if (responseMode !== FormResponseMode.Encrypt || !activeFormMeta?._id)
+      if (
+        !(
+          responseMode === FormResponseMode.Encrypt ||
+          responseMode === FormResponseMode.Multirespondent
+        ) ||
+        !activeFormMeta?._id
+      ) {
         return
+      }
 
-      return dupeStorageModeFormMutation.mutate({
+      return dupeStorageModeOrMultirespondentFormMutation.mutate({
         formIdToDuplicate: activeFormMeta._id,
         title,
         responseMode,
@@ -99,13 +108,13 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     isFetching: isWorkspaceLoading || isPreviewFormLoading,
     isLoading:
       dupeEmailModeFormMutation.isLoading ||
-      dupeStorageModeFormMutation.isLoading,
+      dupeStorageModeOrMultirespondentFormMutation.isLoading,
     keypair,
     currentStep,
     direction,
     formMethods,
     handleDetailsSubmit,
-    handleCreateStorageModeForm,
+    handleCreateStorageModeOrMultirespondentForm,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -28,7 +28,7 @@ import {
   deleteAdminForm,
   deleteWorkspace,
   dupeEmailModeForm,
-  dupeStorageModeForm,
+  dupeStorageModeOrMultirespondentForm,
   moveFormsToWorkspace,
   removeFormsFromWorkspaces,
   updateAdminFeedback,
@@ -108,13 +108,13 @@ export const useDuplicateFormMutations = () => {
     },
   )
 
-  const dupeStorageModeFormMutation = useMutation<
+  const dupeStorageModeOrMultirespondentFormMutation = useMutation<
     FormDto,
     ApiError,
     DuplicateFormBodyDto & { formIdToDuplicate: string }
   >(
     ({ formIdToDuplicate, ...params }) =>
-      dupeStorageModeForm(formIdToDuplicate, params),
+      dupeStorageModeOrMultirespondentForm(formIdToDuplicate, params),
     {
       onSuccess: handleSuccess,
       onError: handleError,
@@ -123,7 +123,7 @@ export const useDuplicateFormMutations = () => {
 
   return {
     dupeEmailModeFormMutation,
-    dupeStorageModeFormMutation,
+    dupeStorageModeOrMultirespondentFormMutation,
   }
 }
 

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -316,7 +316,7 @@ export type DuplicateFormOverwriteDto = {
       emails: string | string[]
     }
   | {
-      responseMode: FormResponseMode.Encrypt
+      responseMode: FormResponseMode.Encrypt | FormResponseMode.Multirespondent
       publicKey: string
     }
 )

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -344,6 +344,7 @@ export const processDuplicateOverrideProps = (
 
   switch (params.responseMode) {
     case FormResponseMode.Encrypt:
+    case FormResponseMode.Multirespondent:
       overrideProps.publicKey = params.publicKey
       break
     case FormResponseMode.Email:


### PR DESCRIPTION
## Problem
We broke form duplication and use-template flows by introducing multi-respondent forms into production. This PR aims to fix the issue with duplication.

Closes FRM-1581

## Solution
Requests never made it to the backend because of a response mode check `responseMode === FormResponseMode.Encrypt` in the relevant providers (duplicate form provider, template form provider). This PR thus updates the relevant mutations to handle storage mode and MRF form duplications, and adds `FormResponseMode.Multirespondent` to the response mode check.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

https://github.com/opengovsg/FormSG/assets/25571626/fde41e63-5d86-422e-ab57-14715d9cfaf3

## Tests

Regression tests
- [ ] Email mode form duplicatable to email mode
- [ ] Storage mode form duplicatable to email mode
- [ ] Email mode form duplicatable to storage mode
- [ ] Storage mode form duplicatable to storage mode

New tests
- [ ] Email mode form duplicatable to MRF
- [ ] Storage mode form duplicatable to MRF
- [ ] MRF duplicatable to email mode
- [ ] MRF duplicatable to storage mode
- [ ] MRF duplicatable to MRF