### PR TITLE
chore: upgrade docker base node image to 3.19

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,8 +28,8 @@ RUN apk update && apk upgrade && \
     # that is guaranteed to work. Upgrades must be done in lockstep.
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
-    chromium=119.0.6045.159-r0 \
+    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
+    chromium=121.0.6167.85-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM node:hydrogen-alpine3.18
+FROM node:hydrogen-alpine3.19
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 
 WORKDIR /opt/formsg

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:hydrogen-alpine3.18 as build
+FROM node:hydrogen-alpine3.19 as build
 
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12
@@ -60,7 +60,7 @@ RUN --mount=type=secret,id=dd_api_key \
 RUN npm prune --production --legacy-peer-deps
 
 # This stage builds the final container
-FROM node:hydrogen-alpine3.18
+FROM node:hydrogen-alpine3.19
 LABEL maintainer=FormSG<formsg@data.gov.sg>
 WORKDIR /opt/formsg
 
@@ -81,7 +81,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-# Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
+    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
     chromium=119.0.6045.159-r0 \
     nss \
     freetype \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -81,8 +81,8 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 
 RUN apk add --no-cache \
-    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
-    chromium=119.0.6045.159-r0 \
+    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
+    chromium=121.0.6167.85-r0 \
     nss \
     freetype \
     freetype-dev \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Keeping your Docker base image up-to-date to benefit from security fixes in the latest version of the chosen image.

## Solution
<!-- How did you solve the problem? -->

- Upgrade to latest hydrogen(node:18)-alpine `v3.19`
- Upgrade chromium to match [node v3.19](https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=)