### PR TITLE
chore: upgrade mongodb server core to 9.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "libphonenumber-js": "^1.10.48",
         "lodash": "^4.17.21",
         "moment-timezone": "0.5.41",
-        "mongodb-memory-server-core": "^7.6.3",
+        "mongodb-memory-server-core": "^9.1.6",
         "mongodb-uri": "^0.9.7",
         "mongoose": "^6.12.0",
         "multiparty": ">=4.2.3",
@@ -6761,16 +6761,6 @@
         "tar-stream": "^3.1.5"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.51.2",
       "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.51.2.tgz",
@@ -8750,15 +8740,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "bson": "*"
-      }
-    },
     "node_modules/@types/busboy": {
       "version": "1.5.0",
       "dev": true,
@@ -9067,15 +9048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/mongodb-uri": {
       "version": "0.9.1",
       "dev": true,
@@ -9243,10 +9215,6 @@
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.22.tgz",
       "integrity": "sha512-7yQiX6MWSFSvc/1wW5smJMZTZ4fHOd+hqLr3qr/HONDxHEa2bnYAsOcGBOEqFIjd4yetwMOdEDdeW+udRAQnHA=="
-    },
-    "node_modules/@types/tmp": {
-      "version": "0.2.3",
-      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -10525,11 +10493,11 @@
       }
     },
     "node_modules/async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/async-mutex/node_modules/tslib": {
@@ -11233,14 +11201,6 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/bluebird": {
@@ -13586,13 +13546,6 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/denque": {
-      "version": "1.4.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -17014,10 +16967,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -17355,16 +17304,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stdin": {
@@ -23033,16 +22972,6 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "node_modules/md5-file": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "bin": {
-        "md5-file": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "dev": true,
@@ -23360,36 +23289,38 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
-      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
-        "aws4": {
+        "@aws-sdk/credential-providers": {
           "optional": true
         },
-        "bson-ext": {
+        "@mongodb-js/zstd": {
           "optional": true
         },
         "kerberos": {
           "optional": true
         },
         "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
           "optional": true
         },
         "snappy": {
@@ -23407,40 +23338,36 @@
       }
     },
     "node_modules/mongodb-memory-server-core": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-7.6.3.tgz",
-      "integrity": "sha512-5rv79YlPoPvguRfFv1fvR78z69/QohGD+65f9UYWDfD70ykXpf6tAXPpWJ4ww/ues7FIVepkFCr3aiUvu6lA+A==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.1.6.tgz",
+      "integrity": "sha512-3H/dq5II+XcSbK80hicMw4zFlDxcpjt4oWJq76RlOVuLoaf3AFqVheR6Vqx9ymlIqER4Jni58FMCIIRbesia1A==",
       "dependencies": {
-        "@types/mongodb": "^3.6.20",
-        "@types/tmp": "^0.2.2",
-        "async-mutex": "^0.3.2",
-        "camelcase": "^6.1.0",
-        "debug": "^4.2.0",
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
         "find-cache-dir": "^3.3.2",
-        "get-port": "^5.1.1",
-        "https-proxy-agent": "^5.0.0",
-        "md5-file": "^5.0.0",
-        "mkdirp": "^1.0.4",
-        "mongodb": "^3.7.3",
-        "new-find-package-json": "^1.1.0",
-        "semver": "^7.3.5",
-        "tar-stream": "^2.1.4",
-        "tmp": "^0.2.1",
-        "tslib": "^2.3.0",
-        "uuid": "^8.3.1",
+        "follow-redirects": "^1.15.3",
+        "https-proxy-agent": "^7.0.2",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.5.4",
+        "tar-stream": "^3.0.0",
+        "tslib": "^2.6.2",
         "yauzl": "^2.10.0"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.20.1"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/bl": {
-      "version": "4.1.0",
-      "license": "MIT",
+    "node_modules/mongodb-memory-server-core/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
@@ -23468,6 +23395,18 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/mongodb-memory-server-core/node_modules/make-dir": {
       "version": "3.1.0",
       "license": "MIT",
@@ -23488,16 +23427,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/pkg-dir": {
       "version": "4.2.0",
       "license": "MIT",
@@ -23508,21 +23437,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -23533,31 +23451,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/mongodb-uri": {
       "version": "0.9.7",
@@ -23567,20 +23464,11 @@
       }
     },
     "node_modules/mongodb/node_modules/bson": {
-      "version": "1.1.6",
-      "license": "Apache-2.0",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "engines": {
-        "node": ">=0.6.19"
-      }
-    },
-    "node_modules/mongodb/node_modules/optional-require": {
-      "version": "1.1.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/mongoose": {
@@ -23830,21 +23718,15 @@
       "integrity": "sha512-kPZKRs4VkdloCGQXPoP84q4sT/1Z+lYM61AXyV8wWa2hnuo5KpPBF2S3crSFnMrOgUISmEBP8Vo/ngGZX60NhA=="
     },
     "node_modules/new-find-package-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-1.2.0.tgz",
-      "integrity": "sha512-Z4v/wBxApGh1cCGEhNmq4p8wjDvM6R6vEuYzlAhzOlXBKLJfjyMvwd+ZHR9fyYKVvXfEn4Z3YX6MD470PxpVbQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
       "dependencies": {
-        "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">=12.22.0"
       }
-    },
-    "node_modules/new-find-package-json/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/ngrok": {
       "version": "4.3.3",
@@ -26543,13 +26425,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -26889,17 +26764,6 @@
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/sax": {
@@ -28190,6 +28054,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
@@ -29208,16 +29082,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
-    },
     "node_modules/tmp-promise": {
       "version": "1.1.0",
       "dev": true,
@@ -29247,20 +29111,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tmpl": {
@@ -36896,16 +36746,6 @@
             "pump": "^3.0.0",
             "tar-stream": "^3.1.5"
           }
-        },
-        "tar-stream": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-          "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
         }
       }
     },
@@ -38602,14 +38442,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "requires": {
-        "bson": "*"
-      }
-    },
     "@types/busboy": {
       "version": "1.5.0",
       "dev": true,
@@ -38885,15 +38717,6 @@
       "version": "3.0.5",
       "dev": true
     },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/mongodb-uri": {
       "version": "0.9.1",
       "dev": true
@@ -39044,9 +38867,6 @@
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.22.tgz",
       "integrity": "sha512-7yQiX6MWSFSvc/1wW5smJMZTZ4fHOd+hqLr3qr/HONDxHEa2bnYAsOcGBOEqFIjd4yetwMOdEDdeW+udRAQnHA=="
-    },
-    "@types/tmp": {
-      "version": "0.2.3"
     },
     "@types/tough-cookie": {
       "version": "4.0.2",
@@ -39899,11 +39719,11 @@
       "dev": true
     },
     "async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       },
       "dependencies": {
         "tslib": {
@@ -40384,13 +40204,6 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bl": {
-      "version": "2.2.1",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "bluebird": {
@@ -42043,9 +41856,6 @@
     },
     "delegates": {
       "version": "1.0.0"
-    },
-    "denque": {
-      "version": "1.4.1"
     },
     "depd": {
       "version": "2.0.0"
@@ -44394,9 +44204,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0"
-    },
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -44612,9 +44419,6 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
-    },
-    "get-port": {
-      "version": "5.1.1"
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -48594,9 +48398,6 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "md5-file": {
-      "version": "5.0.0"
-    },
     "md5.js": {
       "version": "1.3.5",
       "dev": true,
@@ -48819,26 +48620,20 @@
       }
     },
     "mongodb": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
-      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "dependencies": {
         "bson": {
-          "version": "1.1.6"
-        },
-        "optional-require": {
-          "version": "1.1.8",
-          "requires": {
-            "require-at": "^1.0.6"
-          }
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+          "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="
         }
       }
     },
@@ -48852,36 +48647,30 @@
       }
     },
     "mongodb-memory-server-core": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-7.6.3.tgz",
-      "integrity": "sha512-5rv79YlPoPvguRfFv1fvR78z69/QohGD+65f9UYWDfD70ykXpf6tAXPpWJ4ww/ues7FIVepkFCr3aiUvu6lA+A==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.1.6.tgz",
+      "integrity": "sha512-3H/dq5II+XcSbK80hicMw4zFlDxcpjt4oWJq76RlOVuLoaf3AFqVheR6Vqx9ymlIqER4Jni58FMCIIRbesia1A==",
       "requires": {
-        "@types/mongodb": "^3.6.20",
-        "@types/tmp": "^0.2.2",
-        "async-mutex": "^0.3.2",
-        "camelcase": "^6.1.0",
-        "debug": "^4.2.0",
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
         "find-cache-dir": "^3.3.2",
-        "get-port": "^5.1.1",
-        "https-proxy-agent": "^5.0.0",
-        "md5-file": "^5.0.0",
-        "mkdirp": "^1.0.4",
-        "mongodb": "^3.7.3",
-        "new-find-package-json": "^1.1.0",
-        "semver": "^7.3.5",
-        "tar-stream": "^2.1.4",
-        "tmp": "^0.2.1",
-        "tslib": "^2.3.0",
-        "uuid": "^8.3.1",
+        "follow-redirects": "^1.15.3",
+        "https-proxy-agent": "^7.0.2",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.5.4",
+        "tar-stream": "^3.0.0",
+        "tslib": "^2.6.2",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "bl": {
-          "version": "4.1.0",
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
+            "debug": "^4.3.4"
           }
         },
         "camelcase": {
@@ -48895,6 +48684,15 @@
             "pkg-dir": "^4.1.0"
           }
         },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
         "make-dir": {
           "version": "3.1.0",
           "requires": {
@@ -48906,46 +48704,24 @@
             }
           }
         },
-        "mkdirp": {
-          "version": "1.0.4"
-        },
         "pkg-dir": {
           "version": "4.2.0",
           "requires": {
             "find-up": "^4.0.0"
           }
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "tar-stream": {
-          "version": "2.2.0",
-          "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
           }
         },
         "tslib": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "uuid": {
-          "version": "8.3.2"
         }
       }
     },
@@ -49139,19 +48915,11 @@
       "integrity": "sha512-kPZKRs4VkdloCGQXPoP84q4sT/1Z+lYM61AXyV8wWa2hnuo5KpPBF2S3crSFnMrOgUISmEBP8Vo/ngGZX60NhA=="
     },
     "new-find-package-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-1.2.0.tgz",
-      "integrity": "sha512-Z4v/wBxApGh1cCGEhNmq4p8wjDvM6R6vEuYzlAhzOlXBKLJfjyMvwd+ZHR9fyYKVvXfEn4Z3YX6MD470PxpVbQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
       "requires": {
-        "debug": "^4.3.4",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
+        "debug": "^4.3.4"
       }
     },
     "ngrok": {
@@ -51059,9 +50827,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6"
-    },
     "require-directory": {
       "version": "2.1.1"
     },
@@ -51294,13 +51059,6 @@
       "dev": true,
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
-    "saslprep": {
-      "version": "1.0.3",
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
       }
     },
     "sax": {
@@ -52251,6 +52009,16 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "requires": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "terser": {
       "version": "4.8.0",
       "dev": true,
@@ -52938,22 +52706,6 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "tmp": {
-      "version": "0.2.1",
-      "requires": {
-        "rimraf": "^3.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "tmp-promise": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "libphonenumber-js": "^1.10.48",
     "lodash": "^4.17.21",
     "moment-timezone": "0.5.41",
-    "mongodb-memory-server-core": "^7.6.3",
+    "mongodb-memory-server-core": "^9.1.6",
     "mongodb-uri": "^0.9.7",
     "mongoose": "^6.12.0",
     "multiparty": ">=4.2.3",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

With mongoose6 being stable on FormSG, we can now proceed to upgrade other mongo-related packages to their latest versions. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**Updated dependencies**:

- `dependency` : `"mongodb-memory-server-core": "^9.1.6"`
