### PR TITLE
fix: force mongodb connection to direct on localdev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - '9229:9229' # Node debugger port
     environment:
       - NODE_ENV=development
-      - DB_HOST=mongodb://database:27017/formsg
+      - DB_HOST=mongodb://database:27017/formsg?directConnection=true
       - APP_NAME=FormSG
       - APP_URL=http://localhost:5001
       - FE_APP_URL=http://localhost:3000


### PR DESCRIPTION
## Problem

On local dev, several BE APIs will fail with `Server selection timed out after 30000` from MongoDB.


## Solution

Add `directConnection=true` to force all db operations [to one single host](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connections/connection-guide/#direct-connection) designated in the connection URI. 

**Background**
The APIs failures were not completely deterministic, however some APIs fails much more constantly than other. APIs that never failed were POST requests, and specifically those that causes a DB `write`. While, those that failed consistently were APIs that were targeting `read: secondary` (while `read: secondaryPreferred` didn't fail).

**Aside: Definitions**
> **secondary**
> Operations read only from the [secondary](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-secondary) members of the set.

> **secondaryPreferred**
> Operations typically read data from secondary members of the replica set. If the replica set has only one single primary member and no other members, operations read data from the primary member.
---

The above explains the phenomenon of why it:
1. didn't fail on deployed environments (`staging`, `uat`, ...)
2. only [certain](https://github.com/opengovsg/FormSG/blob/develop/src/app/models/form_statistics_total.server.model.ts#L37) [APIs](https://github.com/opengovsg/FormSG/blob/develop/src/app/models/payment.server.model.ts#L123) [fail](https://github.com/opengovsg/FormSG/blob/develop/src/app/services/sms/sms_count.server.model.ts#L149)
---

**Now what?**
We have multiple approaches here:
1. Setup `replicaSet` on our localdev following the bitnami [guide](https://github.com/bitnami/containers/blob/main/bitnami/mongodb/README.md#setting-up-replication)
2. Force `directConnection` such that all operations are routed to `primary` replica, even for those that specifically targets `secondary`
3. Update all `secondary` to `secondaryPreferred`

For option 1, it incurs 2x more memory consumption as each additional DB docker instance adds `~200MB`, and we have to spin up the secondary + the arbiter (to co-ordinate leader election) node -- I've tried setting this up, but didn't manage to successfully find the correct configuration after a few hours.

For option 2, all traffic will be channeled to the singular DB on docker. This is chosen as it is the simplest fix while mimicking our prior local dev behaviour. 

For option 3, it will cause some reads that we intend to only be on secondary to be channeled to the primary node. i.e., generation of document stats on the landing page which is non-mission critical.