### PR TITLE
feat(payment): webhook with charge information

### DIFF
--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -265,6 +265,7 @@ describe('Submission Model', () => {
               verifiedContent: undefined,
               version: 0,
               created: submission.created,
+              paymentContent: {},
             },
           },
         })
@@ -318,6 +319,7 @@ describe('Submission Model', () => {
               verifiedContent: undefined,
               version: 0,
               created: submission.created,
+              paymentContent: {},
             },
           },
         })
@@ -354,6 +356,7 @@ describe('Submission Model', () => {
               verifiedContent: undefined,
               version: 0,
               created: submission.created,
+              paymentContent: {},
             },
           },
         })
@@ -451,7 +454,7 @@ describe('Submission Model', () => {
         })
 
         // Act
-        const actualWebhookView = submission.getWebhookView()
+        const actualWebhookView = await submission.getWebhookView()
 
         // Assert
         expect(actualWebhookView).toEqual({
@@ -463,6 +466,7 @@ describe('Submission Model', () => {
             verifiedContent: undefined,
             attachmentDownloadUrls: {},
             version: 1,
+            paymentContent: {},
           },
         })
       })
@@ -483,7 +487,7 @@ describe('Submission Model', () => {
         })
 
         // Act
-        const actualWebhookView = submission.getWebhookView()
+        const actualWebhookView = await submission.getWebhookView()
 
         // Assert
         expect(actualWebhookView).toEqual({
@@ -495,6 +499,7 @@ describe('Submission Model', () => {
             encryptedContent: MOCK_ENCRYPTED_CONTENT,
             verifiedContent: MOCK_VERIFIED_CONTENT,
             version: 1,
+            paymentContent: {},
           },
         })
       })
@@ -526,7 +531,7 @@ describe('Submission Model', () => {
         ).populate('form', 'webhook')
 
         // Act
-        const actualWebhookView = populatedSubmission!.getWebhookView()
+        const actualWebhookView = await populatedSubmission!.getWebhookView()
 
         // Assert
         expect(actualWebhookView).toEqual({
@@ -538,6 +543,7 @@ describe('Submission Model', () => {
             encryptedContent: MOCK_ENCRYPTED_CONTENT,
             verifiedContent: MOCK_VERIFIED_CONTENT,
             version: 1,
+            paymentContent: {},
           },
         })
       })
@@ -559,7 +565,7 @@ describe('Submission Model', () => {
         })
 
         // Act
-        const actualWebhookView = submission.getWebhookView()
+        const actualWebhookView = await submission.getWebhookView()
 
         // Assert
         expect(actualWebhookView).toBeNull()

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -34,7 +34,7 @@ import {
   WebhookData,
   WebhookView,
 } from '../../types'
-import { getPaymentFields } from '../modules/payments/payment.service.utils'
+import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -224,7 +224,7 @@ EncryptSubmissionSchema.methods.getWebhookView = async function (
     await (this as IPopulatedWebhookSubmission).populate('paymentId')
   }
   const paymentContent = this.populated('paymentId')
-    ? getPaymentFields(this.paymentId)
+    ? getPaymentWebhookEventObject(this.paymentId)
     : {}
 
   const webhookData: WebhookData = {

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -145,8 +145,8 @@ export const EmailSubmissionSchema = new Schema<IEmailSubmissionSchema>({
 /**
  * Returns null as email submission does not have a webhook view
  */
-EmailSubmissionSchema.methods.getWebhookView = function (): null {
-  return null
+EmailSubmissionSchema.methods.getWebhookView = function (): Promise<null> {
+  return Promise.resolve(null)
 }
 
 const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
@@ -259,7 +259,7 @@ EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
   submissionId: string,
 ): Promise<SubmissionWebhookInfo | null> {
   return this.findById(submissionId)
-    .populate('form', 'webhook', 'paymentId')
+    .populate([{ path: 'form', select: 'webhook' }, { path: 'paymentId' }])
     .then((populatedSubmission: IPopulatedWebhookSubmission | null) => {
       if (!populatedSubmission) return null
       const webhookView = populatedSubmission.getWebhookView()

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -34,6 +34,7 @@ import {
   WebhookData,
   WebhookView,
 } from '../../types'
+import { getPaymentFields } from '../modules/payments/payment.service.utils'
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -209,15 +210,22 @@ export const EncryptSubmissionSchema = new Schema<
  * Returns an object which represents the encrypted submission
  * which will be posted to the webhook URL.
  */
-EncryptSubmissionSchema.methods.getWebhookView = function (
+EncryptSubmissionSchema.methods.getWebhookView = async function (
   this: IEncryptedSubmissionSchema | IPopulatedWebhookSubmission,
-): WebhookView {
+): Promise<WebhookView> {
   const formId = this.populated('form')
     ? String((this as IPopulatedWebhookSubmission).form._id)
     : String(this.form)
   const attachmentRecords = Object.fromEntries(
     this.attachmentMetadata ?? new Map(),
   )
+
+  if (this.paymentId) {
+    await (this as IPopulatedWebhookSubmission).populate('paymentId')
+  }
+  const paymentContent = this.populated('paymentId')
+    ? getPaymentFields(this.paymentId)
+    : {}
 
   const webhookData: WebhookData = {
     formId,
@@ -227,6 +235,7 @@ EncryptSubmissionSchema.methods.getWebhookView = function (
     version: this.version,
     created: this.created,
     attachmentDownloadUrls: attachmentRecords,
+    paymentContent,
   }
 
   return {
@@ -250,13 +259,19 @@ EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
   submissionId: string,
 ): Promise<SubmissionWebhookInfo | null> {
   return this.findById(submissionId)
-    .populate('form', 'webhook')
+    .populate('form', 'webhook', 'paymentId')
     .then((populatedSubmission: IPopulatedWebhookSubmission | null) => {
       if (!populatedSubmission) return null
+      const webhookView = populatedSubmission.getWebhookView()
+      return Promise.all([populatedSubmission, webhookView])
+    })
+    .then((arr) => {
+      if (!arr) return null
+      const [populatedSubmission, webhookView] = arr
       return {
         webhookUrl: populatedSubmission.form.webhook?.url ?? '',
         isRetryEnabled: !!populatedSubmission.form.webhook?.isRetryEnabled,
-        webhookView: populatedSubmission.getWebhookView(),
+        webhookView,
       }
     })
 }

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -3,14 +3,20 @@ import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import config from '../../../app/config/config'
 import { IPaymentSchema } from '../../../types'
+import { PaymentWebhookEventObject } from '../webhook/webhook.types'
 
-export const getPaymentFields = (payment: IPaymentSchema) => {
+export const getPaymentWebhookEventObject = (
+  payment: IPaymentSchema,
+): PaymentWebhookEventObject | object => {
+  // PaymentType.Fixed is deprecated, no need to send any additional fields
+  // We don't want admins to continue using this type of payment
   if (payment.payment_fields_snapshot.payment_type === PaymentType.Fixed) {
     return {}
   }
 
+  const paymentEventType = 'payment_charge' // currently only one type of payment
   return {
-    type: 'payment_charge',
+    type: paymentEventType,
     status: payment.status,
     payer: payment.email,
     url: `${config.app.appUrl}/api/v3/${getPaymentInvoiceDownloadUrlPath(

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -1,3 +1,4 @@
+import config from 'src/app/config/config'
 import { IPaymentSchema } from 'src/types'
 
 import { centsToDollars } from '../../../../shared/utils/payments'
@@ -8,7 +9,10 @@ export const getPaymentFields = (payment: IPaymentSchema) => {
     type: 'payment_charge',
     status: payment.status,
     payer: payment.email,
-    url: getPaymentInvoiceDownloadUrlPath(payment.formId, payment._id),
+    url: `${config.app.appUrl}/api/v3/${getPaymentInvoiceDownloadUrlPath(
+      payment.formId,
+      payment._id,
+    )}`,
     paymentIntent: payment.paymentIntentId,
     amount: centsToDollars(payment.amount),
     productService:

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -1,8 +1,7 @@
-import config from 'src/app/config/config'
-import { IPaymentSchema } from 'src/types'
-
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
+import config from '../../../app/config/config'
+import { IPaymentSchema } from '../../../types'
 
 export const getPaymentFields = (payment: IPaymentSchema) => {
   return {

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -1,0 +1,62 @@
+import { IPaymentSchema } from 'src/types'
+
+import { centsToDollars } from '../../../../shared/utils/payments'
+import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
+
+export const getPaymentFields = (payment: IPaymentSchema) => {
+  return [
+    {
+      _id: '__PAYMENT__STATUS', // Payments will have prefixes
+      question: 'Payment status', // follows csv title
+      answer: payment.status, // value as per csv
+      fieldType: 'textfield', // all payment columns are textfields
+    },
+    {
+      _id: '__PAYMENT__PAYER',
+      question: 'Payer',
+      answer: payment.email,
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__PROOF_OF_PAYMENT',
+      question: 'Proof of Payment',
+      answer: getPaymentInvoiceDownloadUrlPath(payment.formId, payment._id),
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__INTENT_ID',
+      question: 'Payment intent ID',
+      answer: payment.paymentIntentId,
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__AMOUNT',
+      question: 'Payment amount',
+      answer: centsToDollars(payment.amount),
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__PRODUCT_SERVICE',
+      question: 'Product/service',
+      answer:
+        payment.products
+          ?.map(({ data, quantity }) => `${data.name} x ${quantity}`)
+          .join(', ') || '-',
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__DATETIME',
+      question: 'Payment date and time',
+      answer: payment.completedPayment?.paymentDate ?? '-',
+      fieldType: 'textfield',
+    },
+    {
+      _id: '__PAYMENT__TRANSACTION_FEE',
+      question: 'Transaction fee',
+      answer: payment.completedPayment?.transactionFee
+        ? centsToDollars(payment.completedPayment.transactionFee)
+        : '-',
+      fieldType: 'textfield',
+    },
+  ]
+}

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -4,59 +4,20 @@ import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 
 export const getPaymentFields = (payment: IPaymentSchema) => {
-  return [
-    {
-      _id: '__PAYMENT__STATUS', // Payments will have prefixes
-      question: 'Payment status', // follows csv title
-      answer: payment.status, // value as per csv
-      fieldType: 'textfield', // all payment columns are textfields
-    },
-    {
-      _id: '__PAYMENT__PAYER',
-      question: 'Payer',
-      answer: payment.email,
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__PROOF_OF_PAYMENT',
-      question: 'Proof of Payment',
-      answer: getPaymentInvoiceDownloadUrlPath(payment.formId, payment._id),
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__INTENT_ID',
-      question: 'Payment intent ID',
-      answer: payment.paymentIntentId,
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__AMOUNT',
-      question: 'Payment amount',
-      answer: centsToDollars(payment.amount),
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__PRODUCT_SERVICE',
-      question: 'Product/service',
-      answer:
-        payment.products
-          ?.map(({ data, quantity }) => `${data.name} x ${quantity}`)
-          .join(', ') || '-',
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__DATETIME',
-      question: 'Payment date and time',
-      answer: payment.completedPayment?.paymentDate ?? '-',
-      fieldType: 'textfield',
-    },
-    {
-      _id: '__PAYMENT__TRANSACTION_FEE',
-      question: 'Transaction fee',
-      answer: payment.completedPayment?.transactionFee
-        ? centsToDollars(payment.completedPayment.transactionFee)
-        : '-',
-      fieldType: 'textfield',
-    },
-  ]
+  return {
+    type: 'payment_charge',
+    status: payment.status,
+    payer: payment.email,
+    url: getPaymentInvoiceDownloadUrlPath(payment.formId, payment._id),
+    paymentIntent: payment.paymentIntentId,
+    amount: centsToDollars(payment.amount),
+    productService:
+      payment.products
+        ?.map(({ data, quantity }) => `${data.name} x ${quantity}`)
+        .join(', ') || '-',
+    dateTime: payment.completedPayment?.paymentDate ?? '-',
+    transactionFee: payment.completedPayment?.transactionFee
+      ? centsToDollars(payment.completedPayment.transactionFee)
+      : '-',
+  }
 }

--- a/src/app/modules/payments/payment.service.utils.ts
+++ b/src/app/modules/payments/payment.service.utils.ts
@@ -1,9 +1,14 @@
+import { PaymentType } from '../../../../shared/types'
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import config from '../../../app/config/config'
 import { IPaymentSchema } from '../../../types'
 
 export const getPaymentFields = (payment: IPaymentSchema) => {
+  if (payment.payment_fields_snapshot.payment_type === PaymentType.Fixed) {
+    return {}
+  }
+
   return {
     type: 'payment_charge',
     status: payment.status,

--- a/src/app/modules/webhook/webhook.types.ts
+++ b/src/app/modules/webhook/webhook.types.ts
@@ -53,3 +53,10 @@ export type RetryInterval = {
   base: number
   jitter: number
 }
+
+export type PaymentWebhookEventType = 'payment_charge'
+
+export type PaymentWebhookEventObject = {
+  type: PaymentWebhookEventType
+  [key: string]: unknown
+}

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/types/submission'
 
 import { IFormSchema } from './form'
+import { IPaymentSchema } from './payment'
 
 export interface WebhookData {
   formId: string
@@ -20,6 +21,7 @@ export interface WebhookData {
   version: IEncryptedSubmissionSchema['version']
   created: IEncryptedSubmissionSchema['created']
   attachmentDownloadUrls: Record<string, string>
+  paymentContent?: Record<string, unknown>
 }
 
 export interface WebhookView {
@@ -43,11 +45,14 @@ export interface IPopulatedWebhookSubmission
     _id: IFormSchema['_id']
     webhook: IFormSchema['webhook']
   }
+  paymentId: IPaymentSchema
 }
 
 export interface ISubmissionSchema extends SubmissionBase, Document {
   // Allows for population and correct typing
   form: any
+  paymentId: any
+
   created?: Date
 }
 
@@ -65,15 +70,17 @@ export interface IEmailSubmissionSchema
   // Allows for population and correct typing
   form: any
   submissionType: SubmissionType.Email
-  getWebhookView(): null
+  getWebhookView(): Promise<null>
 }
 export interface IEncryptedSubmissionSchema
   extends StorageModeSubmissionBase,
     ISubmissionSchema {
   // Allows for population and correct typing
   form: any
+  paymentId: any
+
   submissionType: SubmissionType.Encrypt
-  getWebhookView(): WebhookView
+  getWebhookView(): Promise<WebhookView>
 }
 export interface IMultirespondentSubmissionSchema
   extends MultirespondentSubmissionBase,
@@ -81,7 +88,7 @@ export interface IMultirespondentSubmissionSchema
   // Allows for population and correct typing
   form: any
   submissionType: SubmissionType.Multirespondent
-  getWebhookView(): null
+  getWebhookView(): Promise<null>
 }
 
 // When retrieving from database, the attachmentMetadata type becomes an object

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,5 +1,7 @@
 import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
+import { PaymentWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
+
 import {
   EmailModeSubmissionBase,
   MultirespondentSubmissionBase,
@@ -21,7 +23,7 @@ export interface WebhookData {
   version: IEncryptedSubmissionSchema['version']
   created: IEncryptedSubmissionSchema['created']
   attachmentDownloadUrls: Record<string, string>
-  paymentContent?: Record<string, unknown>
+  paymentContent?: PaymentWebhookEventObject | object
 }
 
 export interface WebhookView {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Payment information isn't available on webhooks. Requester needs the `charge.succeeded` to tabulate results for their downstream departments.

Closes FRM-1513

## Solution

This document shall only study the `charge.succeeded` event.

<!-- How did you solve the problem? -->
### Two levels of events

**charge.succeeded**

This is easy, but don’t have payout-specific information. i.e., accurate transaction fees

**payout.completed** 

This can be hard as the submission time as already past for 1-7 days, but more accurate for payment information.

---

## Challenges

Webhook formats are in this format (very different from individual response result aka CSVs)

```jsonc
// payload
{
  formId: '65b35a8a80a538729345cec8',
  submissionId: '65ba77e9033a92fc0ba6d2c6',
  encryptedContent: 't9YNFhRRdT/TIRzRLIRaY/HWxHVeY5q6KqTyh47qciY=;Kb1cWpLMl/qylMzLHWRyV6VwNwJFLazA:AyTlHQiTzj3Ga9ptY7/aVdzozxDXJDAn2d1GQa4Ja8V3ZmACi2B3vJyHdYDwfyI5E1n8qNy4tiNPtzmLrhXCSKcA3a3rN6MqDpwB8JVnpJhNf3kN0f6QvBJ+ohP5/jBVNSlsr0Ykay/eZHAobT+kNRMSSw==',
  version: 2.1,
  created: '2024-01-31T16:40:09.652Z',
  attachmentDownloadUrls: {}
  paymentContent: {}
}
// decrypted payload.responses
{
  "responses": [
    {
      "_id": "65ba75b0bf1717b793865cc6",
      "question": "Short answer",
      "answer": "1",
      "fieldType": "textfield"
    }
  ]
}
```

## Proposal

```jsonc
{
  formId: '6421687426357b01435ea8ee',
  submissionId: '65bcae1f9cf1635d0f540f8c',
  encryptedContent: '6ltkGyTL5VbJc1unih4WlIy1CfzlLfKtgzgIs8FBHSU=;MuA4+XpfTyGwNdgzAZss2C86g0enmlCX:UZfzzRUjaK8Xws0XHzRIUE0NH2xL9qJteSDuirYfQVr8HIX1j5rDGhmNpIXilTbliY3PsIWOhg0q0w8Vi3bdeuZ38s18svLkJjFKgDdPa2kWqplt3CDkCivI+oNdc81VbjNuMoZFrJkHV8nCAXsd1iiN9A==',
  version: 2.1,
  created: '2024-02-02T08:56:09.678Z',
  attachmentDownloadUrls: {},
  paymentContent: {
    type: 'payment_charge',
    status: 'succeeded',
    payer: 'some@email.com,
    url: 'https://form.gov.sg/api/v3/payments/6421687426357b01435ea8ee/65bcae1f9cf1635d0f540f88/invoice/download',
    paymentIntent: 'pi_3OfIXUC0kzPzcBpr1WOcsRKD',
    amount: '1.00',
    productService: '1 x 1',
    dateTime: '2024-02-02T08:56:08.000Z',
    transactionFee: '0.54'
  }
}
```

Additional Downstream changes required on plumber and zapier. Zapier can be managed later, as the requester is currently using plumber.

## Tests
Regression on non-payment forms
- [ ] Create a form without payment fields
- [ ] Setup webhook
- [ ] Observe that submission is successful
- [ ] Observe that webhook is sent with fields `paymentContent: {}` + `encryptedContent`
- [ ] Observe that webhook retry is sent with fields `paymentContent: {}` + `encryptedContent`

`paymentContent` webhook data is sent for payment forms
- [ ] Create a form with payment fields
- [ ] Setup webhook
- [ ] Observe that payment submission is successful
- [ ] Observe that webhook is sent with correct fields `paymentContent: {...}` + `encryptedContent`
- [ ] Observe that webhook retry is sent with correct fields `paymentContent: {...}` + `encryptedContent`
