### PR TITLE
fix: add polyfill for Object.FromEntries

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
         "lodash": "^4.17.21",
         "lottie-web": "^5.9.4",
         "p-queue": "^7.2.0",
+        "polyfill-object.fromentries": "^1.0.1",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-csv": "^2.2.2",
@@ -36307,6 +36308,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/polyfill-object.fromentries": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/polyfill-object.fromentries/-/polyfill-object.fromentries-1.0.1.tgz",
+      "integrity": "sha512-zlEL/n2S73hX7BQXIPapzirQw4yM/VC7slrcOyfbsH0ZyUQ/lLh4NF9wshSJ354v0F3KDMC8FCxeTQ7UUPpu9g=="
     },
     "node_modules/popmotion": {
       "version": "11.0.3",
@@ -75865,6 +75871,11 @@
       "requires": {
         "@babel/runtime": "^7.17.8"
       }
+    },
+    "polyfill-object.fromentries": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/polyfill-object.fromentries/-/polyfill-object.fromentries-1.0.1.tgz",
+      "integrity": "sha512-zlEL/n2S73hX7BQXIPapzirQw4yM/VC7slrcOyfbsH0ZyUQ/lLh4NF9wshSJ354v0F3KDMC8FCxeTQ7UUPpu9g=="
     },
     "popmotion": {
       "version": "11.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "lodash": "^4.17.21",
     "lottie-web": "^5.9.4",
     "p-queue": "^7.2.0",
+    "polyfill-object.fromentries": "^1.0.1",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",
     "react-csv": "^2.2.2",

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,3 +1,5 @@
+import 'polyfill-object.fromentries'
+
 import { useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

[`Object.FromEntries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries) is incompatible with older browsers. This results in an error being thrown when the public form page is loaded.

Closes FRM-1612

## Solution
<!-- How did you solve the problem? -->
Add a polyfill from the package [polyfill-object.fromentries](https://www.npmjs.com/package/polyfill-object.fromentries)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Regression**
- [ ] Go to a public form page. You should be able to load the page and submit the form successfully.

MRF
- [ ] As a form admin, go to an MRF form that has a workflow
- [ ] Submit the form once.
- [ ] Open the form as the second respondent, using the link sent in the email.
- [ ] Submit the form. The response should be submitted successfully.


## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `polyfill-object.fromentries` : Provides polyfill for `Object.fromEntries()`

