### PR TITLE
chore: update readme for installing virus-scanner packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ To install the relevant npm packages, run the following in the root direcory:
 npm install
 ```
 
+To also install the required virus-scanner packages on local, run the following in the `serverless/virus-scanner` directory:
+```bash
+npm install
+```
+
 To prevent breaking changes to webpack4 introduced in node 17 and above, enable the `--openssl-legacy-provider` flag:
 
 ```bash


### PR DESCRIPTION
Part of international efforts.

Some teams wasn't aware that they needed to also run `npm install` for virus-scanner so that their local-dev can run.