### PR TITLE
fix: add patch to feed default ValidationOptions on table shorttext

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -105,6 +105,7 @@ import {
   checkIsApiSecretKeyName,
   generateTwilioCredSecretKeyName,
   getUpdatedFormFields,
+  insertTableShortTextColumnDefaultValidationOptions,
   processDuplicateOverrideProps,
 } from './admin-form.utils'
 
@@ -652,8 +653,10 @@ export const updateFormField = (
   fieldId: string,
   newField: FieldUpdateDto,
 ): ResultAsync<FormFieldSchema, PossibleDatabaseError | FieldNotFoundError> => {
+  const _newField = insertTableShortTextColumnDefaultValidationOptions(newField)
+
   return ResultAsync.fromPromise(
-    form.updateFormFieldById(fieldId, newField),
+    form.updateFormFieldById(fieldId, _newField),
     (error) => {
       logger.error({
         message: 'Error encountered while updating form field',

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -9,6 +9,7 @@ import {
   FieldUpdateDto,
   FormResponseMode,
   FormStatus,
+  TextValidationOptions,
 } from '../../../../../shared/types'
 import {
   reorder,
@@ -605,7 +606,7 @@ export const insertTableShortTextColumnDefaultValidationOptions = (
   newField: FieldUpdateDto,
 ) => {
   if (newField.fieldType === BasicField.Table) {
-    const defaultValidationOptions = {
+    const defaultValidationOptions: TextValidationOptions = {
       customVal: null,
       selectedValidation: null,
     }

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -4,7 +4,9 @@ import { err, ok, Result } from 'neverthrow'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
+  BasicField,
   DuplicateFormBodyDto,
+  FieldUpdateDto,
   FormResponseMode,
   FormStatus,
 } from '../../../../../shared/types'
@@ -585,4 +587,37 @@ export const mapGoGovErrors = (error: AxiosError): GoGovError => {
         } message`,
       )
   }
+}
+
+// TODO: remove once we upgrade to Mongoose 7.x
+/**
+ * Manually insert default validation options for short text columns in tables.
+ * Due to a bug in Mongoose 6.x, default values are not inherited for discriminators.
+ *
+ * See https://github.com/Automattic/mongoose/issues/12135
+ *
+ * Fixed in Mongoose 7.x
+ * @param newField
+ * @returns
+ */
+
+export const insertTableShortTextColumnDefaultValidationOptions = (
+  newField: FieldUpdateDto,
+) => {
+  if (newField.fieldType === BasicField.Table) {
+    const defaultValidationOptions = {
+      customVal: null,
+      selectedValidation: null,
+    }
+    newField.columns.map((column) => {
+      if (column.columnType === BasicField.ShortText) {
+        column.ValidationOptions = {
+          ...defaultValidationOptions,
+          ...column.ValidationOptions,
+        }
+      }
+      return column
+    })
+  }
+  return newField
 }


### PR DESCRIPTION
## Problem

Due to this issue on [Mongoose 6.x](https://www.github.com/Automattic/mongoose/issues/12135), discriminated fields doesn't respect inherited defaults.

This currently affects our Table field where a `dropdown` column is updated to `shortText`. This would then be updated into the DB without a `ValidationOptions` field. Consequently, code that references `column.ValidationOptions.*` would throw an error as the object is `undefined`.

Note: Inserting a new `shortText` column uses the [helper function](https://github.com/opengovsg/FormSG/blob/fix/mongoose-manual-base-schema-inheritance/frontend/src/features/admin-form/create/builder-and-design/utils/columnCreation.ts#L15) that contains the `ValidationOptions` field, thus not affected by this change.

## Solution

Add a patch that checks for shortText and provide a defaulted `ValidationOptions` object to it.

## Tests
Bug fix tests, reproduction steps
- [ ] Add new table field
- [ ] Add new textField column on table
- [ ] Save field
- [ ] Ensure as a respondent submit form succeeds
- [ ] Change textField to dropdown
- [ ] Save field
- [ ] Change dropdown field to textField
- [ ] Save field
- [ ] Ensure as a respondent submit form succeeds