### PR TITLE
fix: recaptcha cn

### DIFF
--- a/src/app/loaders/express/constants.ts
+++ b/src/app/loaders/express/constants.ts
@@ -30,6 +30,7 @@ export const CSP_CORE_DIRECTIVES = {
     'https://*.googletagmanager.com/gtag/',
     'https://*.cloudflareinsights.com/', // Cloudflare web analytics https://developers.cloudflare.com/analytics/types-of-analytics/#web-analytics
     'https://www.gstatic.com/charts/', // React Google Charts for FormSG charts
+    'https://www.gstatic.cn',
   ],
   connectSrc: [
     "'self'",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users from CN are unable to load FormSG as they were looking at loading `www.gstatic.cn` which was blocked by our CSP rules.
Closes FRMSD-22
## Solution
<!-- How did you solve the problem? -->
Add [`www.gstatic.cn`](https://www.whois.com/whois/gstatic.com) into our CSP.