### PR TITLE
chore(dev): add virus scanner npm install to root install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "scripts": {
-    "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
+    "postinstall": "npm run postinstall:frontend && npm run postinstall:shared && npm run postinstall:virus-scanner",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env jest",
     "test:backend:ci": "env-cmd -f __tests__/setup/.test-env jest --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.2",
@@ -52,7 +52,8 @@
     "pre-commit": "lint-staged",
     "storybook": "npm run --prefix frontend storybook",
     "postinstall:frontend": "npm --prefix frontend install",
-    "postinstall:shared": "npm --prefix shared install"
+    "postinstall:shared": "npm --prefix shared install",
+    "postinstall:virus-scanner": "npm --prefix serverless/virus-scanner install"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.347.1",


### PR DESCRIPTION
## Problem
`npm install` in the root directory only performs package installation for the frontend and backend, even though `npm run dev` attempts to run the frontend, backend and virus scanner services.

## Solution

Add virus scanner package installation into the root `postinstall` step.

**Breaking Changes** 
- No - this PR is backwards compatible  
