### PR TITLE
chore: sync frontend package version with root

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "form-frontend",
-  "version": "6.102.0",
+  "version": "6.106.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "form-frontend",
-      "version": "6.102.0",
+      "version": "6.106.0",
       "hasInstallScript": true,
       "dependencies": {
         "@chakra-ui/react": "^1.8.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-frontend",
-  "version": "6.102.0",
+  "version": "6.106.0",
   "homepage": ".",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`frontend/package.json::version` is out-of-sync with root.

## Solution
<!-- How did you solve the problem? -->
Update it to `6.106.0` to match root.