### PR TITLE
chore: add advertising for Checkpoint

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -77,6 +77,7 @@ export const LANDING_PAGE_EXAMPLE_FORMS = [
 
 export const OGP_ALL_PRODUCTS = 'https://www.open.gov.sg/products/overview'
 export const OGP_POSTMAN = 'https://postman.gov.sg'
+export const OGP_CHECKPOINT = 'https://checkpoint.gov.sg'
 export const OGP_FORMSG_COLLATE = 'https://collate.form.gov.sg'
 export const OGP_SGID = 'https://go.gov.sg/sgid-formsg'
 

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -50,16 +50,9 @@ export const EmailFormSection = ({
 
   useEffect(() => reset({ emails: initialEmails }), [initialEmails, reset])
 
-  const mdComponents = useMdComponents()
-
   return (
     <>
-      <Flex bg="primary.100" p="1rem">
-        <Icon as={BiBulb} color="primary.500" fontSize="1.5rem" mr="0.5rem" />
-        <MarkdownText
-          components={mdComponents}
-        >{`Require routing and approval? [Try using Checkpoint to set up an approval workflow](${OGP_CHECKPOINT})`}</MarkdownText>
-      </Flex>
+      <CheckpointAdvertisingInfobox />
       <FormProvider {...formMethods}>
         <FormControl isInvalid={!isEmpty(errors)}>
           <FormLabel
@@ -74,6 +67,19 @@ export const EmailFormSection = ({
         </FormControl>
       </FormProvider>
     </>
+  )
+}
+
+const CheckpointAdvertisingInfobox = () => {
+  const mdComponents = useMdComponents()
+
+  return (
+    <Flex bg="primary.100" p="1rem">
+      <Icon as={BiBulb} color="primary.500" fontSize="1.5rem" mr="0.5rem" />
+      <MarkdownText
+        components={mdComponents}
+      >{`Require routing and approval? [Try using Checkpoint to set up an approval workflow](${OGP_CHECKPOINT})`}</MarkdownText>
+    </Flex>
   )
 }
 

--- a/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailFormSection.tsx
@@ -5,14 +5,17 @@ import {
   useForm,
   useFormContext,
 } from 'react-hook-form'
-import { FormControl } from '@chakra-ui/react'
+import { BiBulb } from 'react-icons/bi'
+import { Flex, FormControl, Icon } from '@chakra-ui/react'
 import { get, isEmpty, isEqual } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
-import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
+import { GUIDE_PREVENT_EMAIL_BOUNCE, OGP_CHECKPOINT } from '~constants/links'
+import { useMdComponents } from '~hooks/useMdComponents'
 import { ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import { MarkdownText } from '~components/MarkdownText'
 import { TagInput } from '~components/TagInput'
 
 import { useMutateFormSettings } from '../mutations'
@@ -47,20 +50,30 @@ export const EmailFormSection = ({
 
   useEffect(() => reset({ emails: initialEmails }), [initialEmails, reset])
 
+  const mdComponents = useMdComponents()
+
   return (
-    <FormProvider {...formMethods}>
-      <FormControl isInvalid={!isEmpty(errors)}>
-        <FormLabel
-          isRequired
-          useMarkdownForDescription
-          description={`Add at least **2 recipients** to prevent loss of response. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
-        >
-          Emails where responses will be sent
-        </FormLabel>
-        <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
-        <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
-      </FormControl>
-    </FormProvider>
+    <>
+      <Flex bg="primary.100" p="1rem">
+        <Icon as={BiBulb} color="primary.500" fontSize="1.5rem" mr="0.5rem" />
+        <MarkdownText
+          components={mdComponents}
+        >{`Require routing and approval? [Try using Checkpoint to set up an approval workflow](${OGP_CHECKPOINT})`}</MarkdownText>
+      </Flex>
+      <FormProvider {...formMethods}>
+        <FormControl isInvalid={!isEmpty(errors)}>
+          <FormLabel
+            isRequired
+            useMarkdownForDescription
+            description={`Add at least **2 recipients** to prevent loss of response. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
+          >
+            Emails where responses will be sent
+          </FormLabel>
+          <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
+          <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
+        </FormControl>
+      </FormProvider>
+    </>
   )
 }
 

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -70,6 +70,7 @@ export const FormResponseOptions = forwardRef<
         <Tile.Subtitle>Receive responses in your inbox</Tile.Subtitle>
         <OptionDescription
           listItems={[
+            'Supported by Checkpoint, an approval workflow tool',
             'Attachments: up to 7MB per form',
             'Up to Restricted and Sensitive (High) data',
           ]}


### PR DESCRIPTION
## Problem
We want to add advertising for Checkpoint on the FormSG platform. This PR does it.

## Solution

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

Form creation modal

![image](https://github.com/opengovsg/FormSG/assets/25571626/2ad24bb6-0ea8-4c8f-a671-12540a2290fc)

Form settings screen

<img width="1210" alt="image" src="https://github.com/opengovsg/FormSG/assets/25571626/487c0982-ed29-43e5-bb08-8f5c215b319d">
